### PR TITLE
[wallet-ext] Start migrating to unified alias

### DIFF
--- a/apps/wallet/configs/ts/tsconfig.common.json
+++ b/apps/wallet/configs/ts/tsconfig.common.json
@@ -17,9 +17,8 @@
         "baseUrl": "../../",
         "sourceMap": true,
         "paths": {
-            // for internal aliases start them with _ for eslint to use the correct import group
-            "_src/*": ["./src/*"],
-            "_shared/*": ["./src/shared/*"],
+            "~/*": ["./src/*"],
+            // Deprecated aliases:
             "_app/*": ["./src/ui/app/*"],
             "_assets/*": ["./src/ui/assets/*"],
             "_images/*": ["./src/ui/assets/images/*"],
@@ -35,7 +34,6 @@
             "_messages/*": ["./src/shared/messaging/messages/*"],
             "_payloads": ["./src/shared/messaging/messages/payloads/"],
             "_payloads/*": ["./src/shared/messaging/messages/payloads/*"],
-            "_styles/*": ["./src/ui/styles/*"],
             "_variables": ["./src/ui/styles/variables"],
             "_variables/*": ["./src/ui/styles/variables/*"],
             "_values": ["./src/ui/styles/values"],
@@ -43,6 +41,7 @@
             "_utils": ["./src/ui/styles/utils"],
             "_utils/*": ["./src/ui/styles/utils/*"],
             "_font-icons/*": ["./font-icons/*"],
+            // Internal packages:
             "@mysten/sui.js": ["../../sdk/typescript/src/"],
             "@mysten/bcs": ["../../sdk/bcs/src/"],
             "@mysten/wallet-standard": [

--- a/apps/wallet/src/background/Alarms.ts
+++ b/apps/wallet/src/background/Alarms.ts
@@ -6,7 +6,7 @@ import Browser from 'webextension-polyfill';
 import {
     AUTO_LOCK_TIMER_DEFAULT_INTERVAL_MINUTES,
     AUTO_LOCK_TIMER_STORAGE_KEY,
-} from '_src/shared/constants';
+} from '~/shared/constants';
 
 export const LOCK_ALARM_NAME = 'lock-keyring-alarm';
 

--- a/apps/wallet/src/background/Transactions.ts
+++ b/apps/wallet/src/background/Transactions.ts
@@ -10,7 +10,7 @@ import { Window } from './Window';
 import type { TransactionDataType } from '_messages/payloads/transactions/ExecuteTransactionRequest';
 import type { TransactionRequest } from '_payloads/transactions';
 import type { TransactionRequestResponse } from '_payloads/transactions/ui/TransactionRequestResponse';
-import type { ContentScriptConnection } from '_src/background/connections/ContentScriptConnection';
+import type { ContentScriptConnection } from '~/background/connections/ContentScriptConnection';
 
 const TX_STORE_KEY = 'transactions';
 

--- a/apps/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/apps/wallet/src/background/connections/ContentScriptConnection.ts
@@ -9,8 +9,6 @@ import {
     isHasPermissionRequest,
 } from '_payloads/permissions';
 import { isExecuteTransactionRequest } from '_payloads/transactions';
-import Permissions from '_src/background/Permissions';
-import Transactions from '_src/background/Transactions';
 
 import type { SuiAddress } from '@mysten/sui.js';
 import type { Message } from '_messages';
@@ -24,6 +22,9 @@ import type {
 } from '_payloads/permissions';
 import type { ExecuteTransactionResponse } from '_payloads/transactions';
 import type { Runtime } from 'webextension-polyfill';
+
+import Permissions from '~/background/Permissions';
+import Transactions from '~/background/Transactions';
 
 export class ContentScriptConnection extends Connection {
     public static readonly CHANNEL: PortChannelName =

--- a/apps/wallet/src/background/connections/KeepAliveConnection.ts
+++ b/apps/wallet/src/background/connections/KeepAliveConnection.ts
@@ -3,11 +3,11 @@
 
 import { BehaviorSubject, filter, map, take } from 'rxjs';
 
-import Keyring from '_src/background/keyring';
-import { IS_SESSION_STORAGE_SUPPORTED } from '_src/background/keyring/VaultStorage';
-import { MSG_DISABLE_AUTO_RECONNECT } from '_src/content-script/keep-bg-alive';
-
 import type { Runtime } from 'webextension-polyfill';
+
+import Keyring from '~/background/keyring';
+import { IS_SESSION_STORAGE_SUPPORTED } from '~/background/keyring/VaultStorage';
+import { MSG_DISABLE_AUTO_RECONNECT } from '~/content-script/keep-bg-alive';
 
 const MIN_DISCONNECT_TIMEOUT = 1000 * 30;
 const MAX_DISCONNECT_TIMEOUT = 1000 * 60 * 3;

--- a/apps/wallet/src/background/connections/UiConnection.ts
+++ b/apps/wallet/src/background/connections/UiConnection.ts
@@ -13,10 +13,6 @@ import {
 import { isDisconnectApp } from '_payloads/permissions/DisconnectApp';
 import { isGetTransactionRequests } from '_payloads/transactions/ui/GetTransactionRequests';
 import { isTransactionRequestResponse } from '_payloads/transactions/ui/TransactionRequestResponse';
-import Permissions from '_src/background/Permissions';
-import Tabs from '_src/background/Tabs';
-import Transactions from '_src/background/Transactions';
-import Keyring from '_src/background/keyring';
 
 import type { Message } from '_messages';
 import type { PortChannelName } from '_messaging/PortChannelName';
@@ -26,6 +22,11 @@ import type { UpdateActiveOrigin } from '_payloads/tabs/updateActiveOrigin';
 import type { TransactionRequest } from '_payloads/transactions';
 import type { GetTransactionRequestsResponse } from '_payloads/transactions/ui/GetTransactionRequestsResponse';
 import type { Runtime } from 'webextension-polyfill';
+
+import Permissions from '~/background/Permissions';
+import Tabs from '~/background/Tabs';
+import Transactions from '~/background/Transactions';
+import Keyring from '~/background/keyring';
 
 export class UiConnection extends Connection {
     public static readonly CHANNEL: PortChannelName = 'sui_ui<->background';

--- a/apps/wallet/src/background/connections/index.ts
+++ b/apps/wallet/src/background/connections/index.ts
@@ -6,10 +6,11 @@ import Browser from 'webextension-polyfill';
 import { ContentScriptConnection } from './ContentScriptConnection';
 import { KeepAliveConnection } from './KeepAliveConnection';
 import { UiConnection } from './UiConnection';
-import { KEEP_ALIVE_BG_PORT_NAME } from '_src/content-script/keep-bg-alive';
 
 import type { Connection } from './Connection';
 import type { Permission } from '_payloads/permissions';
+
+import { KEEP_ALIVE_BG_PORT_NAME } from '~/content-script/keep-bg-alive';
 
 export class Connections {
     #connections: (Connection | KeepAliveConnection)[] = [];

--- a/apps/wallet/src/background/index.ts
+++ b/apps/wallet/src/background/index.ts
@@ -9,8 +9,9 @@ import Permissions from './Permissions';
 import { Connections } from './connections';
 import Keyring from './keyring';
 import { IS_SESSION_STORAGE_SUPPORTED } from './keyring/VaultStorage';
-import { openInNewTab } from '_shared/utils';
-import { MSG_CONNECT } from '_src/content-script/keep-bg-alive';
+
+import { MSG_CONNECT } from '~/content-script/keep-bg-alive';
+import { openInNewTab } from '~/shared//utils';
 
 Browser.runtime.onInstalled.addListener(async ({ reason, previousVersion }) => {
     // TODO: Our versions don't use semver, and instead are date-based. Instead of using the semver

--- a/apps/wallet/src/background/keyring/Vault.ts
+++ b/apps/wallet/src/background/keyring/Vault.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { encrypt, decrypt } from '_shared/cryptography/keystore';
+import { encrypt, decrypt } from '~/shared//cryptography/keystore';
 import {
     entropyToMnemonic,
     entropyToSerialized,
     mnemonicToEntropy,
     toEntropy,
     validateEntropy,
-} from '_shared/utils/bip39';
+} from '~/shared//utils/bip39';
 
 export const LATEST_VAULT_VERSION = 1;
 

--- a/apps/wallet/src/background/keyring/VaultStorage.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.ts
@@ -5,10 +5,11 @@ import { randomBytes } from '@noble/hashes/utils';
 import Browser from 'webextension-polyfill';
 
 import { Vault } from './Vault';
-import { getRandomEntropy, toEntropy } from '_shared/utils/bip39';
 
 import type { StoredData } from './Vault';
 import type { Storage } from 'webextension-polyfill';
+
+import { getRandomEntropy, toEntropy } from '~/shared//utils/bip39';
 
 export const IS_SESSION_STORAGE_SUPPORTED = 'chrome' in global;
 const SESSION_STORAGE: Storage.LocalStorageArea | null =

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -9,19 +9,20 @@ import Browser from 'webextension-polyfill';
 import { VaultStorage } from './VaultStorage';
 import { createMessage } from '_messages';
 import { isKeyringPayload } from '_payloads/keyring';
-import { entropyToSerialized } from '_shared/utils/bip39';
-import Alarms from '_src/background/Alarms';
-import {
-    AUTO_LOCK_TIMER_MAX_MINUTES,
-    AUTO_LOCK_TIMER_MIN_MINUTES,
-    AUTO_LOCK_TIMER_STORAGE_KEY,
-} from '_src/shared/constants';
 
 import type { Keypair } from '@mysten/sui.js';
 import type { Message } from '_messages';
 import type { ErrorPayload } from '_payloads';
 import type { KeyringPayload } from '_payloads/keyring';
-import type { Connection } from '_src/background/connections/Connection';
+import type { Connection } from '~/background/connections/Connection';
+
+import Alarms from '~/background/Alarms';
+import { entropyToSerialized } from '~/shared//utils/bip39';
+import {
+    AUTO_LOCK_TIMER_MAX_MINUTES,
+    AUTO_LOCK_TIMER_MIN_MINUTES,
+    AUTO_LOCK_TIMER_STORAGE_KEY,
+} from '~/shared/constants';
 
 type KeyringEvents = {
     lockedStatusUpdate: boolean;

--- a/apps/wallet/src/content-script/messages-proxy.ts
+++ b/apps/wallet/src/content-script/messages-proxy.ts
@@ -6,7 +6,7 @@ import { take } from 'rxjs';
 import { PortStream } from '_messaging/PortStream';
 import { WindowMessageStream } from '_messaging/WindowMessageStream';
 
-import type { Message } from '_src/shared/messaging/messages';
+import type { Message } from '~/shared/messaging/messages';
 
 function createPort(
     windowMsgStream: WindowMessageStream,

--- a/apps/wallet/src/shared/sentry.ts
+++ b/apps/wallet/src/shared/sentry.ts
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/react';
 import { BrowserTracing } from '@sentry/tracing';
 import Browser from 'webextension-polyfill';
 
-import { growthbook } from '_src/ui/app/experimentation/feature-gating';
+import { growthbook } from '~/ui/app/experimentation/feature-gating';
 
 const WALLET_VERSION = Browser.runtime.getManifest().version;
 const SENTRY_DSN =

--- a/apps/wallet/src/ui/app/components/explorer-link/index.tsx
+++ b/apps/wallet/src/ui/app/components/explorer-link/index.tsx
@@ -10,12 +10,13 @@ import ExternalLink from '_components/external-link';
 import Icon, { SuiIcons } from '_components/icon';
 import { useAppSelector } from '_hooks';
 import { activeAccountSelector } from '_redux/slices/account';
-import { trackEvent } from '_src/shared/plausible';
 
 import type { ObjectId, SuiAddress, TransactionDigest } from '@mysten/sui.js';
 import type { ReactNode } from 'react';
 
 import st from './ExplorerLink.module.scss';
+
+import { trackEvent } from '~/shared/plausible';
 
 export type ExplorerLinkProps = (
     | {

--- a/apps/wallet/src/ui/app/components/menu/content/account/auto-lock-timer-selector/index.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/account/auto-lock-timer-selector/index.tsx
@@ -12,14 +12,15 @@ import { setKeyringLockTimeout } from '_app/wallet/actions';
 import Alert from '_components/alert';
 import Loading from '_components/loading';
 import { useAppDispatch } from '_hooks';
+
+import st from './AutoLockTimerSelector.module.scss';
+
 import {
     AUTO_LOCK_TIMER_DEFAULT_INTERVAL_MINUTES,
     AUTO_LOCK_TIMER_STORAGE_KEY,
     AUTO_LOCK_TIMER_MIN_MINUTES,
     AUTO_LOCK_TIMER_MAX_MINUTES,
-} from '_src/shared/constants';
-
-import st from './AutoLockTimerSelector.module.scss';
+} from '~/shared/constants';
 
 const validation = Yup.object({
     timer: Yup.number()

--- a/apps/wallet/src/ui/app/components/menu/content/menu-list/index.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/menu-list/index.tsx
@@ -14,9 +14,10 @@ import ExternalLink from '_components/external-link';
 import Icon, { SuiIcons } from '_components/icon';
 import { useNextMenuUrl } from '_components/menu/hooks';
 import { useAppDispatch, useAppSelector, useMiddleEllipsis } from '_hooks';
-import { ToS_LINK } from '_src/shared/constants';
 
 import st from './MenuList.module.scss';
+
+import { ToS_LINK } from '~/shared/constants';
 
 function MenuList() {
     const accountUrl = useNextMenuUrl(true, '/account');

--- a/apps/wallet/src/ui/app/components/sui-apps/DisconnectApp.tsx
+++ b/apps/wallet/src/ui/app/components/sui-apps/DisconnectApp.tsx
@@ -13,11 +13,12 @@ import Icon, { SuiIcons } from '_components/icon';
 import Overlay from '_components/overlay';
 import { useAppDispatch } from '_hooks';
 import { revokeAppPermissionByOrigin } from '_redux/slices/permissions';
-import { trackEvent } from '_src/shared/plausible';
 
 import type { SuiAddress } from '@mysten/sui.js';
 
 import st from './DisconnectApp.module.scss';
+
+import { trackEvent } from '~/shared/plausible';
 
 type DisconnectAppProps = {
     name: string;

--- a/apps/wallet/src/ui/app/components/sui-apps/SuiApp.tsx
+++ b/apps/wallet/src/ui/app/components/sui-apps/SuiApp.tsx
@@ -7,9 +7,10 @@ import { memo, useState, useCallback } from 'react';
 import DisconnectApp from './DisconnectApp';
 import ExternalLink from '_components/external-link';
 import { useMiddleEllipsis } from '_hooks';
-import { trackEvent } from '_src/shared/plausible';
 
 import st from './SuiApp.module.scss';
+
+import { trackEvent } from '~/shared/plausible';
 
 type Displaytype = {
     displaytype: 'full' | 'card';

--- a/apps/wallet/src/ui/app/components/sui-apps/index.tsx
+++ b/apps/wallet/src/ui/app/components/sui-apps/index.tsx
@@ -13,11 +13,12 @@ import LoadingIndicator from '_components/loading/LoadingIndicator';
 import { useAppSelector, useAppDispatch } from '_hooks';
 import { getCuratedApps } from '_redux/slices/dapps';
 import { mintDemoNFT } from '_redux/slices/sui-objects';
-import { trackEvent } from '_src/shared/plausible';
 
 import type { SerializedError } from '@reduxjs/toolkit';
 
 import st from './Playground.module.scss';
+
+import { trackEvent } from '~/shared/plausible';
 
 function AppsPlayGround() {
     const [mintInProgress, setMintInProgress] = useState(false);

--- a/apps/wallet/src/ui/app/hooks/useFullscreenGuard.ts
+++ b/apps/wallet/src/ui/app/hooks/useFullscreenGuard.ts
@@ -5,7 +5,8 @@ import { useEffect } from 'react';
 
 import useAppSelector from './useAppSelector';
 import { AppType } from '_redux/slices/app/AppType';
-import { openInNewTab } from '_shared/utils';
+
+import { openInNewTab } from '~/shared//utils';
 
 export default function useFullscreenGuard(enabled: boolean) {
     const appType = useAppSelector((state) => state.app.appType);

--- a/apps/wallet/src/ui/app/pages/home/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/index.tsx
@@ -11,7 +11,8 @@ import Loading from '_components/loading';
 import { useInitializedGuard, useAppDispatch } from '_hooks';
 import PageLayout from '_pages/layout';
 import { fetchAllOwnedAndRequiredObjects } from '_redux/slices/sui-objects';
-import { usePageView } from '_shared/utils';
+
+import { usePageView } from '~/shared//utils';
 
 const POLL_SUI_OBJECTS_INTERVAL = 4000;
 

--- a/apps/wallet/src/ui/app/pages/home/tokens/TokensDetails.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/TokensDetails.tsx
@@ -18,9 +18,10 @@ import { SuiIcons } from '_font-icons/output/sui-icons';
 import { useAppSelector, useObjectsState } from '_hooks';
 import { accountAggregateBalancesSelector } from '_redux/slices/account';
 import { GAS_TYPE_ARG, Coin } from '_redux/slices/sui-objects/Coin';
-import { FEATURES } from '_src/ui/app/experimentation/features';
 
 import st from './TokensPage.module.scss';
+
+import { FEATURES } from '~/ui/app/experimentation/features';
 
 type TokenDetailsProps = {
     coinType?: string;

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -24,12 +24,13 @@ import {
 } from '_redux/slices/account';
 import { Coin, GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 import { sendTokens } from '_redux/slices/transactions';
-import { trackEvent } from '_src/shared/plausible';
 
 import type { SerializedError } from '@reduxjs/toolkit';
 import type { FormikHelpers } from 'formik';
 
 import st from './TransferCoinPage.module.scss';
+
+import { trackEvent } from '~/shared/plausible';
 
 const initialValues = {
     to: '',

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
@@ -4,7 +4,8 @@
 import * as Yup from 'yup';
 
 import { SUI_ADDRESS_VALIDATION } from '_components/address-input/validation';
-import { createTokenValidation } from '_src/shared/validation';
+
+import { createTokenValidation } from '~/shared/validation';
 
 export function createValidationSchemaStepTwo() {
     return Yup.object({

--- a/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
@@ -13,9 +13,10 @@ import Icon, { SuiIcons } from '_components/icon';
 import Loading from '_components/loading';
 import { useAppDispatch } from '_hooks';
 import { loadEntropyFromKeyring } from '_redux/slices/account';
-import { entropyToMnemonic, toEntropy } from '_shared/utils/bip39';
 
 import st from './Backup.module.scss';
+
+import { entropyToMnemonic, toEntropy } from '~/shared//utils/bip39';
 
 export type BackupPageProps = {
     mode?: 'created' | 'imported';

--- a/apps/wallet/src/ui/app/pages/initialize/create/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/create/index.tsx
@@ -13,9 +13,10 @@ import Loading from '_components/loading';
 import { useAppDispatch } from '_hooks';
 import PasswordFields from '_pages/initialize/shared/password-fields';
 import { createVault } from '_redux/slices/account';
-import { PRIVACY_POLICY_LINK, ToS_LINK } from '_shared/constants';
 
 import st from './Create.module.scss';
+
+import { PRIVACY_POLICY_LINK, ToS_LINK } from '~/shared//constants';
 
 const CreatePage = () => {
     const dispatch = useAppDispatch();

--- a/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
@@ -9,8 +9,9 @@ import StepTwo from './steps/StepTwo';
 import CardLayout from '_app/shared/card-layout';
 import { useAppDispatch } from '_hooks';
 import { createVault, logout } from '_redux/slices/account';
-import { MAIN_UI_URL } from '_shared/utils';
-import { entropyToSerialized, mnemonicToEntropy } from '_shared/utils/bip39';
+
+import { MAIN_UI_URL } from '~/shared//utils';
+import { entropyToSerialized, mnemonicToEntropy } from '~/shared//utils/bip39';
 
 const initialValues = {
     mnemonic: '',

--- a/apps/wallet/src/ui/app/pages/initialize/import/validation.ts
+++ b/apps/wallet/src/ui/app/pages/initialize/import/validation.ts
@@ -3,7 +3,7 @@
 
 import * as Yup from 'yup';
 
-import { normalizeMnemonics, validateMnemonics } from '_src/shared/utils/bip39';
+import { normalizeMnemonics, validateMnemonics } from '~/shared/utils/bip39';
 
 export const mnemonicValidation = Yup.string()
     .ensure()

--- a/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
+++ b/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
@@ -18,9 +18,10 @@ import Icon, { SuiIcons } from '_components/icon';
 import Loading from '_components/loading';
 import { useAppDispatch, useAppSelector } from '_hooks';
 import { createDappStatusSelector } from '_redux/slices/permissions';
-import { trackEvent } from '_src/shared/plausible';
 
 import st from './DappStatus.module.scss';
+
+import { trackEvent } from '~/shared/plausible';
 
 function DappStatus() {
     const dispatch = useAppDispatch();

--- a/apps/wallet/src/ui/app/shared/faucet/request-button/index.tsx
+++ b/apps/wallet/src/ui/app/shared/faucet/request-button/index.tsx
@@ -8,11 +8,12 @@ import Button from '_app/shared/button';
 import { requestGas } from '_app/shared/faucet/actions';
 import Icon, { SuiIcons } from '_components/icon';
 import { useAppDispatch, useAppSelector } from '_hooks';
-import { trackEvent } from '_shared/plausible';
 
 import type { ButtonProps } from '_app/shared/button';
 
 import st from './RequestButton.module.scss';
+
+import { trackEvent } from '~/shared//plausible';
 
 type FaucetRequestButtonProps = {
     mode?: ButtonProps['mode'];

--- a/apps/wallet/src/ui/app/staking/stake/validation.ts
+++ b/apps/wallet/src/ui/app/staking/stake/validation.ts
@@ -8,7 +8,8 @@ import {
     GAS_SYMBOL,
     DEFAULT_GAS_BUDGET_FOR_STAKE,
 } from '_redux/slices/sui-objects/Coin';
-import { createTokenValidation } from '_src/shared/validation';
+
+import { createTokenValidation } from '~/shared/validation';
 
 export function createValidationSchema(
     coinType: string,

--- a/apps/wallet/src/ui/index.tsx
+++ b/apps/wallet/src/ui/index.tsx
@@ -14,7 +14,6 @@ import { queryClient } from './app/helpers/queryClient';
 import { ErrorBoundary } from '_components/error-boundary';
 import { initAppType, initNetworkFromStorage } from '_redux/slices/app';
 import { getFromLocationSearch } from '_redux/slices/app/AppType';
-import initSentry from '_src/shared/sentry';
 import store from '_store';
 import { thunkExtras } from '_store/thunk-extras';
 
@@ -23,6 +22,8 @@ import '@fontsource/inter/variable.css';
 import '@fontsource/red-hat-mono/variable.css';
 import '_font-icons/output/sui-icons.scss';
 import 'bootstrap-icons/font/bootstrap-icons.scss';
+
+import initSentry from '~/shared/sentry';
 
 async function init() {
     if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
This add the `~` alias to wallet, mirroring the explorer. In general I think we should consolidate our alias usage down to just one (+ paths for). Right now our aliases are overly ambiguous and I'd rather people keep an idea of the folder structure in their head. I started migrating a couple of the path aliases, but am holding off on doing them all at once.

This will probably make import paths longer, but I think it's a good opportunity for us to reflect on directory structure and try to improve our organization and structure.