### PR TITLE
[WIP] Add the Randomness object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,6 +2591,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastcrypto-tbls"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=2dcf24facddfd15e83325ab714e3b6cb9cd63afe#2dcf24facddfd15e83325ab714e3b6cb9cd63afe"
+dependencies = [
+ "fastcrypto",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "fastcrypto-zkp"
 version = "0.1.0"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=2dcf24facddfd15e83325ab714e3b6cb9cd63afe#2dcf24facddfd15e83325ab714e3b6cb9cd63afe"
@@ -8593,9 +8602,11 @@ dependencies = [
  "anyhow",
  "bcs",
  "better_any",
+ "bincode",
  "curve25519-dalek-ng",
  "digest 0.10.6",
  "fastcrypto",
+ "fastcrypto-tbls",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11036,6 +11036,7 @@ dependencies = [
  "fail 0.5.1",
  "fastcrypto",
  "fastcrypto-derive",
+ "fastcrypto-tbls",
  "fastcrypto-zkp",
  "fastrand",
  "fd-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ move-symbol-pool = { git = "https://github.com/move-language/move", rev = "265e8
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2dcf24facddfd15e83325ab714e3b6cb9cd63afe" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2dcf24facddfd15e83325ab714e3b6cb9cd63afe", package = "fastcrypto-zkp" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2dcf24facddfd15e83325ab714e3b6cb9cd63afe", package = "fastcrypto-tbls" }
 
 # anemo dependencies
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "7ebdcf82b5cccce71e9483d5b028329475a41a20" }

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -16,6 +16,7 @@ smallvec = "1.9.0"
 num_enum = "0.5.7"
 once_cell = "1.16"
 curve25519-dalek-ng = "4.1.1"
+bincode = "1.3.3"
 
 fastcrypto.workspace = true
 fastcrypto-zkp.workspace = true

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -19,6 +19,7 @@ curve25519-dalek-ng = "4.1.1"
 
 fastcrypto.workspace = true
 fastcrypto-zkp.workspace = true
+fastcrypto-tbls.workspace = true
 
 digest = "0.10.3"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/crates/sui-framework/sources/randomness.move
+++ b/crates/sui-framework/sources/randomness.move
@@ -103,4 +103,13 @@ module sui::randomness {
 
     /// Verify signature sig on message "randomness":epoch:id
     native fun native_verify_tbls_signature(epoch: u64, msg: &vector<u8>, sig: &vector<u8>): bool;
+
+    /// Helper functions to sign on messages.
+    native fun native_tbls_sign(epoch: u64, msg: &vector<u8>): vector<u8>;
+
+    #[test_only]
+    public fun sign<T>(self: &Randomness<T>): vector<u8> {
+        let msg = to_bytes(&Domain, self.epoch, &object::id(self));
+        native_tbls_sign(self.epoch, &msg)
+    }
 }

--- a/crates/sui-framework/sources/randomness.move
+++ b/crates/sui-framework/sources/randomness.move
@@ -1,0 +1,106 @@
+// // Copyright (c) Mysten Labs, Inc.
+// // SPDX-License-Identifier: Apache-2.0
+
+/// Randomness objects can only be created, set or consumed. They cannot be created and consumed
+/// in the *same* transaction since it might allow validators decide whether to create and use those
+/// objects *after* seeing the randomness they depend on.
+///
+/// - On creation, the object contains the epoch in which it was created and a unique object id.
+///
+/// - After the object creation transaction is committed, anyone can retrieve the BLS signature on
+///   message "randomness":epoch:id from validators (signed using the Threshold-BLS key of that
+///   epoch).
+///
+/// - Anyone that can mutate the object can set the randomness of the object by supplying the BLS
+///   signature. This operation verifies the signature and sets the value of the randomness object
+///   to be the hash of the signature.
+///
+///   Note that there is exactly one signature that could pass this verification for an object,
+///   thus, the only options the owner of the object has after retrieving the signature (and learning
+///   the randomness) is to either set the randomness or leave it unset. Applications that use
+///   Randomness objects must make sure they handle both options (e.g., debit the user on object
+///   creation so even if the user aborts, depending on the randomness it received, the application
+///   is not harmed).
+///
+/// - Once set, the actual randomness value can be read/consumed.
+///
+///
+/// This object can be used as a shared-/owned-object.
+///
+module sui::randomness {
+    use std::hash::sha3_256;
+    use std::option;
+    use std::vector;
+    use sui::bcs;
+    use sui::object::{Self, UID, ID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    /// Set is called with an invalid signature.
+    const EInvalidSignature: u64 = 0;
+    /// Already set object cannot be set again.
+    const EAlreadySet: u64 = 1;
+
+    /// All signatures are prefixed with Domain.
+    const Domain: vector<u8> = b"randomness";
+
+    struct Randomness<phantom T> has key {
+        id: UID,
+        epoch: u64,
+        value: option::Option<vector<u8>>
+    }
+
+    public fun new<T: drop>(_w: T, ctx: &mut TxContext): Randomness<T> {
+        Randomness<T> {
+            id: object::new(ctx),
+            epoch: tx_context::epoch(ctx),
+            value: option::none(),
+        }
+    }
+
+    public fun transfer<T>(self: Randomness<T>, to: address) {
+        transfer::transfer(self, to);
+    }
+
+    public fun share_object<T>(self: Randomness<T>) {
+        transfer::share_object(self);
+    }
+
+    /// Owner(s) can use this function for setting the randomness.
+    public fun set<T>(self: &mut Randomness<T>, sig: vector<u8>) {
+        assert!(option::is_none(&self.value), EAlreadySet);
+        let msg = to_bytes(&Domain, self.epoch, &object::id(self));
+        assert!(native_verify_tbls_signature(self.epoch, &msg, &sig), EInvalidSignature);
+        let hashed = sha3_256(sig);
+        self.value = option::some(hashed);
+    }
+
+    /// Delete the object.
+    public fun destroy<T>(r: Randomness<T>) {
+        let Randomness { id, epoch: _, value: _ } = r;
+        object::delete(id);
+    }
+
+    /// Read the epoch of the object.
+    public fun epoch<T>(self: &Randomness<T>): u64 {
+        self.epoch
+    }
+
+    /// Read the current value of the object.
+    public fun value<T>(self: &Randomness<T>): &option::Option<vector<u8>> {
+        &self.value
+    }
+
+    fun to_bytes(domain: &vector<u8>, epoch: u64, id: &ID): vector<u8> {
+        let buffer: vector<u8> = vector::empty();
+        let domain = *domain;
+        // All elements below are of fixed sizes.
+        vector::append(&mut buffer, domain);
+        vector::append(&mut buffer, bcs::to_bytes(&epoch));
+        vector::append(&mut buffer, object::id_to_bytes(id));
+        buffer
+    }
+
+    /// Verify signature sig on message "randomness":epoch:id
+    native fun native_verify_tbls_signature(epoch: u64, msg: &vector<u8>, sig: &vector<u8>): bool;
+}

--- a/crates/sui-framework/sources/randomness.move
+++ b/crates/sui-framework/sources/randomness.move
@@ -1,6 +1,8 @@
 // // Copyright (c) Mysten Labs, Inc.
 // // SPDX-License-Identifier: Apache-2.0
 
+// TODO: Since the first version is insecure, should we name the module differently? e.g., insecure_randomness?
+
 /// Randomness objects can only be created, set or consumed. They cannot be created and consumed
 /// in the *same* transaction since it might allow validators decide whether to create and use those
 /// objects *after* seeing the randomness they depend on.
@@ -15,14 +17,14 @@
 ///   signature. This operation verifies the signature and sets the value of the randomness object
 ///   to be the hash of the signature.
 ///
-///   Note that there is exactly one signature that could pass this verification for an object,
+///   Note that there is a single signature that could pass the verification for a specific object,
 ///   thus, the only options the owner of the object has after retrieving the signature (and learning
 ///   the randomness) is to either set the randomness or leave it unset. Applications that use
 ///   Randomness objects must make sure they handle both options (e.g., debit the user on object
 ///   creation so even if the user aborts, depending on the randomness it received, the application
 ///   is not harmed).
 ///
-/// - Once set, the actual randomness value can be read/consumed.
+/// - Once set, the random value can be read/consumed.
 ///
 ///
 /// This object can be used as a shared-/owned-object.
@@ -56,6 +58,7 @@ module sui::randomness {
             epoch: tx_context::epoch(ctx),
             value: option::none(),
         }
+        // TODO: Front load the fee?
     }
 
     public fun transfer<T>(self: Randomness<T>, to: address) {
@@ -101,10 +104,10 @@ module sui::randomness {
         buffer
     }
 
-    /// Verify signature sig on message "randomness":epoch:id
+    /// Verify signature sig on message msg using the epoch's BLS key.
     native fun native_verify_tbls_signature(epoch: u64, msg: &vector<u8>, sig: &vector<u8>): bool;
 
-    /// Helper functions to sign on messages.
+    /// Helper functions to sign on messages in tests.
     native fun native_tbls_sign(epoch: u64, msg: &vector<u8>): vector<u8>;
 
     #[test_only]

--- a/crates/sui-framework/sources/randomness.move
+++ b/crates/sui-framework/sources/randomness.move
@@ -58,7 +58,7 @@ module sui::randomness {
             epoch: tx_context::epoch(ctx),
             value: option::none(),
         }
-        // TODO: Front load the fee?
+        // TODO: Front load the fee.
     }
 
     public fun transfer<T>(self: Randomness<T>, to: address) {
@@ -96,9 +96,8 @@ module sui::randomness {
 
     fun to_bytes(domain: &vector<u8>, epoch: u64, id: &ID): vector<u8> {
         let buffer: vector<u8> = vector::empty();
-        let domain = *domain;
         // All elements below are of fixed sizes.
-        vector::append(&mut buffer, domain);
+        vector::append(&mut buffer, *domain);
         vector::append(&mut buffer, bcs::to_bytes(&epoch));
         vector::append(&mut buffer, object::id_to_bytes(id));
         buffer

--- a/crates/sui-framework/src/natives/crypto/mod.rs
+++ b/crates/sui-framework/src/natives/crypto/mod.rs
@@ -8,3 +8,4 @@ pub mod ed25519;
 pub mod elliptic_curve;
 pub mod groth16;
 pub mod hmac;
+pub mod tbls;

--- a/crates/sui-framework/src/natives/crypto/tbls.rs
+++ b/crates/sui-framework/src/natives/crypto/tbls.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::legacy_empty_cost;
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{Value, VectorRef},
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub fn verify_tbls_signature(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 2);
+
+    let sig = pop_arg!(args, VectorRef);
+    let msg = pop_arg!(args, VectorRef);
+    let epoch = pop_arg!(args, u64);
+
+    // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/3593
+    let cost = legacy_empty_cost();
+
+    let res = Ok(());
+    // TODO: verify_bls with the mocked generator
+    match XX {
+        Ok(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(true)])),
+        _ => Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    }
+}

--- a/crates/sui-framework/src/natives/crypto/tbls.rs
+++ b/crates/sui-framework/src/natives/crypto/tbls.rs
@@ -30,8 +30,8 @@ pub fn verify_tbls_signature(
     let cost = legacy_empty_cost();
 
     let (pk_bls, _pk_vss) = mocked_dkg::generate_public_keys(1, epoch);
-    let sig = types::Signature::from(sig.as_bytes_ref());
-    let valid = tbls::ThresholdBls12381MinSig::verify(&pk_bls, &msg.as_bytes_ref(), sig);
+    let sig: types::Signature = bincode::deserialize(&sig.as_bytes_ref()).unwrap();
+    let valid = types::ThresholdBls12381MinSig::verify(&pk_bls, &msg.as_bytes_ref(), &sig).is_ok();
 
     match valid {
         true => Ok(NativeResult::ok(cost, smallvec![Value::bool(true)])),
@@ -55,10 +55,11 @@ pub fn tbls_sign(
     let cost = legacy_empty_cost();
 
     let (sk, _pk) = mocked_dkg::generate_full_key_pair(epoch);
-    let sig = tbls::ThresholdBls12381MinSig::sign(&sk, &msg.as_bytes_ref());
+    let sig = types::ThresholdBls12381MinSig::sign(&sk, &msg.as_bytes_ref());
+    let sig = bincode::serialize(&sig).unwrap();
 
     Ok(NativeResult::ok(
         cost,
-        smallvec![Value::vector_u8(sig.to_bytes())],
+        smallvec![Value::vector_u8(sig)],
     ))
 }

--- a/crates/sui-framework/src/natives/crypto/tbls.rs
+++ b/crates/sui-framework/src/natives/crypto/tbls.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::legacy_empty_cost;
+use fastcrypto_tbls::{mocked_dkg, tbls::ThresholdBls, types};
 use move_binary_format::errors::PartialVMResult;
 use move_vm_runtime::native_functions::NativeContext;
 use move_vm_types::{
@@ -12,7 +13,8 @@ use move_vm_types::{
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
-use fastcrypto_tbls::{mocked_dkg, tbls, tbls::ThresholdBls, types};
+
+pub const SERIALIZATION_FAILED: u64 = 0;
 
 pub fn verify_tbls_signature(
     _context: &mut NativeContext,
@@ -29,9 +31,16 @@ pub fn verify_tbls_signature(
     // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/3593
     let cost = legacy_empty_cost();
 
+    // Fetch the relevant BLS public key. This is an interim, insecure solution until we implement
+    // the DKG protocol. Then we would fetch the key of the relevant epoch from the objects DB.
+    // Since we don't need the BLS vss key, we can just use threshold = 1.
     let (pk_bls, _pk_vss) = mocked_dkg::generate_public_keys(1, epoch);
-    let sig: types::Signature = bincode::deserialize(&sig.as_bytes_ref()).unwrap();
-    let valid = types::ThresholdBls12381MinSig::verify(&pk_bls, &msg.as_bytes_ref(), &sig).is_ok();
+
+    // Verify the given signature.
+    let sig: Result<types::Signature, _> = bincode::deserialize(&sig.as_bytes_ref());
+    let valid = sig.is_ok()
+        && types::ThresholdBls12381MinSig::verify(&pk_bls, &msg.as_bytes_ref(), &sig.unwrap())
+            .is_ok();
 
     match valid {
         true => Ok(NativeResult::ok(cost, smallvec![Value::bool(true)])),
@@ -56,10 +65,10 @@ pub fn tbls_sign(
 
     let (sk, _pk) = mocked_dkg::generate_full_key_pair(epoch);
     let sig = types::ThresholdBls12381MinSig::sign(&sk, &msg.as_bytes_ref());
-    let sig = bincode::serialize(&sig).unwrap();
+    let sig = bincode::serialize(&sig);
 
-    Ok(NativeResult::ok(
-        cost,
-        smallvec![Value::vector_u8(sig)],
-    ))
+    match sig {
+        Ok(sig) => Ok(NativeResult::ok(cost, smallvec![Value::vector_u8(sig)])),
+        Err(_) => Ok(NativeResult::err(cost, SERIALIZATION_FAILED)),
+    }
 }

--- a/crates/sui-framework/src/natives/mod.rs
+++ b/crates/sui-framework/src/natives/mod.rs
@@ -149,6 +149,11 @@ pub fn all_natives(
             make_native!(object::record_new_uid),
         ),
         (
+            "randomness",
+            "native_verify_tbls_signature",
+            make_native!(tbls::verify_tbls_signature),
+        ),
+        (
             "test_scenario",
             "take_from_address_by_id",
             make_native!(test_scenario::take_from_address_by_id),

--- a/crates/sui-framework/src/natives/mod.rs
+++ b/crates/sui-framework/src/natives/mod.rs
@@ -23,7 +23,7 @@ use move_vm_types::{
 };
 use std::sync::Arc;
 
-use self::crypto::{bls12381, bulletproofs, ecdsa_k1, ed25519, elliptic_curve, groth16, hmac};
+use self::crypto::{bls12381, bulletproofs, ecdsa_k1, ed25519, elliptic_curve, groth16, hmac, tbls};
 
 pub fn all_natives(
     move_stdlib_addr: AccountAddress,
@@ -152,6 +152,11 @@ pub fn all_natives(
             "randomness",
             "native_verify_tbls_signature",
             make_native!(tbls::verify_tbls_signature),
+        ),
+        (
+            "randomness",
+            "native_tbls_sign",
+            make_native!(tbls::tbls_sign),
         ),
         (
             "test_scenario",

--- a/crates/sui-framework/src/natives/mod.rs
+++ b/crates/sui-framework/src/natives/mod.rs
@@ -23,7 +23,9 @@ use move_vm_types::{
 };
 use std::sync::Arc;
 
-use self::crypto::{bls12381, bulletproofs, ecdsa_k1, ed25519, elliptic_curve, groth16, hmac, tbls};
+use self::crypto::{
+    bls12381, bulletproofs, ecdsa_k1, ed25519, elliptic_curve, groth16, hmac, tbls,
+};
 
 pub fn all_natives(
     move_stdlib_addr: AccountAddress,

--- a/crates/sui-framework/tests/crypto/hmac_tests.move
+++ b/crates/sui-framework/tests/crypto/hmac_tests.move
@@ -17,6 +17,4 @@ module sui::hmac_tests {
         let outout_bytes = digest::sha3_256_digest_to_bytes(&output);
         assert!(outout_bytes == expected_output_bytes, 0);
     }
-
-
 }

--- a/crates/sui-framework/tests/randomness_tests.move
+++ b/crates/sui-framework/tests/randomness_tests.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::randomness_tests {
+    use sui::randomness;
+    use sui::test_scenario;
+    use sui::tx_context;
+    use std::option;
+
+    const TEST_USER1_ADDR: address = @0xA11CE;
+    const TEST_USER2_ADDR: address = @0xA12CE;
+
+    struct WITENESS has drop {}
+
+    #[test]
+    fun test_tbls() {
+        let scenario_val = test_scenario::begin(TEST_USER1_ADDR);
+        let scenario = &mut scenario_val;
+        let ctx = test_scenario::ctx(scenario);
+
+        test_scenario::next_tx(scenario, TEST_USER1_ADDR);
+        let r = randomness::new(WITENESS {}, ctx);
+        assert!(randomness::epoch(&r) == tx_context::epoch(ctx));
+        assert!(option::is_none(randomness::value(&r)));
+
+        // how to set pk and sign with sk?
+        // randomness::set(&mut r, []);
+
+        randomness::destroy(r);
+
+        test_scenario::end(scenario_val);
+    }
+}

--- a/crates/sui-framework/tests/randomness_tests.move
+++ b/crates/sui-framework/tests/randomness_tests.move
@@ -19,16 +19,32 @@ module sui::randomness_tests {
         let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
 
-        test_scenario::next_tx(scenario, TEST_USER1_ADDR);
+        // Create a new Randomness
         let r = randomness::new(WITENESS {}, ctx);
-        assert!(randomness::epoch(&r) == tx_context::epoch(ctx));
-        assert!(option::is_none(randomness::value(&r)));
+        assert!(randomness::epoch(&r) == tx_context::epoch(ctx), 0);
+        assert!(option::is_none(randomness::value(&r)), 0);
 
-        // how to set pk and sign with sk?
-        // randomness::set(&mut r, []);
+        // Get a valid signature and set the object.
+        let sig = randomness::sign(&r);
+        randomness::set(&mut r, sig);
+        assert!(option::is_some(randomness::value(&r)), 0);
 
         randomness::destroy(r);
-
         test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = randomness::EInvalidSignature)]
+    fun test_tbls_invalid_signature() {
+        let scenario_val = test_scenario::begin(TEST_USER1_ADDR);
+        let scenario = &mut scenario_val;
+        let ctx = test_scenario::ctx(scenario);
+
+        let r1 = randomness::new(WITENESS {}, ctx);
+        let r2 = randomness::new(WITENESS {}, ctx);
+        let sig = randomness::sign(&r2);
+        // Signature should be invalid.
+        randomness::set(&mut r1, sig);
+        abort 42 // never reached.
     }
 }

--- a/crates/sui-framework/tests/randomness_tests.move
+++ b/crates/sui-framework/tests/randomness_tests.move
@@ -3,19 +3,18 @@
 
 #[test_only]
 module sui::randomness_tests {
+    use std::option;
     use sui::randomness;
     use sui::test_scenario;
     use sui::tx_context;
-    use std::option;
 
-    const TEST_USER1_ADDR: address = @0xA11CE;
-    const TEST_USER2_ADDR: address = @0xA12CE;
+    const TEST_USER_ADDR: address = @0xA11CE;
 
     struct WITENESS has drop {}
 
     #[test]
-    fun test_tbls() {
-        let scenario_val = test_scenario::begin(TEST_USER1_ADDR);
+    fun test_tbls_happy_flow() {
+        let scenario_val = test_scenario::begin(TEST_USER_ADDR);
         let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
 
@@ -36,7 +35,7 @@ module sui::randomness_tests {
     #[test]
     #[expected_failure(abort_code = randomness::EInvalidSignature)]
     fun test_tbls_invalid_signature() {
-        let scenario_val = test_scenario::begin(TEST_USER1_ADDR);
+        let scenario_val = test_scenario::begin(TEST_USER_ADDR);
         let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
 

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -195,6 +195,7 @@ eyre = { version = "0.6", features = ["auto-install", "track-caller"] }
 fail-9fbad63c4bcf4a8f = { package = "fail", version = "0.4", default-features = false }
 fail-d8f496e17d97b5cb = { package = "fail", version = "0.5", default-features = false }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2dcf24facddfd15e83325ab714e3b6cb9cd63afe", features = ["copy_key", "secure"] }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2dcf24facddfd15e83325ab714e3b6cb9cd63afe", default-features = false }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2dcf24facddfd15e83325ab714e3b6cb9cd63afe", default-features = false }
 fastrand = { version = "1", default-features = false }
 fd-lock = { version = "3", default-features = false }
@@ -857,6 +858,7 @@ fail-9fbad63c4bcf4a8f = { package = "fail", version = "0.4", default-features = 
 fail-d8f496e17d97b5cb = { package = "fail", version = "0.5", default-features = false }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2dcf24facddfd15e83325ab714e3b6cb9cd63afe", features = ["copy_key", "secure"] }
 fastcrypto-derive = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2dcf24facddfd15e83325ab714e3b6cb9cd63afe", default-features = false }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2dcf24facddfd15e83325ab714e3b6cb9cd63afe", default-features = false }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2dcf24facddfd15e83325ab714e3b6cb9cd63afe", default-features = false }
 fastrand = { version = "1", default-features = false }
 fd-lock = { version = "3", default-features = false }

--- a/sui_programmability/examples/math/sources/randomness_basic.move
+++ b/sui_programmability/examples/math/sources/randomness_basic.move
@@ -21,9 +21,10 @@ module math::randomness_basics {
     }
 
     /// After the object is created, the signature that is associated with this object can be retrieved from nodes.
-    /// It then can be used for setting the object. Afterwards, the random value can be read from obj (see
-    /// randomness::value).
+    /// It then can be used for setting the object.
+    /// After it is set, the random value can be read from object (see randomness::value).
     public entry fun set_randomness(rnd: &mut randomness::Randomness<WITENESS>, sig: vector<u8>) {
+        /// set can be called also from a function that sets it and immediately reads the randomness.
         randomness::set(rnd, sig);
     }
 }

--- a/sui_programmability/examples/math/sources/randomness_basic.move
+++ b/sui_programmability/examples/math/sources/randomness_basic.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Basic examples of how to work with Randomness objects.
+module math::randomness_basics {
+    use sui::randomness;
+    use sui::tx_context::TxContext;
+    use sui::tx_context;
+
+    /// A local (private) witness for associating Randomness objects to this specific module.
+    struct WITENESS has drop {}
+
+    /// Create a new Randomness object for the sender.
+    public entry fun create_owned_randomness(ctx: &mut TxContext) {
+        randomness::transfer(randomness::new(WITENESS {}, ctx), tx_context::sender(ctx));
+    }
+
+    /// Create a new shared Randomness object.
+    public entry fun create_shared_randomness(ctx: &mut TxContext) {
+        randomness::share_object(randomness::new(WITENESS {}, ctx));
+    }
+
+    /// After the object is created, the signature that is associated with this object can be retrieved from nodes.
+    /// It then can be used for setting the object. Afterwards, the random value can be read from obj (see
+    /// randomness::value).
+    public entry fun set_randomness(rnd: &mut randomness::Randomness<WITENESS>, sig: vector<u8>) {
+        randomness::set(rnd, sig);
+    }
+}

--- a/sui_programmability/examples/math/tests/randomness_basic_tests.move
+++ b/sui_programmability/examples/math/tests/randomness_basic_tests.move
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module math::randomness_basic_tests {
+    use std::option;
+    use sui::randomness;
+    use sui::test_scenario;
+    use math::randomness_basics;
+    use sui::randomness::Randomness;
+
+    const TEST_USER_ADDR: address = @0xA11CE;
+
+    #[test]
+    fun test_owned_object() {
+        let scenario_val = test_scenario::begin(TEST_USER_ADDR);
+        let scenario = &mut scenario_val;
+        let ctx = test_scenario::ctx(scenario);
+
+        randomness_basics::create_owned_randomness(ctx);
+        test_scenario::next_tx(scenario, TEST_USER_ADDR);
+        let r = test_scenario::take_from_sender<Randomness<randomness_basics::WITENESS>>(scenario);
+        assert!(option::is_none(randomness::value(&r)), 0);
+
+        // Get a valid signature and set the object.
+        let sig = randomness::sign(&r);
+        randomness_basics::set_randomness(&mut r, sig);
+        assert!(option::is_some(randomness::value(&r)), 0);
+
+        randomness::destroy(r);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_shared_object() {
+        let scenario_val = test_scenario::begin(TEST_USER_ADDR);
+        let scenario = &mut scenario_val;
+        let ctx = test_scenario::ctx(scenario);
+
+        randomness_basics::create_shared_randomness(ctx);
+        test_scenario::next_tx(scenario, TEST_USER_ADDR);
+        let r = test_scenario::take_shared<Randomness<randomness_basics::WITENESS>>(scenario);
+        assert!(option::is_none(randomness::value(&r)), 0);
+
+        // Get a valid signature and set the object.
+        let sig = randomness::sign(&r);
+        randomness_basics::set_randomness(&mut r, sig);
+        assert!(option::is_some(randomness::value(&r)), 0);
+
+        test_scenario::return_shared(r);
+        test_scenario::end(scenario_val);
+    }
+}


### PR DESCRIPTION
Implementation of the Move contract and native functions according to the [HLD](https://www.notion.so/mystenlabs/HLD-Randomness-Beacon-b9bc8179bde74639bc99baa9a6e8bdf7). Currently all the crypto is computed locally in the native functions.

See [PR](https://github.com/MystenLabs/sui/pull/6824) for the related JSON-RPC API.
