### PR TITLE
Normalize object type consistently

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -67,6 +67,7 @@ use sui_types::messages_checkpoint::{
 };
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::{Owner, PastObjectRead};
+use sui_types::parse_sui_struct_tag;
 use sui_types::query::{EventQuery, TransactionQuery};
 use sui_types::storage::{ObjectKey, WriteKind};
 use sui_types::sui_system_state::SuiSystemState;
@@ -2272,8 +2273,10 @@ impl AuthorityState {
                     .await?
             }
             EventQuery::MoveEvent(struct_name) => {
+                let normalized_struct_name =
+                    parse_sui_struct_tag(&struct_name)?.to_canonical_string();
                 es.events_by_move_event_struct_name(
-                    &struct_name,
+                    &normalized_struct_name,
                     tx_num,
                     event_num,
                     limit,

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -103,6 +103,7 @@ impl CoinReadApi {
     fn get_owner_coin_iterator<'a>(
         &'a self,
         owner: SuiAddress,
+        // TODO: update the type to be `StructTag` instead of String
         coin_type: &'a Option<String>,
     ) -> Result<impl Iterator<Item = ObjectID> + '_, Error> {
         Ok(self
@@ -290,7 +291,7 @@ impl CoinReadApiServer for CoinReadApi {
 fn is_coin_type(type_: &StructTag, coin_type: &Option<String>) -> bool {
     if Coin::is_coin(type_) || LockedCoin::is_locked_coin(type_) {
         return if let Some(coin_type) = coin_type {
-            matches!(type_.type_params.first(), Some(TypeTag::Struct(type_)) if &type_.to_string() == coin_type)
+            matches!(type_.type_params.first(), Some(TypeTag::Struct(type_)) if &type_.to_canonical_string() == coin_type)
         } else {
             true
         };

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -113,15 +113,7 @@ impl RpcReadApiServer for ReadApi {
                 .await
                 .and_then(|read| read.into_object())
                 .map_err(|e| anyhow!(e))?;
-            object_info.push(SuiObjectInfo {
-                object_id: object.id(),
-                version: object.version(),
-                digest: object.digest(),
-                // Package cannot be owned by object, safe to unwrap.
-                type_: format!("{}", object.type_().unwrap()),
-                owner: object.owner,
-                previous_transaction: object.previous_transaction,
-            });
+            object_info.push(object.into());
         }
         Ok(object_info)
     }

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -910,7 +910,7 @@ impl fmt::Display for ObjectType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ObjectType::Package => write!(f, "Package"),
-            ObjectType::Struct(t) => write!(f, "{}", t),
+            ObjectType::Struct(t) => write!(f, "{}", t.to_canonical_string()),
         }
     }
 }

--- a/crates/sui-types/src/event.rs
+++ b/crates/sui-types/src/event.rs
@@ -448,10 +448,10 @@ impl Event {
     }
 
     /// Extracts the move event name (StructTag) from a SuiEvent, if available
-    /// "0x2::devnet_nft::MintNFTEvent"
+    /// "0x0000000000000000000000000000000000000002::devnet_nft::MintNFTEvent"
     pub fn move_event_name(&self) -> Option<String> {
         if let Event::MoveEvent { type_, .. } = self {
-            Some(type_.to_string())
+            Some(type_.to_canonical_string())
         } else {
             None
         }

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -281,7 +281,7 @@ impl<S> TemporaryStore<S> {
                         &ctx,
                         obj.owner,
                         // Safe to unwrap, package cannot mutate
-                        obj.data.type_().unwrap().to_string(),
+                        obj.data.type_().unwrap().to_canonical_string(),
                         obj.id(),
                         obj.version(),
                     ));
@@ -292,7 +292,7 @@ impl<S> TemporaryStore<S> {
                         package_id: ctx.package_id,
                         transaction_module: ctx.transaction_module,
                         sender: ctx.sender,
-                        object_type: obj.data.type_().unwrap().to_string(),
+                        object_type: obj.data.type_().unwrap().to_canonical_string(),
                         object_id: obj.id(),
                         version: obj.version(),
                     });
@@ -312,7 +312,7 @@ impl<S> TemporaryStore<S> {
                     Event::new_object(
                         &ctx,
                         obj.owner,
-                        obj.type_().unwrap().to_string(),
+                        obj.type_().unwrap().to_canonical_string(),
                         id,
                         obj.version(),
                     )


### PR DESCRIPTION
For consistency, the object type, object ids, and Sui addresses should all be fully qualified(`00000000000000000000000000000002` instead of `0x2`) in the RPC responses. For RPC requests, people should be able to pass either way as long as it's supported by `parse_sui_struct_tag`. 


closes https://github.com/MystenLabs/sui/issues/6441 and https://github.com/MystenLabs/sui/issues/6120