### PR TITLE
[indexer] Fix schema generation with patch file

### DIFF
--- a/crates/sui-indexer/diesel.toml
+++ b/crates/sui-indexer/diesel.toml
@@ -3,6 +3,7 @@
 
 [print_schema]
 file = "src/schema.rs"
+patch_file = "src/schema.patch"
 
 [migrations_directory]
 dir = "migrations"

--- a/crates/sui-indexer/src/schema.patch
+++ b/crates/sui-indexer/src/schema.patch
@@ -1,0 +1,7 @@
+diff --git a/crates/sui-indexer/src/schema.rs b/crates/sui-indexer/src/schema.rs
+--- a/crates/sui-indexer/src/schema.rs
++++ b/crates/sui-indexer/src/schema.rs
+@@ -1 +1,3 @@
++// Copyright (c) Mysten Labs, Inc.
++// SPDX-License-Identifier: Apache-2.0
+ // @generated automatically by Diesel CLI.

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+// @generated automatically by Diesel CLI.
 
 diesel::table! {
     address_logs (last_processed_id) {


### PR DESCRIPTION
I noticed that when we generate the schema in the indexer we actually need to manually modify the file to get CI to pass. This fixes that by applying a diff.