### PR TITLE
[script/lldb] Custom LLDB command to print estimated frame sizes

### DIFF
--- a/scripts/lldb_frame_sizes.py
+++ b/scripts/lldb_frame_sizes.py
@@ -1,0 +1,63 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import lldb
+
+# = LLDB Frame Sizes =
+#
+# LLDB Utility to print the current backtrace with estimated stack
+# frame sizes (useful for figuring out which frames are contributing
+# most to a stack overlow).
+#
+# == Usage ==
+#
+#     (lldb) command script import ./sui/scripts/lldb_frame_sizes
+#     Loaded "frame-sizes" command.
+#     (lldb) ...
+#     
+#     Process XXXXX stopped
+#     ...
+#     (lldb) frame-sizes
+
+def frame_sizes(debugger, command, result, internal_dict):
+    """Estimates the sizes of stack frames in the current backtrace.
+
+    Prints the function called in each stackframe along with an estimate of its
+    frame size, based on stack pointers and frame pointer.
+
+    This function assumes that stacks always grow down, and that the base/frame
+    pointer is always available on a frame, which may not be true on all
+    platforms or at all optimization levels, but works well for debug Apple
+    ARM64 builds."""
+
+    thread = debugger.GetSelectedTarget().GetProcess().GetSelectedThread()
+    if len(thread) == 0:
+        return
+
+    # Stacks grow down (into lower addresses), so the stack pointer at
+    # the top of the stack should be the lowest address we see
+    frame_lo = thread.GetFrameAtIndex(0).GetSP()
+
+    for frame in iter(thread):
+        frame_hi = frame.GetFP()
+        frame_sz = frame_hi - frame_lo
+        frame_lo = frame_hi
+
+        line_entry = frame.GetLineEntry()
+        file_spec = line_entry.GetFileSpec()
+        print(
+            "{:>10}B {} ({}:{}:{})".format(
+                frame_sz,
+                frame.GetDisplayFunctionName(),
+                file_spec.GetFilename(),
+                line_entry.GetLine(),
+                line_entry.GetColumn(),
+            ),
+            file=result,
+        )
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand(
+        'command script add -f lldb_frame_sizes.frame_sizes frame-sizes',
+    )
+    print('Loaded "frame-sizes" command.')


### PR DESCRIPTION
Used to investigate #5583 and other issues like it (stack overflows) by figuring out which functions' stack frames contribute most to an overflowing stack.

## Test Plan

Used in an LLDB debug session, e.g.:

```
$ rust-lldb ~/sui/target/debug/deps/sui-core-.... test_move_call_mutable_object_not_mutated
(lldb) command script import ~/sui/scripts/lldb_frame_sizes.py
(lldb) run
(lldb) frame-sizes
```

## Example output

```
      3248B move_compiler::hlir::translate::single_type::h95b182c918e9a004 (translate.rs:514:0)
      3808B move_compiler::hlir::translate::type_::h4478e4293e0438a5 (translate.rs:534:25)
     80608B move_compiler::hlir::translate::exp_::exp_loop::h8602552e346e1ddd (translate.rs:861:18)
      2416B move_compiler::hlir::translate::exp_::h694ef605af4c0906 (translate.rs:1032:5)
      1488B move_compiler::hlir::translate::exp::hde040490305c887f (translate.rs:811:14)
      8880B move_compiler::hlir::translate::exp_evaluation_order::hb55b4dcfc3e28fa8 (translate.rs:1387:18)
     73520B move_compiler::hlir::translate::exp_impl::h6ae8d9cffb6bda2a (translate.rs:1309:22)
     80608B move_compiler::hlir::translate::exp_::exp_loop::h8602552e346e1ddd (translate.rs:1019:29)
      2416B move_compiler::hlir::translate::exp_::h694ef605af4c0906 (translate.rs:1032:5)
      1488B move_compiler::hlir::translate::exp::hde040490305c887f (translate.rs:811:14)
     73520B move_compiler::hlir::translate::exp_impl::h6ae8d9cffb6bda2a (translate.rs:1192:24)
     80608B move_compiler::hlir::translate::exp_::exp_loop::h8602552e346e1ddd (translate.rs:1019:29)
      2416B move_compiler::hlir::translate::exp_::h694ef605af4c0906 (translate.rs:1032:5)
      1488B move_compiler::hlir::translate::exp::hde040490305c887f (translate.rs:811:14)
     73520B move_compiler::hlir::translate::exp_impl::h6ae8d9cffb6bda2a (translate.rs:1209:21)
     ... [snip] ...
```