### PR TITLE
Add a delete range based objects table pruner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4182,6 +4182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
+
+[[package]]
 name = "move-abigen"
 version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=265e8792ff2935db8246ddb308b36b893d507851#265e8792ff2935db8246ddb308b36b893d507851"
@@ -8484,8 +8490,10 @@ dependencies = [
  "either",
  "eyre",
  "fastcrypto",
+ "fs_extra",
  "futures",
  "itertools",
+ "more-asserts",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -11207,6 +11215,7 @@ dependencies = [
  "mio 0.8.5",
  "mockall",
  "mockall_derive",
+ "more-asserts",
  "move-abigen",
  "move-binary-format",
  "move-borrow-graph",

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -5,6 +5,7 @@ use crate::node::default_checkpoints_per_epoch;
 use crate::{
     genesis,
     genesis_config::{GenesisConfig, ValidatorConfigInfo, ValidatorGenesisInfo},
+    node::AuthorityStorePruningConfig,
     p2p::P2pConfig,
     utils, ConsensusConfig, NetworkConfig, NodeConfig, ValidatorInfo, AUTHORITIES_DB_NAME,
     CONSENSUS_DB_NAME,
@@ -319,6 +320,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     grpc_load_shed: initial_accounts_config.grpc_load_shed,
                     grpc_concurrency_limit: initial_accounts_config.grpc_concurrency_limit,
                     p2p_config,
+                    authority_store_pruning_config: AuthorityStorePruningConfig::validator_config(),
                 }
             })
             .collect();

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -84,6 +84,9 @@ pub struct NodeConfig {
     pub p2p_config: P2pConfig,
 
     pub genesis: Genesis,
+
+    #[serde(default = "default_authority_store_pruning_config")]
+    pub authority_store_pruning_config: AuthorityStorePruningConfig,
 }
 
 fn default_key_pair() -> Arc<AuthorityKeyPair> {
@@ -96,6 +99,10 @@ fn default_worker_key_pair() -> Arc<NetworkKeyPair> {
 
 fn default_sui_key_pair() -> Arc<SuiKeyPair> {
     Arc::new((sui_types::crypto::get_key_pair::<AccountKeyPair>().1).into())
+}
+
+fn default_authority_store_pruning_config() -> AuthorityStorePruningConfig {
+    AuthorityStorePruningConfig::default()
 }
 
 fn default_grpc_address() -> Multiaddr {
@@ -202,6 +209,41 @@ impl ConsensusConfig {
 
     pub fn narwhal_config(&self) -> &ConsensusParameters {
         &self.narwhal_config
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct AuthorityStorePruningConfig {
+    pub objects_num_latest_versions_to_retain: u64,
+    pub objects_pruning_period_secs: u64,
+    pub objects_pruning_initial_delay_secs: u64,
+}
+
+impl Default for AuthorityStorePruningConfig {
+    fn default() -> Self {
+        Self {
+            objects_num_latest_versions_to_retain: u64::MAX,
+            objects_pruning_period_secs: u64::MAX,
+            objects_pruning_initial_delay_secs: u64::MAX,
+        }
+    }
+}
+
+impl AuthorityStorePruningConfig {
+    pub fn validator_config() -> Self {
+        Self {
+            objects_num_latest_versions_to_retain: 2,
+            objects_pruning_period_secs: 12 * 60 * 60,
+            objects_pruning_initial_delay_secs: 60 * 60,
+        }
+    }
+    pub fn fullnode_config() -> Self {
+        Self {
+            objects_num_latest_versions_to_retain: 5,
+            objects_pruning_period_secs: 24 * 60 * 60,
+            objects_pruning_initial_delay_secs: 60 * 60,
+        }
     }
 }
 

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::node::default_checkpoints_per_epoch;
+use crate::node::AuthorityStorePruningConfig;
 use crate::p2p::{P2pConfig, SeedPeer};
 use crate::{builder, genesis, utils, Config, NodeConfig, ValidatorInfo};
 use fastcrypto::traits::KeyPair;
@@ -203,6 +204,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             grpc_load_shed: None,
             grpc_concurrency_limit: None,
             p2p_config,
+            authority_store_pruning_config: AuthorityStorePruningConfig::fullnode_config(),
         })
     }
 }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -51,6 +51,10 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    authority-store-pruning-config:
+      objects-num-latest-versions-to-retain: 2
+      objects-pruning-period-secs: 43200
+      objects-pruning-initial-delay-secs: 3600
   - protocol-key-pair: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1BhvqNz/bRVQQKZW9IGbExEbUsV0aoa6cvOV+6/i7DhH0egUDmJKdR/fa18gULxyBc+dMABMkLDHQK/9Mmzmc8wrI6LSTVPir+sobfxmj9QGAInW0rF7eZ3Tb5DTMuVKejONQ=
     worker-key-pair: pPBKumCrkESEmAiG/7UfSMyIlAyKCQaysBb0RA9oxIjUlkEGAVZiydeHbfhB9gYL7kzDBgkDW+FtKKCCdkKJrw==
     account-key-pair: ACxHMS0iupHOTDgHm2HYa+f/ft9OjvxBk5+C7f/APsXUezeV+HwuWFqdYT/NOM6oMWQ2IMvai7GOMn5YNPn+FWA=
@@ -99,6 +103,10 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    authority-store-pruning-config:
+      objects-num-latest-versions-to-retain: 2
+      objects-pruning-period-secs: 43200
+      objects-pruning-initial-delay-secs: 3600
   - protocol-key-pair: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+Kt3u+U2JjIjkDb3v+RxfEF+c8sdH+28rw37APWyR7bLhpXjPVEvosJMeJfJD1ZsMMNmKFs47odbPHX9QQmmS6wrbMTSwVb6BQNLbXyX7ANg/jkIivwH9ask6H/TXnaWPI=
     worker-key-pair: 1Dh27FOw52h9QAd9IijyRq42PtJGYtmCZ2RvXYPDEXq1VgdNLiQC+WWvRST+Sy8o3vw/3KhkD6LkKgSI3cA21A==
     account-key-pair: ANoED1MVNxaUbvcp8K7QXQLx/JQAamix308cQdCKwKu2YYJojLU7C+8u2vatwd7CUkkEgsvOGsRqjhCYXQPZRPM=
@@ -147,6 +155,10 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    authority-store-pruning-config:
+      objects-num-latest-versions-to-retain: 2
+      objects-pruning-period-secs: 43200
+      objects-pruning-initial-delay-secs: 3600
   - protocol-key-pair: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2uz/V77XIckA6StE/EZlRNgbSM1SoRSSa6hV1ZMI/88FcbJ5lK3LXQOjKy5PLzAaGsOwMwMHHYL+0K0NlGfxagFS3ZTOpep8jmH0JfvlrHyUmuyBz+hCncZlBdyNH7ydPQ=
     worker-key-pair: EHX7HidEWjJgbesq5yxWacBkHUx/wALB90Mm8SiaEZbxwBkF+0PK7tSN8SKVyFzxOP/rMtxd+udylT/0hBBhPA==
     account-key-pair: AEgi5sKIaNYxb+8Vr0MKLUWpdrRfjLPiCeYy4hQTtSBHkXLa5CsQhIUzlhFBEFTP1eKxJ6lBGRYzNkOjrDamlU8=
@@ -195,6 +207,10 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    authority-store-pruning-config:
+      objects-num-latest-versions-to-retain: 2
+      objects-pruning-period-secs: 43200
+      objects-pruning-initial-delay-secs: 3600
   - protocol-key-pair: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY2LKRqlcXQ8gPmO3CO3s3dl0lrqWlZovhKpzENp8u9pfBsBwUrId0LiiiqQmP5hlGIVXp7GiO2wX9ApVqo6d7/nZNYB3hOX5NaeinAfDxN4Q6VzStZNxQS3bN/CiKF3/iE=
     worker-key-pair: UkqY1k2SrJLzldSoAqzDZp1vudV6MzAZqojam0XY2ZMLuRQO9Y+pqy4+d18HnybxccBJ0Peox1wNntUCw83jtg==
     account-key-pair: AB86G1ccGVVMFPrc3src2g3fB3NMyEcsS5pzI+Yr6cyKJ0hDQggulPK2ZTpGNWrch+vg73OQ9lWfRXu9uN+Qo88=
@@ -243,6 +259,10 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    authority-store-pruning-config:
+      objects-num-latest-versions-to-retain: 2
+      objects-pruning-period-secs: 43200
+      objects-pruning-initial-delay-secs: 3600
   - protocol-key-pair: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnWEMb3Jb7ZvUxW7p0L15A9+Ny8jfF4iDYHfNhg7BiZTXnhH7PRqjjRKWiGtteU4i5UBGlk8bfQSL3/irX6AKKlrCeq9hDdpJepQFWPVhieWLV0wwgqu0wIbxNDn2/0eHJU=
     worker-key-pair: Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA7wMp6899Qoe0RPBXQsG+CDt54MPp/xImMAyKkV3ZKPbQ==
     account-key-pair: AHH6sQEDMUJH0Spm5nDLrKbFAUcBHYL/VIORf2ervCbbpvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=
@@ -291,6 +311,10 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    authority-store-pruning-config:
+      objects-num-latest-versions-to-retain: 2
+      objects-pruning-period-secs: 43200
+      objects-pruning-initial-delay-secs: 3600
   - protocol-key-pair: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjuVqZ6UqSbldl5MDBHXjF3VHT99e6CgZTuSXpFCRSfw+GMYVuQEwO09WVY8511moRYTuFgfR51108NKCT8re+ppKiuqitxb4BlONYsg4CavliJXCWosawcKZDcea7D6Fe0=
     worker-key-pair: 5RWlYF22jS9i76zLl8jP2D3D8GC5ht+IP1dWUBGZxi993DP7RJ8jr9I9OXm/Mf3nxvRozBZQnRUoPY8tvhMCGA==
     account-key-pair: AKHC3Gr1i6u+zAK1Yj1vys0hB83qha4jRCfzoHqLAo6FQ5EkvCcy5cw1JKStwSs0v/QByW0I8JXCqdnagoupCMg=
@@ -339,6 +363,10 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    authority-store-pruning-config:
+      objects-num-latest-versions-to-retain: 2
+      objects-pruning-period-secs: 43200
+      objects-pruning-initial-delay-secs: 3600
 account_keys:
   - 10wECHkYvXqL5/CY6WhjbfFPotZb5tjEbpmumqbRxul6/9LaD95rkXfiBEoGJR8u81q9fCiP+O7nXOsprVTPUQ==
   - ZTWBfKEmFOyYM9oBU9dNfREBuAU5fm2OBhg/vPtI00ee91o4Td1upRqxdMC/5khQi58pBG83ZvbMUnI2shFOvw==

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -76,7 +76,8 @@ reqwest = { version = "0.11.13", features = ["json"] }
 
 [dev-dependencies]
 clap = { version = "3.2.17", features = ["derive"] }
-
+fs_extra = "1.2.0"
+more-asserts="0.3.1"
 serde-reflection = "0.3.6"
 serde_yaml = "0.8.26"
 pretty_assertions = "1.2.1"

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 use std::{collections::HashMap, pin::Pin, sync::Arc};
+use sui_config::node::AuthorityStorePruningConfig;
 use sui_protocol_constants::MAX_TX_GAS;
 use tap::TapFallible;
 use tokio::sync::mpsc::unbounded_channel;
@@ -105,6 +106,7 @@ mod tbls_tests;
 
 pub mod authority_per_epoch_store;
 
+pub mod authority_store_pruner;
 pub mod authority_store_tables;
 
 pub(crate) mod authority_notify_read;
@@ -1556,6 +1558,7 @@ impl AuthorityState {
                 None,
                 &genesis_committee,
                 genesis,
+                &AuthorityStorePruningConfig::default(),
             )
             .await
             .unwrap(),

--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -1,0 +1,377 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use super::*;
+
+use std::{
+    collections::BTreeSet,
+    sync::atomic::{AtomicBool, AtomicU64},
+};
+use sui_types::batch::TxSequenceNumber;
+
+use tokio::sync::Notify;
+use typed_store::traits::Map;
+
+use parking_lot::Mutex;
+
+pub struct TransactionNotifierMetrics {
+    low_watermark: IntGauge,
+    high_watermark: IntGauge,
+}
+
+impl TransactionNotifierMetrics {
+    pub fn new(registry: &prometheus::Registry) -> TransactionNotifierMetrics {
+        Self {
+            low_watermark: register_int_gauge_with_registry!(
+                "low_watermark",
+                "Low watermark sequence number",
+                registry,
+            )
+            .unwrap(),
+            high_watermark: register_int_gauge_with_registry!(
+                "high_watermark",
+                "High watermark sequence number",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+pub struct TransactionNotifier {
+    state: Arc<AuthorityStore>,
+    low_watermark: AtomicU64,
+    notify: Notify,
+    has_stream: AtomicBool,
+    is_closed: AtomicBool,
+    inner: Mutex<LockedNotifier>,
+    notifier_metrics: TransactionNotifierMetrics,
+}
+
+struct LockedNotifier {
+    high_watermark: u64,
+    live_tickets: BTreeSet<TxSequenceNumber>,
+}
+
+impl TransactionNotifier {
+    /// Create a new transaction notifier for the authority store
+    pub fn new(
+        state: Arc<AuthorityStore>,
+        registry: &prometheus::Registry,
+    ) -> SuiResult<TransactionNotifier> {
+        let seq = state.next_sequence_number()?;
+        Ok(TransactionNotifier {
+            state,
+            low_watermark: AtomicU64::new(seq),
+            notify: Notify::new(),
+            has_stream: AtomicBool::new(false),
+            is_closed: AtomicBool::new(false),
+
+            // Keep a set of the tickets that are still being processed
+            // This is the size of the number of concurrent processes.
+            inner: Mutex::new(LockedNotifier {
+                high_watermark: seq,
+                live_tickets: BTreeSet::new(),
+            }),
+            notifier_metrics: TransactionNotifierMetrics::new(registry),
+        })
+    }
+
+    pub fn low_watermark(&self) -> TxSequenceNumber {
+        self.low_watermark.load(Ordering::SeqCst)
+    }
+
+    pub fn notify(&self, seq: u64) {
+        let mut inner = self.inner.lock();
+        inner.live_tickets.remove(&seq);
+
+        // The new low watermark is either the lowest outstanding ticket
+        // or the high watermark.
+        let new_low_watermark = *inner
+            .live_tickets
+            .iter()
+            .next()
+            .unwrap_or(&inner.high_watermark);
+
+        self.low_watermark
+            .store(new_low_watermark, Ordering::SeqCst);
+        self.notify.notify_one();
+    }
+
+    /// Get a ticket with a sequence number
+    pub fn ticket(self: &Arc<Self>) -> SuiResult<TransactionNotifierTicket> {
+        if self.is_closed.load(Ordering::SeqCst) {
+            return Err(SuiError::ClosedNotifierError);
+        }
+
+        let mut inner = self.inner.lock();
+        // Insert the ticket into the set of live tickets.
+        let seq = inner.high_watermark;
+        inner.high_watermark += 1;
+        inner.live_tickets.insert(seq);
+        self.notifier_metrics
+            .low_watermark
+            .set(self.low_watermark().try_into().unwrap());
+        self.notifier_metrics
+            .high_watermark
+            .set(inner.high_watermark.try_into().unwrap());
+        Ok(TransactionNotifierTicket {
+            transaction_notifier: self.clone(),
+            seq,
+        })
+    }
+
+    /// Get an iterator, and return an error if an iterator for this stream already exists.
+    pub fn iter_from(
+        self: &Arc<Self>,
+        next_seq: u64,
+    ) -> SuiResult<impl futures::Stream<Item = (TxSequenceNumber, ExecutionDigests)> + Unpin> {
+        if self
+            .has_stream
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Err(SuiError::ConcurrentIteratorError);
+        }
+
+        // The state we inject in the async stream
+        let transaction_notifier = self.clone();
+        let temp_buffer: VecDeque<(TxSequenceNumber, ExecutionDigests)> = VecDeque::new();
+        let uniqueness_guard = IterUniquenessGuard(transaction_notifier.clone());
+        let initial_state = (
+            transaction_notifier,
+            temp_buffer,
+            next_seq,
+            uniqueness_guard,
+        );
+
+        Ok(Box::pin(futures::stream::unfold(
+            initial_state,
+            |state| async move {
+                let (transaction_notifier, mut temp_buffer, mut next_seq, uniqueness_guard) = state;
+
+                loop {
+                    // If we have data in the buffer return that first
+                    if let Some(item) = temp_buffer.pop_front() {
+                        return Some((
+                            item,
+                            (
+                                transaction_notifier,
+                                temp_buffer,
+                                next_seq,
+                                uniqueness_guard,
+                            ),
+                        ));
+                    }
+
+                    // Always stop at low watermark guarantees that transactions are
+                    // always returned in order.
+                    let last_safe = transaction_notifier.low_watermark();
+
+                    // Get the stream of updates since the last point we requested ...
+                    if let Ok(iter) = transaction_notifier
+                        .clone()
+                        .state
+                        .perpetual_tables
+                        .executed_sequence
+                        .iter()
+                        .skip_to(&next_seq)
+                    {
+                        // ... continued here with take_while. And expand the buffer with the new items.
+                        temp_buffer.extend(
+                            iter.take_while(|(tx_seq, _tx_digest)| *tx_seq < last_safe)
+                                .map(|(tx_seq, _tx_digest)| (tx_seq, _tx_digest)),
+                        );
+
+                        // Update what the next item would be to no re-read messages in the buffer
+                        if !temp_buffer.is_empty() {
+                            next_seq = temp_buffer[temp_buffer.len() - 1].0 + 1;
+                        }
+
+                        // If we have data in the buffer return that first
+                        if let Some(item) = temp_buffer.pop_front() {
+                            return Some((
+                                item,
+                                (
+                                    transaction_notifier,
+                                    temp_buffer,
+                                    next_seq,
+                                    uniqueness_guard,
+                                ),
+                            ));
+                        } else {
+                            // If the notifier is closed, then exit
+                            if transaction_notifier.is_closed.load(Ordering::SeqCst) {
+                                return None;
+                            }
+                        }
+                    } else {
+                        return None;
+                    }
+
+                    // Wait for a notification to get more data
+                    transaction_notifier.notify.notified().await;
+                }
+            },
+        )))
+    }
+
+    /// Signal we want to close this channel.
+    pub fn close(&self) {
+        self.is_closed.store(true, Ordering::SeqCst);
+        self.notify.notify_one();
+    }
+}
+
+struct IterUniquenessGuard(Arc<TransactionNotifier>);
+
+impl Drop for IterUniquenessGuard {
+    fn drop(&mut self) {
+        self.0.has_stream.store(false, Ordering::SeqCst);
+    }
+}
+
+pub struct TransactionNotifierTicket {
+    transaction_notifier: Arc<TransactionNotifier>,
+    seq: u64,
+}
+
+impl TransactionNotifierTicket {
+    /// Get the ticket sequence number
+    pub fn seq(&self) -> u64 {
+        self.seq
+    }
+    pub fn notify(self) {
+        self.transaction_notifier.notify(self.seq);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use futures::StreamExt;
+    use std::env;
+    use std::fs;
+
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn test_notifier() {
+        let dir = env::temp_dir();
+        let path = dir.join(format!("DB_{:?}", ObjectID::random()));
+        fs::create_dir(&path).unwrap();
+
+        let seed = [1u8; 32];
+        let (committee, _, _authority_key) =
+            crate::authority_batch::batch_tests::init_state_parameters_from_rng(
+                &mut StdRng::from_seed(seed),
+            );
+
+        let store = Arc::new(
+            AuthorityStore::open_with_committee(
+                &path,
+                None,
+                &committee,
+                &Genesis::get_default_genesis(),
+                &AuthorityStorePruningConfig::default(),
+            )
+            .await
+            .unwrap(),
+        );
+
+        let notifier = Arc::new(
+            TransactionNotifier::new(store.clone(), &prometheus::Registry::default()).unwrap(),
+        );
+
+        // TEST 1: Happy sequence
+
+        {
+            let t0 = notifier.ticket().expect("ok");
+            store.side_sequence(t0.seq(), &ExecutionDigests::random());
+            t0.notify();
+        }
+
+        {
+            let t0 = notifier.ticket().expect("ok");
+            store.side_sequence(t0.seq(), &ExecutionDigests::random());
+            t0.notify();
+        }
+
+        {
+            let t0 = notifier.ticket().expect("ok");
+            store.side_sequence(t0.seq(), &ExecutionDigests::random());
+            t0.notify();
+        }
+
+        let mut iter = notifier.iter_from(0).unwrap();
+
+        // Trying to take a second concurrent stream fails.
+        assert!(matches!(
+            notifier.iter_from(0),
+            Err(SuiError::ConcurrentIteratorError)
+        ));
+
+        assert!(matches!(iter.next().await, Some((0, _))));
+        assert!(matches!(iter.next().await, Some((1, _))));
+        assert!(matches!(iter.next().await, Some((2, _))));
+
+        assert!(timeout(Duration::from_millis(10), iter.next())
+            .await
+            .is_err());
+
+        // TEST 2: Drop a ticket
+
+        {
+            let t0 = notifier.ticket().expect("ok");
+            assert_eq!(t0.seq(), 3);
+            t0.notify();
+        }
+
+        {
+            let t0 = notifier.ticket().expect("ok");
+            store.side_sequence(t0.seq(), &ExecutionDigests::random());
+            t0.notify();
+        }
+
+        let x = iter.next().await;
+        assert!(matches!(x, Some((4, _))));
+
+        assert!(timeout(Duration::from_millis(10), iter.next())
+            .await
+            .is_err());
+
+        // TEST 3: Drop & out of order
+
+        let t5 = notifier.ticket().expect("ok");
+        let t6 = notifier.ticket().expect("ok");
+        let t7 = notifier.ticket().expect("ok");
+        let t8 = notifier.ticket().expect("ok");
+
+        store.side_sequence(t6.seq(), &ExecutionDigests::random());
+        t6.notify();
+
+        store.side_sequence(t5.seq(), &ExecutionDigests::random());
+        t5.notify();
+
+        t7.notify();
+
+        store.side_sequence(t8.seq(), &ExecutionDigests::random());
+        t8.notify();
+
+        assert!(matches!(iter.next().await, Some((5, _))));
+        assert!(matches!(iter.next().await, Some((6, _))));
+        assert!(matches!(iter.next().await, Some((8, _))));
+
+        assert!(timeout(Duration::from_millis(10), iter.next())
+            .await
+            .is_err());
+
+        drop(iter);
+
+        // After we drop an iterator we can get another one
+        assert!(notifier.iter_from(0).is_ok());
+    }
+}

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::authority_store_pruner::AuthorityStorePruner;
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use arc_swap::ArcSwap;
@@ -10,6 +11,7 @@ use std::iter;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use sui_config::node::AuthorityStorePruningConfig;
 use sui_storage::{
     lock_service::ObjectLockStatus,
     mutex_table::{LockGuard, MutexTable},
@@ -40,7 +42,7 @@ pub struct AuthorityStore {
     /// Internal vector of locks to manage concurrent writes to the database
     mutex_table: MutexTable<ObjectDigest>,
 
-    pub(crate) perpetual_tables: AuthorityPerpetualTables,
+    pub(crate) perpetual_tables: Arc<AuthorityPerpetualTables>,
     epoch_store: ArcSwap<AuthorityPerEpochStore>,
 
     // needed for re-opening epoch db.
@@ -49,6 +51,7 @@ pub struct AuthorityStore {
 
     // Implementation detail to support notify_read_effects().
     pub(crate) effects_notify_read: NotifyRead<TransactionDigest, SignedTransactionEffects>,
+    _store_pruner: AuthorityStorePruner,
 }
 
 impl AuthorityStore {
@@ -59,8 +62,9 @@ impl AuthorityStore {
         db_options: Option<Options>,
         genesis: &Genesis,
         committee_store: &Arc<CommitteeStore>,
+        pruning_config: &AuthorityStorePruningConfig,
     ) -> SuiResult<Self> {
-        let perpetual_tables = AuthorityPerpetualTables::open(path, db_options.clone());
+        let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(path, db_options.clone()));
         if perpetual_tables.database_is_empty()? {
             perpetual_tables.set_recovery_epoch(0)?;
         }
@@ -75,7 +79,15 @@ impl AuthorityStore {
                 genesis.committee()?
             }
         };
-        Self::open_inner(path, db_options, genesis, perpetual_tables, committee).await
+        Self::open_inner(
+            path,
+            db_options,
+            genesis,
+            perpetual_tables,
+            committee,
+            pruning_config,
+        )
+        .await
     }
 
     pub async fn open_with_committee_for_testing(
@@ -83,17 +95,19 @@ impl AuthorityStore {
         db_options: Option<Options>,
         committee: &Committee,
         genesis: &Genesis,
+        pruning_config: &AuthorityStorePruningConfig,
     ) -> SuiResult<Self> {
         // TODO: Since we always start at genesis, the committee should be technically the same
         // as the genesis committee.
         assert_eq!(committee.epoch, 0);
-        let perpetual_tables = AuthorityPerpetualTables::open(path, db_options.clone());
+        let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(path, db_options.clone()));
         Self::open_inner(
             path,
             db_options,
             genesis,
             perpetual_tables,
             committee.clone(),
+            pruning_config,
         )
         .await
     }
@@ -102,8 +116,9 @@ impl AuthorityStore {
         path: &Path,
         db_options: Option<Options>,
         genesis: &Genesis,
-        perpetual_tables: AuthorityPerpetualTables,
+        perpetual_tables: Arc<AuthorityPerpetualTables>,
         committee: Committee,
+        pruning_config: &AuthorityStorePruningConfig,
     ) -> SuiResult<Self> {
         let epoch_tables = Arc::new(AuthorityPerEpochStore::new(
             committee,
@@ -116,7 +131,7 @@ impl AuthorityStore {
         let lockdb_path: PathBuf = path.join("lockdb");
         let lock_service =
             LockService::new(lockdb_path, None).expect("Could not initialize lockdb");
-
+        let _store_pruner = AuthorityStorePruner::new(perpetual_tables.clone(), pruning_config);
         let store = Self {
             lock_service,
             mutex_table: MutexTable::new(NUM_SHARDS, SHARD_SIZE),
@@ -124,6 +139,7 @@ impl AuthorityStore {
             epoch_store: epoch_tables.into(),
             path: path.into(),
             db_options,
+            _store_pruner,
             effects_notify_read: NotifyRead::new(),
         };
         // Only initialize an empty database.

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -1,0 +1,302 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{cmp::Ordering, sync::Arc, time::Duration};
+use sui_config::node::AuthorityStorePruningConfig;
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber, VersionNumber},
+    storage::ObjectKey,
+};
+use tokio::{
+    sync::oneshot::{self, Sender},
+    time::{self, Instant},
+};
+use tracing::log::{error, info};
+use typed_store::Map;
+
+use super::authority_store_tables::AuthorityPerpetualTables;
+
+const MAX_OPS_IN_ONE_WRITE_BATCH: u64 = 10000;
+
+pub struct AuthorityStorePruner {
+    _objects_pruner_cancel_handle: oneshot::Sender<()>,
+}
+
+impl AuthorityStorePruner {
+    fn prune_objects(
+        num_versions_to_retain: u64,
+        perpetual_db: Arc<AuthorityPerpetualTables>,
+    ) -> u64 {
+        let iter = perpetual_db.objects.iter().skip_to_last().reverse();
+        let mut total_keys_scanned = 0;
+        let mut total_objects_scanned = 0;
+        let mut num_versions_for_key = 0;
+        let mut object_id: Option<ObjectID> = None;
+        let mut seq_num: Option<VersionNumber> = None;
+        let mut num_pending_wb_ops = 0;
+        let mut total_pruned: u64 = 0;
+        let mut wb = perpetual_db.objects.batch();
+        for (key, _value) in iter {
+            total_keys_scanned += 1;
+            if let Some(obj_id) = object_id {
+                if obj_id != key.0 {
+                    total_objects_scanned += 1;
+                    if let Some(seq) = seq_num {
+                        // delete keys in range [(obj_id, VersionNumber::ZERO), (obj_id, seq))
+                        let start = ObjectKey(obj_id, SequenceNumber::from_u64(0));
+                        let end = ObjectKey(obj_id, seq);
+                        if let Ok(new_wb) = wb.delete_range(&perpetual_db.objects, &start, &end) {
+                            wb = new_wb;
+                            num_pending_wb_ops += 1;
+                        } else {
+                            error!("Failed to invoke delete_range on write batch while compacting objects");
+                            wb = perpetual_db.objects.batch();
+                            num_pending_wb_ops = 0;
+                            break;
+                        }
+                        if num_pending_wb_ops >= MAX_OPS_IN_ONE_WRITE_BATCH {
+                            if wb.write().is_err() {
+                                error!("Failed to commit write batch while compacting objects");
+                                wb = perpetual_db.objects.batch();
+                                num_pending_wb_ops = 0;
+                                break;
+                            } else {
+                                info!("Committed write batch while compacting objects, keys scanned = {:?}, objects scanned = {:?}", total_keys_scanned, total_objects_scanned);
+                            }
+                            wb = perpetual_db.objects.batch();
+                            num_pending_wb_ops = 0;
+                        }
+                    }
+                    num_versions_for_key = 0;
+                    object_id = Some(key.0);
+                    seq_num = None;
+                }
+                num_versions_for_key += 1;
+                // We'll keep maximum `num_versions_to_retain` latest version of any object
+                match num_versions_for_key.cmp(&num_versions_to_retain) {
+                    Ordering::Equal => {
+                        seq_num = Some(key.1);
+                    }
+                    Ordering::Greater => {
+                        total_pruned += 1;
+                    }
+                    Ordering::Less => {}
+                }
+            } else {
+                num_versions_for_key = 1;
+                total_objects_scanned = 1;
+                object_id = Some(key.0);
+            }
+        }
+        if let Some(obj_id) = object_id {
+            if let Some(seq) = seq_num {
+                // delete keys in range [(obj_id, VersionNumber::ZERO), (obj_id, seq))
+                let start = ObjectKey(obj_id, SequenceNumber::from_u64(0));
+                let end = ObjectKey(obj_id, seq);
+                if let Ok(new_wb) = wb.delete_range(&perpetual_db.objects, &start, &end) {
+                    wb = new_wb;
+                    num_pending_wb_ops += 1;
+                } else {
+                    error!("Failed to invoke delete_range on write batch while compacting objects");
+                    wb = perpetual_db.objects.batch();
+                    num_pending_wb_ops = 0;
+                }
+            }
+        }
+        if num_pending_wb_ops > 0 {
+            if wb.write().is_err() {
+                error!("Failed to commit write batch while compacting objects");
+            } else {
+                info!("Committed write batch while compacting objects, keys scanned = {:?}, objects scanned = {:?}", total_keys_scanned, total_objects_scanned);
+            }
+        }
+        info!(
+            "Finished compacting objects, keys scanned = {:?}, objects scanned = {:?}",
+            total_keys_scanned, total_objects_scanned
+        );
+        total_pruned
+    }
+
+    fn setup_objects_pruning(
+        num_versions_to_retain: u64,
+        pruning_timeperiod: Duration,
+        pruning_initial_delay: Duration,
+        perpetual_db: Arc<AuthorityPerpetualTables>,
+    ) -> Sender<()> {
+        let (sender, mut recv) = tokio::sync::oneshot::channel();
+        if num_versions_to_retain == u64::MAX {
+            info!("Skipping pruning of objects table as we want to retain all versions");
+            return sender;
+        }
+        let mut prune_interval =
+            tokio::time::interval_at(Instant::now() + pruning_initial_delay, pruning_timeperiod);
+        prune_interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+        tokio::task::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = prune_interval.tick() => {
+                        info!("Starting pruning of objects table");
+                        let perpetual_db = perpetual_db.clone();
+                        let num_pruned = Self::prune_objects(num_versions_to_retain, perpetual_db);
+                        info!("Finished pruning with total object versions pruned = {}", num_pruned);
+                    }
+                    _ = &mut recv => break,
+                }
+            }
+        });
+        sender
+    }
+    pub fn new(
+        perpetual_db: Arc<AuthorityPerpetualTables>,
+        pruning_config: &AuthorityStorePruningConfig,
+    ) -> Self {
+        AuthorityStorePruner {
+            _objects_pruner_cancel_handle: Self::setup_objects_pruning(
+                pruning_config.objects_num_latest_versions_to_retain,
+                Duration::from_secs(pruning_config.objects_pruning_period_secs),
+                Duration::from_secs(pruning_config.objects_pruning_initial_delay_secs),
+                perpetual_db,
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, sync::Arc};
+
+    use crate::authority::authority_store_tables::AuthorityPerpetualTables;
+    use fs_extra::dir::get_size;
+    use more_asserts as ma;
+    use sui_types::{
+        base_types::{ObjectID, SequenceNumber},
+        object::Object,
+        storage::ObjectKey,
+    };
+    use tracing::log::info;
+    use typed_store::Map;
+
+    use super::AuthorityStorePruner;
+
+    async fn test_pruning(
+        perpetual_db: Arc<AuthorityPerpetualTables>,
+        num_versions_per_object: u64,
+        num_object_versions_to_retain: u64,
+        total_unique_object_ids: u32,
+    ) -> Result<u64, anyhow::Error> {
+        // this contains the set of keys that should not have been pruned
+        let mut expected = HashSet::new();
+        let ids = ObjectID::in_range(ObjectID::ZERO, total_unique_object_ids.into())?;
+        for id in ids {
+            for (counter, i) in (0..num_versions_per_object).rev().enumerate() {
+                let object_key = ObjectKey(id, SequenceNumber::from_u64(i));
+                if counter < num_object_versions_to_retain.try_into().unwrap() {
+                    // latest `num_object_versions_to_retain` should not have been pruned
+                    expected.insert(object_key);
+                }
+                perpetual_db.objects.insert(
+                    &ObjectKey(id, SequenceNumber::from(i)),
+                    &Object::immutable_with_id_for_testing(id),
+                )?;
+            }
+        }
+        assert_eq!(
+            expected.len() as u64,
+            std::cmp::min(num_object_versions_to_retain, num_versions_per_object)
+                * total_unique_object_ids as u64
+        );
+        let total_pruned = AuthorityStorePruner::prune_objects(
+            num_object_versions_to_retain,
+            perpetual_db.clone(),
+        );
+        let mut after_pruning = HashSet::new();
+        let iter = perpetual_db.objects.iter();
+        for (k, _v) in iter {
+            after_pruning.insert(k);
+        }
+        assert_eq!(expected, after_pruning);
+        Ok(total_pruned)
+    }
+
+    #[tokio::test]
+    async fn test_rights_versions_are_pruned() -> Result<(), anyhow::Error> {
+        {
+            let primary_path = tempfile::tempdir()?.into_path();
+            let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
+            // add 3 versions for every object id and 1000 unique object ids
+            let total_pruned = test_pruning(
+                perpetual_db,
+                /* num_versions_per_object */ 3,
+                /* num_object_versions_to_retain */ 2,
+                /* total_unique_object_ids */ 1000,
+            )
+            .await;
+            // We had 3 versions for 1000 unique object ids, we wanted to retain 2 version per object id i.e. we should have pruned 1000 keys
+            assert_eq!(1000, total_pruned.unwrap());
+        }
+        {
+            let primary_path = tempfile::tempdir()?.into_path();
+            let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
+            // add 3 versions for every object id and 1000 unique object ids
+            let total_pruned = test_pruning(
+                perpetual_db,
+                /* num_versions_per_object */ 2,
+                /* num_object_versions_to_retain */ 2,
+                /* total_unique_object_ids */ 1000,
+            )
+            .await;
+            // We had only 2 version per key, we did not prune anything
+            assert_eq!(0, total_pruned.unwrap());
+        }
+        {
+            let primary_path = tempfile::tempdir()?.into_path();
+            let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
+            // add 3 versions for every object id and 1000 unique object ids
+            let total_pruned = test_pruning(
+                perpetual_db,
+                /* num_versions_per_object */ 1,
+                /* num_object_versions_to_retain */ 2,
+                /* total_unique_object_ids */ 1000,
+            )
+            .await;
+            // We had only 1 version per key, we did not prune anything
+            assert_eq!(0, total_pruned.unwrap());
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_db_size_after_compaction() -> Result<(), anyhow::Error> {
+        let primary_path = tempfile::tempdir()?.into_path();
+        let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
+        let total_unique_object_ids = 100_000;
+        let num_versions_per_object = 10;
+        let ids = ObjectID::in_range(ObjectID::ZERO, total_unique_object_ids)?;
+        for id in ids {
+            for i in (0..num_versions_per_object).rev() {
+                perpetual_db.objects.insert(
+                    &ObjectKey(id, SequenceNumber::from(i)),
+                    &Object::immutable_with_id_for_testing(id),
+                )?;
+            }
+        }
+        perpetual_db.objects.rocksdb.flush()?;
+
+        let before_compaction_size = get_size(primary_path.clone()).unwrap();
+
+        let total_pruned = AuthorityStorePruner::prune_objects(2, perpetual_db.clone());
+        info!("Total pruned keys = {:?}", total_pruned);
+        let start = ObjectKey(ObjectID::ZERO, SequenceNumber::MIN);
+        let end = ObjectKey(ObjectID::MAX, SequenceNumber::MAX);
+        perpetual_db.objects.compact_range(&start, &end)?;
+
+        let after_compaction_size = get_size(primary_path).unwrap();
+
+        info!(
+            "Before compaction disk size = {:?}, after compaction disk size = {:?}",
+            before_compaction_size, after_compaction_size
+        );
+        ma::assert_le!(after_compaction_size, before_compaction_size);
+        Ok(())
+    }
+}

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2391,6 +2391,7 @@ async fn test_authority_persist() {
             None,
             &committee,
             &Genesis::get_default_genesis(),
+            &AuthorityStorePruningConfig::default(),
         )
         .await
         .unwrap(),
@@ -2422,6 +2423,7 @@ async fn test_authority_persist() {
             None,
             &committee,
             &Genesis::get_default_genesis(),
+            &AuthorityStorePruningConfig::default(),
         )
         .await
         .unwrap(),

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -1,0 +1,863 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use fastcrypto::traits::KeyPair;
+use rand::{prelude::StdRng, SeedableRng};
+use sui_config::genesis::Genesis;
+use sui_config::node::AuthorityStorePruningConfig;
+use sui_storage::node_sync_store::NodeSyncStore;
+use sui_types::committee::Committee;
+use sui_types::crypto::get_key_pair;
+use sui_types::crypto::get_key_pair_from_rng;
+use sui_types::crypto::AccountKeyPair;
+use sui_types::crypto::AuthorityKeyPair;
+use sui_types::crypto::AuthorityPublicKeyBytes;
+use sui_types::messages_checkpoint::CheckpointRequest;
+use sui_types::messages_checkpoint::CheckpointResponse;
+
+use super::*;
+use crate::authority::authority_tests::*;
+use crate::authority::*;
+use crate::safe_client::SafeClient;
+
+use crate::authority_client::{AuthorityAPI, BatchInfoResponseItemStream};
+use crate::epoch::committee_store::CommitteeStore;
+use crate::safe_client::SafeClientMetrics;
+use async_trait::async_trait;
+use futures::stream;
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::sync::Arc;
+use sui_types::messages::{
+    AccountInfoRequest, AccountInfoResponse, BatchInfoRequest, BatchInfoResponseItem,
+    CertifiedTransaction, CommitteeInfoRequest, CommitteeInfoResponse, ObjectInfoRequest,
+    ObjectInfoResponse, Transaction, TransactionInfoRequest, TransactionInfoResponse,
+};
+
+use sui_macros::sim_test;
+use sui_simulator::nondeterministic;
+
+pub(crate) fn init_state_parameters_from_rng<R>(
+    rng: &mut R,
+) -> (Committee, SuiAddress, AuthorityKeyPair)
+where
+    R: rand::CryptoRng + rand::RngCore,
+{
+    let (authority_address, authority_key): (_, AuthorityKeyPair) = get_key_pair_from_rng(rng);
+    let mut authorities: BTreeMap<AuthorityPublicKeyBytes, u64> = BTreeMap::new();
+    authorities.insert(
+        /* address */ authority_key.public().into(),
+        /* voting right */ 1,
+    );
+    let committee = Committee::new(0, authorities).unwrap();
+
+    (committee, authority_address, authority_key)
+}
+
+pub(crate) async fn init_state(
+    committee: Committee,
+    authority_key: AuthorityKeyPair,
+    store: Arc<AuthorityStore>,
+) -> Arc<AuthorityState> {
+    let name = authority_key.public().into();
+    let secrete = Arc::pin(authority_key);
+    let dir = env::temp_dir();
+    let epoch_path = dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
+    let node_sync_path = dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
+    fs::create_dir(&epoch_path).unwrap();
+    let committee_store = Arc::new(CommitteeStore::new(epoch_path, &committee, None));
+
+    let node_sync_store = Arc::new(NodeSyncStore::open_tables_read_write(
+        node_sync_path,
+        None,
+        None,
+    ));
+
+    AuthorityState::new(
+        name,
+        secrete,
+        store,
+        node_sync_store,
+        committee_store,
+        None,
+        None,
+        None,
+        &prometheus::Registry::new(),
+    )
+    .await
+}
+
+#[sim_test]
+async fn test_open_manager() {
+    // let (_, authority_key) = get_key_pair();
+
+    // Create a random directory to store the DB
+    let dir = env::temp_dir();
+    let path = dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
+    fs::create_dir(&path).unwrap();
+
+    let seed = [1u8; 32];
+
+    let (committee, _, authority_key) =
+        init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
+    {
+        // Create an authority
+        let store = Arc::new(
+            AuthorityStore::open_with_committee(
+                &path,
+                None,
+                &committee,
+                &Genesis::get_default_genesis(),
+                &AuthorityStorePruningConfig::default(),
+            )
+            .await
+            .unwrap(),
+        );
+        let authority_state = init_state(committee, authority_key, store.clone()).await;
+
+        // TEST 1: init from an empty database should return to a zero block
+        let last_block = authority_state
+            .init_batches_from_database()
+            .expect("No error expected.");
+
+        assert_eq!(0, last_block.next_sequence_number);
+
+        // TEST 2: init from a db with a transaction not in the sequence makes a new block
+        //         when we re-open the database.
+
+        store
+            .perpetual_tables
+            .executed_sequence
+            .insert(&0, &ExecutionDigests::random())
+            .expect("no error on write");
+        drop(store);
+        drop(authority_state);
+    }
+
+    // TODO: The right fix is to invoke some function on DBMap and release the rocksdb arc references
+    // being held in the background thread but this will suffice for now
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // drop all
+    let (committee, _, authority_key) =
+        init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
+    {
+        // Create an authority
+        let store = Arc::new(
+            AuthorityStore::open_with_committee(
+                &path,
+                None,
+                &committee,
+                &Genesis::get_default_genesis(),
+                &AuthorityStorePruningConfig::default(),
+            )
+            .await
+            .unwrap(),
+        );
+        let authority_state = init_state(committee, authority_key, store.clone()).await;
+
+        let last_block = authority_state
+            .init_batches_from_database()
+            .expect("No error expected.");
+
+        assert_eq!(1, last_block.next_sequence_number);
+
+        // TEST 3: If the database contains out of order transactions we just make a block with gaps
+        store
+            .perpetual_tables
+            .executed_sequence
+            .insert(&2, &ExecutionDigests::random())
+            .expect("no error on write");
+        drop(store);
+        drop(authority_state);
+    }
+    // TODO: The right fix is to invoke some function on DBMap and release the rocksdb arc references
+    // being held in the background thread but this will suffice for now
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // drop all
+    let (committee, _, authority_key) =
+        init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
+    {
+        // Create an authority
+        let store = Arc::new(
+            AuthorityStore::open_with_committee(
+                &path,
+                None,
+                &committee,
+                &Genesis::get_default_genesis(),
+                &AuthorityStorePruningConfig::default(),
+            )
+            .await
+            .unwrap(),
+        );
+        let authority_state = init_state(committee, authority_key, store.clone()).await;
+
+        let last_block = authority_state.init_batches_from_database().unwrap();
+
+        assert_eq!(last_block.next_sequence_number, 3);
+        assert_eq!(last_block.initial_sequence_number, 2);
+        assert_eq!(last_block.size, 1);
+        drop(store);
+        drop(authority_state);
+    }
+}
+
+#[sim_test]
+async fn test_batch_manager_happy_path() {
+    telemetry_subscribers::init_for_testing();
+    // Create a random directory to store the DB
+    let dir = env::temp_dir();
+    let path = dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
+    fs::create_dir(&path).unwrap();
+
+    // Create an authority
+    let seed = [1u8; 32];
+    let (committee, _, authority_key) =
+        init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
+    let store = Arc::new(
+        AuthorityStore::open_with_committee(
+            &path,
+            None,
+            &committee,
+            &Genesis::get_default_genesis(),
+            &AuthorityStorePruningConfig::default(),
+        )
+        .await
+        .unwrap(),
+    );
+
+    // Make a test key pair
+    let authority_state = Arc::new(init_state(committee, authority_key, store.clone()).await);
+
+    let inner_state = authority_state.clone();
+    let _join = tokio::task::spawn(async move {
+        inner_state
+            .run_batch_service_once(1000, Duration::from_millis(500))
+            .await
+    });
+
+    // TEST 1: init from an empty database should return to a zero block
+
+    // Send a transaction.
+    {
+        let t0 = authority_state.batch_notifier.ticket().expect("ok");
+        store.side_sequence(t0.seq(), &ExecutionDigests::random());
+        t0.notify();
+    }
+
+    // First we get a transaction update
+    let mut rx = authority_state.subscribe_batch();
+    assert!(matches!(
+        rx.recv().await.unwrap(),
+        UpdateItem::Transaction((0, _))
+    ));
+
+    // Then we (eventually) get a batch
+    assert!(matches!(rx.recv().await.unwrap(), UpdateItem::Batch(_)));
+
+    {
+        let t0 = authority_state.batch_notifier.ticket().expect("ok");
+        store.side_sequence(t0.seq(), &ExecutionDigests::random());
+        t0.notify();
+    }
+
+    assert_eq!(authority_state.metrics.num_batch_service_tasks.get(), 1);
+
+    // When we close the sending channel we also also end the service task
+    authority_state.batch_notifier.close();
+
+    // But the block is made, and sent as a notification.
+    assert!(matches!(
+        rx.recv().await.unwrap(),
+        UpdateItem::Transaction((1, _))
+    ));
+    assert!(matches!(rx.recv().await.unwrap(), UpdateItem::Batch(_)));
+
+    _join.await.expect("No errors in task").expect("ok");
+
+    assert_eq!(authority_state.metrics.num_batch_service_tasks.get(), 0);
+}
+
+// get the next tx item, ignoring any batches that happen to come in.
+async fn get_next_tx(rx: &mut tokio::sync::broadcast::Receiver<UpdateItem>) -> UpdateItem {
+    loop {
+        if let UpdateItem::Transaction(tx) = rx.recv().await.unwrap() {
+            return UpdateItem::Transaction(tx);
+        }
+    }
+}
+
+#[sim_test]
+async fn test_batch_manager_out_of_order() {
+    // Create a random directory to store the DB
+    let dir = env::temp_dir();
+    let path = dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
+    fs::create_dir(&path).unwrap();
+
+    // Create an authority
+    let seed = [1u8; 32];
+    let (committee, _, authority_key) =
+        init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
+    let store = Arc::new(
+        AuthorityStore::open_with_committee(
+            &path,
+            None,
+            &committee,
+            &Genesis::get_default_genesis(),
+            &AuthorityStorePruningConfig::default(),
+        )
+        .await
+        .unwrap(),
+    );
+    let authority_state = Arc::new(init_state(committee, authority_key, store.clone()).await);
+
+    let inner_state = authority_state.clone();
+    let _join = tokio::task::spawn(async move {
+        inner_state
+            .run_batch_service_once(1000, Duration::from_millis(500))
+            .await
+    });
+    // Send transactions out of order
+    let mut rx = authority_state.subscribe_batch();
+
+    {
+        let t0 = authority_state.batch_notifier.ticket().expect("ok");
+        let t1 = authority_state.batch_notifier.ticket().expect("ok");
+        let t2 = authority_state.batch_notifier.ticket().expect("ok");
+        let t3 = authority_state.batch_notifier.ticket().expect("ok");
+
+        store.side_sequence(t1.seq(), &ExecutionDigests::random());
+        store.side_sequence(t3.seq(), &ExecutionDigests::random());
+        store.side_sequence(t2.seq(), &ExecutionDigests::random());
+        store.side_sequence(t0.seq(), &ExecutionDigests::random());
+
+        t0.notify();
+        t1.notify();
+        t2.notify();
+        t3.notify();
+    }
+
+    // Get transactions in order then batch.
+    assert!(matches!(
+        get_next_tx(&mut rx).await,
+        UpdateItem::Transaction((0, _))
+    ));
+
+    assert!(matches!(
+        get_next_tx(&mut rx).await,
+        UpdateItem::Transaction((1, _))
+    ));
+    assert!(matches!(
+        get_next_tx(&mut rx).await,
+        UpdateItem::Transaction((2, _))
+    ));
+    assert!(matches!(
+        get_next_tx(&mut rx).await,
+        UpdateItem::Transaction((3, _))
+    ));
+
+    // Then we (eventually) get a batch
+    assert!(matches!(rx.recv().await.unwrap(), UpdateItem::Batch(_)));
+
+    // When we close the sending channel we also also end the service task
+    authority_state.batch_notifier.close();
+
+    _join.await.expect("No errors in task").expect("ok");
+}
+
+#[sim_test]
+async fn test_batch_manager_drop_out_of_order() {
+    // Create a random directory to store the DB
+    let dir = env::temp_dir();
+    let path = dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
+    fs::create_dir(&path).unwrap();
+
+    // Create an authority
+    let seed = [1u8; 32];
+    let (committee, _, authority_key) =
+        init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
+    let store = Arc::new(
+        AuthorityStore::open_with_committee(
+            &path,
+            None,
+            &committee,
+            &Genesis::get_default_genesis(),
+            &AuthorityStorePruningConfig::default(),
+        )
+        .await
+        .unwrap(),
+    );
+    let authority_state = Arc::new(init_state(committee, authority_key, store.clone()).await);
+
+    let inner_state = authority_state.clone();
+    let _join = tokio::task::spawn(async move {
+        inner_state
+            // Make sure that a batch will not be formed due to time, but will be formed
+            // when there are 4 transactions.
+            .run_batch_service_once(4, Duration::from_millis(10000))
+            .await
+    });
+    // Send transactions out of order
+    let mut rx = authority_state.subscribe_batch();
+
+    let t0 = authority_state.batch_notifier.ticket().expect("ok");
+    let t1 = authority_state.batch_notifier.ticket().expect("ok");
+    let t2 = authority_state.batch_notifier.ticket().expect("ok");
+    let t3 = authority_state.batch_notifier.ticket().expect("ok");
+
+    store.side_sequence(t1.seq(), &ExecutionDigests::random());
+    t1.notify();
+    store.side_sequence(t3.seq(), &ExecutionDigests::random());
+    t3.notify();
+    store.side_sequence(t2.seq(), &ExecutionDigests::random());
+    t2.notify();
+
+    // Give a chance to send signals
+    tokio::task::yield_now().await;
+    // Still nothing has arrived out of order
+    assert_eq!(rx.len(), 0);
+
+    store.side_sequence(t0.seq(), &ExecutionDigests::random());
+    t0.notify();
+
+    // Get transactions in order then batch.
+    assert!(matches!(
+        get_next_tx(&mut rx).await,
+        UpdateItem::Transaction((0, _))
+    ));
+
+    assert!(matches!(
+        get_next_tx(&mut rx).await,
+        UpdateItem::Transaction((1, _))
+    ));
+    assert!(matches!(
+        get_next_tx(&mut rx).await,
+        UpdateItem::Transaction((2, _))
+    ));
+    assert!(matches!(
+        get_next_tx(&mut rx).await,
+        UpdateItem::Transaction((3, _))
+    ));
+
+    // Then we (eventually) get a batch
+    assert!(matches!(rx.recv().await.unwrap(), UpdateItem::Batch(_)));
+
+    // When we close the sending channel we also also end the service task
+    authority_state.batch_notifier.close();
+
+    _join.await.expect("No errors in task").expect("ok");
+}
+
+#[sim_test]
+async fn test_handle_move_order_with_batch() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_payment_object_id = ObjectID::random();
+    let (authority_state_, pkg_ref) =
+        init_state_with_ids_and_object_basics(vec![(sender, gas_payment_object_id)]).await;
+    let authority_state = Arc::new(authority_state_);
+    let inner_state = authority_state.clone();
+    let _join = tokio::task::spawn(async move {
+        inner_state
+            .run_batch_service_once(1000, Duration::from_millis(500))
+            .await
+    });
+    // Send transactions out of order
+    let mut rx = authority_state.subscribe_batch();
+
+    tokio::task::yield_now().await;
+
+    let effects = create_move_object(
+        &pkg_ref,
+        &authority_state,
+        &gas_payment_object_id,
+        &sender,
+        &sender_key,
+    )
+    .await
+    .unwrap();
+
+    // Second and after is the one
+    let y = rx.recv().await.unwrap();
+    println!("{:?}", y);
+    assert!(matches!(
+        y,
+        UpdateItem::Transaction((0, x)) if x.transaction == effects.transaction_digest
+    ));
+
+    assert!(matches!(rx.recv().await.unwrap(), UpdateItem::Batch(_)));
+
+    authority_state.batch_notifier.close();
+    _join.await.expect("No issues ending task.").expect("ok");
+}
+
+#[derive(Clone)]
+struct TrustworthyAuthorityClient(Arc<AuthorityState>);
+
+#[async_trait]
+impl AuthorityAPI for TrustworthyAuthorityClient {
+    async fn handle_transaction(
+        &self,
+        _transaction: Transaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        Ok(TransactionInfoResponse {
+            signed_transaction: None,
+            certified_transaction: None,
+            signed_effects: None,
+        })
+    }
+
+    async fn handle_certificate(
+        &self,
+        _certificate: CertifiedTransaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        Ok(TransactionInfoResponse {
+            signed_transaction: None,
+            certified_transaction: None,
+            signed_effects: None,
+        })
+    }
+
+    async fn handle_account_info_request(
+        &self,
+        _request: AccountInfoRequest,
+    ) -> Result<AccountInfoResponse, SuiError> {
+        Ok(AccountInfoResponse {
+            object_ids: vec![],
+            owner: Default::default(),
+        })
+    }
+
+    async fn handle_object_info_request(
+        &self,
+        _request: ObjectInfoRequest,
+    ) -> Result<ObjectInfoResponse, SuiError> {
+        Ok(ObjectInfoResponse {
+            parent_certificate: None,
+            requested_object_reference: None,
+            object_and_lock: None,
+        })
+    }
+
+    /// Handle Object information requests for this account.
+    async fn handle_transaction_info_request(
+        &self,
+        _request: TransactionInfoRequest,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        Ok(TransactionInfoResponse {
+            signed_transaction: None,
+            certified_transaction: None,
+            signed_effects: None,
+        })
+    }
+
+    async fn handle_checkpoint(
+        &self,
+        _request: CheckpointRequest,
+    ) -> Result<CheckpointResponse, SuiError> {
+        unimplemented!();
+    }
+
+    /// Handle Batch information requests for this authority.
+    async fn handle_batch_stream(
+        &self,
+        request: BatchInfoRequest,
+    ) -> Result<BatchInfoResponseItemStream, SuiError> {
+        let secret = self.0.secret.clone();
+        let name = self.0.name;
+        let batch_size = 3;
+
+        let mut items = Vec::new();
+        let mut last_batch = AuthorityBatch::initial();
+        items.push({
+            let item = SignedBatch::new_with_zero_epoch(last_batch.clone(), &*secret, name);
+            BatchInfoResponseItem(UpdateItem::Batch(item))
+        });
+        let mut seq = 0;
+        while last_batch.next_sequence_number < request.length {
+            let mut transactions = Vec::new();
+            for _i in 0..batch_size {
+                let rnd = ExecutionDigests::random();
+                transactions.push((seq, rnd));
+                items.push(BatchInfoResponseItem(UpdateItem::Transaction((seq, rnd))));
+                seq += 1;
+            }
+
+            let new_batch = AuthorityBatch::make_next(&last_batch, &transactions).unwrap();
+            last_batch = new_batch;
+            items.push({
+                let item = SignedBatch::new_with_zero_epoch(last_batch.clone(), &*secret, name);
+                BatchInfoResponseItem(UpdateItem::Batch(item))
+            });
+        }
+
+        items.reverse();
+
+        let stream = stream::unfold(items, |mut items| async move {
+            items.pop().map(|item| (Ok(item), items))
+        });
+        Ok(Box::pin(stream))
+    }
+
+    async fn handle_committee_info_request(
+        &self,
+        _request: CommitteeInfoRequest,
+    ) -> Result<CommitteeInfoResponse, SuiError> {
+        unimplemented!();
+    }
+}
+
+impl TrustworthyAuthorityClient {
+    fn new(state: Arc<AuthorityState>) -> Self {
+        Self(state)
+    }
+}
+
+#[derive(Clone)]
+struct ByzantineAuthorityClient(Arc<AuthorityState>);
+
+#[async_trait]
+impl AuthorityAPI for ByzantineAuthorityClient {
+    async fn handle_transaction(
+        &self,
+        _transaction: Transaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        Ok(TransactionInfoResponse {
+            signed_transaction: None,
+            certified_transaction: None,
+            signed_effects: None,
+        })
+    }
+
+    async fn handle_certificate(
+        &self,
+        _certificate: CertifiedTransaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        Ok(TransactionInfoResponse {
+            signed_transaction: None,
+            certified_transaction: None,
+            signed_effects: None,
+        })
+    }
+
+    async fn handle_account_info_request(
+        &self,
+        _request: AccountInfoRequest,
+    ) -> Result<AccountInfoResponse, SuiError> {
+        Ok(AccountInfoResponse {
+            object_ids: vec![],
+            owner: Default::default(),
+        })
+    }
+
+    async fn handle_object_info_request(
+        &self,
+        _request: ObjectInfoRequest,
+    ) -> Result<ObjectInfoResponse, SuiError> {
+        Ok(ObjectInfoResponse {
+            parent_certificate: None,
+            requested_object_reference: None,
+            object_and_lock: None,
+        })
+    }
+
+    /// Handle Object information requests for this account.
+    async fn handle_transaction_info_request(
+        &self,
+        _request: TransactionInfoRequest,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        Ok(TransactionInfoResponse {
+            signed_transaction: None,
+            certified_transaction: None,
+            signed_effects: None,
+        })
+    }
+
+    async fn handle_checkpoint(
+        &self,
+        _request: CheckpointRequest,
+    ) -> Result<CheckpointResponse, SuiError> {
+        unimplemented!()
+    }
+
+    /// Handle Batch information requests for this authority.
+    /// This function comes from a byzantine authority that has incorrect behavior.
+    async fn handle_batch_stream(
+        &self,
+        request: BatchInfoRequest,
+    ) -> Result<BatchInfoResponseItemStream, SuiError> {
+        let secret = self.0.secret.clone();
+        let name = self.0.name;
+        let batch_size = 3;
+
+        let mut items = Vec::new();
+        let mut last_batch = AuthorityBatch::initial();
+        items.push({
+            let item = SignedBatch::new_with_zero_epoch(last_batch.clone(), &*secret, name);
+            BatchInfoResponseItem(UpdateItem::Batch(item))
+        });
+        let mut seq = 0;
+        while last_batch.next_sequence_number < request.length {
+            let mut transactions = Vec::new();
+            for _i in 0..batch_size {
+                let rnd = ExecutionDigests::random();
+                transactions.push((seq, rnd));
+                items.push(BatchInfoResponseItem(UpdateItem::Transaction((seq, rnd))));
+                seq += 1;
+            }
+
+            // Introduce byzantine behaviour:
+            // Pop last transaction
+            let (seq, _) = transactions.pop().unwrap();
+            // Insert a different one
+            transactions.push((seq, ExecutionDigests::random()));
+
+            let new_batch = AuthorityBatch::make_next(&last_batch, &transactions).unwrap();
+            last_batch = new_batch;
+            items.push({
+                let item = SignedBatch::new_with_zero_epoch(last_batch.clone(), &*secret, name);
+                BatchInfoResponseItem(UpdateItem::Batch(item))
+            });
+        }
+
+        items.reverse();
+
+        let stream = stream::unfold(items, |mut items| async move {
+            items.pop().map(|item| (Ok(item), items))
+        });
+        Ok(Box::pin(stream))
+    }
+
+    async fn handle_committee_info_request(
+        &self,
+        _request: CommitteeInfoRequest,
+    ) -> Result<CommitteeInfoResponse, SuiError> {
+        unimplemented!();
+    }
+}
+
+impl ByzantineAuthorityClient {
+    fn new(state: Arc<AuthorityState>) -> Self {
+        Self(state)
+    }
+}
+
+#[sim_test]
+async fn test_safe_batch_stream() {
+    // Create a random directory to store the DB
+    let dir = env::temp_dir();
+    let path = dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
+    fs::create_dir(&path).unwrap();
+
+    let (_, authority_key): (_, AuthorityKeyPair) = get_key_pair();
+    let mut authorities: BTreeMap<AuthorityPublicKeyBytes, u64> = BTreeMap::new();
+    let public_key_bytes = authority_key.public().into();
+    println!("init public key {:?}", public_key_bytes);
+
+    authorities.insert(public_key_bytes, 1);
+    let committee = Committee::new(0, authorities).unwrap();
+    let store = Arc::new(
+        AuthorityStore::open_with_committee(
+            &path.join("store"),
+            None,
+            &committee,
+            &Genesis::get_default_genesis(),
+            &AuthorityStorePruningConfig::default(),
+        )
+        .await
+        .unwrap(),
+    );
+    let state = init_state(committee.clone(), authority_key, store).await;
+    let committee_store = state.committee_store().clone();
+
+    // Happy path:
+    let auth_client = TrustworthyAuthorityClient::new(state);
+    let safe_client = SafeClient::new(
+        auth_client,
+        committee_store,
+        public_key_bytes,
+        SafeClientMetrics::new_for_tests(public_key_bytes),
+    );
+
+    let request = BatchInfoRequest {
+        start: Some(0),
+        length: 15,
+    };
+    let batch_stream = safe_client.handle_batch_stream(request.clone()).await;
+
+    // No errors expected
+    assert!(batch_stream.is_ok());
+    let items = batch_stream
+        .unwrap()
+        .collect::<Vec<Result<BatchInfoResponseItem, SuiError>>>()
+        .await;
+
+    // Check length
+    assert!(!items.is_empty());
+    assert_eq!(items.len(), 15 + 6); // 15 items, and 6 batches (enclosing them)
+
+    let mut error_found = false;
+    for item in items {
+        if item.is_err() {
+            error_found = true;
+            println!("error found: {:?}", item);
+        }
+    }
+
+    assert!(!error_found);
+
+    // Byzantine cases:
+    let (_, authority_key): (_, AuthorityKeyPair) = get_key_pair();
+    let state_b =
+        AuthorityState::new_for_testing(committee.clone(), &authority_key, None, None).await;
+    let committee_store = state_b.committee_store().clone();
+    let auth_client_from_byzantine = ByzantineAuthorityClient::new(state_b);
+    let public_key_bytes_b = authority_key.public().into();
+    let safe_client_from_byzantine = SafeClient::new(
+        auth_client_from_byzantine,
+        committee_store,
+        public_key_bytes_b,
+        SafeClientMetrics::new_for_tests(public_key_bytes_b),
+    );
+
+    let mut batch_stream = safe_client_from_byzantine
+        .handle_batch_stream(request.clone())
+        .await;
+
+    // We still expect an ok result
+    assert!(batch_stream.is_ok());
+
+    let items = batch_stream
+        .unwrap()
+        .collect::<Vec<Result<BatchInfoResponseItem, SuiError>>>()
+        .await;
+
+    // Check length
+    assert!(!items.is_empty());
+    assert_eq!(items.len(), 15 + 6); // 15 items, and 6 batches (enclosing them)
+
+    let request_b = BatchInfoRequest {
+        start: Some(0),
+        length: 10,
+    };
+    batch_stream = safe_client_from_byzantine
+        .handle_batch_stream(request_b.clone())
+        .await;
+
+    // We still expect an ok result
+    assert!(batch_stream.is_ok());
+
+    let items = batch_stream
+        .unwrap()
+        .collect::<Vec<Result<BatchInfoResponseItem, SuiError>>>()
+        .await;
+
+    let mut error_found = false;
+    for item in items {
+        if item.is_err() {
+            error_found = true;
+        }
+    }
+    assert!(error_found);
+}

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -15,6 +15,7 @@ use narwhal_worker::TrivialTransactionValidator;
 use prometheus::Registry;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_config::node::AuthorityStorePruningConfig;
 use sui_types::crypto::KeypairTraits;
 use test_utils::authority::test_and_configure_authority_configs;
 use tokio::sync::mpsc::channel;
@@ -54,6 +55,7 @@ async fn test_narwhal_manager() {
             None,
             genesis,
             &committee_store,
+            &AuthorityStorePruningConfig::default(),
         )
         .await
         .unwrap(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -138,6 +138,7 @@ impl SuiNode {
                 None,
                 genesis,
                 &committee_store,
+                &config.authority_store_pruning_config,
             )
             .await?,
         );

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -753,6 +753,7 @@ impl ObjectID {
     pub const LENGTH: usize = AccountAddress::LENGTH;
     /// Hex address: 0x0
     pub const ZERO: Self = Self::new([0u8; Self::LENGTH]);
+    pub const MAX: Self = Self::new([0xff; Self::LENGTH]);
     /// Creates a new ObjectID
     pub const fn new(obj_id: [u8; Self::LENGTH]) -> Self {
         Self(AccountAddress::new(obj_id))

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -211,6 +211,7 @@ flume = { version = "0.10", default-features = false, features = ["async", "futu
 fnv = { version = "1", features = ["std"] }
 form_urlencoded = { version = "1", default-features = false }
 fragile = { version = "2", default-features = false }
+fs_extra = { version = "1", default-features = false }
 funty = { version = "1", default-features = false }
 futures = { version = "0.3", features = ["alloc", "async-await", "bilock", "executor", "futures-executor", "std", "unstable"] }
 futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std", "unstable"] }
@@ -318,6 +319,7 @@ miniz_oxide-d8f496e17d97b5cb = { package = "miniz_oxide", version = "0.5", defau
 miniz_oxide-3b31131e45eafb45 = { package = "miniz_oxide", version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
+more-asserts = { version = "0.3", default-features = false }
 move-abigen = { git = "https://github.com/move-language/move", rev = "265e8792ff2935db8246ddb308b36b893d507851", default-features = false }
 move-binary-format = { git = "https://github.com/move-language/move", rev = "265e8792ff2935db8246ddb308b36b893d507851" }
 move-borrow-graph = { git = "https://github.com/move-language/move", rev = "265e8792ff2935db8246ddb308b36b893d507851", default-features = false }
@@ -874,6 +876,7 @@ flume = { version = "0.10", default-features = false, features = ["async", "futu
 fnv = { version = "1", features = ["std"] }
 form_urlencoded = { version = "1", default-features = false }
 fragile = { version = "2", default-features = false }
+fs_extra = { version = "1", default-features = false }
 funty = { version = "1", default-features = false }
 futures = { version = "0.3", features = ["alloc", "async-await", "bilock", "executor", "futures-executor", "std", "unstable"] }
 futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std", "unstable"] }
@@ -994,6 +997,7 @@ miniz_oxide-3b31131e45eafb45 = { package = "miniz_oxide", version = "0.6", defau
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
+more-asserts = { version = "0.3", default-features = false }
 move-abigen = { git = "https://github.com/move-language/move", rev = "265e8792ff2935db8246ddb308b36b893d507851", default-features = false }
 move-binary-format = { git = "https://github.com/move-language/move", rev = "265e8792ff2935db8246ddb308b36b893d507851" }
 move-borrow-graph = { git = "https://github.com/move-language/move", rev = "265e8792ff2935db8246ddb308b36b893d507851", default-features = false }
@@ -1439,7 +1443,6 @@ debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8", features = ["alloc"] }
 errno = { version = "0.2", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
-fs_extra = { version = "1", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 inferno = { version = "0.11", default-features = false, features = ["indexmap", "nameattr"] }
 io-lifetimes = { version = "1", default-features = false, features = ["close", "libc", "windows-sys"] }
@@ -1525,7 +1528,6 @@ encoding_rs = { version = "0.8", features = ["alloc"] }
 findshlibs = { version = "0.10", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
-fs_extra = { version = "1", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 inferno = { version = "0.11", default-features = false, features = ["indexmap", "nameattr"] }
 io-lifetimes = { version = "1", default-features = false, features = ["close", "libc", "windows-sys"] }


### PR DESCRIPTION
Trying out a simple `delete_range` based approach worked quite effectively. Testing it out on a cluster of 4 validators (2 running with pruning and 2 without) and only retaining latest 2 object versions, I see pruning to be quite efficient with reclaiming disk space.
<img width="1144" alt="Screen Shot 2022-12-16 at 11 54 01 AM" src="https://user-images.githubusercontent.com/106645797/208178858-7a7f95d3-f916-4470-953c-8441b27682a7.png">
While it is straightforward to prune older versions on validators (since they are not needed for txn execution), it is more nuanced for full nodes. I think we probably want to keep older object versions longer to fulfill read and hence in the config, I've set it to retain 5 latest versions on full nodes  (vs 2 on validators) and pruning cycle every 5 hours (which gives an average ttl of 2.5 hrs)
