### PR TITLE
return VerifiedEnvelope from AuthorityAggregator

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -151,7 +151,7 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
             QuorumDriverResponse::EffectsCert(result) => {
                 let (tx_cert, effects_cert) = *result;
                 let tx_cert: SuiCertifiedTransaction = tx_cert.try_into().unwrap();
-                let effects = ExecutionEffects::CertifiedTransactionEffects(effects_cert);
+                let effects = ExecutionEffects::CertifiedTransactionEffects(effects_cert.into());
                 Ok((tx_cert, effects))
             }
             other => panic!("This should not happen, got: {:?}", other),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -38,7 +38,8 @@ use sui_storage::{
     node_sync_store::NodeSyncStore,
     IndexStore,
 };
-use sui_types::messages::{CertifiedTransaction, CertifiedTransactionEffects};
+use sui_types::messages::VerifiedCertificate;
+use sui_types::messages::VerifiedCertifiedTransactionEffects;
 use tokio::sync::mpsc::channel;
 use tower::ServiceBuilder;
 use tracing::info;
@@ -428,8 +429,12 @@ impl SuiNode {
 
     pub fn subscribe_to_transaction_orchestrator_effects(
         &self,
-    ) -> Result<tokio::sync::broadcast::Receiver<(CertifiedTransaction, CertifiedTransactionEffects)>>
-    {
+    ) -> Result<
+        tokio::sync::broadcast::Receiver<(
+            VerifiedCertificate,
+            VerifiedCertifiedTransactionEffects,
+        )>,
+    > {
         self.transaction_orchestrator
             .as_ref()
             .map(|to| to.subscribe_to_effects_queue())

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1894,6 +1894,10 @@ pub type UnsignedTransactionEffects = TransactionEffectsEnvelope<EmptySignInfo>;
 pub type SignedTransactionEffects = TransactionEffectsEnvelope<AuthoritySignInfo>;
 pub type CertifiedTransactionEffects = TransactionEffectsEnvelope<AuthorityStrongQuorumSignInfo>;
 
+pub type VerifiedTransactionEffectsEnvelope<S> = VerifiedEnvelope<TransactionEffects, S>;
+pub type VerifiedCertifiedTransactionEffects =
+    VerifiedTransactionEffectsEnvelope<AuthorityStrongQuorumSignInfo>;
+
 pub type ValidExecutionDigests = Envelope<ExecutionDigests, CertificateProof>;
 pub type ValidTransactionEffectsDigest = Envelope<TransactionEffectsDigest, CertificateProof>;
 pub type ValidTransactionEffects = TransactionEffectsEnvelope<CertificateProof>;
@@ -2197,7 +2201,6 @@ pub type IsTransactionExecutedLocally = bool;
 pub enum ExecuteTransactionResponse {
     ImmediateReturn,
     TxCert(Box<CertifiedTransaction>),
-    // TODO: Change to CertifiedTransactionEffects eventually.
     EffectsCert(
         Box<(
             CertifiedTransaction,
@@ -2207,7 +2210,7 @@ pub enum ExecuteTransactionResponse {
     ),
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, schemars::JsonSchema)]
+#[derive(Clone, Debug, schemars::JsonSchema)]
 pub enum QuorumDriverRequestType {
     ImmediateReturn,
     WaitForTxCert,
@@ -2220,11 +2223,11 @@ pub struct QuorumDriverRequest {
     pub request_type: QuorumDriverRequestType,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub enum QuorumDriverResponse {
     ImmediateReturn,
-    TxCert(Box<CertifiedTransaction>),
-    EffectsCert(Box<(CertifiedTransaction, CertifiedTransactionEffects)>),
+    TxCert(Box<VerifiedCertificate>),
+    EffectsCert(Box<(VerifiedCertificate, VerifiedCertifiedTransactionEffects)>),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
as title, so the receiving end does not need to verify it.

**I in fact think we do not even need to verify in AuthorityAggregator because the verification is already done in safe_client. Thoughts?** 