### PR TITLE
validator returns ValidatorHaltedAtEpochEnd in handle_transaction when it's hatled

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -172,6 +172,9 @@ pub struct ValidatorServiceMetrics {
     pub handle_transaction_non_consensus_latency: Histogram,
     pub handle_certificate_consensus_latency: Histogram,
     pub handle_certificate_non_consensus_latency: Histogram,
+
+    num_rejected_tx_in_epoch_boundary: IntCounter,
+    num_rejected_cert_in_epoch_boundary: IntCounter,
 }
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -233,6 +236,18 @@ impl ValidatorServiceMetrics {
                 "validator_service_handle_certificate_non_consensus_latency",
                 "Latency of handling a non-consensus transaction certificate",
                 LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            num_rejected_tx_in_epoch_boundary: register_int_counter_with_registry!(
+                "validator_service_num_rejected_tx_in_epoch_boundary",
+                "Number of rejected transaction during epoch transitioning",
+                registry,
+            )
+            .unwrap(),
+            num_rejected_cert_in_epoch_boundary: register_int_counter_with_registry!(
+                "validator_service_num_rejected_cert_in_epoch_boundary",
+                "Number of rejected transaction certificate during epoch transitioning",
                 registry,
             )
             .unwrap(),
@@ -363,7 +378,12 @@ impl ValidatorService {
         let info = state
             .handle_transaction(transaction)
             .instrument(span)
-            .await?;
+            .await
+            .tap_err(|e| {
+                if let SuiError::ValidatorHaltedAtEpochEnd = e {
+                    metrics.num_rejected_tx_in_epoch_boundary.inc();
+                }
+            })?;
 
         Ok(tonic::Response::new(info.into()))
     }
@@ -414,7 +434,11 @@ impl ValidatorService {
                 &state.name,
                 certificate.clone().into(),
             );
-            let waiter = consensus_adapter.submit(transaction)?;
+            let waiter = consensus_adapter.submit(transaction).tap_err(|e| {
+                if let SuiError::ValidatorHaltedAtEpochEnd = e {
+                    metrics.num_rejected_cert_in_epoch_boundary.inc();
+                }
+            })?;
             if certificate.contains_shared_object() {
                 // This is expect on tokio JoinHandle result, not SuiResult
                 waiter


### PR DESCRIPTION
This PR does two things:
1. validator returns `ValidatorHaltedAtEpochEnd` if they are halted when handling a transaction. When the validator is doing reconfig, it's not likely txes signed at this time are going through, so it could save both validator/fullnode some time to properly handle the transient error. Also note this is best effort because the validator could be halted after signing a tx and before a tx cert is formed. For `handle_certificate`, the check is already done in `consensus_adapter.submit`.
3. add two metrics `num_rejected_tx_in_epoch_boundary` and `num_rejected_cert_in_epoch_boundary`