### PR TITLE
[indexer][fix] try join all tokio threads and tasks

### DIFF
--- a/crates/sui-indexer/src/processors/address_processor.rs
+++ b/crates/sui-indexer/src/processors/address_processor.rs
@@ -26,16 +26,18 @@ impl AddressProcessor {
         let mut pg_pool_conn = get_pg_pool_connection(self.pg_connection_pool.clone())?;
 
         let address_log = read_address_log(&mut pg_pool_conn)?;
-        let last_processed_id = address_log.last_processed_id;
+        let mut last_processed_id = address_log.last_processed_id;
 
-        // fetch transaction rows from DB, with filter id > last_processed_id and limit of batch size.
-        let txn_vec =
-            read_transactions(&mut pg_pool_conn, last_processed_id, TRANSACTION_BATCH_SIZE)?;
-        let addr_vec: Vec<NewAddress> = txn_vec.into_iter().map(transaction_to_address).collect();
-        let next_processed_id = last_processed_id + addr_vec.len() as i64;
+        loop {
+            // fetch transaction rows from DB, with filter id > last_processed_id and limit of batch size.
+            let txn_vec =
+                read_transactions(&mut pg_pool_conn, last_processed_id, TRANSACTION_BATCH_SIZE)?;
+            let addr_vec: Vec<NewAddress> =
+                txn_vec.into_iter().map(transaction_to_address).collect();
+            last_processed_id += addr_vec.len() as i64;
 
-        commit_addresses(&mut pg_pool_conn, addr_vec)?;
-        commit_address_log(&mut pg_pool_conn, next_processed_id)?;
-        Ok(())
+            commit_addresses(&mut pg_pool_conn, addr_vec)?;
+            commit_address_log(&mut pg_pool_conn, last_processed_id)?;
+        }
     }
 }


### PR DESCRIPTION
I made a noob mistake here, before the PR, main process would return instantly, instead of waiting for spawned threads and tasks. I also fixed the addr processor, which only handled one batch before the fix.

Tested locally and the main process was indeed waiting and all spawned threads and tasks can proceed as expected.