### PR TITLE
Record an initial checkpoint boundary at (0, 0) so that we cannot miss txns

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -255,8 +255,11 @@ impl AuthorityPerEpochStore {
         Ok(self.tables.next_shared_object_versions.multi_get(ids)?)
     }
 
-    pub fn get_last_checkpoint_boundary(&self) -> Option<(u64, u64)> {
-        self.tables.checkpoint_boundary.iter().skip_to_last().next()
+    pub fn get_last_checkpoint_boundary(&self) -> (u64, Option<u64>) {
+        match self.tables.checkpoint_boundary.iter().skip_to_last().next() {
+            Some((idx, height)) => (idx, Some(height)),
+            None => (0, None),
+        }
     }
 
     pub fn get_last_consensus_index(&self) -> SuiResult<ExecutionIndicesWithHash> {
@@ -269,12 +272,14 @@ impl AuthorityPerEpochStore {
 
     pub fn get_transactions_in_checkpoint_range(
         &self,
-        from_height_excluded: u64,
+        from_height_excluded: Option<u64>,
         to_height_included: u64,
     ) -> SuiResult<Vec<TransactionDigest>> {
-        let iter = self.tables.consensus_message_order.iter();
-        let last_previous = ExecutionIndices::end_for_commit(from_height_excluded);
-        let iter = iter.skip_to(&last_previous)?;
+        let mut iter = self.tables.consensus_message_order.iter();
+        if let Some(from_height_excluded) = from_height_excluded {
+            let last_previous = ExecutionIndices::end_for_commit(from_height_excluded);
+            iter = iter.skip_to(&last_previous)?;
+        }
         // skip_to lands to key the last_key or key after it
         // technically here we need to check if first item in stream has a key equal to last_previous
         // however in practice this can not happen because number of batches in certificate is

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1208,20 +1208,21 @@ impl AuthorityStore {
     ) -> SuiResult<Option<(u64, Vec<TransactionDigest>)>> {
         let epoch_tables = self.epoch_store();
 
-        let Some((index, from_height_excluded)) = epoch_tables.get_last_checkpoint_boundary() else {
-            return Ok(None);
-        };
-        if from_height_excluded >= to_height_included {
-            // Due to crash recovery we might enter this function twice for same boundary
-            debug!("Not returning last checkpoint - already processed");
-            return Ok(None);
+        let (index, from_height_excluded) = epoch_tables.get_last_checkpoint_boundary();
+
+        if let Some(from_height_excluded) = from_height_excluded {
+            if from_height_excluded >= to_height_included {
+                // Due to crash recovery we might enter this function twice for same boundary
+                debug!("Not returning last checkpoint - already processed");
+                return Ok(None);
+            }
         }
 
         let roots = epoch_tables
             .get_transactions_in_checkpoint_range(from_height_excluded, to_height_included)?;
 
         debug!(
-            "Selected {} roots between narwhal commit rounds {} and {}",
+            "Selected {} roots between narwhal commit rounds {:?} and {}",
             roots.len(),
             from_height_excluded,
             to_height_included
@@ -1237,23 +1238,22 @@ impl AuthorityStore {
     pub fn record_checkpoint_boundary(&self, commit_round: u64) -> SuiResult {
         let epoch_tables = self.epoch_store();
 
-        if let Some((index, height)) = epoch_tables.get_last_checkpoint_boundary() {
+        let (index, height) = epoch_tables.get_last_checkpoint_boundary();
+
+        if let Some(height) = height {
             if height >= commit_round {
                 // Due to crash recovery we might see same boundary twice
                 debug!("Not recording checkpoint boundary - already updated");
-            } else {
-                let index = index + 1;
-                debug!(
-                    "Recording checkpoint boundary {} at {}",
-                    index, commit_round
-                );
-                epoch_tables.insert_checkpoint_boundary(index, commit_round)?;
+                return Ok(());
             }
-        } else {
-            // Table is empty
-            debug!("Recording first checkpoint boundary at {}", commit_round);
-            epoch_tables.insert_checkpoint_boundary(0, commit_round)?;
         }
+
+        let index = index + 1;
+        debug!(
+            "Recording checkpoint boundary {} at {}",
+            index, commit_round
+        );
+        epoch_tables.insert_checkpoint_boundary(index, commit_round)?;
         Ok(())
     }
 


### PR DESCRIPTION
Otherwise, it is possible for transactions that arrive from consensus prior to the first checkpoint boundary being recorded to go uncheckpointed.

No new tests in this PR, but this was causing test failures in my node_sync deletion PR.