### PR TITLE
crypto: Improve keytool usage and elaborate comments

### DIFF
--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -103,7 +103,11 @@ where
         // Note: since EffectsCert is not stored today, we need to gather that from validators
         // (and maybe store it for caching purposes)
 
-        let transaction = request.transaction.verify()?;
+        let tx_digest = *request.transaction.digest();
+        let transaction = request
+            .transaction
+            .verify()
+            .tap_err(|e| debug!(?tx_digest, "Failed to verify user signature: {:?}", e))?;
 
         // We will shortly refactor the TransactionOrchestrator with a queue-based implementation.
         // TDOO: `should_enqueue` will be used to determine if the transaction should be enqueued.
@@ -126,7 +130,6 @@ where
                 QuorumDriverRequestType::WaitForEffectsCert
             }
         };
-        let tx_digest = *transaction.digest();
         let execution_result = self
             .quorum_driver
             .execute_transaction(QuorumDriverRequest {


### PR DESCRIPTION
my original plan was to convert all network/worker kp to use SuiKeyPair, turns out its a quite invasive change. here we improve the keytool command to work better for the PE team to load a pubkey in hex. 

note that the output of load-keypair should print both the encoding with and without flag outputs (the former can be used to unpack, the latter is what the validator and node config uses. )
``` 
target/debug/sui keytool generate ed25519
Keypair wrote to file path: "0x246ea3b175bc04689c1cf0ad163e8259cd8b9877.key" with scheme: ED25519

target/debug/sui keytool load-keypair 0x246ea3b175bc04689c1cf0ad163e8259cd8b9877.key
Encoded with flag (uses as input for `keytool unpack`): AGYmFrMPqr2gGvGxZPnX8GEUJaH7Ip4Bi+diVefMoKwJt+VrRktDlB1eSwdXzBCopz2TSHywe12ekdQf0T2U4HE=
Ed25519 Keypair: t+VrRktDlB1eSwdXzBCopz2TSHywe12ekdQf0T2U4HFmJhazD6q9oBrxsWT51/BhFCWh+yKeAYvnYlXnzKCsCQ==

target/debug/sui keytool unpack AGYmFrMPqr2gGvGxZPnX8GEUJaH7Ip4Bi+diVefMoKwJt+VrRktDlB1eSwdXzBCopz2TSHywe12ekdQf0T2U4HE=
Keypair Base64: "AGYmFrMPqr2gGvGxZPnX8GEUJaH7Ip4Bi+diVefMoKwJt+VrRktDlB1eSwdXzBCopz2TSHywe12ekdQf0T2U4HE="
Address: 0x246ea3b175bc04689c1cf0ad163e8259cd8b9877
Pubkey Base64: Ed25519(ZiYWsw+qvaAa8bFk+dfwYRQlofsingGL52JV58ygrAk=)
Pubkey Hex: "662616b30faabda01af1b164f9d7f0611425a1fb229e018be76255e7cca0ac09"
Scheme: ED25519
```