### PR TITLE
Fix skipped checkpoints bug

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -177,6 +177,13 @@ impl CheckpointExecutor {
                 Some(Ok((checkpoint, next_committee))) = pending.next() => {
                     match next_committee {
                         None => {
+                            // Ensure that we are not skipping checkpoints at any point
+                            if let Some(prev_highest) = self.checkpoint_store.get_highest_executed_checkpoint_seq_number().unwrap() {
+                                assert_eq!(prev_highest + 1, checkpoint.sequence_number());
+                            } else {
+                                assert_eq!(checkpoint.sequence_number(), 0);
+                            }
+
                             let new_highest = checkpoint.sequence_number();
                             debug!(
                                 "Bumping highest_executed_checkpoint watermark to {:?}",
@@ -300,17 +307,16 @@ impl CheckpointExecutor {
         let num_tasks_to_schedule = std::cmp::min(checkpoints_diff, tasks_diff as u64);
 
         // get all checkpoints to be scheduled, less the last (which we got already above)
-        let range: Vec<u64> = (next_to_exec..(next_to_exec + num_tasks_to_schedule)).collect();
+        let range: Vec<u64> = (next_to_exec..(next_to_exec + num_tasks_to_schedule - 1)).collect();
 
         let mut checkpoints_to_schedule = self
             .checkpoint_store
             .multi_get_checkpoint_by_sequence_number(&range)?
             .into_iter()
-            .map(|tx| tx.unwrap())
+            .map(|checkpoint| checkpoint.unwrap())
             .collect::<Vec<VerifiedCheckpoint>>();
 
         checkpoints_to_schedule.sort_by_key(|a| a.sequence_number());
-        checkpoints_to_schedule.push(latest_synced_checkpoint);
         let checkpoints_to_schedule = checkpoints_to_schedule;
         debug!(
             "Scheduling {:?} lagging checkpoints",

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -294,39 +294,23 @@ impl CheckpointExecutor {
             // follow case. Avoid reading from DB and used checkpoint passed
             // from StateSync
             Ordering::Equal => return self.schedule_checkpoint(latest_synced_checkpoint, pending),
-            // Need to catch up more than 1. Continue
-            Ordering::Less => {}
-        }
-
-        // Schedule as many checkpoints as possible in order to catch up quickly.
-        // The highest we can schedule is bounded by the min of the number of
-        // checkpoints that *need* to be scheduled and the number of tasks available
-        // to schedule within
-        let checkpoints_diff = latest_synced_checkpoint.sequence_number() - next_to_exec + 1;
-        let tasks_diff = self.task_limit - pending.len();
-        let num_tasks_to_schedule = std::cmp::min(checkpoints_diff, tasks_diff as u64);
-
-        // get all checkpoints to be scheduled, less the last (which we got already above)
-        let range: Vec<u64> = (next_to_exec..(next_to_exec + num_tasks_to_schedule - 1)).collect();
-
-        let mut checkpoints_to_schedule = self
-            .checkpoint_store
-            .multi_get_checkpoint_by_sequence_number(&range)?
-            .into_iter()
-            .map(|checkpoint| checkpoint.unwrap())
-            .collect::<Vec<VerifiedCheckpoint>>();
-
-        checkpoints_to_schedule.sort_by_key(|a| a.sequence_number());
-        let checkpoints_to_schedule = checkpoints_to_schedule;
-        debug!(
-            "Scheduling {:?} lagging checkpoints",
-            checkpoints_to_schedule.len(),
-        );
-
-        for checkpoint in checkpoints_to_schedule.into_iter() {
-            self.schedule_checkpoint(checkpoint, pending)?;
-            if self.end_of_epoch {
-                return Ok(());
+            // Need to catch up more than 1. Read from store
+            Ordering::Less => {
+                for i in next_to_exec..=latest_synced_checkpoint.sequence_number() {
+                    if pending.len() >= self.task_limit || self.end_of_epoch {
+                        break;
+                    }
+                    let checkpoint = self
+                        .checkpoint_store
+                        .get_checkpoint_by_sequence_number(i)?
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "Checkpoint sequence number {:?} does not exist in checkpoint store",
+                                i
+                            )
+                        });
+                    self.schedule_checkpoint(checkpoint, pending)?;
+                }
             }
         }
 
@@ -338,6 +322,10 @@ impl CheckpointExecutor {
         checkpoint: VerifiedCheckpoint,
         pending: &mut CheckpointExecutionBuffer,
     ) -> SuiResult {
+        info!(
+            "Scheduling checkpoint {:?} for execution",
+            checkpoint.sequence_number()
+        );
         // Mismatch between node epoch and checkpoint epoch after startup
         // crash recovery is invalid
         let checkpoint_epoch = checkpoint.epoch();


### PR DESCRIPTION
This bug may cause checkpoints (and thus, reconfig) to be skipped under the following conditions:
* Node is behind on checkpoint execution and needs to schedule many at once
* We have received a synced checkpoint message from StateSync for a checkpoint that is greater than the range of scheduled catch-up checkpoints

In such a case (before this fix), we would attempt to calculate the number of checkpoints that need to be scheduled based on available concurrency capacity and the number of checkpoints that need to be scheduled, do a multi-get to fetch these from the store, and as an optimization, we append to this list the checkpoint received from statesync to avoid the db write.

This causes us to get a sequence such as `[0,1,2,3,10]` if we have a max concurrency of 5, are starting from 0, and receive a message that the last synced checkpoint is 10.

The fix here is to remove the append. We also now check that we are ratcheting the `highest_executed_checkpoint` watermark sequentially at all times, without skips. Note that this assert fails if the bug fix is removed and we run `cargo nextest run -- checkpoint_executor_test`