### PR TITLE
[MSCF-15] Tournament start & end round

### DIFF
--- a/dapps/satoshi-multiplayer/contract/sources/satoshi_flip_match.move
+++ b/dapps/satoshi-multiplayer/contract/sources/satoshi_flip_match.move
@@ -50,6 +50,9 @@ module contract::satoshi_flip_match {
         outcome.winner
     }
 
+    public fun id(match: &Match): UID {
+        match.id
+    }
 
     // functions
 


### PR DESCRIPTION
- [x] `start_round`: Split players into pairs of two and create a match for each pair. Assign host and guesser and transfer match to host.
- [x] `end_round`: Get all active matches, find their winner and add them to tournament's players so that we can proceed to the next round with winners being the new set of players.