### PR TITLE
Implement `Display` and `Debug` traits consistently for various digests

### DIFF
--- a/narwhal/dag/src/node_dag.rs
+++ b/narwhal/dag/src/node_dag.rs
@@ -277,13 +277,13 @@ mod tests {
 
     impl fmt::Debug for TestDigest {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-            write!(f, "{}", Hex::encode(self.0).get(0..16).ok_or(fmt::Error)?)
+            write!(f, "{}", Hex::encode(self.0).get(0..8).ok_or(fmt::Error)?)
         }
     }
 
     impl fmt::Display for TestDigest {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-            write!(f, "{}", Hex::encode(self.0).get(0..16).ok_or(fmt::Error)?)
+            write!(f, "{}", Hex::encode(self.0).get(0..8).ok_or(fmt::Error)?)
         }
     }
 

--- a/narwhal/primary/src/block_synchronizer/peers.rs
+++ b/narwhal/primary/src/block_synchronizer/peers.rs
@@ -400,11 +400,7 @@ mod tests {
 
     impl fmt::Display for MockDigest {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-            write!(
-                f,
-                "{}",
-                base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
-            )
+            write!(f, "{}", base64::encode(self.0).get(0..8).ok_or(fmt::Error)?)
         }
     }
 

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -12,6 +12,7 @@ use crypto::{AggregateSignature, PublicKey, Signature};
 use dag::node_dag::Affiliated;
 use derive_builder::Builder;
 use fastcrypto::{
+    encoding::{Base64, Encoding},
     hash::{Digest, Hash, HashFunction},
     traits::{AggregateAuthenticator, EncodeDecodeBase64, Signer, VerifyingKey},
     SignatureService, Verifier,
@@ -115,7 +116,7 @@ pub struct BatchDigest(pub [u8; crypto::DIGEST_LENGTH]);
 
 impl fmt::Debug for BatchDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", base64::encode(self.0))
+        write!(f, "b#{}", base64::encode(self.0))
     }
 }
 
@@ -123,8 +124,8 @@ impl fmt::Display for BatchDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{}",
-            base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
+            "b#{}",
+            Base64::encode(self.0).get(0..8).ok_or(fmt::Error)?
         )
     }
 }
@@ -299,7 +300,7 @@ impl From<HeaderDigest> for Digest<{ crypto::DIGEST_LENGTH }> {
 
 impl fmt::Debug for HeaderDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", base64::encode(self.0))
+        write!(f, "h#{}", Base64::encode(self.0))
     }
 }
 
@@ -307,8 +308,8 @@ impl fmt::Display for HeaderDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{}",
-            base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
+            "h#{}",
+            Base64::encode(self.0).get(0..8).ok_or(fmt::Error)?
         )
     }
 }
@@ -447,7 +448,7 @@ impl From<VoteDigest> for Digest<{ crypto::DIGEST_LENGTH }> {
 
 impl fmt::Debug for VoteDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", base64::encode(self.0))
+        write!(f, "v#{}", Base64::encode(self.0))
     }
 }
 
@@ -455,8 +456,8 @@ impl fmt::Display for VoteDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{}",
-            base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
+            "v#{}",
+            Base64::encode(self.0).get(0..8).ok_or(fmt::Error)?
         )
     }
 }
@@ -732,7 +733,7 @@ impl From<CertificateDigest> for CertificateDigestProto {
 
 impl fmt::Debug for CertificateDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", base64::encode(self.0))
+        write!(f, "c#{}", Base64::encode(self.0))
     }
 }
 
@@ -740,8 +741,8 @@ impl fmt::Display for CertificateDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{}",
-            base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
+            "c#{}",
+            Base64::encode(self.0).get(0..8).ok_or(fmt::Error)?
         )
     }
 }


### PR DESCRIPTION
Currently the `Display` and `Debug` trait implementations for various digests are a bit inconsistent. This makes it harder to understand log messages or search for relevant information. This PR makes the following change:
1. Use `fastcrypto::encoding::Base64` to encode all types of digests for `Display` and `Debug`, across Sui and Narwhal.
2. For `Display`, output the first 8 characters in the base64 encoding which should be enough as a unique identifier within a reasonable time window. For `Debug`, output the full base64 encoding.
3. Prepend type identifier to the output, e.g. `t#`, `e#`.

Some of the digests are shown to the user via `Display`, e.g. `ObjectDigest`. If and how we want to update the `Display` output needs to be considered too. I believe it is ok to show users the hash truncated to 8-character base64, but LMK if this should not be the case.


