### PR TITLE
Fix reconfig epoch store swap bug

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -167,7 +167,7 @@ impl AuthorityPerEpochStore {
         let reconfig_state = tables
             .load_reconfig_state()
             .expect("Load reconfig state at initialization cannot fail");
-        let wal_path = parent_path.join("recovery_log");
+        let wal_path = AuthorityEpochTables::path(epoch_id, parent_path).join("recovery_log");
         let wal = Arc::new(DBWriteAheadLog::new(wal_path));
         let epoch_alive = NotifyOnce::new();
         Self {


### PR DESCRIPTION
Can be reproed in a unit tests in simplest form as follows:
* Create a committee
* Create a test authority state
* Create a committe for epoch + 1
* Call reconfig

Before, this would trigger the following rocksdb lock error: https://gist.github.com/williampsmith/396022a474f20d3f7c618e6ede15ef1b

This is because we are using the same directory for the new WAL. The fix is to follow the epoch store convention and prefix the path with an epoch id to ensure uniqueness