### PR TITLE
log when user signature verification fails

### DIFF
--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -103,7 +103,11 @@ where
         // Note: since EffectsCert is not stored today, we need to gather that from validators
         // (and maybe store it for caching purposes)
 
-        let transaction = request.transaction.verify()?;
+        let tx_digest = *request.transaction.digest();
+        let transaction = request
+            .transaction
+            .verify()
+            .tap_err(|e| debug!(?tx_digest, "Failed to verify user signature: {:?}", e))?;
 
         // We will shortly refactor the TransactionOrchestrator with a queue-based implementation.
         // TDOO: `should_enqueue` will be used to determine if the transaction should be enqueued.
@@ -126,7 +130,6 @@ where
                 QuorumDriverRequestType::WaitForEffectsCert
             }
         };
-        let tx_digest = *transaction.digest();
         let execution_result = self
             .quorum_driver
             .execute_transaction(QuorumDriverRequest {


### PR DESCRIPTION
as title, to add some level of traceability of transaction failures at this stage. Context is we are seeing some user sig verification failures in a certain env but it shouldn't happen