### PR TITLE
[explorer][wallet] Display links in properties

### DIFF
--- a/apps/explorer/src/pages/object-result/views/TokenView.tsx
+++ b/apps/explorer/src/pages/object-result/views/TokenView.tsx
@@ -24,6 +24,7 @@ import { type DataType } from '../ObjectResultType';
 
 import styles from './ObjectView.module.css';
 
+import { Link } from '~/ui/Link';
 import { LinkWithQuery } from '~/ui/utils/LinkWithQuery';
 
 function TokenView({ data }: { data: DataType }) {
@@ -202,7 +203,21 @@ function TokenView({ data }: { data: DataType }) {
                             {properties.map(([key, value], index) => (
                                 <tr key={index}>
                                     <td>{key}</td>
-                                    <td>{value}</td>
+                                    <td>
+                                        {/* TODO: Use normalized module to determine this display. */}
+                                        {value.startsWith('http://') ||
+                                        value.startsWith('https://') ? (
+                                            <Link
+                                                href={value}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                            >
+                                                {value}
+                                            </Link>
+                                        ) : (
+                                            value
+                                        )}
+                                    </td>
                                 </tr>
                             ))}
                         </tbody>

--- a/apps/explorer/src/pages/object-result/views/TokenView.tsx
+++ b/apps/explorer/src/pages/object-result/views/TokenView.tsx
@@ -205,8 +205,9 @@ function TokenView({ data }: { data: DataType }) {
                                     <td>{key}</td>
                                     <td>
                                         {/* TODO: Use normalized module to determine this display. */}
-                                        {value.startsWith('http://') ||
-                                        value.startsWith('https://') ? (
+                                        {typeof value === 'string' &&
+                                        (value.startsWith('http://') ||
+                                            value.startsWith('https://')) ? (
                                             <Link
                                                 href={value}
                                                 target="_blank"


### PR DESCRIPTION
This is a quick hack to get links displaying in explorer and wallet, but inspecting the property to see if it's URL-like. In general, this is not how we want this to work, and instead want to look at the type of the object to determine this instead, but that would require rebuilding these property views entirely, which we're not doing yet.

While updating the wallet I noticed we have this extended attributes display, but that we don't display the rest of the top-level properties of the object. I updated to display these additional properties.

![Screen Shot 2022-12-15 at 3 05 49 PM](https://user-images.githubusercontent.com/109986297/207986001-5748b643-f2b9-4571-8cbb-eaf435ae1f1c.png)
