### PR TITLE
wallet-ext: keyring fix locking and reviving race condition

### DIFF
--- a/apps/wallet/src/background/index.ts
+++ b/apps/wallet/src/background/index.ts
@@ -45,7 +45,7 @@ Keyring.on('lockedStatusUpdate', (isLocked: boolean) => {
 
 Browser.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === LOCK_ALARM_NAME) {
-        Keyring.lock();
+        Keyring.reviveDone.finally(() => Keyring.lock());
     }
 });
 

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -32,11 +32,11 @@ class Keyring {
     #locked = true;
     #keypair: Keypair | null = null;
     #vault: VaultStorage;
-    #reviveDone: Promise<void>;
+    public readonly reviveDone: Promise<void>;
 
     constructor() {
         this.#vault = new VaultStorage();
-        this.#reviveDone = this.revive().catch((e) => {
+        this.reviveDone = this.revive().catch((e) => {
             // if for some reason decrypting the vault fails or anything else catch
             // the error to allow the user to login using the password
         });
@@ -134,7 +134,7 @@ class Keyring {
             } else if (isKeyringPayload(payload, 'walletStatusUpdate')) {
                 // wait to avoid ui showing locked and then unlocked screen
                 // ui waits until it receives this status to render
-                await this.#reviveDone;
+                await this.reviveDone;
                 uiConnection.send(
                     createMessage<KeyringPayload<'walletStatusUpdate'>>(
                         {


### PR DESCRIPTION
* when it's time to lock the keyring due to inactivity there is a race condition between reviving from session storage and locking because of the alarm. (Keyring is trying to revive since bg service wakes up to respond to the alarm and before completing we lock it)
* this fixes it by waiting reviving to complete before locking
* this only happens if bg service was inactive before the alarm was triggered

closes: APPS-302