### PR TITLE
[Narwhal] Tolerate timestamp drift among primaries

### DIFF
--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -207,8 +207,8 @@ impl Proposer {
             .max()
             .unwrap_or(0);
         if current_time < parent_max_time {
-            error!(
-                "Current time {} earlier than max parent time {}",
+            debug!(
+                "Current time of this primary is {} earlier than max parent time {}",
                 current_time, parent_max_time
             );
         }


### PR DESCRIPTION
Timestamp drift among primaries should be tolerated. It should not result in a node slowing down processing, or error logs.

Currently this condition seems to result in the majority of error and warning logs in private testnet.