### PR TITLE
[Not for review] Trigger key error

### DIFF
--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -22,21 +22,10 @@ use sui_types::{
 pub const TEST_COMMITTEE_SIZE: usize = 4;
 
 /// Generate `COMMITTEE_SIZE` test cryptographic key pairs.
-pub fn test_validator_keys() -> Vec<(AuthorityKeyPair, AuthorityKeyPair, SuiKeyPair, SuiKeyPair)> {
+pub fn test_validator_keys() -> Vec<AuthorityKeyPair> {
     let mut rng = StdRng::from_seed([0; 32]);
     (0..TEST_COMMITTEE_SIZE)
-        .map(|_| {
-            (
-                get_key_pair_from_rng(&mut rng).1,
-                get_key_pair_from_rng(&mut rng).1,
-                get_key_pair_from_rng::<AccountKeyPair, _>(&mut rng)
-                    .1
-                    .into(),
-                get_key_pair_from_rng::<AccountKeyPair, _>(&mut rng)
-                    .1
-                    .into(),
-            )
-        })
+        .map(|_| get_key_pair_from_rng(&mut rng).1)
         .collect()
 }
 
@@ -57,7 +46,7 @@ pub fn test_committee() -> Committee {
         0,
         test_validator_keys()
             .into_iter()
-            .map(|(key, _, _, _)| {
+            .map(|key| {
                 (
                     AuthorityPublicKeyBytes::from(key.public()),
                     /* voting right */ 1,

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -428,7 +428,7 @@ pub fn make_tx_certs_and_signed_effects_with_committee(
     let mut effect_sigs = Vec::new();
     for tx in transactions {
         let mut sigs: Vec<AuthoritySignInfo> = Vec::new();
-        for (key, _, _, _) in test_validator_keys() {
+        for key in test_validator_keys() {
             let vote = VerifiedSignedTransaction::new(
                 committee.epoch,
                 tx.clone(),


### PR DESCRIPTION
With this PR, we will observe the following test error:
```

called `Result::unwrap()` on an `Err` value: InvalidSignature { error: "General cryptographic error" }
thread 'test_good_snapshot' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidSignature { error: "General cryptographic error" }', /Users/xun/github/sui-upstream/crates/test-utils/src/transaction.rs:429:14
stack backtrace:
   0: rust_begin_unwind
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:142:14
   2: core::result::unwrap_failed
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/result.rs:1785:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/result.rs:1107:23
   4: test_utils::transaction::submit_single_owner_transaction::{{closure}}
             at /Users/xun/github/sui-upstream/crates/test-utils/src/transaction.rs:426:21
   5: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/mod.rs:91:19
   6: test_utils::transaction::publish_package_for_effects::{{closure}}
             at /Users/xun/github/sui-upstream/crates/test-utils/src/transaction.rs:68:85
   7: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/mod.rs:91:19
   8: test_utils::transaction::publish_package::{{closure}}
             at /Users/xun/github/sui-upstream/crates/test-utils/src/transaction.rs:59:73
   9: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/mod.rs:91:19
  10: test_utils::transaction::publish_counter_package::{{closure}}
             at /Users/xun/github/sui-upstream/crates/test-utils/src/transaction.rs:75:47
  11: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/mod.rs:91:19
  12: empirical_transaction_cost::create_txes::{{closure}}
             at ./tests/empirical_transaction_cost.rs:188:85
  13: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/mod.rs:91:19
  14: empirical_transaction_cost::run_actual_and_estimate_costs::{{closure}}
             at ./tests/empirical_transaction_cost.rs:257:71
  15: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/mod.rs:91:19
  16: empirical_transaction_cost::test_good_snapshot::{{closure}}
             at ./tests/empirical_transaction_cost.rs:50:9
  17: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/mod.rs:91:19
  18: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/future.rs:124:9
  19: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/future.rs:124:9
  20: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/scheduler/current_thread.rs:531:57
  21: tokio::runtime::coop::with_budget
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/coop.rs:102:5
  22: tokio::runtime::coop::budget
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/coop.rs:68:5
  23: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/scheduler/current_thread.rs:531:25
  24: tokio::runtime::scheduler::current_thread::Context::enter
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/scheduler/current_thread.rs:340:19
  25: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/scheduler/current_thread.rs:530:36
  26: tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/scheduler/current_thread.rs:601:57
  27: tokio::macros::scoped_tls::ScopedKey<T>::set
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/macros/scoped_tls.rs:61:9
  28: tokio::runtime::scheduler::current_thread::CoreGuard::enter
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/scheduler/current_thread.rs:601:27
  29: tokio::runtime::scheduler::current_thread::CoreGuard::block_on
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/scheduler/current_thread.rs:520:19
  30: tokio::runtime::scheduler::current_thread::CurrentThread::block_on
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/scheduler/current_thread.rs:154:24
  31: tokio::runtime::runtime::Runtime::block_on
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.22.0/src/runtime/runtime.rs:279:47
  32: empirical_transaction_cost::test_good_snapshot
             at ./tests/empirical_transaction_cost.rs:59:5
  33: empirical_transaction_cost::test_good_snapshot::{{closure}}
             at ./tests/empirical_transaction_cost.rs:45:7
  34: core::ops::function::FnOnce::call_once
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/ops/function.rs:248:5
  35: core::ops::function::FnOnce::call_once
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

error: test failed, to rerun pass `--test empirical_transaction_cost`
error: 1 target failed:
    `--test empirical_transaction_cost`

```