### PR TITLE
[gas] Do not charge for loading Sui Framework or Move stdlib

### DIFF
--- a/crates/sui-core/src/execution_engine.rs
+++ b/crates/sui-core/src/execution_engine.rs
@@ -27,7 +27,6 @@ use sui_types::storage::{ChildObjectResolver, DeleteKind, ParentSync, WriteKind}
 #[cfg(test)]
 use sui_types::temporary_store;
 use sui_types::temporary_store::InnerTemporaryStore;
-use sui_types::SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION;
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest, TxContext},
     gas::SuiGasStatus,
@@ -39,6 +38,9 @@ use sui_types::{
     storage::BackingPackageStore,
     sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
     SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
+};
+use sui_types::{
+    MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 
 use crate::authority::TemporaryStore;
@@ -117,8 +119,10 @@ fn charge_gas_for_object_read<S>(
     // fetching only unique objects.
     let total_size = temporary_store
         .objects()
-        .values()
-        .map(|obj| obj.object_size_for_gas_metering())
+        .iter()
+        // don't charge for loading Sui Framework or Move stdlib
+        .filter(|(id, _)| *id != &SUI_FRAMEWORK_OBJECT_ID && *id != &MOVE_STDLIB_OBJECT_ID)
+        .map(|(_, obj)| obj.object_size_for_gas_metering())
         .sum();
     gas_status.charge_storage_read(total_size)
 }

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -4,12 +4,12 @@ expression: common_costs_actual
 ---
 {
   "MergeCoin": {
-    "computation_cost": 733,
+    "computation_cost": 63,
     "storage_cost": 32,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 984,
+    "computation_cost": 226,
     "storage_cost": 119,
     "storage_rebate": 0
   },
@@ -29,7 +29,7 @@ expression: common_costs_actual
     "storage_rebate": 15
   },
   "SplitCoin": {
-    "computation_cost": 844,
+    "computation_cost": 173,
     "storage_cost": 80,
     "storage_rebate": 0
   },

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -56,6 +56,7 @@ pub mod utils;
 /// 0x1-- account address where Move stdlib modules are stored
 /// Same as the ObjectID
 pub const MOVE_STDLIB_ADDRESS: AccountAddress = AccountAddress::ONE;
+pub const MOVE_STDLIB_OBJECT_ID: ObjectID = ObjectID::from_single_byte(1);
 
 /// 0x2-- account address where sui framework modules are stored
 /// Same as the ObjectID


### PR DESCRIPTION
- The code for the Sui Framework and Move stdlib will live directly in the validator binary, so using these won't actually trigger an on-chain read. No need to charge users for this.
- For Sui Framework developers, it's quite cumbersome to change the gas snapshot tests every time code in the Sui Framework changes (since it tweaks the loading cost). This is a pain for us today, but in the future it will also be a pain for third-party devs--a change in the size of the Sui Framework due to a framework upgrade will change the gas cost for a dependent package `P` even if the actual functions called by `P` are unchanged by the upgrade. This PR alleviates both the present and future pain.

One thing I am worried about: how do we currently charge for loading package deps? I want to make sure we also don't charge for loading these packages if (e.g.) a tx calls `M::f()` and `M` directly on indirectly depends on the Sui Framework (as it commonly will). It doesn't look like my changes will handle this case, but I can't find the code that charges for loading deps.

[Edited: this gets charged by looking at every loaded object (including packages) at the end of the tx and charging accordingly. The change here thus does the right thing w.r.t transitive deps.]