### PR TITLE
[Faucet] Fix current_requests_in_flight metrics

### DIFF
--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -119,7 +119,10 @@ where
     fn call(&mut self, req: Request<Body>) -> Self::Future {
         let started_at = Instant::now();
         let metrics = self.metrics.clone();
-        let mut inner = self.inner.clone();
+        let clone = self.inner.clone();
+        // take the service that was ready
+        // https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
+        let mut inner = std::mem::replace(&mut self.inner, clone);
         let whitelist = self.method_whitelist.clone();
 
         let res_fut = async move {


### PR DESCRIPTION
We have observed a monotonic increase in the `current_requests_in_flight` in the prometheus dashboard. It is highly likely due to the fact that when the client connection is closed in the [middle](https://github.com/MystenLabs/sui/blob/main/crates/sui-faucet/src/metrics_layer.rs#L74-L77) of the request metrics middleware, the response future will be dropped and `current_requests_in_flight.dec()` will never be called

## Testing
 

Start validators, full node and faucet:
```
sui$ ./target/debug/sui genesis -f
sui$ ./target/debug/sui start
Start faucet with restricted resources:

sui$ ./target/debug/sui-faucet 
```

Send some requests to the faucet 
```
curl --location --request POST 'http://127.0.0.1:5003/gas' \
--header 'Content-Type: application/json' \
--data-raw '{
    "FixedAmountRequest": {
        "recipient": "D319FF9E39F619823D7B7D1F6E896B817AA1B113"
    }
}'
```

Open http://localhost:9184/metrics in browser, and see the following metrics

```
# HELP current_executions_in_flight Current number of transactions being executed in Faucet
# TYPE current_executions_in_flight gauge
current_executions_in_flight 0
# HELP current_requests_in_flight Current number of requests being processed in Faucet
# TYPE current_requests_in_flight gauge
current_requests_in_flight 0
# HELP process_latency Latency of processing a Faucet request
# TYPE process_latency histogram
process_latency_bucket{le="0.001"} 0
process_latency_bucket{le="0.005"} 0
process_latency_bucket{le="0.01"} 0
process_latency_bucket{le="0.05"} 5
process_latency_bucket{le="0.1"} 7
process_latency_bucket{le="0.5"} 7
process_latency_bucket{le="1"} 7
process_latency_bucket{le="2.5"} 7
process_latency_bucket{le="5"} 7
process_latency_bucket{le="10"} 7
process_latency_bucket{le="20"} 7
process_latency_bucket{le="30"} 7
process_latency_bucket{le="60"} 7
process_latency_bucket{le="90"} 7
process_latency_bucket{le="+Inf"} 7
process_latency_sum 0.38282945500000004
process_latency_count 7
# HELP total_available_coins Total number of available coins in queue
# TYPE total_available_coins gauge
total_available_coins 5
# HELP total_discarded_coins Total number of discarded coins
# TYPE total_discarded_coins gauge
total_discarded_coins 0
# HELP total_requests_failed Total number of requests that started but failed with an uncaught error
# TYPE total_requests_failed counter
total_requests_failed 0
# HELP total_requests_received Total number of requests received in Faucet
# TYPE total_requests_received counter
total_requests_received 7
# HELP total_requests_shed Total number of requests that were dropped because the service was saturated
# TYPE total_requests_shed counter
total_requests_shed 0
# HELP total_requests_succeeded Total number of requests processed successfully in Faucet
# TYPE total_requests_succeeded counter
total_requests_succeeded 7
# HELP uptime uptime of the node service in seconds
# TYPE uptime counter
uptime{version="0.20.0-64de41173"} 1052
```
verify that `current_executions_in_flight` is 0