### PR TITLE
[explorer] Deprecate Longtext, remove most usage of it

### DIFF
--- a/apps/explorer/src/components/events/eventDisplay.tsx
+++ b/apps/explorer/src/components/events/eventDisplay.tsx
@@ -16,6 +16,7 @@ import { getOwnerStr } from '../../utils/objectUtils';
 import { truncate } from '../../utils/stringUtils';
 
 import type { Category } from '../../pages/transaction-result/TransactionResultType';
+import type { LinkObj } from '../transaction-card/TxCardUtils';
 import type {
     MoveEvent,
     NewObjectEvent,
@@ -28,7 +29,6 @@ import type {
     CoinBalanceChangeEvent,
     MutateObjectEvent,
 } from '@mysten/sui.js';
-import type { LinkObj } from '~/ui/TableCard';
 
 export type ContentItem = {
     label: string;
@@ -187,15 +187,15 @@ export function coinBalanceChangeEventDisplay(
 }
 
 export function getAddressesLinks(item: ContentItem[]): LinkObj[] {
-    return item.map((content) => {
-        return {
-            url: content.value,
-            name: truncate(content.value, 20),
-            copy: false,
-            category: content.category,
-            isLink: true,
-        } as LinkObj;
-    });
+    return item
+        .filter((itm) => !!itm.category)
+        .map((content) => {
+            return {
+                url: content.value,
+                name: truncate(content.value, 20),
+                category: content.category,
+            } as LinkObj;
+        });
 }
 
 export function deleteObjectEventDisplay(

--- a/apps/explorer/src/components/longtext/Longtext.tsx
+++ b/apps/explorer/src/components/longtext/Longtext.tsx
@@ -17,6 +17,7 @@ import styles from './Longtext.module.css';
 import { Link } from '~/ui/Link';
 import { useNavigateWithQuery } from '~/ui/utils/LinkWithQuery';
 
+/** @deprecated Use new UI components instead of Longtext. */
 function Longtext({
     text,
     category = 'unknown',

--- a/apps/explorer/src/components/ownedobjects/views/OwnedCoinView.tsx
+++ b/apps/explorer/src/components/ownedobjects/views/OwnedCoinView.tsx
@@ -6,13 +6,13 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { ReactComponent as OpenIcon } from '../../../assets/SVGIcons/12px/ShowNHideDown.svg';
 import { ReactComponent as ClosedIcon } from '../../../assets/SVGIcons/12px/ShowNHideRight.svg';
-import Longtext from '../../longtext/Longtext';
 import Pagination from '../../pagination/Pagination';
 import { type DataType, ITEMS_PER_PAGE } from '../OwnedObjectConstants';
 
 import styles from '../styles/OwnedCoin.module.css';
 
 import { useFormatCoin } from '~/hooks/useFormatCoin';
+import { ObjectLink } from '~/ui/InternalLink';
 
 function CoinItem({
     id,
@@ -30,7 +30,7 @@ function CoinItem({
             <div className={styles.openrow}>
                 <div className={styles.label}>Object ID</div>
                 <div className={`${styles.oneline} ${styles.value}`}>
-                    <Longtext text={id} category="object" />
+                    <ObjectLink objectId={id} noTruncate />
                 </div>
             </div>
             <div className={styles.openrow}>

--- a/apps/explorer/src/components/ownedobjects/views/OwnedNFTView.tsx
+++ b/apps/explorer/src/components/ownedobjects/views/OwnedNFTView.tsx
@@ -1,12 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { trimStdLibPrefix, alttextgen } from '../../../utils/stringUtils';
+import { trimStdLibPrefix } from '../../../utils/stringUtils';
 import DisplayBox from '../../displaybox/DisplayBox';
-import Longtext from '../../longtext/Longtext';
 import { type DataType } from '../OwnedObjectConstants';
 
 import styles from '../styles/OwnedObjects.module.css';
+
+import { ObjectLink } from '~/ui/InternalLink';
 
 export default function OwnedNFTView({ results }: { results: DataType }) {
     return (
@@ -21,11 +22,7 @@ export default function OwnedNFTView({ results }: { results: DataType }) {
                             <div className={styles.name}>{entryObj.name}</div>
                         )}
                         <div>
-                            <Longtext
-                                text={entryObj.id}
-                                category="object"
-                                alttext={alttextgen(entryObj.id)}
-                            />
+                            <ObjectLink objectId={entryObj.id} />
                         </div>
                         <div className={styles.typevalue}>
                             {trimStdLibPrefix(entryObj.Type)}

--- a/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
@@ -19,7 +19,6 @@ import {
 import { Fragment } from 'react';
 
 import { ReactComponent as ContentArrowRight } from '../../assets/SVGIcons/16px/ArrowRight.svg';
-import Longtext from '../../components/longtext/Longtext';
 import { getAmount } from '../../utils/getAmount';
 import { deduplicate } from '../../utils/searchUtil';
 import { truncate } from '../../utils/stringUtils';
@@ -28,6 +27,7 @@ import { TxTimeType } from '../tx-time/TxTimeType';
 import styles from './RecentTxCard.module.css';
 
 import { useFormatCoin } from '~/hooks/useFormatCoin';
+import { AddressLink, ObjectLink, TransactionLink } from '~/ui/InternalLink';
 import { TransactionType } from '~/ui/TransactionType';
 
 export type TxnData = {
@@ -42,15 +42,13 @@ export type TxnData = {
     timestamp_ms?: number;
 };
 
+type Category = 'object' | 'transaction' | 'address';
+
 export type LinkObj = {
     url: string;
     name?: string;
-    copy?: boolean;
     category?: Category;
-    isLink?: boolean;
 };
-
-type Category = 'object' | 'transaction' | 'address' | 'unknown';
 
 export function SuiAmount({
     amount,
@@ -80,13 +78,13 @@ export function TxAddresses({ content }: { content: LinkObj[] }) {
         <section className={styles.addresses}>
             {content.map((itm, idx) => (
                 <Fragment key={idx + itm.url}>
-                    <Longtext
-                        text={itm.url}
-                        alttext={itm.name}
-                        category={itm.category || 'unknown'}
-                        isLink={itm?.isLink}
-                        copyButton={itm?.copy ? '16' : 'none'}
-                    />
+                    {itm.category === 'address' ? (
+                        <AddressLink address={itm.url} />
+                    ) : itm.category === 'object' ? (
+                        <ObjectLink objectId={itm.url} />
+                    ) : (
+                        <TransactionLink digest={itm.url} />
+                    )}
                     {idx !== content.length - 1 && <ContentArrowRight />}
                 </Fragment>
             ))}
@@ -109,8 +107,6 @@ export const genTableDataFromTxData = (
                             url: txn.txId,
                             name: truncate(txn.txId, truncateLength),
                             category: 'transaction',
-                            isLink: true,
-                            copy: false,
                         },
                     ]}
                 />
@@ -122,8 +118,6 @@ export const genTableDataFromTxData = (
                             url: txn.From,
                             name: truncate(txn.From, truncateLength),
                             category: 'address',
-                            isLink: true,
-                            copy: false,
                         },
                         ...(txn.To
                             ? [
@@ -131,8 +125,6 @@ export const genTableDataFromTxData = (
                                       url: txn.To,
                                       name: truncate(txn.To, truncateLength),
                                       category: 'address',
-                                      isLink: true,
-                                      copy: false,
                                   } as const,
                               ]
                             : []),

--- a/apps/explorer/src/pages/object-result/views/PkgView.tsx
+++ b/apps/explorer/src/pages/object-result/views/PkgView.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 import { ErrorBoundary } from '../../../components/error-boundary/ErrorBoundary';
-import Longtext from '../../../components/longtext/Longtext';
 import PkgModulesWrapper from '../../../components/module/PkgModulesWrapper';
 import TxForID from '../../../components/transaction-card/TxForID';
 import { getOwnerStr } from '../../../utils/objectUtils';
@@ -11,6 +10,7 @@ import { type DataType } from '../ObjectResultType';
 import styles from './ObjectView.module.css';
 
 import { Heading } from '~/ui/Heading';
+import { AddressLink, ObjectLink } from '~/ui/InternalLink';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
 
 function PkgView({ data }: { data: DataType }) {
@@ -20,10 +20,6 @@ function PkgView({ data }: { data: DataType }) {
         tx_digest: data.data.tx_digest,
         owner: getOwnerStr(data.owner),
     };
-
-    const isPublisherGenesis =
-        viewedData.objType === 'Move Package' &&
-        viewedData?.publisherAddress === 'Genesis';
 
     const checkIsPropertyType = (value: any) =>
         ['number', 'string'].includes(typeof value);
@@ -52,10 +48,9 @@ function PkgView({ data }: { data: DataType }) {
                                             id="objectID"
                                             className={styles.objectid}
                                         >
-                                            <Longtext
-                                                text={viewedData.id}
-                                                category="object"
-                                                isLink={false}
+                                            <ObjectLink
+                                                objectId={viewedData.id}
+                                                noTruncate
                                             />
                                         </td>
                                     </tr>
@@ -69,12 +64,11 @@ function PkgView({ data }: { data: DataType }) {
                                         <tr>
                                             <td>Publisher</td>
                                             <td id="lasttxID">
-                                                <Longtext
-                                                    text={
+                                                <AddressLink
+                                                    address={
                                                         viewedData.publisherAddress
                                                     }
-                                                    category="address"
-                                                    isLink={!isPublisherGenesis}
+                                                    noTruncate
                                                 />
                                             </td>
                                         </tr>

--- a/apps/explorer/src/pages/object-result/views/TokenView.tsx
+++ b/apps/explorer/src/pages/object-result/views/TokenView.tsx
@@ -25,7 +25,7 @@ import { type DataType } from '../ObjectResultType';
 import styles from './ObjectView.module.css';
 
 import { Link } from '~/ui/Link';
-import { LinkWithQuery } from '~/ui/utils/LinkWithQuery';
+import { ObjectLink, TransactionLink } from '~/ui/InternalLink';
 
 function TokenView({ data }: { data: DataType }) {
     const viewedData = {
@@ -88,21 +88,21 @@ function TokenView({ data }: { data: DataType }) {
                             <tr>
                                 <td>Type</td>
                                 <td>
-                                    <LinkWithQuery
+                                    {/* TODO: Support module links on `ObjectLink` */}
+                                    <Link
                                         to={genhref(viewedData.objType)}
-                                        className={styles.objecttypelink}
+                                        variant="mono"
                                     >
                                         {trimStdLibPrefix(viewedData.objType)}
-                                    </LinkWithQuery>
+                                    </Link>
                                 </td>
                             </tr>
                             <tr>
                                 <td>Object ID</td>
                                 <td id="objectID" className={styles.objectid}>
-                                    <Longtext
-                                        text={viewedData.id}
-                                        category="object"
-                                        isLink={false}
+                                    <ObjectLink
+                                        objectId={viewedData.id}
+                                        noTruncate
                                     />
                                 </td>
                             </tr>
@@ -111,10 +111,9 @@ function TokenView({ data }: { data: DataType }) {
                                 <tr>
                                     <td>Last Transaction ID</td>
                                     <td>
-                                        <Longtext
-                                            text={viewedData.tx_digest}
-                                            category="transaction"
-                                            isLink
+                                        <TransactionLink
+                                            digest={viewedData.tx_digest}
+                                            noTruncate
                                         />
                                     </td>
                                 </tr>

--- a/apps/explorer/src/pages/object-result/views/TokenView.tsx
+++ b/apps/explorer/src/pages/object-result/views/TokenView.tsx
@@ -145,10 +145,10 @@ function TokenView({ data }: { data: DataType }) {
                                 <tr>
                                     <td>Contract ID</td>
                                     <td>
-                                        <Longtext
-                                            text={viewedData.contract_id.bytes}
-                                            category="object"
-                                            isLink
+                                        <ObjectLink
+                                            objectId={
+                                                viewedData.contract_id.bytes
+                                            }
                                         />
                                     </td>
                                 </tr>

--- a/apps/explorer/src/pages/object-result/views/TokenView.tsx
+++ b/apps/explorer/src/pages/object-result/views/TokenView.tsx
@@ -24,8 +24,8 @@ import { type DataType } from '../ObjectResultType';
 
 import styles from './ObjectView.module.css';
 
-import { Link } from '~/ui/Link';
 import { ObjectLink, TransactionLink } from '~/ui/InternalLink';
+import { Link } from '~/ui/Link';
 
 function TokenView({ data }: { data: DataType }) {
     const viewedData = {

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -328,9 +328,9 @@ function TransactionView({
         );
     });
 
-    let eventTitlesDisplay = eventTitles.map((et) => (
-        <div key={et[1]} className={styles.eventtitle}>
-            <Longtext text={et[0]} category="unknown" isLink={false} />
+    let eventTitlesDisplay = eventTitles.map(([title, key]) => (
+        <div key={key} className={styles.eventtitle}>
+            {title}
         </div>
     ));
 

--- a/apps/explorer/src/pages/transaction-result/TxLinks.tsx
+++ b/apps/explorer/src/pages/transaction-result/TxLinks.tsx
@@ -4,13 +4,11 @@
 import cl from 'clsx';
 import { useState, useCallback } from 'react';
 
-import Longtext from '../../components/longtext/Longtext';
-
-import type { Category } from './TransactionResultType';
 import type { SuiObjectRef } from '@mysten/sui.js';
 
 import styles from './TxLinks.module.css';
 
+import { ObjectLink } from '~/ui/InternalLink';
 import { IconTooltip } from '~/ui/Tooltip';
 
 type Addresslist = {
@@ -38,17 +36,17 @@ function TxLinks({ data }: { data: Addresslist }) {
                         )
                         .map((obj, idx) => (
                             <li key={idx}>
-                                <Longtext
-                                    text={obj.objectId}
-                                    category={data?.category as Category}
-                                    isLink
-                                    copyButton="16"
-                                    extra={
+                                <div className="inline-flex items-center gap-1.5">
+                                    <ObjectLink
+                                        objectId={obj.objectId}
+                                        noTruncate
+                                    />
+                                    <div className="h-4 w-4 leading-none text-gray-60 hover:text-steel">
                                         <IconTooltip
                                             tip={`VERSION ${obj.version}`}
                                         />
-                                    }
-                                />
+                                    </div>
+                                </div>
                             </li>
                         ))}
                 </ul>

--- a/apps/explorer/src/ui/InternalLink.tsx
+++ b/apps/explorer/src/ui/InternalLink.tsx
@@ -3,32 +3,70 @@
 
 import { formatAddress } from '../utils/stringUtils';
 
-import { Link } from '~/ui/Link';
+import { Link, type LinkProps } from '~/ui/Link';
 
-export type AddressLinkProps = {
+export interface AddressLinkProps extends LinkProps {
     address: string;
     noTruncate?: boolean;
-};
+}
 
-export type ObjectLinkProps = {
+export interface ObjectLinkProps extends LinkProps {
     objectId: string;
     noTruncate?: boolean;
-};
+}
 
-export function AddressLink({ address, noTruncate }: AddressLinkProps) {
+export interface TransactionLinkProps extends LinkProps {
+    digest: string;
+    noTruncate?: boolean;
+}
+
+export function AddressLink({
+    address,
+    noTruncate,
+    ...props
+}: AddressLinkProps) {
     const truncatedAddress = noTruncate ? address : formatAddress(address);
     return (
-        <Link variant="mono" to={`/address/${encodeURIComponent(address)}`}>
+        <Link
+            variant="mono"
+            to={`/address/${encodeURIComponent(address)}`}
+            {...props}
+        >
             {truncatedAddress}
         </Link>
     );
 }
 
-export function ObjectLink({ objectId, noTruncate }: ObjectLinkProps) {
+export function ObjectLink({
+    objectId,
+    noTruncate,
+    ...props
+}: ObjectLinkProps) {
     const truncatedObjectId = noTruncate ? objectId : formatAddress(objectId);
     return (
-        <Link variant="mono" to={`/object/${encodeURIComponent(objectId)}`}>
+        <Link
+            variant="mono"
+            to={`/object/${encodeURIComponent(objectId)}`}
+            {...props}
+        >
             {truncatedObjectId}
+        </Link>
+    );
+}
+
+export function TransactionLink({
+    digest,
+    noTruncate,
+    ...props
+}: TransactionLinkProps) {
+    const truncatedDigest = noTruncate ? digest : formatAddress(digest);
+    return (
+        <Link
+            variant="mono"
+            to={`/transaction/${encodeURIComponent(digest)}`}
+            {...props}
+        >
+            {truncatedDigest}
         </Link>
     );
 }

--- a/apps/explorer/src/ui/Link.tsx
+++ b/apps/explorer/src/ui/Link.tsx
@@ -8,13 +8,13 @@ import { ButtonOrLink, type ButtonOrLinkProps } from './utils/ButtonOrLink';
 const linkStyles = cva(
     [
         // TODO: Remove when CSS reset is applied.
-        'cursor-pointer no-underline bg-transparent p-0 border-none',
+        'cursor-pointer no-underline bg-transparent p-0 border-none text-left',
     ],
     {
         variants: {
             variant: {
                 text: 'text-body font-semibold text-steel-dark hover:text-steel-darker active:text-steel disabled:text-gray-60',
-                mono: 'font-mono text-bodySmall font-medium text-sui-dark',
+                mono: 'font-mono text-bodySmall font-medium text-sui-dark break-all',
             },
             uppercase: {
                 true: 'uppercase',


### PR DESCRIPTION
This formally deprecates the `Longtext` component, and removes most of the usage of it. This component became the everything component, and our new goal is to make smaller easier to compose components instead. The only remaining usage is for the "unknown" category case, which should mostly be removed once we finish up search disambiguation.