### PR TITLE
[explorer] Use before send in sentry

### DIFF
--- a/apps/explorer/src/index.tsx
+++ b/apps/explorer/src/index.tsx
@@ -35,6 +35,7 @@ if (import.meta.env.PROD) {
             try {
                 // Filter out any code from unknown sources:
                 if (
+                    !event.exception?.values?.[0].stacktrace ||
                     event.exception?.values?.[0].stacktrace?.frames?.[0]
                         .filename === '<anonymous>'
                 ) {

--- a/apps/explorer/src/index.tsx
+++ b/apps/explorer/src/index.tsx
@@ -31,6 +31,20 @@ if (import.meta.env.PROD) {
         tracesSampler: () => {
             return growthbook.getFeatureValue('explorer-sentry-tracing', 0);
         },
+        beforeSend(event) {
+            try {
+                // Filter out any code from unknown sources:
+                if (
+                    event.exception?.values?.[0].stacktrace?.frames?.[0]
+                        .filename === '<anonymous>'
+                ) {
+                    return null;
+                }
+            } catch (e) {}
+
+            return event;
+        },
+
         denyUrls: [
             // Chrome extensions
             /extensions\//i,


### PR DESCRIPTION
This uses `beforeSend` to avoid sending errors with an `<anonymous>` source, which is generally injected code from extensions.