### PR TITLE
crypto: Add back bls keytool generate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ tsconfig.tsbuildinfo
 wallet.log.*
 sui.log.*
 .vercel
+
+# misc
+*.key

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -291,3 +291,14 @@ fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
     Ok(())
 }
+
+#[test]
+fn test_keytool_bls12381() -> Result<(), anyhow::Error> {
+    let mut keystore = Keystore::from(InMemKeystore::new(0));
+    KeyToolCommand::Generate {
+        key_scheme: SignatureScheme::BLS12381,
+        derivation_path: None,
+    }
+    .execute(&mut keystore)?;
+    Ok(())
+}


### PR DESCRIPTION
add back the BLS keytool generate that is removed by https://github.com/MystenLabs/sui/pull/6638