### PR TITLE
[JSON-RPC API] - Make coin read api more intuitive  

### DIFF
--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -37,13 +37,13 @@ pub const QUERY_MAX_RESULT_LIMIT: usize = 1000;
 #[open_rpc(namespace = "sui", tag = "Coin Query API")]
 #[rpc(server, client, namespace = "sui")]
 pub trait CoinReadApi {
-    /// Return the list of Coin objects owned by an address.
+    /// Return all Coin<`coin_type`> objects owned by an address.
     #[method(name = "getCoins")]
     async fn get_coins(
         &self,
         /// the owner's Sui address
         owner: SuiAddress,
-        /// fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC)
+        /// optional fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC), default to 0x2::sui::SUI if not specified.
         coin_type: Option<String>,
         /// optional paging cursor
         cursor: Option<ObjectID>,
@@ -51,14 +51,34 @@ pub trait CoinReadApi {
         limit: Option<usize>,
     ) -> RpcResult<CoinPage>;
 
-    /// Return the total coin balance for each coin type.
-    #[method(name = "getBalance")]
-    async fn get_balances(
+    /// Return all Coin objects owned by an address.
+    #[method(name = "getAllCoins")]
+    async fn get_all_coins(
         &self,
         /// the owner's Sui address
         owner: SuiAddress,
-        /// fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC)
+        /// optional paging cursor
+        cursor: Option<ObjectID>,
+        /// maximum number of items per page
+        limit: Option<usize>,
+    ) -> RpcResult<CoinPage>;
+
+    /// Return the total coin balance for one coin type, owned by the address owner.
+    #[method(name = "getBalance")]
+    async fn get_balance(
+        &self,
+        /// the owner's Sui address
+        owner: SuiAddress,
+        /// optional fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC), default to 0x2::sui::SUI if not specified.
         coin_type: Option<String>,
+    ) -> RpcResult<Balance>;
+
+    /// Return the total coin balance for all coin type, owned by the address owner.
+    #[method(name = "getAllBalances")]
+    async fn get_all_balances(
+        &self,
+        /// the owner's Sui address
+        owner: SuiAddress,
     ) -> RpcResult<Vec<Balance>>;
 
     /// Return metadata(e.g., symbol, decimals) for a coin

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -227,16 +227,15 @@ async fn test_get_coins() -> Result<(), anyhow::Error> {
 }
 
 #[sim_test]
-async fn test_get_balances() -> Result<(), anyhow::Error> {
+async fn test_get_balance() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
 
-    let result: Vec<Balance> = http_client.get_balances(*address, None).await?;
-    assert_eq!(1, result.len());
-    assert_eq!("0x2::sui::SUI", result[0].coin_type);
-    assert_eq!(500000000000000, result[0].total_balance);
-    assert_eq!(5, result[0].coin_object_count);
+    let result: Balance = http_client.get_balance(*address, None).await?;
+    assert_eq!("0x2::sui::SUI", result.coin_type);
+    assert_eq!(500000000000000, result.total_balance);
+    assert_eq!(5, result.coin_object_count);
 
     Ok(())
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -520,13 +520,13 @@
       ]
     },
     {
-      "name": "sui_getBalance",
+      "name": "sui_getAllBalances",
       "tags": [
         {
           "name": "Coin Query API"
         }
       ],
-      "description": "Return the total coin balance for each coin type.",
+      "description": "Return the total coin balance for all coin type, owned by the address owner.",
       "params": [
         {
           "name": "owner",
@@ -534,13 +534,6 @@
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/SuiAddress"
-          }
-        },
-        {
-          "name": "coin_type",
-          "description": "fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC)",
-          "schema": {
-            "type": "string"
           }
         }
       ],
@@ -552,6 +545,81 @@
           "items": {
             "$ref": "#/components/schemas/Balance"
           }
+        }
+      }
+    },
+    {
+      "name": "sui_getAllCoins",
+      "tags": [
+        {
+          "name": "Coin Query API"
+        }
+      ],
+      "description": "Return all Coin objects owned by an address.",
+      "params": [
+        {
+          "name": "owner",
+          "description": "the owner's Sui address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        },
+        {
+          "name": "cursor",
+          "description": "optional paging cursor",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "limit",
+          "description": "maximum number of items per page",
+          "schema": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "CoinPage",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/Page_for_Coin_and_ObjectID"
+        }
+      }
+    },
+    {
+      "name": "sui_getBalance",
+      "tags": [
+        {
+          "name": "Coin Query API"
+        }
+      ],
+      "description": "Return the total coin balance for one coin type, owned by the address owner.",
+      "params": [
+        {
+          "name": "owner",
+          "description": "the owner's Sui address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        },
+        {
+          "name": "coin_type",
+          "description": "optional fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC), default to 0x2::sui::SUI if not specified.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "Balance",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/Balance"
         }
       }
     },
@@ -588,7 +656,7 @@
           "name": "Coin Query API"
         }
       ],
-      "description": "Return the list of Coin objects owned by an address.",
+      "description": "Return all Coin<`coin_type`> objects owned by an address.",
       "params": [
         {
           "name": "owner",
@@ -600,7 +668,7 @@
         },
         {
           "name": "coin_type",
-          "description": "fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC)",
+          "description": "optional fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC), default to 0x2::sui::SUI if not specified.",
           "schema": {
             "type": "string"
           }

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -199,6 +199,15 @@ impl CoinReadApi {
             .await?)
     }
 
+    pub async fn get_all_coins(
+        &self,
+        owner: SuiAddress,
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+    ) -> SuiRpcResult<CoinPage> {
+        Ok(self.api.http.get_all_coins(owner, cursor, limit).await?)
+    }
+
     pub fn get_coins_stream(
         &self,
         owner: SuiAddress,
@@ -225,12 +234,16 @@ impl CoinReadApi {
         )
     }
 
-    pub async fn get_balances(
+    pub async fn get_balance(
         &self,
         owner: SuiAddress,
         coin_type: Option<String>,
-    ) -> SuiRpcResult<Vec<Balance>> {
-        Ok(self.api.http.get_balances(owner, coin_type).await?)
+    ) -> SuiRpcResult<Balance> {
+        Ok(self.api.http.get_balance(owner, coin_type).await?)
+    }
+
+    pub async fn get_all_balances(&self, owner: SuiAddress) -> SuiRpcResult<Vec<Balance>> {
+        Ok(self.api.http.get_all_balances(owner).await?)
     }
 
     pub async fn get_coin_metadata(&self, coin_type: String) -> SuiRpcResult<SuiCoinMetadata> {


### PR DESCRIPTION
* change get_coins and get_balance to get_coins, get_all_coins and get_balance, get_all_balance to make it more intuitive
* get_coins and get_balance will return coins and balance for 0x2::Sui::SUI by default if coin_type not specified.