### PR TITLE
[reconfig] Initiate reconfig every N checkpoints

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::node::default_checkpoints_per_epoch;
 use crate::{
     genesis,
     genesis_config::{GenesisConfig, ValidatorConfigInfo, ValidatorGenesisInfo},
@@ -312,6 +313,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     enable_event_processing: false,
                     enable_checkpoint: false,
                     enable_reconfig: false,
+                    checkpoints_per_epoch: default_checkpoints_per_epoch(),
                     genesis: crate::node::Genesis::new(genesis.clone()),
                     grpc_load_shed: initial_accounts_config.grpc_load_shed,
                     grpc_concurrency_limit: initial_accounts_config.grpc_concurrency_limit,

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -312,7 +312,6 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     consensus_config: Some(consensus_config),
                     enable_event_processing: false,
                     enable_checkpoint: false,
-                    enable_reconfig: false,
                     checkpoints_per_epoch: default_checkpoints_per_epoch(),
                     genesis: crate::node::Genesis::new(genesis.clone()),
                     grpc_load_shed: initial_accounts_config.grpc_load_shed,

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -30,6 +30,8 @@ use sui_types::sui_serde::KeyPairBase64;
 // Default max number of concurrent requests served
 pub const DEFAULT_GRPC_CONCURRENCY_LIMIT: usize = 20000000000;
 
+pub const DEFAULT_CHECKPOINTS_PER_EPOCH: u64 = 1200;
+
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -70,6 +72,11 @@ pub struct NodeConfig {
 
     #[serde(default)]
     pub enable_reconfig: bool,
+
+    /// Number of checkpoints per epoch. Exposing this in config to allow easier testing.
+    /// It will be removed down the road.
+    #[serde(default = "default_checkpoints_per_epoch")]
+    pub checkpoints_per_epoch: u64,
 
     #[serde(default)]
     pub grpc_load_shed: Option<bool>,
@@ -121,6 +128,10 @@ pub fn default_websocket_address() -> Option<SocketAddr> {
 
 pub fn default_concurrency_limit() -> Option<usize> {
     Some(DEFAULT_GRPC_CONCURRENCY_LIMIT)
+}
+
+pub fn default_checkpoints_per_epoch() -> u64 {
+    DEFAULT_CHECKPOINTS_PER_EPOCH
 }
 
 pub fn bool_true() -> bool {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -30,8 +30,6 @@ use sui_types::sui_serde::KeyPairBase64;
 // Default max number of concurrent requests served
 pub const DEFAULT_GRPC_CONCURRENCY_LIMIT: usize = 20000000000;
 
-pub const DEFAULT_CHECKPOINTS_PER_EPOCH: u64 = 1200;
-
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -70,13 +68,13 @@ pub struct NodeConfig {
     #[serde(default)]
     pub enable_checkpoint: bool,
 
-    #[serde(default)]
-    pub enable_reconfig: bool,
-
-    /// Number of checkpoints per epoch. Exposing this in config to allow easier testing.
-    /// It will be removed down the road.
+    /// Number of checkpoints per epoch.
+    /// Some means reconfiguration is enabled.
+    /// None means reconfiguration is disabled.
+    /// Exposing this in config to allow easier testing with shorter epoch.
+    /// TODO: It will be removed down the road.
     #[serde(default = "default_checkpoints_per_epoch")]
-    pub checkpoints_per_epoch: u64,
+    pub checkpoints_per_epoch: Option<u64>,
 
     #[serde(default)]
     pub grpc_load_shed: Option<bool>,
@@ -130,8 +128,8 @@ pub fn default_concurrency_limit() -> Option<usize> {
     Some(DEFAULT_GRPC_CONCURRENCY_LIMIT)
 }
 
-pub fn default_checkpoints_per_epoch() -> u64 {
-    DEFAULT_CHECKPOINTS_PER_EPOCH
+pub fn default_checkpoints_per_epoch() -> Option<u64> {
+    None
 }
 
 pub fn bool_true() -> bool {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -193,7 +193,6 @@ impl<'a> FullnodeConfigBuilder<'a> {
             consensus_config: None,
             enable_event_processing: self.enable_event_store,
             enable_checkpoint: false,
-            enable_reconfig: false,
             checkpoints_per_epoch: default_checkpoints_per_epoch(),
             genesis: validator_config.genesis.clone(),
             grpc_load_shed: None,

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::node::default_checkpoints_per_epoch;
 use crate::p2p::{P2pConfig, SeedPeer};
 use crate::{builder, genesis, utils, Config, NodeConfig, ValidatorInfo};
 use fastcrypto::traits::KeyPair;
@@ -193,6 +194,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             enable_event_processing: self.enable_event_store,
             enable_checkpoint: false,
             enable_reconfig: false,
+            checkpoints_per_epoch: default_checkpoints_per_epoch(),
             genesis: validator_config.genesis.clone(),
             grpc_load_shed: None,
             grpc_concurrency_limit: None,

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -44,8 +44,7 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
     enable-event-processing: false
     enable-checkpoint: false
-    enable-reconfig: false
-    checkpoints-per-epoch: 1200
+    checkpoints-per-epoch: ~
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -93,8 +92,7 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
     enable-event-processing: false
     enable-checkpoint: false
-    enable-reconfig: false
-    checkpoints-per-epoch: 1200
+    checkpoints-per-epoch: ~
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -142,8 +140,7 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
     enable-event-processing: false
     enable-checkpoint: false
-    enable-reconfig: false
-    checkpoints-per-epoch: 1200
+    checkpoints-per-epoch: ~
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -191,8 +188,7 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
     enable-event-processing: false
     enable-checkpoint: false
-    enable-reconfig: false
-    checkpoints-per-epoch: 1200
+    checkpoints-per-epoch: ~
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -240,8 +236,7 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
     enable-event-processing: false
     enable-checkpoint: false
-    enable-reconfig: false
-    checkpoints-per-epoch: 1200
+    checkpoints-per-epoch: ~
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -289,8 +284,7 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
     enable-event-processing: false
     enable-checkpoint: false
-    enable-reconfig: false
-    checkpoints-per-epoch: 1200
+    checkpoints-per-epoch: ~
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -338,8 +332,7 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
     enable-event-processing: false
     enable-checkpoint: false
-    enable-reconfig: false
-    checkpoints-per-epoch: 1200
+    checkpoints-per-epoch: ~
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -45,6 +45,7 @@ validator_configs:
     enable-event-processing: false
     enable-checkpoint: false
     enable-reconfig: false
+    checkpoints-per-epoch: 1200
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -93,6 +94,7 @@ validator_configs:
     enable-event-processing: false
     enable-checkpoint: false
     enable-reconfig: false
+    checkpoints-per-epoch: 1200
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -141,6 +143,7 @@ validator_configs:
     enable-event-processing: false
     enable-checkpoint: false
     enable-reconfig: false
+    checkpoints-per-epoch: 1200
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -189,6 +192,7 @@ validator_configs:
     enable-event-processing: false
     enable-checkpoint: false
     enable-reconfig: false
+    checkpoints-per-epoch: 1200
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -237,6 +241,7 @@ validator_configs:
     enable-event-processing: false
     enable-checkpoint: false
     enable-reconfig: false
+    checkpoints-per-epoch: 1200
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -285,6 +290,7 @@ validator_configs:
     enable-event-processing: false
     enable-checkpoint: false
     enable-reconfig: false
+    checkpoints-per-epoch: 1200
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -333,6 +339,7 @@ validator_configs:
     enable-event-processing: false
     enable-checkpoint: false
     enable-reconfig: false
+    checkpoints-per-epoch: 1200
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -346,3 +353,4 @@ account_keys:
   - cHifntmjxd4QLaC71WRMoOeCpvicyDJMbTKRuo2v3R9UjI8DXP6RwO6c5B70OPjZEdiV0XB+RVfcjX6/JKfZeg==
   - mTzV/JVz4RdheOnQVFF3xuCPFF4AYAPyShHQCUizJX9pHbCeXB5wKAz9LCwtuoC4PCML0v4vko2/c16HlmPrbQ==
 genesis: "[fake genesis]"
+

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
+use sui_types::error::SuiResult;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ReconfigCertStatus {
@@ -45,6 +46,11 @@ impl ReconfigState {
     pub fn should_accept_consensus_certs(&self) -> bool {
         !matches!(self.status, ReconfigCertStatus::RejectAllCerts)
     }
+}
+
+#[async_trait::async_trait]
+pub trait ReconfigurationInitiator {
+    async fn close_epoch(&self) -> SuiResult;
 }
 
 /*

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -441,6 +441,8 @@ impl SuiNode {
             sender: consensus_adapter.clone(),
             signer: state.secret.clone(),
             authority: config.protocol_public_key(),
+            enable_reconfig: config.enable_reconfig,
+            checkpoints_per_epoch: config.checkpoints_per_epoch,
         });
 
         let certified_checkpoint_output = SendCheckpointToStateSync::new(state_sync_handle);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -441,7 +441,6 @@ impl SuiNode {
             sender: consensus_adapter.clone(),
             signer: state.secret.clone(),
             authority: config.protocol_public_key(),
-            enable_reconfig: config.enable_reconfig,
             checkpoints_per_epoch: config.checkpoints_per_epoch,
         });
 


### PR DESCRIPTION
This PR adds the initial trigger for starting reconfiguration. It's done at every N checkpoints.
An alternative is to initiate this at some fixed time. However we currently don't have timestamp out of Narwhal yet, and it's significantly more complicated to do this through time. For Wave 2 where we are doing it every ~6 hours, time makes less sense because it's not aligned on days anyway. We could just tune the frequency to match roughly 6 hours when we ship to Wave 2.