### PR TITLE
[tokenomics] Pass storage reinvest rate to advance epoch system call

### DIFF
--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -44,6 +44,7 @@ sui-storage = { path = "../sui-storage" }
 sui-config = { path = "../sui-config" }
 sui-json = { path = "../sui-json" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
+sui-protocol-constants = { path = "../sui-protocol-constants" }
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/crates/sui-core/src/execution_engine.rs
+++ b/crates/sui-core/src/execution_engine.rs
@@ -10,6 +10,7 @@ use sui_types::base_types::SequenceNumber;
 use tracing::{debug, instrument};
 
 use sui_adapter::adapter;
+use sui_protocol_constants::STORAGE_FUND_REINVEST_RATE;
 use sui_types::coin::{transfer_coin, update_input_coins, Coin};
 use sui_types::committee::EpochId;
 use sui_types::error::{ExecutionError, ExecutionErrorKind};
@@ -317,6 +318,7 @@ fn execution_loop<
                         CallArg::Pure(bcs::to_bytes(&storage_charge).unwrap()),
                         CallArg::Pure(bcs::to_bytes(&computation_charge).unwrap()),
                         CallArg::Pure(bcs::to_bytes(&storage_rebate).unwrap()),
+                        CallArg::Pure(bcs::to_bytes(&STORAGE_FUND_REINVEST_RATE).unwrap()),
                     ],
                     gas_status.create_move_gas_status(),
                     tx_ctx,

--- a/crates/sui-protocol-constants/src/lib.rs
+++ b/crates/sui-protocol-constants/src/lib.rs
@@ -24,7 +24,7 @@ pub const MAX_LOOP_DEPTH: usize = 5;
 /// Maximum number of type arguments that can be bound to generic type parameters. Enforced by the Move bytecode verifier.
 pub const MAX_GENERIC_INSTANTIATION_LENGTH: usize = 32;
 
-/// Maximum number of paramters that a Move function can have. Enforced by the Move bytecode verifier.
+/// Maximum number of parameters that a Move function can have. Enforced by the Move bytecode verifier.
 pub const MAX_FUNCTION_PARAMETERS: usize = 128;
 
 /// Maximum number of basic blocks that a Move function can have. Enforced by the Move bytecode verifier.
@@ -97,3 +97,10 @@ pub const OBJ_DATA_COST_REFUNDABLE: u64 = 100;
 // This depends on the size of various fields including the effects
 // TODO: I don't fully understand this^ and more details would be useful
 pub const OBJ_METADATA_COST_NON_REFUNDABLE: u64 = 50;
+
+/// === Tokenomics ===
+
+// TODO: placeholder value here
+pub const STORAGE_REBATE_RATE: f64 = 1.0;
+
+pub const STORAGE_FUND_REINVEST_RATE: u64 = 0;

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -10,6 +10,7 @@ use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use sui_protocol_constants::STORAGE_REBATE_RATE;
 use tracing::trace;
 
 use crate::coin::Coin;
@@ -31,9 +32,6 @@ use crate::{
         WriteKind,
     },
 };
-
-// TODO: placeholder value here
-const STORAGE_REBATE_RATE: f64 = 1.0;
 
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -89,7 +89,8 @@ async fn advance_epoch_tx_test_impl(
         .collect::<anyhow::Result<Vec<_>>>()
         .unwrap();
     for (state, cert) in states.iter().zip(results) {
-        state.execute_certificate_internal(&cert).await.unwrap();
+        let results = state.execute_certificate_internal(&cert).await.unwrap();
+        assert!(results.signed_effects.unwrap().status.is_ok());
     }
 }
 


### PR DESCRIPTION
We forgot to pass the storage reinvest rate to advance epoch system call. Adds a new default rate of 0.
Also move another tokenomics related constant to the protocol constant crate.