### PR TITLE
[JSON-RPC Governance APIs] - New apis for getting delegation/validator information

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -20,7 +20,6 @@ use prometheus::{
     IntCounterVec, IntGauge, Registry,
 };
 use serde::de::DeserializeOwned;
-use std::cmp::Ordering as CmpOrdering;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1936,11 +1936,11 @@ impl AuthorityState {
             .get_owner_objects_iterator(owner)?
             .filter(move |o| Self::matches_type(&ObjectType::Struct(type_.clone()), &o.type_))
             .map(|info| info.object_id);
-        let mut staked_suis = vec![];
+        let mut move_objects = vec![];
         for id in object_ids {
-            staked_suis.push(self.get_move_object(&id).await?)
+            move_objects.push(self.get_move_object(&id).await?)
         }
-        Ok(staked_suis)
+        Ok(move_objects)
     }
 
     fn matches_type(type_: &ObjectType, other_type: &ObjectType) -> bool {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -9,6 +9,7 @@ use fastcrypto::traits::KeyPair;
 use move_bytecode_utils::module_cache::SyncModuleCache;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
+use move_core_types::language_storage::StructTag;
 use move_core_types::parser::parse_struct_tag;
 use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
@@ -18,6 +19,8 @@ use prometheus::{
     register_int_counter_with_registry, register_int_gauge_with_registry, Histogram, IntCounter,
     IntCounterVec, IntGauge, Registry,
 };
+use serde::de::DeserializeOwned;
+use std::cmp::Ordering as CmpOrdering;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
@@ -1811,6 +1814,24 @@ impl AuthorityState {
         }
     }
 
+    async fn get_move_object<T>(&self, object_id: &ObjectID) -> SuiResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let o = self.get_object_read(object_id).await?.into_object()?;
+        if let Some(move_object) = o.data.try_as_move() {
+            Ok(bcs::from_bytes(move_object.contents()).map_err(|e| {
+                SuiError::ObjectDeserializationError {
+                    error: format!("{e}"),
+                }
+            })?)
+        } else {
+            Err(SuiError::ObjectDeserializationError {
+                error: format!("Provided object : [{object_id}] is not a Move object."),
+            })
+        }
+    }
+
     /// This function aims to serve rpc reads on past objects and
     /// we don't expect it to be called for other purposes.
     /// Depending on the object pruning policies that will be enforced in the
@@ -1901,6 +1922,38 @@ impl AuthorityState {
             indexes.get_owner_objects_iterator(owner)
         } else {
             Err(SuiError::IndexStoreNotAvailable)
+        }
+    }
+
+    pub async fn get_move_objects<T>(
+        &self,
+        owner: SuiAddress,
+        type_: &StructTag,
+    ) -> SuiResult<Vec<T>>
+    where
+        T: DeserializeOwned,
+    {
+        let object_ids = self
+            .get_owner_objects_iterator(owner)?
+            .filter(move |o| Self::matches_type(&ObjectType::Struct(type_.clone()), &o.type_))
+            .map(|info| info.object_id);
+        let mut staked_suis = vec![];
+        for id in object_ids {
+            staked_suis.push(self.get_move_object(&id).await?)
+        }
+        Ok(staked_suis)
+    }
+
+    fn matches_type(type_: &ObjectType, other_type: &ObjectType) -> bool {
+        match (type_, other_type) {
+            (ObjectType::Package, ObjectType::Package) => true,
+            (ObjectType::Struct(type_), ObjectType::Struct(other_type)) => {
+                type_.address == other_type.address
+                    && type_.module == other_type.module
+                    && type_.name == other_type.name
+                    && (type_.type_params.is_empty() || type_.type_params == other_type.type_params)
+            }
+            _ => false,
         }
     }
 

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -4,7 +4,7 @@
 /// This file contain response types used by RPC, most of the types mirrors it's internal type counterparts.
 /// These mirrored types allow us to optimise the JSON serde without impacting the internal types, which are optimise for storage.
 ///
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::fmt::Write;
 use std::fmt::{Display, Formatter};
@@ -29,6 +29,8 @@ use serde_json::Value;
 use serde_with::serde_as;
 
 use fastcrypto::encoding::{Base64, Encoding};
+use tracing::warn;
+
 use sui_json::SuiJsonValue;
 use sui_types::base_types::{
     AuthorityName, ObjectDigest, ObjectID, ObjectInfo, ObjectRef, SequenceNumber, SuiAddress,
@@ -56,7 +58,6 @@ use sui_types::object::{
     Data, MoveObject, Object, ObjectFormatOptions, ObjectRead, Owner, PastObjectRead,
 };
 use sui_types::{parse_sui_struct_tag, parse_sui_type_tag};
-use tracing::warn;
 
 #[cfg(test)]
 #[path = "unit_tests/rpc_types_tests.rs"]
@@ -74,6 +75,7 @@ pub struct Balance {
     pub coin_type: String,
     pub coin_object_count: usize,
     pub total_balance: u128,
+    pub locked_balance: HashMap<EpochId, u128>,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -84,6 +86,7 @@ pub struct Coin {
     pub version: SequenceNumber,
     pub digest: ObjectDigest,
     pub balance: u64,
+    pub locked_until_epoch: Option<EpochId>,
 }
 
 impl Coin {

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -25,7 +25,7 @@ use sui_types::base_types::{
 use sui_types::committee::EpochId;
 use sui_types::crypto::SignatureScheme;
 use sui_types::event::EventID;
-use sui_types::governance::{Delegation, PendingDelegation, StakedSui};
+use sui_types::governance::DelegatedStake;
 use sui_types::messages::CommitteeInfoResponse;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::query::{EventQuery, TransactionQuery};
@@ -286,22 +286,13 @@ pub trait RpcFullNodeReadApi {
 #[open_rpc(namespace = "sui", tag = "Governance Read API")]
 #[rpc(server, client, namespace = "sui")]
 pub trait GovernanceReadApi {
-    /// Return all [StakedSui] owned by the `owner` address.
-    #[method(name = "getStakedSui")]
-    async fn get_staked_sui(&self, owner: SuiAddress) -> RpcResult<Vec<StakedSui>>;
+    /// Return all [DelegatedStake].
+    #[method(name = "getDelegatedStakes")]
+    async fn get_delegated_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>>;
 
-    /// Return all [Delegation] owned by the `owner` address.
-    #[method(name = "getDelegations")]
-    async fn get_delegations(&self, owner: SuiAddress) -> RpcResult<Vec<Delegation>>;
-
-    /// Return all [Delegation] owned by the `owner` address.
-    #[method(name = "getPendingDelegations")]
-    async fn get_pending_delegations(&self, owner: SuiAddress)
-        -> RpcResult<Vec<PendingDelegation>>;
-
-    /// Return all validators scheduled for next epoch.
-    #[method(name = "nextEpochValidators")]
-    async fn next_epoch_validators(&self) -> RpcResult<Vec<ValidatorMetadata>>;
+    /// Return all validators available for stake delegation.
+    #[method(name = "getValidators")]
+    async fn get_validators(&self) -> RpcResult<Vec<ValidatorMetadata>>;
 
     /// Return the committee information for the asked `epoch`.
     #[method(name = "getCommitteeInfo")]
@@ -555,7 +546,7 @@ pub trait RpcTransactionBuilder {
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes>;
 
-    // Switch delegation from the current validator to a new one.
+    /// Switch delegation from the current validator to a new one.
     #[method(name = "requestSwitchDelegation")]
     async fn request_switch_delegation(
         &self,

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -1,0 +1,111 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use jsonrpsee::core::RpcResult;
+use std::sync::Arc;
+
+use crate::api::GovernanceReadApiServer;
+use crate::error::Error;
+use crate::SuiRpcModule;
+use async_trait::async_trait;
+use jsonrpsee::RpcModule;
+use sui_core::authority::AuthorityState;
+use sui_open_rpc::Module;
+use sui_types::base_types::SuiAddress;
+use sui_types::committee::EpochId;
+use sui_types::governance::{Delegation, PendingDelegation, StakedSui};
+use sui_types::messages::{CommitteeInfoRequest, CommitteeInfoResponse};
+use sui_types::sui_system_state::{SuiSystemState, ValidatorMetadata};
+
+pub struct GovernanceReadApi {
+    state: Arc<AuthorityState>,
+}
+
+impl GovernanceReadApi {
+    pub fn new(state: Arc<AuthorityState>) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl GovernanceReadApiServer for GovernanceReadApi {
+    async fn get_staked_sui(&self, owner: SuiAddress) -> RpcResult<Vec<StakedSui>> {
+        Ok(self
+            .state
+            .get_move_objects(owner, &StakedSui::type_())
+            .await
+            .map_err(Error::from)?)
+    }
+    async fn get_delegations(&self, owner: SuiAddress) -> RpcResult<Vec<Delegation>> {
+        Ok(self
+            .state
+            .get_move_objects(owner, &Delegation::type_())
+            .await
+            .map_err(Error::from)?)
+    }
+
+    async fn get_pending_delegations(
+        &self,
+        owner: SuiAddress,
+    ) -> RpcResult<Vec<PendingDelegation>> {
+        let system_state: SuiSystemState = self.get_sui_system_state().await?;
+        let validators = system_state
+            .validators
+            .pending_validators
+            .iter()
+            .chain(system_state.validators.active_validators.iter());
+        Ok(validators
+            .flat_map(|v| {
+                v.delegation_staking_pool
+                    .pending_delegations
+                    .iter()
+                    .filter_map(|d| {
+                        if d.delegator == owner {
+                            Some(PendingDelegation {
+                                validator_address: v.metadata.sui_address,
+                                pool_starting_epoch: v.delegation_staking_pool.starting_epoch,
+                                principal_sui_amount: d.sui_amount,
+                            })
+                        } else {
+                            None
+                        }
+                    })
+            })
+            .collect::<Vec<_>>())
+    }
+
+    async fn next_epoch_validators(&self) -> RpcResult<Vec<ValidatorMetadata>> {
+        Ok(self
+            .state
+            .get_sui_system_state_object()
+            .await
+            .map_err(Error::from)?
+            .validators
+            .next_epoch_validators)
+    }
+
+    async fn get_committee_info(&self, epoch: Option<EpochId>) -> RpcResult<CommitteeInfoResponse> {
+        Ok(self
+            .state
+            .handle_committee_info_request(&CommitteeInfoRequest { epoch })
+            .map_err(Error::from)?)
+    }
+
+    async fn get_sui_system_state(&self) -> RpcResult<SuiSystemState> {
+        Ok(self
+            .state
+            .get_sui_system_state_object()
+            .await
+            .map_err(Error::from)?)
+    }
+}
+
+impl SuiRpcModule for GovernanceReadApi {
+    fn rpc(self) -> RpcModule<Self> {
+        self.into_rpc()
+    }
+
+    fn rpc_doc_module() -> Module {
+        crate::api::GovernanceReadApiOpenRpc::module_doc()
+    }
+}

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -24,9 +24,9 @@ pub mod bcs_api;
 pub mod coin_api;
 pub mod error;
 pub mod event_api;
+pub mod governance_api;
 mod metrics;
 pub mod read_api;
-
 pub mod streaming_api;
 pub mod transaction_builder_api;
 pub mod transaction_execution_api;

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -27,7 +27,7 @@ use sui_open_rpc::Module;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest, TxSequenceNumber};
 use sui_types::crypto::sha3_hash;
-use sui_types::messages::{CommitteeInfoRequest, CommitteeInfoResponse, TransactionData};
+use sui_types::messages::TransactionData;
 use sui_types::move_package::normalize_modules;
 use sui_types::object::{Data, ObjectRead};
 use sui_types::query::TransactionQuery;

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -12,7 +12,6 @@ use sui_adapter::execution_mode;
 use sui_json::SuiJsonValue;
 use sui_transaction_builder::TransactionBuilder;
 use sui_types::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
-use sui_types::sui_system_state::SuiSystemState;
 use tap::TapFallible;
 
 use fastcrypto::encoding::Base64;
@@ -27,7 +26,6 @@ use sui_json_rpc_types::{
 use sui_open_rpc::Module;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest, TxSequenceNumber};
-use sui_types::committee::EpochId;
 use sui_types::crypto::sha3_hash;
 use sui_types::messages::{CommitteeInfoRequest, CommitteeInfoResponse, TransactionData};
 use sui_types::move_package::normalize_modules;
@@ -408,20 +406,6 @@ impl RpcFullNodeReadApiServer for FullNodeApi {
             .await
             .map_err(|e| anyhow!("{e}"))?
             .try_into()?)
-    }
-
-    async fn get_committee_info(&self, epoch: Option<EpochId>) -> RpcResult<CommitteeInfoResponse> {
-        Ok(self
-            .state
-            .handle_committee_info_request(&CommitteeInfoRequest { epoch })
-            .map_err(|e| anyhow!("{e}"))?)
-    }
-
-    async fn get_sui_system_state(&self) -> RpcResult<SuiSystemState> {
-        Ok(self
-            .state
-            .get_sui_system_state_object()
-            .map_err(|e| anyhow!("{e}"))?)
     }
 }
 

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -281,6 +281,70 @@ impl RpcTransactionBuilderServer for FullNodeTransactionBuilderApi {
         };
         Ok(TransactionBytes::from_data(data)?)
     }
+
+    async fn request_add_delegation(
+        &self,
+        signer: SuiAddress,
+        coins: Vec<ObjectID>,
+        amount: Option<u64>,
+        validator: SuiAddress,
+        gas: Option<ObjectID>,
+        gas_budget: u64,
+    ) -> RpcResult<TransactionBytes> {
+        Ok(TransactionBytes::from_data(
+            self.builder
+                .request_add_delegation(signer, coins, amount, validator, gas, gas_budget)
+                .await?,
+        )?)
+    }
+
+    async fn request_withdraw_delegation(
+        &self,
+        signer: SuiAddress,
+        delegation: ObjectID,
+        staked_sui: ObjectID,
+        principal_withdraw_amount: u64,
+        gas: Option<ObjectID>,
+        gas_budget: u64,
+    ) -> RpcResult<TransactionBytes> {
+        Ok(TransactionBytes::from_data(
+            self.builder
+                .request_withdraw_delegation(
+                    signer,
+                    delegation,
+                    staked_sui,
+                    principal_withdraw_amount,
+                    gas,
+                    gas_budget,
+                )
+                .await?,
+        )?)
+    }
+
+    async fn request_switch_delegation(
+        &self,
+        signer: SuiAddress,
+        delegation: ObjectID,
+        staked_sui: ObjectID,
+        new_validator_address: SuiAddress,
+        switch_pool_token_amount: u64,
+        gas: Option<ObjectID>,
+        gas_budget: u64,
+    ) -> RpcResult<TransactionBytes> {
+        Ok(TransactionBytes::from_data(
+            self.builder
+                .request_switch_delegation(
+                    signer,
+                    delegation,
+                    staked_sui,
+                    new_validator_address,
+                    switch_pool_token_amount,
+                    gas,
+                    gas_budget,
+                )
+                .await?,
+        )?)
+    }
 }
 
 impl SuiRpcModule for FullNodeTransactionBuilderApi {

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -1,14 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
+use crate::api::CoinReadApiClient;
+use crate::api::GovernanceReadApiClient;
+use crate::api::{RpcFullNodeReadApiClient, TransactionExecutionApiClient};
+use crate::api::{RpcReadApiClient, RpcTransactionBuilderClient};
+use fastcrypto::traits::KeyPair;
+use fastcrypto::traits::ToFromBytes;
+use signature::Signature;
 use std::path::Path;
 
 #[cfg(not(msim))]
 use std::str::FromStr;
 
-use sui_config::SUI_KEYSTORE_FILENAME;
+use sui_config::{ValidatorInfo, SUI_KEYSTORE_FILENAME};
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
+use sui_json_rpc_types::SuiObjectInfo;
 use sui_json_rpc_types::{
     Balance, CoinPage, GetObjectDataResponse, SuiCoinMetadata, SuiEvent,
     SuiExecuteTransactionResponse, SuiExecutionStatus, SuiTransactionResponse, TransactionBytes,
@@ -17,20 +24,24 @@ use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_types::balance::Supply;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::TransactionDigest;
-use sui_types::coin::{TreasuryCap, COIN_MODULE_NAME};
+use sui_types::coin::{TreasuryCap, COIN_MODULE_NAME, LOCKED_COIN_MODULE_NAME};
 use sui_types::gas_coin::GAS;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::object::Owner;
 use sui_types::query::{EventQuery, TransactionQuery};
+use sui_types::sui_system_state::{ValidatorMetadata, SUI_SYSTEM_MODULE_NAME};
 use sui_types::utils::to_sender_signed_transaction;
-use sui_types::{parse_sui_struct_tag, parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS};
+use sui_types::{
+    parse_sui_struct_tag, parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
+};
 use test_utils::network::TestClusterBuilder;
 
-use crate::api::CoinReadApiClient;
-use crate::api::{RpcFullNodeReadApiClient, TransactionExecutionApiClient};
-use crate::api::{RpcReadApiClient, RpcTransactionBuilderClient};
-
 use sui_macros::sim_test;
+use sui_types::crypto::{
+    generate_proof_of_possession, get_key_pair, AccountKeyPair, AuthorityKeyPair,
+    AuthoritySignature, NetworkKeyPair, SuiKeyPair,
+};
+use sui_types::governance::StakedSui;
 
 use tokio::time::{sleep, Duration};
 
@@ -735,4 +746,297 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
     assert_eq!(4, page.data.len());
 
     Ok(())
+}
+
+#[tokio::test]
+async fn test_locked_sui() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await?;
+
+    let http_client = cluster.rpc_client();
+    let address = cluster.accounts.first().unwrap();
+
+    let objects = http_client.get_objects_owned_by_address(*address).await?;
+    assert_eq!(5, objects.len());
+    // verify coins and balance before test
+    let coins: CoinPage = http_client.get_coins(*address, None, None, None).await?;
+    let balance: Vec<Balance> = http_client.get_all_balances(*address).await?;
+
+    assert_eq!(5, coins.data.len());
+    for coin in &coins.data {
+        assert!(coin.locked_until_epoch.is_none());
+    }
+
+    assert_eq!(1, balance.len());
+    assert!(balance[0].locked_balance.is_empty());
+
+    // lock one coin
+    let transaction_bytes: TransactionBytes = http_client
+        .move_call(
+            *address,
+            SUI_FRAMEWORK_ADDRESS.into(),
+            LOCKED_COIN_MODULE_NAME.to_string(),
+            "lock_coin".to_string(),
+            vec![parse_sui_type_tag("0x2::sui::SUI")?.into()],
+            vec![
+                SuiJsonValue::from_str(&coins.data[0].coin_object_id.to_string())?,
+                SuiJsonValue::from_str(&format!("{address}"))?,
+                SuiJsonValue::from_bcs_bytes(&bcs::to_bytes(&"20")?)?,
+            ],
+            None,
+            1000,
+        )
+        .await?;
+    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
+    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
+    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+
+    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+
+    http_client
+        .execute_transaction_serialized_sig(
+            tx_bytes,
+            signature_bytes,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+        )
+        .await?;
+
+    let balances: Vec<Balance> = http_client.get_all_balances(*address).await?;
+
+    assert_eq!(1, balance.len());
+
+    let balance = balances.first().unwrap();
+
+    assert_eq!(4, balance.coin_object_count);
+    assert_eq!(1, balance.locked_balance.len());
+    assert!(balance.locked_balance.contains_key(&20));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_delegation() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await?;
+
+    let http_client = cluster.rpc_client();
+    let address = cluster.accounts.first().unwrap();
+
+    let objects: Vec<SuiObjectInfo> = http_client.get_objects_owned_by_address(*address).await?;
+    assert_eq!(5, objects.len());
+
+    // Check StakedSui object before test
+    let staked_sui: Vec<StakedSui> = http_client.get_staked_sui(*address).await?;
+    assert!(staked_sui.is_empty());
+
+    // Check pending delegation before test
+    let pending_delegation = http_client.get_pending_delegations(*address).await?;
+    assert!(pending_delegation.is_empty());
+
+    let validators: Vec<ValidatorMetadata> = http_client.next_epoch_validators().await?;
+
+    // Delegate some SUI
+    let transaction_bytes: TransactionBytes = http_client
+        .request_add_delegation(
+            *address,
+            vec![objects[0].object_id],
+            Some(1000000),
+            validators[0].sui_address,
+            None,
+            10000,
+        )
+        .await?;
+    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
+    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
+    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+
+    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+
+    http_client
+        .execute_transaction_serialized_sig(
+            tx_bytes,
+            signature_bytes,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+        )
+        .await?;
+
+    // Check StakedSui object
+    let staked_sui: Vec<StakedSui> = http_client.get_staked_sui(*address).await?;
+    assert_eq!(1, staked_sui.len());
+    assert_eq!(1000000, staked_sui[0].principal());
+    assert!(staked_sui[0].locked_until_epoch().is_none());
+
+    // Check pending delegation
+    let pending_delegation = http_client.get_pending_delegations(*address).await?;
+    assert_eq!(1, pending_delegation.len());
+    assert_eq!(1000000, pending_delegation[0].principal_sui_amount);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_delegation_with_locked_sui() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await?;
+
+    let http_client = cluster.rpc_client();
+    let address = cluster.accounts.first().unwrap();
+
+    let objects: Vec<SuiObjectInfo> = http_client.get_objects_owned_by_address(*address).await?;
+    assert_eq!(5, objects.len());
+
+    // lock some SUI
+    let transaction_bytes: TransactionBytes = http_client
+        .move_call(
+            *address,
+            SUI_FRAMEWORK_ADDRESS.into(),
+            LOCKED_COIN_MODULE_NAME.to_string(),
+            "lock_coin".to_string(),
+            vec![parse_sui_type_tag("0x2::sui::SUI")?.into()],
+            vec![
+                SuiJsonValue::from_str(&objects[0].object_id.to_string())?,
+                SuiJsonValue::from_str(&format!("{address}"))?,
+                SuiJsonValue::from_bcs_bytes(&bcs::to_bytes(&"20")?)?,
+            ],
+            None,
+            1000,
+        )
+        .await?;
+    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
+    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
+    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+
+    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+
+    http_client
+        .execute_transaction_serialized_sig(
+            tx_bytes,
+            signature_bytes,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+        )
+        .await?;
+
+    let validators: Vec<ValidatorMetadata> = http_client.next_epoch_validators().await?;
+
+    // Delegate some locked SUI
+    let coins: CoinPage = http_client.get_coins(*address, None, None, None).await?;
+    let locked_sui = coins
+        .data
+        .iter()
+        .find_map(|coin| coin.locked_until_epoch.map(|_| coin.coin_object_id))
+        .unwrap();
+
+    let transaction_bytes: TransactionBytes = http_client
+        .request_add_delegation(
+            *address,
+            vec![locked_sui],
+            Some(1000000),
+            validators[0].sui_address,
+            None,
+            10000,
+        )
+        .await?;
+    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+
+    http_client
+        .execute_transaction_serialized_sig(
+            tx_bytes,
+            signature_bytes,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+        )
+        .await?;
+
+    // Check StakedSui object
+    let staked_sui: Vec<StakedSui> = http_client.get_staked_sui(*address).await?;
+    assert_eq!(1, staked_sui.len());
+    assert_eq!(1000000, staked_sui[0].principal());
+    assert_eq!(Some(20), staked_sui[0].locked_until_epoch());
+
+    // Check pending delegation
+    let pending_delegation = http_client.get_pending_delegations(*address).await?;
+    assert_eq!(1, pending_delegation.len());
+    assert_eq!(1000000, pending_delegation[0].principal_sui_amount);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_next_epoch_validators() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await?;
+
+    let http_client = cluster.rpc_client();
+    let address = cluster.accounts.first().unwrap();
+    let objects: Vec<SuiObjectInfo> = http_client.get_objects_owned_by_address(*address).await?;
+
+    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
+    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
+    let SuiKeyPair::Ed25519(keypair) = keystore.get_key(&address)? else { panic!() };
+
+    let validators = http_client.next_epoch_validators().await?;
+    assert_eq!(4, validators.len());
+
+    let (validator_info, signature) = get_new_validator(keypair);
+
+    // add validator
+    let transaction_bytes: TransactionBytes = http_client
+        .move_call(
+            *address,
+            SUI_FRAMEWORK_ADDRESS.into(),
+            SUI_SYSTEM_MODULE_NAME.to_string(),
+            "request_add_validator".to_string(),
+            vec![],
+            vec![
+                SuiJsonValue::from_object_id(SUI_SYSTEM_STATE_OBJECT_ID),
+                SuiJsonValue::from_bcs_bytes(validator_info.protocol_key.as_bytes())?,
+                SuiJsonValue::from_bcs_bytes(validator_info.network_key.as_bytes())?,
+                SuiJsonValue::from_bcs_bytes(Signature::as_bytes(&signature))?,
+                SuiJsonValue::from_bcs_bytes(&bcs::to_bytes(validator_info.name())?)?,
+                SuiJsonValue::from_bcs_bytes(&validator_info.network_address.to_vec())?,
+                SuiJsonValue::from_bcs_bytes(&validator_info.p2p_address.to_vec())?,
+                SuiJsonValue::from_bcs_bytes(&validator_info.narwhal_worker_address.to_vec())?,
+                SuiJsonValue::from_object_id(objects[0].object_id),
+                SuiJsonValue::from_bcs_bytes(&bcs::to_bytes(&"1000")?)?,
+                SuiJsonValue::from_bcs_bytes(&bcs::to_bytes(&"50")?)?,
+            ],
+            None,
+            10000,
+        )
+        .await?;
+    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+
+    http_client
+        .execute_transaction_serialized_sig(
+            tx_bytes,
+            signature_bytes,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+        )
+        .await?;
+
+    let validators = http_client.next_epoch_validators().await?;
+    assert_eq!(5, validators.len());
+    Ok(())
+}
+
+pub fn get_new_validator(account_keypair: &AccountKeyPair) -> (ValidatorInfo, AuthoritySignature) {
+    let keypair: AuthorityKeyPair = get_key_pair().1;
+    let worker_keypair: NetworkKeyPair = get_key_pair().1;
+    let network_keypair: NetworkKeyPair = get_key_pair().1;
+    let pop = generate_proof_of_possession(&keypair, account_keypair.public().into());
+    (
+        ValidatorInfo {
+            name: "".to_string(),
+            protocol_key: keypair.public().into(),
+            worker_key: worker_keypair.public().clone(),
+            account_key: account_keypair.public().clone().into(),
+            network_key: network_keypair.public().clone(),
+            stake: 1,
+            delegation: 0,
+            gas_price: 1,
+            commission_rate: 0,
+            network_address: sui_config::utils::new_tcp_network_address(),
+            p2p_address: sui_config::utils::new_tcp_network_address(),
+            narwhal_primary_address: sui_config::utils::new_tcp_network_address(),
+            narwhal_worker_address: sui_config::utils::new_tcp_network_address(),
+        },
+        pop,
+    )
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -90,6 +90,7 @@ pub struct ValidatorComponents {
     checkpoint_service_exit: watch::Sender<()>,
     checkpoint_metrics: Arc<CheckpointMetrics>,
 }
+use sui_json_rpc::governance_api::GovernanceReadApi;
 
 pub struct SuiNode {
     config: NodeConfig,
@@ -758,6 +759,7 @@ pub async fn build_server(
     server.register_module(FullNodeApi::new(state.clone()))?;
     server.register_module(BcsApiImpl::new(state.clone()))?;
     server.register_module(FullNodeTransactionBuilderApi::new(state.clone()))?;
+    server.register_module(GovernanceReadApi::new(state.clone()))?;
 
     if let Some(transaction_orchestrator) = transaction_orchestrator {
         server.register_module(FullNodeTransactionExecutionApi::new(

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -813,10 +813,10 @@
       "name": "sui_getCommitteeInfo",
       "tags": [
         {
-          "name": "Full Node API"
+          "name": "Governance Read API"
         }
       ],
-      "description": "Return the committee information for the asked epoch",
+      "description": "Return the committee information for the asked `epoch`.",
       "params": [
         {
           "name": "epoch",
@@ -833,6 +833,34 @@
         "required": true,
         "schema": {
           "$ref": "#/components/schemas/CommitteeInfoResponse"
+        }
+      }
+    },
+    {
+      "name": "sui_getDelegatedStakes",
+      "tags": [
+        {
+          "name": "Governance Read API"
+        }
+      ],
+      "description": "Return all [DelegatedStake].",
+      "params": [
+        {
+          "name": "owner",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec<DelegatedStake>",
+        "required": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/DelegatedStake"
+          }
         }
       }
     },
@@ -1503,10 +1531,10 @@
       "name": "sui_getSuiSystemState",
       "tags": [
         {
-          "name": "Full Node API"
+          "name": "Governance Read API"
         }
       ],
-      "description": "Return SuiSystemState",
+      "description": "Return [SuiSystemState]",
       "params": [],
       "result": {
         "name": "SuiSystemState",
@@ -1882,6 +1910,26 @@
           "type": "array",
           "items": {
             "$ref": "#/components/schemas/TransactionDigest"
+          }
+        }
+      }
+    },
+    {
+      "name": "sui_getValidators",
+      "tags": [
+        {
+          "name": "Governance Read API"
+        }
+      ],
+      "description": "Return all validators available for stake delegation.",
+      "params": [],
+      "result": {
+        "name": "Vec<ValidatorMetadata>",
+        "required": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/ValidatorMetadata"
           }
         }
       }
@@ -2271,6 +2319,223 @@
             "items": {
               "$ref": "#/components/schemas/Base64"
             }
+          }
+        },
+        {
+          "name": "gas",
+          "description": "gas object to be used in this transaction, node will pick one from the signer's possession if not provided",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "gas_budget",
+          "description": "the gas budget, the transaction will fail if the gas cost exceed the budget",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "TransactionBytes",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/TransactionBytes"
+        }
+      }
+    },
+    {
+      "name": "sui_requestAddDelegation",
+      "tags": [
+        {
+          "name": "Transaction Builder API"
+        }
+      ],
+      "description": "Add delegated stake to a validator's staking pool using multiple coins and amount.",
+      "params": [
+        {
+          "name": "signer",
+          "description": "the transaction signer's Sui address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        },
+        {
+          "name": "coins",
+          "description": "Coin<SUI> or LockedCoin<SUI> object to delegate",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectID"
+            }
+          }
+        },
+        {
+          "name": "amount",
+          "description": "delegation amount",
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "validator",
+          "description": "the validator's Sui address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        },
+        {
+          "name": "gas",
+          "description": "gas object to be used in this transaction, node will pick one from the signer's possession if not provided",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "gas_budget",
+          "description": "the gas budget, the transaction will fail if the gas cost exceed the budget",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "TransactionBytes",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/TransactionBytes"
+        }
+      }
+    },
+    {
+      "name": "sui_requestSwitchDelegation",
+      "tags": [
+        {
+          "name": "Transaction Builder API"
+        }
+      ],
+      "description": "Switch delegation from the current validator to a new one.",
+      "params": [
+        {
+          "name": "signer",
+          "description": "the transaction signer's Sui address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        },
+        {
+          "name": "delegation",
+          "description": "Delegation object ID",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "staked_sui",
+          "description": "StakedSui object ID",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "new_validator_address",
+          "description": "Validator to switch to",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        },
+        {
+          "name": "switch_pool_token_amount",
+          "description": "Switching stake amount",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "gas",
+          "description": "gas object to be used in this transaction, node will pick one from the signer's possession if not provided",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "gas_budget",
+          "description": "the gas budget, the transaction will fail if the gas cost exceed the budget",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "TransactionBytes",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/TransactionBytes"
+        }
+      }
+    },
+    {
+      "name": "sui_requestWithdrawDelegation",
+      "tags": [
+        {
+          "name": "Transaction Builder API"
+        }
+      ],
+      "description": "Withdraw some portion of a delegation from a validator's staking pool.",
+      "params": [
+        {
+          "name": "signer",
+          "description": "the transaction signer's Sui address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        },
+        {
+          "name": "delegation",
+          "description": "Delegation object ID",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "staked_sui",
+          "description": "StakedSui object ID",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "principal_withdraw_amount",
+          "description": "Principal amount to withdraw",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         },
         {
@@ -2803,6 +3068,14 @@
           "digest": {
             "$ref": "#/components/schemas/ObjectDigest"
           },
+          "lockedUntilEpoch": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          },
           "version": {
             "$ref": "#/components/schemas/SequenceNumber"
           }
@@ -2898,6 +3171,68 @@
                 }
               }
             }
+          }
+        ]
+      },
+      "DelegatedStake": {
+        "type": "object",
+        "required": [
+          "delegation_status",
+          "staked_sui"
+        ],
+        "properties": {
+          "delegation_status": {
+            "$ref": "#/components/schemas/DelegationStatus"
+          },
+          "staked_sui": {
+            "$ref": "#/components/schemas/StakedSui"
+          }
+        }
+      },
+      "Delegation": {
+        "type": "object",
+        "required": [
+          "id",
+          "pool_tokens",
+          "principal_sui_amount",
+          "staked_sui_id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/UID"
+          },
+          "pool_tokens": {
+            "$ref": "#/components/schemas/Balance"
+          },
+          "principal_sui_amount": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "staked_sui_id": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        }
+      },
+      "DelegationStatus": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "Pending"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "Active"
+            ],
+            "properties": {
+              "Active": {
+                "$ref": "#/components/schemas/Delegation"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -4674,6 +5009,45 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
+          }
+        }
+      },
+      "StakedSui": {
+        "type": "object",
+        "required": [
+          "delegation_request_epoch",
+          "id",
+          "pool_starting_epoch",
+          "principal",
+          "validator_address"
+        ],
+        "properties": {
+          "delegation_request_epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "id": {
+            "$ref": "#/components/schemas/UID"
+          },
+          "pool_starting_epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "principal": {
+            "$ref": "#/components/schemas/Balance"
+          },
+          "sui_token_lock": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "validator_address": {
+            "$ref": "#/components/schemas/SuiAddress"
           }
         }
       },

--- a/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
+++ b/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
@@ -13,6 +13,7 @@ use sui_json_rpc::api::EventReadApiOpenRpc;
 use sui_json_rpc::api::EventStreamingApiOpenRpc;
 use sui_json_rpc::bcs_api::BcsApiImpl;
 use sui_json_rpc::coin_api::CoinReadApi;
+use sui_json_rpc::governance_api::GovernanceReadApi;
 use sui_json_rpc::read_api::{FullNodeApi, ReadApi};
 use sui_json_rpc::sui_rpc_doc;
 use sui_json_rpc::transaction_builder_api::FullNodeTransactionBuilderApi;
@@ -55,6 +56,7 @@ async fn main() {
     open_rpc.add_module(EventReadApiOpenRpc::module_doc());
     open_rpc.add_module(FullNodeTransactionExecutionApi::rpc_doc_module());
     open_rpc.add_module(FullNodeTransactionBuilderApi::rpc_doc_module());
+    open_rpc.add_module(GovernanceReadApi::rpc_doc_module());
 
     open_rpc.add_examples(RpcExampleProvider::new().examples());
 

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -9,6 +9,7 @@ use jsonrpsee::core::client::Subscription;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use sui_json_rpc::api::GovernanceReadApiClient;
 use sui_json_rpc_types::{
     Balance, Coin, CoinPage, DynamicFieldPage, EventPage, GetObjectDataResponse,
     GetPastObjectDataResponse, GetRawObjectDataResponse, SuiCoinMetadata, SuiEventEnvelope,

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -17,7 +17,7 @@ use rpc_types::{SuiCertifiedTransaction, SuiParsedTransactionResponse, SuiTransa
 use serde_json::Value;
 pub use sui_json as json;
 
-use crate::apis::{CoinReadApi, EventApi, QuorumDriver, ReadApi};
+use crate::apis::{CoinReadApi, EventApi, GovernanceApi, QuorumDriver, ReadApi};
 pub use sui_json_rpc_types as rpc_types;
 use sui_json_rpc_types::{GetRawObjectDataResponse, SuiObjectInfo};
 use sui_transaction_builder::{DataReader, TransactionBuilder};
@@ -47,6 +47,7 @@ pub struct SuiClient {
     coin_read_api: CoinReadApi,
     event_api: EventApi,
     quorum_driver: QuorumDriver,
+    governance_api: GovernanceApi,
 }
 
 pub(crate) struct RpcClient {
@@ -156,6 +157,7 @@ impl SuiClient {
         let event_api = EventApi::new(api.clone());
         let transaction_builder = TransactionBuilder(read_api.clone());
         let coin_read_api = CoinReadApi::new(api.clone());
+        let governance_api = GovernanceApi::new(api.clone());
 
         Ok(SuiClient {
             api,
@@ -164,6 +166,7 @@ impl SuiClient {
             coin_read_api,
             event_api,
             quorum_driver,
+            governance_api,
         })
     }
 
@@ -207,6 +210,9 @@ impl SuiClient {
     }
     pub fn quorum_driver(&self) -> &QuorumDriver {
         &self.quorum_driver
+    }
+    pub fn governance_api(&self) -> &GovernanceApi {
+        &self.governance_api
     }
 }
 

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -701,9 +701,9 @@ impl TransactionBuilder {
         let object_type = object
             .data
             .type_()
-            .map(|type_| parse_sui_struct_tag(type_))
+            .map(parse_sui_struct_tag)
             .transpose()?
-            .map_or(ObjectType::Package, |type_| ObjectType::Struct(type_));
+            .map_or(ObjectType::Package, ObjectType::Struct);
 
         Ok((object.reference.to_object_ref(), object_type))
     }

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::future::join_all;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, ensure};
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::TypeTag;
 
@@ -18,16 +18,26 @@ use sui_json::{resolve_move_function_args, SuiJsonCallArg, SuiJsonValue};
 use sui_json_rpc_types::GetRawObjectDataResponse;
 use sui_json_rpc_types::SuiObjectInfo;
 use sui_json_rpc_types::{RPCTransactionRequestParams, SuiData, SuiTypeTag};
-use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::base_types::{ObjectID, ObjectRef, ObjectType, SuiAddress};
+use sui_types::coin::{Coin, LockedCoin};
 use sui_types::error::SuiError;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
     CallArg, InputObjectKind, MoveCall, ObjectArg, SingleTransactionKind, TransactionData,
     TransactionKind, TransferObject,
 };
+
+use sui_types::governance::{
+    ADD_DELEGATION_LOCKED_COIN_FUN_NAME, ADD_DELEGATION_MUL_COIN_FUN_NAME,
+    SWITCH_DELEGATION_FUN_NAME, WITHDRAW_DELEGATION_FUN_NAME,
+};
 use sui_types::move_package::MovePackage;
 use sui_types::object::{Object, Owner};
-use sui_types::{coin, fp_ensure, SUI_FRAMEWORK_OBJECT_ID};
+use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
+use sui_types::{
+    coin, fp_ensure, parse_sui_struct_tag, SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
+    SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+};
 
 #[async_trait]
 pub trait DataReader {
@@ -543,14 +553,158 @@ impl TransactionBuilder {
         ))
     }
 
+    pub async fn request_add_delegation(
+        &self,
+        signer: SuiAddress,
+        mut coins: Vec<ObjectID>,
+        amount: Option<u64>,
+        validator: SuiAddress,
+        gas: Option<ObjectID>,
+        gas_budget: u64,
+    ) -> anyhow::Result<TransactionData> {
+        let gas = self
+            .select_gas(signer, gas, gas_budget, coins.clone())
+            .await?;
+
+        let mut obj_vec = vec![];
+        let coin = coins
+            .pop()
+            .ok_or_else(|| anyhow!("Coins input should contain at lease one coin object."))?;
+        let (oref, coin_type) = self.get_object_ref_and_type(coin).await?;
+        obj_vec.push(ObjectArg::ImmOrOwnedObject(oref));
+
+        let ObjectType::Struct(type_) = &coin_type else{
+            return Err(anyhow!("Provided object [{coin}] is not a move object."))
+        };
+        ensure!(
+            Coin::is_coin(type_) || LockedCoin::is_locked_coin(type_),
+            "Expecting either Coin<T> or LockedCoin<T> as input coin objects. Received [{type_}]"
+        );
+
+        for coin in coins {
+            let (oref, type_) = self.get_object_ref_and_type(coin).await?;
+            ensure!(
+                type_ == coin_type,
+                "All coins should be the same type, expecting {coin_type}, got {type_}."
+            );
+            obj_vec.push(ObjectArg::ImmOrOwnedObject(oref))
+        }
+
+        let function = if Coin::is_coin(type_) {
+            ADD_DELEGATION_MUL_COIN_FUN_NAME
+        } else {
+            ADD_DELEGATION_LOCKED_COIN_FUN_NAME
+        }
+        .to_owned();
+
+        Ok(TransactionData::new_move_call(
+            signer,
+            self.get_object_ref(SUI_FRAMEWORK_OBJECT_ID).await?,
+            SUI_SYSTEM_MODULE_NAME.to_owned(),
+            function,
+            vec![],
+            gas,
+            vec![
+                CallArg::Object(ObjectArg::SharedObject {
+                    id: SUI_SYSTEM_STATE_OBJECT_ID,
+                    initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                }),
+                CallArg::ObjVec(obj_vec),
+                CallArg::Pure(bcs::to_bytes(&amount)?),
+                CallArg::Pure(bcs::to_bytes(&validator)?),
+            ],
+            gas_budget,
+        ))
+    }
+
+    pub async fn request_withdraw_delegation(
+        &self,
+        signer: SuiAddress,
+        delegation: ObjectID,
+        staked_sui: ObjectID,
+        principal_withdraw_amount: u64,
+        gas: Option<ObjectID>,
+        gas_budget: u64,
+    ) -> anyhow::Result<TransactionData> {
+        let delegation = self.get_object_ref(delegation).await?;
+        let staked_sui = self.get_object_ref(staked_sui).await?;
+        let gas = self.select_gas(signer, gas, gas_budget, vec![]).await?;
+
+        Ok(TransactionData::new_move_call(
+            signer,
+            self.get_object_ref(SUI_FRAMEWORK_OBJECT_ID).await?,
+            SUI_SYSTEM_MODULE_NAME.to_owned(),
+            WITHDRAW_DELEGATION_FUN_NAME.to_owned(),
+            vec![],
+            gas,
+            vec![
+                CallArg::Object(ObjectArg::SharedObject {
+                    id: SUI_SYSTEM_STATE_OBJECT_ID,
+                    initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                }),
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(delegation)),
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(staked_sui)),
+                CallArg::Pure(bcs::to_bytes(&principal_withdraw_amount)?),
+            ],
+            gas_budget,
+        ))
+    }
+
+    pub async fn request_switch_delegation(
+        &self,
+        signer: SuiAddress,
+        delegation: ObjectID,
+        staked_sui: ObjectID,
+        new_validator_address: SuiAddress,
+        switch_pool_token_amount: u64,
+        gas: Option<ObjectID>,
+        gas_budget: u64,
+    ) -> anyhow::Result<TransactionData> {
+        let delegation = self.get_object_ref(delegation).await?;
+        let staked_sui = self.get_object_ref(staked_sui).await?;
+        let gas = self.select_gas(signer, gas, gas_budget, vec![]).await?;
+
+        Ok(TransactionData::new_move_call(
+            signer,
+            self.get_object_ref(SUI_FRAMEWORK_OBJECT_ID).await?,
+            SUI_SYSTEM_MODULE_NAME.to_owned(),
+            SWITCH_DELEGATION_FUN_NAME.to_owned(),
+            vec![],
+            gas,
+            vec![
+                CallArg::Object(ObjectArg::SharedObject {
+                    id: SUI_SYSTEM_STATE_OBJECT_ID,
+                    initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                }),
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(delegation)),
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(staked_sui)),
+                CallArg::Pure(bcs::to_bytes(&new_validator_address)?),
+                CallArg::Pure(bcs::to_bytes(&switch_pool_token_amount)?),
+            ],
+            gas_budget,
+        ))
+    }
+
     // TODO: we should add retrial to reduce the transaction building error rate
     async fn get_object_ref(&self, object_id: ObjectID) -> anyhow::Result<ObjectRef> {
-        Ok(self
-            .0
-            .get_object(object_id)
-            .await?
-            .object()?
-            .reference
-            .to_object_ref())
+        self.get_object_ref_and_type(object_id)
+            .await
+            .map(|(oref, _)| oref)
+    }
+
+    async fn get_object_ref_and_type(
+        &self,
+        object_id: ObjectID,
+    ) -> anyhow::Result<(ObjectRef, ObjectType)> {
+        let object = self.0.get_object(object_id).await?.into_object()?;
+
+        let object_type = object
+            .data
+            .type_()
+            .map(|type_| parse_sui_struct_tag(type_))
+            .transpose()?
+            .map_or(ObjectType::Package, |type_| ObjectType::Struct(type_));
+
+        Ok((object.reference.to_object_ref(), object_type))
     }
 }

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -10,6 +10,7 @@ use move_core_types::{
 use serde::{Deserialize, Serialize};
 
 use crate::base_types::SequenceNumber;
+use crate::committee::EpochId;
 use crate::object::{MoveObject, Owner};
 use crate::storage::{DeleteKind, SingleTxContext, WriteKind};
 use crate::temporary_store::TemporaryStore;
@@ -35,6 +36,9 @@ pub const PAY_MODULE_NAME: &IdentStr = ident_str!("pay");
 pub const PAY_JOIN_FUNC_NAME: &IdentStr = ident_str!("join");
 pub const PAY_SPLIT_N_FUNC_NAME: &IdentStr = ident_str!("divide_and_keep");
 pub const PAY_SPLIT_VEC_FUNC_NAME: &IdentStr = ident_str!("split_vec");
+
+pub const LOCKED_COIN_MODULE_NAME: &IdentStr = ident_str!("locked_coin");
+pub const LOCKED_COIN_STRUCT_NAME: &IdentStr = ident_str!("LockedCoin");
 
 // Rust version of the Move sui::coin::Coin type
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Eq, PartialEq)]
@@ -271,5 +275,21 @@ impl TryFrom<Object> for CoinMetadata {
         Err(SuiError::TypeError {
             error: format!("Object type is not a CoinMetadata: {:?}", object),
         })
+    }
+}
+// Rust version of the Move sui::locked_coin::LockedCoin type
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Eq, PartialEq)]
+pub struct LockedCoin {
+    pub id: UID,
+    pub balance: Balance,
+    pub locked_until_epoch: EpochId,
+}
+
+impl LockedCoin {
+    /// Is this other StructTag representing a Coin?
+    pub fn is_locked_coin(other: &StructTag) -> bool {
+        other.address == SUI_FRAMEWORK_ADDRESS
+            && other.module.as_ident_str() == LOCKED_COIN_MODULE_NAME
+            && other.name.as_ident_str() == LOCKED_COIN_STRUCT_NAME
     }
 }

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -8,7 +8,7 @@ use move_core_types::language_storage::StructTag;
 use crate::balance::Balance;
 use crate::base_types::{ObjectID, SuiAddress};
 use crate::committee::EpochId;
-use crate::id::UID;
+use crate::id::{ID, UID};
 use crate::SUI_FRAMEWORK_ADDRESS;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -28,17 +28,9 @@ pub const SWITCH_DELEGATION_FUN_NAME: &IdentStr = ident_str!("request_switch_del
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct Delegation {
-    id: UID,
-    validator_address: SuiAddress,
-    pool_starting_epoch: EpochId,
-    pool_tokens: Balance,
-    principal_sui_amount: u64,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
-pub struct PendingDelegation {
-    pub validator_address: SuiAddress,
-    pub pool_starting_epoch: EpochId,
+    pub id: UID,
+    pub staked_sui_id: ID,
+    pub pool_tokens: Balance,
     pub principal_sui_amount: u64,
 }
 
@@ -56,8 +48,11 @@ impl Delegation {
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct StakedSui {
     id: UID,
+    validator_address: SuiAddress,
+    pool_starting_epoch: u64,
+    delegation_request_epoch: u64,
     principal: Balance,
-    locked_until_epoch: Option<EpochId>,
+    sui_token_lock: Option<EpochId>,
 }
 
 impl StakedSui {
@@ -78,7 +73,19 @@ impl StakedSui {
         self.principal.value()
     }
 
-    pub fn locked_until_epoch(&self) -> Option<EpochId> {
-        self.locked_until_epoch
+    pub fn sui_token_lock(&self) -> Option<EpochId> {
+        self.sui_token_lock
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct DelegatedStake {
+    pub staked_sui: StakedSui,
+    pub delegation_status: DelegationStatus,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub enum DelegationStatus {
+    Pending,
+    Active(Delegation),
 }

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::ident_str;
+use move_core_types::identifier::IdentStr;
+use move_core_types::language_storage::StructTag;
+
+use crate::balance::Balance;
+use crate::base_types::{ObjectID, SuiAddress};
+use crate::committee::EpochId;
+use crate::id::UID;
+use crate::SUI_FRAMEWORK_ADDRESS;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+pub const STAKING_POOL_MODULE_NAME: &IdentStr = ident_str!("staking_pool");
+pub const STAKED_SUI_STRUCT_NAME: &IdentStr = ident_str!("StakedSui");
+pub const DELEGATION_STRUCT_NAME: &IdentStr = ident_str!("Delegation");
+
+pub const ADD_DELEGATION_MUL_COIN_FUN_NAME: &IdentStr =
+    ident_str!("request_add_delegation_mul_coin");
+pub const ADD_DELEGATION_FUN_NAME: &IdentStr = ident_str!("request_add_delegation_mul_coin");
+pub const ADD_DELEGATION_LOCKED_COIN_FUN_NAME: &IdentStr =
+    ident_str!("request_add_delegation_mul_locked_coin");
+pub const WITHDRAW_DELEGATION_FUN_NAME: &IdentStr = ident_str!("request_withdraw_delegation");
+pub const SWITCH_DELEGATION_FUN_NAME: &IdentStr = ident_str!("request_switch_delegation");
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct Delegation {
+    id: UID,
+    validator_address: SuiAddress,
+    pool_starting_epoch: EpochId,
+    pool_tokens: Balance,
+    principal_sui_amount: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct PendingDelegation {
+    pub validator_address: SuiAddress,
+    pub pool_starting_epoch: EpochId,
+    pub principal_sui_amount: u64,
+}
+
+impl Delegation {
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            module: STAKING_POOL_MODULE_NAME.to_owned(),
+            name: DELEGATION_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+pub struct StakedSui {
+    id: UID,
+    principal: Balance,
+    locked_until_epoch: Option<EpochId>,
+}
+
+impl StakedSui {
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            module: STAKING_POOL_MODULE_NAME.to_owned(),
+            name: STAKED_SUI_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+
+    pub fn id(&self) -> ObjectID {
+        self.id.id.bytes
+    }
+
+    pub fn principal(&self) -> u64 {
+        self.principal.value()
+    }
+
+    pub fn locked_until_epoch(&self) -> Option<EpochId> {
+        self.locked_until_epoch
+    }
+}

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -32,6 +32,7 @@ pub mod dynamic_field;
 pub mod event;
 pub mod gas;
 pub mod gas_coin;
+pub mod governance;
 pub mod id;
 pub mod in_memory_storage;
 pub mod intent;


### PR DESCRIPTION
This PR added governance api with `get_delegated_stakes`, `get_validators` and transaction builder methods for `request_add_delegation_mul_coin` and `request_add_delegation_mul_locked_coin`.

I have also moved `get_committee_info` and `get_sui_system_state` to the new API module.

