### PR TITLE
[explorer] Fix sentry tracing

### DIFF
--- a/apps/explorer/src/index.tsx
+++ b/apps/explorer/src/index.tsx
@@ -13,7 +13,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import App from './app/App';
-import { growthbook } from './utils/growthbook';
+import { featuresPromise, growthbook } from './utils/growthbook';
 import { plausible } from './utils/plausible';
 import { reportWebVitals } from './utils/vitals';
 
@@ -28,8 +28,18 @@ if (import.meta.env.PROD) {
         dsn: 'https://e4251274d1b141d7ba272103fa0f8d83@o1314142.ingest.sentry.io/6564988',
         environment: import.meta.env.VITE_VERCEL_ENV,
         integrations: [new BrowserTracing()],
-        tracesSampler: () => {
-            return growthbook.getFeatureValue('explorer-sentry-tracing', 0);
+        // NOTE: We don't use `tracesSampler` because it can't be async so we can't wait for the config to load.
+        async beforeSendTransaction(event) {
+            await featuresPromise;
+            const sampleRate = growthbook.getFeatureValue(
+                'explorer-sentry-tracing',
+                0
+            );
+            if (sampleRate > Math.random()) {
+                return event;
+            } else {
+                return null;
+            }
         },
         beforeSend(event) {
             try {

--- a/apps/explorer/src/index.tsx
+++ b/apps/explorer/src/index.tsx
@@ -28,7 +28,10 @@ if (import.meta.env.PROD) {
         dsn: 'https://e4251274d1b141d7ba272103fa0f8d83@o1314142.ingest.sentry.io/6564988',
         environment: import.meta.env.VITE_VERCEL_ENV,
         integrations: [new BrowserTracing()],
-        // NOTE: We don't use `tracesSampler` because it can't be async so we can't wait for the config to load.
+        // NOTE: Even though this is set to 1, we actually will properly sample the event in `beforeSendTransaction`.
+        // We don't do sampling here or in `tracesSampler` because those can't be async, so we can't wait for
+        // the features from growthbook to load before applying sampling.
+        tracesSampleRate: 1,
         async beforeSendTransaction(event) {
             await featuresPromise;
             const sampleRate = growthbook.getFeatureValue(

--- a/apps/explorer/src/utils/growthbook.ts
+++ b/apps/explorer/src/utils/growthbook.ts
@@ -9,6 +9,11 @@ const GROWTHBOOK_API_KEY = import.meta.env.PROD
 
 export const growthbook = new GrowthBook();
 
+let resolveFeaturesPromise: () => void;
+export const featuresPromise: Promise<void> = new Promise((resolve) => {
+    resolveFeaturesPromise = resolve;
+});
+
 export async function loadFeatures() {
     try {
         const res = await fetch(
@@ -24,6 +29,8 @@ export async function loadFeatures() {
         growthbook.setFeatures(data.features);
     } catch (e) {
         console.warn('Failed to fetch feature definitions from Growthbook', e);
+    } finally {
+        resolveFeaturesPromise();
     }
 }
 


### PR DESCRIPTION
I noticed that if growthbook features haven't loaded before `tracesSampler` is called, that we'll just drop transactions on the floor. For the wallet this isn't an issue because we init after features load, but for explorer this causes transactions to get dropped. This updates our sentry logic to apply sampling later so that we can actually ensure that we don't miss transactions just because we're async loading features.