### PR TITLE
Allow table summary command to print key/value size quantile breakdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9164,6 +9164,7 @@ dependencies = [
  "textwrap 0.16.0",
  "tokio",
  "tracing",
+ "typed-store",
  "workspace-hack",
 ]
 
@@ -10196,6 +10197,7 @@ dependencies = [
  "collectable",
  "eyre",
  "fdlimit",
+ "hdrhistogram",
  "num_cpus",
  "once_cell",
  "proc-macro2 1.0.47",

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -27,7 +27,7 @@ use sui_types::messages::{
 };
 use tracing::{debug, trace, warn};
 use typed_store::rocks::{DBBatch, DBMap, DBOptions, TypedStoreError};
-use typed_store::traits::TypedStoreDebug;
+use typed_store::traits::{TableSummary, TypedStoreDebug};
 
 use crate::authority::authority_notify_read::NotifyRead;
 use crate::authority::{CertTxGuard, MAX_TX_RECOVERY_RETRY};

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -8,7 +8,7 @@ use sui_storage::default_db_options;
 use sui_types::base_types::SequenceNumber;
 use sui_types::messages::TrustedCertificate;
 use typed_store::rocks::{DBMap, DBOptions};
-use typed_store::traits::TypedStoreDebug;
+use typed_store::traits::{TableSummary, TypedStoreDebug};
 
 use typed_store_derive::DBMapUtils;
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -41,7 +41,7 @@ use sui_types::messages_checkpoint::{
 use tokio::sync::{mpsc, watch, Notify};
 use tracing::{debug, error, info, warn};
 use typed_store::rocks::{DBMap, TypedStoreError};
-use typed_store::traits::TypedStoreDebug;
+use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store::Map;
 use typed_store_derive::DBMapUtils;
 

--- a/crates/sui-core/src/epoch/committee_store.rs
+++ b/crates/sui-core/src/epoch/committee_store.rs
@@ -8,7 +8,7 @@ use sui_types::base_types::ObjectID;
 use sui_types::committee::{Committee, EpochId};
 use sui_types::error::SuiResult;
 use typed_store::rocks::{DBMap, DBOptions};
-use typed_store::traits::TypedStoreDebug;
+use typed_store::traits::{TableSummary, TypedStoreDebug};
 
 use typed_store::Map;
 use typed_store_derive::DBMapUtils;

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 use typed_store::rocks::DBMap;
 use typed_store::rocks::DBOptions;
 use typed_store::traits::Map;
-use typed_store::traits::TypedStoreDebug;
+use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store_derive::DBMapUtils;
 
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest, TxSequenceNumber};

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -27,7 +27,7 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tracing::{debug, error, info, trace, warn};
 use typed_store::rocks::{DBBatch, DBMap, DBOptions};
 use typed_store::traits::Map;
-use typed_store::traits::TypedStoreDebug;
+use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store_derive::DBMapUtils;
 
 use sui_types::base_types::{ObjectDigest, ObjectID, ObjectRef, SequenceNumber, TransactionDigest};

--- a/crates/sui-storage/src/node_sync_store.rs
+++ b/crates/sui-storage/src/node_sync_store.rs
@@ -1,0 +1,325 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+
+use sui_types::{
+    base_types::{
+        AuthorityName, EpochId, ExecutionDigests, TransactionDigest, TransactionEffectsDigest,
+    },
+    batch::TxSequenceNumber,
+    committee::StakeUnit,
+    error::SuiResult,
+    messages::{SignedTransactionEffects, TrustedCertificate, VerifiedCertificate},
+};
+
+use typed_store::rocks::DBMap;
+
+use typed_store::traits::Map;
+use typed_store::traits::{TableSummary, TypedStoreDebug};
+use typed_store_derive::DBMapUtils;
+
+use tracing::trace;
+
+#[cfg(test)]
+use std::sync::Arc;
+
+/// NodeSyncStore store is used by nodes to store downloaded objects (pending_certs, etc) that have
+/// not yet been applied to the node's SuiDataStore.
+#[derive(DBMapUtils)]
+pub struct NodeSyncStore {
+    /// Certificates that have been fetched from remote validators, but not sequenced.
+    /// Entries are cleared after execution.
+    pending_certs: DBMap<(EpochId, TransactionDigest), TrustedCertificate>,
+
+    /// Verified true effects.
+    /// Entries are cleared after execution.
+    pending_effects: DBMap<(EpochId, TransactionDigest), SignedTransactionEffects>,
+
+    /// The persisted batch streams (minus the signed batches) from each authority.
+    batch_streams: DBMap<(EpochId, AuthorityName, TxSequenceNumber), ExecutionDigests>,
+
+    /// The latest received sequence from each authority.
+    latest_seq: DBMap<(EpochId, AuthorityName), TxSequenceNumber>,
+
+    /// Which peers have claimed to have executed which effects?
+    effects_votes: DBMap<
+        (
+            EpochId,
+            TransactionDigest,
+            TransactionEffectsDigest,
+            AuthorityName,
+        ),
+        StakeUnit,
+    >,
+}
+
+impl NodeSyncStore {
+    #[cfg(test)]
+    pub fn new_for_test() -> Arc<Self> {
+        let working_dir = tempfile::tempdir().unwrap();
+        let db_path = working_dir.path().join("sync_store");
+        Arc::new(NodeSyncStore::open_tables_read_write(db_path, None, None))
+    }
+
+    pub fn store_cert(&self, epoch_id: EpochId, cert: &VerifiedCertificate) -> SuiResult {
+        Ok(self
+            .pending_certs
+            .insert(&(epoch_id, *cert.digest()), cert.serializable_ref())?)
+    }
+
+    pub fn batch_store_certs(&self, certs: impl Iterator<Item = VerifiedCertificate>) -> SuiResult {
+        let batch = self.pending_certs.batch().insert_batch(
+            &self.pending_certs,
+            certs.map(|cert| ((cert.epoch(), *cert.digest()), cert.serializable())),
+        )?;
+        batch.write()?;
+        Ok(())
+    }
+
+    pub fn store_effects(
+        &self,
+        epoch_id: EpochId,
+        tx: &TransactionDigest,
+        effects: &SignedTransactionEffects,
+    ) -> SuiResult {
+        Ok(self.pending_effects.insert(&(epoch_id, *tx), effects)?)
+    }
+
+    pub fn get_cert_and_effects(
+        &self,
+        epoch_id: EpochId,
+        tx: &TransactionDigest,
+    ) -> SuiResult<(
+        Option<VerifiedCertificate>,
+        Option<SignedTransactionEffects>,
+    )> {
+        Ok((
+            self.pending_certs.get(&(epoch_id, *tx))?.map(|c| c.into()),
+            self.pending_effects.get(&(epoch_id, *tx))?,
+        ))
+    }
+
+    pub fn get_cert(
+        &self,
+        epoch_id: EpochId,
+        tx: &TransactionDigest,
+    ) -> SuiResult<Option<VerifiedCertificate>> {
+        Ok(self.pending_certs.get(&(epoch_id, *tx))?.map(|c| c.into()))
+    }
+
+    pub fn get_effects(
+        &self,
+        epoch_id: EpochId,
+        tx: &TransactionDigest,
+    ) -> SuiResult<Option<SignedTransactionEffects>> {
+        Ok(self.pending_effects.get(&(epoch_id, *tx))?)
+    }
+
+    pub fn cleanup_cert(&self, epoch_id: EpochId, digest: &TransactionDigest) -> SuiResult {
+        self.pending_certs.remove(&(epoch_id, *digest))?;
+        self.pending_effects.remove(&(epoch_id, *digest))?;
+        self.clear_effects_votes(epoch_id, *digest)?;
+
+        Ok(())
+    }
+
+    pub fn enqueue_execution_digests(
+        &self,
+        epoch_id: EpochId,
+        peer: AuthorityName,
+        seq: TxSequenceNumber,
+        digests: &ExecutionDigests,
+    ) -> SuiResult {
+        let mut write_batch = self.batch_streams.batch();
+        trace!(?peer, ?seq, ?digests, "persisting digests to db");
+        write_batch = write_batch.insert_batch(
+            &self.batch_streams,
+            std::iter::once(((epoch_id, peer, seq), digests)),
+        )?;
+
+        match self.latest_seq.get(&(epoch_id, peer))? {
+            // Note: this can actually happen, because when you request a starting sequence
+            // from the validator, it sends you any preceding txes that were in the same
+            // batch.
+            Some(prev_latest) if prev_latest > seq => (),
+
+            _ => {
+                trace!(?peer, ?seq, "recording latest sequence to db");
+                write_batch = write_batch
+                    .insert_batch(&self.latest_seq, std::iter::once(((epoch_id, peer), seq)))?;
+            }
+        }
+
+        write_batch.write()?;
+        Ok(())
+    }
+
+    pub fn batch_stream_iter<'a>(
+        &'a self,
+        epoch_id: EpochId,
+        peer: &'a AuthorityName,
+    ) -> SuiResult<impl Iterator<Item = (TxSequenceNumber, ExecutionDigests)> + 'a> {
+        Ok(self
+            .batch_streams
+            .iter()
+            .skip_to(&(epoch_id, *peer, 0))?
+            .take_while(move |((e, name, _), _)| *e == epoch_id && *name == *peer)
+            .map(|((_, _, seq), digests)| (seq, digests)))
+    }
+
+    pub fn latest_seq_for_peer(
+        &self,
+        epoch_id: EpochId,
+        peer: &AuthorityName,
+    ) -> SuiResult<Option<TxSequenceNumber>> {
+        Ok(self.latest_seq.get(&(epoch_id, *peer))?)
+    }
+
+    pub fn remove_batch_stream_item(
+        &self,
+        epoch_id: EpochId,
+        peer: AuthorityName,
+        seq: TxSequenceNumber,
+    ) -> SuiResult {
+        Ok(self.batch_streams.remove(&(epoch_id, peer, seq))?)
+    }
+
+    pub fn record_effects_vote(
+        &self,
+        epoch_id: EpochId,
+        peer: AuthorityName,
+        digest: TransactionDigest,
+        effects_digest: TransactionEffectsDigest,
+        stake: StakeUnit,
+    ) -> SuiResult {
+        trace!(?effects_digest, ?peer, ?stake, "recording vote");
+        Ok(self
+            .effects_votes
+            .insert(&(epoch_id, digest, effects_digest, peer), &stake)?)
+    }
+
+    fn iter_fx_digest(
+        &self,
+        epoch_id: EpochId,
+        digest: TransactionDigest,
+        effects_digest: TransactionEffectsDigest,
+    ) -> SuiResult<
+        impl Iterator<
+                Item = (
+                    (TransactionDigest, TransactionEffectsDigest, AuthorityName),
+                    StakeUnit,
+                ),
+            > + '_,
+    > {
+        Ok(self
+            .effects_votes
+            .iter()
+            .skip_to(&(epoch_id, digest, effects_digest, AuthorityName::ZERO))?
+            .take_while(move |((e, tx, fx, _), _)| {
+                *e == epoch_id && *tx == digest && *fx == effects_digest
+            })
+            .map(|((_, tx, fx, peer), vote)| ((tx, fx, peer), vote)))
+    }
+
+    pub fn count_effects_votes(
+        &self,
+        epoch_id: EpochId,
+        digest: TransactionDigest,
+        effects_digest: TransactionEffectsDigest,
+    ) -> SuiResult<StakeUnit> {
+        Ok(self
+            .iter_fx_digest(epoch_id, digest, effects_digest)?
+            .map(|((_, _, _), stake)| stake)
+            .sum())
+    }
+
+    pub fn get_voters(
+        &self,
+        epoch_id: EpochId,
+        digest: TransactionDigest,
+        effects_digest: TransactionEffectsDigest,
+    ) -> SuiResult<BTreeSet<AuthorityName>> {
+        Ok(self
+            .iter_fx_digest(epoch_id, digest, effects_digest)?
+            .map(|((_, _, peer), _)| peer)
+            .collect())
+    }
+
+    pub fn clear_effects_votes(&self, epoch_id: EpochId, digest: TransactionDigest) -> SuiResult {
+        trace!(effects_digest = ?digest, "clearing votes");
+        Ok(self.effects_votes.multi_remove(
+            self.effects_votes
+                .iter()
+                .skip_to(&(
+                    epoch_id,
+                    digest,
+                    TransactionEffectsDigest::ZERO,
+                    AuthorityName::ZERO,
+                ))?
+                .take_while(move |((e, d, _, _), _)| *e == epoch_id && *d == digest)
+                .map(|(k, _)| k),
+        )?)
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use sui_types::crypto::{get_authority_key_pair, KeypairTraits};
+
+    #[tokio::test]
+    async fn test_stake_votes() {
+        let db = NodeSyncStore::new_for_test();
+
+        let epoch_id: EpochId = 1;
+
+        let (_, kp1) = get_authority_key_pair();
+        let (_, kp2) = get_authority_key_pair();
+        let peer1: AuthorityName = kp1.public().into();
+        let peer2: AuthorityName = kp2.public().into();
+
+        let tx1 = TransactionDigest::random();
+        let tx2 = TransactionDigest::random();
+        let digest1 = TransactionEffectsDigest::random();
+        let digest2 = TransactionEffectsDigest::random();
+
+        db.record_effects_vote(epoch_id, peer1, tx1, digest1, 1)
+            .unwrap();
+        assert_eq!(db.count_effects_votes(epoch_id, tx1, digest1).unwrap(), 1);
+
+        db.record_effects_vote(epoch_id, peer2, tx1, digest1, 2)
+            .unwrap();
+        assert_eq!(db.count_effects_votes(epoch_id, tx1, digest1).unwrap(), 3);
+
+        assert_eq!(
+            db.get_voters(epoch_id, tx1, digest1).unwrap(),
+            [peer1, peer2].iter().cloned().collect()
+        );
+
+        // redundant votes do not increase total
+        db.record_effects_vote(epoch_id, peer2, tx1, digest1, 2)
+            .unwrap();
+        assert_eq!(db.count_effects_votes(epoch_id, tx1, digest1).unwrap(), 3);
+
+        db.record_effects_vote(epoch_id, peer1, tx2, digest2, 1)
+            .unwrap();
+        db.record_effects_vote(epoch_id, peer2, tx2, digest2, 2)
+            .unwrap();
+
+        db.clear_effects_votes(epoch_id, tx1).unwrap();
+        // digest1 is cleared
+        assert_eq!(db.count_effects_votes(epoch_id, tx1, digest1).unwrap(), 0);
+        // digest2 is not
+        assert_eq!(db.count_effects_votes(epoch_id, tx2, digest2).unwrap(), 3);
+
+        // Votes for different effects digests are isolated.
+        db.record_effects_vote(epoch_id, peer1, tx1, digest1, 1)
+            .unwrap();
+        db.record_effects_vote(epoch_id, peer2, tx1, digest2, 2)
+            .unwrap();
+        assert_eq!(db.count_effects_votes(epoch_id, tx1, digest1).unwrap(), 1);
+        assert_eq!(db.count_effects_votes(epoch_id, tx1, digest2).unwrap(), 2);
+    }
+}

--- a/crates/sui-storage/src/write_ahead_log.rs
+++ b/crates/sui-storage/src/write_ahead_log.rs
@@ -13,7 +13,7 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use sui_types::base_types::TransactionDigest;
-use typed_store::traits::TypedStoreDebug;
+use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store_derive::DBMapUtils;
 
 use sui_types::error::{SuiError, SuiResult};

--- a/crates/sui-storage/src/write_path_pending_tx_log.rs
+++ b/crates/sui-storage/src/write_path_pending_tx_log.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use sui_types::base_types::TransactionDigest;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{TrustedTransction, VerifiedTransaction};
-use typed_store::traits::TypedStoreDebug;
+use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store::{rocks::DBMap, traits::Map};
 use typed_store_derive::DBMapUtils;
 

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -32,6 +32,7 @@ sui-types = { path = "../sui-types" }
 sui-network = { path = "../sui-network" }
 
 telemetry-subscribers.workspace = true
+typed-store.workspace = true
 
 colored = "2.0.0"
 workspace-hack.workspace = true

--- a/crates/sui-tool/src/db_tool/db_dump.rs
+++ b/crates/sui-tool/src/db_tool/db_dump.rs
@@ -17,6 +17,7 @@ use sui_storage::{lock_service::LockServiceImpl, IndexStoreTables};
 use sui_types::base_types::EpochId;
 use sui_types::messages::{SignedTransactionEffects, TrustedCertificate};
 use sui_types::temporary_store::InnerTemporaryStore;
+use typed_store::traits::TableSummary;
 
 #[derive(EnumString, Parser, Debug)]
 pub enum StoreName {
@@ -58,7 +59,7 @@ pub fn table_summary(
     epoch: Option<EpochId>,
     db_path: PathBuf,
     table_name: &str,
-) -> anyhow::Result<(usize, usize, usize)> {
+) -> anyhow::Result<TableSummary> {
     match store_name {
         StoreName::Validator => {
             let epoch_tables = AuthorityEpochTables::describe_tables();

--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -68,11 +68,28 @@ pub fn print_db_table_summary(
     path: PathBuf,
     table_name: &str,
 ) -> anyhow::Result<()> {
-    let (count_keys, key_bytes, value_bytes) = table_summary(store, epoch, path, table_name)?;
+    let summary = table_summary(store, epoch, path, table_name)?;
+    let quantiles = vec![25, 50, 75, 90, 99];
     println!(
-        "Total keys = {}, key bytes = {}, value bytes = {}",
-        count_keys, key_bytes, value_bytes
+        "Total num keys = {}, total key bytes = {}, total value bytes = {}",
+        summary.num_keys, summary.key_bytes_total, summary.value_bytes_total
     );
+    println!("Key size distribution:\n");
+    quantiles.iter().for_each(|q| {
+        println!(
+            "p{:?} -> {:?} bytes\n",
+            q,
+            summary.key_hist.value_at_quantile(*q as f64 / 100.0)
+        );
+    });
+    println!("Value size distribution:\n");
+    quantiles.iter().for_each(|q| {
+        println!(
+            "p{:?} -> {:?} bytes\n",
+            q,
+            summary.value_hist.value_at_quantile(*q as f64 / 100.0)
+        );
+    });
     Ok(())
 }
 

--- a/crates/typed-store-derive/Cargo.toml
+++ b/crates/typed-store-derive/Cargo.toml
@@ -15,11 +15,12 @@ proc-macro = true
 proc-macro2 = "1.0.47"
 quote = "1.0.23"
 syn = { version = "1.0.104", features = ["full"] }
+typed-store = { path = "../typed-store" }
 workspace-hack.workspace = true
+
 
 [dev-dependencies]
 eyre = "0.6.8"
 rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
 tempfile = "3.3.0"
-typed-store = { path = "../typed-store" }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -17,6 +17,7 @@ once_cell = "1.15.0"
 tap = "1.0.1"
 num_cpus = "1.14.0"
 prometheus = "0.13.3"
+hdrhistogram = "7.5.1"
 # deactivation of bzip2 due to https://github.com/rust-rocksdb/rust-rocksdb/issues/609
 rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
 serde = { version = "1.0.140", features = ["derive"] }

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -95,6 +95,14 @@ where
     fn try_catch_up_with_primary(&self) -> Result<(), Self::Error>;
 }
 
+pub struct TableSummary {
+    pub num_keys: u64,
+    pub key_bytes_total: usize,
+    pub value_bytes_total: usize,
+    pub key_hist: hdrhistogram::Histogram<u64>,
+    pub value_hist: hdrhistogram::Histogram<u64>,
+}
+
 pub trait TypedStoreDebug {
     /// Dump a DB table with pagination
     fn dump_table(
@@ -112,4 +120,7 @@ pub trait TypedStoreDebug {
 
     /// Count the entries in the table
     fn count_table_keys(&self, table_name: String) -> eyre::Result<usize>;
+
+    /// Return table summary of the input table
+    fn table_summary(&self, table_name: String) -> eyre::Result<TableSummary>;
 }

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -15,6 +15,7 @@ use typed_store::rocks::be_fix_int_ser;
 use typed_store::rocks::list_tables;
 use typed_store::rocks::DBMap;
 use typed_store::traits::Map;
+use typed_store::traits::TableSummary;
 use typed_store::traits::TypedStoreDebug;
 use typed_store::Store;
 use typed_store_derive::DBMapUtils;
@@ -117,14 +118,14 @@ async fn macro_test() {
     assert_eq!(7, tbls_secondary.count_keys("table2").unwrap());
 
     // check raw byte sizes of key and values
-    let (count, key_bytes, value_bytes) = tbls_secondary.table_summary("table1").unwrap();
-    assert_eq!(9, count);
-    assert_eq!(raw_key_bytes1, key_bytes);
-    assert_eq!(raw_value_bytes1, value_bytes);
-    let (count, key_bytes, value_bytes) = tbls_secondary.table_summary("table2").unwrap();
-    assert_eq!(7, count);
-    assert_eq!(raw_key_bytes2, key_bytes);
-    assert_eq!(raw_value_bytes2, value_bytes);
+    let summary1 = tbls_secondary.table_summary("table1").unwrap();
+    assert_eq!(9, summary1.num_keys);
+    assert_eq!(raw_key_bytes1, summary1.key_bytes_total);
+    assert_eq!(raw_value_bytes1, summary1.value_bytes_total);
+    let summary2 = tbls_secondary.table_summary("table2").unwrap();
+    assert_eq!(7, summary2.num_keys);
+    assert_eq!(raw_key_bytes2, summary2.key_bytes_total);
+    assert_eq!(raw_value_bytes2, summary2.value_bytes_total);
 
     // Test all entries
     let m = tbls_secondary.dump("table1", 100, 0).unwrap();


### PR DESCRIPTION
Refactor table_summary command to move out of macro and add printing size distributions as well.