### PR TITLE
[frontend ci] Run turbo CI on main

### DIFF
--- a/.github/workflows/turborepo.yml
+++ b/.github/workflows/turborepo.yml
@@ -1,5 +1,11 @@
 name: Turborepo CI
-on: pull_request
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
 jobs:
   audit:
     name: pnpm audit


### PR DESCRIPTION
This should let branches derived from main share the install / turbo cache, which should make runs faster.