### PR TITLE
[consensus] Ensure ConsensusAdapter tasks terminate before reconfiguration can proceed

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1926,7 +1926,7 @@ impl AuthorityState {
         })
     }
 
-    pub fn reconfigure(&self, new_committee: Committee) -> SuiResult {
+    pub async fn reconfigure(&self, new_committee: Committee) -> SuiResult {
         fp_ensure!(
             self.epoch() + 1 == new_committee.epoch,
             SuiError::from("Invalid new epoch")
@@ -1936,7 +1936,7 @@ impl AuthorityState {
         self.db()
             .perpetual_tables
             .set_recovery_epoch(new_committee.epoch)?;
-        self.db().reopen_epoch_db(new_committee);
+        self.db().reopen_epoch_db(new_committee).await;
         Ok(())
     }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -144,7 +144,7 @@ impl AuthorityStore {
         Ok(store)
     }
 
-    pub(crate) fn reopen_epoch_db(&self, new_committee: Committee) {
+    pub(crate) async fn reopen_epoch_db(&self, new_committee: Committee) {
         info!(new_epoch = ?new_committee.epoch, "re-opening AuthorityEpochTables for new epoch");
         let epoch_tables = Arc::new(AuthorityPerEpochStore::new(
             new_committee,
@@ -152,7 +152,7 @@ impl AuthorityStore {
             self.db_options.clone(),
         ));
         let previous_store = self.epoch_store.swap(epoch_tables);
-        previous_store.epoch_terminated();
+        previous_store.epoch_terminated().await;
     }
 
     pub fn epoch_store(&self) -> Guard<Arc<AuthorityPerEpochStore>> {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -181,6 +181,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
 
     authority_state
         .reconfigure(second_committee.committee().clone())
+        .await
         .unwrap();
 
     // checkpoint execution should resume
@@ -295,6 +296,7 @@ pub async fn test_reconfig_crash_recovery() {
 
     authority_state
         .reconfigure(second_committee.committee().clone())
+        .await
         .unwrap();
 
     // checkpoint execution should resume

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -609,6 +609,7 @@ impl SuiNode {
                 // TODO: (Laura) wait for stop complete signal
                 self.state
                     .reconfigure(new_committee.committee)
+                    .await
                     .expect("Reconfigure authority state cannot fail");
                 info!("Validator State has been reconfigured");
                 if self.state.is_validator() {


### PR DESCRIPTION
At some point reconfiguration process calls `AuthorityState::reconfigure`, which in turn calls `AuthorityPerEpochStore::epoch_terminated`. With this PR we want to make sure that epoch_terminated does not finish until there is no pending consensus adapter tasks, to make sure we do not have race condition between consensus adapter terminating and narwhal restarting that can lead to polluting new narwhal epoch with messages from previous epoch.

See more comments in `ConsensusAdapter` code for details.