### PR TITLE
[Stress] fix local benchmark; run benchmark in release mode

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -70,8 +70,8 @@ jobs:
     - name: Run benchmarks
       run: |
         set -o pipefail
-        cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 100 --run-duration 60s 2>&1 | huniq | tee -a artifacts/owned.txt
-        cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --shared-counter 100 --run-duration 60s 2>&1 | huniq | tee -a artifacts/shared.txt
+        cargo run --release --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 100 --run-duration 60s 2>&1 | huniq | tee -a artifacts/owned.txt
+        cargo run --release --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --shared-counter 100 --run-duration 60s 2>&1 | huniq | tee -a artifacts/shared.txt
         pushd narwhal/benchmark && fab local | tail -n 31 | tee -a ../../artifacts/narwhal.txt && popd
 
     - name: Retrieve benchmark results

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,10 @@ jobs:
       - name: cargo test
         run: |
           cargo nextest run --profile ci
-      - name: Doctests
+      - name: benchmark (smoke)
+        run: |
+          cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s
+      - name: doctests
         run: |
           cargo test --doc
       - name: rustdoc


### PR DESCRIPTION
As chatted with @lxfind, add an infinite wait for server runtime thread in stress client. This fixes the issue here: https://github.com/MystenLabs/sui/actions/runs/3735884139/jobs/6339625259#step:8:944

Add a smoke test for benchmark in CI.

Build stress benchmark in release mode in the benchmark workflow.