### PR TITLE
[reconfig] Restart authority store using perpetual epoch

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1933,7 +1933,9 @@ impl AuthorityState {
         );
 
         self.committee_store.insert_new_committee(&new_committee)?;
-        self.db().perpetual_tables.set_epoch(new_committee.epoch)?;
+        self.db()
+            .perpetual_tables
+            .set_recovery_epoch(new_committee.epoch)?;
         self.db().reopen_epoch_db(new_committee);
         Ok(())
     }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1808,7 +1808,7 @@ impl AuthorityState {
 
         // unwrap ok - for testing only.
         let store = Arc::new(
-            AuthorityStore::open_with_committee(
+            AuthorityStore::open_with_committee_for_testing(
                 &path.join("store"),
                 None,
                 &genesis_committee,
@@ -1927,14 +1927,13 @@ impl AuthorityState {
     }
 
     pub fn reconfigure(&self, new_committee: Committee) -> SuiResult {
-        // TODO: We should move the committee into epoch db store, so that the operation below
-        // can become atomic.
         fp_ensure!(
             self.epoch() + 1 == new_committee.epoch,
-            SuiError::from("Invalid new epoch to sign and update")
+            SuiError::from("Invalid new epoch")
         );
 
         self.committee_store.insert_new_committee(&new_committee)?;
+        self.db().perpetual_tables.set_epoch(new_committee.epoch)?;
         self.db().reopen_epoch_db(new_committee);
         Ok(())
     }

--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -271,7 +271,7 @@ mod tests {
             );
 
         let store = Arc::new(
-            AuthorityStore::open_with_committee(
+            AuthorityStore::open_with_committee_for_testing(
                 &path,
                 None,
                 &committee,

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -57,36 +57,45 @@ pub struct AuthorityStore {
 
 impl AuthorityStore {
     /// Open an authority store by directory path.
-    /// If the store is empty, initialize it using genesis objects.
+    /// If the store is empty, initialize it using genesis.
     pub async fn open(
         path: &Path,
         db_options: Option<Options>,
         genesis: &Genesis,
+        committee_store: &Arc<CommitteeStore>,
     ) -> SuiResult<Self> {
         let perpetual_tables = AuthorityPerpetualTables::open(path, db_options.clone());
-        let committee = if perpetual_tables.database_is_empty()? {
-            genesis.committee()?
-        } else {
-            perpetual_tables.get_committee()?
+        let cur_epoch = perpetual_tables.get_epoch()?;
+        let committee = match committee_store.get_committee(&cur_epoch)? {
+            Some(committee) => committee,
+            None => {
+                // If we cannot find the corresponding committee from the committee store, we must
+                // be at genesis. This is because we always first insert to the committee store
+                // before updating the current epoch in the perpetual tables.
+                assert_eq!(cur_epoch, 0);
+                genesis.committee()?
+            }
         };
         Self::open_inner(path, db_options, genesis, perpetual_tables, committee).await
     }
 
-    pub async fn open_with_committee(
+    pub async fn open_with_committee_for_testing(
         path: &Path,
         db_options: Option<Options>,
         committee: &Committee,
         genesis: &Genesis,
     ) -> SuiResult<Self> {
+        assert_eq!(committee.epoch, 0);
         let perpetual_tables = AuthorityPerpetualTables::open(path, db_options.clone());
-        Self::open_inner(
+        let store = Self::open_inner(
             path,
             db_options,
             genesis,
             perpetual_tables,
             committee.clone(),
         )
-        .await
+        .await?;
+        Ok(store)
     }
 
     async fn open_inner(

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1766,7 +1766,7 @@ async fn test_handle_certificate_with_shared_object_interrupted_retry() {
         // NOTE: this test fails if execute_certificate() is used here instead, while keeping
         // try_execute_for_test() above. This is because owned object locks are not cleared
         // atomically after a transaction completes, causing inconsistency when TransactionManager
-        // calss get_missing_input_objects(). This would be an issue for crash recovery too.
+        // calls get_missing_input_objects(). This would be an issue for crash recovery too.
         // TODO: fix the issue and test interrupting both execute_certificate() and
         // try_execute_for_test(), and calling execute_certificate() again.
         let info = authority_state
@@ -2231,7 +2231,7 @@ async fn test_authority_persist() {
 
     // Create an authority
     let store = Arc::new(
-        AuthorityStore::open_with_committee(
+        AuthorityStore::open_with_committee_for_testing(
             &path,
             None,
             &committee,
@@ -2265,7 +2265,7 @@ async fn test_authority_persist() {
             &mut StdRng::from_seed(seed),
         );
     let store = Arc::new(
-        AuthorityStore::open_with_committee(
+        AuthorityStore::open_with_committee_for_testing(
             &path,
             None,
             &committee,

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -94,7 +94,7 @@ async fn test_open_manager() {
     {
         // Create an authority
         let store = Arc::new(
-            AuthorityStore::open_with_committee(
+            AuthorityStore::open_with_committee_for_testing(
                 &path,
                 None,
                 &committee,
@@ -134,7 +134,7 @@ async fn test_open_manager() {
     {
         // Create an authority
         let store = Arc::new(
-            AuthorityStore::open_with_committee(
+            AuthorityStore::open_with_committee_for_testing(
                 &path,
                 None,
                 &committee,
@@ -170,7 +170,7 @@ async fn test_open_manager() {
     {
         // Create an authority
         let store = Arc::new(
-            AuthorityStore::open_with_committee(
+            AuthorityStore::open_with_committee_for_testing(
                 &path,
                 None,
                 &committee,
@@ -204,7 +204,7 @@ async fn test_batch_manager_happy_path() {
     let (committee, _, authority_key) =
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     let store = Arc::new(
-        AuthorityStore::open_with_committee(
+        AuthorityStore::open_with_committee_for_testing(
             &path,
             None,
             &committee,
@@ -287,7 +287,7 @@ async fn test_batch_manager_out_of_order() {
     let (committee, _, authority_key) =
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     let store = Arc::new(
-        AuthorityStore::open_with_committee(
+        AuthorityStore::open_with_committee_for_testing(
             &path,
             None,
             &committee,
@@ -364,7 +364,7 @@ async fn test_batch_manager_drop_out_of_order() {
     let (committee, _, authority_key) =
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     let store = Arc::new(
-        AuthorityStore::open_with_committee(
+        AuthorityStore::open_with_committee_for_testing(
             &path,
             None,
             &committee,
@@ -742,7 +742,7 @@ async fn test_safe_batch_stream() {
     authorities.insert(public_key_bytes, 1);
     let committee = Committee::new(0, authorities).unwrap();
     let store = Arc::new(
-        AuthorityStore::open_with_committee(
+        AuthorityStore::open_with_committee_for_testing(
             &path.join("store"),
             None,
             &committee,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -124,14 +124,21 @@ impl SuiNode {
         let genesis = config.genesis()?;
 
         let secret = Arc::pin(config.protocol_key_pair().copy());
-        let committee = genesis.committee()?;
-        let store =
-            Arc::new(AuthorityStore::open(&config.db_path().join("store"), None, genesis).await?);
+        let genesis_committee = genesis.committee()?;
         let committee_store = Arc::new(CommitteeStore::new(
             config.db_path().join("epochs"),
-            &committee,
+            &genesis_committee,
             None,
         ));
+        let store = Arc::new(
+            AuthorityStore::open(
+                &config.db_path().join("store"),
+                None,
+                genesis,
+                &committee_store,
+            )
+            .await?,
+        );
 
         let checkpoint_store = CheckpointStore::new(&config.db_path().join("checkpoints"));
         let state_sync_store = RocksDbStore::new(


### PR DESCRIPTION
We cannot restart the authority store using the epoch/committee from on-chain state, because that could get ahead of the actual current epoch of the node, which should only change at reconfiguration.
This PR adds a persisted current epoch to the perpetual tables, and use that as source of truth. It's only updated at reconfiguration. And when we restart, we rely on it to locate the proper epoch table.