### PR TITLE
remove ImmediateReturn and WaitForTxCert mode 

### DIFF
--- a/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -49,41 +49,6 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
 
         let fullnode = ctx.get_fullnode_client();
 
-        // Test WaitForEffectsCert
-        let txn = txns.swap_remove(0);
-        let txn_digest = *txn.digest();
-
-        info!("Test execution with ImmediateReturn");
-        let response = fullnode
-            .quorum_driver()
-            .execute_transaction(
-                txn.clone(),
-                Some(ExecuteTransactionRequestType::ImmediateReturn),
-            )
-            .await?;
-        assert_eq!(txn_digest, response.tx_digest);
-
-        // Verify fullnode observes the txn
-        ctx.let_fullnode_sync(vec![txn_digest], 5).await;
-        Self::verify_transaction(fullnode, txn_digest).await;
-
-        info!("Test execution with WaitForTxCert");
-        let txn = txns.swap_remove(0);
-        let txn_digest = *txn.digest();
-        let response = fullnode
-            .quorum_driver()
-            .execute_transaction(
-                txn.clone(),
-                Some(ExecuteTransactionRequestType::WaitForTxCert),
-            )
-            .await?;
-        assert_eq!(txn_digest, response.tx_digest);
-        response.tx_cert.unwrap();
-
-        // Verify fullnode observes the txn
-        ctx.let_fullnode_sync(vec![txn_digest], 5).await;
-        Self::verify_transaction(fullnode, txn_digest).await;
-
         info!("Test execution with WaitForEffectsCert");
         let txn = txns.swap_remove(0);
         let txn_digest = *txn.digest();

--- a/crates/sui-core/src/quorum_driver/metrics.rs
+++ b/crates/sui-core/src/quorum_driver/metrics.rs
@@ -9,15 +9,9 @@ use prometheus::{
 
 #[derive(Clone, Debug)]
 pub struct QuorumDriverMetrics {
-    pub(crate) total_requests_immediate_return: IntCounter,
-    pub(crate) total_ok_responses_immediate_return: IntCounter,
-    pub(crate) total_requests_wait_for_tx_cert: IntCounter,
-    pub(crate) total_ok_responses_wait_for_tx_cert: IntCounter,
     pub(crate) total_requests_wait_for_effects_cert: IntCounter,
     pub(crate) total_ok_responses_wait_for_effects_cert: IntCounter,
 
-    pub(crate) latency_sec_immediate_return: Histogram,
-    pub(crate) latency_sec_wait_for_tx_cert: Histogram,
     pub(crate) latency_sec_wait_for_effects_cert: Histogram,
 
     pub(crate) current_requests_in_flight: IntGauge,
@@ -37,30 +31,6 @@ const LATENCY_SEC_BUCKETS: &[f64] = &[
 impl QuorumDriverMetrics {
     pub fn new(registry: &Registry) -> Self {
         Self {
-            total_requests_immediate_return: register_int_counter_with_registry!(
-                "quorum_driver_total_requests_immediate_return",
-                "Total number of immediate_return requests received",
-                registry,
-            )
-            .unwrap(),
-            total_ok_responses_immediate_return: register_int_counter_with_registry!(
-                "quorum_driver_total_ok_responses_immediate_return",
-                "Total number of immediate_return requests processed with Ok responses",
-                registry,
-            )
-            .unwrap(),
-            total_requests_wait_for_tx_cert: register_int_counter_with_registry!(
-                "quorum_driver_total_requests_wait_for_tx_cert",
-                "Total number of wait_for_tx_cert requests received",
-                registry,
-            )
-            .unwrap(),
-            total_ok_responses_wait_for_tx_cert: register_int_counter_with_registry!(
-                "quorum_driver_total_ok_responses_wait_for_tx_cert",
-                "Total number of wait_fort_tx_cert requests processed with Ok responses",
-                registry,
-            )
-            .unwrap(),
             total_requests_wait_for_effects_cert: register_int_counter_with_registry!(
                 "quorum_driver_total_requests_wait_for_effects_cert",
                 "Total number of wait_for_effects_cert requests received",
@@ -70,20 +40,6 @@ impl QuorumDriverMetrics {
             total_ok_responses_wait_for_effects_cert: register_int_counter_with_registry!(
                 "quorum_driver_total_ok_responses_wait_for_effects_cert",
                 "Total number of wait_for_effects_cert requests processed with Ok responses",
-                registry,
-            )
-            .unwrap(),
-            latency_sec_immediate_return: register_histogram_with_registry!(
-                "quorum_driver_latency_sec_immediate_return",
-                "Latency of processing an immdediate_return execution request, in sec",
-                LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            latency_sec_wait_for_tx_cert: register_histogram_with_registry!(
-                "quorum_driver_latency_sec_wait_for_tx_cert",
-                "Latency of processing an wait_for_tx_cert execution request, in sec",
-                LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -398,12 +398,6 @@ impl Display for SuiParsedTransactionResponse {
 #[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub enum SuiExecuteTransactionResponse {
-    ImmediateReturn {
-        tx_digest: TransactionDigest,
-    },
-    TxCert {
-        certificate: SuiCertifiedTransaction,
-    },
     // TODO: Change to CertifiedTransactionEffects eventually.
     EffectsCert {
         certificate: SuiCertifiedTransaction,
@@ -417,18 +411,9 @@ pub enum SuiExecuteTransactionResponse {
 impl SuiExecuteTransactionResponse {
     pub fn from_execute_transaction_response(
         resp: ExecuteTransactionResponse,
-        tx_digest: TransactionDigest,
         resolver: &impl GetModule,
     ) -> Result<Self, anyhow::Error> {
         Ok(match resp {
-            ExecuteTransactionResponse::ImmediateReturn => {
-                SuiExecuteTransactionResponse::ImmediateReturn { tx_digest }
-            }
-            ExecuteTransactionResponse::TxCert(certificate) => {
-                SuiExecuteTransactionResponse::TxCert {
-                    certificate: (*certificate).try_into()?,
-                }
-            }
             ExecuteTransactionResponse::EffectsCert(cert) => {
                 let (certificate, effects, is_executed_locally) = *cert;
                 let certificate: SuiCertifiedTransaction = certificate.try_into()?;

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -526,14 +526,9 @@ pub trait EventReadApi {
 pub trait TransactionExecutionApi {
     /// Execute the transaction and wait for results if desired.
     /// Request types:
-    /// 1. ImmediateReturn: immediately returns a response to client without waiting
-    ///     for any execution results.  Note the transaction may fail without being
-    ///     noticed by client in this mode. After getting the response, the client
-    ///     may poll the node to check the result of the transaction.
-    /// 2. WaitForTxCert: waits for TransactionCertificate and then return to client.
-    /// 3. WaitForEffectsCert: waits for TransactionEffectsCert and then return to client.
+    /// 1. WaitForEffectsCert: waits for TransactionEffectsCert and then return to client.
     ///     This mode is a proxy for transaction finality.
-    /// 4. WaitForLocalExecution: waits for TransactionEffectsCert and make sure the node
+    /// 2. WaitForLocalExecution: waits for TransactionEffectsCert and make sure the node
     ///     executed the transaction locally before returning the client. The local execution
     ///     makes sure this node is aware of this transaction when client fires subsequent queries.
     ///     However if the node fails to execute the transaction locally in a timely manner,

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -61,7 +61,6 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
         )
         .map_err(|e| anyhow!(e))?;
         let txn = Transaction::from_data(tx_data, Intent::default(), signature);
-        let txn_digest = *txn.digest();
 
         let transaction_orchestrator = self.transaction_orchestrator.clone();
         let response = spawn_monitored_task!(transaction_orchestrator.execute_transaction(
@@ -76,7 +75,6 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
 
         SuiExecuteTransactionResponse::from_execute_transaction_response(
             response,
-            txn_digest,
             self.module_cache.as_ref(),
         )
         .map_err(jsonrpsee::core::Error::from)
@@ -94,7 +92,6 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
             .map_err(|e| anyhow!(e))?;
 
         let txn = Transaction::from_data(tx_data, Intent::default(), signature);
-        let txn_digest = *txn.digest();
 
         let transaction_orchestrator = self.transaction_orchestrator.clone();
         let response = spawn_monitored_task!(transaction_orchestrator.execute_transaction(
@@ -109,7 +106,6 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
 
         SuiExecuteTransactionResponse::from_execute_transaction_response(
             response,
-            txn_digest,
             self.module_cache.as_ref(),
         )
         .map_err(jsonrpsee::core::Error::from)

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -76,12 +76,11 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    if let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response {
-        assert_eq!(
-            dryrun_response.transaction_digest,
-            effects.effects.transaction_digest
-        );
-    }
+    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
+    assert_eq!(
+        dryrun_response.transaction_digest,
+        effects.effects.transaction_digest
+    );
     Ok(())
 }
 
@@ -274,9 +273,7 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiExecuteTransactionResponse::EffectsCert {effects,..} = tx_response else {
-        panic!()
-    };
+    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
 
     let package_id = effects
         .effects
@@ -337,9 +334,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiExecuteTransactionResponse::EffectsCert {effects,..} = tx_response else {
-        panic!()
-    };
+    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
 
     let package_id = effects
         .effects
@@ -418,9 +413,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiExecuteTransactionResponse::EffectsCert {effects,..} = tx_response else {
-        panic!()
-    };
+    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
 
     assert_eq!(SuiExecutionStatus::Success, effects.effects.status);
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -173,7 +173,7 @@
           "name": "APIs to execute transactions."
         }
       ],
-      "description": "Execute the transaction and wait for results if desired. Request types: 1. ImmediateReturn: immediately returns a response to client without waiting     for any execution results.  Note the transaction may fail without being     noticed by client in this mode. After getting the response, the client     may poll the node to check the result of the transaction. 2. WaitForTxCert: waits for TransactionCertificate and then return to client. 3. WaitForEffectsCert: waits for TransactionEffectsCert and then return to client.     This mode is a proxy for transaction finality. 4. WaitForLocalExecution: waits for TransactionEffectsCert and make sure the node     executed the transaction locally before returning the client. The local execution     makes sure this node is aware of this transaction when client fires subsequent queries.     However if the node fails to execute the transaction locally in a timely manner,     a bool type in the response is set to false to indicated the case.",
+      "description": "Execute the transaction and wait for results if desired. Request types: 1. WaitForEffectsCert: waits for TransactionEffectsCert and then return to client.     This mode is a proxy for transaction finality. 2. WaitForLocalExecution: waits for TransactionEffectsCert and make sure the node     executed the transaction locally before returning the client. The local execution     makes sure this node is aware of this transaction when client fires subsequent queries.     However if the node fails to execute the transaction locally in a timely manner,     a bool type in the response is set to false to indicated the case.",
       "params": [
         {
           "name": "tx_bytes",
@@ -3672,8 +3672,6 @@
       "ExecuteTransactionRequestType": {
         "type": "string",
         "enum": [
-          "ImmediateReturn",
-          "WaitForTxCert",
           "WaitForEffectsCert",
           "WaitForLocalExecution"
         ]
@@ -4682,46 +4680,6 @@
       },
       "SuiExecuteTransactionResponse": {
         "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "ImmediateReturn"
-            ],
-            "properties": {
-              "ImmediateReturn": {
-                "type": "object",
-                "required": [
-                  "tx_digest"
-                ],
-                "properties": {
-                  "tx_digest": {
-                    "$ref": "#/components/schemas/TransactionDigest"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "TxCert"
-            ],
-            "properties": {
-              "TxCert": {
-                "type": "object",
-                "required": [
-                  "certificate"
-                ],
-                "properties": {
-                  "certificate": {
-                    "$ref": "#/components/schemas/CertifiedTransaction"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
           {
             "type": "object",
             "required": [

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -128,7 +128,7 @@ pub async fn submit(
         .quorum_driver()
         .execute_transaction(
             signed_tx,
-            Some(ExecuteTransactionRequestType::ImmediateReturn),
+            Some(ExecuteTransactionRequestType::WaitForEffectsCert),
         )
         .await?;
 

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -360,28 +360,6 @@ impl QuorumDriver {
 
         Ok(match (request_type, resp) {
             (
-                ExecuteTransactionRequestType::ImmediateReturn,
-                SuiExecuteTransactionResponse::ImmediateReturn { tx_digest },
-            ) => TransactionExecutionResult {
-                tx_digest,
-                tx_cert: None,
-                effects: None,
-                confirmed_local_execution: false,
-                timestamp_ms: None,
-                parsed_data: None,
-            },
-            (
-                ExecuteTransactionRequestType::WaitForTxCert,
-                SuiExecuteTransactionResponse::TxCert { certificate },
-            ) => TransactionExecutionResult {
-                tx_digest: certificate.transaction_digest,
-                tx_cert: Some(certificate),
-                effects: None,
-                confirmed_local_execution: false,
-                timestamp_ms: None,
-                parsed_data: None,
-            },
-            (
                 ExecuteTransactionRequestType::WaitForEffectsCert,
                 SuiExecuteTransactionResponse::EffectsCert {
                     certificate,
@@ -416,12 +394,6 @@ impl QuorumDriver {
                     timestamp_ms: None,
                     parsed_data: None,
                 }
-            }
-            (other_request_type, other_resp) => {
-                return Err(RpcError::InvalidTransactionResponse(
-                    other_resp,
-                    other_request_type,
-                ))
             }
         })
     }

--- a/crates/sui-sdk/src/error.rs
+++ b/crates/sui-sdk/src/error.rs
@@ -1,9 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_json_rpc_types::SuiExecuteTransactionResponse;
 use sui_types::base_types::TransactionDigest;
-use sui_types::messages::ExecuteTransactionRequestType;
 use thiserror::Error;
 
 pub type SuiRpcResult<T = ()> = Result<T, RpcError>;
@@ -14,8 +12,6 @@ pub enum RpcError {
     RpcError(#[from] jsonrpsee::core::Error),
     #[error("Subscription error : {0}")]
     Subscription(String),
-    #[error("Invalid response type {0:?} for request type: {1:?}")]
-    InvalidTransactionResponse(SuiExecuteTransactionResponse, ExecuteTransactionRequestType),
     #[error("Encountered error when confirming tx status for {0:?}, err: {1:?}")]
     TransactionConfirmationError(TransactionDigest, jsonrpsee::core::Error),
     #[error("Failed to confirm tx status for {0:?} within {1} seconds.")]

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2200,8 +2200,6 @@ impl ConsensusTransaction {
 
 #[derive(Serialize, Deserialize, Clone, Debug, schemars::JsonSchema)]
 pub enum ExecuteTransactionRequestType {
-    ImmediateReturn,
-    WaitForTxCert,
     WaitForEffectsCert,
     WaitForLocalExecution,
 }
@@ -2220,8 +2218,6 @@ pub type IsTransactionExecutedLocally = bool;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ExecuteTransactionResponse {
-    ImmediateReturn,
-    TxCert(Box<CertifiedTransaction>),
     EffectsCert(
         Box<(
             CertifiedTransaction,
@@ -2231,23 +2227,13 @@ pub enum ExecuteTransactionResponse {
     ),
 }
 
-#[derive(Clone, Debug, schemars::JsonSchema)]
-pub enum QuorumDriverRequestType {
-    ImmediateReturn,
-    WaitForTxCert,
-    WaitForEffectsCert,
-}
-
 #[derive(Clone, Debug)]
 pub struct QuorumDriverRequest {
     pub transaction: VerifiedTransaction,
-    pub request_type: QuorumDriverRequestType,
 }
 
 #[derive(Clone, Debug)]
 pub enum QuorumDriverResponse {
-    ImmediateReturn,
-    TxCert(Box<VerifiedCertificate>),
     EffectsCert(Box<(VerifiedCertificate, VerifiedCertifiedTransactionEffects)>),
 }
 


### PR DESCRIPTION
1. we've seen close to 0, if not 0 usages on `ImmediateReturn` and `WaitForTxCert` for transaction execution
2. we're refactoring QuorumDriver/TransactionOrchestrator, removing these two types will simplify the implementation.

You may notice some structs/enums can be further cleaned up, e.g. `QuorumDriverResponse`: These changes are spin off from another big PR, keeping them in this way temporarily will lead to the least rebase conflicts, also they will be removed/updated in subsequent PRs shortly.