### PR TITLE
wallet-ext: use bg service for signing

### DIFF
--- a/.changeset/three-coats-rescue.md
+++ b/.changeset/three-coats-rescue.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Add method to deserialize a public key, using it's schema and base64 data

--- a/apps/wallet/src/background/keyring/Account.ts
+++ b/apps/wallet/src/background/keyring/Account.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Keypair, SuiAddress } from '@mysten/sui.js';
+import type {
+    SignaturePubkeyPair,
+    Keypair,
+    SuiAddress,
+    Base64DataBuffer,
+} from '@mysten/sui.js';
 
 export type AccountType = 'derived' | 'imported';
 
@@ -25,5 +30,13 @@ export class Account {
 
     exportKeypair() {
         return this.#keypair.export();
+    }
+
+    async sign(data: Base64DataBuffer): Promise<SignaturePubkeyPair> {
+        return {
+            signatureScheme: this.#keypair.getKeyScheme(),
+            signature: this.#keypair.signData(data),
+            pubKey: this.#keypair.getPublicKey(),
+        };
     }
 }

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -3,7 +3,11 @@
 
 import { isBasePayload } from '_payloads';
 
-import type { ExportedKeypair } from '@mysten/sui.js';
+import type {
+    ExportedKeypair,
+    SignatureScheme,
+    SuiAddress,
+} from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 
 type MethodToPayloads = {
@@ -43,6 +47,14 @@ type MethodToPayloads = {
     setLockTimeout: {
         args: { timeout: number };
         return: never;
+    };
+    signData: {
+        args: { data: string; address: SuiAddress };
+        return: {
+            signatureScheme: SignatureScheme;
+            signature: string;
+            pubKey: string;
+        };
     };
 };
 

--- a/apps/wallet/src/ui/app/background-client/BackgroundServiceSigner.ts
+++ b/apps/wallet/src/ui/app/background-client/BackgroundServiceSigner.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SignerWithProvider } from '@mysten/sui.js';
+
+import type { BackgroundClient } from '.';
+import type {
+    Base64DataBuffer,
+    Provider,
+    SignaturePubkeyPair,
+    SuiAddress,
+    TxnDataSerializer,
+} from '@mysten/sui.js';
+
+export class BackgroundServiceSigner extends SignerWithProvider {
+    readonly #address: SuiAddress;
+    readonly #backgroundClient: BackgroundClient;
+
+    constructor(
+        address: SuiAddress,
+        backgroundClient: BackgroundClient,
+        provider?: Provider,
+        serializer?: TxnDataSerializer
+    ) {
+        super(provider, serializer);
+        this.#address = address;
+        this.#backgroundClient = backgroundClient;
+    }
+
+    async getAddress(): Promise<string> {
+        return this.#address;
+    }
+
+    signData(data: Base64DataBuffer): Promise<SignaturePubkeyPair> {
+        return this.#backgroundClient.signData(this.#address, data);
+    }
+
+    connect(provider: Provider): SignerWithProvider {
+        return new BackgroundServiceSigner(
+            this.#address,
+            this.#backgroundClient,
+            provider
+        );
+    }
+}

--- a/apps/wallet/src/ui/app/hooks/useSigner.ts
+++ b/apps/wallet/src/ui/app/hooks/useSigner.ts
@@ -4,6 +4,9 @@
 import { thunkExtras } from '_redux/store/thunk-extras';
 
 export function useSigner() {
-    const { api, keypairVault } = thunkExtras;
-    return api.getSignerInstance(keypairVault.getKeypair());
+    const { api, keypairVault, background } = thunkExtras;
+    return api.getSignerInstance(
+        keypairVault.getKeypair().getPublicKey().toSuiAddress(),
+        background
+    );
 }

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -6,11 +6,11 @@ import { Coin as CoinAPI, SUI_TYPE_ARG } from '@mysten/sui.js';
 import type {
     ObjectId,
     SuiObject,
-    RawSigner,
     SuiAddress,
     SuiMoveObject,
     JsonRpcProvider,
     SuiExecuteTransactionResponse,
+    SignerWithProvider,
 } from '@mysten/sui.js';
 
 const COIN_TYPE = '0x2::coin::Coin';
@@ -85,7 +85,7 @@ export class Coin {
      * @param validator The sui address of the chosen validator
      */
     public static async stakeCoin(
-        signer: RawSigner,
+        signer: SignerWithProvider,
         coins: SuiMoveObject[],
         amount: bigint,
         validator: SuiAddress
@@ -107,7 +107,7 @@ export class Coin {
     }
 
     private static async requestSuiCoinWithExactAmount(
-        signer: RawSigner,
+        signer: SignerWithProvider,
         coins: SuiMoveObject[],
         amount: bigint
     ): Promise<ObjectId> {
@@ -143,7 +143,7 @@ export class Coin {
     }
 
     private static async selectSuiCoinWithExactAmount(
-        signer: RawSigner,
+        signer: SignerWithProvider,
         coins: SuiMoveObject[],
         amount: bigint,
         refreshData = false

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { RawSigner, SuiExecuteTransactionResponse } from '@mysten/sui.js';
+import type {
+    SignerWithProvider,
+    SuiExecuteTransactionResponse,
+} from '@mysten/sui.js';
 
 const DEFAULT_NFT_IMAGE =
     'ipfs://QmZPWWy5Si54R3d26toaqRiqvCH7HkGdXkxwUgCm2oKKM2?filename=img-sq-01.png';
@@ -14,7 +17,7 @@ export class ExampleNFT {
      * @param signer A signer with connection to the fullnode
      */
     public static async mintExampleNFT(
-        signer: RawSigner,
+        signer: SignerWithProvider,
         name?: string,
         description?: string,
         imageUrl?: string

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -74,9 +74,12 @@ export const deserializeTxn = createAsyncThunk<
     AppThunkConfig
 >(
     'deserialize-transaction',
-    async (data, { dispatch, extra: { api, keypairVault } }) => {
+    async (data, { dispatch, extra: { api, keypairVault, background } }) => {
         const { id, serializedTxn } = data;
-        const signer = api.getSignerInstance(keypairVault.getKeypair());
+        const signer = api.getSignerInstance(
+            keypairVault.getKeypair().getPublicKey().toSuiAddress(),
+            background
+        );
         const localSerializer = new LocalTxnDataSerializer(signer.provider);
         const txnBytes = new Base64DataBuffer(serializedTxn);
         const version = await api.instance.fullNode.getRpcApiVersion();
@@ -143,7 +146,10 @@ export const respondToTransactionRequest = createAsyncThunk<
         let txResult: SuiTransactionResponse | undefined = undefined;
         let tsResultError: string | undefined;
         if (approved) {
-            const signer = api.getSignerInstance(keypairVault.getKeypair());
+            const signer = api.getSignerInstance(
+                keypairVault.getKeypair().getPublicKey().toSuiAddress(),
+                background
+            );
             try {
                 let response: SuiExecuteTransactionResponse;
                 if (

--- a/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -39,11 +39,14 @@ export const sendTokens = createAsyncThunk<
     'sui-objects/send-tokens',
     async (
         { tokenTypeArg, amount, recipientAddress, gasBudget },
-        { getState, extra: { api, keypairVault }, dispatch }
+        { getState, extra: { api, keypairVault, background }, dispatch }
     ) => {
         const state = getState();
         const coins: SuiMoveObject[] = accountCoinsSelector(state);
-        const signer = api.getSignerInstance(keypairVault.getKeypair());
+        const signer = api.getSignerInstance(
+            keypairVault.getKeypair().getPublicKey().toSuiAddress(),
+            background
+        );
         const response = await signer.signAndExecuteTransaction(
             await CoinAPI.newPayTransaction(
                 coins,
@@ -73,7 +76,7 @@ export const stakeTokens = createAsyncThunk<
     'sui-objects/stake',
     async (
         { tokenTypeArg, amount, validatorAddress },
-        { getState, extra: { api, keypairVault }, dispatch }
+        { getState, extra: { api, keypairVault, background }, dispatch }
     ) => {
         const state = getState();
         const coinType = Coin.getCoinTypeFromArg(tokenTypeArg);
@@ -88,7 +91,10 @@ export const stakeTokens = createAsyncThunk<
             .map(({ data }) => data as SuiMoveObject);
 
         const response = await Coin.stakeCoin(
-            api.getSignerInstance(keypairVault.getKeypair()),
+            api.getSignerInstance(
+                keypairVault.getKeypair().getPublicKey().toSuiAddress(),
+                background
+            ),
             coins,
             amount,
             validatorAddress

--- a/apps/wallet/testSetup.ts
+++ b/apps/wallet/testSetup.ts
@@ -2,37 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { webcrypto } from 'crypto';
-import { vi } from 'vitest';
-
-import type { Storage } from 'webextension-polyfill';
 
 if (!globalThis.crypto) {
     globalThis.crypto = webcrypto as Crypto;
-}
-
-function mockStorage(): Storage.LocalStorageArea {
-    return {
-        clear: vi.fn(),
-        get: vi.fn(),
-        remove: vi.fn(),
-        set: vi.fn(),
-        onChanged: {
-            addListener: vi.fn(),
-            hasListener: vi.fn(),
-            hasListeners: vi.fn(),
-            removeListener: vi.fn(),
-        },
-        QUOTA_BYTES: 5242880,
-    };
 }
 
 // Create a fake chrome object so that the webextension polyfill can load:
 globalThis.chrome = {
     runtime: {
         id: 'some-test-id-from-test-setup',
-    },
-    storage: {
-        local: mockStorage(),
-        session: mockStorage(),
     },
 };

--- a/apps/wallet/testSetup.ts
+++ b/apps/wallet/testSetup.ts
@@ -2,14 +2,37 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { webcrypto } from 'crypto';
+import { vi } from 'vitest';
+
+import type { Storage } from 'webextension-polyfill';
 
 if (!globalThis.crypto) {
     globalThis.crypto = webcrypto as Crypto;
+}
+
+function mockStorage(): Storage.LocalStorageArea {
+    return {
+        clear: vi.fn(),
+        get: vi.fn(),
+        remove: vi.fn(),
+        set: vi.fn(),
+        onChanged: {
+            addListener: vi.fn(),
+            hasListener: vi.fn(),
+            hasListeners: vi.fn(),
+            removeListener: vi.fn(),
+        },
+        QUOTA_BYTES: 5242880,
+    };
 }
 
 // Create a fake chrome object so that the webextension polyfill can load:
 globalThis.chrome = {
     runtime: {
         id: 'some-test-id-from-test-setup',
+    },
+    storage: {
+        local: mockStorage(),
+        session: mockStorage(),
     },
 };

--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Ed25519PublicKey } from './ed25519-publickey';
+import { Secp256k1PublicKey } from './secp256k1-publickey';
+
 /**
  * Value to be converted into public key.
  */
@@ -59,4 +62,17 @@ export interface PublicKey {
    * Return the Sui address associated with this public key
    */
   toSuiAddress(): string;
+}
+
+export function publicKeyFromSerialized(
+  schema: SignatureScheme,
+  pubKey: string
+): PublicKey {
+  if (schema === 'ED25519') {
+    return new Ed25519PublicKey(pubKey);
+  }
+  if (schema === 'Secp256k1') {
+    return new Secp256k1PublicKey(pubKey);
+  }
+  throw new Error('Unknown public key schema');
 }


### PR DESCRIPTION
* ts-sdk: deserialize a public key from base64 data and schema
* wallet-ext: move signing to background service 
  * creates  a new SignerWithProvider that communicates with the bg service to sign the data
  * this will allow to remove key pairs from the UI.

closes: APPS-279