### PR TITLE
Fix benchmark and add latency breakdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
  "rcgen 0.9.3",
  "ring",
  "rustls",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "tap",
  "tokio",
@@ -206,7 +206,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -605,7 +605,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
@@ -637,7 +637,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
- "serde 1.0.150",
+ "serde 1.0.151",
  "sync_wrapper",
  "tower",
  "tower-http",
@@ -752,7 +752,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b06b4c1f053002b70e7084ac944c77d58d5d92b2110dbc5e852735e00ad3ccc"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
  "thiserror",
 ]
 
@@ -762,7 +762,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -797,7 +797,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -1026,7 +1026,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "regex-automata",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -1042,7 +1042,7 @@ dependencies = [
  "merlin",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_derive",
  "sha3 0.9.1",
  "subtle-ng",
@@ -1091,7 +1091,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -1111,7 +1111,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -1120,7 +1120,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -1132,7 +1132,7 @@ dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.14",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "thiserror",
 ]
@@ -1202,7 +1202,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits 0.2.15",
- "serde 1.0.150",
+ "serde 1.0.151",
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
@@ -1238,7 +1238,7 @@ checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -1359,7 +1359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -1368,7 +1368,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
  "termcolor",
  "unicode-width",
 ]
@@ -1442,7 +1442,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom 5.1.2",
  "rust-ini",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -1488,7 +1488,7 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "prost-types",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "thread_local",
  "tokio",
@@ -1604,7 +1604,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -1851,7 +1851,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.6.4",
- "serde 1.0.150",
+ "serde 1.0.151",
  "subtle-ng",
  "zeroize",
 ]
@@ -2103,7 +2103,7 @@ dependencies = [
  "once_cell",
  "petgraph 0.6.2",
  "rayon",
- "serde 1.0.150",
+ "serde 1.0.151",
  "toml",
 ]
 
@@ -2298,7 +2298,7 @@ dependencies = [
  "chrono",
  "nom 6.1.2",
  "rust_decimal",
- "serde 1.0.150",
+ "serde 1.0.151",
  "time 0.3.15",
 ]
 
@@ -2327,7 +2327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "pkcs8",
- "serde 1.0.150",
+ "serde 1.0.151",
  "signature",
  "zeroize",
 ]
@@ -2341,7 +2341,7 @@ dependencies = [
  "curve25519-dalek-ng",
  "hex",
  "rand_core 0.6.4",
- "serde 1.0.150",
+ "serde 1.0.151",
  "sha2 0.9.9",
  "thiserror",
  "zeroize",
@@ -2356,7 +2356,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.150",
+ "serde 1.0.151",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -2370,7 +2370,7 @@ dependencies = [
  "curve25519-dalek-fiat",
  "ed25519",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -2568,7 +2568,7 @@ dependencies = [
  "rfc6979",
  "schemars",
  "secp256k1",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_bytes",
  "serde_with",
  "sha2 0.10.6",
@@ -2907,7 +2907,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
  "typenum",
  "version_check",
 ]
@@ -3002,7 +3002,7 @@ dependencies = [
  "gloo-utils",
  "js-sys",
  "pin-project",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "thiserror",
  "wasm-bindgen",
@@ -3029,7 +3029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8e8fc851e9c7b9852508bc6e3f690f452f474417e8545ec9857b7f7377036b5"
 dependencies = [
  "js-sys",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "wasm-bindgen",
  "web-sys",
@@ -3067,7 +3067,7 @@ dependencies = [
  "petgraph 0.6.2",
  "rayon",
  "semver 1.0.14",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "smallvec",
  "static_assertions",
@@ -3086,7 +3086,7 @@ dependencies = [
  "diffus",
  "guppy-workspace-hack",
  "semver 1.0.14",
- "serde 1.0.150",
+ "serde 1.0.151",
  "toml",
 ]
 
@@ -3135,7 +3135,7 @@ dependencies = [
  "owo-colors",
  "pathdiff",
  "rayon",
- "serde 1.0.150",
+ "serde 1.0.151",
  "tabular",
  "target-spec",
  "toml",
@@ -3472,7 +3472,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -3520,7 +3520,7 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -3574,7 +3574,7 @@ dependencies = [
  "linked-hash-map",
  "pest",
  "pest_derive",
- "serde 1.0.150",
+ "serde 1.0.151",
  "similar",
  "yaml-rust",
 ]
@@ -3752,7 +3752,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rustc-hash",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "soketto",
  "thiserror",
@@ -3772,7 +3772,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "rustc-hash",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "thiserror",
  "tokio",
@@ -3802,7 +3802,7 @@ dependencies = [
  "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "soketto",
  "tokio",
@@ -3819,7 +3819,7 @@ source = "git+https://github.com/patrickkuo/jsonrpsee.git?rev=adc19a124ed7045744
 dependencies = [
  "anyhow",
  "beef",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "thiserror",
  "tracing",
@@ -4013,7 +4013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4194,7 +4194,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4206,7 +4206,7 @@ dependencies = [
  "move-core-types",
  "once_cell",
  "ref-cast",
- "serde 1.0.150",
+ "serde 1.0.151",
  "variant_count",
 ]
 
@@ -4227,7 +4227,7 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4309,7 +4309,7 @@ dependencies = [
  "read-write-set",
  "read-write-set-dynamic",
  "reqwest",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -4329,7 +4329,7 @@ dependencies = [
  "move-core-types",
  "num-bigint",
  "once_cell",
- "serde 1.0.150",
+ "serde 1.0.151",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -4377,7 +4377,7 @@ dependencies = [
  "primitive-types",
  "rand 0.8.5",
  "ref-cast",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_bytes",
  "uint",
 ]
@@ -4399,7 +4399,7 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4435,7 +4435,7 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4449,7 +4449,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4514,7 +4514,7 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4540,7 +4540,7 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4570,7 +4570,7 @@ dependencies = [
  "ptree",
  "regex",
  "reqwest",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_yaml",
  "sha2 0.9.9",
  "tempfile",
@@ -4609,7 +4609,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "simplelog",
  "tokio",
@@ -4638,7 +4638,7 @@ dependencies = [
  "pretty",
  "rand 0.8.5",
  "regex",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "tera",
  "tokio",
@@ -4652,7 +4652,7 @@ dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4667,7 +4667,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4694,7 +4694,7 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4712,7 +4712,7 @@ dependencies = [
  "move-model",
  "move-stackless-bytecode",
  "num",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4744,7 +4744,7 @@ version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=265e8792ff2935db8246ddb308b36b893d507851#265e8792ff2935db8246ddb308b36b893d507851"
 dependencies = [
  "once_cell",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4854,7 +4854,7 @@ dependencies = [
  "move-core-types",
  "move-vm-types",
  "once_cell",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -4866,7 +4866,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "once_cell",
- "serde 1.0.150",
+ "serde 1.0.151",
  "smallvec",
 ]
 
@@ -4891,7 +4891,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.8.5",
  "real_tokio",
- "serde 1.0.150",
+ "serde 1.0.151",
  "socket2",
  "tokio-util 0.7.4 (git+https://github.com/mystenmark/tokio-madsim-fork.git?rev=bb463863b8155543731bdf7850057c083cf1b427)",
  "toml",
@@ -4922,7 +4922,7 @@ dependencies = [
  "multibase",
  "multihash",
  "percent-encoding",
- "serde 1.0.150",
+ "serde 1.0.151",
  "static_assertions",
  "unsigned-varint",
  "url",
@@ -4995,7 +4995,7 @@ dependencies = [
  "futures",
  "http",
  "multiaddr",
- "serde 1.0.150",
+ "serde 1.0.151",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5066,7 +5066,7 @@ dependencies = [
  "narwhal-crypto",
  "narwhal-test-utils",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "serde_with",
  "tempfile",
@@ -5101,7 +5101,7 @@ dependencies = [
  "pprof",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "telemetry-subscribers",
  "thiserror",
  "tokio",
@@ -5126,7 +5126,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "readonly",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde-reflection",
  "serde_bytes",
  "serde_json",
@@ -5150,7 +5150,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
- "serde 1.0.150",
+ "serde 1.0.151",
  "thiserror",
  "workspace-hack",
 ]
@@ -5199,7 +5199,7 @@ dependencies = [
  "narwhal-types",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "tap",
  "telemetry-subscribers",
  "tempfile",
@@ -5236,7 +5236,7 @@ dependencies = [
  "narwhal-types",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "thiserror",
  "tokio",
  "tokio-util 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5339,7 +5339,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "roaring",
- "serde 1.0.150",
+ "serde 1.0.151",
  "tap",
  "telemetry-subscribers",
  "tempfile",
@@ -5405,7 +5405,7 @@ dependencies = [
  "once_cell",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "telemetry-subscribers",
  "tempfile",
  "thiserror",
@@ -5450,7 +5450,7 @@ dependencies = [
  "rand 0.8.5",
  "roaring",
  "rustversion",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_test",
  "serde_with",
  "signature",
@@ -5494,7 +5494,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "reqwest",
- "serde 1.0.150",
+ "serde 1.0.151",
  "tap",
  "telemetry-subscribers",
  "tempfile",
@@ -5544,7 +5544,7 @@ dependencies = [
  "hakari",
  "hex",
  "once_cell",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -5559,7 +5559,7 @@ dependencies = [
  "guppy",
  "nexlint",
  "regex",
- "serde 1.0.150",
+ "serde 1.0.151",
  "toml",
 ]
 
@@ -6086,7 +6086,7 @@ dependencies = [
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -6706,7 +6706,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph 0.6.2",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde-value",
  "tint",
 ]
@@ -6969,7 +6969,7 @@ dependencies = [
  "rand 0.7.3",
  "rcgen 0.10.0",
  "rustls",
- "serde 1.0.150",
+ "serde 1.0.151",
  "tracing",
  "webpki",
  "workspace-hack",
@@ -7157,7 +7157,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -7471,7 +7471,7 @@ dependencies = [
  "dyn-clone",
  "either",
  "schemars_derive",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
 ]
 
@@ -7581,7 +7581,7 @@ version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -7607,9 +7607,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
@@ -7632,7 +7632,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5b14ebbcc4e4f2b3642fa99c388649da58d1dc3308c7d109f39f565d1710f0"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
  "thiserror",
 ]
 
@@ -7643,7 +7643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
- "serde 1.0.150",
+ "serde 1.0.151",
  "thiserror",
 ]
 
@@ -7654,7 +7654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.0",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -7663,14 +7663,14 @@ version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -7697,7 +7697,7 @@ dependencies = [
  "indexmap",
  "itoa",
  "ryu",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -7717,7 +7717,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3434c4787dcd7c8c0837ffbb01e6e34091f8983b2df9655e66393a867f99f7aa"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -7729,7 +7729,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -7742,7 +7742,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "serde_with_macros",
  "time 0.3.15",
@@ -7768,7 +7768,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
- "serde 1.0.150",
+ "serde 1.0.151",
  "yaml-rust",
 ]
 
@@ -8286,7 +8286,7 @@ dependencies = [
  "rocksdb",
  "rustyline",
  "rustyline-derive",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "serde_with",
  "serde_yaml",
@@ -8374,7 +8374,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "rocksdb",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "serde_with",
  "strum",
@@ -8413,7 +8413,7 @@ dependencies = [
  "move-core-types",
  "prometheus",
  "reqwest",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "sui",
  "sui-config",
@@ -8456,7 +8456,7 @@ dependencies = [
  "narwhal-crypto",
  "once_cell",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_with",
  "serde_yaml",
  "sui-adapter",
@@ -8507,7 +8507,7 @@ dependencies = [
  "reqwest",
  "rocksdb",
  "scopeguard",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde-reflection",
  "serde_json",
  "serde_with",
@@ -8551,7 +8551,7 @@ dependencies = [
  "move-cli",
  "move-disassembler",
  "move-package",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "strum",
  "strum_macros",
@@ -8575,7 +8575,7 @@ dependencies = [
  "move-core-types",
  "move-vm-types",
  "once_cell",
- "serde 1.0.150",
+ "serde 1.0.151",
  "sui-protocol-constants",
  "workspace-hack",
 ]
@@ -8593,7 +8593,7 @@ dependencies = [
  "mysten-metrics",
  "prometheus",
  "scopeguard",
- "serde 1.0.150",
+ "serde 1.0.151",
  "sui",
  "sui-config",
  "sui-json-rpc-types",
@@ -8637,7 +8637,7 @@ dependencies = [
  "move-vm-types",
  "num_enum",
  "once_cell",
- "serde 1.0.150",
+ "serde 1.0.151",
  "smallvec",
  "sui-framework-build",
  "sui-types",
@@ -8677,7 +8677,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "narwhal-network",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "sui",
  "sui-config",
@@ -8708,7 +8708,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "schemars",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "sui-adapter",
  "sui-framework-build",
@@ -8736,7 +8736,7 @@ dependencies = [
  "mysten-metrics",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "signature",
  "sui-config",
  "sui-core",
@@ -8777,7 +8777,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "schemars",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "serde_with",
  "sui-json",
@@ -8794,7 +8794,7 @@ dependencies = [
  "bip32",
  "fastcrypto",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "signature",
  "slip10_ed25519",
@@ -8828,7 +8828,7 @@ dependencies = [
  "mysten-network",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "sui-config",
  "sui-types",
  "tap",
@@ -8889,7 +8889,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.8.5",
  "schemars",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "sui",
  "sui-core",
@@ -8939,7 +8939,7 @@ dependencies = [
  "mysten-metrics",
  "once_cell",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "serde_with",
  "signature",
@@ -8982,7 +8982,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "rand 0.8.5",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "sui",
  "sui-config",
@@ -9060,7 +9060,7 @@ dependencies = [
  "once_cell",
  "pretty_assertions",
  "rocksdb",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "sqlx",
  "strum",
@@ -9106,7 +9106,7 @@ name = "sui-telemetry"
 version = "0.1.0"
 dependencies = [
  "reqwest",
- "serde 1.0.150",
+ "serde 1.0.151",
  "tokio",
  "tracing",
  "workspace-hack",
@@ -9121,7 +9121,7 @@ dependencies = [
  "clap 3.2.23",
  "http",
  "move-package",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "sui",
  "sui-cluster-test",
@@ -9147,7 +9147,7 @@ dependencies = [
  "multiaddr",
  "mysten-network",
  "rocksdb",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_with",
  "strum",
  "strum_macros",
@@ -9232,7 +9232,7 @@ dependencies = [
  "rand 0.8.5",
  "roaring",
  "schemars",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde-name",
  "serde_bytes",
  "serde_json",
@@ -9367,7 +9367,7 @@ checksum = "6a4b9859e2d5bf61d17ccdf2659396d69b207d956f2cb60e09df319394a8ccd4"
 dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
- "serde 1.0.150",
+ "serde 1.0.151",
  "target-lexicon",
 ]
 
@@ -9422,7 +9422,7 @@ dependencies = [
  "pest_derive",
  "rand 0.8.5",
  "regex",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "slug",
  "unic-segment",
@@ -9459,7 +9459,7 @@ version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd4a3a7f00909d5a1d1f83b86b65d91e4c94f80b0c2d0ae37e2ef44da7b7a0a0"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
  "test-fuzz-internal",
  "test-fuzz-macro",
  "test-fuzz-runtime",
@@ -9474,7 +9474,7 @@ dependencies = [
  "cargo_metadata",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "serde 1.0.150",
+ "serde 1.0.151",
  "strum_macros",
 ]
 
@@ -9505,7 +9505,7 @@ dependencies = [
  "bincode",
  "hex",
  "num-traits 0.2.15",
- "serde 1.0.150",
+ "serde 1.0.151",
  "sha-1 0.10.1",
  "test-fuzz-internal",
 ]
@@ -9638,7 +9638,7 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
- "serde 1.0.150",
+ "serde 1.0.151",
  "time-macros",
 ]
 
@@ -9682,7 +9682,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
 ]
 
@@ -9836,7 +9836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "indexmap",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -9848,7 +9848,7 @@ dependencies = [
  "combine",
  "indexmap",
  "itertools",
- "serde 1.0.150",
+ "serde 1.0.151",
 ]
 
 [[package]]
@@ -10031,7 +10031,7 @@ checksum = "a788f2119fde477cd33823330c14004fa8cdac6892fd6f12181bbda9dbf14fc9"
 dependencies = [
  "gethostname",
  "log",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde_json",
  "time 0.3.15",
  "tracing",
@@ -10198,7 +10198,7 @@ dependencies = [
  "quote 1.0.21",
  "rocksdb",
  "rstest",
- "serde 1.0.150",
+ "serde 1.0.151",
  "syn 1.0.105",
  "tap",
  "tempfile",
@@ -11433,7 +11433,7 @@ dependencies = [
  "semver-parser",
  "send_wrapper",
  "serde 0.8.23",
- "serde 1.0.150",
+ "serde 1.0.151",
  "serde-hjson",
  "serde-name",
  "serde-reflection",

--- a/narwhal/benchmark/benchmark/logs.py
+++ b/narwhal/benchmark/benchmark/logs.py
@@ -1,7 +1,8 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-from datetime import datetime
+from datetime import datetime, timezone
+from itertools import chain
 from dateutil import parser
 from glob import glob
 from logging import exception
@@ -51,9 +52,21 @@ class LogParser:
         except (ValueError, IndexError, AttributeError) as e:
             exception(e)
             raise ParseError(f'Failed to parse nodes\' logs: {e}')
-        proposals, commits, self.configs, primary_ips = zip(*results)
+        proposals, commits, self.configs, primary_ips, batch_to_header_latencies, header_to_cert_latencies, cert_commit_latencies, request_vote_outbound_latencies = zip(
+            *results)
         self.proposals = self._merge_results([x.items() for x in proposals])
         self.commits = self._merge_results([x.items() for x in commits])
+        self.batch_to_header_latencies = {
+            k: v for x in batch_to_header_latencies for k, v in x.items()
+        }
+        self.header_to_cert_latencies = {
+            k: v for x in header_to_cert_latencies for k, v in x.items()
+        }
+        self.cert_commit_latencies = {
+            k: v for x in cert_commit_latencies for k, v in x.items()
+        }
+        self.request_vote_outbound_latencies = list(
+            chain(*request_vote_outbound_latencies))
 
         # Parse the workers logs.
         try:
@@ -62,9 +75,13 @@ class LogParser:
         except (ValueError, IndexError, AttributeError) as e:
             exception(e)
             raise ParseError(f'Failed to parse workers\' logs: {e}')
-        sizes, self.received_samples, workers_ips = zip(*results)
+        sizes, self.received_samples, workers_ips, batch_creation_latencies = zip(
+            *results)
         self.sizes = {
             k: v for x in sizes for k, v in x.items() if k in self.commits
+        }
+        self.batch_creation_latencies = {
+            k: v for x in batch_creation_latencies for k, v in x.items()
         }
 
         # Determine whether the primary and the workers are collocated.
@@ -114,6 +131,22 @@ class LogParser:
         tmp = [(d, self._to_posix(t)) for t, d in tmp]
         commits = self._merge_results([tmp])
 
+        tmp = findall(
+            r'.* Batch ([^ ]+) from worker \d+ took (\d+\.\d+) seconds to be included in a proposed header', log)
+        batch_to_header_latencies = {d: float(t) for d, t in tmp}
+
+        tmp = findall(
+            r'.* Header ([^ ]+) took (\d+\.\d+) seconds to be materialized to a certificate [^ ]+', log)
+        header_to_cert_latencies = {d: float(t) for d, t in tmp}
+
+        tmp = findall(
+            r'.* Certificate ([^ ]+) took (\d+\.\d+) seconds to be committed at round \d+', log)
+        cert_commit_latencies = {d: float(t) for d, t in tmp}
+
+        tmp = findall(
+            r'\/narwhal\.PrimaryToPrimary\/RequestVote.*direction=outbound.*latency=(\d+) ms', log)
+        request_vote_outbound_latencies = [float(d) for d in tmp]
+
         configs = {
             'header_num_of_batches_threshold': int(
                 search(r'Header number of batches threshold .* (\d+)', log).group(1)
@@ -146,7 +179,7 @@ class LogParser:
 
         ip = search(r'booted on (/ip4/\d+.\d+.\d+.\d+)', log).group(1)
 
-        return proposals, commits, configs, ip
+        return proposals, commits, configs, ip, batch_to_header_latencies, header_to_cert_latencies, cert_commit_latencies, request_vote_outbound_latencies
 
     def _parse_workers(self, log):
         if search(r'(?:panicked)', log) is not None:
@@ -158,12 +191,17 @@ class LogParser:
         tmp = findall(r'Batch ([^ ]+) contains sample tx (\d+)', log)
         samples = {int(s): d for d, s in tmp}
 
+        tmp = findall(
+            r'.* Batch ([^ ]+) took (\d+\.\d+) seconds to create due to .*', log)
+        batch_creation_latencies = {d: float(t) for d, t in tmp}
+
         ip = search(r'booted on (/ip4/\d+.\d+.\d+.\d+)', log).group(1)
 
-        return sizes, samples, ip
+        return sizes, samples, ip, batch_creation_latencies
 
     def _to_posix(self, string):
-        x = parser.isoparse(string[:24])
+        x = parser.parse(string[:24], ignoretz=True)
+        x = x.astimezone(timezone.utc)
         return datetime.timestamp(x)
 
     def _consensus_throughput(self):
@@ -216,6 +254,16 @@ class LogParser:
         consensus_tps, consensus_bps, _ = self._consensus_throughput()
         end_to_end_tps, end_to_end_bps, duration = self._end_to_end_throughput()
         end_to_end_latency = self._end_to_end_latency() * 1_000
+        batch_creation_latency = mean(
+            self.batch_creation_latencies.values()) * 1000
+        batch_to_header_latency = mean(
+            self.batch_to_header_latencies.values()) * 2 * 1000
+        header_to_cert_latency = mean(
+            self.header_to_cert_latencies.values()) * 1000
+        cert_commit_latency = mean(
+            self.cert_commit_latencies.values()) * 1000
+        request_vote_outbound_latency = mean(
+            self.request_vote_outbound_latencies)
 
         return (
             '\n'
@@ -242,6 +290,12 @@ class LogParser:
             f' Max concurrent requests: {max_concurrent_requests:,} \n'
             '\n'
             ' + RESULTS:\n'
+            f' Batch creation latency: {round(batch_creation_latency):,} ms\n'
+            f' Batch to header latency: {round(batch_to_header_latency):,} ms\n'
+            f' Header to certificate latency: {round(header_to_cert_latency):,} ms\n'
+            f' \tRequest vote outbound latency: {round(request_vote_outbound_latency):,} ms\n'
+            f' Certificate commit latency: {round(cert_commit_latency):,} ms\n'
+            f'\n'
             f' Consensus TPS: {round(consensus_tps):,} tx/s\n'
             f' Consensus BPS: {round(consensus_bps):,} B/s\n'
             f' Consensus latency: {round(consensus_latency):,} ms\n'

--- a/narwhal/benchmark/benchmark/logs.py
+++ b/narwhal/benchmark/benchmark/logs.py
@@ -257,7 +257,7 @@ class LogParser:
         batch_creation_latency = mean(
             self.batch_creation_latencies.values()) * 1000
         batch_to_header_latency = mean(
-            self.batch_to_header_latencies.values()) * 2 * 1000
+            self.batch_to_header_latencies.values()) * 1000
         header_to_cert_latency = mean(
             self.header_to_cert_latencies.values()) * 1000
         cert_commit_latency = mean(
@@ -291,8 +291,9 @@ class LogParser:
             '\n'
             ' + RESULTS:\n'
             f' Batch creation latency: {round(batch_creation_latency):,} ms\n'
-            f' Batch to header latency: {round(batch_to_header_latency):,} ms\n'
-            f' Header to certificate latency: {round(header_to_cert_latency):,} ms\n'
+            f' Header creation latency: {round(batch_to_header_latency * 2):,} ms\n'
+            f' \tBatch to header latency: {round(batch_to_header_latency):,} ms\n'
+            f' Certificate creation latency: {round(header_to_cert_latency):,} ms\n'
             f' \tRequest vote outbound latency: {round(request_vote_outbound_latency):,} ms\n'
             f' Certificate commit latency: {round(cert_commit_latency):,} ms\n'
             f'\n'

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -28,7 +28,7 @@ def local(ctx, debug=True):
     node_params = {
         'header_num_of_batches_threshold': 1,
         'max_header_num_of_batches': 1000,
-        'max_header_delay': '5000ms',  # ms
+        'max_header_delay': '2000ms',  # ms
         'gc_depth': 50,  # rounds
         'sync_retry_delay': '10_000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -20,15 +20,15 @@ def local(ctx, debug=True):
         'faults': 0,
         'nodes': 4,
         'workers': 1,
-        'rate': 50_000,
+        'rate': 200,
         'tx_size': 512,
-        'duration': 20,
+        'duration': 60,
         'failpoints': False
     }
     node_params = {
-        'header_num_of_batches_threshold': 32,
+        'header_num_of_batches_threshold': 1,
         'max_header_num_of_batches': 1000,
-        'max_header_delay': '200ms',  # ms
+        'max_header_delay': '5000ms',  # ms
         'gc_depth': 50,  # rounds
         'sync_retry_delay': '10_000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -20,15 +20,15 @@ def local(ctx, debug=True):
         'faults': 0,
         'nodes': 4,
         'workers': 1,
-        'rate': 200,
+        'rate': 50_000,
         'tx_size': 512,
         'duration': 60,
         'failpoints': False
     }
     node_params = {
-        'header_num_of_batches_threshold': 1,
+        'header_num_of_batches_threshold': 32,
         'max_header_num_of_batches': 1000,
-        'max_header_delay': '2000ms',  # ms
+        'max_header_delay': '5000ms',  # ms
         'gc_depth': 50,  # rounds
         'sync_retry_delay': '10_000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -28,7 +28,7 @@ def local(ctx, debug=True):
     node_params = {
         'header_num_of_batches_threshold': 32,
         'max_header_num_of_batches': 1000,
-        'max_header_delay': '5000ms',  # ms
+        'max_header_delay': '2000ms',  # ms
         'gc_depth': 50,  # rounds
         'sync_retry_delay': '10_000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -183,6 +183,15 @@ impl ConsensusState {
             .with_label_values(&[])
             .set(last_committed_round as i64);
 
+        #[cfg(feature = "benchmark")]
+        // NOTE: This log entry is used to compute performance.
+        tracing::info!(
+            "Certificate {:?} took {} seconds to be committed at round {}",
+            certificate.digest(),
+            certificate.metadata.created_at.elapsed().as_secs_f64(),
+            last_committed_round
+        );
+
         self.metrics
             .certificate_commit_latency
             .observe(certificate.metadata.created_at.elapsed().as_secs_f64());

--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -31,7 +31,7 @@ use types::{
     error::{DagError, DagResult},
     metered_channel::{Receiver, Sender},
     Certificate, CertificateDigest, Header, HeaderDigest, PrimaryToPrimaryClient,
-    ReconfigureNotification, RequestVoteRequest, Round, Timestamp, Vote,
+    ReconfigureNotification, RequestVoteRequest, Round, Vote,
 };
 
 #[cfg(test)]
@@ -390,7 +390,7 @@ impl Core {
                             format!("!!!missing certificate for digest {parent_digest:?}!!!\n")
                         }
                         Err(e) => format!(
-                            "!!!error retreiving certificate for digest {parent_digest:?}: {e:?}\n"
+                            "!!!error retrieving certificate for digest {parent_digest:?}: {e:?}\n"
                         ),
                     };
                     msg.push_str(&parent_msg);
@@ -449,7 +449,9 @@ impl Core {
         // Broadcast the certificate.
         let epoch = certificate.epoch();
         let round = certificate.header.round;
-        let created_at = certificate.header.created_at;
+        let header_to_certificate_duration =
+            Duration::from_millis(certificate.metadata.created_at - certificate.header.created_at)
+                .as_secs_f64();
         let network_keys = self
             .committee
             .others_primaries(&self.name)
@@ -479,14 +481,14 @@ impl Core {
         self.metrics
             .header_to_certificate_latency
             .with_label_values(&[&epoch.to_string()])
-            .observe(created_at.elapsed().as_secs_f64());
+            .observe(header_to_certificate_duration);
 
         #[cfg(feature = "benchmark")]
         // NOTE: This log entry is used to compute performance.
         tracing::info!(
             "Header {:?} took {} seconds to be materialized to a certificate {:?}",
             certificate.header.digest(),
-            created_at.elapsed().as_secs_f64(),
+            header_to_certificate_duration,
             certificate.digest()
         );
 

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -20,7 +20,7 @@ use types::now;
 use types::{
     error::{DagError, DagResult},
     metered_channel::{Receiver, Sender},
-    BatchDigest, Certificate, Header, ReconfigureNotification, Round, Timestamp, TimestampMs,
+    BatchDigest, Certificate, Header, ReconfigureNotification, Round, TimestampMs,
 };
 
 /// Messages sent to the proposer about our own batch digests
@@ -88,9 +88,9 @@ pub struct Proposer {
     /// Holds the map of proposed previous round headers, used to ensure that
     /// all batches' digest included will eventually be re-sent.
     proposed_headers: BTreeMap<Round, Header>,
-    /// Commited headers channel on which we get updates on which of
+    /// Committed headers channel on which we get updates on which of
     /// our own headers have been committed.
-    rx_commited_own_headers: Receiver<(Round, Vec<Round>)>,
+    rx_committed_own_headers: Receiver<(Round, Vec<Round>)>,
 
     /// Metrics handler
     metrics: Arc<PrimaryMetrics>,
@@ -114,7 +114,7 @@ impl Proposer {
         rx_our_digests: Receiver<OurDigestMessage>,
         tx_headers: Sender<Header>,
         tx_narwhal_round_updates: watch::Sender<Round>,
-        rx_commited_own_headers: Receiver<(Round, Vec<Round>)>,
+        rx_committed_own_headers: Receiver<(Round, Vec<Round>)>,
         metrics: Arc<PrimaryMetrics>,
     ) -> JoinHandle<()> {
         let genesis = Certificate::genesis(&committee);
@@ -140,7 +140,7 @@ impl Proposer {
                     last_leader: None,
                     digests: Vec::with_capacity(2 * max_header_num_of_batches),
                     proposed_headers: BTreeMap::new(),
-                    rx_commited_own_headers,
+                    rx_committed_own_headers,
                     metrics,
                 }
                 .run()
@@ -241,22 +241,33 @@ impl Proposer {
         self.proposed_headers.insert(this_round, header.clone());
 
         // Update metrics related to latency
-        for (_digest, _worker_id, created_at_timestamp) in digests {
+        for (_digest, _worker_id, created_at_timestamp) in digests.clone() {
+            let batch_inclusion_duration =
+                Duration::from_millis(header.created_at - created_at_timestamp).as_secs_f64();
+
             #[cfg(feature = "benchmark")]
             {
                 // NOTE: This log entry is used to compute performance.
                 tracing::info!(
-                    "Batch {:?} from worker {} took {} seconds to be included in a proposed header",
+                    "Batch {:?} from worker {} took {} seconds from creation to be included in a proposed header",
                     _digest,
                     _worker_id,
-                    created_at_timestamp.elapsed().as_secs_f64()
+                    batch_inclusion_duration
                 );
             }
 
             self.metrics
                 .proposer_batch_latency
-                .observe(created_at_timestamp.elapsed().as_secs_f64());
+                .observe(batch_inclusion_duration);
         }
+
+        #[cfg(feature = "benchmark")]
+        // NOTE: This log entry is used to compute performance.
+        tracing::info!(
+            "Header {:?} was created in {} seconds",
+            header.digest(),
+            Duration::from_millis(header.created_at - digests.first().unwrap().2).as_secs_f64()
+        );
 
         Ok(header)
     }
@@ -298,6 +309,11 @@ impl Proposer {
 
         if let Some(leader) = self.last_leader.as_ref() {
             debug!("Got leader {} for round {}", leader.origin(), self.round);
+        } else {
+            debug!(
+                "Leader {} not valid for round {} because we are missing its parent certificate",
+                leader_name, self.round
+            );
         }
 
         self.last_leader.is_some()
@@ -445,14 +461,14 @@ impl Proposer {
                     }
                 }
 
-                Some((commit_round, commit_headers)) = self.rx_commited_own_headers.recv() => {
+                Some((commit_round, commit_headers)) = self.rx_committed_own_headers.recv() => {
                     // Remove committed headers from the list of pending
                     for round in &commit_headers {
                         self.proposed_headers.remove(round);
                     }
 
                     // Now for any round much below the current commit round we re-insert
-                    // the batches into the digests we need to send, effectivelly re-sending
+                    // the batches into the digests we need to send, effectively re-sending
                     // them
                     let mut digests_to_resend = Vec::new();
                     let mut retransmit_rounds = Vec::new();

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -309,11 +309,6 @@ impl Proposer {
 
         if let Some(leader) = self.last_leader.as_ref() {
             debug!("Got leader {} for round {}", leader.origin(), self.round);
-        } else {
-            debug!(
-                "Leader {} not valid for round {} because we are missing its parent certificate",
-                leader_name, self.round
-            );
         }
 
         self.last_leader.is_some()

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -241,7 +241,18 @@ impl Proposer {
         self.proposed_headers.insert(this_round, header.clone());
 
         // Update metrics related to latency
-        for (_, _, created_at_timestamp) in digests {
+        for (_digest, _worker_id, created_at_timestamp) in digests {
+            #[cfg(feature = "benchmark")]
+            {
+                // NOTE: This log entry is used to compute performance.
+                tracing::info!(
+                    "Batch {:?} from worker {} took {} seconds to be included in a proposed header",
+                    _digest,
+                    _worker_id,
+                    created_at_timestamp.elapsed().as_secs_f64()
+                );
+            }
+
             self.metrics
                 .proposer_batch_latency
                 .observe(created_at_timestamp.elapsed().as_secs_f64());

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -267,12 +267,12 @@ impl BatchMaker {
             return None;
         }
 
-        #[cfg(feature = "benchmark")]
-        // NOTE: This log entry is used to compute performance.
-        tracing::info!(
+        let batch_creation_duration = self.batch_start_timestamp.elapsed().as_secs_f64();
+
+        tracing::debug!(
             "Batch {:?} took {} seconds to create due to {}",
             batch.digest(),
-            self.batch_start_timestamp.elapsed().as_secs_f64(),
+            batch_creation_duration,
             reason
         );
 
@@ -282,7 +282,7 @@ impl BatchMaker {
         self.node_metrics
             .created_batch_latency
             .with_label_values(&[self.committee.epoch.to_string().as_str(), reason])
-            .observe(self.batch_start_timestamp.elapsed().as_secs_f64());
+            .observe(batch_creation_duration);
 
         // Clone things to not capture self
         let store = self.store.clone();

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -267,6 +267,15 @@ impl BatchMaker {
             return None;
         }
 
+        #[cfg(feature = "benchmark")]
+        // NOTE: This log entry is used to compute performance.
+        tracing::info!(
+            "Batch {:?} took {} seconds to create due to {}",
+            batch.digest(),
+            self.batch_start_timestamp.elapsed().as_secs_f64(),
+            reason
+        );
+
         // we are deliberately measuring this after the sending to the downstream
         // channel tx_message as the operation is blocking and affects any further
         // batch creation.


### PR DESCRIPTION
Standardized posix time calculation which should fix negative latencies being returned by benchmark when timezone was mismatched

Also included further breakdown of narwhal latencies ([investigation notes](https://www.notion.so/mystenlabs/End2End-Latency-Investigation-027092e6dbd84aaa9784d502a8cd4d6a)) and updated local benchmark parameters, which is used in CI, to match what we are currently using in production.

```
-----------------------------------------
 SUMMARY:
-----------------------------------------
 + CONFIG:
 Faults: 0 node(s)
 Committee size: 4 node(s)
 Worker(s) per node: 1 worker(s)
 Collocate primary and workers: True
 Input rate: 200 tx/s
 Transaction size: 512 B
 Execution time: 60 s

 Header number of batches threshold: 1 digests
 Header maximum number of batches: 1,000 digests
 Max header delay: 2,000 ms
 GC depth: 50 round(s)
 Sync retry delay: 10,000 ms
 Sync retry nodes: 3 node(s)
 batch size: 500,000 B
 Max batch delay: 200 ms
 Max concurrent requests: 500,000 

 + RESULTS:
 Batch creation latency: 179 ms
 Header creation latency: 462 ms
        Batch to header latency: 231 ms
 Certificate creation latency: 13 ms
        Request vote outbound latency: 6 ms
 Certificate commit latency: 460 ms

 Consensus TPS: 159 tx/s
 Consensus BPS: 81,616 B/s
 Consensus latency: 472 ms

 End-to-end TPS: 159 tx/s
 End-to-end BPS: 81,414 B/s
 End-to-end latency: 604 ms
-----------------------------------------
```