### PR TITLE
Reject change epoch transaction from handle_certificate() RPC

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -749,7 +749,7 @@ impl AuthorityState {
 
     /// Executes a certificate for its effects.
     #[instrument(level = "trace", skip_all)]
-    pub async fn execute_certificate(
+    pub(crate) async fn execute_certificate(
         &self,
         certificate: &VerifiedCertificate,
     ) -> SuiResult<VerifiedTransactionInfoResponse> {
@@ -759,15 +759,16 @@ impl AuthorityState {
 
         self.metrics.total_cert_attempts.inc();
 
-        if self.is_fullnode() {
-            return Err(SuiError::GenericStorageError(
-                "cannot execute cert without effects on fullnode".into(),
-            ));
-        }
-
-        if self.is_cert_awaiting_sequencing(certificate)? {
-            debug!("shared object cert has not been sequenced by narwhal");
-            return Err(SuiError::SharedObjectLockNotSetError);
+        if certificate.contains_shared_object()
+            && !self
+                .database
+                .consensus_message_processed(&ConsensusTransactionKey::Certificate(
+                    *certificate.digest(),
+                ))?
+        {
+            return Err(SuiError::CertificateNotSequencedError {
+                digest: *certificate.digest(),
+            });
         }
 
         self.enqueue_certificates_for_execution(vec![certificate.clone()])
@@ -2438,22 +2439,6 @@ impl AuthorityState {
         // We only notify i.e. update low watermark once database changes are committed
         notifier_ticket.notify();
         Ok(seq)
-    }
-
-    /// Returns true if certificate is a shared-object cert but has not been sequenced.
-    fn is_cert_awaiting_sequencing(&self, certificate: &CertifiedTransaction) -> SuiResult<bool> {
-        // always an error to call this on fullnode.
-        assert!(!self.is_fullnode());
-
-        if !certificate.contains_shared_object() {
-            Ok(false)
-        } else {
-            self.database
-                .consensus_message_processed(&ConsensusTransactionKey::Certificate(
-                    *certificate.digest(),
-                ))
-                .map(|r| !r)
-        }
     }
 
     /// Check whether certificate was processed by consensus.

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -76,8 +76,6 @@ pub enum SuiError {
     NotSharedObjectError,
     #[error("An object that's owned by another object cannot be deleted or wrapped. It must be transferred to an account address first before deletion")]
     DeleteObjectOwnedObject,
-    #[error("The shared locks for this transaction have not yet been set.")]
-    SharedObjectLockNotSetError,
     #[error("Invalid Batch Transaction: {}", error)]
     InvalidBatchTransaction { error: String },
     #[error(
@@ -98,7 +96,8 @@ pub enum SuiError {
     IncorrectSigner { error: String },
     #[error("Value was not signed by a known authority")]
     UnknownSigner,
-    // Certificate verification
+
+    // Certificate verification and execution
     #[error(
         "Signature or certificate from wrong epoch, expected {expected_epoch}, got {actual_epoch}"
     )]
@@ -169,6 +168,11 @@ pub enum SuiError {
         effects_digests: Vec<TransactionEffectsDigest>,
         checkpoint: CheckpointSequenceNumber,
     },
+    #[error("The shared locks for this transaction have not yet been set.")]
+    SharedObjectLockNotSetError,
+    #[error("The certificate needs to be sequenced by Narwhal before execution: {digest:?}")]
+    CertificateNotSequencedError { digest: TransactionDigest },
+
     // Synchronization validation
     #[error("Transaction index must increase by one")]
     UnexpectedTransactionIndex,


### PR DESCRIPTION
Change epoch transaction should not use the execute_certificate() codepath, but it can be done accidentally in tests or through the RPC interface. Reject the transaction explicitly to give a better error message.