### PR TITLE
[reconfig] Add epoch id to ConsensusHandler

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -11,11 +11,12 @@ use narwhal_types::ConsensusOutput;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex};
-use sui_types::base_types::AuthorityName;
+use sui_types::base_types::{AuthorityName, EpochId};
 use sui_types::messages::ConsensusTransaction;
 use tracing::{debug, instrument, warn};
 
 pub struct ConsensusHandler {
+    _epoch: EpochId,
     state: Arc<AuthorityState>,
     last_seen: Mutex<ExecutionIndicesWithHash>,
     checkpoint_service: Arc<CheckpointService>,
@@ -25,6 +26,7 @@ impl ConsensusHandler {
     pub fn new(state: Arc<AuthorityState>, checkpoint_service: Arc<CheckpointService>) -> Self {
         let last_seen = Mutex::new(Default::default());
         Self {
+            _epoch: state.epoch(),
             state,
             last_seen,
             checkpoint_service,


### PR DESCRIPTION
`ConsensusHandler` is the interface where Narwhal talks to Sui. To ensure strong data consistency, for instance, when creating checkpoints we want to know exactly which epoch we are creating it for, we need a top-down passed epoch id that doesn't change in the middle.
This PR adds epoch id to ConsensusHandler. ConsensusHandler is reconstructed each time we reconfigure, to make sure it's always associated with a single constant epoch. In order to do so, ConsensusHandler needs to be moved out of Narwhal config, and put into the message we send to the narwhal manager.