### PR TITLE
[reconfiguration] Acquire reconfiguration lock in AuthorityServer

### DIFF
--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -123,7 +123,13 @@ async fn submit_transaction_to_consensus_adapter() {
     // Submit the transaction and ensure the adapter reports success to the caller. Note
     // that consensus may drop some transactions (so we may need to resubmit them).
     let transaction = ConsensusTransaction::new_certificate_message(&state.name, certificate);
-    adapter.submit(transaction.clone()).unwrap().await.unwrap();
+    let waiter = adapter
+        .submit(
+            transaction.clone(),
+            Some(&state.epoch_store().get_reconfig_state_read_lock_guard()),
+        )
+        .unwrap();
+    waiter.await.unwrap();
 }
 
 pub struct ConsensusMockServer {


### PR DESCRIPTION
When submitting certificate we need to acquire and check the lock very early own, before verifying signatures and executing certificate. See comments on https://github.com/MystenLabs/sui/pull/6951 for more context.