### PR TITLE
Remove usages of `pending_certificates` table outside of `TransactionManager`

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -329,25 +329,14 @@ impl AuthorityPerEpochStore {
         Ok(roots)
     }
 
-    /// Gets one pending certificate.
+    /// `pending_certificates` table related methods. Should only be used from TransactionManager.
+
+    /// Gets one certificate pending execution.
     pub fn get_pending_certificate(
         &self,
         tx: &TransactionDigest,
     ) -> Result<Option<VerifiedCertificate>, TypedStoreError> {
         Ok(self.tables.pending_certificates.get(tx)?.map(|c| c.into()))
-    }
-
-    pub fn multi_get_pending_certificate(
-        &self,
-        transaction_digests: &[TransactionDigest],
-    ) -> SuiResult<Vec<Option<VerifiedCertificate>>> {
-        Ok(self
-            .tables
-            .pending_certificates
-            .multi_get(transaction_digests)?
-            .into_iter()
-            .map(|o| o.map(|c| c.into()))
-            .collect())
     }
 
     /// Gets all pending certificates. Used during recovery.

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -103,14 +103,6 @@ impl ReadStore for RocksDbStore {
             return Ok(Some(transaction.into()));
         }
 
-        if let Some(transaction) = self
-            .authority_store
-            .epoch_store()
-            .get_pending_certificate(digest)?
-        {
-            return Ok(Some(transaction));
-        }
-
         Ok(None)
     }
 


### PR DESCRIPTION
Reading and checking existence of certificates from the `pending_certificates` table may reduce temporary storage cost a bit, but it seems better to reduce coupling between components by using only the `synced_certificates` and `certificates` tables as the set of all known certificates. In this case, `synced_certificates` table does not need to clean up a certificate after inserting it into `pending_certificates`, reducing complexity for enqueueing transactions. Instead, it would be natural to cleanup `synced_certificates` after a certificate commits, likely similar to how synced effects would be cleaned up.