### PR TITLE
Distinguish insufficient gas errors

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1186,7 +1186,7 @@ async fn test_immutable_gas() {
         .await;
     assert!(matches!(
         result.unwrap_err(),
-        SuiError::InsufficientGas { .. }
+        SuiError::GasObjectNotOwnedObject { .. }
     ));
 }
 
@@ -1215,7 +1215,7 @@ async fn test_objected_owned_gas() {
     let result = authority_state.handle_transaction(transaction).await;
     assert!(matches!(
         result.unwrap_err(),
-        SuiError::InsufficientGas { .. }
+        SuiError::GasObjectNotOwnedObject { .. }
     ));
 }
 
@@ -1641,7 +1641,7 @@ async fn test_handle_transfer_sui_with_amount_insufficient_gas() {
     let result = authority_state.handle_transaction(transaction).await;
     assert!(matches!(
         result.unwrap_err(),
-        SuiError::InsufficientGas { .. }
+        SuiError::GasBalanceTooLowToCoverGasBudget { .. }
     ));
 }
 

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -238,7 +238,7 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
         response.unwrap_err(),
-        SuiError::InsufficientGas { .. }
+        SuiError::GasBalanceTooLowToCoverGasBudget { .. }
     ));
 
     Ok(())

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -30,11 +30,9 @@ async fn test_tx_less_than_minimum_gas_budget() {
     let err = result.response.unwrap_err();
     assert_eq!(
         err,
-        SuiError::InsufficientGas {
-            error: format!(
-                "Gas budget is {}, smaller than minimum requirement {}",
-                budget, *MIN_GAS_BUDGET
-            )
+        SuiError::GasBudgetTooLow {
+            gas_budget: budget,
+            min_budget: *MIN_GAS_BUDGET
         }
     );
 }
@@ -49,8 +47,9 @@ async fn test_tx_more_than_maximum_gas_budget() {
     let err = result.response.unwrap_err();
     assert_eq!(
         err,
-        SuiError::InsufficientGas {
-            error: format!("Gas budget set too high; maximum is {}", *MAX_GAS_BUDGET)
+        SuiError::GasBudgetTooHigh {
+            gas_budget: budget,
+            max_budget: *MAX_GAS_BUDGET
         }
     );
 }
@@ -67,13 +66,10 @@ async fn test_tx_gas_balance_less_than_budget() {
     let err = result.response.unwrap_err();
     assert_eq!(
         err,
-        SuiError::InsufficientGas {
-            error: format!(
-                "Gas balance is {}, not enough to pay {} with gas price of {}",
-                gas_balance,
-                gas_price * budget,
-                gas_price
-            )
+        SuiError::GasBalanceTooLowToCoverGasBudget {
+            gas_balance: gas_balance as u128,
+            gas_budget: (gas_price * budget) as u128,
+            gas_price
         }
     );
 }
@@ -147,13 +143,10 @@ async fn test_native_transfer_gas_price_is_used() {
     let err = result.response.unwrap_err();
     assert_eq!(
         err,
-        SuiError::InsufficientGas {
-            error: format!(
-                "Gas balance is {}, not enough to pay {} with gas price of {}",
-                gas_balance,
-                (gas_budget as u128) * (gas_price as u128),
-                gas_price
-            )
+        SuiError::GasBalanceTooLowToCoverGasBudget {
+            gas_balance: (gas_balance as u128),
+            gas_budget: (gas_budget as u128) * (gas_price as u128),
+            gas_price
         }
     );
 }

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -72,11 +72,10 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
     let err = res.txn_result.unwrap_err();
     assert_eq!(
         err,
-        SuiError::InsufficientGas {
-            error: format!(
-                "Gas balance is {}, not enough to pay {} with gas price of {}",
-                1000, 1200, 1
-            )
+        SuiError::GasBalanceTooLowToCoverGasBudget {
+            gas_balance: 1000,
+            gas_budget: 1200,
+            gas_price: 1
         }
     );
 }
@@ -101,13 +100,10 @@ async fn test_pay_sui_failure_insufficient_total_balance_one_input_coin() {
     let err = res.txn_result.unwrap_err();
     assert_eq!(
         err,
-        SuiError::InsufficientGas {
-            error: format!(
-                "Total balance is {}, not enough to pay {} with gas price of {}",
-                1000,
-                100 + 100 + 900,
-                1
-            )
+        SuiError::GasBalanceTooLowToCoverGasBudget {
+            gas_balance: 1000,
+            gas_budget: 100 + 100 + 900,
+            gas_price: 1
         }
     );
 }
@@ -133,11 +129,10 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
     let err = res.txn_result.unwrap_err();
     assert_eq!(
         err,
-        SuiError::InsufficientGas {
-            error: format!(
-                "Gas balance is {}, not enough to pay {} with gas price of {}",
-                400, 801, 1
-            )
+        SuiError::GasBalanceTooLowToCoverGasBudget {
+            gas_balance: 400,
+            gas_budget: 801,
+            gas_price: 1
         }
     );
 }
@@ -163,13 +158,10 @@ async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() 
     let err = res.txn_result.unwrap_err();
     assert_eq!(
         err,
-        SuiError::InsufficientGas {
-            error: format!(
-                "Total balance is {}, not enough to pay {} with gas price of {}",
-                400 + 600,
-                400 + 400 + 201,
-                1
-            )
+        SuiError::GasBalanceTooLowToCoverGasBudget {
+            gas_balance: 400 + 600,
+            gas_budget: 400 + 400 + 201,
+            gas_price: 1
         }
     );
 }
@@ -331,11 +323,10 @@ async fn test_pay_all_sui_failure_insufficient_gas_one_input_coin() {
     let err = res.txn_result.unwrap_err();
     assert_eq!(
         err,
-        SuiError::InsufficientGas {
-            error: format!(
-                "Gas balance is {}, not enough to pay {} with gas price of {}",
-                1000, 2000, 1
-            )
+        SuiError::GasBalanceTooLowToCoverGasBudget {
+            gas_balance: 1000,
+            gas_budget: 2000,
+            gas_price: 1
         }
     );
 }
@@ -351,11 +342,10 @@ async fn test_pay_all_sui_failure_insufficient_gas_budget_multiple_input_coins()
     let err = res.txn_result.unwrap_err();
     assert_eq!(
         err,
-        SuiError::InsufficientGas {
-            error: format!(
-                "Gas balance is {}, not enough to pay {} with gas price of {}",
-                1000, 2500, 1
-            )
+        SuiError::GasBalanceTooLowToCoverGasBudget {
+            gas_balance: 1000,
+            gas_budget: 2500,
+            gas_price: 1
         }
     );
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -307,10 +307,23 @@ pub enum SuiError {
     },
 
     // Gas related errors
-    #[error("Gas budget set higher than max: {error:?}.")]
-    GasBudgetTooHigh { error: String },
-    #[error("Insufficient gas: {error:?}.")]
-    InsufficientGas { error: String },
+    #[error("Gas object is not an owned object with owner: {:?}.", owner)]
+    GasObjectNotOwnedObject { owner: Owner },
+    #[error("Gas budget: {:?} is higher than max: {:?}.", gas_budget, max_budget)]
+    GasBudgetTooHigh { gas_budget: u64, max_budget: u64 },
+    #[error("Gas budget: {:?} is lower than min: {:?}.", gas_budget, min_budget)]
+    GasBudgetTooLow { gas_budget: u64, min_budget: u64 },
+    #[error(
+        "Balance of gas object {:?} is lower than gas budget: {:?}, with gas price: {:?}.",
+        gas_balance,
+        gas_budget,
+        gas_price
+    )]
+    GasBalanceTooLowToCoverGasBudget {
+        gas_balance: u128,
+        gas_budget: u128,
+        gas_price: u64,
+    },
 
     // Internal state errors
     #[error("Attempt to update state of TxContext from a different instance than original.")]


### PR DESCRIPTION
Before this PR, `InsufficientGas` is an enum in both `ExecutionFailureStatus` and `SuiError` but the meanings are different:
- `SuiError::InsufficientGas` means the balance of gas object is lower than the specified gas budget
- `ExecutionFailureStatus::InsufficientGas` means that the txn failed b/c the actual gas cost has gone beyond `gas_budget`

As a result, sometimes it was a bit tricky to tell the exact error on the client side if the type info of `ExecutionFailureStatus` or `SuiError` was missing. This PR renames the one in `SuiError` to `InsufficientGasForGasBudget` to distinguish them.