### PR TITLE
[checkpoint] Move per-epoch tables to per epoch store

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1041,6 +1041,9 @@ impl AuthorityPerEpochStore {
 }
 
 impl PerEpochCheckpointStore for AuthorityPerEpochStore {
+    fn get_epoch(&self) -> EpochId {
+        self.epoch()
+    }
     fn get_pending_checkpoints(
         &self,
     ) -> Vec<(CheckpointCommitHeight, (Vec<TransactionDigest>, bool))> {

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -715,13 +715,13 @@ impl CheckpointSignatureAggregator {
 pub trait CheckpointServiceNotify {
     fn notify_checkpoint_signature(
         &self,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
+        epoch_store: &AuthorityPerEpochStore,
         info: &CheckpointSignatureMessage,
     ) -> SuiResult;
 
     fn notify_checkpoint(
         &self,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
+        epoch_store: &AuthorityPerEpochStore,
         index: CheckpointCommitHeight,
         roots: Vec<TransactionDigest>,
         last_checkpoint_of_epoch: bool,
@@ -811,7 +811,7 @@ impl CheckpointService {
 impl CheckpointServiceNotify for CheckpointService {
     fn notify_checkpoint_signature(
         &self,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
+        epoch_store: &AuthorityPerEpochStore,
         info: &CheckpointSignatureMessage,
     ) -> SuiResult {
         let sequence = info.summary.summary.sequence_number;
@@ -847,7 +847,7 @@ impl CheckpointServiceNotify for CheckpointService {
 
     fn notify_checkpoint(
         &self,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
+        epoch_store: &AuthorityPerEpochStore,
         index: CheckpointCommitHeight,
         roots: Vec<TransactionDigest>,
         last_checkpoint_of_epoch: bool,
@@ -878,7 +878,7 @@ pub struct CheckpointServiceNoop {}
 impl CheckpointServiceNotify for CheckpointServiceNoop {
     fn notify_checkpoint_signature(
         &self,
-        _: &Arc<AuthorityPerEpochStore>,
+        _: &AuthorityPerEpochStore,
         _: &CheckpointSignatureMessage,
     ) -> SuiResult {
         Ok(())
@@ -886,7 +886,7 @@ impl CheckpointServiceNotify for CheckpointServiceNoop {
 
     fn notify_checkpoint(
         &self,
-        _: &Arc<AuthorityPerEpochStore>,
+        _: &AuthorityPerEpochStore,
         _: CheckpointCommitHeight,
         _: Vec<TransactionDigest>,
         _: bool,


### PR DESCRIPTION
This PR moves checkpoint per-epoch tables into the epoch store.
Other than copy-paste refactoring, it makes a few notable changes:
1. Passes the per epoch store around in all function interfaces that requires read/write the epoch store.
2. In all places in the checkpoint code where we are calling `state.epoch()`, replace it with the passed-down epoch instead. This ensures we never end up with inconsistent epoch.

This change also opens up the possibility where a checkpoint service is tied to a specific epoch, and that we could spawn a new checkpoint service during reconfiguration.