### PR TITLE
Indexer README: add latest release checkout

### DIFF
--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -22,7 +22,12 @@ diesel setup
 # and then run 
 diesel migration run
 ```
-2. cargo run under `/sui-indexer`
+2. checkout [the latest devnet release](https://github.com/MystenLabs/sui/releases), otherwise API version mismatch could cause errors
+```sh
+# an example LATEST_RELEASE is: releases/sui-v0.19.0-release
+git checkout <LATEST_RELEASE>
+```
+3. cargo run under `/sui-indexer`
 ```sh
 # DATABASE_URL should be the same value as above
 cargo run --bin sui-indexer -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443"

--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -22,12 +22,12 @@ diesel setup
 # and then run 
 diesel migration run
 ```
-2. checkout [the latest devnet release](https://github.com/MystenLabs/sui/releases), otherwise API version mismatch could cause errors
+2. checkout the latest devnet commit by running commands below, otherwise API version mismatch could cause errors
 ```sh
-# an example LATEST_RELEASE is: releases/sui-v0.19.0-release
-git checkout <LATEST_RELEASE>
+git fetch upstream devnet
+git reset --hard upstream/devnet
 ```
-3. cargo run under `/sui-indexer`
+3. Go to `sui/crates/sui-indexer` and run command:
 ```sh
 # DATABASE_URL should be the same value as above
 cargo run --bin sui-indexer -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443"

--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -27,7 +27,7 @@ diesel migration run
 git fetch upstream devnet
 git reset --hard upstream/devnet
 ```
-3. Go to `sui/crates/sui-indexer` and run command:
+3. Go to `sui/crates/sui-indexer` and run the following command:
 ```sh
 # DATABASE_URL should be the same value as above
 cargo run --bin sui-indexer -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443"


### PR DESCRIPTION
Otherwise, it could cause errors like
```
2022-12-21T22:17:41.989821Z  WARN sui_indexer::handlers::handler_orchestrator: Indexer event handler failed with error: FullNodeReadingError("Failed reading event page with cursor Some(EventID { tx_seq: 37, event_seq: 3 }) and error: RpcError(ParseError(Error(\"missing field `version`\", line: 1, column: 2253)))"), retrying...
```