### PR TITLE
[reconfig] Move all consensus handler functions to per-epoch store

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -150,7 +150,8 @@ pub struct AuthorityMetrics {
     pub(crate) execution_driver_executed_transactions: IntCounter,
     pub(crate) execution_driver_execution_failures: IntCounter,
 
-    skipped_consensus_txns: IntCounter,
+    // TODO: Add this back for use.
+    _skipped_consensus_txns: IntCounter,
 
     /// Post processing metrics
     post_processing_total_events_emitted: IntCounter,
@@ -314,7 +315,7 @@ impl AuthorityMetrics {
                 registry,
             )
             .unwrap(),
-            skipped_consensus_txns: register_int_counter_with_registry!(
+            _skipped_consensus_txns: register_int_counter_with_registry!(
                 "skipped_consensus_txns",
                 "Total number of consensus transactions skipped",
                 registry,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -12,7 +12,7 @@ use move_core_types::identifier::Identifier;
 use move_core_types::parser::parse_struct_tag;
 use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
-use mysten_metrics::{monitored_scope, spawn_monitored_task};
+use mysten_metrics::spawn_monitored_task;
 use prometheus::{
     register_histogram_with_registry, register_int_counter_with_registry,
     register_int_gauge_with_registry, Histogram, IntCounter, IntGauge, Registry,
@@ -32,7 +32,6 @@ use narwhal_config::{
     Committee as ConsensusCommittee, WorkerCache as ConsensusWorkerCache,
     WorkerId as ConsensusWorkerId,
 };
-use narwhal_types::CommittedSubDag;
 use sui_adapter::{adapter, execution_mode};
 use sui_config::genesis::Genesis;
 use sui_json_rpc_types::{
@@ -75,9 +74,7 @@ use crate::authority::authority_notify_read::NotifyRead;
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority_aggregator::TransactionCertifier;
 use crate::checkpoints::CheckpointServiceNotify;
-use crate::consensus_handler::{
-    SequencedConsensusTransaction, VerifiedSequencedConsensusTransaction,
-};
+use crate::consensus_handler::VerifiedSequencedConsensusTransaction;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::epoch::reconfiguration::ReconfigState;
 use crate::execution_driver::execution_process;
@@ -2171,12 +2168,12 @@ impl AuthorityState {
     /// Errors returned by this call are treated as critical errors and cause node to panic.
     pub(crate) async fn handle_consensus_transaction<C: CheckpointServiceNotify>(
         &self,
-        current_epoch: EpochId,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
         transaction: VerifiedSequencedConsensusTransaction,
         checkpoint_service: &Arc<C>,
     ) -> SuiResult {
-        if let Some(certificate) = self
-            .process_consensus_transaction(current_epoch, transaction, checkpoint_service)
+        if let Some(certificate) = epoch_store
+            .process_consensus_transaction(transaction, checkpoint_service, &self.database)
             .await?
         {
             // The certificate has already been inserted into the pending_certificates table by
@@ -2184,112 +2181,6 @@ impl AuthorityState {
             self.transaction_manager.enqueue(vec![certificate]).await?;
         }
         Ok(())
-    }
-
-    /// Depending on the type of the VerifiedSequencedConsensusTransaction wrapper,
-    /// - Verify and initialize the state to execute the certificate.
-    ///   Returns a VerifiedCertificate only if this succeeds.
-    /// - Or update the state for checkpoint or epoch change protocol. Returns None.
-    pub(crate) async fn process_consensus_transaction<C: CheckpointServiceNotify>(
-        &self,
-        current_epoch: EpochId,
-        transaction: VerifiedSequencedConsensusTransaction,
-        checkpoint_service: &Arc<C>,
-    ) -> SuiResult<Option<VerifiedCertificate>> {
-        let _scope = monitored_scope("HandleConsensusTransaction");
-        let VerifiedSequencedConsensusTransaction(SequencedConsensusTransaction {
-            certificate: consensus_output,
-            consensus_index,
-            transaction,
-        }) = transaction;
-        let tracking_id = transaction.get_tracking_id();
-        let epoch_store = match self.load_epoch_store(current_epoch) {
-            Ok(s) => s,
-            Err(err) => {
-                // Epoch has changed while this transaction is being processed. Ignore it.
-                debug!(
-                    "Error loading epoch store in process_consensus_transaction: {:?}",
-                    err
-                );
-                return Ok(None);
-            }
-        };
-        match &transaction.kind {
-            ConsensusTransactionKind::UserTransaction(certificate) => {
-                if certificate.epoch() != current_epoch {
-                    // Epoch has changed after this certificate was sequenced, ignore it.
-                    debug!(
-                        "Certificate epoch ({:?}) doesn't match the current epoch ({:?})",
-                        certificate.epoch(),
-                        current_epoch
-                    );
-                    return Ok(None);
-                }
-                let authority = (&consensus_output.header.author).into();
-                if epoch_store.has_sent_end_of_publish(&authority)? {
-                    // This can not happen with valid authority
-                    // With some edge cases narwhal might sometimes resend previously seen certificate after EndOfPublish
-                    // However this certificate will be filtered out before this line by `consensus_message_processed` call in `verify_consensus_transaction`
-                    // If we see some new certificate here it means authority is byzantine and sent certificate after EndOfPublish (or we have some bug in ConsensusAdapter)
-                    warn!("[Byzantine authority] Authority {:?} sent a new, previously unseen certificate {:?} after it sent EndOfPublish message to consensus", authority.concise(), certificate.digest());
-                    return Ok(None);
-                }
-                // Safe because signatures are verified when VerifiedSequencedConsensusTransaction
-                // is constructed.
-                let certificate = VerifiedCertificate::new_unchecked(*certificate.clone());
-
-                debug!(
-                    ?tracking_id,
-                    tx_digest = ?certificate.digest(),
-                    "handle_consensus_transaction UserTransaction",
-                );
-
-                if !epoch_store
-                    .get_reconfig_state_read_lock_guard()
-                    .should_accept_consensus_certs()
-                {
-                    debug!("Ignoring consensus certificate for transaction {:?} because of end of epoch",
-                    certificate.digest());
-                    return Ok(None);
-                }
-
-                if certificate.contains_shared_object() {
-                    epoch_store
-                        .record_shared_object_cert_from_consensus(
-                            &transaction,
-                            &certificate,
-                            consensus_index,
-                            &self.database,
-                        )
-                        .await?;
-                } else {
-                    epoch_store
-                        .record_owned_object_cert_from_consensus(
-                            &transaction,
-                            &certificate,
-                            consensus_index,
-                        )
-                        .await?;
-                }
-
-                Ok(Some(certificate))
-            }
-            ConsensusTransactionKind::CheckpointSignature(info) => {
-                checkpoint_service.notify_checkpoint_signature(info)?;
-                epoch_store
-                    .record_consensus_transaction_processed(&transaction, consensus_index)?;
-                Ok(None)
-            }
-            ConsensusTransactionKind::EndOfPublish(authority) => {
-                debug!("Received EndOfPublish from {:?}", authority.concise());
-                epoch_store.record_end_of_publish(
-                    *authority,
-                    transaction.key(),
-                    consensus_index,
-                )?;
-                Ok(None)
-            }
-        }
     }
 
     pub async fn create_advance_epoch_tx_cert(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -17,7 +17,6 @@ use prometheus::{
     register_histogram_with_registry, register_int_counter_with_registry,
     register_int_gauge_with_registry, Histogram, IntCounter, IntGauge, Registry,
 };
-use std::cmp::Ordering as CmpOrdering;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
@@ -2167,58 +2166,6 @@ impl AuthorityState {
         self.database.get_latest_parent_entry(object_id)
     }
 
-    /// Verifies transaction signatures and other data
-    /// Important: This function can potentially be called in parallel and you can not rely on order of transactions to perform verification
-    /// If this function return an error, transaction is skipped and is not passed to handle_consensus_transaction
-    /// This function returns unit error and is responsible for emitting log messages for internal errors
-    pub(crate) fn verify_consensus_transaction(
-        &self,
-        current_epoch: EpochId,
-        transaction: SequencedConsensusTransaction,
-    ) -> Result<VerifiedSequencedConsensusTransaction, ()> {
-        let _scope = monitored_scope("VerifyConsensusTransaction");
-        if self
-            .load_epoch_store(current_epoch)
-            .map_err(|err| {
-                debug!(
-                    "Error loading epoch store in verify_consensus_transaction: {:?}",
-                    err
-                )
-            })?
-            .is_consensus_message_processed(&transaction.transaction.key())
-            .expect("Storage error")
-        {
-            debug!(
-                consensus_index=?transaction.consensus_index.index.transaction_index,
-                tracking_id=?transaction.transaction.tracking_id,
-                "handle_consensus_transaction UserTransaction [skip]",
-            );
-            self.metrics.skipped_consensus_txns.inc();
-            return Err(());
-        }
-        // Signatures are verified as part of narwhal payload verification in SuiTxValidator
-        match &transaction.transaction.kind {
-            ConsensusTransactionKind::UserTransaction(_certificate) => {}
-            ConsensusTransactionKind::CheckpointSignature(data) => {
-                if transaction.sender_authority() != data.summary.auth_signature.authority {
-                    warn!("CheckpointSignature authority {} does not match narwhal certificate source {}", data.summary.auth_signature.authority, transaction.certificate.origin() );
-                    return Err(());
-                }
-            }
-            ConsensusTransactionKind::EndOfPublish(authority) => {
-                if &transaction.sender_authority() != authority {
-                    warn!(
-                        "EndOfPublish authority {} does not match narwhal certificate source {}",
-                        authority,
-                        transaction.certificate.origin()
-                    );
-                    return Err(());
-                }
-            }
-        }
-        Ok(VerifiedSequencedConsensusTransaction(transaction))
-    }
-
     /// The transaction passed here went through verification in verify_consensus_transaction.
     /// This method is called in the exact sequence message are ordered in consensus.
     /// Errors returned by this call are treated as critical errors and cause node to panic.
@@ -2343,40 +2290,6 @@ impl AuthorityState {
                 Ok(None)
             }
         }
-    }
-
-    pub(crate) fn handle_commit_boundary<C: CheckpointServiceNotify>(
-        &self,
-        current_epoch: EpochId,
-        committed_dag: &Arc<CommittedSubDag>,
-        checkpoint_service: &Arc<C>,
-    ) -> SuiResult {
-        let round = committed_dag.round();
-        debug!("Commit boundary at {}", round);
-        // This exchange is restart safe because of following:
-        //
-        // We try to read last checkpoint content and send it to the checkpoint service
-        // CheckpointService::notify_checkpoint is idempotent in case you send same last checkpoint multiple times
-        //
-        // Only after CheckpointService::notify_checkpoint stores checkpoint in it's store we update checkpoint boundary
-        let epoch_store = self.load_epoch_store(current_epoch)?;
-        if let Some((index, roots)) = epoch_store.last_checkpoint(round)? {
-            let final_checkpoint_round = epoch_store.final_epoch_checkpoint()?;
-            let final_checkpoint = match final_checkpoint_round.map(|r| r.cmp(&round)) {
-                Some(CmpOrdering::Less) => {
-                    debug!(
-                        "Not forming checkpoint for round {} above final checkpoint round {:?}",
-                        round, final_checkpoint_round
-                    );
-                    return Ok(());
-                }
-                Some(CmpOrdering::Equal) => true,
-                Some(CmpOrdering::Greater) => false,
-                None => false,
-            };
-            checkpoint_service.notify_checkpoint(index, roots, final_checkpoint)?;
-        }
-        epoch_store.record_checkpoint_boundary(round)
     }
 
     pub async fn create_advance_epoch_tx_cert(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2329,16 +2329,17 @@ impl AuthorityState {
             }
             ConsensusTransactionKind::CheckpointSignature(info) => {
                 checkpoint_service.notify_checkpoint_signature(info)?;
-                self.database
-                    .record_consensus_transaction_processed(&transaction, consensus_index)
-                    .await?;
+                epoch_store
+                    .record_consensus_transaction_processed(&transaction, consensus_index)?;
                 Ok(None)
             }
             ConsensusTransactionKind::EndOfPublish(authority) => {
                 debug!("Received EndOfPublish from {:?}", authority.concise());
-                self.database
-                    .record_end_of_publish(*authority, &transaction, consensus_index)
-                    .await?;
+                epoch_store.record_end_of_publish(
+                    *authority,
+                    transaction.key(),
+                    consensus_index,
+                )?;
                 Ok(None)
             }
         }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -632,11 +632,14 @@ impl AuthorityPerEpochStore {
         )
     }
 
-    pub fn finish_consensus_transaction_process(
+    pub fn record_consensus_transaction_processed(
         &self,
-        key: ConsensusTransactionKey,
+        transaction: &ConsensusTransaction,
         consensus_index: ExecutionIndicesWithHash,
-    ) -> SuiResult {
+    ) -> Result<(), SuiError> {
+        // user certificates need to use record_(shared|owned)_object_cert_from_consensus
+        assert!(!transaction.is_user_certificate());
+        let key = transaction.key();
         let write_batch = self.tables.last_consensus_index.batch();
         self.finish_consensus_transaction_process_with_batch(write_batch, key, consensus_index)
     }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1060,28 +1060,6 @@ impl AuthorityStore {
         )
     }
 
-    pub async fn record_end_of_publish(
-        &self,
-        authority: AuthorityName,
-        transaction: &ConsensusTransaction,
-        consensus_index: ExecutionIndicesWithHash,
-    ) -> SuiResult {
-        self.epoch_store()
-            .record_end_of_publish(authority, transaction.key(), consensus_index)
-    }
-
-    pub async fn record_consensus_transaction_processed(
-        &self,
-        transaction: &ConsensusTransaction,
-        consensus_index: ExecutionIndicesWithHash,
-    ) -> Result<(), SuiError> {
-        // user certificates need to use record_(shared|owned)_object_cert_from_consensus
-        assert!(!transaction.is_user_certificate());
-        let key = transaction.key();
-        self.epoch_store()
-            .finish_consensus_transaction_process(key, consensus_index)
-    }
-
     /// Return the latest consensus index. It is used to bootstrap the consensus client.
     pub fn last_consensus_index(&self) -> SuiResult<ExecutionIndicesWithHash> {
         self.epoch_store().get_last_consensus_index()

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -131,14 +131,16 @@ impl ExecutionState for ConsensusHandler {
             .consensus_handler_processed_bytes
             .inc_by(bytes as u64);
 
+        let Ok(epoch_store) = self.state.load_epoch_store(self.epoch) else {
+            return;
+        };
+
         for sequenced_transaction in sequenced_transactions {
-            let verified_transaction = match self
-                .state
-                .verify_consensus_transaction(self.epoch, sequenced_transaction)
-            {
-                Ok(verified_transaction) => verified_transaction,
-                Err(()) => continue,
-            };
+            let verified_transaction =
+                match epoch_store.verify_consensus_transaction(sequenced_transaction) {
+                    Ok(verified_transaction) => verified_transaction,
+                    Err(()) => continue,
+                };
 
             self.state
                 .handle_consensus_transaction(
@@ -150,12 +152,8 @@ impl ExecutionState for ConsensusHandler {
                 .expect("Unrecoverable error in consensus handler");
         }
 
-        self.state
-            .handle_commit_boundary(
-                self.epoch,
-                &consensus_output.sub_dag,
-                &self.checkpoint_service,
-            )
+        epoch_store
+            .handle_commit_boundary(&consensus_output.sub_dag, &self.checkpoint_service)
             .expect("Unrecoverable error in consensus handler when processing commit boundary")
     }
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -10,6 +10,7 @@ use narwhal_executor::{ExecutionIndices, ExecutionState};
 use narwhal_types::ConsensusOutput;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use sui_types::base_types::{AuthorityName, EpochId};
 use sui_types::messages::ConsensusTransaction;
@@ -144,7 +145,7 @@ impl ExecutionState for ConsensusHandler {
 
             self.state
                 .handle_consensus_transaction(
-                    self.epoch,
+                    epoch_store.deref(),
                     verified_transaction,
                     &self.checkpoint_service,
                 )

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3169,7 +3169,10 @@ pub(crate) async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCe
         ConsensusTransaction::new_certificate_message(&authority.name, cert.clone().into_inner()),
     );
 
-    if let Ok(transaction) = authority.verify_consensus_transaction(cert.epoch(), transaction) {
+    if let Ok(transaction) = authority
+        .epoch_store()
+        .verify_consensus_transaction(transaction)
+    {
         authority
             .handle_consensus_transaction(
                 cert.epoch(),
@@ -3190,7 +3193,10 @@ pub(crate) async fn send_consensus_no_execution(
         ConsensusTransaction::new_certificate_message(&authority.name, cert.clone().into_inner()),
     );
 
-    if let Ok(transaction) = authority.verify_consensus_transaction(cert.epoch(), transaction) {
+    if let Ok(transaction) = authority
+        .epoch_store()
+        .verify_consensus_transaction(transaction)
+    {
         // Call process_consensus_transaction() instead of handle_consensus_transaction(), to avoid actually executing cert.
         // This allows testing cert execution independently.
         authority

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::consensus_handler::SequencedConsensusTransaction;
 use crate::{
     authority_client::{AuthorityAPI, NetworkAuthorityClient},
     authority_server::AuthorityServer,
@@ -30,6 +31,7 @@ use std::task::{Context, Poll};
 use sui_json_rpc_types::SuiExecutionResult;
 use sui_types::utils::to_sender_signed_transaction;
 
+use std::ops::Deref;
 use std::{convert::TryInto, env};
 use sui_adapter::genesis;
 use sui_protocol_constants::MAX_MOVE_PACKAGE_SIZE;
@@ -3175,7 +3177,7 @@ pub(crate) async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCe
     {
         authority
             .handle_consensus_transaction(
-                cert.epoch(),
+                authority.epoch_store().deref(),
                 transaction,
                 &Arc::new(CheckpointServiceNoop {}),
             )
@@ -3200,10 +3202,11 @@ pub(crate) async fn send_consensus_no_execution(
         // Call process_consensus_transaction() instead of handle_consensus_transaction(), to avoid actually executing cert.
         // This allows testing cert execution independently.
         authority
+            .epoch_store()
             .process_consensus_transaction(
-                cert.epoch(),
                 transaction,
                 &Arc::new(CheckpointServiceNoop {}),
+                &authority.db(),
             )
             .await
             .unwrap();

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -10,6 +10,7 @@ use multiaddr::Multiaddr;
 use narwhal_types::Transactions;
 use narwhal_types::TransactionsServer;
 use narwhal_types::{Empty, TransactionProto};
+use std::ops::Deref;
 use sui_network::tonic;
 use sui_types::crypto::deterministic_random_account_key;
 use sui_types::utils::to_sender_signed_transaction;
@@ -106,7 +107,7 @@ async fn submit_transaction_to_consensus_adapter() {
         async fn submit_to_consensus(&self, transaction: &ConsensusTransaction) -> SuiResult {
             self.0
                 .handle_consensus_transaction(
-                    0,
+                    self.0.epoch_store().deref(),
                     VerifiedSequencedConsensusTransaction::new_test(transaction.clone()),
                     &Arc::new(CheckpointServiceNoop {}),
                 )


### PR DESCRIPTION
All of the functions in authority.rs called by consensus handler only access epoch store (with one exception that reads the parent sync table). Move all of them into the per-epoch store.