### PR TITLE
[reconfig] Remove AuthorityState from ConsensusHandler

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -148,8 +148,7 @@ pub struct AuthorityMetrics {
     pub(crate) execution_driver_executed_transactions: IntCounter,
     pub(crate) execution_driver_execution_failures: IntCounter,
 
-    // TODO: Add this back for use.
-    _skipped_consensus_txns: IntCounter,
+    pub(crate) skipped_consensus_txns: IntCounter,
 
     /// Post processing metrics
     post_processing_total_events_emitted: IntCounter,
@@ -313,7 +312,7 @@ impl AuthorityMetrics {
                 registry,
             )
             .unwrap(),
-            _skipped_consensus_txns: register_int_counter_with_registry!(
+            skipped_consensus_txns: register_int_counter_with_registry!(
                 "skipped_consensus_txns",
                 "Total number of consensus transactions skipped",
                 registry,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -398,7 +398,7 @@ pub struct AuthorityState {
     committee_store: Arc<CommitteeStore>,
 
     /// Manages pending certificates and their missing input objects.
-    pub(crate) transaction_manager: Arc<TransactionManager>,
+    transaction_manager: Arc<TransactionManager>,
 
     pub metrics: Arc<AuthorityMetrics>,
 }
@@ -1461,7 +1461,7 @@ impl AuthorityState {
             event_handler,
             transaction_streamer,
             committee_store,
-            transaction_manager: transaction_manager.clone(),
+            transaction_manager,
             metrics,
         });
 
@@ -1546,6 +1546,10 @@ impl AuthorityState {
         state.create_owner_index_if_empty().unwrap();
 
         state
+    }
+
+    pub fn transaction_manager(&self) -> &Arc<TransactionManager> {
+        &self.transaction_manager
     }
 
     /// Adds certificates to the pending certificate store and transaction manager for ordered execution.

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -904,7 +904,7 @@ impl AuthorityPerEpochStore {
     /// The transaction passed here went through verification in verify_consensus_transaction.
     /// This method is called in the exact sequence message are ordered in consensus.
     /// Errors returned by this call are treated as critical errors and cause node to panic.
-    pub async fn handle_consensus_transaction<C: CheckpointServiceNotify>(
+    pub(crate) async fn handle_consensus_transaction<C: CheckpointServiceNotify>(
         &self,
         transaction: VerifiedSequencedConsensusTransaction,
         checkpoint_service: &Arc<C>,
@@ -926,7 +926,7 @@ impl AuthorityPerEpochStore {
     /// - Verify and initialize the state to execute the certificate.
     ///   Returns a VerifiedCertificate only if this succeeds.
     /// - Or update the state for checkpoint or epoch change protocol. Returns None.
-    pub async fn process_consensus_transaction<C: CheckpointServiceNotify>(
+    pub(crate) async fn process_consensus_transaction<C: CheckpointServiceNotify>(
         &self,
         transaction: VerifiedSequencedConsensusTransaction,
         checkpoint_service: &Arc<C>,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -40,6 +40,7 @@ use crate::notify_once::NotifyOnce;
 use crate::stake_aggregator::StakeAggregator;
 use crate::transaction_manager::TransactionManager;
 use mysten_metrics::monitored_scope;
+use prometheus::IntCounter;
 use std::cmp::Ordering as CmpOrdering;
 use sui_types::message_envelope::TrustedEnvelope;
 use sui_types::storage::{transaction_input_object_keys, ObjectKey, ParentSync};
@@ -862,6 +863,7 @@ impl AuthorityPerEpochStore {
     pub(crate) fn verify_consensus_transaction(
         &self,
         transaction: SequencedConsensusTransaction,
+        skipped_consensus_txns: &IntCounter,
     ) -> Result<VerifiedSequencedConsensusTransaction, ()> {
         let _scope = monitored_scope("VerifyConsensusTransaction");
         if self
@@ -873,8 +875,7 @@ impl AuthorityPerEpochStore {
                 tracking_id=?transaction.transaction.tracking_id,
                 "handle_consensus_transaction UserTransaction [skip]",
             );
-            // TODO: Add metrics back.
-            // self.metrics.skipped_consensus_txns.inc();
+            skipped_consensus_txns.inc();
             return Err(());
         }
         // Signatures are verified as part of narwhal payload verification in SuiTxValidator

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1060,11 +1060,6 @@ impl AuthorityStore {
         )
     }
 
-    /// Return the latest consensus index. It is used to bootstrap the consensus client.
-    pub fn last_consensus_index(&self) -> SuiResult<ExecutionIndicesWithHash> {
-        self.epoch_store().get_last_consensus_index()
-    }
-
     pub fn get_transaction(
         &self,
         transaction_digest: &TransactionDigest,

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
-use crate::authority::authority_per_epoch_store::{
-    AuthorityPerEpochStore, ExecutionIndicesWithHash,
-};
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use arc_swap::ArcSwap;
 use once_cell::sync::OnceCell;
 use rocksdb::Options;

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -235,7 +235,7 @@ impl CheckpointExecutorEventLoop {
     }
 
     /// Executes all checkpoints for the current epoch. At epoch boundary,
-    /// awaits the queue of scheduled checkpoints and returns the committe
+    /// awaits the queue of scheduled checkpoints and returns the committee
     /// of the next epoch.
     pub async fn execute_checkpoints_for_epoch(
         &mut self,
@@ -362,7 +362,7 @@ impl CheckpointExecutorEventLoop {
         // Note that either of these can be higher. If the node crashes with many
         // scheduled tasks, then the in-memory watermark starts as None, but the
         // persistent watermark is set, hence we start there. If we get a new
-        // messsage with checkpoints tasks scheduled, then the in-memory watermark
+        // message with checkpoints tasks scheduled, then the in-memory watermark
         // will be greater, and hence we start from there.
         let next_to_exec = std::cmp::max(
             highest_executed_seq_num
@@ -548,7 +548,7 @@ async fn execute_transactions(
         .insert_pending_certificates(&synced_txns)?;
 
     authority_state
-        .transaction_manager
+        .transaction_manager()
         .enqueue(synced_txns)
         .await?;
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -20,11 +20,17 @@ use sui_types::storage::ParentSync;
 use tracing::{debug, instrument, warn};
 
 pub struct ConsensusHandler<T> {
+    /// A store created for each epoch. ConsensusHandler is recreated each epoch, with the
+    /// corresponding store. This store is also used to get the current epoch ID.
     epoch_store: Arc<AuthorityPerEpochStore>,
     last_seen: Mutex<ExecutionIndicesWithHash>,
     checkpoint_service: Arc<CheckpointService>,
+    /// transaction_manager is needed to schedule certificates execution received from Narwhal.
     transaction_manager: Arc<TransactionManager>,
+    /// parent_sync_store is needed when determining the next version to assign for shared objects.
     parent_sync_store: T,
+    // TODO: ConsensusHandler doesn't really share metrics with AuthorityState. We could define
+    // a new metrics type here if we want to.
     metrics: Arc<AuthorityMetrics>,
 }
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -6,6 +6,7 @@ use crate::authority::authority_per_epoch_store::{
 };
 use crate::authority::AuthorityState;
 use crate::checkpoints::CheckpointService;
+use crate::transaction_manager::TransactionManager;
 use async_trait::async_trait;
 use mysten_metrics::monitored_scope;
 use narwhal_executor::{ExecutionIndices, ExecutionState};
@@ -23,6 +24,7 @@ pub struct ConsensusHandler {
     state: Arc<AuthorityState>,
     last_seen: Mutex<ExecutionIndicesWithHash>,
     checkpoint_service: Arc<CheckpointService>,
+    transaction_manager: Arc<TransactionManager>,
 }
 
 impl ConsensusHandler {
@@ -30,6 +32,7 @@ impl ConsensusHandler {
         state: Arc<AuthorityState>,
         epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_service: Arc<CheckpointService>,
+        transaction_manager: Arc<TransactionManager>,
     ) -> Self {
         let last_seen = Mutex::new(Default::default());
         Self {
@@ -37,6 +40,7 @@ impl ConsensusHandler {
             state,
             last_seen,
             checkpoint_service,
+            transaction_manager,
         }
     }
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -145,10 +145,10 @@ impl<T: ParentSync + Send + Sync> ExecutionState for ConsensusHandler<T> {
             .inc_by(bytes as u64);
 
         for sequenced_transaction in sequenced_transactions {
-            let verified_transaction = match self
-                .epoch_store
-                .verify_consensus_transaction(sequenced_transaction)
-            {
+            let verified_transaction = match self.epoch_store.verify_consensus_transaction(
+                sequenced_transaction,
+                &self.metrics.skipped_consensus_txns,
+            ) {
                 Ok(verified_transaction) => verified_transaction,
                 Err(()) => continue,
             };

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -19,7 +19,7 @@ use crate::authority::{AuthorityMetrics, AuthorityStore};
 /// subscribes to the stream of ready certificates published by the TransactionManager, and can
 /// execute them in parallel.
 /// TODO: use TransactionManager for fullnode.
-pub(crate) struct TransactionManager {
+pub struct TransactionManager {
     authority_store: Arc<AuthorityStore>,
     tx_ready_certificates: UnboundedSender<VerifiedCertificate>,
     metrics: Arc<AuthorityMetrics>,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3172,7 +3172,7 @@ pub(crate) async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCe
 
     if let Ok(transaction) = authority
         .epoch_store()
-        .verify_consensus_transaction(transaction)
+        .verify_consensus_transaction(transaction, &authority.metrics.skipped_consensus_txns)
     {
         authority
             .epoch_store()
@@ -3198,7 +3198,7 @@ pub(crate) async fn send_consensus_no_execution(
 
     if let Ok(transaction) = authority
         .epoch_store()
-        .verify_consensus_transaction(transaction)
+        .verify_consensus_transaction(transaction, &authority.metrics.skipped_consensus_txns)
     {
         // Call process_consensus_transaction() instead of handle_consensus_transaction(), to avoid actually executing cert.
         // This allows testing cert execution independently.

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -31,7 +31,6 @@ use std::task::{Context, Poll};
 use sui_json_rpc_types::SuiExecutionResult;
 use sui_types::utils::to_sender_signed_transaction;
 
-use std::ops::Deref;
 use std::{convert::TryInto, env};
 use sui_adapter::genesis;
 use sui_protocol_constants::MAX_MOVE_PACKAGE_SIZE;
@@ -3176,10 +3175,12 @@ pub(crate) async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCe
         .verify_consensus_transaction(transaction)
     {
         authority
+            .epoch_store()
             .handle_consensus_transaction(
-                authority.epoch_store().deref(),
                 transaction,
                 &Arc::new(CheckpointServiceNoop {}),
+                authority.transaction_manager(),
+                authority.db(),
             )
             .await
             .unwrap();

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -10,7 +10,6 @@ use multiaddr::Multiaddr;
 use narwhal_types::Transactions;
 use narwhal_types::TransactionsServer;
 use narwhal_types::{Empty, TransactionProto};
-use std::ops::Deref;
 use sui_network::tonic;
 use sui_types::crypto::deterministic_random_account_key;
 use sui_types::utils::to_sender_signed_transaction;
@@ -106,10 +105,12 @@ async fn submit_transaction_to_consensus_adapter() {
     impl SubmitToConsensus for SubmitDirectly {
         async fn submit_to_consensus(&self, transaction: &ConsensusTransaction) -> SuiResult {
             self.0
+                .epoch_store()
                 .handle_consensus_transaction(
-                    self.0.epoch_store().deref(),
                     VerifiedSequencedConsensusTransaction::new_test(transaction.clone()),
                     &Arc::new(CheckpointServiceNoop {}),
+                    self.0.transaction_manager(),
+                    self.0.db(),
                 )
                 .await
         }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -471,6 +471,7 @@ impl SuiNode {
             state.clone(),
             state.epoch_store().clone(),
             checkpoint_service,
+            state.transaction_manager().clone(),
         ));
         let narwhal_config = NarwhalConfiguration {
             primary_keypair: config.protocol_key_pair().copy(),
@@ -630,6 +631,7 @@ impl SuiNode {
                         self.state.clone(),
                         self.state.epoch_store().clone(),
                         validator_components.checkpoint_service.clone(),
+                        self.state.transaction_manager().clone(),
                     ));
                     validator_components
                         .narwhal_manager

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -79,7 +79,7 @@ use sui_types::error::{SuiError, SuiResult};
 
 pub struct ValidatorComponents {
     _validator_server_handle: tokio::task::JoinHandle<Result<()>>,
-    narwhal_manager: NarwhalManager<ConsensusHandler>,
+    narwhal_manager: NarwhalManager<ConsensusHandler<Arc<AuthorityStore>>>,
     consensus_adapter: Arc<ConsensusAdapter>,
     checkpoint_service: Arc<CheckpointService>,
 }
@@ -455,7 +455,7 @@ impl SuiNode {
         state: Arc<AuthorityState>,
         checkpoint_service: Arc<CheckpointService>,
         registry_service: RegistryService,
-    ) -> Result<NarwhalManager<ConsensusHandler>> {
+    ) -> Result<NarwhalManager<ConsensusHandler<Arc<AuthorityStore>>>> {
         let system_state = state
             .get_sui_system_state_object()
             .expect("Reading Sui system state object cannot fail");
@@ -468,10 +468,11 @@ impl SuiNode {
             .address;
         let worker_cache = system_state.get_current_epoch_narwhal_worker_cache(transactions_addr);
         let consensus_handler = Arc::new(ConsensusHandler::new(
-            state.clone(),
             state.epoch_store().clone(),
             checkpoint_service,
             state.transaction_manager().clone(),
+            state.db(),
+            state.metrics.clone(),
         ));
         let narwhal_config = NarwhalConfiguration {
             primary_keypair: config.protocol_key_pair().copy(),
@@ -628,10 +629,11 @@ impl SuiNode {
                     let worker_cache =
                         system_state.get_current_epoch_narwhal_worker_cache(transactions_addr);
                     let consensus_handler = Arc::new(ConsensusHandler::new(
-                        self.state.clone(),
                         self.state.epoch_store().clone(),
                         validator_components.checkpoint_service.clone(),
                         self.state.transaction_manager().clone(),
+                        self.state.db(),
+                        self.state.metrics.clone(),
                     ));
                     validator_components
                         .narwhal_manager

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -467,7 +467,11 @@ impl SuiNode {
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?
             .address;
         let worker_cache = system_state.get_current_epoch_narwhal_worker_cache(transactions_addr);
-        let consensus_handler = Arc::new(ConsensusHandler::new(state.clone(), checkpoint_service));
+        let consensus_handler = Arc::new(ConsensusHandler::new(
+            state.clone(),
+            state.epoch_store().clone(),
+            checkpoint_service,
+        ));
         let narwhal_config = NarwhalConfiguration {
             primary_keypair: config.protocol_key_pair().copy(),
             network_keypair: config.network_key_pair.copy(),
@@ -624,6 +628,7 @@ impl SuiNode {
                         system_state.get_current_epoch_narwhal_worker_cache(transactions_addr);
                     let consensus_handler = Arc::new(ConsensusHandler::new(
                         self.state.clone(),
+                        self.state.epoch_store().clone(),
                         validator_components.checkpoint_service.clone(),
                     ));
                     validator_components


### PR DESCRIPTION
This PR completely removes `AuthorityState` from `ConsensusHandler`.
To do so, we introduce explicit dependencies to the per-epoch store, transaction manager (which eventually does depend on the state, however), and parent sync store (for reading the parent_sync table).
This helps us reason about dependency and when it would access per-epoch store vs the perpetual store