### PR TITLE
[Benchmark] clamp data recorded in histogram

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -277,7 +277,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
                 let mut num_in_flight: u64 = 0;
                 let mut num_submitted = 0;
                 let mut latency_histogram =
-                    hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
+                    hdrhistogram::Histogram::<u64>::new_with_max(120_000, 3).unwrap();
                 let mut request_interval =
                     time::interval(Duration::from_micros(request_delay_micros));
                 request_interval.set_missed_tick_behavior(time::MissedTickBehavior::Burst);
@@ -435,7 +435,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
                                     num_success += 1;
                                     num_in_flight -= 1;
                                     free_pool.push(new_payload);
-                                    latency_histogram.record(latency.as_millis().try_into().unwrap()).unwrap();
+                                    latency_histogram.saturating_record(latency.as_millis().try_into().unwrap());
                                     BenchDriver::update_progress(*start_time, run_duration, progress.clone());
                                     if progress.is_finished() {
                                         break;
@@ -479,7 +479,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
                 num_error: 0,
                 num_success: 0,
                 latency_ms: HistogramWrapper {
-                    histogram: hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap(),
+                    histogram: hdrhistogram::Histogram::<u64>::new_with_max(120_000, 3).unwrap(),
                 },
             };
             let mut stat_collection: BTreeMap<usize, Stats> = BTreeMap::new();
@@ -502,7 +502,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
                 let mut num_success: u64 = 0;
                 let mut num_error: u64 = 0;
                 let mut latency_histogram =
-                    hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
+                    hdrhistogram::Histogram::<u64>::new_with_max(120_000, 3).unwrap();
                 let mut num_in_flight: u64 = 0;
                 let mut num_submitted: u64 = 0;
                 let mut num_no_gas = 0;


### PR DESCRIPTION
Otherwise it seems after setup phase, there can be histogram recording errors from latencies exceeding 100s.