### PR TITLE
separate Epoch related errors in authority_aggregator.handle_transaction

### DIFF
--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -2,15 +2,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::AuthorityState;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fastcrypto::traits::ToFromBytes;
 use multiaddr::Multiaddr;
-use mysten_metrics::spawn_monitored_task;
 use mysten_network::config::Config;
 use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::time::Duration;
 use sui_config::genesis::Genesis;
 use sui_config::ValidatorInfo;
@@ -20,7 +17,6 @@ use sui_types::committee::CommitteeWithNetAddresses;
 use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::sui_system_state::SuiSystemState;
-use sui_types::{committee::Committee, crypto::AuthorityKeyPair, object::Object};
 use sui_types::{error::SuiError, messages::*};
 
 use sui_network::tonic::transport::Channel;
@@ -253,169 +249,4 @@ pub fn make_authority_clients(
         authority_clients.insert(authority.protocol_key(), client);
     }
     authority_clients
-}
-
-#[derive(Clone, Copy, Default)]
-pub struct LocalAuthorityClientFaultConfig {
-    pub fail_before_handle_transaction: bool,
-    pub fail_after_handle_transaction: bool,
-    pub fail_before_handle_confirmation: bool,
-    pub fail_after_handle_confirmation: bool,
-}
-
-impl LocalAuthorityClientFaultConfig {
-    pub fn reset(&mut self) {
-        *self = Self::default();
-    }
-}
-
-#[derive(Clone)]
-pub struct LocalAuthorityClient {
-    pub state: Arc<AuthorityState>,
-    pub fault_config: LocalAuthorityClientFaultConfig,
-}
-
-#[async_trait]
-impl AuthorityAPI for LocalAuthorityClient {
-    async fn handle_transaction(
-        &self,
-        transaction: Transaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
-        if self.fault_config.fail_before_handle_transaction {
-            return Err(SuiError::from("Mock error before handle_transaction"));
-        }
-        let state = self.state.clone();
-        let transaction = transaction.verify()?;
-        let result = state.handle_transaction(transaction).await;
-        if self.fault_config.fail_after_handle_transaction {
-            return Err(SuiError::GenericAuthorityError {
-                error: "Mock error after handle_transaction".to_owned(),
-            });
-        }
-        result.map(|r| r.into())
-    }
-
-    async fn handle_certificate(
-        &self,
-        certificate: CertifiedTransaction,
-    ) -> Result<HandleCertificateResponse, SuiError> {
-        let state = self.state.clone();
-        let fault_config = self.fault_config;
-        spawn_monitored_task!(Self::handle_certificate(state, certificate, fault_config))
-            .await
-            .unwrap()
-    }
-
-    async fn handle_account_info_request(
-        &self,
-        request: AccountInfoRequest,
-    ) -> Result<AccountInfoResponse, SuiError> {
-        let state = self.state.clone();
-        state.handle_account_info_request(request).await
-    }
-
-    async fn handle_object_info_request(
-        &self,
-        request: ObjectInfoRequest,
-    ) -> Result<ObjectInfoResponse, SuiError> {
-        let state = self.state.clone();
-        state
-            .handle_object_info_request(request)
-            .await
-            .map(|r| r.into())
-    }
-
-    /// Handle Object information requests for this account.
-    async fn handle_transaction_info_request(
-        &self,
-        request: TransactionInfoRequest,
-    ) -> Result<TransactionInfoResponse, SuiError> {
-        let state = self.state.clone();
-        state
-            .handle_transaction_info_request(request)
-            .await
-            .map(|r| r.into())
-    }
-
-    async fn handle_checkpoint(
-        &self,
-        request: CheckpointRequest,
-    ) -> Result<CheckpointResponse, SuiError> {
-        let state = self.state.clone();
-
-        state.handle_checkpoint_request(&request)
-    }
-
-    async fn handle_committee_info_request(
-        &self,
-        request: CommitteeInfoRequest,
-    ) -> Result<CommitteeInfoResponse, SuiError> {
-        let state = self.state.clone();
-
-        state.handle_committee_info_request(&request)
-    }
-}
-
-impl LocalAuthorityClient {
-    pub async fn new(committee: Committee, secret: AuthorityKeyPair, genesis: &Genesis) -> Self {
-        let state = AuthorityState::new_for_testing(committee, &secret, None, Some(genesis)).await;
-        Self {
-            state,
-            fault_config: LocalAuthorityClientFaultConfig::default(),
-        }
-    }
-
-    pub async fn new_with_objects(
-        committee: Committee,
-        secret: AuthorityKeyPair,
-        objects: Vec<Object>,
-        genesis: &Genesis,
-    ) -> Self {
-        let client = Self::new(committee, secret, genesis).await;
-
-        for object in objects {
-            client.state.insert_genesis_object(object).await;
-        }
-
-        client
-    }
-
-    pub fn new_from_authority(state: Arc<AuthorityState>) -> Self {
-        Self {
-            state,
-            fault_config: LocalAuthorityClientFaultConfig::default(),
-        }
-    }
-
-    async fn handle_certificate(
-        state: Arc<AuthorityState>,
-        certificate: CertifiedTransaction,
-        fault_config: LocalAuthorityClientFaultConfig,
-    ) -> Result<HandleCertificateResponse, SuiError> {
-        if fault_config.fail_before_handle_confirmation {
-            return Err(SuiError::GenericAuthorityError {
-                error: "Mock error before handle_confirmation_transaction".to_owned(),
-            });
-        }
-        // Check existing effects before verifying the cert to allow querying certs finalized
-        // from previous epochs.
-        let tx_digest = *certificate.digest();
-        let epoch_store = state.epoch_store();
-        let signed_effects =
-            match state.get_signed_effects_and_maybe_resign(epoch_store.epoch(), &tx_digest) {
-                Ok(Some(effects)) => effects,
-                _ => {
-                    let certificate = { certificate.verify(epoch_store.committee())? };
-                    state
-                        .try_execute_immediately(&certificate, &epoch_store)
-                        .await?
-                }
-            };
-        if fault_config.fail_after_handle_confirmation {
-            return Err(SuiError::GenericAuthorityError {
-                error: "Mock error after handle_confirmation_transaction".to_owned(),
-            });
-        }
-        Ok(HandleCertificateResponse { signed_effects })
-    }
 }

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -34,5 +34,6 @@ pub mod validator_info;
 #[cfg(test)]
 #[path = "unit_tests/pay_sui_tests.rs"]
 mod pay_sui_tests;
+pub mod test_authority_clients;
 
 pub const SUI_CORE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -1,0 +1,372 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use crate::{authority::AuthorityState, authority_client::AuthorityAPI};
+use async_trait::async_trait;
+use mysten_metrics::spawn_monitored_task;
+use sui_config::genesis::Genesis;
+use sui_types::{
+    committee::Committee,
+    crypto::AuthorityKeyPair,
+    error::SuiError,
+    messages::{
+        AccountInfoRequest, AccountInfoResponse, CertifiedTransaction, CommitteeInfoRequest,
+        CommitteeInfoResponse, ObjectInfoRequest, ObjectInfoResponse, Transaction,
+        TransactionInfoRequest, TransactionInfoResponse,
+    },
+    messages_checkpoint::{CheckpointRequest, CheckpointResponse},
+    object::Object,
+};
+use sui_types::{error::SuiResult, messages::HandleCertificateResponse};
+
+#[derive(Clone, Copy, Default)]
+pub struct LocalAuthorityClientFaultConfig {
+    pub fail_before_handle_transaction: bool,
+    pub fail_after_handle_transaction: bool,
+    pub fail_before_handle_confirmation: bool,
+    pub fail_after_handle_confirmation: bool,
+}
+
+impl LocalAuthorityClientFaultConfig {
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+#[derive(Clone)]
+pub struct LocalAuthorityClient {
+    pub state: Arc<AuthorityState>,
+    pub fault_config: LocalAuthorityClientFaultConfig,
+}
+
+#[async_trait]
+impl AuthorityAPI for LocalAuthorityClient {
+    async fn handle_transaction(
+        &self,
+        transaction: Transaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        if self.fault_config.fail_before_handle_transaction {
+            return Err(SuiError::from("Mock error before handle_transaction"));
+        }
+        let state = self.state.clone();
+        let transaction = transaction.verify()?;
+        let result = state.handle_transaction(transaction).await;
+        if self.fault_config.fail_after_handle_transaction {
+            return Err(SuiError::GenericAuthorityError {
+                error: "Mock error after handle_transaction".to_owned(),
+            });
+        }
+        result.map(|r| r.into())
+    }
+
+    async fn handle_certificate(
+        &self,
+        certificate: CertifiedTransaction,
+    ) -> Result<HandleCertificateResponse, SuiError> {
+        let state = self.state.clone();
+        let fault_config = self.fault_config;
+        spawn_monitored_task!(Self::handle_certificate(state, certificate, fault_config))
+            .await
+            .unwrap()
+    }
+
+    async fn handle_account_info_request(
+        &self,
+        request: AccountInfoRequest,
+    ) -> Result<AccountInfoResponse, SuiError> {
+        let state = self.state.clone();
+        state.handle_account_info_request(request).await
+    }
+
+    async fn handle_object_info_request(
+        &self,
+        request: ObjectInfoRequest,
+    ) -> Result<ObjectInfoResponse, SuiError> {
+        let state = self.state.clone();
+        state
+            .handle_object_info_request(request)
+            .await
+            .map(|r| r.into())
+    }
+
+    /// Handle Object information requests for this account.
+    async fn handle_transaction_info_request(
+        &self,
+        request: TransactionInfoRequest,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        let state = self.state.clone();
+        state
+            .handle_transaction_info_request(request)
+            .await
+            .map(|r| r.into())
+    }
+
+    async fn handle_checkpoint(
+        &self,
+        request: CheckpointRequest,
+    ) -> Result<CheckpointResponse, SuiError> {
+        let state = self.state.clone();
+
+        state.handle_checkpoint_request(&request)
+    }
+
+    async fn handle_committee_info_request(
+        &self,
+        request: CommitteeInfoRequest,
+    ) -> Result<CommitteeInfoResponse, SuiError> {
+        let state = self.state.clone();
+
+        state.handle_committee_info_request(&request)
+    }
+}
+
+impl LocalAuthorityClient {
+    pub async fn new(committee: Committee, secret: AuthorityKeyPair, genesis: &Genesis) -> Self {
+        let state = AuthorityState::new_for_testing(committee, &secret, None, Some(genesis)).await;
+        Self {
+            state,
+            fault_config: LocalAuthorityClientFaultConfig::default(),
+        }
+    }
+
+    pub async fn new_with_objects(
+        committee: Committee,
+        secret: AuthorityKeyPair,
+        objects: Vec<Object>,
+        genesis: &Genesis,
+    ) -> Self {
+        let client = Self::new(committee, secret, genesis).await;
+
+        for object in objects {
+            client.state.insert_genesis_object(object).await;
+        }
+
+        client
+    }
+
+    pub fn new_from_authority(state: Arc<AuthorityState>) -> Self {
+        Self {
+            state,
+            fault_config: LocalAuthorityClientFaultConfig::default(),
+        }
+    }
+
+    async fn handle_certificate(
+        state: Arc<AuthorityState>,
+        certificate: CertifiedTransaction,
+        fault_config: LocalAuthorityClientFaultConfig,
+    ) -> Result<HandleCertificateResponse, SuiError> {
+        if fault_config.fail_before_handle_confirmation {
+            return Err(SuiError::GenericAuthorityError {
+                error: "Mock error before handle_confirmation_transaction".to_owned(),
+            });
+        }
+        // Check existing effects before verifying the cert to allow querying certs finalized
+        // from previous epochs.
+        let tx_digest = *certificate.digest();
+        let epoch_store = state.epoch_store();
+        let signed_effects =
+            match state.get_signed_effects_and_maybe_resign(epoch_store.epoch(), &tx_digest) {
+                Ok(Some(effects)) => effects,
+                _ => {
+                    let certificate = { certificate.verify(epoch_store.committee())? };
+                    state
+                        .try_execute_immediately(&certificate, &epoch_store)
+                        .await?
+                }
+            };
+        if fault_config.fail_after_handle_confirmation {
+            return Err(SuiError::GenericAuthorityError {
+                error: "Mock error after handle_confirmation_transaction".to_owned(),
+            });
+        }
+        Ok(HandleCertificateResponse { signed_effects })
+    }
+}
+
+#[derive(Clone)]
+pub struct MockAuthorityApi {
+    delay: Duration,
+    count: Arc<Mutex<u32>>,
+    handle_committee_info_request_result: Option<SuiResult<CommitteeInfoResponse>>,
+    handle_object_info_request_result: Option<SuiResult<ObjectInfoResponse>>,
+}
+
+impl MockAuthorityApi {
+    pub fn new(delay: Duration, count: Arc<Mutex<u32>>) -> Self {
+        MockAuthorityApi {
+            delay,
+            count,
+            handle_committee_info_request_result: None,
+            handle_object_info_request_result: None,
+        }
+    }
+    pub fn set_handle_committee_info_request_result(
+        &mut self,
+        result: SuiResult<CommitteeInfoResponse>,
+    ) {
+        self.handle_committee_info_request_result = Some(result);
+    }
+
+    pub fn set_handle_object_info_request(&mut self, result: SuiResult<ObjectInfoResponse>) {
+        self.handle_object_info_request_result = Some(result);
+    }
+}
+
+#[async_trait]
+impl AuthorityAPI for MockAuthorityApi {
+    /// Initiate a new transaction to a Sui or Primary account.
+    async fn handle_transaction(
+        &self,
+        _transaction: Transaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        unreachable!();
+    }
+
+    /// Execute a certificate.
+    async fn handle_certificate(
+        &self,
+        _certificate: CertifiedTransaction,
+    ) -> Result<HandleCertificateResponse, SuiError> {
+        unreachable!()
+    }
+
+    /// Handle Account information requests for this account.
+    async fn handle_account_info_request(
+        &self,
+        _request: AccountInfoRequest,
+    ) -> Result<AccountInfoResponse, SuiError> {
+        unreachable!();
+    }
+
+    /// Handle Object information requests for this account.
+    async fn handle_object_info_request(
+        &self,
+        _request: ObjectInfoRequest,
+    ) -> Result<ObjectInfoResponse, SuiError> {
+        self.handle_object_info_request_result.clone().unwrap()
+    }
+
+    /// Handle Object information requests for this account.
+    async fn handle_transaction_info_request(
+        &self,
+        _request: TransactionInfoRequest,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        let count = {
+            let mut count = self.count.lock().unwrap();
+            *count += 1;
+            *count
+        };
+
+        // timeout until the 15th request
+        if count < 15 {
+            tokio::time::sleep(self.delay).await;
+        }
+
+        let res = TransactionInfoResponse {
+            signed_transaction: None,
+            certified_transaction: None,
+            signed_effects: None,
+        };
+        Ok(res)
+    }
+
+    async fn handle_checkpoint(
+        &self,
+        _request: CheckpointRequest,
+    ) -> Result<CheckpointResponse, SuiError> {
+        unreachable!();
+    }
+
+    async fn handle_committee_info_request(
+        &self,
+        _request: CommitteeInfoRequest,
+    ) -> Result<CommitteeInfoResponse, SuiError> {
+        self.handle_committee_info_request_result.clone().unwrap()
+    }
+}
+
+#[derive(Clone)]
+pub struct HandleTransactionTestAuthorityClient {
+    pub tx_info_resp_to_return: TransactionInfoResponse,
+}
+
+#[async_trait]
+impl AuthorityAPI for HandleTransactionTestAuthorityClient {
+    async fn handle_transaction(
+        &self,
+        _transaction: Transaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        Ok(self.tx_info_resp_to_return.clone())
+    }
+
+    async fn handle_certificate(
+        &self,
+        _certificate: CertifiedTransaction,
+    ) -> Result<HandleCertificateResponse, SuiError> {
+        unimplemented!()
+    }
+
+    async fn handle_account_info_request(
+        &self,
+        _request: AccountInfoRequest,
+    ) -> Result<AccountInfoResponse, SuiError> {
+        unimplemented!()
+    }
+
+    async fn handle_object_info_request(
+        &self,
+        _request: ObjectInfoRequest,
+    ) -> Result<ObjectInfoResponse, SuiError> {
+        unimplemented!()
+    }
+
+    async fn handle_transaction_info_request(
+        &self,
+        _request: TransactionInfoRequest,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        unimplemented!()
+    }
+
+    async fn handle_checkpoint(
+        &self,
+        _request: CheckpointRequest,
+    ) -> Result<CheckpointResponse, SuiError> {
+        unimplemented!()
+    }
+
+    async fn handle_committee_info_request(
+        &self,
+        _request: CommitteeInfoRequest,
+    ) -> Result<CommitteeInfoResponse, SuiError> {
+        unimplemented!()
+    }
+}
+
+impl HandleTransactionTestAuthorityClient {
+    pub fn new() -> Self {
+        Self {
+            tx_info_resp_to_return: TransactionInfoResponse {
+                signed_transaction: None,
+                certified_transaction: None,
+                signed_effects: None,
+            },
+        }
+    }
+
+    pub fn set_tx_info_response(&mut self, resp: TransactionInfoResponse) {
+        self.tx_info_resp_to_return = resp;
+    }
+}
+
+impl Default for HandleTransactionTestAuthorityClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -3,8 +3,8 @@
 
 use crate::authority::{AuthorityState, EffectsNotifyRead};
 use crate::authority_aggregator::{AuthorityAggregator, TimeoutConfig};
-use crate::authority_client::LocalAuthorityClient;
 use crate::epoch::committee_store::CommitteeStore;
+use crate::test_authority_clients::LocalAuthorityClient;
 use fastcrypto::traits::KeyPair;
 use prometheus::Registry;
 use signature::Signer;

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -7,8 +7,8 @@ use crate::authority_aggregator::authority_aggregator_tests::{
     create_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
     transfer_object_move_transaction,
 };
-use crate::authority_client::LocalAuthorityClient;
 use crate::safe_client::SafeClient;
+use crate::test_authority_clients::LocalAuthorityClient;
 use crate::test_utils::init_local_authorities;
 
 use std::collections::BTreeSet;

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -3,6 +3,7 @@
 
 use std::path::Path;
 
+#[cfg(not(msim))]
 use std::str::FromStr;
 
 use sui_config::SUI_KEYSTORE_FILENAME;

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -119,10 +119,14 @@ pub enum SuiError {
     },
     #[error("Invalid Authority Bitmap: {}", error)]
     InvalidAuthorityBitmap { error: String },
-    #[error("Unexpected validator response from handle_transaction: {err}")]
-    UnexpectedResultFromValidatorHandleTransaction { err: String },
     #[error("Transaction certificate processing failed: {err}")]
     ErrorWhileProcessingCertificate { err: String },
+    #[error(
+        "Failed to get a quorum of signed effects when processing transaction: {effects_map:?}"
+    )]
+    QuorumFailedToFormEffectsCertWhenProcessingTransaction {
+        effects_map: BTreeMap<(EpochId, TransactionEffectsDigest), (Vec<AuthorityName>, StakeUnit)>,
+    },
     #[error(
         "Failed to process transaction on a quorum of validators to form a transaction certificate. Locked objects: {:#?}. Validator errors: {:#?}",
         conflicting_tx_digests,

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -241,6 +241,10 @@ impl<T: Message, S> VerifiedEnvelope<T, S> {
         self.0 .0
     }
 
+    pub fn inner(&self) -> &Envelope<T, S> {
+        &self.0 .0
+    }
+
     pub fn into_message(self) -> T {
         self.into_inner().into_data()
     }


### PR DESCRIPTION
Meat is in `authority_aggregator.rs`. Currently we mix errors with wrong epoch and others such as validator returns an invalid response due to data corruption. This PR separates the errors and add tests.
Also moving `LocalAuthorityClient` and `MockAuthorityApi` into a new test-only file.