### PR TITLE
discovery: remove possible deadlock when reading state 

### DIFF
--- a/crates/sui-network/src/discovery/builder.rs
+++ b/crates/sui-network/src/discovery/builder.rs
@@ -81,9 +81,12 @@ impl UnstartedDiscovery {
             state,
         } = self;
 
+        let discovery_config = config.discovery.clone().unwrap_or_default();
+
         (
             DiscoveryEventLoop {
                 config,
+                discovery_config,
                 network,
                 tasks: JoinSet::new(),
                 pending_dials: Default::default(),

--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -240,7 +240,7 @@ impl DiscoveryEventLoop {
             .collect::<Vec<_>>();
 
         // No need to connect to any more peers if we're already connected to a bunch
-        let number_of_connections = self.state.read().unwrap().connected_peers.len();
+        let number_of_connections = state.connected_peers.len();
         let number_to_dial = std::cmp::min(
             eligible.len(),
             MAX_NUMBER_OF_CONNECTIONS.saturating_sub(number_of_connections),


### PR DESCRIPTION
Eliminate a possible deadlock due to trying to aquire the read lock on
State while already holding a read lock.

Also introduce a config in order to control some of the mechanics of discovery.