### PR TITLE
Fix bench driver panic followup

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -66,7 +66,7 @@ impl BenchMetrics {
             num_error: register_int_counter_vec_with_registry!(
                 "num_error",
                 "Total number of transaction errors",
-                &["workload", "error_type"],
+                &["workload"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -24,7 +24,7 @@ use tracing::{debug, error};
 macro_rules! check_error {
     ($address:expr, $cond:expr, $msg:expr) => {
         $cond.tap_err(|err| {
-            if matches!(err, SuiError::ValidatorHaltedAtEpochEnd) {
+            if err.indicates_epoch_change() {
                 debug!(?err, authority=?$address, "Not a real client error");
             } else {
                 error!(?err, authority=?$address, $msg);


### PR DESCRIPTION
Forgot to fix the metric definition.
Also don't print error in SafeClient if it's due to epoch change