### PR TITLE
Allow modules to read the decimals of CoinMeta.

### DIFF
--- a/crates/sui-framework/sources/coin.move
+++ b/crates/sui-framework/sources/coin.move
@@ -270,6 +270,13 @@ module sui::coin {
     public entry fun burn_<T>(c: &mut TreasuryCap<T>, coin: Coin<T>) {
         burn(c, coin);
     }
+    
+    // === Read coin metadata ===
+    public fun decimals<T>(
+        metadata: &CoinMetadata<T>
+    ): u8 {
+        metadata.decimals
+    }
 
     // === Update coin metadata ===
 


### PR DESCRIPTION
# Why we need the decimals of coin onchain?
Currently, I'm working on a lending platform on Sui. When I try to calculate the usd value of an asset, below is an example:
- 1. Retrieve SUI price from an oracle
- 2. The price is: 1.02$
- 3. The underlying SUI amount is 2SUI, but in contract it's 2 * 10**9
- 4. I need to first divide the amount by 10**9. Now I stuck, I actually have no clue on chain about the decimals of SUI.

## Solution to the problem

So I come up with a solution for this problem:
```move
module my_protocol::decimals_registry {
  
  use std::type_name::{Self, TypeName};
  use sui::table::{Self, Table};
  use sui::object::{Self, UID};
  use sui::tx_context::TxContext;
  use sui::transfer;
  use sui::coin::{Self, CoinMetadata};
  
  struct DecimalsRegisttry has key {
    id: UID,
    table: Table<TypeName, u8>
  }
  
  fun init(ctx: &mut TxContext) {
    transfer::share_object(
      DecimalsRegisttry {
        id: object::new(ctx),
        table: table::new(ctx)
      }
    )
  }
  
  // Since coinMeta is 1:1 for a coin,
  // CoinMeta is the single source of truth for the coin
  // Anyone can add the registry
  public entry fun register_decimals<T>(
    registry: &mut DecimalsRegisttry,
    coinMeta: &CoinMetadata<T>
  ) {
    let typeName = type_name::get<T>();
    // Returns the decimals of this coin
    // Adding this read method, won't cause any issues for coin framework
    let decimals = coin::decimals(coinMeta);
    table::add(&mut registry.table, typeName, decimals);
  }
  
  public entry fun get_decimals<T>(
    registry: &DecimalsRegisttry,
  ): u8 {
    let typeName = type_name::get<T>();
    *table::borrow(&registry.table, typeName)
  }
}
```
## Change request

All I need is: in the coin framework, add a read method to get the decimals from CoinMeta, it won't cause any side afffect.

```move
    // === Read coin metadata ===
    public fun decimals<T>(
        metadata: &CoinMetadata<T>
    ): u8 {
        metadata.decimals
    }
```
