### PR TITLE
allow to create AuthorityAggregator with existing metrics 

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -298,6 +298,36 @@ impl<A> AuthorityAggregator<A> {
         }
     }
 
+    pub fn new_with_metrics(
+        committee: Committee,
+        committee_store: Arc<CommitteeStore>,
+        authority_clients: BTreeMap<AuthorityName, A>,
+        safe_client_metrics_base: SafeClientMetricsBase,
+        auth_agg_metrics: AuthAggMetrics,
+    ) -> Self {
+        Self {
+            committee,
+            authority_clients: authority_clients
+                .into_iter()
+                .map(|(name, api)| {
+                    (
+                        name,
+                        SafeClient::new(
+                            api,
+                            committee_store.clone(),
+                            name,
+                            SafeClientMetrics::new(&safe_client_metrics_base, name),
+                        ),
+                    )
+                })
+                .collect(),
+            metrics: auth_agg_metrics,
+            safe_client_metrics_base: Arc::new(safe_client_metrics_base),
+            timeouts: Default::default(),
+            committee_store,
+        }
+    }
+
     /// This function recreates AuthorityAggregator with the given committee.
     /// It also updates committee store which impacts other of its references.
     /// If it is called on a Validator/Fullnode, it **may** interleave with the the authority active's
@@ -383,23 +413,29 @@ impl<A> AuthorityAggregator<A> {
 }
 
 impl AuthorityAggregator<NetworkAuthorityClient> {
-    /// Create a new network authority aggregator by reading the committee and network address
-    /// information from the system state object on-chain.
+    /// Create a new network authority aggregator by reading the committee and
+    /// network address information from the system state object on-chain.
+    /// This function needs metrics parameters because registry will panic
+    /// if we attempt to register already-registered metrics again.
     pub fn new_from_system_state(
         store: &Arc<AuthorityStore>,
         committee_store: &Arc<CommitteeStore>,
-        prometheus_registry: &Registry,
+        safe_client_metrics_base: SafeClientMetricsBase,
+        auth_agg_metrics: AuthAggMetrics,
     ) -> anyhow::Result<Self> {
         let net_config = default_mysten_network_config();
         let sui_system_state = store.get_sui_system_state_object()?;
-
+        // TODO: the function returns on URL parsing errors. In this case we should
+        // tolerate it as long as we have 2f+1 good validators.
+        // GH issue: https://github.com/MystenLabs/sui/issues/7019
         let authority_clients =
             make_network_authority_client_sets_from_system_state(&sui_system_state, &net_config)?;
-        Ok(Self::new(
+        Ok(Self::new_with_metrics(
             sui_system_state.get_current_epoch_committee().committee,
             committee_store.clone(),
             authority_clients,
-            prometheus_registry,
+            safe_client_metrics_base,
+            auth_agg_metrics,
         ))
     }
 }
@@ -449,10 +485,12 @@ impl TransactionCertifier for NetworkTransactionCertifier {
         self_state: &AuthorityState,
         timeout: Duration,
     ) -> anyhow::Result<VerifiedCertificate> {
+        let registry = Registry::new();
         let net = AuthorityAggregator::new_from_system_state(
             &self_state.db(),
             self_state.committee_store(),
-            &Registry::new(),
+            SafeClientMetricsBase::new(&registry),
+            AuthAggMetrics::new(&registry),
         )?;
 
         net.authorty_ask_for_cert_with_retry_and_timeout(transaction, self_state, timeout)

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -182,6 +182,8 @@ impl AuthorityAPI for NetworkAuthorityClient {
     }
 }
 
+// This function errs on URL parsing error. This may happen
+// when a validator provides a bad URL.
 pub fn make_network_authority_client_sets_from_system_state(
     sui_system_state: &SuiSystemState,
     network_config: &Config,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -20,10 +20,13 @@ use prometheus::Registry;
 use std::collections::HashMap;
 use std::sync::Arc;
 use sui_config::{ConsensusConfig, NodeConfig};
-use sui_core::authority_aggregator::{AuthorityAggregator, NetworkTransactionCertifier};
+use sui_core::authority_aggregator::{
+    AuthAggMetrics, AuthorityAggregator, NetworkTransactionCertifier,
+};
 use sui_core::authority_server::ValidatorService;
 use sui_core::checkpoints::checkpoint_executor;
 use sui_core::epoch::committee_store::CommitteeStore;
+use sui_core::safe_client::SafeClientMetricsBase;
 use sui_core::storage::RocksDbStore;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_core::transaction_streamer::TransactionStreamer;
@@ -178,7 +181,8 @@ impl SuiNode {
         let net = AuthorityAggregator::new_from_system_state(
             &store,
             &committee_store,
-            &prometheus_registry,
+            SafeClientMetricsBase::new(&prometheus_registry),
+            AuthAggMetrics::new(&prometheus_registry),
         )?;
 
         let transaction_streamer = if is_full_node {


### PR DESCRIPTION
In https://github.com/MystenLabs/sui/pull/7024, `fn new_from_system_state` is used to create new AuthorityAggregator for a new epoch. In current AuthorityAggregator construction functions, we always create new metrics `AuthAggMetrics` and `SafeClientMetricsBase` with an existing Prom registry. This does not work because attempting to register already-registered metrics with the same registry will [return an error](https://docs.rs/prometheus/latest/src/prometheus/registry.rs.html#48). 

This PR creates an `fn new_with_metrics` to allow to create AuthorityAggregator with `AuthAggMetrics` and `SafeClientMetricsBase` rather than a registry. 

Note: `fn new_from_system_state` works fine today because its only callsite uses a new Registry rather than the "global" one. This may not be a big deal for the callsite, which only happens for the epoch change tx during reconfig, but is certainly a problem for other cases.