### PR TITLE
[QD Reconfig] 3. add reconfig observer

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -173,11 +173,8 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
                         err
                     ),
                     Ok(auth_agg) => {
-                        if let Err(err) = self.qd.update_validators(Arc::new(auth_agg)).await {
-                            error!("Reconfiguration - Error when updating authority aggregator in quorum driver: {}", err);
-                        } else {
-                            info!("Reconfiguration - Reconfiguration to epoch {new_epoch} is done");
-                        }
+                        self.qd.update_validators(Arc::new(auth_agg)).await;
+                        info!("Reconfiguration - Reconfiguration to epoch {new_epoch} is done");
                     }
                 }
             }

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -4,6 +4,8 @@
 mod metrics;
 pub use metrics::*;
 
+pub mod reconfig_observer;
+
 use arc_swap::ArcSwap;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Formatter};
@@ -300,12 +302,12 @@ where
         Ok(response)
     }
 
-    pub async fn update_validators(
-        &self,
-        new_validators: Arc<AuthorityAggregator<A>>,
-    ) -> SuiResult {
+    pub async fn update_validators(&self, new_validators: Arc<AuthorityAggregator<A>>) {
+        info!(
+            "Quorum Drvier updating AuthorityAggregator with committee {:?}",
+            new_validators.committee
+        );
         self.validators.store(new_validators);
-        Ok(())
     }
 
     // TODO currently this function is not epoch-boundary-safe. We need to make it so.
@@ -607,6 +609,10 @@ where
 
     pub fn authority_aggregator(&self) -> &ArcSwap<AuthorityAggregator<A>> {
         self.quorum_driver.authority_aggregator()
+    }
+
+    pub fn current_epoch(&self) -> EpochId {
+        self.quorum_driver.current_epoch()
     }
 
     /// Process a QuorumDriverTask.

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use std::sync::Arc;
+use sui_types::committee::Committee;
+use tokio::sync::broadcast::error::RecvError;
+use tracing::{info, warn};
+
+use crate::{
+    authority::AuthorityStore,
+    authority_aggregator::{AuthAggMetrics, AuthorityAggregator},
+    authority_client::NetworkAuthorityClient,
+    epoch::committee_store::CommitteeStore,
+    safe_client::SafeClientMetricsBase,
+};
+
+use super::QuorumDriver;
+
+#[async_trait]
+pub trait ReconfigObserver<A> {
+    async fn run(&mut self, quorum_driver: Arc<QuorumDriver<A>>);
+}
+
+pub struct OnsiteReconfigObserver {
+    reconfig_rx: tokio::sync::broadcast::Receiver<Committee>,
+    authority_store: Arc<AuthorityStore>,
+    committee_store: Arc<CommitteeStore>,
+    safe_client_metrics_base: SafeClientMetricsBase,
+    auth_agg_metrics: AuthAggMetrics,
+}
+
+impl OnsiteReconfigObserver {
+    pub fn new(
+        reconfig_rx: tokio::sync::broadcast::Receiver<Committee>,
+        authority_store: Arc<AuthorityStore>,
+        committee_store: Arc<CommitteeStore>,
+        safe_client_metrics_base: SafeClientMetricsBase,
+        auth_agg_metrics: AuthAggMetrics,
+    ) -> Self {
+        Self {
+            reconfig_rx,
+            authority_store,
+            committee_store,
+            safe_client_metrics_base,
+            auth_agg_metrics,
+        }
+    }
+
+    async fn create_authority_aggregator_from_system_state(
+        &self,
+    ) -> AuthorityAggregator<NetworkAuthorityClient> {
+        AuthorityAggregator::new_from_system_state(
+            &self.authority_store,
+            &self.committee_store,
+            self.safe_client_metrics_base.clone(),
+            self.auth_agg_metrics.clone(),
+        )
+        // TODO: we should tolerate when <= f validators give invalid addresses
+        // GH issue: https://github.com/MystenLabs/sui/issues/7019
+        .unwrap_or_else(|e| {
+            panic!(
+                "Failed to create AuthorityAggregator from System State: {:?}",
+                e
+            )
+        })
+    }
+}
+
+#[async_trait]
+impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
+    async fn run(&mut self, quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>) {
+        // A tiny optimization: when a very stale node just starts, the
+        // channel may fill up committees quickly. Here we skip directly to
+        // the last known committee by looking at SuiSystemState.
+        let authority_agg = self.create_authority_aggregator_from_system_state().await;
+        if authority_agg.committee.epoch > quorum_driver.current_epoch() {
+            quorum_driver
+                .update_validators(Arc::new(authority_agg))
+                .await;
+        }
+        loop {
+            match self.reconfig_rx.recv().await {
+                Ok(committee) => {
+                    info!("Got reconfig message: {}", committee);
+                    if committee.epoch > quorum_driver.current_epoch() {
+                        let authority_agg =
+                            self.create_authority_aggregator_from_system_state().await;
+                        quorum_driver
+                            .update_validators(Arc::new(authority_agg))
+                            .await;
+                    } else {
+                        // This should only happen when the node just starts
+                        warn!("Epoch number decreased - ignoring committee: {}", committee);
+                    }
+                }
+                // It's ok to miss messages due to overflow here
+                Err(RecvError::Lagged(_)) => {
+                    continue;
+                }
+                Err(RecvError::Closed) => panic!("Do not expect the channel to be closed"),
+            }
+        }
+    }
+}

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -162,8 +162,7 @@ async fn test_quorum_driver_update_validators_and_max_retry_times() {
     aggregator.committee.epoch = 10;
     quorum_driver_clone
         .update_validators(Arc::new(aggregator))
-        .await
-        .unwrap();
+        .await;
     assert_eq!(
         quorum_driver_handler.clone_quorum_driver().current_epoch(),
         10

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -33,6 +33,7 @@ macro_rules! check_error {
     }
 }
 
+#[derive(Clone)]
 pub struct SafeClientMetricsBase {
     total_requests_by_address_method: IntCounterVec,
     total_responses_by_address_method: IntCounterVec,

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -284,6 +284,10 @@ where
         &self.quorum_driver_handler
     }
 
+    pub fn clone_quorum_driver(&self) -> Arc<QuorumDriverHandler<A>> {
+        self.quorum_driver_handler.clone()
+    }
+
     pub fn clone_authority_aggregator(&self) -> Arc<AuthorityAggregator<A>> {
         self.quorum_driver().authority_aggregator().load_full()
     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -50,7 +50,6 @@ use sui_storage::{
     IndexStore,
 };
 use sui_types::committee::Committee;
-use sui_types::committee::EpochId;
 use sui_types::crypto::KeypairTraits;
 use sui_types::messages::QuorumDriverResponse;
 use tokio::sync::mpsc::channel;

--- a/crates/sui/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/sui/tests/onsite_reconfig_observer_tests.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::async_yields_async)]
+use prometheus::Registry;
+use sui_core::authority_aggregator::AuthAggMetrics;
+use sui_core::quorum_driver::reconfig_observer::OnsiteReconfigObserver;
+use sui_core::quorum_driver::reconfig_observer::ReconfigObserver;
+use sui_core::safe_client::SafeClientMetricsBase;
+use test_utils::authority::{spawn_fullnodes, spawn_test_authorities, test_authority_configs};
+use test_utils::network::wait_for_nodes_transition_to_epoch;
+use tracing::info;
+
+#[tokio::test]
+async fn test_onsite_reconfig_observer_basic() {
+    telemetry_subscribers::init_for_testing();
+    let config = test_authority_configs();
+    let authorities = spawn_test_authorities([].into_iter(), &config).await;
+    let fullnodes = spawn_fullnodes(&config, 1).await;
+    let fullnode = &fullnodes[0];
+
+    let _observer_handle = fullnode
+        .with_async(|node| async {
+            let qd = node
+                .transaction_orchestrator()
+                .unwrap()
+                .clone_quorum_driver();
+            assert_eq!(qd.current_epoch(), 0);
+            let rx = node.subscribe_to_epoch_change().await;
+            let registry = Registry::new();
+            let mut observer = OnsiteReconfigObserver::new(
+                rx,
+                node.clone_authority_store(),
+                node.clone_committee_store(),
+                SafeClientMetricsBase::new(&registry),
+                AuthAggMetrics::new(&registry),
+            );
+            let qd_clone = qd.clone_quorum_driver();
+            tokio::task::spawn(async move { observer.run(qd_clone).await })
+        })
+        .await;
+    info!("Shutting down epoch 0");
+    for handle in &authorities {
+        handle
+            .with_async(|node| async { node.close_epoch().await.unwrap() })
+            .await;
+    }
+    // Wait for all nodes to reach the next epoch.
+    info!("Waiting for nodes to advance to epoch 1");
+    wait_for_nodes_transition_to_epoch(authorities.iter().chain(fullnodes.iter()), 1).await;
+
+    // Give it some time for the update to happen
+    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+    fullnode.with(|node| {
+        let qd = node
+            .transaction_orchestrator()
+            .unwrap()
+            .clone_quorum_driver();
+        assert_eq!(qd.current_epoch(), 1);
+        assert_eq!(
+            node.clone_authority_aggregator().unwrap().committee.epoch,
+            1
+        );
+    });
+}

--- a/crates/sui/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/sui/tests/onsite_reconfig_observer_tests.rs
@@ -11,7 +11,9 @@ use test_utils::authority::{spawn_fullnodes, spawn_test_authorities, test_author
 use test_utils::network::wait_for_nodes_transition_to_epoch;
 use tracing::info;
 
-#[tokio::test]
+use sui_macros::sim_test;
+
+#[sim_test]
 async fn test_onsite_reconfig_observer_basic() {
     telemetry_subscribers::init_for_testing();
     let config = test_authority_configs();

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -8,12 +8,11 @@ use std::time::Duration;
 use sui_config::{NetworkConfig, NodeConfig, ValidatorInfo};
 use sui_core::authority_client::AuthorityAPI;
 use sui_core::authority_client::NetworkAuthorityClient;
-use sui_types::object::Object;
-
 pub use sui_node::{SuiNode, SuiNodeHandle};
 use sui_types::base_types::ObjectID;
 use sui_types::crypto::TEST_COMMITTEE_SIZE;
 use sui_types::messages::{ObjectInfoRequest, ObjectInfoRequestKind};
+use sui_types::object::Object;
 
 /// The default network buffer size of a test authority.
 pub const NETWORK_BUFFER_SIZE: usize = 65_000;
@@ -104,6 +103,19 @@ where
         handles.push(node);
     }
     handles
+}
+
+/// This function can be called after `spawn_test_authorities` to
+/// start fullnodes.
+pub async fn spawn_fullnodes(config: &NetworkConfig, fullnode_num: u8) -> Vec<SuiNodeHandle> {
+    let mut fullnode_handles = Vec::new();
+    for _ in 0..fullnode_num {
+        let registry_service = RegistryService::new(Registry::new());
+        let fullnode_config = config.fullnode_config_builder().build().unwrap();
+        let node = start_node(&fullnode_config, registry_service).await;
+        fullnode_handles.push(node);
+    }
+    fullnode_handles
 }
 
 /// Get a network client to communicate with the consensus.


### PR DESCRIPTION
1. This PR adds ReconfigObserver Trait. RO detects reconfigs and updates quorum driver the new committee. 
2. `OnsiteReconfigObserver` is the RO that lives in `Fullnode`/`TransactionOrchestrator` that subscribes to the checkpoint executor reconfig channel. Note the integration of `OnsiteReconfigObserver` and `TransactionOrchestrator` happens in the follow-up PR