### PR TITLE
[authority store] replace struct used for storing individual objects

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -131,6 +131,7 @@ pub mod authority_per_epoch_store_pruner;
 
 pub mod authority_store_pruner;
 pub mod authority_store_tables;
+pub mod authority_store_types;
 
 pub(crate) mod authority_notify_read;
 pub(crate) mod authority_store;

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -4,6 +4,7 @@
 use super::authority_notify_read::NotifyRead;
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::authority::authority_store_types::StoreObjectPair;
 use either::Either;
 use move_core_types::resolver::ModuleResolver;
 use once_cell::sync::OnceCell;
@@ -294,10 +295,11 @@ impl AuthorityStore {
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, SuiError> {
-        Ok(self
-            .perpetual_tables
+        self.perpetual_tables
             .objects
-            .get(&ObjectKey(*object_id, version))?)
+            .get(&ObjectKey(*object_id, version))?
+            .map(|object| self.perpetual_tables.object(object))
+            .transpose()
     }
 
     /// Read an object and return it, or Ok(None) if the object was not found.
@@ -523,10 +525,17 @@ impl AuthorityStore {
         let mut write_batch = self.perpetual_tables.objects.batch();
 
         // Insert object
+        let StoreObjectPair(store_object, indirect_object) = object.clone().into();
         write_batch = write_batch.insert_batch(
             &self.perpetual_tables.objects,
-            std::iter::once((ObjectKey::from(object_ref), object)),
+            std::iter::once((ObjectKey::from(object_ref), store_object)),
         )?;
+        if let Some(indirect_obj) = indirect_object {
+            write_batch = write_batch.insert_batch(
+                &self.perpetual_tables.indirect_move_objects,
+                std::iter::once((indirect_obj.digest(), indirect_obj)),
+            )?;
+        }
 
         // Update the index
         if object.get_single_owner().is_some() {
@@ -558,9 +567,19 @@ impl AuthorityStore {
         batch = batch
             .insert_batch(
                 &self.perpetual_tables.objects,
-                ref_and_objects
-                    .iter()
-                    .map(|(oref, o)| (ObjectKey::from(oref), **o)),
+                ref_and_objects.iter().map(|(oref, o)| {
+                    (
+                        ObjectKey::from(oref),
+                        StoreObjectPair::from((**o).clone()).0,
+                    )
+                }),
+            )?
+            .insert_batch(
+                &self.perpetual_tables.indirect_move_objects,
+                ref_and_objects.iter().filter_map(|(_, o)| {
+                    let StoreObjectPair(_, indirect_object) = (**o).clone().into();
+                    indirect_object.map(|obj| (obj.digest(), obj))
+                }),
             )?
             .insert_batch(
                 &self.perpetual_tables.parent_sync,
@@ -690,13 +709,24 @@ impl AuthorityStore {
         )?;
 
         // Insert each output object into the stores
-        write_batch = write_batch.insert_batch(
-            &self.perpetual_tables.objects,
-            written.iter().map(|(_, (obj_ref, new_object, _kind))| {
+        let (new_objects, new_indirect_move_objects): (Vec<_>, Vec<_>) = written
+            .iter()
+            .map(|(_, (obj_ref, new_object, _))| {
                 debug!(?obj_ref, "writing object");
-                (ObjectKey::from(obj_ref), new_object)
-            }),
-        )?;
+                let StoreObjectPair(store_object, indirect_object) = new_object.clone().into();
+                (
+                    (ObjectKey::from(obj_ref), store_object),
+                    indirect_object.map(|obj| (obj.digest(), obj)),
+                )
+            })
+            .unzip();
+
+        write_batch = write_batch
+            .insert_batch(&self.perpetual_tables.objects, new_objects.into_iter())?
+            .merge_batch(
+                &self.perpetual_tables.indirect_move_objects,
+                new_indirect_move_objects.into_iter().flatten(),
+            )?;
 
         write_batch =
             write_batch.insert_batch(&self.perpetual_tables.events, [(events.digest(), events)])?;
@@ -1048,8 +1078,13 @@ impl AuthorityStore {
                     .into_iter()
                     .zip($object_keys)
                     .filter_map(|(obj_opt, key)| {
-                        let obj =
-                            obj_opt.expect(&format!("Older object version not found: {:?}", key));
+                        let obj = self
+                            .perpetual_tables
+                            .object(
+                                obj_opt
+                                    .expect(&format!("Older object version not found: {:?}", key)),
+                            )
+                            .expect("Matching indirect object not found");
 
                         if obj.is_immutable() {
                             return None;

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -11,9 +11,13 @@ use sui_types::base_types::SequenceNumber;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::storage::ObjectStore;
 use typed_store::metrics::SamplingInterval;
+use typed_store::rocks::util::{empty_compaction_filter, reference_count_merge_operator};
 use typed_store::rocks::{DBMap, DBOptions, MetricConf, ReadWriteOptions};
 use typed_store::traits::{Map, TableSummary, TypedStoreDebug};
 
+use crate::authority::authority_store_types::{
+    StoreData, StoreMoveObject, StoreObject, StoreObjectPair,
+};
 use typed_store_derive::DBMapUtils;
 
 const CURRENT_EPOCH_KEY: u64 = 0;
@@ -23,6 +27,8 @@ const CURRENT_EPOCH_KEY: u64 = 0;
 pub struct AuthorityPerpetualTables {
     /// This is a map between the object (ID, version) and the latest state of the object, namely the
     /// state that is needed to process new transactions.
+    /// State is represented by `StoreObject` enum, which is either a move module, a move object, or
+    /// a pointer to an object stored in the `indirect_move_objects` table.
     ///
     /// Note that while this map can store all versions of an object, we will eventually
     /// prune old object versions from the db.
@@ -33,7 +39,10 @@ pub struct AuthorityPerpetualTables {
     /// been written out, and which must be retried. But, they cannot be retried unless their input
     /// objects are still accessible!
     #[default_options_override_fn = "objects_table_default_config"]
-    pub(crate) objects: DBMap<ObjectKey, Object>,
+    pub(crate) objects: DBMap<ObjectKey, StoreObject>,
+
+    #[default_options_override_fn = "indirect_move_objects_table_default_config"]
+    pub(crate) indirect_move_objects: DBMap<ObjectDigest, StoreMoveObject>,
 
     /// This is a map between object references of currently active objects that can be mutated,
     /// and the transaction that they are lock on for use by this specific authority. Where an object
@@ -125,7 +134,17 @@ impl AuthorityPerpetualTables {
             .skip_prior_to(&ObjectKey(object_id, version))else {
             return None
         };
-        iter.reverse().next().map(|(_, o)| o)
+        iter.reverse().next().and_then(|(_, o)| self.object(o).ok())
+    }
+
+    pub fn object(&self, store_object: StoreObject) -> Result<Object, SuiError> {
+        let indirect_object = match store_object.data {
+            StoreData::IndirectObject(ref metadata) => {
+                self.indirect_move_objects.get(&metadata.digest)?
+            }
+            _ => None,
+        };
+        StoreObjectPair(store_object, indirect_object).try_into()
     }
 
     pub fn get_latest_parent_entry(
@@ -210,7 +229,7 @@ impl ObjectStore for &AuthorityPerpetualTables {
                 );
                 Ok(None)
             }
-            Some((obj_ref, _)) if obj_ref.2.is_alive() => Ok(Some(obj)),
+            Some((obj_ref, _)) if obj_ref.2.is_alive() => Ok(Some(self.object(obj)?)),
             _ => Ok(None),
         }
     }
@@ -251,6 +270,7 @@ impl Iterator for LiveSetIter<'_> {
 fn owned_object_transaction_locks_table_default_config() -> DBOptions {
     default_db_options(None, None).1
 }
+
 fn objects_table_default_config() -> DBOptions {
     let db_options = default_db_options(None, None).1;
     DBOptions {
@@ -260,9 +280,24 @@ fn objects_table_default_config() -> DBOptions {
         },
     }
 }
+
 fn transactions_table_default_config() -> DBOptions {
     default_db_options(None, None).1
 }
+
 fn effects_table_default_config() -> DBOptions {
     default_db_options(None, None).1
+}
+
+fn indirect_move_objects_table_default_config() -> DBOptions {
+    let mut options = default_db_options(None, None).1;
+    options.options.set_merge_operator(
+        "refcount operator",
+        reference_count_merge_operator,
+        reference_count_merge_operator,
+    );
+    options
+        .options
+        .set_compaction_filter("empty filter", empty_compaction_filter);
+    options
 }

--- a/crates/sui-core/src/authority/authority_store_types.rs
+++ b/crates/sui-core/src/authority/authority_store_types.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::language_storage::StructTag;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use serde_with::Bytes;
+use std::convert::{From, TryFrom};
+use sui_types::base_types::{ObjectDigest, SequenceNumber, TransactionDigest};
+use sui_types::crypto::{sha3_hash, Signable};
+use sui_types::error::SuiError;
+use sui_types::move_package::MovePackage;
+use sui_types::object::{Data, MoveObject, Object, Owner};
+
+/// Forked version of [`sui_types::object::Object`]
+/// Used for efficient storing of move objects in the database
+#[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
+pub struct StoreObject {
+    pub data: StoreData,
+    pub owner: Owner,
+    pub previous_transaction: TransactionDigest,
+    pub storage_rebate: u64,
+}
+
+/// Forked version of [`sui_types::object::Data`]
+/// Adds extra enum value `IndirectObject`, which represents a reference to an object stored separately
+#[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
+pub enum StoreData {
+    Move(MoveObject),
+    Package(MovePackage),
+    IndirectObject(IndirectObjectMetadata),
+}
+
+/// Metadata of stored moved object
+#[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
+pub struct IndirectObjectMetadata {
+    version: SequenceNumber,
+    pub digest: ObjectDigest,
+}
+
+/// Separately stored move object
+#[serde_as]
+#[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
+pub struct StoreMoveObject {
+    pub type_: StructTag,
+    has_public_transfer: bool,
+    #[serde_as(as = "Bytes")]
+    contents: Vec<u8>,
+    /// reference count of `MoveMetadata` that point to the same content
+    /// once it hits 0, the object gets deleted by a compaction job
+    ref_count: usize,
+}
+
+impl<W> Signable<W> for StoreMoveObject
+where
+    W: std::io::Write,
+{
+    fn write(&self, writer: &mut W) {
+        write!(writer, "StoreMoveObject::").expect("Hasher should not fail");
+        bcs::serialize_into(writer, &self).expect("Message serialization should not fail");
+    }
+}
+
+impl StoreMoveObject {
+    pub fn digest(&self) -> ObjectDigest {
+        ObjectDigest::new(sha3_hash(self))
+    }
+}
+
+pub struct StoreObjectPair(pub StoreObject, pub Option<StoreMoveObject>);
+
+impl From<Object> for StoreObjectPair {
+    fn from(object: Object) -> Self {
+        let mut indirect_object = None;
+
+        let data = match object.data {
+            Data::Package(package) => StoreData::Package(package),
+            Data::Move(move_obj) => {
+                // TODO: add real heuristic to decide if object needs to be stored indirectly
+                if cfg!(test) {
+                    let move_object = StoreMoveObject {
+                        type_: move_obj.type_.clone(),
+                        has_public_transfer: move_obj.has_public_transfer(),
+                        contents: move_obj.contents().to_vec(),
+                        ref_count: 1,
+                    };
+                    let digest = move_object.digest();
+                    indirect_object = Some(move_object);
+                    StoreData::IndirectObject(IndirectObjectMetadata {
+                        version: move_obj.version(),
+                        digest,
+                    })
+                } else {
+                    StoreData::Move(move_obj)
+                }
+            }
+        };
+        let store_object = StoreObject {
+            data,
+            owner: object.owner,
+            previous_transaction: object.previous_transaction,
+            storage_rebate: object.storage_rebate,
+        };
+        Self(store_object, indirect_object)
+    }
+}
+
+impl TryFrom<StoreObjectPair> for Object {
+    type Error = SuiError;
+
+    fn try_from(object: StoreObjectPair) -> Result<Self, Self::Error> {
+        let StoreObjectPair(store_object, indirect_object) = object;
+
+        let data = match (store_object.data, indirect_object) {
+            (StoreData::Move(object), None) => Data::Move(object),
+            (StoreData::Package(package), None) => Data::Package(package),
+            (StoreData::IndirectObject(metadata), Some(indirect_obj)) => unsafe {
+                Data::Move(MoveObject::new_from_execution_with_limit(
+                    indirect_obj.type_,
+                    indirect_obj.has_public_transfer,
+                    metadata.version,
+                    indirect_obj.contents,
+                    // verification is already done during initial execution
+                    u64::MAX,
+                )?)
+            },
+            _ => {
+                return Err(SuiError::StorageCorruptedFieldError(
+                    "inconsistent object representation".to_string(),
+                ))
+            }
+        };
+
+        Ok(Self {
+            data,
+            owner: store_object.owner,
+            previous_transaction: store_object.previous_transaction,
+            storage_rebate: store_object.storage_rebate,
+        })
+    }
+}

--- a/crates/sui-tool/src/db_tool/db_dump.rs
+++ b/crates/sui-tool/src/db_tool/db_dump.rs
@@ -10,13 +10,13 @@ use std::path::PathBuf;
 use strum_macros::EnumString;
 use sui_core::authority::authority_per_epoch_store::AuthorityEpochTables;
 use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
+use sui_core::authority::authority_store_types::StoreData;
 use sui_core::epoch::committee_store::CommitteeStore;
 use sui_storage::default_db_options;
 use sui_storage::write_ahead_log::DBWriteAheadLogTables;
 use sui_storage::IndexStoreTables;
 use sui_types::base_types::{EpochId, ObjectID};
 use sui_types::messages::{SignedTransactionEffects, TrustedCertificate};
-use sui_types::object::Data;
 use sui_types::temporary_store::InnerTemporaryStore;
 use typed_store::rocks::MetricConf;
 use typed_store::traits::{Map, TableSummary};
@@ -102,7 +102,7 @@ pub fn duplicate_objects_summary(db_path: PathBuf) -> (usize, usize, usize, usiz
     let mut data: HashMap<Vec<u8>, usize> = HashMap::new();
 
     for (key, value) in iter {
-        if let Data::Move(object) = value.data {
+        if let StoreData::Move(object) = value.data {
             if object_id != key.0 {
                 for (k, cnt) in data.iter() {
                     total_bytes += k.len() * cnt;

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -94,7 +94,9 @@ impl MoveObject {
         )
     }
 
-    unsafe fn new_from_execution_with_limit(
+    /// # Safety
+    /// This function should ONLY be called if has_public_transfer has been determined by the type_
+    pub unsafe fn new_from_execution_with_limit(
         type_: StructTag,
         has_public_transfer: bool,
         version: SequenceNumber,

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -3,6 +3,7 @@
 mod errors;
 pub(crate) mod iter;
 pub(crate) mod keys;
+pub mod util;
 pub(crate) mod values;
 
 use crate::{
@@ -487,6 +488,14 @@ impl RocksDBBatch {
         delegate_batch_call!(self.put_cf(cf, key, value))
     }
 
+    pub fn merge_cf<K, V>(&mut self, cf: &impl AsColumnFamilyRef, key: K, value: V)
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        delegate_batch_call!(self.merge_cf(cf, key, value))
+    }
+
     pub fn delete_range_cf<K: AsRef<[u8]>>(
         &mut self,
         cf: &impl AsColumnFamilyRef,
@@ -544,7 +553,7 @@ pub struct DBMap<K, V> {
     _phantom: PhantomData<fn(K) -> V>,
     // the rocksDB ColumnFamily under which the map is stored
     cf: String,
-    opts: ReadWriteOptions,
+    pub opts: ReadWriteOptions,
     db_metrics: Arc<DBMetrics>,
     read_sample_interval: SamplingInterval,
     write_sample_interval: SamplingInterval,
@@ -1129,6 +1138,46 @@ impl DBBatch {
                 let k_buf = be_fix_int_ser(k.borrow())?;
                 let v_buf = bincode::serialize(v.borrow())?;
                 self.batch.put_cf(&db.cf(), k_buf, v_buf);
+                Ok(())
+            })?;
+        Ok(self)
+    }
+
+    /// merges a range of (key, value) pairs given as an iterator
+    pub fn merge_batch<J: Borrow<K>, K: Serialize, U: Borrow<V>, V: Serialize>(
+        mut self,
+        db: &DBMap<K, V>,
+        new_vals: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<Self, TypedStoreError> {
+        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+
+        new_vals
+            .into_iter()
+            .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
+                let k_buf = be_fix_int_ser(k.borrow())?;
+                let v_buf = bincode::serialize(v.borrow())?;
+                self.batch.merge_cf(&db.cf(), k_buf, v_buf);
+                Ok(())
+            })?;
+        Ok(self)
+    }
+
+    /// similar to `merge_batch` but allows merge with partial values
+    pub fn partial_merge_batch<J: Borrow<K>, K: Serialize, V: Serialize, B: AsRef<[u8]>>(
+        mut self,
+        db: &DBMap<K, V>,
+        new_vals: impl IntoIterator<Item = (J, B)>,
+    ) -> Result<Self, TypedStoreError> {
+        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+        new_vals
+            .into_iter()
+            .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
+                let k_buf = be_fix_int_ser(k.borrow())?;
+                self.batch.merge_cf(&db.cf(), k_buf, v);
                 Ok(())
             })?;
         Ok(self)

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1,8 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
+use crate::rocks::util::reference_count_merge_operator;
+use crate::RocksDB::DBWithThreadMode;
 use crate::{reopen, retry_transaction, retry_transaction_forever};
 use rstest::rstest;
+use serde::Deserialize;
 
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir()
@@ -923,6 +926,129 @@ async fn open_as_secondary_test() {
 
     // New value should be present
     assert_eq!(secondary_db.get(&0).unwrap(), Some("10".to_string()));
+}
+
+#[derive(Serialize, Deserialize, Copy, Clone)]
+struct ObjectWithRefCount {
+    value: i64,
+    ref_count: i64,
+}
+
+fn increment_counter(db: &DBMap<String, ObjectWithRefCount>, key: &str, value: i64) {
+    let batch = db
+        .batch()
+        .partial_merge_batch(db, [(key.to_string(), value.to_le_bytes())])
+        .unwrap();
+    batch.write().unwrap();
+}
+
+#[tokio::test]
+async fn refcount_test() {
+    let key = "key".to_string();
+    let mut options = rocksdb::Options::default();
+    options.set_merge_operator(
+        "refcount operator",
+        reference_count_merge_operator,
+        reference_count_merge_operator,
+    );
+    let db = DBMap::<String, ObjectWithRefCount>::open(
+        temp_dir(),
+        MetricConf::default(),
+        Some(options),
+        None,
+        &ReadWriteOptions::default(),
+    )
+    .expect("failed to open rocksdb");
+    let object = ObjectWithRefCount {
+        value: 3,
+        ref_count: 1,
+    };
+    // increment value 10 times
+    let iterations = 10;
+    for _ in 0..iterations {
+        db.batch()
+            .merge_batch(&db, [(key.to_string(), object)])
+            .unwrap()
+            .write()
+            .unwrap();
+    }
+    let value = db
+        .get(&key)
+        .expect("failed to read value")
+        .expect("value is empty");
+    assert_eq!(value.value, object.value);
+    assert_eq!(value.ref_count, iterations);
+
+    // decrement value
+    increment_counter(&db, &key, -1);
+    let value = db.get(&key).unwrap().unwrap();
+    assert_eq!(value.value, object.value);
+    assert_eq!(value.ref_count, iterations - 1);
+}
+
+#[tokio::test]
+async fn refcount_with_compaction_test() {
+    let key = "key".to_string();
+    let mut options = rocksdb::Options::default();
+    options.set_merge_operator(
+        "refcount operator",
+        reference_count_merge_operator,
+        reference_count_merge_operator,
+    );
+    let db = DBMap::<String, ObjectWithRefCount>::open(
+        temp_dir(),
+        MetricConf::default(),
+        Some(options),
+        None,
+        &ReadWriteOptions::default(),
+    )
+    .expect("failed to open rocksdb");
+
+    let object = ObjectWithRefCount {
+        value: 3,
+        ref_count: 1,
+    };
+    let batch = db
+        .batch()
+        .merge_batch(&db, [(key.to_string(), object)])
+        .unwrap();
+    batch.write().unwrap();
+    // increment value once
+    increment_counter(&db, &key, 1);
+    let value = db.get(&key).unwrap().unwrap();
+    assert_eq!(value.value, object.value);
+
+    // decrement value to 0
+    increment_counter(&db, &key, -1);
+    increment_counter(&db, &key, -1);
+    // ref count went to zero. Reading value returns empty array
+    let value = db.get_raw_bytes(&key).unwrap().unwrap();
+    assert!(value.is_empty());
+
+    // refcount increment makes value visible again
+    increment_counter(&db, &key, 1);
+    let value = db.get(&key).unwrap().unwrap();
+    assert_eq!(value.value, object.value);
+
+    // decrement to zero, run compaction and increment back to 1
+    let _snapshot;
+    if let DBWithThreadMode(db) = &*db.rocksdb {
+        _snapshot = db.underlying.snapshot();
+    };
+
+    increment_counter(&db, &key, -1);
+    db.compact_range(
+        &object,
+        &ObjectWithRefCount {
+            value: 100,
+            ref_count: 1,
+        },
+    )
+    .unwrap();
+    increment_counter(&db, &key, 1);
+    // snapshot creation prevents compaction job from removing the value
+    let value = db.get(&key).unwrap().unwrap();
+    assert_eq!(value.value, object.value);
 }
 
 fn open_map<P: AsRef<Path>, K, V>(

--- a/crates/typed-store/src/rocks/util.rs
+++ b/crates/typed-store/src/rocks/util.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use rocksdb::{CompactionDecision, MergeOperands};
+use std::cmp::Ordering;
+
+/// custom rocksdb merge operator used for storing objects with reference counts
+/// important: reference count field must be 64-bit integer and must be last in struct declaration
+/// should be used with immutable objects only
+pub fn reference_count_merge_operator(
+    _key: &[u8],
+    stored_value: Option<&[u8]>,
+    operands: &MergeOperands,
+) -> Option<Vec<u8>> {
+    let (mut value, mut ref_count) = stored_value.map_or((None, 0), deserialize_ref_count_value);
+
+    for operand in operands {
+        if !operand.is_empty() {
+            let (new_value, delta) = deserialize_ref_count_value(operand);
+            // assure original value is immutable
+            assert!(value.is_none() || new_value.is_none() || value == new_value);
+            if value.is_none() && new_value.is_some() {
+                value = new_value;
+            }
+            ref_count += delta;
+        }
+    }
+    match ref_count.cmp(&0) {
+        Ordering::Greater => Some([value.unwrap_or(b""), &ref_count.to_le_bytes()].concat()),
+        Ordering::Equal => Some(vec![]),
+        Ordering::Less => Some(ref_count.to_le_bytes().to_vec()),
+    }
+}
+
+pub fn empty_compaction_filter(_level: u32, _key: &[u8], value: &[u8]) -> CompactionDecision {
+    if value.is_empty() {
+        CompactionDecision::Remove
+    } else {
+        CompactionDecision::Keep
+    }
+}
+
+fn deserialize_ref_count_value(bytes: &[u8]) -> (Option<&[u8]>, i64) {
+    assert!(bytes.len() >= 8);
+    let (value, rc_bytes) = bytes.split_at(bytes.len() - 8);
+    let ref_count = i64::from_le_bytes(rc_bytes.try_into().unwrap());
+    (if value.is_empty() { None } else { Some(value) }, ref_count)
+}


### PR DESCRIPTION
Currently, objects are stored in rocksdb as mapping `objects: DBMap<ObjectKey, Object>`.
There are a lot of duplicates in db because different versions of an object with the exactly same content are stored separately.  
In the `devnet-prod` environment such duplicated objects consume >42% of the disk space.
Even with a new pruning job, it can take a while before rocksdb frees the storage, because of the way compaction works.

This PR introduces the StoreObject struct, which is a slightly forked version of the original object struct.
It adds additional value into the underlying Data enum that allows referencing object value by its digest instead of directly embedding it. For external call sites interface remains the same.

Each indirect object carries reference count field that represents how many object versions share the same value. Value gets automatically updated by rocksdb merge operator. Once it hits 0, compaction job will GC it.

Notes: 
* **PR is not backward compatible**. Requires wipe of the state
* heuristic for deciding to store objects directly or indirectly is still TBD. Once landed, initially all objects will still be embedded. Then we can run experiment comparing performance regression of indirectly stored object vs embedded
* full switch to indirect objects requires changes to the pruner. Those changes were stripped from PR to avoid extra complexity. Plan here is to switch to live pruner first  

Pointers for code review:
* `crates/sui-core/src/authority/authority_store_types.rs` contains type definitions for new object representation
* `crates/typed-store/src/rocks/util.rs` contains merge operator and compaction filter for rocksdb used to implement reference count column