### PR TITLE
Add a passive reconfiguration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=3aeccfeb0f021ad5801c1ab4dcf4004de7780847#3aeccfeb0f021ad5801c1ab4dcf4004de7780847"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=465f7d6c351e83003da9c9b77e8e3e352be7621e#465f7d6c351e83003da9c9b77e8e3e352be7621e"
 dependencies = [
  "ahash 0.7.6",
  "async-task",
@@ -4909,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=3aeccfeb0f021ad5801c1ab4dcf4004de7780847#3aeccfeb0f021ad5801c1ab4dcf4004de7780847"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=465f7d6c351e83003da9c9b77e8e3e352be7621e#465f7d6c351e83003da9c9b77e8e3e352be7621e"
 dependencies = [
  "darling",
  "proc-macro2 1.0.47",

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -42,6 +42,7 @@ pub struct ConfigBuilder<R = OsRng> {
     initial_accounts_config: Option<GenesisConfig>,
     with_swarm: bool,
     validator_ip_sel: ValidatorIpSelection,
+    checkpoints_per_epoch: Option<u64>,
 }
 
 impl ConfigBuilder {
@@ -60,6 +61,7 @@ impl ConfigBuilder {
             } else {
                 ValidatorIpSelection::Localhost
             },
+            checkpoints_per_epoch: default_checkpoints_per_epoch(),
         }
     }
 }
@@ -95,6 +97,11 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn with_checkpoints_per_epoch(mut self, ckpts: u64) -> Self {
+        self.checkpoints_per_epoch = Some(ckpts);
+        self
+    }
+
     pub fn rng<N: rand::RngCore + rand::CryptoRng>(self, rng: N) -> ConfigBuilder<N> {
         ConfigBuilder {
             rng: Some(rng),
@@ -104,6 +111,7 @@ impl<R> ConfigBuilder<R> {
             initial_accounts_config: self.initial_accounts_config,
             with_swarm: self.with_swarm,
             validator_ip_sel: self.validator_ip_sel,
+            checkpoints_per_epoch: self.checkpoints_per_epoch,
         }
     }
 }
@@ -315,7 +323,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     consensus_config: Some(consensus_config),
                     enable_event_processing: false,
                     enable_checkpoint: false,
-                    checkpoints_per_epoch: default_checkpoints_per_epoch(),
+                    checkpoints_per_epoch: self.checkpoints_per_epoch,
                     genesis: crate::node::Genesis::new(genesis.clone()),
                     grpc_load_shed: initial_accounts_config.grpc_load_shed,
                     grpc_concurrency_limit: initial_accounts_config.grpc_concurrency_limit,

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -407,7 +407,7 @@ impl CheckpointExecutorEventLoop {
         checkpoint: VerifiedCheckpoint,
         pending: &mut CheckpointExecutionBuffer,
     ) -> SuiResult {
-        info!(
+        debug!(
             "Scheduling checkpoint {:?} for execution",
             checkpoint.sequence_number()
         );

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -91,10 +91,11 @@ impl CheckpointOutput for LogCheckpointOutput {
             summary.sequence_number, contents
         );
         info!(
-            "Creating checkpoint {:?} at sequence {}, previous digest {:?}, transactions count {}, content digest {:?}",
+            "Creating checkpoint {:?} at epoch {}, sequence {}, previous digest {:?}, transactions count {}, content digest {:?}",
             Hex::encode(summary.digest()),
+            summary.epoch,
             summary.sequence_number,
-            summary.previous_digest,
+            summary.previous_digest.map(Hex::encode),
             contents.size(),
             Hex::encode(summary.content_digest),
         );

--- a/crates/sui-macros/Cargo.toml
+++ b/crates/sui-macros/Cargo.toml
@@ -16,4 +16,4 @@ syn = "1.0.104"
 workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "3aeccfeb0f021ad5801c1ab4dcf4004de7780847", package = "msim-macros" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "465f7d6c351e83003da9c9b77e8e3e352be7621e", package = "msim-macros" }

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -16,4 +16,4 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 telemetry-subscribers.workspace = true
 
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "3aeccfeb0f021ad5801c1ab4dcf4004de7780847", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "465f7d6c351e83003da9c9b77e8e3e352be7621e", package = "msim" }

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -27,6 +27,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_count: usize,
     fullnode_rpc_addr: Option<SocketAddr>,
     with_event_store: bool,
+    checkpoints_per_epoch: Option<u64>,
 }
 
 impl SwarmBuilder {
@@ -40,6 +41,7 @@ impl SwarmBuilder {
             fullnode_count: 0,
             fullnode_rpc_addr: None,
             with_event_store: false,
+            checkpoints_per_epoch: None,
         }
     }
 }
@@ -54,6 +56,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_count: self.fullnode_count,
             fullnode_rpc_addr: self.fullnode_rpc_addr,
             with_event_store: false,
+            checkpoints_per_epoch: None,
         }
     }
 
@@ -94,6 +97,11 @@ impl<R> SwarmBuilder<R> {
         self.fullnode_rpc_addr = Some(fullnode_rpc_addr);
         self
     }
+
+    pub fn with_checkpoints_per_epoch(mut self, ckpts: u64) -> Self {
+        self.checkpoints_per_epoch = Some(ckpts);
+        self
+    }
 }
 
 impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
@@ -109,6 +117,10 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
 
         if let Some(initial_accounts_config) = self.initial_accounts_config {
             config_builder = config_builder.initial_accounts_config(initial_accounts_config);
+        }
+
+        if let Some(checkpoints_per_epoch) = self.checkpoints_per_epoch {
+            config_builder = config_builder.with_checkpoints_per_epoch(checkpoints_per_epoch);
         }
 
         let network_config = config_builder

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -57,6 +57,10 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
 
     let context = &mut test_cluster.wallet;
 
+    // TODO: test fails on CI due to flakiness without this. Once https://github.com/MystenLabs/sui/pull/7056 is
+    // merged we should be able to root out the flakiness.
+    sleep(Duration::from_millis(10)).await;
+
     let (transferred_object, _, receiver, digest, _, _) = transfer_coin(context).await?;
 
     wait_for_tx(digest, node.state().clone()).await;

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -103,6 +103,10 @@ async fn advance_epoch_tx_test_impl(
 #[sim_test]
 async fn basic_reconfig_end_to_end_test() {
     let authorities = spawn_test_authorities([].into_iter(), &test_authority_configs()).await;
+
+    // TODO: If this line is removed, the validators never advance to the next epoch
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
     // Close epoch on 3 (2f+1) validators.
     for handle in authorities.iter().skip(1) {
         handle.with(|node| node.close_epoch().unwrap());

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -11,10 +11,15 @@ use sui_core::authority_aggregator::{
 };
 use sui_core::authority_client::AuthorityAPI;
 use sui_core::test_utils::init_local_authorities;
+use sui_macros::sim_test;
 use sui_types::error::SuiError;
 use sui_types::gas::GasCostSummary;
 use sui_types::messages::VerifiedTransaction;
-use test_utils::authority::{spawn_test_authorities, test_authority_configs};
+use test_utils::{
+    authority::{spawn_test_authorities, test_authority_configs},
+    network::TestClusterBuilder,
+};
+use tokio::time::sleep;
 
 #[sim_test]
 async fn local_advance_epoch_tx_test() {
@@ -118,6 +123,25 @@ async fn basic_reconfig_end_to_end_test() {
         .collect();
     join_all(handles).await;
 }
+
+// This test just starts up a cluster that reconfigures itself under 0 load.
+#[sim_test]
+#[ignore] // test is flaky right now
+async fn test_passive_reconfig() {
+    let _test_cluster = TestClusterBuilder::new()
+        .with_checkpoints_per_epoch(10)
+        .build()
+        .await
+        .unwrap();
+
+    let duration_secs: u64 = std::env::var("RECONFIG_TEST_DURATION")
+        .ok()
+        .map(|v| v.parse().unwrap())
+        .unwrap_or(30);
+
+    sleep(Duration::from_secs(duration_secs)).await;
+}
+
 /*
 
 use futures::future::join_all;

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -16,7 +16,7 @@ use sui_types::gas::GasCostSummary;
 use sui_types::messages::VerifiedTransaction;
 use test_utils::authority::{spawn_test_authorities, test_authority_configs};
 
-#[tokio::test]
+#[sim_test]
 async fn local_advance_epoch_tx_test() {
     // This test checks the following functionalities related to advance epoch transaction:
     // 1. The create_advance_epoch_tx_cert API in AuthorityState can properly sign an advance
@@ -43,7 +43,7 @@ async fn local_advance_epoch_tx_test() {
     advance_epoch_tx_test_impl(states, &certifier).await;
 }
 
-#[tokio::test]
+#[sim_test]
 async fn network_advance_epoch_tx_test() {
     // Same as local_advance_epoch_tx_test, but uses network clients.
     let authorities = spawn_test_authorities([].into_iter(), &test_authority_configs()).await;
@@ -95,7 +95,7 @@ async fn advance_epoch_tx_test_impl(
     }
 }
 
-#[tokio::test]
+#[sim_test]
 async fn basic_reconfig_end_to_end_test() {
     let authorities = spawn_test_authorities([].into_iter(), &test_authority_configs()).await;
     // Close epoch on 3 (2f+1) validators.

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -108,6 +108,7 @@ pub struct TestClusterBuilder {
     num_validators: Option<usize>,
     fullnode_rpc_port: Option<u16>,
     enable_fullnode_events: bool,
+    checkpoints_per_epoch: Option<u64>,
 }
 
 impl TestClusterBuilder {
@@ -117,6 +118,7 @@ impl TestClusterBuilder {
             fullnode_rpc_port: None,
             num_validators: None,
             enable_fullnode_events: false,
+            checkpoints_per_epoch: None,
         }
     }
 
@@ -137,6 +139,11 @@ impl TestClusterBuilder {
 
     pub fn enable_fullnode_events(mut self) -> Self {
         self.enable_fullnode_events = true;
+        self
+    }
+
+    pub fn with_checkpoints_per_epoch(mut self, ckpts: u64) -> Self {
+        self.checkpoints_per_epoch = Some(ckpts);
         self
     }
 
@@ -196,6 +203,10 @@ impl TestClusterBuilder {
 
         if let Some(genesis_config) = self.genesis_config.take() {
             builder = builder.initial_accounts_config(genesis_config);
+        }
+
+        if let Some(checkpoints_per_epoch) = self.checkpoints_per_epoch {
+            builder = builder.with_checkpoints_per_epoch(checkpoints_per_epoch);
         }
 
         let mut swarm = builder.build();

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -54,9 +54,9 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "3aeccfeb0f021ad5801c1ab4dcf4004de7780847"'
+    --config 'patch.crates-io.tokio.rev = "465f7d6c351e83003da9c9b77e8e3e352be7621e"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "3aeccfeb0f021ad5801c1ab4dcf4004de7780847"'
+    --config 'patch.crates-io.futures-timer.rev = "465f7d6c351e83003da9c9b77e8e3e352be7621e"'
   )
 fi
 


### PR DESCRIPTION
The test is currently flaky (need to hunt down the non-determinism), and so is ignored. To run:

```
cargo simtest  --test reconfiguration_tests test_passive_reconfig --run-ignored all
```