### PR TITLE
[QD Reconfig] 4. Install reconfig observer in TransactionOrchestrator

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -442,6 +442,10 @@ impl AuthorityState {
         &self.committee_store
     }
 
+    pub fn clone_committee_store(&self) -> Arc<CommitteeStore> {
+        self.committee_store.clone()
+    }
+
     /// This is a private method and should be kept that way. It doesn't check whether
     /// the provided transaction is a system transaction, and hence can only be called internally.
     async fn handle_transaction_impl(

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -448,7 +448,6 @@ impl AuthorityAggregator<NetworkAuthorityClient> {
 /// However to make testing easier, we sometimes want to use local authority clients that do not
 /// involve full-fledged network Sui nodes (e.g. when we want to abstract out Narwhal). In order
 /// to support both network clients and local clients, this trait is defined to hide the difference.
-/// We implement this trait for both NetworkTransactionCertifier and LocalTransactionCertifier.
 #[async_trait]
 pub trait TransactionCertifier: Sync + Send + 'static {
     /// This function first loads the Sui system state object from `self_state`, get the committee

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -30,6 +30,8 @@ use std::fmt::Write;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{QuorumDriverResponse, VerifiedCertificate, VerifiedTransaction};
 
+use self::reconfig_observer::ReconfigObserver;
+
 #[cfg(test)]
 mod tests;
 
@@ -468,6 +470,7 @@ pub struct QuorumDriverHandler<A> {
     quorum_driver: Arc<QuorumDriver<A>>,
     effects_subscriber: tokio::sync::broadcast::Receiver<QuorumDriverResponse>,
     quorum_driver_metrics: Arc<QuorumDriverMetrics>,
+    reconfig_observer: Arc<dyn ReconfigObserver<A> + Sync + Send>,
     _processor_handle: JoinHandle<()>,
 }
 
@@ -475,47 +478,10 @@ impl<A> QuorumDriverHandler<A>
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
-    pub(crate) fn new_with_notify_read(
+    pub(crate) fn new(
         validators: Arc<AuthorityAggregator<A>>,
         notifier: Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>,
-        metrics: Arc<QuorumDriverMetrics>,
-    ) -> Self {
-        Self::new_impl(validators, notifier, metrics)
-    }
-
-    pub fn new(validators: Arc<AuthorityAggregator<A>>, metrics: Arc<QuorumDriverMetrics>) -> Self {
-        Self::new_impl(
-            validators,
-            Arc::new(NotifyRead::<TransactionDigest, QuorumDriverResult>::new()),
-            metrics,
-        )
-    }
-
-    /// Used in tests when smaller number of retries is desired
-    pub fn new_with_max_retry_times(
-        validators: Arc<AuthorityAggregator<A>>,
-        metrics: Arc<QuorumDriverMetrics>,
-        max_retry_times: u8,
-    ) -> Self {
-        Self::new_impl_with_max_retry_times(
-            validators,
-            Arc::new(NotifyRead::<TransactionDigest, QuorumDriverResult>::new()),
-            metrics,
-            max_retry_times,
-        )
-    }
-
-    fn new_impl(
-        validators: Arc<AuthorityAggregator<A>>,
-        notifier: Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>,
-        metrics: Arc<QuorumDriverMetrics>,
-    ) -> Self {
-        Self::new_impl_with_max_retry_times(validators, notifier, metrics, TX_MAX_RETRY_TIMES)
-    }
-
-    fn new_impl_with_max_retry_times(
-        validators: Arc<AuthorityAggregator<A>>,
-        notifier: Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>,
+        reconfig_observer: Arc<dyn ReconfigObserver<A> + Sync + Send>,
         metrics: Arc<QuorumDriverMetrics>,
         max_retry_times: u8,
     ) -> Self {
@@ -531,7 +497,7 @@ where
             max_retry_times,
         ));
         let metrics_clone = metrics.clone();
-        let handle = {
+        let processor_handle = {
             let quorum_driver_clone = quorum_driver.clone();
             spawn_monitored_task!(Self::task_queue_processor(
                 quorum_driver_clone,
@@ -539,11 +505,22 @@ where
                 metrics_clone
             ))
         };
+        let reconfig_observer_clone = reconfig_observer.clone();
+        {
+            let quorum_driver_clone = quorum_driver.clone();
+            spawn_monitored_task!({
+                async move {
+                    let mut reconfig_observer_clone = reconfig_observer_clone.clone_boxed();
+                    reconfig_observer_clone.run(quorum_driver_clone).await;
+                }
+            });
+        };
         Self {
             quorum_driver,
-            _processor_handle: handle,
             effects_subscriber: subscriber_rx,
             quorum_driver_metrics: metrics,
+            reconfig_observer,
+            _processor_handle: processor_handle,
         }
     }
 
@@ -583,7 +560,7 @@ where
             max_retry_times: self.quorum_driver.max_retry_times,
         });
         let metrics = self.quorum_driver_metrics.clone();
-        let handle = {
+        let processor_handle = {
             let quorum_driver_copy = quorum_driver.clone();
             spawn_monitored_task!(Self::task_queue_processor(
                 quorum_driver_copy,
@@ -591,11 +568,23 @@ where
                 metrics,
             ))
         };
+        {
+            let quorum_driver_copy = quorum_driver.clone();
+            let reconfig_observer = self.reconfig_observer.clone();
+            spawn_monitored_task!({
+                async move {
+                    let mut reconfig_observer_clone = reconfig_observer.clone_boxed();
+                    reconfig_observer_clone.run(quorum_driver_copy).await;
+                }
+            })
+        };
+
         Self {
             quorum_driver,
-            _processor_handle: handle,
             effects_subscriber: subscriber_rx,
             quorum_driver_metrics: self.quorum_driver_metrics.clone(),
+            reconfig_observer: self.reconfig_observer.clone(),
+            _processor_handle: processor_handle,
         }
     }
 
@@ -739,5 +728,63 @@ fn convert_to_quorum_driver_error_if_nonretryable(
             debug!(?tx_digest, "Got retryable error when {action}: {err}");
             None
         }
+    }
+}
+
+pub struct QuorumDriverHandlerBuilder<A> {
+    validators: Arc<AuthorityAggregator<A>>,
+    metrics: Arc<QuorumDriverMetrics>,
+    notifier: Option<Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>>,
+    reconfig_observer: Option<Arc<dyn ReconfigObserver<A> + Sync + Send>>,
+    max_retry_times: u8,
+}
+
+impl<A> QuorumDriverHandlerBuilder<A>
+where
+    A: AuthorityAPI + Send + Sync + 'static + Clone,
+{
+    pub fn new(validators: Arc<AuthorityAggregator<A>>, metrics: Arc<QuorumDriverMetrics>) -> Self {
+        Self {
+            validators,
+            metrics,
+            notifier: None,
+            reconfig_observer: None,
+            max_retry_times: TX_MAX_RETRY_TIMES,
+        }
+    }
+
+    pub(crate) fn with_notifier(
+        mut self,
+        notifier: Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>,
+    ) -> Self {
+        self.notifier = Some(notifier);
+        self
+    }
+
+    pub fn with_reconfig_observer(
+        mut self,
+        reconfig_observer: Arc<dyn ReconfigObserver<A> + Sync + Send>,
+    ) -> Self {
+        self.reconfig_observer = Some(reconfig_observer);
+        self
+    }
+
+    /// Used in tests when smaller number of retries is desired
+    pub fn with_max_retry_times(mut self, max_retry_times: u8) -> Self {
+        self.max_retry_times = max_retry_times;
+        self
+    }
+
+    pub fn start(self) -> QuorumDriverHandler<A> {
+        QuorumDriverHandler::new(
+            self.validators,
+            self.notifier.unwrap_or_else(|| {
+                Arc::new(NotifyRead::<TransactionDigest, QuorumDriverResult>::new())
+            }),
+            self.reconfig_observer
+                .expect("Reconfig observer is missing"),
+            self.metrics,
+            self.max_retry_times,
+        )
     }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -50,7 +50,6 @@ use sui_storage::{
     IndexStore,
 };
 use sui_types::committee::Committee;
-use sui_types::committee::EpochId;
 use sui_types::crypto::KeypairTraits;
 use sui_types::messages::QuorumDriverResponse;
 use tokio::sync::mpsc::channel;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -50,6 +50,7 @@ use sui_storage::{
     IndexStore,
 };
 use sui_types::committee::Committee;
+use sui_types::committee::EpochId;
 use sui_types::crypto::KeypairTraits;
 use sui_types::messages::QuorumDriverResponse;
 use tokio::sync::mpsc::channel;

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -108,6 +108,8 @@ async fn advance_epoch_tx_test_impl(
 
 #[sim_test]
 async fn basic_reconfig_end_to_end_test() {
+    // TODO remove this sleep when this test passes consistently
+    sleep(Duration::from_secs(1)).await;
     let authorities = spawn_test_authorities([].into_iter(), &test_authority_configs()).await;
     trigger_reconfiguration(&authorities).await;
 }


### PR DESCRIPTION
This PR installs OnsiteReconfigObserver in TransactionOrchestrator that reconfig QuorumDriver