### PR TITLE
[reconfiguration] Do not attempt to revert transaction that was not executed.

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -212,13 +212,21 @@ impl AuthorityStore {
         &self,
         transaction_digest: &TransactionDigest,
     ) -> SuiResult<TransactionEffects> {
-        self.perpetual_tables
-            .executed_effects
-            .get(transaction_digest)?
-            .map(|data| data.into_data())
+        self.get_effects_if_exists(transaction_digest)?
             .ok_or(SuiError::TransactionNotFound {
                 digest: *transaction_digest,
             })
+    }
+
+    pub fn get_effects_if_exists(
+        &self,
+        transaction_digest: &TransactionDigest,
+    ) -> SuiResult<Option<TransactionEffects>> {
+        Ok(self
+            .perpetual_tables
+            .executed_effects
+            .get(transaction_digest)?
+            .map(|data| data.into_data()))
     }
 
     /// Returns true if we have an effects structure for this transaction digest
@@ -1149,7 +1157,11 @@ impl AuthorityStore {
     /// 3. All new object states are deleted.
     /// 4. owner_index table change is reverted.
     pub async fn revert_state_update(&self, tx_digest: &TransactionDigest) -> SuiResult {
-        let effects = self.get_effects(tx_digest)?;
+        let effects = self.get_effects_if_exists(tx_digest)?;
+        let Some(effects) = effects else {
+            debug!("Not reverting {tx_digest} as it was not executed");
+            return Ok(())
+        };
 
         let mut write_batch = self.perpetual_tables.certificates.batch();
         write_batch =


### PR DESCRIPTION
We use pending certificates from consensus adapter as a list of transactions to revert, some of those transactions might actually be cut off from execution before epoch change and won't be executed. To handle that we make `revert_state_update` be able to handle non-existing transactions correctly.

Thank you @laura-makdah  for spotting the reporting the bug