### PR TITLE
[reconfiguration] Avoid race condition between execution and reconfiguration.

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -19,6 +19,7 @@ use sui_types::object::Owner;
 use sui_types::object::PACKAGE_VERSION;
 use sui_types::storage::{ChildObjectResolver, ObjectKey};
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tracing::{debug, info, trace};
 use typed_store::rocks::DBBatch;
@@ -47,7 +48,15 @@ pub struct AuthorityStore {
     // Implementation detail to support notify_read_effects().
     pub(crate) effects_notify_read: NotifyRead<TransactionDigest, SignedTransactionEffects>,
     _store_pruner: AuthorityStorePruner,
+    /// This lock denotes current 'execution epoch'.
+    /// Execution acquires read lock, checks certificate epoch and holds it until all writes are complete.
+    /// Reconfiguration acquires write lock, changes the epoch and revert all transactions
+    /// from previous epoch that are executed but did not make into checkpoint.
+    execution_lock: RwLock<EpochId>,
 }
+
+pub type ExecutionLockReadGuard<'a> = RwLockReadGuard<'a, EpochId>;
+pub type ExecutionLockWriteGuard<'a> = RwLockWriteGuard<'a, EpochId>;
 
 impl AuthorityStore {
     /// Open an authority store by directory path.
@@ -115,6 +124,7 @@ impl AuthorityStore {
         committee: Committee,
         pruning_config: &AuthorityStorePruningConfig,
     ) -> SuiResult<Self> {
+        let epoch = committee.epoch;
         let epoch_tables = Arc::new(AuthorityPerEpochStore::new(
             committee,
             path,
@@ -131,6 +141,7 @@ impl AuthorityStore {
             db_options,
             _store_pruner,
             effects_notify_read: NotifyRead::new(),
+            execution_lock: RwLock::new(epoch),
         };
         // Only initialize an empty database.
         if store
@@ -376,6 +387,28 @@ impl AuthorityStore {
         }
 
         Ok(missing)
+    }
+
+    /// Attempts to acquire execution lock for certificate
+    /// Returns the lock if certificate is matching current executed epoch
+    /// Returns None otherwise
+    pub async fn execution_lock_for_certificate(
+        &self,
+        certificate: &CertifiedTransaction,
+    ) -> SuiResult<ExecutionLockReadGuard> {
+        let lock = self.execution_lock.read().await;
+        if *lock == certificate.epoch() {
+            Ok(lock)
+        } else {
+            Err(SuiError::WrongEpoch {
+                expected_epoch: *lock,
+                actual_epoch: certificate.epoch(),
+            })
+        }
+    }
+
+    pub async fn execution_lock_for_reconfiguration(&self) -> ExecutionLockWriteGuard {
+        self.execution_lock.write().await
     }
 
     /// When making changes, please see if get_missing_input_objects() above needs


### PR DESCRIPTION
This PR adds a separate RwLock to authority state to guard execution epoch. See comments on `reconfigure()` and `process_certificate()` methods on the order of this epoch change and epoch on the epoch store.

This ensures that before we attempt to revert transactions, no transaction is being executed in parallel.

Also, after epoch change, if any transaction were scheduled for the previous epoch, it will be rejected as execution epoch carries the epoch number and `process_certificates` checks that epoch number.