### PR TITLE
[sdk] Fix nested type parsing in TypeTag

### DIFF
--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -18,6 +18,7 @@ export * from './serialization/hex';
 export * from './signers/txn-data-serializers/rpc-txn-data-serializer';
 export * from './signers/txn-data-serializers/txn-data-serializer';
 export * from './signers/txn-data-serializers/local-txn-data-serializer';
+export * from './signers/txn-data-serializers/type-tag-serializer';
 
 export * from './signers/signer';
 export * from './signers/raw-signer';

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -158,7 +158,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
             function: moveCall.function,
             typeArguments: moveCall.typeArguments.map((a) =>
               typeof a === 'string'
-                ? TypeTagSerializer.parseFromStr(a)
+                ? TypeTagSerializer.parseFromStr(a, true)
                 : (a as TypeTag)
             ),
             arguments: await new CallArgSerializer(

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -158,7 +158,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
             function: moveCall.function,
             typeArguments: moveCall.typeArguments.map((a) =>
               typeof a === 'string'
-                ? new TypeTagSerializer().parseFromStr(a)
+                ? TypeTagSerializer.parseFromStr(a)
                 : (a as TypeTag)
             ),
             arguments: await new CallArgSerializer(

--- a/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts
@@ -7,7 +7,7 @@ const VECTOR_REGEX = /^vector<(.+)>$/;
 const STRUCT_REGEX = /^([^:]+)::([^:]+)::([^<]+)(<(.+)>)?/;
 
 export class TypeTagSerializer {
-  parseFromStr(str: string): TypeTag {
+  static parseFromStr(str: string): TypeTag {
     if (str === 'address') {
       return { address: null };
     } else if (str === 'bool') {
@@ -29,7 +29,7 @@ export class TypeTagSerializer {
     }
     const vectorMatch = str.match(VECTOR_REGEX);
     if (vectorMatch) {
-      return { vector: this.parseFromStr(vectorMatch[1]) };
+      return { vector: TypeTagSerializer.parseFromStr(vectorMatch[1]) };
     }
 
     const structMatch = str.match(STRUCT_REGEX);
@@ -42,7 +42,7 @@ export class TypeTagSerializer {
           typeParams:
             structMatch[5] === undefined
               ? []
-              : this.parseStructTypeArgs(structMatch[5]),
+              : TypeTagSerializer.parseStructTypeArgs(structMatch[5]),
         },
       };
     }
@@ -52,7 +52,7 @@ export class TypeTagSerializer {
     );
   }
 
-  parseStructTypeArgs(str: string): TypeTag[] {
+  static parseStructTypeArgs(str: string): TypeTag[] {
     // split `str` by all `,` outside angle brackets
     const tok: Array<string> = [];
     let word = '';
@@ -75,10 +75,10 @@ export class TypeTagSerializer {
 
     tok.push(word.trim());
 
-    return tok.map((tok) => this.parseFromStr(tok));
+    return tok.map(TypeTagSerializer.parseFromStr);
   }
 
-  tagToString(tag: TypeTag): string {
+  static tagToString(tag: TypeTag): string {
     if ('bool' in tag) {
       return 'bool';
     }
@@ -107,12 +107,12 @@ export class TypeTagSerializer {
       return 'signer';
     }
     if ('vector' in tag) {
-      return `vector<${this.tagToString(tag.vector)}>`;
+      return `vector<${TypeTagSerializer.tagToString(tag.vector)}>`;
     }
     if ('struct' in tag) {
       const struct = tag.struct;
       const typeParams = struct.typeParams
-        .map((tag) => this.tagToString(tag))
+        .map(TypeTagSerializer.tagToString)
         .join(', ');
       return `${struct.address}::${struct.module}::${struct.name}${
         typeParams ? `<${typeParams}>` : ''

--- a/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts
@@ -77,4 +77,47 @@ export class TypeTagSerializer {
 
     return tok.map((tok) => this.parseFromStr(tok));
   }
+
+  tagToString(tag: TypeTag): string {
+    if ('bool' in tag) {
+      return 'bool';
+    }
+    if ('u8' in tag) {
+      return 'u8';
+    }
+    if ('u16' in tag) {
+      return 'u16';
+    }
+    if ('u32' in tag) {
+      return 'u32';
+    }
+    if ('u64' in tag) {
+      return 'u64';
+    }
+    if ('u128' in tag) {
+      return 'u128';
+    }
+    if ('u256' in tag) {
+      return 'u256';
+    }
+    if ('address' in tag) {
+      return 'address';
+    }
+    if ('signer' in tag) {
+      return 'signer';
+    }
+    if ('vector' in tag) {
+      return `vector<${this.tagToString(tag.vector)}>`;
+    }
+    if ('struct' in tag) {
+      const struct = tag.struct;
+      const typeParams = struct.typeParams
+        .map((tag) => this.tagToString(tag))
+        .join(', ');
+      return `${struct.address}::${struct.module}::${struct.name}${
+        typeParams ? `<${typeParams}>` : ''
+      }`;
+    }
+    throw new Error('Invalid TypeTag');
+  }
 }

--- a/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { normalizeSuiAddress, TypeTag } from '../../types';
+import { TypeTag } from '../../types';
 
 const VECTOR_REGEX = /^vector<(.+)>$/;
-const STRUCT_REGEX = /^([^:]+)::([^:]+)::(.+)/;
-const STRUCT_TYPE_TAG_REGEX = /^[^<]+<(.+)>$/;
+const STRUCT_REGEX = /^([^:]+)::([^:]+)::([^<]+)(<(.+)>)?/;
 
 export class TypeTagSerializer {
   parseFromStr(str: string): TypeTag {
@@ -35,33 +34,47 @@ export class TypeTagSerializer {
 
     const structMatch = str.match(STRUCT_REGEX);
     if (structMatch) {
-      try {
-        return {
-          struct: {
-            address: normalizeSuiAddress(structMatch[1]),
-            module: structMatch[2],
-            name: structMatch[3].match(/^([^<]+)/)![1],
-            typeParams: this.parseStructTypeTag(structMatch[3]),
-          },
-        };
-      } catch (e) {
-        throw new Error(`Encounter error parsing type args for ${str}`);
-      }
+      return {
+        struct: {
+          address: structMatch[1],
+          module: structMatch[2],
+          name: structMatch[3],
+          typeParams:
+            structMatch[5] === undefined
+              ? []
+              : this.parseStructTypeArgs(structMatch[5]),
+        },
+      };
     }
 
     throw new Error(
-      `Encounter unexpected token when parsing type args for ${str}`
+      `Encountered unexpected token when parsing type args for ${str}`
     );
   }
 
-  parseStructTypeTag(str: string): TypeTag[] {
-    const typeTagsMatch = str.match(STRUCT_TYPE_TAG_REGEX);
-    if (!typeTagsMatch) {
-      return [];
+  parseStructTypeArgs(str: string): TypeTag[] {
+    // split `str` by all `,` outside angle brackets
+    const tok: Array<string> = [];
+    let word = '';
+    let nestedAngleBrackets = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str[i];
+      if (char === '<') {
+        nestedAngleBrackets++;
+      }
+      if (char === '>') {
+        nestedAngleBrackets--;
+      }
+      if (nestedAngleBrackets === 0 && char === ',') {
+        tok.push(word.trim());
+        word = '';
+        continue;
+      }
+      word += char;
     }
-    // TODO: This will fail if the struct has nested type args with commas. Need
-    // to implement proper parsing for this case
-    const typeTags = typeTagsMatch[1].split(',');
-    return typeTags.map((tag) => this.parseFromStr(tag));
+
+    tok.push(word.trim());
+
+    return tok.map((tok) => this.parseFromStr(tok));
   }
 }

--- a/sdk/typescript/test/unit/signers/txn-data-serializers/type-tag-serializer.test.ts
+++ b/sdk/typescript/test/unit/signers/txn-data-serializers/type-tag-serializer.test.ts
@@ -1,0 +1,59 @@
+import { it, describe, expect } from 'vitest';
+import { TypeTagSerializer } from '../../../../src/signers/txn-data-serializers/type-tag-serializer';
+
+describe('parseFromStr', () => {
+  it('parses nested struct type from a string', () => {
+    const typeStr =
+      '0x2::balance::Supply<0x72de5feb63c0ab6ed1cda7e5b367f3d0a999add7::amm::LP<0x2::sui::SUI, 0xfee024a3c0c03ada5cdbda7d0e8b68802e6dec80::example_coin::EXAMPLE_COIN>>';
+    const act = new TypeTagSerializer().parseFromStr(typeStr);
+    const exp = {
+      struct: {
+        address: '0x2',
+        module: 'balance',
+        name: 'Supply',
+        typeParams: [
+          {
+            struct: {
+              address: '0x72de5feb63c0ab6ed1cda7e5b367f3d0a999add7',
+              module: 'amm',
+              name: 'LP',
+              typeParams: [
+                {
+                  struct: {
+                    address: '0x2',
+                    module: 'sui',
+                    name: 'SUI',
+                    typeParams: [],
+                  },
+                },
+                {
+                  struct: {
+                    address: '0xfee024a3c0c03ada5cdbda7d0e8b68802e6dec80',
+                    module: 'example_coin',
+                    name: 'EXAMPLE_COIN',
+                    typeParams: [],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    expect(act).toEqual(exp);
+  });
+
+  it('parses non parametrized struct type from a string', () => {
+    const typeStr = '0x72de5feb63c0ab6ed1cda7e5b367f3d0a999add7::foo::FOO';
+    const act = new TypeTagSerializer().parseFromStr(typeStr);
+    const exp = {
+      struct: {
+        address: '0x72de5feb63c0ab6ed1cda7e5b367f3d0a999add7',
+        module: 'foo',
+        name: 'FOO',
+        typeParams: [],
+      },
+    };
+    expect(act).toEqual(exp);
+  });
+});

--- a/sdk/typescript/test/unit/signers/txn-data-serializers/type-tag-serializer.test.ts
+++ b/sdk/typescript/test/unit/signers/txn-data-serializers/type-tag-serializer.test.ts
@@ -57,3 +57,46 @@ describe('parseFromStr', () => {
     expect(act).toEqual(exp);
   });
 });
+
+describe('tagToString', () => {
+  it('converts nested struct type to a string', () => {
+    const type = {
+      struct: {
+        address: '0x2',
+        module: 'balance',
+        name: 'Supply',
+        typeParams: [
+          {
+            struct: {
+              address: '0x72de5feb63c0ab6ed1cda7e5b367f3d0a999add7',
+              module: 'amm',
+              name: 'LP',
+              typeParams: [
+                {
+                  struct: {
+                    address: '0x2',
+                    module: 'sui',
+                    name: 'SUI',
+                    typeParams: [],
+                  },
+                },
+                {
+                  struct: {
+                    address: '0xfee024a3c0c03ada5cdbda7d0e8b68802e6dec80',
+                    module: 'example_coin',
+                    name: 'EXAMPLE_COIN',
+                    typeParams: [],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const act = new TypeTagSerializer().tagToString(type);
+    const exp =
+      '0x2::balance::Supply<0x72de5feb63c0ab6ed1cda7e5b367f3d0a999add7::amm::LP<0x2::sui::SUI, 0xfee024a3c0c03ada5cdbda7d0e8b68802e6dec80::example_coin::EXAMPLE_COIN>>';
+    expect(act).toEqual(exp);
+  });
+});

--- a/sdk/typescript/test/unit/signers/txn-data-serializers/type-tag-serializer.test.ts
+++ b/sdk/typescript/test/unit/signers/txn-data-serializers/type-tag-serializer.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { it, describe, expect } from 'vitest';
 import { TypeTagSerializer } from '../../../../src/signers/txn-data-serializers/type-tag-serializer';
 

--- a/sdk/typescript/test/unit/signers/txn-data-serializers/type-tag-serializer.test.ts
+++ b/sdk/typescript/test/unit/signers/txn-data-serializers/type-tag-serializer.test.ts
@@ -8,7 +8,7 @@ describe('parseFromStr', () => {
   it('parses nested struct type from a string', () => {
     const typeStr =
       '0x2::balance::Supply<0x72de5feb63c0ab6ed1cda7e5b367f3d0a999add7::amm::LP<0x2::sui::SUI, 0xfee024a3c0c03ada5cdbda7d0e8b68802e6dec80::example_coin::EXAMPLE_COIN>>';
-    const act = new TypeTagSerializer().parseFromStr(typeStr);
+    const act = TypeTagSerializer.parseFromStr(typeStr);
     const exp = {
       struct: {
         address: '0x2',
@@ -48,7 +48,7 @@ describe('parseFromStr', () => {
 
   it('parses non parametrized struct type from a string', () => {
     const typeStr = '0x72de5feb63c0ab6ed1cda7e5b367f3d0a999add7::foo::FOO';
-    const act = new TypeTagSerializer().parseFromStr(typeStr);
+    const act = TypeTagSerializer.parseFromStr(typeStr);
     const exp = {
       struct: {
         address: '0x72de5feb63c0ab6ed1cda7e5b367f3d0a999add7',
@@ -97,7 +97,7 @@ describe('tagToString', () => {
         ],
       },
     };
-    const act = new TypeTagSerializer().tagToString(type);
+    const act = TypeTagSerializer.tagToString(type);
     const exp =
       '0x2::balance::Supply<0x72de5feb63c0ab6ed1cda7e5b367f3d0a999add7::amm::LP<0x2::sui::SUI, 0xfee024a3c0c03ada5cdbda7d0e8b68802e6dec80::example_coin::EXAMPLE_COIN>>';
     expect(act).toEqual(exp);


### PR DESCRIPTION
I've fixed the parsing of nested types in TypeTag ([this comment](https://github.com/MystenLabs/sui/blob/main/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts#L62-L63)). Also implemented a `tagToString` function which does the oposite of `parseFromStr` (converts `TagType` -> `string`)

NOTE: I've removed `normalizeSuiAddress` from address field parsing in `parseFromString` because I don't think this is the right place to use it (`0x2::sui::SUI` becomes `{ address: 0x000000...00002::sui::SUI, ...}`). Especially because the RPC should support both https://github.com/MystenLabs/sui/pull/6777:
> For RPC requests, people should be able to pass either way as long as it's supported by parse_sui_struct_tag.

Changes:
- fixed parsing of nested struct types
- added `parseFromString` function
- made `TypeTagParser` methods static
- exported TypeTagParser in `index.ts`
- removed `normalizeSuiAddress` from parsing struct type address field

Test plan -- added unit tests.