### PR TITLE
[move] Changed how prover treats certain functions

### DIFF
--- a/crates/sui-framework/docs/bcs.md
+++ b/crates/sui-framework/docs/bcs.md
@@ -58,6 +58,7 @@ let leftovers = bcs::into_remainder_bytes(prepared);
 -  [Function `peel_option_u8`](#0x2_bcs_peel_option_u8)
 -  [Function `peel_option_u64`](#0x2_bcs_peel_option_u64)
 -  [Function `peel_option_u128`](#0x2_bcs_peel_option_u128)
+-  [Module Specification](#@Module_Specification_1)
 
 
 <pre><code><b>use</b> <a href="">0x1::bcs</a>;
@@ -421,18 +422,6 @@ See more here: https://en.wikipedia.org/wiki/LEB128
 
 </details>
 
-<details>
-<summary>Specification</summary>
-
-
-
-<pre><code><b>pragma</b> intrinsic = <b>true</b>;
-</code></pre>
-
-
-
-</details>
-
 <a name="0x2_bcs_peel_vec_address"></a>
 
 ## Function `peel_vec_address`
@@ -757,3 +746,12 @@ Peel <code>Option&lt;u128&gt;</code> from serialized bytes.
 
 
 </details>
+
+<a name="@Module_Specification_1"></a>
+
+## Module Specification
+
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>

--- a/crates/sui-framework/docs/bls12381.md
+++ b/crates/sui-framework/docs/bls12381.md
@@ -43,6 +43,18 @@ BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_bls12381_bls12381_min_sig_verify_with_domain"></a>
 
 ## Function `bls12381_min_sig_verify_with_domain`
@@ -102,6 +114,18 @@ BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="bls12381.md#0x2_bls12381_bls12381_min_pk_verify">bls12381_min_pk_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/bulletproofs.md
+++ b/crates/sui-framework/docs/bulletproofs.md
@@ -37,6 +37,18 @@ Only bit_length = 64, 32, 16, 8 will work.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_bulletproofs_verify_full_range_proof"></a>
 
 ## Function `verify_full_range_proof`

--- a/crates/sui-framework/docs/ed25519.md
+++ b/crates/sui-framework/docs/ed25519.md
@@ -42,6 +42,18 @@ Otherwise, return false.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_ed25519_ed25519_verify_with_domain"></a>
 
 ## Function `ed25519_verify_with_domain`

--- a/crates/sui-framework/docs/elliptic_curve.md
+++ b/crates/sui-framework/docs/elliptic_curve.md
@@ -110,6 +110,18 @@ Private
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_elliptic_curve_native_add_ristretto_point"></a>
 
 ## Function `native_add_ristretto_point`
@@ -129,6 +141,18 @@ A native move wrapper around the addition of Ristretto points. Returns self + ot
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_add_ristretto_point">native_add_ristretto_point</a>(point1: <a href="">vector</a>&lt;u8&gt;, point2: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
 </code></pre>
 
 
@@ -160,6 +184,18 @@ A native move wrapper around the subtraction of Ristretto points. Returns self -
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_elliptic_curve_native_scalar_from_u64"></a>
 
 ## Function `native_scalar_from_u64`
@@ -185,6 +221,18 @@ A native move wrapper for the creation of Scalars on Curve25519.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_elliptic_curve_native_scalar_from_bytes"></a>
 
 ## Function `native_scalar_from_bytes`
@@ -204,6 +252,18 @@ A native move wrapper for the creation of Scalars on Curve25519.
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_scalar_from_bytes">native_scalar_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/groth16.md
+++ b/crates/sui-framework/docs/groth16.md
@@ -275,6 +275,18 @@ This can be used as inputs for the <code>verify_groth16_proof</code> function.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_groth16_verify_groth16_proof"></a>
 
 ## Function `verify_groth16_proof`
@@ -328,6 +340,18 @@ Native functions that flattens the inputs into arrays of vectors and passed to t
 
 
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="groth16.md#0x2_groth16_verify_groth16_proof_internal">verify_groth16_proof_internal</a>(vk_gamma_abc_g1_bytes: &<a href="">vector</a>&lt;u8&gt;, alpha_g1_beta_g2_bytes: &<a href="">vector</a>&lt;u8&gt;, gamma_g2_neg_pc_bytes: &<a href="">vector</a>&lt;u8&gt;, delta_g2_neg_pc_bytes: &<a href="">vector</a>&lt;u8&gt;, public_proof_inputs: &<a href="">vector</a>&lt;u8&gt;, proof_points: &<a href="">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/hmac.md
+++ b/crates/sui-framework/docs/hmac.md
@@ -39,6 +39,18 @@ A native move wrapper around the HMAC-SHA3-256. Returns the digest.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_hmac_hmac_sha3_256"></a>
 
 ## Function `hmac_sha3_256`

--- a/crates/sui-framework/sources/bcs.move
+++ b/crates/sui-framework/sources/bcs.move
@@ -157,10 +157,6 @@ module sui::bcs {
         total
     }
 
-    spec peel_vec_length {
-        pragma intrinsic = true;
-    }
-
     /// Peel a vector of `address` from serialized bytes.
     public fun peel_vec_address(bcs: &mut BCS): vector<address> {
         let (len, i, res) = (peel_vec_length(bcs), 0, vector[]);
@@ -267,6 +263,9 @@ module sui::bcs {
             option::none()
         }
     }
+
+    // TODO: re-enable once bit-wise operators in peel_vec_length are supported in the prover
+    spec module { pragma verify = false; }
 
     // === Tests ===
 

--- a/crates/sui-framework/sources/crypto/bls12381.spec.move
+++ b/crates/sui-framework/sources/crypto/bls12381.spec.move
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::bls12381 {
+    spec bls12381_min_sig_verify {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec bls12381_min_pk_verify {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework/sources/crypto/bulletproofs.spec.move
+++ b/crates/sui-framework/sources/crypto/bulletproofs.spec.move
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::bulletproofs {
+    spec native_verify_full_range_proof {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework/sources/crypto/ed25519.spec.move
+++ b/crates/sui-framework/sources/crypto/ed25519.spec.move
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::ed25519 {
+    spec ed25519_verify {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework/sources/crypto/elliptic_curve.spec.move
+++ b/crates/sui-framework/sources/crypto/elliptic_curve.spec.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::elliptic_curve {
+    spec native_create_pedersen_commitment {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec native_add_ristretto_point {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec native_subtract_ristretto_point {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec native_scalar_from_u64 {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec native_scalar_from_bytes {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework/sources/crypto/groth16.spec.move
+++ b/crates/sui-framework/sources/crypto/groth16.spec.move
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::groth16 {
+    spec prepare_verifying_key {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec verify_groth16_proof_internal {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework/sources/crypto/hmac.spec.move
+++ b/crates/sui-framework/sources/crypto/hmac.spec.move
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::hmac {
+    spec native_hmac_sha3_256 {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -115,58 +115,9 @@ procedure {:inline 1} $2_dynamic_field_has_child_object_with_ty{{S}}(parent: int
 
 {%- endfor %}
 
-
-// ==================================================================================
-// Native bls12381
-
-procedure {:inline 1} $2_bls12381_bls12381_min_sig_verify(hash: Vec (int), public_key: Vec (int), msg: Vec (int)) returns (res: bool);
-
-procedure {:inline 1} $2_bls12381_bls12381_min_pk_verify(hash: Vec (int), public_key: Vec (int), msg: Vec (int)) returns (res: bool);
-
-// ==================================================================================
-// Native ed25519
-
-procedure {:inline 1} $2_ed25519_ed25519_verify(signature: Vec (int), public_key: Vec (int), msg: Vec (int)) returns (res: bool);
-
-// ==================================================================================
-// Native bulletproofs
-
-procedure {:inline 1} $2_bulletproofs_native_verify_full_range_proof(proof: Vec (int), commitment: Vec (int), bit_length: int) returns (res: bool);
-
-// ==================================================================================
-// Native elliptic_curve
-
-procedure {:inline 1} $2_elliptic_curve_native_create_pedersen_commitment(value: Vec (int), blinding_factor: Vec (int)) returns (res: Vec (int));
-
-procedure {:inline 1} $2_elliptic_curve_native_add_ristretto_point(point1: Vec (int), point2: Vec (int)) returns (res: Vec (int));
-
-procedure {:inline 1} $2_elliptic_curve_native_subtract_ristretto_point(point1: Vec (int), point2: Vec (int)) returns (res: Vec (int));
-
-procedure {:inline 1} $2_elliptic_curve_native_scalar_from_u64(value: int) returns (res: Vec (int));
-
-procedure {:inline 1} $2_elliptic_curve_native_scalar_from_bytes(bytes: Vec (int)) returns (res: Vec (int));
-
-// ==================================================================================
-// Native hmac
-
-procedure {:inline 1} $2_hmac_native_hmac_sha3_256(key: Vec (int), msg: Vec (int)) returns (res: Vec (int));
-
-// ==================================================================================
-// Native groth
-
-procedure {:inline 1} $2_groth16_prepare_verifying_key(verifying_key: Vec (int)) returns (res: $2_groth16_PreparedVerifyingKey);
-
-procedure {:inline 1} $2_groth16_verify_groth16_proof_internal(vk_gamma_abc_g1_bytes: Vec (int), alpha_g1_beta_g2_bytes: Vec (int), gamma_g2_neg_pc_bytes: Vec (int), delta_g2_neg_pc_bytes: Vec (int), public_proof_inputs: Vec (int), proof_points: Vec (int)) returns (res: bool);
-
 // ==================================================================================
 // Reads and writes to dynamic fields (skeletons)
 
 function GetDynField<T, V>(o: T, addr: int): V;
 
 function UpdateDynField<T, V>(o: T, addr: int, v: V): T;
-
-// ==================================================================================
-// Intrinsics bcs
-
-// placeholder - need to add support for bitwise operators in Boogie to implement this
-procedure {:inline 1} $2_bcs_peel_vec_length(bcs: $Mutation $2_bcs_BCS) returns (res: int, m: $Mutation $2_bcs_BCS);


### PR DESCRIPTION
While the Prover worked fine on the framework code without these changes, it would not work correctly on user modules. The reason for it was that some Boogie skeletons featured user-defined types in their parameters and these were not being pulled by the prover as dependencies. In particular, this was a problem for the `bcs` module and for the `groth16` module but I made the change for all crypto-related native methods for uniformity.