### PR TITLE
[epoch] Pass epoch store to handle_transaction

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -456,7 +456,8 @@ pub trait TransactionCertifier: Sync + Send + 'static {
     async fn create_certificate(
         &self,
         transaction: &VerifiedTransaction,
-        self_state: &AuthorityState,
+        self_store: &Arc<AuthorityStore>,
+        committee_store: &Arc<CommitteeStore>,
         timeout: Duration,
     ) -> anyhow::Result<VerifiedCertificate>;
 }
@@ -482,18 +483,19 @@ impl TransactionCertifier for NetworkTransactionCertifier {
     async fn create_certificate(
         &self,
         transaction: &VerifiedTransaction,
-        self_state: &AuthorityState,
+        self_store: &Arc<AuthorityStore>,
+        committee_store: &Arc<CommitteeStore>,
         timeout: Duration,
     ) -> anyhow::Result<VerifiedCertificate> {
         let registry = Registry::new();
         let net = AuthorityAggregator::new_from_system_state(
-            &self_state.db(),
-            self_state.committee_store(),
+            self_store,
+            committee_store,
             SafeClientMetricsBase::new(&registry),
             AuthAggMetrics::new(&registry),
         )?;
 
-        net.authorty_ask_for_cert_with_retry_and_timeout(transaction, self_state, timeout)
+        net.authorty_ask_for_cert_with_retry_and_timeout(transaction, self_store, timeout)
             .await
     }
 }
@@ -503,10 +505,11 @@ impl TransactionCertifier for LocalTransactionCertifier {
     async fn create_certificate(
         &self,
         transaction: &VerifiedTransaction,
-        self_state: &AuthorityState,
+        self_store: &Arc<AuthorityStore>,
+        committee_store: &Arc<CommitteeStore>,
         timeout: Duration,
     ) -> anyhow::Result<VerifiedCertificate> {
-        let sui_system_state = self_state.get_sui_system_state_object()?;
+        let sui_system_state = self_store.get_sui_system_state_object()?;
         let committee = sui_system_state.get_current_epoch_committee().committee;
         let clients: BTreeMap<_, _> = committee.names().map(|name|
             // unwrap is fine because LocalAuthorityClient is only used for testing.
@@ -514,12 +517,12 @@ impl TransactionCertifier for LocalTransactionCertifier {
         ).collect();
         let net = AuthorityAggregator::new(
             committee,
-            self_state.committee_store().clone(),
+            committee_store.clone(),
             clients,
             &Registry::new(),
         );
 
-        net.authorty_ask_for_cert_with_retry_and_timeout(transaction, self_state, timeout)
+        net.authorty_ask_for_cert_with_retry_and_timeout(transaction, self_store, timeout)
             .await
     }
 }
@@ -1836,20 +1839,14 @@ where
     pub async fn authorty_ask_for_cert_with_retry_and_timeout(
         &self,
         transaction: &VerifiedTransaction,
-        state: &AuthorityState,
+        self_store: &Arc<AuthorityStore>,
         timeout: Duration,
     ) -> anyhow::Result<VerifiedCertificate> {
         let result = tokio::time::timeout(timeout, async {
             loop {
                 // We may have already executed this transaction somewhere else.
                 // If so, no need to try to get it from the network.
-                if let Ok(Some(VerifiedTransactionInfoResponse {
-                    certified_transaction: Some(cert),
-                    ..
-                })) = state
-                    .get_tx_info_already_executed(transaction.digest())
-                    .await
-                {
+                if let Ok(Some(cert)) = self_store.get_certified_transaction(transaction.digest()) {
                     return cert;
                 }
                 match self.process_transaction(transaction.clone()).await {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -353,7 +353,7 @@ impl ValidatorService {
                     &state.name,
                     certificate.clone().into(),
                 );
-                consensus_adapter.submit(transaction, Some(&reconfiguration_lock))?;
+                consensus_adapter.submit(transaction, Some(&reconfiguration_lock), &epoch_store)?;
                 // Do not wait for the result, because the transaction might have already executed.
                 // Instead, check or wait for the existence of certificate effects below.
             }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -363,7 +363,9 @@ impl CheckpointBuilder {
         let content_info = match new_checkpoint {
             Some((summary, contents)) => {
                 // Only create checkpoint if content is not empty
-                self.output.checkpoint_created(&summary, &contents).await?;
+                self.output
+                    .checkpoint_created(&summary, &contents, epoch_store)
+                    .await?;
 
                 self.metrics
                     .transactions_included_in_checkpoint
@@ -1092,6 +1094,7 @@ mod tests {
             &self,
             summary: &CheckpointSummary,
             contents: &CheckpointContents,
+            _epoch_store: &Arc<AuthorityPerEpochStore>,
         ) -> SuiResult {
             self.try_send((contents.clone(), summary.clone())).unwrap();
             Ok(())

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -347,7 +347,7 @@ impl CheckpointBuilder {
         let unsorted = self.complete_checkpoint_effects(epoch_store, roots)?;
         let sorted = CasualOrder::casual_sort(unsorted);
         let new_checkpoint = self
-            .create_checkpoint(epoch_store.epoch(), sorted, last_checkpoint_of_epoch)
+            .create_checkpoint(epoch_store, sorted, last_checkpoint_of_epoch)
             .await?;
         self.write_checkpoint(epoch_store, height, new_checkpoint)
             .await?;
@@ -399,7 +399,7 @@ impl CheckpointBuilder {
 
     async fn create_checkpoint(
         &self,
-        epoch: EpochId,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
         mut effects: Vec<TransactionEffects>,
         last_checkpoint_of_epoch: bool,
     ) -> anyhow::Result<Option<(CheckpointSummary, CheckpointContents)>> {
@@ -407,11 +407,11 @@ impl CheckpointBuilder {
         let epoch_rolling_gas_cost_summary = Self::get_epoch_total_gas_cost(
             last_checkpoint.as_ref().map(|(_, c)| c),
             &effects,
-            epoch,
+            epoch_store.epoch(),
         );
         if last_checkpoint_of_epoch {
             self.augment_epoch_last_checkpoint(
-                epoch,
+                epoch_store,
                 &epoch_rolling_gas_cost_summary,
                 &mut effects,
             )
@@ -440,7 +440,7 @@ impl CheckpointBuilder {
             .map(|(_, c)| c.sequence_number + 1)
             .unwrap_or_default();
         let summary = CheckpointSummary::new(
-            epoch,
+            epoch_store.epoch(),
             sequence_number,
             network_total_transactions,
             &contents,
@@ -484,14 +484,14 @@ impl CheckpointBuilder {
 
     async fn augment_epoch_last_checkpoint(
         &self,
-        epoch: EpochId,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
         epoch_total_gas_cost: &GasCostSummary,
         effects: &mut Vec<TransactionEffects>,
     ) -> anyhow::Result<()> {
         let cert = self
             .state
             .create_advance_epoch_tx_cert(
-                epoch + 1,
+                epoch_store,
                 epoch_total_gas_cost,
                 Duration::from_secs(60), // TODO: Is 60s enough?
                 self.transaction_certifier.deref(),

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use sui_types::error::SuiResult;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -49,7 +51,7 @@ impl ReconfigState {
 }
 
 pub trait ReconfigurationInitiator {
-    fn close_epoch(&self) -> SuiResult;
+    fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) -> SuiResult;
 }
 
 /*

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -283,7 +283,9 @@ impl SuiNode {
             .as_ref()
             .ok_or_else(|| SuiError::from("Node is not a validator"))?
             .consensus_adapter
-            .close_epoch()
+            // TODO: If this function is ever called in non-testing code, we need to make sure this
+            // function has no race with the passive reconfiguration.
+            .close_epoch(&self.state.epoch_store())
     }
 
     pub fn validator_components(&self) -> Option<Arc<ValidatorComponents>> {

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -71,7 +71,7 @@ async fn advance_epoch_tx_test_impl(
 ) {
     let failing_task = states[0]
         .create_advance_epoch_tx_cert(
-            1,
+            &states[0].epoch_store(),
             &GasCostSummary::new(0, 0, 0),
             Duration::from_secs(15),
             certifier,
@@ -86,7 +86,7 @@ async fn advance_epoch_tx_test_impl(
         .map(|state| async {
             state
                 .create_advance_epoch_tx_cert(
-                    1,
+                    &state.epoch_store(),
                     &GasCostSummary::new(0, 0, 0),
                     Duration::from_secs(1000), // A very very long time
                     certifier,


### PR DESCRIPTION
Obtain the epoch store at the beginning of `handle_transaction`, and pass it down all the way to all places to make sure we are using the same epoch store and epoch number.