### PR TITLE
[epoch] Pass epoch store to handle_certificate paths

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1314,30 +1314,6 @@ impl AuthorityStore {
         }
     }
 
-    /// Lock a sequence number for the shared objects of the input transaction based on the effects
-    /// of that transaction. Used by full nodes, which don't listen to consensus.
-    pub async fn acquire_shared_locks_from_effects(
-        &self,
-        certificate: &VerifiedCertificate,
-        effects: &TransactionEffects,
-    ) -> SuiResult {
-        let _tx_lock = self
-            .epoch_store()
-            .acquire_tx_lock(certificate.digest())
-            .await;
-        self.epoch_store()
-            .set_assigned_shared_object_versions(
-                certificate,
-                &effects
-                    .shared_objects
-                    .iter()
-                    .map(|(id, version, _)| (*id, *version))
-                    .collect(),
-                self,
-            )
-            .await
-    }
-
     pub fn get_transaction(
         &self,
         transaction_digest: &TransactionDigest,

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -406,7 +406,9 @@ impl LocalAuthorityClient {
                 Ok(Some(effects)) => effects,
                 _ => {
                     let certificate = { certificate.verify(epoch_store.committee())? };
-                    state.try_execute_immediately(&certificate).await?
+                    state
+                        .try_execute_immediately(&certificate, &epoch_store)
+                        .await?
                 }
             };
         if fault_config.fail_after_handle_confirmation {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -40,6 +40,9 @@ use tokio_stream::StreamExt;
 use tracing::{debug, error, info, warn};
 use typed_store::{rocks::TypedStoreError, Map};
 
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::authority::AuthorityStore;
+use crate::transaction_manager::TransactionManager;
 use crate::{
     authority::{AuthorityState, EffectsNotifyRead},
     checkpoints::CheckpointStore,
@@ -424,11 +427,13 @@ impl CheckpointExecutorEventLoop {
         // Mismatch between node epoch and checkpoint epoch after startup
         // crash recovery is invalid
         let checkpoint_epoch = checkpoint.epoch();
-        let node_epoch = self.authority_state.epoch();
+        let epoch_store = self.authority_state.epoch_store();
         assert_eq!(
-            checkpoint_epoch, node_epoch,
+            checkpoint_epoch,
+            epoch_store.epoch(),
             "Epoch mismatch after startup recovery. checkpoint epoch: {:?}, node epoch: {:?}",
-            checkpoint_epoch, node_epoch,
+            checkpoint_epoch,
+            epoch_store.epoch(),
         );
 
         let next_committee = checkpoint.summary().next_epoch_committee.clone();
@@ -446,8 +451,10 @@ impl CheckpointExecutorEventLoop {
         pending.push_back(spawn_monitored_task!(async move {
             while let Err(err) = execute_checkpoint(
                 checkpoint.clone(),
-                state.clone(),
+                state.db(),
                 store.clone(),
+                epoch_store.clone(),
+                state.transaction_manager().clone(),
                 local_execution_timeout_sec,
             )
             .await
@@ -494,8 +501,10 @@ impl CheckpointExecutorEventLoop {
 
 pub async fn execute_checkpoint(
     checkpoint: VerifiedCheckpoint,
-    authority_state: Arc<AuthorityState>,
+    authority_store: Arc<AuthorityStore>,
     checkpoint_store: Arc<CheckpointStore>,
+    epoch_store: Arc<AuthorityPerEpochStore>,
+    transaction_manager: Arc<TransactionManager>,
     local_execution_timeout_sec: u64,
 ) -> SuiResult {
     debug!(
@@ -512,19 +521,28 @@ pub async fn execute_checkpoint(
         })
         .into_inner();
 
-    execute_transactions(txes, authority_state, local_execution_timeout_sec).await
+    execute_transactions(
+        txes,
+        authority_store,
+        epoch_store,
+        transaction_manager,
+        local_execution_timeout_sec,
+    )
+    .await
 }
 
 async fn execute_transactions(
     execution_digests: Vec<ExecutionDigests>,
     authority_state: Arc<AuthorityState>,
+    authority_store: Arc<AuthorityStore>,
+    epoch_store: Arc<AuthorityPerEpochStore>,
+    transaction_manager: Arc<TransactionManager>,
     log_timeout_sec: u64,
 ) -> SuiResult {
     let all_tx_digests: Vec<TransactionDigest> =
         execution_digests.iter().map(|tx| tx.transaction).collect();
 
-    let synced_txns: Vec<VerifiedCertificate> = authority_state
-        .database
+    let synced_txns: Vec<VerifiedCertificate> = authority_store
         .perpetual_tables
         .synced_transactions
         .multi_get(&all_tx_digests)?
@@ -537,8 +555,7 @@ async fn execute_transactions(
         .iter()
         .map(|digest| digest.effects)
         .collect();
-    let digest_to_effects: HashMap<TransactionDigest, TransactionEffects> = authority_state
-        .database
+    let digest_to_effects: HashMap<TransactionDigest, TransactionEffects> = authority_store
         .perpetual_tables
         .effects
         .multi_get(effects_digests)?
@@ -554,27 +571,25 @@ async fn execute_transactions(
 
     for tx in synced_txns.clone() {
         if tx.contains_shared_object() {
-            authority_state
-                .database
-                .acquire_shared_locks_from_effects(&tx, digest_to_effects.get(tx.digest()).unwrap())
+            epoch_store
+                .acquire_shared_locks_from_effects(
+                    &tx,
+                    digest_to_effects.get(tx.digest()).unwrap(),
+                    &authority_store,
+                )
                 .await?;
         }
     }
-    authority_state
-        .database
-        .epoch_store()
-        .insert_pending_certificates(&synced_txns)?;
+    epoch_store.insert_pending_certificates(&synced_txns)?;
 
-    authority_state.transaction_manager().enqueue(synced_txns)?;
+    transaction_manager.enqueue(synced_txns)?;
 
     // Once synced_txns have been awaited, all txns should have effects committed.
     let mut periods = 1;
     let log_timeout_sec = Duration::from_secs(log_timeout_sec);
 
     loop {
-        let effects_future = authority_state
-            .database
-            .notify_read_effects(all_tx_digests.clone());
+        let effects_future = authority_store.notify_read_effects(all_tx_digests.clone());
 
         match timeout(log_timeout_sec, effects_future).await {
             Err(_elapsed) => {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -533,7 +533,6 @@ pub async fn execute_checkpoint(
 
 async fn execute_transactions(
     execution_digests: Vec<ExecutionDigests>,
-    authority_state: Arc<AuthorityState>,
     authority_store: Arc<AuthorityStore>,
     epoch_store: Arc<AuthorityPerEpochStore>,
     transaction_manager: Arc<TransactionManager>,

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -192,7 +192,12 @@ where
             });
         match timeout(
             LOCAL_EXECUTION_TIMEOUT,
-            validator_state.execute_certificate_with_effects(tx_cert, effects_cert),
+            validator_state.execute_certificate_with_effects(
+                tx_cert,
+                effects_cert,
+                // TODO: Check whether it's safe to call epoch_store here.
+                &validator_state.epoch_store(),
+            ),
         )
         .await
         {

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -128,7 +128,7 @@ async fn submit_transaction_to_consensus_adapter() {
     // Submit the transaction and ensure the adapter reports success to the caller. Note
     // that consensus may drop some transactions (so we may need to resubmit them).
     let transaction = ConsensusTransaction::new_certificate_message(&state.name, certificate);
-    let epoch_store = state.epoch_store();
+    let epoch_store = state.epoch_store_for_testing();
     let waiter = adapter
         .submit(
             transaction.clone(),

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -401,12 +401,18 @@ async fn test_transaction_manager() {
     // Enqueue certs out of dependency order for executions.
     for cert in executed_shared_certs.iter().rev() {
         authorities[3]
-            .enqueue_certificates_for_execution(vec![cert.clone()])
+            .enqueue_certificates_for_execution(
+                vec![cert.clone()],
+                &authorities[3].epoch_store_for_testing(),
+            )
             .unwrap();
     }
     for cert in executed_owned_certs.iter().rev() {
         authorities[3]
-            .enqueue_certificates_for_execution(vec![cert.clone()])
+            .enqueue_certificates_for_execution(
+                vec![cert.clone()],
+                &authorities[3].epoch_store_for_testing(),
+            )
             .unwrap();
     }
 

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -71,7 +71,7 @@ async fn advance_epoch_tx_test_impl(
 ) {
     let failing_task = states[0]
         .create_advance_epoch_tx_cert(
-            &states[0].epoch_store(),
+            &states[0].epoch_store_for_testing(),
             &GasCostSummary::new(0, 0, 0),
             Duration::from_secs(15),
             certifier,
@@ -86,7 +86,7 @@ async fn advance_epoch_tx_test_impl(
         .map(|state| async {
             state
                 .create_advance_epoch_tx_cert(
-                    &state.epoch_store(),
+                    &state.epoch_store_for_testing(),
                     &GasCostSummary::new(0, 0, 0),
                     Duration::from_secs(1000), // A very very long time
                     certifier,
@@ -122,7 +122,7 @@ async fn basic_reconfig_end_to_end_test() {
         .map(|handle| {
             handle.with_async(|node| async {
                 loop {
-                    if node.state().epoch() == 1 {
+                    if node.state().epoch_store_for_testing().epoch() == 1 {
                         break;
                     }
                     tokio::time::sleep(Duration::from_secs(1)).await;

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -15,6 +15,7 @@ use sui_core::authority_client::AuthorityAPI;
 use sui_core::safe_client::SafeClientMetricsBase;
 use sui_core::test_utils::{init_local_authorities, make_transfer_sui_transaction};
 use sui_macros::sim_test;
+use sui_node::SuiNodeHandle;
 use sui_types::crypto::get_account_key_pair;
 use sui_types::error::SuiError;
 use sui_types::gas::GasCostSummary;
@@ -112,25 +113,7 @@ async fn basic_reconfig_end_to_end_test() {
     // TODO: If this line is removed, the validators never advance to the next epoch
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    // Close epoch on 3 (2f+1) validators.
-    for handle in authorities.iter().skip(1) {
-        handle.with(|node| node.close_epoch().unwrap());
-    }
-    // Wait for all nodes to reach the next epoch.
-    let handles: Vec<_> = authorities
-        .iter()
-        .map(|handle| {
-            handle.with_async(|node| async {
-                loop {
-                    if node.state().epoch_store_for_testing().epoch() == 1 {
-                        break;
-                    }
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                }
-            })
-        })
-        .collect();
-    join_all(handles).await;
+    trigger_reconfiguration(&authorities).await;
 }
 
 // This test just starts up a cluster that reconfigures itself under 0 load.
@@ -183,20 +166,35 @@ async fn test_validator_resign_effects() {
     assert_eq!(effects0.epoch(), 0);
     // Give it enough time for the transaction to be checkpointed and hence finalized.
     sleep(Duration::from_secs(10)).await;
-    for handle in authorities {
-        let mut new_committee = net.committee.clone();
-        new_committee.epoch = 1;
-        handle
-            .with_async(
-                |node| async move { node.state().reconfigure(new_committee).await.unwrap() },
-            )
-            .await;
-    }
+    trigger_reconfiguration(&authorities).await;
+    // Manually reconfigure the aggregator.
     net.committee.epoch = 1;
     let effects1 = net.process_certificate(cert.into_inner()).await.unwrap();
     // Ensure that we are able to form a new effects cert in the new epoch.
     assert_eq!(effects1.epoch(), 1);
     assert_eq!(effects0.into_message(), effects1.into_message());
+}
+
+async fn trigger_reconfiguration(authorities: &[SuiNodeHandle]) {
+    // Close epoch on 3 (2f+1) validators.
+    for handle in authorities.iter().skip(1) {
+        handle.with(|node| node.close_epoch().unwrap());
+    }
+    // Wait for all nodes to reach the next epoch.
+    let handles: Vec<_> = authorities
+        .iter()
+        .map(|handle| {
+            handle.with_async(|node| async {
+                loop {
+                    if node.state().epoch_store_for_testing().epoch() == 1 {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            })
+        })
+        .collect();
+    join_all(handles).await;
 }
 
 /*


### PR DESCRIPTION
Obtain the epoch store at the beginning of the handle certificate in authority_server, and pass it along the way. This ensures we are always using the same epoch store. Also unified the use of the epoch store in checkpoint executor.