### PR TITLE
Fix flaky simtest

### DIFF
--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -38,7 +38,7 @@ use sui_types::{
 use tokio::time::timeout;
 use tracing::{info, warn};
 
-const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(15);
+const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(30);
 /// The maximum gas per transaction.
 pub const MAX_GAS: u64 = 2_000;
 


### PR DESCRIPTION
This test always fails on my Mac, but passes on CI. Increasing timeout helps it pass.

```
--- STDERR:                             sui::full_node_tests test_full_node_follows_txes ---
thread '<unnamed>' panicked at 'timed out waiting for effects of digest! deadline has elapsed', /Users/xun/github/sui-upstream/crates/sui-core/src/test_utils.rs:75:13
stack backtrace:
   0: rust_begin_unwind
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:142:14
   2: sui_core::test_utils::wait_for_tx::{{closure}}
             at /Users/xun/github/sui-upstream/crates/sui-core/src/test_utils.rs:75:13
   3: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/mod.rs:91:19
   4: full_node_tests::test_full_node_follows_txes::{{closure}}::{{closure}}::{{closure}}
             at ./tests/full_node_tests.rs:66:46
   5: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/mod.rs:91:19
   6: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/future/future.rs:124:9
   7: async_task::raw::RawTask<F,T,S>::run
             at /Users/xun/.cargo/git/checkouts/async-task-2c3ead35a682b15c/4e45b26/src/raw.rs:511:20
   8: msim::sim::task::Executor::run_all_ready
             at /Users/xun/.cargo/git/checkouts/mysten-sim-6c6e892b5d19dc47/465f7d6/msim/src/sim/task.rs:176:13
   9: msim::sim::task::Executor::block_on
             at /Users/xun/.cargo/git/checkouts/mysten-sim-6c6e892b5d19dc47/465f7d6/msim/src/sim/task.rs:142:13
  10: msim::sim::runtime::Runtime::block_on
             at /Users/xun/.cargo/git/checkouts/mysten-sim-6c6e892b5d19dc47/465f7d6/msim/src/sim/runtime/mod.rs:132:9
  11: full_node_tests::test_full_node_follows_txes::{{closure}}
             at ./tests/full_node_tests.rs:81:7
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
   Canceling due to test failure: 8 tests still running
        PASS [   2.554s]                sui::full_node_tests test_get_objects_read
        PASS [   2.047s]          sui::reconfiguration_tests local_advance_epoch_tx_test
        PASS [   6.583s]                sui::full_node_tests test_full_node_shared_objects
        PASS [   2.546s]           sui::shared_objects_tests many_shared_object_transactions
        PASS [   3.063s]           sui::shared_objects_tests call_shared_object_contract
        PASS [   5.084s]          sui::reconfiguration_tests basic_reconfig_end_to_end_test
        PASS [   9.624s]                sui::full_node_tests test_full_node_sub_and_query_move_event_ok
        PASS [   8.103s]          sui::reconfiguration_tests network_advance_epoch_tx_test
        PASS [  12.147s]                sui::full_node_tests test_full_node_transaction_streaming_basic
        PASS [  25.286s]                sui::full_node_tests test_full_node_sync_flood
------------
     Summary [  25.297s] 18/65 tests run: 17 passed, 1 failed, 6 skipped
        FAIL [   5.095s]                sui::full_node_tests test_full_node_follows_txes
error: test run failed
```