### PR TITLE
Add SuiAuthorityStrongQuorumSignInfo and use it in the JSON RPCs instead of AuthorityStrongQuorumSignInfo

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -27,6 +27,7 @@ use crate::ValidatorProxy;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
+use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::messages::VerifiedTransaction;
 use tokio::sync::Barrier;
 use tokio::time;
@@ -337,7 +338,8 @@ impl Driver<BenchmarkStats> for BenchDriver {
                                                 metrics_cloned.latency_s.with_label_values(&[&b.1.get_workload_type().to_string()]).observe(latency.as_secs_f64());
                                                 metrics_cloned.num_success.with_label_values(&[&b.1.get_workload_type().to_string()]).inc();
                                                 metrics_cloned.num_in_flight.with_label_values(&[&b.1.get_workload_type().to_string()]).dec();
-                                                cert.auth_sign_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_tx_cert.with_label_values(&[&name.unwrap().to_string()]).inc());
+                                                let auth_sign_info = AuthorityStrongQuorumSignInfo::try_from(&cert.auth_sign_info).unwrap();
+                                                auth_sign_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_tx_cert.with_label_values(&[&name.unwrap().to_string()]).inc());
                                                 if let Some(sig_info) = effects.quorum_sig() {
                                                     sig_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_effects_cert.with_label_values(&[&name.unwrap().to_string()]).inc())
                                                 }
@@ -384,7 +386,8 @@ impl Driver<BenchmarkStats> for BenchDriver {
                                             metrics_cloned.latency_s.with_label_values(&[&payload.get_workload_type().to_string()]).observe(latency.as_secs_f64());
                                             metrics_cloned.num_success.with_label_values(&[&payload.get_workload_type().to_string()]).inc();
                                             metrics_cloned.num_in_flight.with_label_values(&[&payload.get_workload_type().to_string()]).dec();
-                                            cert.auth_sign_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_tx_cert.with_label_values(&[&name.unwrap().to_string()]).inc());
+                                            let auth_sign_info = AuthorityStrongQuorumSignInfo::try_from(&cert.auth_sign_info).unwrap();
+                                            auth_sign_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_tx_cert.with_label_values(&[&name.unwrap().to_string()]).inc());
                                             if let Some(sig_info) = effects.quorum_sig() { sig_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_effects_cert.with_label_values(&[&name.unwrap().to_string()]).inc()) }
                                             NextOp::Response(Some((
                                                 latency,

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1803,6 +1803,10 @@ impl TryFrom<CertifiedTransaction> for SuiCertifiedTransaction {
     fn try_from(cert: CertifiedTransaction) -> Result<Self, Self::Error> {
         let digest = *cert.digest();
         let (data, sig) = cert.into_data_and_sig();
+        // We should always have a signature here.
+        if sig.signature.sig.is_none() {
+            return Err(anyhow::anyhow!("Certified transaction is not signed"));
+        }
         Ok(Self {
             transaction_digest: digest,
             data: data.intent_message.value.try_into()?,
@@ -1855,6 +1859,10 @@ impl SuiCertifiedTransactionEffects {
     ) -> Result<Self, anyhow::Error> {
         let digest = *cert.digest();
         let (effects, auth_sign_info) = cert.into_data_and_sig();
+        // We should always have a signature here.
+        if auth_sign_info.signature.sig.is_none() {
+            return Err(anyhow::anyhow!("No quorum signature."));
+        }
         Ok(Self {
             transaction_effects_digest: digest,
             effects: SuiTransactionEffects::try_from(effects, resolver)?,

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -38,7 +38,7 @@ use sui_types::base_types::{
 };
 use sui_types::coin::CoinMetadata;
 use sui_types::committee::EpochId;
-use sui_types::crypto::{AuthorityStrongQuorumSignInfo, Signature};
+use sui_types::crypto::{Signature, SuiAuthorityStrongQuorumSignInfo};
 use sui_types::dynamic_field::DynamicFieldInfo;
 use sui_types::error::{ExecutionError, SuiError};
 use sui_types::event::{BalanceChangeType, Event, EventID};
@@ -1779,7 +1779,7 @@ pub struct SuiCertifiedTransaction {
     /// tx_signature is signed by the transaction sender, committing to the intent message containing the transaction data and intent.
     pub tx_signature: Signature,
     /// authority signature information, if available, is signed by an authority, applied on `data`.
-    pub auth_sign_info: AuthorityStrongQuorumSignInfo,
+    pub auth_sign_info: SuiAuthorityStrongQuorumSignInfo,
 }
 
 impl Display for SuiCertifiedTransaction {
@@ -1807,7 +1807,7 @@ impl TryFrom<CertifiedTransaction> for SuiCertifiedTransaction {
             transaction_digest: digest,
             data: data.intent_message.value.try_into()?,
             tx_signature: data.tx_signature,
-            auth_sign_info: sig,
+            auth_sign_info: SuiAuthorityStrongQuorumSignInfo::from(&sig),
         })
     }
 }
@@ -1827,7 +1827,7 @@ pub struct SuiCertifiedTransactionEffects {
     pub transaction_effects_digest: TransactionEffectsDigest,
     pub effects: SuiTransactionEffects,
     /// authority signature information signed by the quorum of the validators.
-    pub auth_sign_info: AuthorityStrongQuorumSignInfo,
+    pub auth_sign_info: SuiAuthorityStrongQuorumSignInfo,
 }
 
 impl Display for SuiCertifiedTransactionEffects {
@@ -1858,7 +1858,7 @@ impl SuiCertifiedTransactionEffects {
         Ok(Self {
             transaction_effects_digest: digest,
             effects: SuiTransactionEffects::try_from(effects, resolver)?,
-            auth_sign_info,
+            auth_sign_info: SuiAuthorityStrongQuorumSignInfo::from(&auth_sign_info),
         })
     }
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -363,7 +363,7 @@
                 "txSignature": "AG+IXPpjofhGMG9roBEk00xzpNPsBOM6JtTgRKRY8zyvWcwIyrU4qhHVesKT0Pon0W0xP0b6SqIFneWxTvDC4gMETxNsaJH6UBKN/GfiZ46X8iMV/dyLU/zHwVMrBp9VTQ==",
                 "authSignInfo": {
                   "epoch": 0,
-                  "signature": "",
+                  "signature": "AaCQESRLSxMntCxHAXuRk66nmlID2DZn3gU64vkZ7iHSjE2Nbhfr21Ovri7AMdAl4Q==",
                   "signers_map": [
                     58,
                     48,
@@ -1613,7 +1613,7 @@
                 "txSignature": "AGByrNPNX8XcfZpqbzGkBmwlWFJmkPRthbjEleR/MRadhudsaGF+6p6MMw0mjPvsQ+fuSb/O0vTp+2eLhekupQTlSWjlOED/V6Eca5zv6KJs5sFfQMs6XCZi8IwJleWjPw==",
                 "authSignInfo": {
                   "epoch": 0,
-                  "signature": "",
+                  "signature": "AaCQESRLSxMntCxHAXuRk66nmlID2DZn3gU64vkZ7iHSjE2Nbhfr21Ovri7AMdAl4Q==",
                   "signers_map": [
                     58,
                     48,
@@ -2880,28 +2880,6 @@
           }
         ]
       },
-      "AuthorityQuorumSignInfo": {
-        "description": "Represents at least a quorum (could be more) of authority signatures. STRONG_THRESHOLD indicates whether to use the quorum threshold for quorum check. When STRONG_THRESHOLD is true, the quorum is valid when the total stake is at least the quorum threshold (2f+1) of the committee; when STRONG_THRESHOLD is false, the quorum is valid when the total stake is at least the validity threshold (f+1) of the committee.",
-        "type": "object",
-        "required": [
-          "epoch",
-          "signature",
-          "signers_map"
-        ],
-        "properties": {
-          "epoch": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "signature": {
-            "$ref": "#/components/schemas/Base64"
-          },
-          "signers_map": {
-            "$ref": "#/components/schemas/Base64"
-          }
-        }
-      },
       "Balance": {
         "type": "object",
         "required": [
@@ -2943,7 +2921,7 @@
             "description": "authority signature information, if available, is signed by an authority, applied on `data`.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/AuthorityQuorumSignInfo"
+                "$ref": "#/components/schemas/SuiAuthorityStrongQuorumSignInfo"
               }
             ]
           },
@@ -2976,7 +2954,7 @@
             "description": "authority signature information signed by the quorum of the validators.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/AuthorityQuorumSignInfo"
+                "$ref": "#/components/schemas/SuiAuthorityStrongQuorumSignInfo"
               }
             ]
           },
@@ -5156,6 +5134,27 @@
       },
       "SuiAddress": {
         "$ref": "#/components/schemas/Hex"
+      },
+      "SuiAuthorityStrongQuorumSignInfo": {
+        "type": "object",
+        "required": [
+          "epoch",
+          "signature",
+          "signers_map"
+        ],
+        "properties": {
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Base64"
+          },
+          "signers_map": {
+            "$ref": "#/components/schemas/Base64"
+          }
+        }
       },
       "SuiChangeEpoch": {
         "type": "object",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -6,6 +6,7 @@ use std::ops::Range;
 use std::str::FromStr;
 
 use fastcrypto::encoding::Base64;
+use fastcrypto::traits::AggregateAuthenticator;
 use fastcrypto::traits::KeyPair;
 use move_core_types::identifier::Identifier;
 use rand::rngs::StdRng;
@@ -29,8 +30,8 @@ use sui_types::base_types::{
 };
 use sui_types::crypto::AuthorityQuorumSignInfo;
 use sui_types::crypto::{
-    get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, Signature,
-    SuiAuthorityStrongQuorumSignInfo,
+    get_key_pair_from_rng, AccountKeyPair, AggregateAuthoritySignature, AuthorityKeyPair,
+    AuthorityPublicKeyBytes, AuthoritySignature, Signature, SuiAuthorityStrongQuorumSignInfo,
 };
 use sui_types::event::EventID;
 use sui_types::gas_coin::GasCoin;
@@ -463,7 +464,12 @@ impl RpcExampleProvider {
                 tx_signature: signature.clone(),
                 auth_sign_info: SuiAuthorityStrongQuorumSignInfo::from(&AuthorityQuorumSignInfo {
                     epoch: 0,
-                    signature: Default::default(),
+                    // We create a dummy signature since there is no such thing as a default valid
+                    // signature.
+                    signature: AggregateAuthoritySignature::aggregate(&vec![
+                        AuthoritySignature::default(),
+                    ])
+                    .unwrap(),
                     signers_map: Default::default(),
                 }),
             },

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -30,6 +30,7 @@ use sui_types::base_types::{
 use sui_types::crypto::AuthorityQuorumSignInfo;
 use sui_types::crypto::{
     get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, Signature,
+    SuiAuthorityStrongQuorumSignInfo,
 };
 use sui_types::event::EventID;
 use sui_types::gas_coin::GasCoin;
@@ -460,11 +461,11 @@ impl RpcExampleProvider {
                 transaction_digest: *tx_digest,
                 data: SuiTransactionData::try_from(data1).unwrap(),
                 tx_signature: signature.clone(),
-                auth_sign_info: AuthorityQuorumSignInfo {
+                auth_sign_info: SuiAuthorityStrongQuorumSignInfo::from(&AuthorityQuorumSignInfo {
                     epoch: 0,
                     signature: Default::default(),
                     signers_map: Default::default(),
-                },
+                }),
             },
             effects: SuiTransactionEffects {
                 status: SuiExecutionStatus::Success,

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -4,8 +4,8 @@ use anyhow::{anyhow, Error};
 use derive_more::From;
 use eyre::eyre;
 use fastcrypto::bls12381::min_sig::{
-    BLS12381AggregateSignature, BLS12381KeyPair, BLS12381PrivateKey, BLS12381PublicKey,
-    BLS12381Signature, BLS12381AggregateSignatureAsBytes,
+    BLS12381AggregateSignature, BLS12381AggregateSignatureAsBytes, BLS12381KeyPair,
+    BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature,
 };
 use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature};
 use fastcrypto::secp256k1::{Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1Signature};
@@ -40,6 +40,7 @@ use fastcrypto::hash::{HashFunction, Sha3_256};
 use std::fmt::Debug;
 
 pub use enum_dispatch::enum_dispatch;
+use fastcrypto::error::FastCryptoError;
 
 #[cfg(test)]
 #[path = "unit_tests/crypto_tests.rs"]
@@ -51,6 +52,7 @@ pub type AuthorityPublicKey = BLS12381PublicKey;
 pub type AuthorityPrivateKey = BLS12381PrivateKey;
 pub type AuthoritySignature = BLS12381Signature;
 pub type AggregateAuthoritySignature = BLS12381AggregateSignature;
+pub type AggregateAuthoritySignatureAsBytes = BLS12381AggregateSignatureAsBytes;
 
 // TODO(joyqvq): prefix these types with Default, DefaultAccountKeyPair etc
 pub type AccountKeyPair = Ed25519KeyPair;
@@ -1178,19 +1180,31 @@ pub type AuthorityWeakQuorumSignInfo = AuthorityQuorumSignInfo<false>;
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SuiAuthorityStrongQuorumSignInfo {
     pub epoch: EpochId,
-    pub signature: BLS12381AggregateSignatureAsBytes,
+    pub signature: AggregateAuthoritySignatureAsBytes,
     #[schemars(with = "Base64")]
     #[serde_as(as = "SuiBitmap")]
     pub signers_map: RoaringBitmap,
 }
 
 impl From<&AuthorityStrongQuorumSignInfo> for SuiAuthorityStrongQuorumSignInfo {
-    fn from(sig: &AuthorityStrongQuorumSignInfo) -> Self {
+    fn from(info: &AuthorityStrongQuorumSignInfo) -> Self {
         Self {
-            epoch: sig.epoch,
-            signature: BLS12381AggregateSignatureAsBytes::from(&sig.signature),
-            signers_map: sig.signers_map.clone()
+            epoch: info.epoch,
+            signature: (&info.signature).into(),
+            signers_map: info.signers_map.clone(),
         }
+    }
+}
+
+impl TryFrom<&SuiAuthorityStrongQuorumSignInfo> for AuthorityStrongQuorumSignInfo {
+    type Error = FastCryptoError;
+
+    fn try_from(info: &SuiAuthorityStrongQuorumSignInfo) -> Result<Self, Self::Error> {
+        Ok(Self {
+            epoch: info.epoch,
+            signature: (&info.signature).try_into()?,
+            signers_map: info.signers_map.clone(),
+        })
     }
 }
 

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1176,6 +1176,8 @@ pub struct AuthorityQuorumSignInfo<const STRONG_THRESHOLD: bool> {
 pub type AuthorityStrongQuorumSignInfo = AuthorityQuorumSignInfo<true>;
 pub type AuthorityWeakQuorumSignInfo = AuthorityQuorumSignInfo<false>;
 
+// Variant of [AuthorityStrongQuorumSignInfo] but with a serialized signature, to be used in
+// external APIs.
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SuiAuthorityStrongQuorumSignInfo {


### PR DESCRIPTION
Change the external interfaces to use a new type called `SuiAuthorityStrongQuorumSignInfo` which stores a serialized representation of the aggregated signature, instead of `AuthorityStrongQuorumSignInfo` which should be internal only.