### PR TITLE
[sdk] Add typescript types for `SuiMoveObject` fields field

### DIFF
--- a/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -223,7 +223,7 @@ export function TopValidatorsCard({ limit }: { limit?: number }) {
 
     const validatorData =
         data && isSuiObject(data.details) && isSuiMoveObject(data.details.data)
-            ? (data.details.data.fields as ValidatorState)
+            ? (data.details.data.fields as unknown as ValidatorState)
             : null;
 
     const tableData = useMemo(

--- a/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
@@ -20,7 +20,8 @@ export function useGetNFTMeta(objectID: string): NFTMetadata | null {
 
         const { details } = data || {};
         if (!isSuiObject(details) || !data) return null;
-        const fields = getObjectFields(data);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const fields = getObjectFields(data) as Record<string, any> | undefined;
         if (!fields?.url) return null;
         return {
             description:

--- a/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
@@ -20,8 +20,7 @@ export function useGetNFTMeta(objectID: string): NFTMetadata | null {
 
         const { details } = data || {};
         if (!isSuiObject(details) || !data) return null;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const fields = getObjectFields(data) as Record<string, any> | undefined;
+        const fields = getObjectFields(data);
         if (!fields?.url) return null;
         return {
             description:
@@ -29,7 +28,7 @@ export function useGetNFTMeta(objectID: string): NFTMetadata | null {
                     ? fields.description
                     : null,
             name: typeof fields.name === 'string' ? fields.name : null,
-            url: fields.url,
+            url: fields.url as string,
         };
     }, [data, isError]);
 

--- a/apps/wallet/src/ui/app/hooks/useMediaUrl.ts
+++ b/apps/wallet/src/ui/app/hooks/useMediaUrl.ts
@@ -10,7 +10,9 @@ export default function useMediaUrl(objData: SuiData | null) {
     const { fields } = (isSuiMoveObject(objData) && objData) || {};
     return useMemo(() => {
         if (fields) {
-            const mediaUrl = fields.url || fields.metadata?.fields.url;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const flds = fields as Record<string, any>;
+            const mediaUrl = flds.url || flds.metadata?.fields.url;
             if (typeof mediaUrl === 'string') {
                 return mediaUrl.replace(/^ipfs:\/\//, 'https://ipfs.io/ipfs/');
             }

--- a/apps/wallet/src/ui/app/hooks/useNFTBasicData.ts
+++ b/apps/wallet/src/ui/app/hooks/useNFTBasicData.ts
@@ -15,8 +15,7 @@ export default function useNFTBasicData(nftObj: SuiObject | null) {
     let nftFields = null;
     if (nftObj && isSuiMoveObject(nftObj.data)) {
         objType = nftObj.data.type;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        nftFields = getObjectFields(nftObj.data) as
+        nftFields = getObjectFields(nftObj.data) as  // eslint-disable-next-line @typescript-eslint/no-explicit-any
             | Record<string, any>
             | undefined;
     }

--- a/apps/wallet/src/ui/app/hooks/useNFTBasicData.ts
+++ b/apps/wallet/src/ui/app/hooks/useNFTBasicData.ts
@@ -15,7 +15,10 @@ export default function useNFTBasicData(nftObj: SuiObject | null) {
     let nftFields = null;
     if (nftObj && isSuiMoveObject(nftObj.data)) {
         objType = nftObj.data.type;
-        nftFields = getObjectFields(nftObj.data);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        nftFields = getObjectFields(nftObj.data) as
+            | Record<string, any>
+            | undefined;
     }
     const fileExtensionType = useFileExtensionType(filePath || '');
     return {

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isSuiMoveObject, Coin as CoinAPI, SUI_TYPE_ARG } from '@mysten/sui.js';
+import {
+    isSuiMoveObject,
+    Coin as CoinAPI,
+    SUI_TYPE_ARG,
+    isSuiMoveValueUID,
+} from '@mysten/sui.js';
 
 import type {
     ObjectId,
@@ -45,11 +50,15 @@ export class Coin {
     }
 
     public static getBalance(obj: SuiMoveObject): bigint {
-        return BigInt(obj.fields.balance);
+        return BigInt(obj.fields.balance as string);
     }
 
     public static getID(obj: SuiMoveObject): ObjectId {
-        return obj.fields.id.id;
+        if (isSuiMoveValueUID(obj.fields.id)) {
+            return obj.fields.id.id;
+        } else {
+            throw new Error('Invalid coin object');
+        }
     }
 
     public static getCoinTypeFromArg(coinTypeArg: string) {

--- a/apps/wallet/src/ui/app/staking/home/ActiveDelegation.tsx
+++ b/apps/wallet/src/ui/app/staking/home/ActiveDelegation.tsx
@@ -38,7 +38,9 @@ export function ActiveDelegation({ id }: Props) {
         if (!validator) {
             return null;
         }
-        return Buffer.from(validator.fields.name, 'base64').toString();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const fields = validator.fields as Record<string, any>;
+        return Buffer.from(fields.name, 'base64').toString();
     }, [validator]);
 
     if (!validator || !delegation || !validatorName) {

--- a/apps/wallet/src/ui/app/staking/selectors.ts
+++ b/apps/wallet/src/ui/app/staking/selectors.ts
@@ -49,8 +49,10 @@ export function getValidatorSelector(validatorAddress?: string) {
     return createSelector(suiSystemObjectSelector, (systemObj) => {
         const { data } = systemObj || {};
         if (isSuiMoveObject(data)) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const fields = data.fields as Record<string, any>;
             const { active_validators: active, next_epoch_validators: next } =
-                data.fields.validators.fields;
+                fields.validators.fields;
             const validator: SuiMoveObject | undefined = [
                 ...active.map((v: SuiMoveObject) => v.fields.metadata),
                 ...next,

--- a/apps/wallet/src/ui/app/staking/stake/SelectValidatorCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/SelectValidatorCard.tsx
@@ -27,7 +27,7 @@ export function SelectValidatorCard() {
 
     const validatorsData =
         data && isSuiObject(data.details) && isSuiMoveObject(data.details.data)
-            ? (data.details.data.fields as ValidatorState)
+            ? (data.details.data.fields as unknown as ValidatorState)
             : null;
 
     const validators = useMemo(() => {

--- a/apps/wallet/src/ui/app/staking/stake/ValidatorDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/ValidatorDetailCard.tsx
@@ -28,7 +28,7 @@ export function ValidateDetailFormCard({
 
     const validatorsData =
         data && isSuiObject(data.details) && isSuiMoveObject(data.details.data)
-            ? (data.details.data.fields as ValidatorState)
+            ? (data.details.data.fields as unknown as ValidatorState)
             : null;
 
     const validatorByAddress = useMemo(() => {

--- a/apps/wallet/src/ui/app/staking/usePendingDelegation.tsx
+++ b/apps/wallet/src/ui/app/staking/usePendingDelegation.tsx
@@ -84,7 +84,8 @@ export function usePendingDelegation(): [PendingDelegation[], UseQueryResult] {
             return [];
         }
 
-        const systemState = data.details.data.fields as SystemStateObject;
+        const systemState = data.details.data
+            .fields as unknown as SystemStateObject;
 
         const pendingDelegationsPerValidator =
             systemState.validators.fields.active_validators

--- a/sdk/typescript/src/types/framework.ts
+++ b/sdk/typescript/src/types/framework.ts
@@ -16,7 +16,7 @@ import { normalizeSuiObjectId, SuiAddress } from './common';
 
 import { getOption, Option } from './option';
 import { StructTag } from './sui-bcs';
-import { isSuiMoveObject } from './index.guard';
+import { isSuiMoveObject, isSuiMoveValueUID } from './index.guard';
 import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
 
 export const SUI_FRAMEWORK_ADDRESS = '0x2';
@@ -83,7 +83,11 @@ export class Coin {
 
   public static getID(obj: ObjectData): ObjectId {
     if (isSuiMoveObject(obj)) {
-      return obj.fields.id.id;
+      if (isSuiMoveValueUID(obj.fields.id)) {
+        return obj.fields.id.id;
+      } else {
+        throw new Error('Invalid coin object');
+      }
     }
     return getObjectId(obj);
   }
@@ -197,7 +201,7 @@ export class Coin {
       return undefined;
     }
     const balance = getObjectFields(data)?.balance;
-    return BigInt(balance);
+    return BigInt(balance as string);
   }
 
   static getZero(): bigint {

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -7,7 +7,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, Order, MoveEvent, PublishEvent, CoinBalanceChangeEvent, TransferObjectEvent, MutateObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventQuery, EventId, PaginatedEvents, EventType, BalanceChangeType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, Pay, PaySui, PayAllSui, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, DevInspectResults, DevInspectResultsType, DevInspectResultTupleType, ExecutionResultType, MutableReferenceOutputType, ReturnValueType, TransactionEffects, SuiTransactionResponse, SuiTransactionAuthSignersResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, PaginatedTransactionDigests, TransactionQuery, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, CoinMetadata, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PayTx, PaySuiTx, PayAllSuiTx, PublishTx, SharedObjectRef, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData, RpcApiVersion, FaucetCoinInfo, FaucetResponse } from "./index";
+import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, MovePackageContent, SuiData, SuiMoveValueUID, SuiMoveValue, SuiMoveStructWithFields, SuiMoveStructWithTypes, SuiMoveStruct, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, Order, MoveEvent, PublishEvent, CoinBalanceChangeEvent, TransferObjectEvent, MutateObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventQuery, EventId, PaginatedEvents, EventType, BalanceChangeType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, Pay, PaySui, PayAllSui, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, DevInspectResults, DevInspectResultsType, DevInspectResultTupleType, ExecutionResultType, MutableReferenceOutputType, ReturnValueType, TransactionEffects, SuiTransactionResponse, SuiTransactionAuthSignersResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, PaginatedTransactionDigests, TransactionQuery, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, CoinMetadata, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PayTx, PaySuiTx, PayAllSuiTx, PublishTx, SharedObjectRef, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData, RpcApiVersion, FaucetCoinInfo, FaucetResponse } from "./index";
 
 export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
     return (
@@ -65,16 +65,6 @@ export function isSuiObjectInfo(obj: any, _argumentName?: string): obj is SuiObj
     )
 }
 
-export function isObjectContentFields(obj: any, _argumentName?: string): obj is ObjectContentFields {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        Object.entries<any>(obj)
-            .every(([key, _value]) => (isTransactionDigest(key) as boolean))
-    )
-}
-
 export function isMovePackageContent(obj: any, _argumentName?: string): obj is MovePackageContent {
     return (
         (obj !== null &&
@@ -101,13 +91,72 @@ export function isSuiData(obj: any, _argumentName?: string): obj is SuiData {
     )
 }
 
+export function isSuiMoveValueUID(obj: any, _argumentName?: string): obj is SuiMoveValueUID {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        isTransactionDigest(obj.id) as boolean
+    )
+}
+
+export function isSuiMoveValue(obj: any, _argumentName?: string): obj is SuiMoveValue {
+    return (
+        (obj === null ||
+            isTransactionDigest(obj) as boolean ||
+            isSuiMoveTypeParameterIndex(obj) as boolean ||
+            obj === false ||
+            obj === true ||
+            isSuiMoveValueUID(obj) as boolean ||
+            isSuiMoveStructWithTypes(obj) as boolean ||
+            Array.isArray(obj) &&
+            obj.every((e: any) =>
+            (e === null ||
+                isTransactionDigest(e) as boolean ||
+                isSuiMoveTypeParameterIndex(e) as boolean ||
+                e === false ||
+                e === true ||
+                isSuiMoveValueUID(e) as boolean ||
+                isSuiMoveStructWithTypes(e) as boolean)
+            ))
+    )
+}
+
+export function isSuiMoveStructWithFields(obj: any, _argumentName?: string): obj is SuiMoveStructWithFields {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        Object.entries<any>(obj)
+            .every(([key, value]) => (isSuiMoveValue(value) as boolean &&
+                isTransactionDigest(key) as boolean))
+    )
+}
+
+export function isSuiMoveStructWithTypes(obj: any, _argumentName?: string): obj is SuiMoveStructWithTypes {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        isTransactionDigest(obj.type) as boolean &&
+        isSuiMoveStructWithFields(obj.fields) as boolean
+    )
+}
+
+export function isSuiMoveStruct(obj: any, _argumentName?: string): obj is SuiMoveStruct {
+    return (
+        (isSuiMoveStructWithTypes(obj) as boolean ||
+            isSuiMoveStructWithFields(obj) as boolean)
+    )
+}
+
 export function isSuiMoveObject(obj: any, _argumentName?: string): obj is SuiMoveObject {
     return (
         (obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
         isTransactionDigest(obj.type) as boolean &&
-        isObjectContentFields(obj.fields) as boolean &&
+        isSuiMoveStructWithFields(obj.fields) as boolean &&
         (typeof obj.has_public_transfer === "undefined" ||
             obj.has_public_transfer === false ||
             obj.has_public_transfer === true)

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ObjectOwner } from './common';
+import { ObjectOwner, SuiAddress } from './common';
 import { TransactionDigest } from './common';
 
 export type SuiObjectRef = {
@@ -19,8 +19,6 @@ export type SuiObjectInfo = SuiObjectRef & {
   previousTransaction: TransactionDigest;
 };
 
-export type ObjectContentFields = Record<string, any>;
-
 export type MovePackageContent = Record<string, string>;
 
 export type SuiData = { dataType: ObjectType } & (
@@ -28,11 +26,33 @@ export type SuiData = { dataType: ObjectType } & (
   | SuiMovePackage
 );
 
+export type SuiMoveValueUID = { id: ObjectId };
+
+type SuiMoveValueInner =
+  | number
+  | boolean
+  | SuiAddress
+  | string
+  | SuiMoveValueUID
+  | SuiMoveStructWithTypes
+  | null;
+
+export type SuiMoveValue = SuiMoveValueInner | SuiMoveValueInner[];
+
+export type SuiMoveStructWithFields = Record<string, SuiMoveValue>;
+
+export type SuiMoveStructWithTypes = {
+  type: string;
+  fields: SuiMoveStructWithFields;
+};
+
+export type SuiMoveStruct = SuiMoveStructWithTypes | SuiMoveStructWithFields;
+
 export type SuiMoveObject = {
   /** Move type (e.g., "0x2::coin::Coin<0x2::sui::SUI>") */
   type: string;
   /** Fields and values stored inside the Move object */
-  fields: ObjectContentFields;
+  fields: SuiMoveStructWithFields;
   has_public_transfer?: boolean;
 };
 
@@ -252,7 +272,7 @@ export function getMoveObjectType(
 
 export function getObjectFields(
   resp: GetObjectDataResponse | SuiMoveObject
-): ObjectContentFields | undefined {
+): SuiMoveStructWithFields | undefined {
   if ('fields' in resp) {
     return resp.fields;
   }


### PR DESCRIPTION
Replaced `export type ObjectContentFields = Record<string, any>` with proper field types based on https://github.com/MystenLabs/sui/blob/b8ace6ff5e3045f6e3fdd9a7ff076dfd2c236a61/crates/sui-json-rpc-types/src/lib.rs#L1173-L1184

The `SuiMoveStructWithFields` and `SuiMoveStructWithTypes` usage is based on the fact that the RPC will always return `MoveStruct::WithTypes` due to usage of default layout format options in `get_object_read` https://github.com/MystenLabs/sui/blob/9463a5bd7b5a1129537bc9c3d410bef65a85210e/crates/sui-core/src/authority.rs#L1765
And the fact that `SuiMoveObject` always has `SuiMoveStruct::WithFields` in the `fields` field https://github.com/MystenLabs/sui/blob/9463a5bd7b5a1129537bc9c3d410bef65a85210e/crates/sui-json-rpc-types/src/lib.rs#L832-L844


There were some type errors in the wallet and explorer so I converted them back to `Record<string, any>` as an escape hatch until proper type handling is implemented there.
