### PR TITLE
[epoch] Restart checkpoint service at epoch boundary

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -9,7 +9,6 @@ use anemo_tower::trace::DefaultOnFailure;
 use anemo_tower::trace::TraceLayer;
 use anyhow::anyhow;
 use anyhow::Result;
-use arc_swap::ArcSwapOption;
 use checkpoint_executor::CheckpointExecutor;
 use futures::TryFutureExt;
 use mysten_metrics::{spawn_monitored_task, RegistryService};
@@ -56,7 +55,8 @@ use sui_types::crypto::KeypairTraits;
 use sui_types::messages::VerifiedCertificate;
 use sui_types::messages::VerifiedCertifiedTransactionEffects;
 use tokio::sync::mpsc::channel;
-use tokio::sync::Mutex;
+use tokio::sync::{watch, Mutex};
+use tokio::task::JoinHandle;
 use tower::ServiceBuilder;
 use tracing::info;
 use typed_store::DBMetrics;
@@ -81,15 +81,19 @@ use sui_json_rpc::coin_api::CoinReadApi;
 use sui_types::error::{SuiError, SuiResult};
 
 pub struct ValidatorComponents {
-    _validator_server_handle: tokio::task::JoinHandle<Result<()>>,
+    validator_server_handle: tokio::task::JoinHandle<Result<()>>,
     narwhal_manager: NarwhalManager<ConsensusHandler<Arc<AuthorityStore>>>,
     consensus_adapter: Arc<ConsensusAdapter>,
-    checkpoint_service: Arc<CheckpointService>,
+    // dropping this will eventually stop checkpoint tasks. The receiver side of this channel
+    // is copied into each checkpoint service task, and they are listening to any change to this
+    // channel. When the sender is dropped, a change is triggered and those tasks will exit.
+    checkpoint_service_exit: watch::Sender<()>,
+    checkpoint_metrics: Arc<CheckpointMetrics>,
 }
 
 pub struct SuiNode {
     config: NodeConfig,
-    validator_components: ArcSwapOption<ValidatorComponents>,
+    validator_components: Mutex<Option<ValidatorComponents>>,
     _json_rpc_service: Option<ServerHandle>,
     state: Arc<AuthorityState>,
     active: Arc<ActiveAuthority<NetworkAuthorityClient>>,
@@ -242,7 +246,7 @@ impl SuiNode {
                     state.clone(),
                     checkpoint_store.clone(),
                     state_sync_handle.clone(),
-                    registry_service.clone(),
+                    &registry_service,
                 )
                 .await?,
             )
@@ -252,7 +256,7 @@ impl SuiNode {
 
         let node = Self {
             config: config.clone(),
-            validator_components: ArcSwapOption::new(validator_components),
+            validator_components: Mutex::new(validator_components),
             _json_rpc_service: json_rpc_service,
             state,
             active: active_authority,
@@ -278,19 +282,16 @@ impl SuiNode {
         Ok(node)
     }
 
-    pub fn close_epoch(&self) -> SuiResult {
+    pub async fn close_epoch(&self) -> SuiResult {
         self.validator_components
-            .load()
+            .lock()
+            .await
             .as_ref()
             .ok_or_else(|| SuiError::from("Node is not a validator"))?
             .consensus_adapter
             // TODO: If this function is ever called in non-testing code, we need to make sure this
             // function has no race with the passive reconfiguration.
             .close_epoch(&self.state.epoch_store())
-    }
-
-    pub fn validator_components(&self) -> Option<Arc<ValidatorComponents>> {
-        self.validator_components.load().clone()
     }
 
     fn create_p2p_network(
@@ -384,8 +385,8 @@ impl SuiNode {
         state: Arc<AuthorityState>,
         checkpoint_store: Arc<CheckpointStore>,
         state_sync_handle: state_sync::Handle,
-        registry_service: RegistryService,
-    ) -> Result<Arc<ValidatorComponents>> {
+        registry_service: &RegistryService,
+    ) -> Result<ValidatorComponents> {
         let consensus_config = config
             .consensus_config()
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?;
@@ -404,30 +405,82 @@ impl SuiNode {
         )
         .await?;
 
-        let checkpoint_service = Self::start_checkpoint_service(
-            config,
-            consensus_adapter.clone(),
-            checkpoint_store.clone(),
-            state.clone(),
-            state_sync_handle,
-            &registry_service,
-        );
-
         let narwhal_manager = Self::construct_and_run_narwhal_manager(
             config,
             consensus_config,
             state.clone(),
-            checkpoint_service.clone(),
             registry_service,
-        )
-        .await?;
+        )?;
 
-        Ok(Arc::new(ValidatorComponents {
-            _validator_server_handle: validator_server_handle,
+        let checkpoint_metrics = CheckpointMetrics::new(&registry_service.default_registry());
+        Self::start_epoch_specific_validator_components(
+            config,
+            state,
+            consensus_adapter,
+            checkpoint_store,
+            state_sync_handle,
+            narwhal_manager,
+            validator_server_handle,
+            checkpoint_metrics,
+        )
+        .await
+    }
+
+    async fn start_epoch_specific_validator_components(
+        config: &NodeConfig,
+        state: Arc<AuthorityState>,
+        consensus_adapter: Arc<ConsensusAdapter>,
+        checkpoint_store: Arc<CheckpointStore>,
+        state_sync_handle: state_sync::Handle,
+        narwhal_manager: NarwhalManager<ConsensusHandler<Arc<AuthorityStore>>>,
+        validator_server_handle: JoinHandle<Result<()>>,
+        checkpoint_metrics: Arc<CheckpointMetrics>,
+    ) -> Result<ValidatorComponents> {
+        let (checkpoint_service, checkpoint_service_exit) = Self::start_checkpoint_service(
+            config,
+            consensus_adapter.clone(),
+            checkpoint_store,
+            state.clone(),
+            state_sync_handle,
+            checkpoint_metrics.clone(),
+        );
+
+        let consensus_handler = Arc::new(ConsensusHandler::new(
+            state.epoch_store().clone(),
+            checkpoint_service,
+            state.transaction_manager().clone(),
+            state.db(),
+            state.metrics.clone(),
+        ));
+
+        let system_state = state
+            .get_sui_system_state_object()
+            .expect("Reading Sui system state object cannot fail");
+        let committee = Arc::new(system_state.get_current_epoch_narwhal_committee());
+
+        let transactions_addr = &config
+            .consensus_config
+            .as_ref()
+            .ok_or_else(|| anyhow!("Validator is missing consensus config"))?
+            .address;
+        let worker_cache = system_state.get_current_epoch_narwhal_worker_cache(transactions_addr);
+
+        let msg = NarwhalStartMessage {
+            committee: committee.clone(),
+            shared_worker_cache: SharedWorkerCache::from(worker_cache),
+            execution_state: consensus_handler,
+        };
+        info!("Sending start signal to Narwhal");
+        narwhal_manager.tx_start.send(msg).await?;
+        // TODO: (Laura) wait for start complete signal
+
+        Ok(ValidatorComponents {
+            validator_server_handle,
             narwhal_manager,
             consensus_adapter,
-            checkpoint_service,
-        }))
+            checkpoint_service_exit,
+            checkpoint_metrics,
+        })
     }
 
     fn start_checkpoint_service(
@@ -436,8 +489,8 @@ impl SuiNode {
         checkpoint_store: Arc<CheckpointStore>,
         state: Arc<AuthorityState>,
         state_sync_handle: state_sync::Handle,
-        registry_service: &RegistryService,
-    ) -> Arc<CheckpointService> {
+        checkpoint_metrics: Arc<CheckpointMetrics>,
+    ) -> (Arc<CheckpointService>, watch::Sender<()>) {
         let checkpoint_output = Box::new(SubmitCheckpointToConsensus {
             sender: consensus_adapter,
             signer: state.secret.clone(),
@@ -454,43 +507,24 @@ impl SuiNode {
             checkpoint_output,
             Box::new(certified_checkpoint_output),
             Box::new(NetworkTransactionCertifier::default()),
-            CheckpointMetrics::new(&registry_service.default_registry()),
+            checkpoint_metrics,
         )
     }
 
-    async fn construct_and_run_narwhal_manager(
+    fn construct_and_run_narwhal_manager(
         config: &NodeConfig,
         consensus_config: &ConsensusConfig,
         state: Arc<AuthorityState>,
-        checkpoint_service: Arc<CheckpointService>,
-        registry_service: RegistryService,
+        registry_service: &RegistryService,
     ) -> Result<NarwhalManager<ConsensusHandler<Arc<AuthorityStore>>>> {
-        let system_state = state
-            .get_sui_system_state_object()
-            .expect("Reading Sui system state object cannot fail");
-        let committee = Arc::new(system_state.get_current_epoch_narwhal_committee());
-
-        let transactions_addr = &config
-            .consensus_config
-            .as_ref()
-            .ok_or_else(|| anyhow!("Validator is missing consensus config"))?
-            .address;
-        let worker_cache = system_state.get_current_epoch_narwhal_worker_cache(transactions_addr);
-        let consensus_handler = Arc::new(ConsensusHandler::new(
-            state.epoch_store().clone(),
-            checkpoint_service,
-            state.transaction_manager().clone(),
-            state.db(),
-            state.metrics.clone(),
-        ));
         let narwhal_config = NarwhalConfiguration {
             primary_keypair: config.protocol_key_pair().copy(),
             network_keypair: config.network_key_pair().copy(),
             worker_ids_and_keypairs: vec![(0, config.worker_key_pair().copy())],
             storage_base_path: consensus_config.db_path().to_path_buf(),
             parameters: consensus_config.narwhal_config().to_owned(),
-            tx_validator: SuiTxValidator::new(state.clone(), &registry_service.default_registry()),
-            registry_service,
+            tx_validator: SuiTxValidator::new(state, &registry_service.default_registry()),
+            registry_service: registry_service.clone(),
         };
 
         let (tx_start, tr_start) = channel(1);
@@ -503,13 +537,6 @@ impl SuiNode {
             tx_start,
             tx_stop,
         };
-
-        let msg = NarwhalStartMessage {
-            committee: committee.clone(),
-            shared_worker_cache: SharedWorkerCache::from(worker_cache),
-            execution_state: consensus_handler,
-        };
-        narwhal_manager.tx_start.send(msg).await?;
 
         Ok(narwhal_manager)
     }
@@ -604,73 +631,74 @@ impl SuiNode {
                 ?next_epoch,
                 "Received reconfiguration signal. About to reconfigure the system."
             );
+
             let system_state = self
                 .state
                 .get_sui_system_state_object()
                 .expect("Reading Sui system state object cannot fail");
             let new_committee = system_state.get_current_epoch_committee();
             assert_eq!(next_epoch, new_committee.committee.epoch);
-            if let Some(validator_components) = self.validator_components() {
+            self.state
+                .reconfigure(new_committee.committee)
+                .await
+                .expect("Reconfigure authority state cannot fail");
+            info!("Validator State has been reconfigured");
+
+            // The following code handles 4 different cases, depending on whether the node
+            // was a validator in the previous epoch, and whether the node is a validator
+            // in the new epoch.
+            let new_validator_components = if let Some(ValidatorComponents {
+                validator_server_handle,
+                narwhal_manager,
+                consensus_adapter,
+                checkpoint_service_exit,
+                checkpoint_metrics,
+            }) = self.validator_components.lock().await.take()
+            {
                 info!("Reconfiguring the validator.");
-                info!("Shutting down Narwhal");
-                validator_components
-                    .narwhal_manager
-                    .tx_stop
-                    .send(())
-                    .await?;
+                // Stop the old checkpoint service.
+                drop(checkpoint_service_exit);
 
+                info!("Sending shutdown signal to Narwhal");
+                narwhal_manager.tx_stop.send(()).await?;
                 // TODO: (Laura) wait for stop complete signal
-                self.state
-                    .reconfigure(new_committee.committee)
-                    .await
-                    .expect("Reconfigure authority state cannot fail");
-                info!("Validator State has been reconfigured");
-                if self.state.is_validator() {
-                    // Only restart Narwhal if this node is still a validator.
-                    let narwhal_committee = system_state.get_current_epoch_narwhal_committee();
 
-                    let transactions_addr = &self
-                        .config
-                        .consensus_config
-                        .as_ref()
-                        .ok_or_else(|| anyhow!("Validator is missing consensus config"))?
-                        .address;
-                    let worker_cache =
-                        system_state.get_current_epoch_narwhal_worker_cache(transactions_addr);
-                    let consensus_handler = Arc::new(ConsensusHandler::new(
-                        self.state.epoch_store().clone(),
-                        validator_components.checkpoint_service.clone(),
-                        self.state.transaction_manager().clone(),
-                        self.state.db(),
-                        self.state.metrics.clone(),
-                    ));
-                    validator_components
-                        .narwhal_manager
-                        .tx_start
-                        .send(NarwhalStartMessage {
-                            committee: Arc::new(narwhal_committee),
-                            shared_worker_cache: SharedWorkerCache::from(worker_cache),
-                            execution_state: consensus_handler,
-                        })
-                        .await?;
-                    // TODO: (Laura) wait for start complete signal
-                    info!("Starting Narwhal");
+                if self.state.is_validator() {
+                    // Only restart Narwhal if this node is still a validator in the new epoch.
+                    Some(
+                        Self::start_epoch_specific_validator_components(
+                            &self.config,
+                            self.state.clone(),
+                            consensus_adapter,
+                            self.checkpoint_store.clone(),
+                            self.state_sync.clone(),
+                            narwhal_manager,
+                            validator_server_handle,
+                            checkpoint_metrics,
+                        )
+                        .await?,
+                    )
                 } else {
                     info!("This node is no longer a validator after reconfiguration");
+                    None
                 }
             } else if self.state.is_validator() {
                 info!("Promoting the node from fullnode to validator, starting grpc server");
 
-                let validator_components = Self::construct_validator_components(
-                    &self.config,
-                    self.state.clone(),
-                    self.checkpoint_store.clone(),
-                    self.state_sync.clone(),
-                    self.registry_service.clone(),
+                Some(
+                    Self::construct_validator_components(
+                        &self.config,
+                        self.state.clone(),
+                        self.checkpoint_store.clone(),
+                        self.state_sync.clone(),
+                        &self.registry_service,
+                    )
+                    .await?,
                 )
-                .await?;
-                self.validator_components.swap(Some(validator_components));
-            }
+            } else {
+                None
+            };
+            *self.validator_components.lock().await = new_validator_components;
             info!("Reconfiguration finished");
         }
     }

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -162,7 +162,9 @@ async fn reconfig_with_revert_end_to_end_test() {
 
     // Close epoch on 3 (2f+1) validators.
     for handle in authorities.iter().skip(1) {
-        handle.with(|node| node.close_epoch().unwrap());
+        handle
+            .with_async(|node| async { node.close_epoch().await.unwrap() })
+            .await;
     }
 
     // handle transaction on authority 0
@@ -298,7 +300,9 @@ async fn test_validator_resign_effects() {
 async fn trigger_reconfiguration(authorities: &[SuiNodeHandle]) {
     // Close epoch on 3 (2f+1) validators.
     for handle in authorities.iter().skip(1) {
-        handle.with(|node| node.close_epoch().unwrap());
+        handle
+            .with_async(|node| async { node.close_epoch().await.unwrap() })
+            .await;
     }
     // Wait for all nodes to reach the next epoch.
     let handles: Vec<_> = authorities


### PR DESCRIPTION
This PR makes the following changes:
1. Restart checkpoint service at epoch boundary. To do so, we take advantage of the exit sender created in the checkpoint service, and hold it in ValidatorComponents. At epoch boundary, we drop the sender to stop the existing checkpoint service, and then recreate it.
2. Merged some logic that creates validator components both at startup and during reconfiguration.
3. Fixes a bug where we don't reconfigure the state in the case of a fullnode.

A follow-up PR will be passing epoch store to the checkpoint service.