### PR TITLE
add tallying rule score metric and table to per epoch store

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -380,6 +380,9 @@ impl CheckpointExecutor {
             epoch_store.epoch(),
         );
 
+        // Record checkpoint participation for tallying rule.
+        epoch_store.record_certified_checkpoint_signatures(checkpoint.inner())?;
+
         let next_committee = checkpoint.summary().next_epoch_committee.clone();
         let highest_scheduled = checkpoint.sequence_number();
         let metrics = self.metrics.clone();

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1007,6 +1007,11 @@ impl CheckpointServiceNotify for CheckpointService {
             .skip_to_last()
             .next()
         {
+            // TODO(emmazzz): Right now we only record participation of validators whose
+            // checkpoint signatures make it to the certified checkpoint, which is only
+            // f+1 validators, and the rest of the signatures received are ignored. Later
+            // we may want to record those as well so that we have more fine grained scores
+            // for tallying rule.
             if sequence <= last_certified {
                 debug!(
                     "Ignore signature for checkpoint sequence {} from {} - already certified",

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
+use prometheus::{
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, IntGauge, IntGaugeVec,
+    Registry,
+};
 use std::sync::Arc;
 
 pub struct EpochMetrics {
@@ -74,6 +77,9 @@ pub struct EpochMetrics {
     /// to become useful in the network after reconfiguration.
     // TODO: This needs to be reported properly.
     pub epoch_first_checkpoint_ready_time_since_epoch_begin_ms: IntGauge,
+
+    /// Tallying rule scores for all validators this epoch.
+    pub tallying_rule_scores: IntGaugeVec,
 }
 
 impl EpochMetrics {
@@ -149,6 +155,12 @@ impl EpochMetrics {
             epoch_first_checkpoint_ready_time_since_epoch_begin_ms: register_int_gauge_with_registry!(
                 "epoch_first_checkpoint_created_time_since_epoch_begin_ms",
                 "Time interval from when the epoch opens at new epoch to the first checkpoint is created locally",
+                registry
+            ).unwrap(),
+            tallying_rule_scores: register_int_gauge_vec_with_registry!(
+                "tallying_rule_scores",
+                "Tallying rule scores for validators each epoch",
+                &["validator", "epoch"],
                 registry
             ).unwrap(),
         };

--- a/crates/sui-protocol-constants/src/lib.rs
+++ b/crates/sui-protocol-constants/src/lib.rs
@@ -112,9 +112,9 @@ pub const STORAGE_REBATE_RATE: f64 = 1.0;
 pub const STORAGE_FUND_REINVEST_RATE: u64 = 0;
 
 // TODO: placeholder value here
-// 50% of the active validators will have to report one validator as non-performant
+// 66.67% of the active validators will have to report one validator as non-performant
 // during an epoch before this validator's rewards for this epoch are slashed.
-pub const REWARD_SLASHING_THRESHOLD_BPS: u64 = 5000;
+pub const REWARD_SLASHING_THRESHOLD_BPS: u64 = 6667;
 
 // TODO: placeholder value here
 // The share of rewards that will be slashed and redistributed is 10%.


### PR DESCRIPTION
This PR adds a table and a metric to authority per epoch store so that each validator's participation in checkpoint's formation for an epoch can be kept and sent to use as their tallying rule score.