### PR TITLE
Fix latency calculations for batch -> header proposals

### DIFF
--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -235,7 +235,7 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
         for cert in &sub_dag.certificates {
             let mut batches = Vec::with_capacity(num_batches);
             let output_cert = cert.clone();
-            for (digest, worker_id) in cert.header.payload.iter() {
+            for (digest, (worker_id, _)) in cert.header.payload.iter() {
                 self.metrics
                     .subscriber_current_round
                     .set(cert.round() as i64);

--- a/narwhal/node/src/generate_format.rs
+++ b/narwhal/node/src/generate_format.rs
@@ -76,7 +76,11 @@ fn get_registry() -> Result<Registry> {
         .epoch(0)
         .created_at(0)
         .round(1)
-        .payload((0..4u32).map(|wid| (BatchDigest([0u8; 32]), wid)).collect())
+        .payload(
+            (0..4u32)
+                .map(|wid| (BatchDigest([0u8; 32]), (wid, 0u64)))
+                .collect(),
+        )
         .parents(certificates.iter().map(|x| x.digest()).collect())
         .build(&kp)
         .unwrap();

--- a/narwhal/node/tests/staged/narwhal.yaml
+++ b/narwhal/node/tests/staged/narwhal.yaml
@@ -48,7 +48,9 @@ Header:
         SEQ:
           TUPLE:
             - TYPENAME: BatchDigest
-            - U32
+            - TUPLE:
+                - U32
+                - U64
     - parents:
         SEQ:
           TYPENAME: CertificateDigest
@@ -99,4 +101,3 @@ WorkerSynchronizeMessage:
         SEQ:
           TYPENAME: BatchDigest
     - target: STR
-

--- a/narwhal/primary/src/block_synchronizer/mod.rs
+++ b/narwhal/primary/src/block_synchronizer/mod.rs
@@ -529,8 +529,13 @@ impl BlockSynchronizer {
         let mut futures = Vec::new();
 
         for certificate in certificates {
-            let payload: Vec<(BatchDigest, WorkerId)> =
-                certificate.header.payload.clone().into_iter().collect();
+            let payload: Vec<(BatchDigest, WorkerId)> = certificate
+                .header
+                .payload
+                .clone()
+                .into_iter()
+                .map(|(batch, (worker_id, _))| (batch, worker_id))
+                .collect();
 
             let payload_available = if certificate.header.author == self.name {
                 trace!(
@@ -665,7 +670,9 @@ impl BlockSynchronizer {
             .header
             .payload
             .iter()
-            .map(|(batch_digest, worker_id)| payload_store.notify_read((*batch_digest, *worker_id)))
+            .map(|(batch_digest, (worker_id, _))| {
+                payload_store.notify_read((*batch_digest, *worker_id))
+            })
             .collect::<Vec<_>>();
 
         // Wait for all the items to sync - have a timeout

--- a/narwhal/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/narwhal/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -59,8 +59,8 @@ async fn test_successful_headers_synchronization() {
 
         let header = author
             .header_builder(&committee)
-            .with_payload_batch(batch_1.clone(), worker_id_0)
-            .with_payload_batch(batch_2.clone(), worker_id_1)
+            .with_payload_batch(batch_1.clone(), worker_id_0, 0)
+            .with_payload_batch(batch_2.clone(), worker_id_1, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -200,8 +200,8 @@ async fn test_successful_payload_synchronization() {
 
         let header = author
             .header_builder(&committee)
-            .with_payload_batch(batch_1.clone(), worker_id_0)
-            .with_payload_batch(batch_2.clone(), worker_id_1)
+            .with_payload_batch(batch_1.clone(), worker_id_0, 0)
+            .with_payload_batch(batch_2.clone(), worker_id_1, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -373,7 +373,7 @@ async fn test_timeout_while_waiting_for_certificates() {
         .map(|_| {
             let header = author
                 .header_builder(&committee)
-                .with_payload_batch(fixture_batch_with_transactions(10), 0)
+                .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
                 .build(author.keypair())
                 .unwrap();
 
@@ -508,7 +508,7 @@ async fn test_reply_with_certificates_already_in_storage() {
 
         let header = author
             .header_builder(&committee)
-            .with_payload_batch(batch.clone(), 0)
+            .with_payload_batch(batch.clone(), 0, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -607,7 +607,7 @@ async fn test_reply_with_payload_already_in_storage() {
 
         let header = author
             .header_builder(&committee)
-            .with_payload_batch(batch.clone(), 0)
+            .with_payload_batch(batch.clone(), 0, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -619,8 +619,8 @@ async fn test_reply_with_payload_already_in_storage() {
         if i > NUM_OF_CERTIFICATES_WITH_MISSING_PAYLOAD {
             certificate_store.write(certificate.clone()).unwrap();
 
-            for entry in certificate.header.payload {
-                payload_store.async_write(entry, 1).await;
+            for (digest, (worker_id, _)) in certificate.header.payload {
+                payload_store.async_write((digest, worker_id), 1).await;
             }
         }
     }
@@ -710,7 +710,7 @@ async fn test_reply_with_payload_already_in_storage_for_own_certificates() {
 
         let header = primary
             .header_builder(&committee)
-            .with_payload_batch(batch.clone(), 0)
+            .with_payload_batch(batch.clone(), 0, 0)
             .build(primary.keypair())
             .unwrap();
 

--- a/narwhal/primary/src/block_synchronizer/tests/handler_tests.rs
+++ b/narwhal/primary/src/block_synchronizer/tests/handler_tests.rs
@@ -276,8 +276,8 @@ async fn test_synchronize_block_payload() {
         .build(author.keypair())
         .unwrap();
     let cert_stored = fixture.certificate(&header);
-    for e in cert_stored.clone().header.payload {
-        payload_store.async_write(e, 1).await;
+    for (digest, (worker_id, _)) in cert_stored.clone().header.payload {
+        payload_store.async_write((digest, worker_id), 1).await;
     }
 
     // AND a certificate with payload NOT available

--- a/narwhal/primary/src/block_waiter.rs
+++ b/narwhal/primary/src/block_waiter.rs
@@ -126,7 +126,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
             .header
             .payload
             .iter()
-            .map(|(batch_digest, worker_id)| {
+            .map(|(batch_digest, (worker_id, _))| {
                 debug!("Sending batch {batch_digest} request to worker id {worker_id}");
                 let worker_name = self
                     .worker_cache

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -1049,7 +1049,13 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
             if let Some(certificate) = certificate_option {
                 let payload_available = match self
                     .payload_store
-                    .read_all(certificate.header.payload)
+                    .read_all(
+                        certificate
+                            .header
+                            .payload
+                            .into_iter()
+                            .map(|(batch, (worker_id, _))| (batch, worker_id)),
+                    )
                     .await
                 {
                     Ok(payload_result) => payload_result.into_iter().all(|x| x.is_some()),

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -21,7 +21,7 @@ use types::{
     metered_channel::{Receiver, Sender},
     BatchDigest, Certificate, Header, Round, TimestampMs,
 };
-use types::{now, ConditionalBroadcastReceiver};
+use types::{now, Timestamp, ConditionalBroadcastReceiver};
 
 /// Messages sent to the proposer about our own batch digests
 #[derive(Debug)]
@@ -477,8 +477,11 @@ impl Proposer {
                             break;
                         }
 
+                        // Reset batch creation timer to now as we are attempting to resend an existing digest
+                        // that failed to be committed in a previous header.
+                        let created_at_timestamp = now();
                         digests_to_resend.extend(
-                            header.payload.iter().map(|(digest, worker)| (*digest, *worker, 0))
+                            header.payload.iter().map(|(digest, worker)| (*digest, *worker, created_at_timestamp))
                         );
                         retransmit_rounds.push(*round_header);
                     }

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -21,7 +21,7 @@ use types::{
     metered_channel::{Receiver, Sender},
     BatchDigest, Certificate, Header, Round, TimestampMs,
 };
-use types::{now, Timestamp, ConditionalBroadcastReceiver};
+use types::{now, ConditionalBroadcastReceiver};
 
 /// Messages sent to the proposer about our own batch digests
 #[derive(Debug)]

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -221,7 +221,7 @@ impl Proposer {
             this_epoch,
             digests
                 .iter()
-                .map(|(digest, worker_id, _)| (*digest, *worker_id))
+                .map(|(digest, worker_id, created_at)| (*digest, (*worker_id, *created_at)))
                 .collect(),
             parents.iter().map(|x| x.digest()).collect(),
             &self.signature_service,
@@ -477,11 +477,8 @@ impl Proposer {
                             break;
                         }
 
-                        // Reset batch creation timer to now as we are attempting to resend an existing digest
-                        // that failed to be committed in a previous header.
-                        let created_at_timestamp = now();
                         digests_to_resend.extend(
-                            header.payload.iter().map(|(digest, worker)| (*digest, *worker, created_at_timestamp))
+                            header.payload.iter().map(|(digest, (worker, created_at))| (*digest, *worker, *created_at))
                         );
                         retransmit_rounds.push(*round_header);
                     }

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -142,7 +142,7 @@ impl Synchronizer {
         );
 
         let mut missing = HashMap::new();
-        for (digest, worker_id) in header.payload.iter() {
+        for (digest, (worker_id, _)) in header.payload.iter() {
             // Check whether we have the batch. If one of our worker has the batch, the primary stores the pair
             // (digest, worker_id) in its own storage. It is important to verify that we received the batch
             // from the correct worker id to prevent the following attack:

--- a/narwhal/primary/src/tests/block_remover_tests.rs
+++ b/narwhal/primary/src/tests/block_remover_tests.rs
@@ -62,8 +62,8 @@ async fn test_successful_blocks_delete() {
 
         let header = author
             .header_builder(&committee)
-            .with_payload_batch(batch_1.clone(), worker_id_0)
-            .with_payload_batch(batch_2.clone(), worker_id_1)
+            .with_payload_batch(batch_1.clone(), worker_id_0, 0)
+            .with_payload_batch(batch_2.clone(), worker_id_1, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -226,8 +226,8 @@ async fn test_failed_blocks_delete() {
 
         let header = author
             .header_builder(&committee)
-            .with_payload_batch(batch_1.clone(), worker_id_0)
-            .with_payload_batch(batch_2.clone(), worker_id_1)
+            .with_payload_batch(batch_1.clone(), worker_id_0, 0)
+            .with_payload_batch(batch_2.clone(), worker_id_1, 0)
             .build(author.keypair())
             .unwrap();
 

--- a/narwhal/primary/src/tests/block_waiter_tests.rs
+++ b/narwhal/primary/src/tests/block_waiter_tests.rs
@@ -127,8 +127,8 @@ async fn test_successfully_retrieve_multiple_blocks() {
         let batch_2 = fixture_batch_with_transactions(10);
 
         builder = builder
-            .with_payload_batch(batch_1.clone(), worker_id)
-            .with_payload_batch(batch_2.clone(), worker_id);
+            .with_payload_batch(batch_1.clone(), worker_id, 0)
+            .with_payload_batch(batch_2.clone(), worker_id, 0);
 
         for b in [batch_1.clone(), batch_2.clone()] {
             let digest = b.digest();
@@ -158,8 +158,8 @@ async fn test_successfully_retrieve_multiple_blocks() {
         // batches will be used)
         if i > 5 {
             builder = builder
-                .with_payload_batch(common_batch_1.clone(), worker_id)
-                .with_payload_batch(common_batch_2.clone(), worker_id);
+                .with_payload_batch(common_batch_1.clone(), worker_id, 0)
+                .with_payload_batch(common_batch_2.clone(), worker_id, 0);
 
             for b in [common_batch_1.clone(), common_batch_2.clone()] {
                 let digest = b.digest();

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -263,7 +263,7 @@ async fn fetch_certificates_basic() {
     }
 
     // Avoid any sort of missing payload by pre-populating the batch
-    for (digest, worker_id) in headers.iter().flat_map(|h| h.payload.iter()) {
+    for (digest, (worker_id, _)) in headers.iter().flat_map(|h| h.payload.iter()) {
         payload_store.async_write((*digest, *worker_id), 0u8).await;
     }
 

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -329,7 +329,7 @@ async fn test_request_vote_missing_parents() {
     for i in 0..10 {
         let header = author
             .header_builder(&fixture.committee())
-            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -343,8 +343,8 @@ async fn test_request_vote_missing_parents() {
         // should be returned back as non found.
         if i < 5 {
             certificate_store.write(certificate.clone()).unwrap();
-            for payload in certificate.header.payload {
-                payload_store.async_write(payload, 1).await;
+            for (digest, (worker_id, _)) in certificate.header.payload {
+                payload_store.async_write((digest, worker_id), 1).await;
             }
         } else {
             missing_certificates.insert(digest, certificate.clone());
@@ -362,7 +362,7 @@ async fn test_request_vote_missing_parents() {
                 .cloned()
                 .collect(),
         )
-        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0, 0)
         .build(author.keypair())
         .unwrap();
     let mut request = anemo::Request::new(RequestVoteRequest {
@@ -494,7 +494,7 @@ async fn test_request_vote_missing_batches() {
     for primary in fixture.authorities().filter(|a| a.public_key() != name) {
         let header = primary
             .header_builder(&fixture.committee())
-            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0, 0)
             .build(primary.keypair())
             .unwrap();
 
@@ -503,15 +503,15 @@ async fn test_request_vote_missing_batches() {
 
         certificates.insert(digest, certificate.clone());
         certificate_store.write(certificate.clone()).unwrap();
-        for payload in certificate.header.payload {
-            payload_store.async_write(payload, 1).await;
+        for (digest, (worker_id, _)) in certificate.header.payload {
+            payload_store.async_write((digest, worker_id), 1).await;
         }
     }
     let test_header = author
         .header_builder(&fixture.committee())
         .round(2)
         .parents(certificates.keys().cloned().collect())
-        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1)
+        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1, 0)
         .build(author.keypair())
         .unwrap();
     let test_digests: HashSet<_> = test_header
@@ -613,7 +613,7 @@ async fn test_request_vote_already_voted() {
     for primary in fixture.authorities().filter(|a| a.public_key() != name) {
         let header = primary
             .header_builder(&fixture.committee())
-            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0, 0)
             .build(primary.keypair())
             .unwrap();
 
@@ -622,8 +622,8 @@ async fn test_request_vote_already_voted() {
 
         certificates.insert(digest, certificate.clone());
         certificate_store.write(certificate.clone()).unwrap();
-        for payload in certificate.header.payload {
-            payload_store.async_write(payload, 1).await;
+        for (digest, (worker_id, _)) in certificate.header.payload {
+            payload_store.async_write((digest, worker_id), 1).await;
         }
     }
 
@@ -649,7 +649,7 @@ async fn test_request_vote_already_voted() {
         .header_builder(&fixture.committee())
         .round(2)
         .parents(certificates.keys().cloned().collect())
-        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1)
+        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1, 0)
         .build(author.keypair())
         .unwrap();
     let mut request = anemo::Request::new(RequestVoteRequest {
@@ -692,7 +692,7 @@ async fn test_request_vote_already_voted() {
         .header_builder(&fixture.committee())
         .round(2)
         .parents(certificates.keys().cloned().collect())
-        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1)
+        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1, 0)
         .build(author.keypair())
         .unwrap();
     let mut request = anemo::Request::new(RequestVoteRequest {
@@ -929,7 +929,7 @@ async fn test_process_payload_availability_success() {
     for i in 0..10 {
         let header = author
             .header_builder(&fixture.committee())
-            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -945,8 +945,8 @@ async fn test_process_payload_availability_success() {
             // write the certificate
             certificate_store.write(certificate.clone()).unwrap();
 
-            for payload in certificate.header.payload {
-                payload_store.async_write(payload, 1).await;
+            for (digest, (worker_id, _)) in certificate.header.payload {
+                payload_store.async_write((digest, worker_id), 1).await;
             }
         } else {
             missing_certificates.insert(digest);
@@ -1071,7 +1071,7 @@ async fn test_process_payload_availability_when_failures() {
     for _ in 0..10 {
         let header = author
             .header_builder(&committee)
-            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -1163,7 +1163,7 @@ async fn test_request_vote_created_at_in_future() {
     for primary in fixture.authorities().filter(|a| a.public_key() != name) {
         let header = primary
             .header_builder(&fixture.committee())
-            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0, 0)
             .build(primary.keypair())
             .unwrap();
 
@@ -1172,8 +1172,8 @@ async fn test_request_vote_created_at_in_future() {
 
         certificates.insert(digest, certificate.clone());
         certificate_store.write(certificate.clone()).unwrap();
-        for payload in certificate.header.payload {
-            payload_store.async_write(payload, 1).await;
+        for (digest, (worker_id, _)) in certificate.header.payload {
+            payload_store.async_write((digest, worker_id), 1).await;
         }
     }
 
@@ -1203,7 +1203,7 @@ async fn test_request_vote_created_at_in_future() {
         .header_builder(&fixture.committee())
         .round(2)
         .parents(certificates.keys().cloned().collect())
-        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1)
+        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1, 0)
         .created_at(created_at)
         .build(author.keypair())
         .unwrap();
@@ -1233,7 +1233,7 @@ async fn test_request_vote_created_at_in_future() {
         .header_builder(&fixture.committee())
         .round(2)
         .parents(certificates.keys().cloned().collect())
-        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1)
+        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1, 0)
         .created_at(created_at)
         .build(author.keypair())
         .unwrap();

--- a/narwhal/primary/src/tests/proposer_tests.rs
+++ b/narwhal/primary/src/tests/proposer_tests.rs
@@ -20,7 +20,7 @@ async fn propose_empty() {
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let (_tx_parents, rx_parents) = test_utils::test_channel!(1);
-    let (_tx_commited_own_headers, rx_commited_own_headers) = test_utils::test_channel!(1);
+    let (_tx_committed_own_headers, rx_committed_own_headers) = test_utils::test_channel!(1);
     let (_tx_our_digests, rx_our_digests) = test_utils::test_channel!(1);
     let (tx_headers, mut rx_headers) = test_utils::test_channel!(1);
     let (tx_narwhal_round_updates, _rx_narwhal_round_updates) = watch::channel(0u64);
@@ -43,7 +43,7 @@ async fn propose_empty() {
         /* rx_workers */ rx_our_digests,
         /* tx_core */ tx_headers,
         tx_narwhal_round_updates,
-        rx_commited_own_headers,
+        rx_committed_own_headers,
         metrics,
     );
 
@@ -67,7 +67,7 @@ async fn propose_payload_and_repropose_after_n_seconds() {
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let (tx_parents, rx_parents) = test_utils::test_channel!(1);
     let (tx_our_digests, rx_our_digests) = test_utils::test_channel!(1);
-    let (_tx_commited_own_headers, rx_commited_own_headers) = test_utils::test_channel!(1);
+    let (_tx_committed_own_headers, rx_committed_own_headers) = test_utils::test_channel!(1);
     let (tx_headers, mut rx_headers) = test_utils::test_channel!(1);
     let (tx_narwhal_round_updates, _rx_narwhal_round_updates) = watch::channel(0u64);
 
@@ -92,7 +92,7 @@ async fn propose_payload_and_repropose_after_n_seconds() {
         /* rx_workers */ rx_our_digests,
         /* tx_core */ tx_headers,
         tx_narwhal_round_updates,
-        rx_commited_own_headers,
+        rx_committed_own_headers,
         metrics,
     );
 
@@ -102,12 +102,13 @@ async fn propose_payload_and_repropose_after_n_seconds() {
 
     let digest = BatchDigest(name_bytes);
     let worker_id = 0;
+    let created_at_ts = 0;
     let (tx_ack, rx_ack) = tokio::sync::oneshot::channel();
     tx_our_digests
         .send(OurDigestMessage {
             digest,
             worker_id,
-            timestamp: 0,
+            timestamp: created_at_ts,
             ack_channel: tx_ack,
         })
         .await
@@ -116,20 +117,24 @@ async fn propose_payload_and_repropose_after_n_seconds() {
     // Ensure the proposer makes a correct header from the provided payload.
     let header = rx_headers.recv().await.unwrap();
     assert_eq!(header.round, 1);
-    assert_eq!(header.payload.get(&digest), Some(&worker_id));
+    assert_eq!(
+        header.payload.get(&digest),
+        Some(&(worker_id, created_at_ts))
+    );
     assert!(header.verify(&committee, shared_worker_cache).is_ok());
 
     // WHEN available batches are more than the maximum ones
-    let batches: IndexMap<BatchDigest, WorkerId> = fixture_payload((max_num_of_batches * 2) as u8);
+    let batches: IndexMap<BatchDigest, (WorkerId, TimestampMs)> =
+        fixture_payload((max_num_of_batches * 2) as u8);
 
     let mut ack_list = vec![];
-    for (batch_id, worker_id) in batches {
+    for (batch_id, (worker_id, created_at)) in batches {
         let (tx_ack, rx_ack) = tokio::sync::oneshot::channel();
         tx_our_digests
             .send(OurDigestMessage {
                 digest: batch_id,
                 worker_id,
-                timestamp: 0,
+                timestamp: created_at,
                 ack_channel: tx_ack,
             })
             .await
@@ -188,7 +193,7 @@ async fn equivocation_protection() {
     let (tx_our_digests, rx_our_digests) = test_utils::test_channel!(1);
     let (tx_headers, mut rx_headers) = test_utils::test_channel!(1);
     let (tx_narwhal_round_updates, _rx_narwhal_round_updates) = watch::channel(0u64);
-    let (_tx_commited_own_headers, rx_commited_own_headers) = test_utils::test_channel!(1);
+    let (_tx_committed_own_headers, rx_committed_own_headers) = test_utils::test_channel!(1);
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     // Spawn the proposer.
@@ -208,7 +213,7 @@ async fn equivocation_protection() {
         /* rx_workers */ rx_our_digests,
         /* tx_core */ tx_headers,
         tx_narwhal_round_updates,
-        rx_commited_own_headers,
+        rx_committed_own_headers,
         metrics,
     );
 
@@ -218,12 +223,13 @@ async fn equivocation_protection() {
 
     let digest = BatchDigest(name_bytes);
     let worker_id = 0;
+    let created_at_ts = 0;
     let (tx_ack, rx_ack) = tokio::sync::oneshot::channel();
     tx_our_digests
         .send(OurDigestMessage {
             digest,
             worker_id,
-            timestamp: 0,
+            timestamp: created_at_ts,
             ack_channel: tx_ack,
         })
         .await
@@ -243,7 +249,10 @@ async fn equivocation_protection() {
 
     // Ensure the proposer makes a correct header from the provided payload.
     let header = rx_headers.recv().await.unwrap();
-    assert_eq!(header.payload.get(&digest), Some(&worker_id));
+    assert_eq!(
+        header.payload.get(&digest),
+        Some(&(worker_id, created_at_ts))
+    );
     assert!(header.verify(&committee, shared_worker_cache).is_ok());
 
     // restart the proposer.
@@ -255,7 +264,7 @@ async fn equivocation_protection() {
     let (tx_our_digests, rx_our_digests) = test_utils::test_channel!(1);
     let (tx_headers, mut rx_headers) = test_utils::test_channel!(1);
     let (tx_narwhal_round_updates, _rx_narwhal_round_updates) = watch::channel(0u64);
-    let (_tx_commited_own_headers, rx_commited_own_headers) = test_utils::test_channel!(1);
+    let (_tx_committed_own_headers, rx_committed_own_headers) = test_utils::test_channel!(1);
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     let _proposer_handle = Proposer::spawn(
@@ -274,7 +283,7 @@ async fn equivocation_protection() {
         /* rx_workers */ rx_our_digests,
         /* tx_core */ tx_headers,
         tx_narwhal_round_updates,
-        rx_commited_own_headers,
+        rx_committed_own_headers,
         metrics,
     );
 

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -201,7 +201,7 @@ async fn sync_batches_drops_old() {
     for _ in 0..3 {
         let header = author
             .header_builder(&fixture.committee())
-            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -210,15 +210,15 @@ async fn sync_batches_drops_old() {
 
         certificates.insert(digest, certificate.clone());
         certificate_store.write(certificate.clone()).unwrap();
-        for payload in certificate.header.payload {
-            payload_store.async_write(payload, 1).await;
+        for (digest, (worker_id, _)) in certificate.header.payload {
+            payload_store.async_write((digest, worker_id), 1).await;
         }
     }
     let test_header = author
         .header_builder(&fixture.committee())
         .round(2)
         .parents(certificates.keys().cloned().collect())
-        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1)
+        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1, 0)
         .build(author.keypair())
         .unwrap();
 

--- a/narwhal/primary/src/utils.rs
+++ b/narwhal/primary/src/utils.rs
@@ -11,7 +11,7 @@ pub fn map_certificate_batches_by_worker(
 ) -> HashMap<WorkerId, Vec<BatchDigest>> {
     let mut batches_by_worker: HashMap<WorkerId, Vec<BatchDigest>> = HashMap::new();
     for certificate in certificates.iter() {
-        for (batch_id, worker_id) in &certificate.header.payload {
+        for (batch_id, (worker_id, _)) in &certificate.header.payload {
             batches_by_worker
                 .entry(*worker_id)
                 .or_default()

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -64,7 +64,7 @@ async fn test_get_collections() {
 
         let header = author
             .header_builder(&committee)
-            .with_payload_batch(batch.clone(), worker_id)
+            .with_payload_batch(batch.clone(), worker_id, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -267,7 +267,7 @@ async fn test_remove_collections() {
 
         let header = author
             .header_builder(&committee)
-            .with_payload_batch(batch.clone(), worker_id)
+            .with_payload_batch(batch.clone(), worker_id, 0)
             .build(author.keypair())
             .unwrap();
 
@@ -1139,7 +1139,7 @@ async fn fixture_certificate(
     let batch_digest = batch.digest();
 
     let mut payload = IndexMap::new();
-    payload.insert(batch_digest, worker_id);
+    payload.insert(batch_digest, (worker_id, 0));
 
     let header = authority
         .header_builder(committee)

--- a/narwhal/storage/src/proposer_store.rs
+++ b/narwhal/storage/src/proposer_store.rs
@@ -57,7 +57,7 @@ mod test {
             .round(round)
             .epoch(0)
             .parents([CertificateDigest::default()].iter().cloned().collect())
-            .with_payload_batch(fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
             .build(primary.keypair())
             .unwrap();
         header

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -33,7 +33,7 @@ use types::{
     GetCertificatesResponse, Header, HeaderBuilder, PayloadAvailabilityRequest,
     PayloadAvailabilityResponse, PrimaryMessage, PrimaryToPrimary, PrimaryToPrimaryServer,
     PrimaryToWorker, PrimaryToWorkerServer, RequestBatchRequest, RequestBatchResponse,
-    RequestVoteRequest, RequestVoteResponse, Round, SequenceNumber, Transaction, Vote,
+    RequestVoteRequest, RequestVoteResponse, Round, SequenceNumber, TimestampMs, Transaction, Vote,
     WorkerBatchMessage, WorkerDeleteBatchesMessage, WorkerReconfigureMessage,
     WorkerSynchronizeMessage, WorkerToWorker, WorkerToWorkerServer,
 };
@@ -136,13 +136,13 @@ pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore>
     Arc::new(ConsensusStore::new(last_committed_map, sequence_map))
 }
 
-pub fn fixture_payload(number_of_batches: u8) -> IndexMap<BatchDigest, WorkerId> {
-    let mut payload: IndexMap<BatchDigest, WorkerId> = IndexMap::new();
+pub fn fixture_payload(number_of_batches: u8) -> IndexMap<BatchDigest, (WorkerId, TimestampMs)> {
+    let mut payload: IndexMap<BatchDigest, (WorkerId, TimestampMs)> = IndexMap::new();
 
     for _ in 0..number_of_batches {
         let batch_digest = batch().digest();
 
-        payload.insert(batch_digest, 0);
+        payload.insert(batch_digest, (0, 0));
     }
 
     payload
@@ -726,7 +726,7 @@ impl CommitteeFixture {
                     .round(round)
                     .epoch(0)
                     .parents(parents.clone())
-                    .with_payload_batch(fixture_batch_with_transactions(10), 0)
+                    .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
                     .build(a.keypair())
                     .unwrap()
             })

--- a/narwhal/types/src/tests/primary_type_tests.rs
+++ b/narwhal/types/src/tests/primary_type_tests.rs
@@ -33,7 +33,7 @@ fn clean_signed_header(kp: KeyPair) -> impl Strategy<Value = Header> {
         .prop_map(move |(round, epoch, batches, parents)| {
             let payload = batches
                 .into_iter()
-                .map(|(batch_digest, worker_id)| (batch_digest, worker_id as WorkerId))
+                .map(|(batch_digest, worker_id)| (batch_digest, (worker_id as WorkerId, 0)))
                 .collect();
 
             let parents = parents.into_iter().collect();

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -26,8 +26,8 @@ use tokio::{
 use types::{
     error::DagError,
     metered_channel::{Receiver, Sender},
-    Batch, BatchDigest, ConditionalBroadcastReceiver, PrimaryResponse, Transaction, TxResponse,
-    WorkerOurBatchMessage,
+    now, Batch, BatchDigest, ConditionalBroadcastReceiver, PrimaryResponse, Transaction,
+    TxResponse, WorkerOurBatchMessage,
 };
 
 // The number of batches to store / transmit in parallel.
@@ -267,7 +267,11 @@ impl BatchMaker {
         let store = self.store.clone();
         let worker_id = self.id;
         let tx_digest = self.tx_digest.clone();
-        let metadata = batch.metadata.clone();
+        let mut metadata = batch.metadata.clone();
+
+        // batch has been sealed so we can officially set its creation time for
+        // latency calculations.
+        metadata.created_at = now();
 
         Some(async move {
             // Now save it to disk

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -174,7 +174,7 @@ impl BatchMaker {
     async fn seal(
         &self,
         timeout: bool,
-        batch: Batch,
+        mut batch: Batch,
         size: usize,
         responses: Vec<TxResponse>,
     ) -> Option<impl Future<Output = ()>> {
@@ -267,11 +267,11 @@ impl BatchMaker {
         let store = self.store.clone();
         let worker_id = self.id;
         let tx_digest = self.tx_digest.clone();
-        let mut metadata = batch.metadata.clone();
 
-        // batch has been sealed so we can officially set its creation time for
-        // latency calculations.
-        metadata.created_at = now();
+        // The batch has been sealed so we can officially set its creation time
+        // for latency calculations.
+        batch.metadata.created_at = now();
+        let metadata = batch.metadata.clone();
 
         Some(async move {
             // Now save it to disk


### PR DESCRIPTION
Retransmission of headers that were not committed was incorrectly setting the batch `created_at` timestamp to 0