### PR TITLE
Remove unnecessary await in TransactionManager

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1067,7 +1067,7 @@ impl AuthorityPerEpochStore {
         {
             // The certificate has already been inserted into the pending_certificates table by
             // process_consensus_transaction() above.
-            transaction_manager.enqueue(vec![certificate]).await?;
+            transaction_manager.enqueue(vec![certificate])?;
         }
         Ok(())
     }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -357,7 +357,7 @@ impl AuthorityStore {
 
     /// When making changes, please see if check_sequenced_input_objects() below needs
     /// similar changes as well.
-    pub async fn get_missing_input_objects(
+    pub fn get_missing_input_objects(
         &self,
         digest: &TransactionDigest,
         objects: &[InputObjectKind],

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -551,10 +551,7 @@ async fn execute_transactions(
         .epoch_store()
         .insert_pending_certificates(&synced_txns)?;
 
-    authority_state
-        .transaction_manager()
-        .enqueue(synced_txns)
-        .await?;
+    authority_state.transaction_manager().enqueue(synced_txns)?;
 
     // Once synced_txns have been awaited, all txns should have effects committed.
     let mut periods = 1;

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -94,7 +94,7 @@ pub async fn execution_process(
             }
 
             // Remove the certificate that finished execution from the pending_certificates table.
-            authority.certificate_executed(&digest).await;
+            authority.certificate_executed(&digest);
 
             authority
                 .metrics

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -402,13 +402,11 @@ async fn test_transaction_manager() {
     for cert in executed_shared_certs.iter().rev() {
         authorities[3]
             .enqueue_certificates_for_execution(vec![cert.clone()])
-            .await
             .unwrap();
     }
     for cert in executed_owned_certs.iter().rev() {
         authorities[3]
             .enqueue_certificates_for_execution(vec![cert.clone()])
-            .await
             .unwrap();
     }
 


### PR DESCRIPTION
Critical section in `TransactionManager` is short, so it is unnecessary to await on its methods.
- Changed TransactionManager inner lock to `parking_lot::Mutex`.
- Removed `async` from `AuthorityStore::get_missing_input_objects()` and all `TransactionManager` methods.