### PR TITLE
Improve tx digest logging

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1122,7 +1122,7 @@ impl AuthorityState {
         let mut deleted_dynamic_fields = vec![];
         for (id, _, _) in &effects.deleted {
             let Some(old_version) = modified_at_version.get(id) else{
-                error!("Error processing object owner index for tx [{}], cannot find modified at version for deleted object [{id}].", effects.transaction_digest);
+                error!("Error processing object owner index for tx [{:?}], cannot find modified at version for deleted object [{id}].", effects.transaction_digest);
                 continue;
             };
             match self.get_owner_at_version(id, *old_version)? {
@@ -1142,11 +1142,11 @@ impl AuthorityState {
             // For mutated objects, retrieve old owner and delete old index if there is a owner change.
             if let WriteKind::Mutate = kind {
                 let Some(old_version) = modified_at_version.get(id) else{
-                        error!("Error processing object owner index for tx [{}], cannot find modified at version for mutated object [{id}].", effects.transaction_digest);
+                        error!("Error processing object owner index for tx [{:?}], cannot find modified at version for mutated object [{id}].", effects.transaction_digest);
                         continue;
                     };
                 let Some(old_object) = self.database.get_object_by_key(id, *old_version)? else {
-                        error!("Error processing object owner index for tx [{}], cannot find object [{id}] at version [{old_version}].", effects.transaction_digest);
+                        error!("Error processing object owner index for tx [{:?}], cannot find object [{id}] at version [{old_version}].", effects.transaction_digest);
                         continue;
                     };
                 if &old_object.owner != owner {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -180,7 +180,7 @@ impl AuthorityStore {
             pending_certificates.len()
         );
         for digest in pending_certificates {
-            debug!("Reverting {} at the end of epoch", digest);
+            debug!("Reverting {:?} at the end of epoch", digest);
             self.revert_state_update(&digest).await?;
         }
         debug!("All uncommitted local transactions reverted");
@@ -1203,7 +1203,7 @@ impl AuthorityStore {
     pub async fn revert_state_update(&self, tx_digest: &TransactionDigest) -> SuiResult {
         let effects = self.get_effects_if_exists(tx_digest)?;
         let Some(effects) = effects else {
-            debug!("Not reverting {tx_digest} as it was not executed");
+            debug!("Not reverting {:?} as it was not executed", tx_digest);
             return Ok(())
         };
 

--- a/crates/sui-indexer/src/models/events.rs
+++ b/crates/sui-indexer/src/models/events.rs
@@ -74,7 +74,7 @@ pub fn event_to_new_event(e: SuiEventEnvelope) -> Result<NewEvent, IndexerError>
         ))
     })?;
     Ok(NewEvent {
-        transaction_digest: e.tx_digest.map(|digest| digest.to_string()),
+        transaction_digest: e.tx_digest.map(|digest| format!("{:?}", digest)),
         transaction_sequence: e.id.tx_seq,
         event_sequence: e.id.event_seq,
         event_time: Some(timestamp),

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -483,21 +483,6 @@ impl AsRef<[u8]> for TransactionDigest {
     }
 }
 
-impl fmt::Display for TransactionDigest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:#x}", self)
-    }
-}
-
-impl fmt::LowerHex for TransactionDigest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", Hex::encode(self))
-    }
-}
-
 /// Returns a Context for OpenTelemetry tracing from a TransactionDigest
 // NOTE: See https://github.com/MystenLabs/sui/issues/852
 // The current code doesn't really work.  Maybe the traceparent needs to be a specific format,


### PR DESCRIPTION
We print the string everywhere else in the logging as direct string format. This should be kept consistent so that we could find the same tx digest in the logging.