### PR TITLE
[rpc] Expose RPC endpoint for DevInspectMoveCall

### DIFF
--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -187,6 +187,24 @@ pub trait RpcFullNodeReadApi {
     #[method(name = "devInspectTransaction")]
     async fn dev_inspect_transaction(&self, tx_bytes: Base64) -> RpcResult<DevInspectResults>;
 
+    /// Similar to `dev_inspect_transaction` but do not require gas object and budget
+    #[method(name = "devInspectMoveCall")]
+    async fn dev_inspect_move_call(
+        &self,
+        /// the caller's Sui address
+        sender_address: SuiAddress,
+        /// the Move package ID, e.g. `0x2`
+        package_object_id: ObjectID,
+        /// the Move module name, e.g. `devnet_nft`
+        module: String,
+        /// the move function name, e.g. `mint`
+        function: String,
+        /// the type arguments of the Move function
+        type_arguments: Vec<SuiTypeTag>,
+        /// the arguments to be passed into the Move function, in [SuiJson](https://docs.sui.io/build/sui-json) format
+        arguments: Vec<SuiJsonValue>,
+    ) -> RpcResult<DevInspectResults>;
+
     /// Return transaction execution effects including the gas cost summary,
     /// while the effects are not committed to the chain.
     #[method(name = "dryRunTransaction")]

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -154,6 +154,78 @@
       ]
     },
     {
+      "name": "sui_devInspectMoveCall",
+      "tags": [
+        {
+          "name": "Full Node API"
+        }
+      ],
+      "description": "Similar to `dev_inspect_transaction` but do not require gas object and budget",
+      "params": [
+        {
+          "name": "sender_address",
+          "description": "the caller's Sui address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        },
+        {
+          "name": "package_object_id",
+          "description": "the Move package ID, e.g. `0x2`",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "module",
+          "description": "the Move module name, e.g. `devnet_nft`",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "function",
+          "description": "the move function name, e.g. `mint`",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "type_arguments",
+          "description": "the type arguments of the Move function",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TypeTag"
+            }
+          }
+        },
+        {
+          "name": "arguments",
+          "description": "the arguments to be passed into the Move function, in [SuiJson](https://docs.sui.io/build/sui-json) format",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SuiJsonValue"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "DevInspectResults",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/DevInspectResults"
+        }
+      }
+    },
+    {
       "name": "sui_devInspectTransaction",
       "tags": [
         {

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -224,9 +224,16 @@ impl TransactionBuilder {
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> anyhow::Result<TransactionData> {
-        let single_move_call = self
-            .single_move_call::<Mode>(package_object_id, module, function, type_args, call_args)
-            .await?;
+        let single_move_call = SingleTransactionKind::Call(
+            self.single_move_call::<Mode>(
+                package_object_id,
+                module,
+                function,
+                type_args,
+                call_args,
+            )
+            .await?,
+        );
         let input_objects = single_move_call
             .input_objects()?
             .iter()
@@ -248,14 +255,14 @@ impl TransactionBuilder {
         ))
     }
 
-    async fn single_move_call<Mode: ExecutionMode>(
+    pub async fn single_move_call<Mode: ExecutionMode>(
         &self,
         package_object_id: ObjectID,
         module: &str,
         function: &str,
         type_args: Vec<SuiTypeTag>,
         call_args: Vec<SuiJsonValue>,
-    ) -> anyhow::Result<SingleTransactionKind> {
+    ) -> anyhow::Result<MoveCall> {
         let package_ref = self.get_object_ref(package_object_id).await?;
         let module = Identifier::from_str(module)?;
         let function = Identifier::from_str(function)?;
@@ -275,13 +282,13 @@ impl TransactionBuilder {
             )
             .await?;
 
-        Ok(SingleTransactionKind::Call(MoveCall {
+        Ok(MoveCall {
             package: package_ref,
             module,
             function,
             type_arguments: type_args,
             arguments: call_args,
-        }))
+        })
     }
 
     async fn get_object_arg(
@@ -498,14 +505,16 @@ impl TransactionBuilder {
                         .await?
                 }
                 RPCTransactionRequestParams::MoveCallRequestParams(param) => {
-                    self.single_move_call::<Mode>(
-                        param.package_object_id,
-                        &param.module,
-                        &param.function,
-                        param.type_arguments,
-                        param.arguments,
+                    SingleTransactionKind::Call(
+                        self.single_move_call::<Mode>(
+                            param.package_object_id,
+                            &param.module,
+                            &param.function,
+                            param.type_arguments,
+                            param.arguments,
+                        )
+                        .await?,
                     )
-                    .await?
                 }
             };
             tx_kinds.push(single_tx);


### PR DESCRIPTION
This PR is based on https://github.com/MystenLabs/sui/pull/6999 and exposes the dev-inspect-move-call endpoint to RPC. I will follow up with another PR for exposing this in the TS-SDK