### PR TITLE
[checkpoints] Add more logs for better visibility

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -63,6 +63,7 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         let checkpoint_seq = summary.sequence_number;
+        debug!("Sending checkpoint signature at sequence {checkpoint_seq} to consensus");
         LogCheckpointOutput
             .checkpoint_created(summary, contents, epoch_store)
             .await?;


### PR DESCRIPTION
Specifically this adds logs around lifecycle of checkpoint messages - when we send/receive messages in checkpoint builder and aggregator and interaction with consensus.