### PR TITLE
adapter: move execution engine to adapter

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -3,14 +3,14 @@
 
 use std::{collections::BTreeSet, sync::Arc};
 
+use crate::execution_mode::{self, ExecutionMode};
 use move_core_types::language_storage::{ModuleId, StructTag};
 use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
-use sui_adapter::execution_mode::{self, ExecutionMode};
 use sui_types::base_types::{ObjectDigest, SequenceNumber};
 use sui_types::crypto::sha3_hash;
 use tracing::{debug, instrument};
 
-use sui_adapter::adapter;
+use crate::adapter;
 use sui_protocol_constants::{MAX_TX_GAS, STORAGE_FUND_REINVEST_RATE};
 use sui_types::coin::{transfer_coin, update_input_coins, Coin};
 use sui_types::committee::EpochId;
@@ -45,11 +45,7 @@ use sui_types::{
     MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 
-use crate::authority::TemporaryStore;
-
-#[cfg(test)]
-#[path = "unit_tests/pay_sui_tests.rs"]
-mod pay_sui_tests;
+use sui_types::temporary_store::TemporaryStore;
 
 #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
 pub fn execute_transaction_to_effects<
@@ -647,7 +643,7 @@ const FAKE_GAS_OBJECT: ObjectRef = (
     ObjectDigest::MIN,
 );
 
-pub(crate) fn manual_execute_move_call_fake_txn_digest(
+pub fn manual_execute_move_call_fake_txn_digest(
     sender: SuiAddress,
     move_call: MoveCall,
 ) -> TransactionDigest {
@@ -660,7 +656,7 @@ pub(crate) fn manual_execute_move_call_fake_txn_digest(
     TransactionDigest::new(sha3_hash(&txn_data))
 }
 
-pub(crate) fn manual_execute_move_call<
+pub fn manual_execute_move_call<
     Mode: ExecutionMode,
     S: BackingPackageStore + ParentSync + ChildObjectResolver,
 >(

--- a/crates/sui-adapter/src/lib.rs
+++ b/crates/sui-adapter/src/lib.rs
@@ -13,5 +13,6 @@ macro_rules! assert_invariant {
 }
 
 pub mod adapter;
+pub mod execution_engine;
 pub mod execution_mode;
 pub mod genesis;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -81,9 +81,10 @@ use crate::epoch::reconfiguration::ReconfigState;
 use crate::execution_driver::execution_process;
 use crate::module_cache_gauge::ModuleCacheGauge;
 use crate::{
-    event_handler::EventHandler, execution_engine, transaction_input_checker,
+    event_handler::EventHandler, transaction_input_checker,
     transaction_manager::TransactionManager, transaction_streamer::TransactionStreamer,
 };
+use sui_adapter::execution_engine;
 
 #[cfg(test)]
 #[path = "unit_tests/authority_tests.rs"]

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -13,7 +13,6 @@ pub mod consensus_validator;
 pub mod epoch;
 pub mod event_handler;
 mod execution_driver;
-pub mod execution_engine;
 mod histogram;
 pub mod metrics;
 mod module_cache_gauge;
@@ -31,5 +30,9 @@ mod transaction_manager;
 pub mod transaction_orchestrator;
 pub mod transaction_streamer;
 pub mod validator_info;
+
+#[cfg(test)]
+#[path = "unit_tests/pay_sui_tests.rs"]
+mod pay_sui_tests;
 
 pub const SUI_CORE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -1,14 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::*;
-
 use crate::authority::authority_tests::{init_state, send_and_confirm_transaction};
 use crate::authority::AuthorityState;
 use futures::future::join_all;
 use std::collections::HashMap;
+use std::sync::Arc;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::crypto::AccountKeyPair;
-use sui_types::messages::SignedTransactionEffects;
+use sui_types::gas_coin::GasCoin;
+use sui_types::messages::{
+    ExecutionFailureStatus, ExecutionStatus, PayAllSui, PaySui, SignedTransactionEffects,
+    SingleTransactionKind, TransactionData,
+};
+use sui_types::object::Object;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
     base_types::dbg_addr, crypto::get_key_pair, error::SuiError, messages::TransactionKind,

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -36,8 +36,8 @@ use std::{
     path::Path,
     sync::Arc,
 };
+use sui_adapter::execution_engine;
 use sui_adapter::{adapter::new_move_vm, execution_mode, genesis};
-use sui_core::execution_engine;
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
 use sui_types::temporary_store::TemporaryStore;
 use sui_types::utils::to_sender_signed_transaction;


### PR DESCRIPTION
This pulls the execution engine into the sui-adapter crate making it easier to re-use in other crates without needing to depend on sui-core (which may be impossible if sui-core depends on the crate in question)