### PR TITLE
Temporarily disable object pruner

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -288,7 +288,9 @@ impl Default for AuthorityStorePruningConfig {
 impl AuthorityStorePruningConfig {
     pub fn validator_config() -> Self {
         Self {
-            objects_num_latest_versions_to_retain: 2,
+            // TODO: Temporarily disable the pruner, since we are not sure if it properly maintains
+            // most recent 2 versions with lamport versioning.
+            objects_num_latest_versions_to_retain: u64::MAX,
             objects_pruning_period_secs: 12 * 60 * 60,
             objects_pruning_initial_delay_secs: 60 * 60,
         }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -58,7 +58,7 @@ validator_configs:
     genesis:
       genesis: "[fake genesis]"
     authority-store-pruning-config:
-      objects-num-latest-versions-to-retain: 2
+      objects-num-latest-versions-to-retain: 18446744073709551615
       objects-pruning-period-secs: 43200
       objects-pruning-initial-delay-secs: 3600
     checkpoint-executor-config:
@@ -120,7 +120,7 @@ validator_configs:
     genesis:
       genesis: "[fake genesis]"
     authority-store-pruning-config:
-      objects-num-latest-versions-to-retain: 2
+      objects-num-latest-versions-to-retain: 18446744073709551615
       objects-pruning-period-secs: 43200
       objects-pruning-initial-delay-secs: 3600
     checkpoint-executor-config:
@@ -182,7 +182,7 @@ validator_configs:
     genesis:
       genesis: "[fake genesis]"
     authority-store-pruning-config:
-      objects-num-latest-versions-to-retain: 2
+      objects-num-latest-versions-to-retain: 18446744073709551615
       objects-pruning-period-secs: 43200
       objects-pruning-initial-delay-secs: 3600
     checkpoint-executor-config:
@@ -244,7 +244,7 @@ validator_configs:
     genesis:
       genesis: "[fake genesis]"
     authority-store-pruning-config:
-      objects-num-latest-versions-to-retain: 2
+      objects-num-latest-versions-to-retain: 18446744073709551615
       objects-pruning-period-secs: 43200
       objects-pruning-initial-delay-secs: 3600
     checkpoint-executor-config:
@@ -306,7 +306,7 @@ validator_configs:
     genesis:
       genesis: "[fake genesis]"
     authority-store-pruning-config:
-      objects-num-latest-versions-to-retain: 2
+      objects-num-latest-versions-to-retain: 18446744073709551615
       objects-pruning-period-secs: 43200
       objects-pruning-initial-delay-secs: 3600
     checkpoint-executor-config:
@@ -368,7 +368,7 @@ validator_configs:
     genesis:
       genesis: "[fake genesis]"
     authority-store-pruning-config:
-      objects-num-latest-versions-to-retain: 2
+      objects-num-latest-versions-to-retain: 18446744073709551615
       objects-pruning-period-secs: 43200
       objects-pruning-initial-delay-secs: 3600
     checkpoint-executor-config:
@@ -430,7 +430,7 @@ validator_configs:
     genesis:
       genesis: "[fake genesis]"
     authority-store-pruning-config:
-      objects-num-latest-versions-to-retain: 2
+      objects-num-latest-versions-to-retain: 18446744073709551615
       objects-pruning-period-secs: 43200
       objects-pruning-initial-delay-secs: 3600
     checkpoint-executor-config:

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -128,6 +128,9 @@ impl AuthorityStorePruner {
             info!("Skipping pruning of objects table as we want to retain all versions");
             return sender;
         }
+        info!(
+            "Starting object pruning service with num_versions_to_retain={num_versions_to_retain}"
+        );
         let mut prune_interval =
             tokio::time::interval_at(Instant::now() + pruning_initial_delay, pruning_timeperiod);
         prune_interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);


### PR DESCRIPTION
We are seeing errors at epoch boundary complaining old object version not found when reverting transactions.
It's not clear whether that's due to the pruner, but worth disabling it for now and see what happens.
Especially we are not sure whether the pruner keeps most recent 2 versions under lamport versioning.