### PR TITLE
[sdk] Rework type assertions around move objects

### DIFF
--- a/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -1,13 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    Base64DataBuffer,
-    is,
-    SuiObject,
-    SuiMoveObject,
-    SUI_TYPE_ARG,
-} from '@mysten/sui.js';
+import { Base64DataBuffer, is, SuiObject, SUI_TYPE_ARG } from '@mysten/sui.js';
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
 
@@ -225,7 +219,7 @@ export function TopValidatorsCard({ limit }: { limit?: number }) {
     const validatorData =
         data &&
         is(data.details, SuiObject) &&
-        is(data.details.data, SuiMoveObject)
+        data.details.data.dataType === 'moveObject'
             ? (data.details.data.fields as ValidatorState)
             : null;
 

--- a/apps/wallet/src/ui/app/components/sui-object/index.tsx
+++ b/apps/wallet/src/ui/app/components/sui-object/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { is, SuiMoveObject, SuiMovePackage } from '@mysten/sui.js';
+import { is, SuiMovePackage } from '@mysten/sui.js';
 import cl from 'classnames';
 import { memo, useMemo } from 'react';
 import { Link } from 'react-router-dom';
@@ -25,12 +25,11 @@ function SuiObject({ obj, sendNFT }: SuiObjectProps) {
     const { objectId } = obj.reference;
     const shortId = useMiddleEllipsis(objectId);
     const objType =
-        (is(obj.data, SuiMoveObject) && obj.data.type) || 'Move Package';
+        (obj.data.dataType === 'moveObject' && obj.data.type) || 'Move Package';
     const imgUrl = useMediaUrl(obj.data);
     const { keys } = useSuiObjectFields(obj.data);
-    const suiMoveObjectFields = is(obj.data, SuiMoveObject)
-        ? obj.data.fields
-        : null;
+    const suiMoveObjectFields =
+        obj.data.dataType === 'moveObject' ? obj.data.fields : null;
 
     const sendUrl = useMemo(
         () => `/send-nft?${new URLSearchParams({ objectId }).toString()}`,

--- a/apps/wallet/src/ui/app/hooks/useMediaUrl.ts
+++ b/apps/wallet/src/ui/app/hooks/useMediaUrl.ts
@@ -1,13 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { is, SuiMoveObject } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
 import type { SuiData } from '@mysten/sui.js';
 
 export default function useMediaUrl(objData: SuiData | null) {
-    const { fields } = (is(objData, SuiMoveObject) && objData) || {};
+    const { fields } = (objData?.dataType === 'moveObject' && objData) || {};
     return useMemo(() => {
         if (fields) {
             const mediaUrl = fields.url || fields.metadata?.fields.url;

--- a/apps/wallet/src/ui/app/hooks/useNFTBasicData.ts
+++ b/apps/wallet/src/ui/app/hooks/useNFTBasicData.ts
@@ -1,12 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    is,
-    SuiMoveObject,
-    getObjectId,
-    getObjectFields,
-} from '@mysten/sui.js';
+import { getObjectId, getObjectFields } from '@mysten/sui.js';
 
 import useFileExtensionType from './useFileExtensionType';
 import useMediaUrl from './useMediaUrl';
@@ -18,7 +13,7 @@ export default function useNFTBasicData(nftObj: SuiObject | null) {
     const filePath = useMediaUrl(nftObj?.data || null);
     let objType = null;
     let nftFields = null;
-    if (nftObj && is(nftObj.data, SuiMoveObject)) {
+    if (nftObj && nftObj.data.dataType === 'moveObject') {
         objType = nftObj.data.type;
         nftFields = getObjectFields(nftObj.data);
     }

--- a/apps/wallet/src/ui/app/hooks/useSuiObjectFields.ts
+++ b/apps/wallet/src/ui/app/hooks/useSuiObjectFields.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { is, SuiMoveObject } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
 import type { SuiData } from '@mysten/sui.js';
@@ -29,7 +28,7 @@ function sortKeys(a: string, b: string) {
 }
 
 export default function useSuiObjectFields(data: SuiData) {
-    const { fields = null } = is(data, SuiMoveObject) ? data : {};
+    const { fields = null } = data.dataType === 'moveObject' ? data : {};
     return useMemo(() => {
         const keys: string[] = [];
         const otherKeys: string[] = [];

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -1,18 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    is,
-    SuiMoveObject,
-    Coin as CoinAPI,
-    SUI_TYPE_ARG,
-} from '@mysten/sui.js';
+import { Coin as CoinAPI, SUI_TYPE_ARG } from '@mysten/sui.js';
 
 import type {
     ObjectId,
     SuiObject,
     RawSigner,
     SuiAddress,
+    SuiMoveObject,
     JsonRpcProvider,
     SuiExecuteTransactionResponse,
 } from '@mysten/sui.js';
@@ -32,7 +28,8 @@ export const SUI_SYSTEM_STATE_OBJECT_ID =
 export class Coin {
     public static isCoin(obj: SuiObject) {
         return (
-            is(obj.data, SuiMoveObject) && obj.data.type.startsWith(COIN_TYPE)
+            obj.data.dataType === 'moveObject' &&
+            obj.data.type.startsWith(COIN_TYPE)
         );
     }
 

--- a/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -1,12 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    getTransactionDigest,
-    is,
-    SuiMoveObject,
-    Coin as CoinAPI,
-} from '@mysten/sui.js';
+import { getTransactionDigest, Coin as CoinAPI } from '@mysten/sui.js';
 import {
     createAsyncThunk,
     createEntityAdapter,
@@ -20,7 +15,11 @@ import {
 } from '_redux/slices/sui-objects';
 import { Coin } from '_redux/slices/sui-objects/Coin';
 
-import type { SuiAddress, SuiExecuteTransactionResponse } from '@mysten/sui.js';
+import type {
+    SuiAddress,
+    SuiExecuteTransactionResponse,
+    SuiMoveObject,
+} from '@mysten/sui.js';
 import type { RootState } from '_redux/RootReducer';
 import type { AppThunkConfig } from '_store/thunk-extras';
 
@@ -83,7 +82,7 @@ export const stakeTokens = createAsyncThunk<
             .selectAll(state)
             .filter(
                 (anObj) =>
-                    is(anObj.data, SuiMoveObject) &&
+                    anObj.data.dataType === 'moveObject' &&
                     anObj.data.type === coinType
             )
             .map(({ data }) => data as SuiMoveObject);

--- a/apps/wallet/src/ui/app/staking/selectors.ts
+++ b/apps/wallet/src/ui/app/staking/selectors.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { is, SuiMoveObject, Delegation } from '@mysten/sui.js';
+import { Delegation } from '@mysten/sui.js';
 import { createSelector } from '@reduxjs/toolkit';
 
 import { ownedObjects } from '_redux/slices/account';
 import { suiSystemObjectSelector } from '_redux/slices/sui-objects';
 
-import type { DelegationSuiObject } from '@mysten/sui.js';
+import type { DelegationSuiObject, SuiMoveObject } from '@mysten/sui.js';
 
 export const delegationsSelector = createSelector(
     ownedObjects,
@@ -39,7 +39,7 @@ export const totalActiveStakedSelector = createSelector(
 export const epochSelector = createSelector(
     suiSystemObjectSelector,
     (systemObj) =>
-        systemObj && is(systemObj.data, SuiMoveObject)
+        systemObj && systemObj.data.dataType === 'moveObject'
             ? (systemObj.data.fields.epoch as number)
             : null
 );
@@ -48,7 +48,7 @@ export function getValidatorSelector(validatorAddress?: string) {
     // TODO this is limited only to the active and next set of validators. Is there a way to access the list of all validators?
     return createSelector(suiSystemObjectSelector, (systemObj) => {
         const { data } = systemObj || {};
-        if (is(data, SuiMoveObject)) {
+        if (data?.dataType === 'moveObject') {
             const { active_validators: active, next_epoch_validators: next } =
                 data.fields.validators.fields;
             const validator: SuiMoveObject | undefined = [

--- a/apps/wallet/src/ui/app/staking/stake/SelectValidatorCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/SelectValidatorCard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { is, SuiObject, SuiMoveObject } from '@mysten/sui.js';
+import { is, SuiObject } from '@mysten/sui.js';
 import { useState, useMemo } from 'react';
 
 import { getName, STATE_OBJECT } from '../usePendingDelegation';
@@ -28,7 +28,7 @@ export function SelectValidatorCard() {
     const validatorsData =
         data &&
         is(data.details, SuiObject) &&
-        is(data.details.data, SuiMoveObject)
+        data.details.data.dataType === 'moveObject'
             ? (data.details.data.fields as ValidatorState)
             : null;
 

--- a/apps/wallet/src/ui/app/staking/stake/ValidatorDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/ValidatorDetailCard.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import { is, SuiObject, SuiMoveObject, SUI_TYPE_ARG } from '@mysten/sui.js';
+import { is, SuiObject, SUI_TYPE_ARG } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
 import { getName, STATE_OBJECT } from '../usePendingDelegation';
@@ -29,7 +29,7 @@ export function ValidateDetailFormCard({
     const validatorsData =
         data &&
         is(data.details, SuiObject) &&
-        is(data.details.data, SuiMoveObject)
+        data.details.data.dataType === 'moveObject'
             ? (data.details.data.fields as ValidatorState)
             : null;
 

--- a/apps/wallet/src/ui/app/staking/usePendingDelegation.tsx
+++ b/apps/wallet/src/ui/app/staking/usePendingDelegation.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { is, SuiMoveObject, SuiObject, type SuiAddress } from '@mysten/sui.js';
+import { is, SuiObject, type SuiAddress } from '@mysten/sui.js';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -79,7 +79,7 @@ export function usePendingDelegation(): [PendingDelegation[], UseQueryResult] {
             !address ||
             !data ||
             !is(data.details, SuiObject) ||
-            !is(data.details.data, SuiMoveObject)
+            data.details.data.dataType !== 'moveObject'
         ) {
             return [];
         }

--- a/sdk/typescript/src/types/framework.ts
+++ b/sdk/typescript/src/types/framework.ts
@@ -7,7 +7,6 @@ import {
   SuiMoveObject,
   SuiObjectInfo,
   SuiObject,
-  SuiData,
   getMoveObjectType,
   getObjectId,
 } from './objects';
@@ -287,22 +286,22 @@ export class Coin {
   }
 }
 
-export type DelegationData = SuiMoveObject &
-  Pick<SuiData, 'dataType'> & {
-    type: '0x2::delegation::Delegation';
-    fields: {
-      active_delegation: Option<number>;
-      delegate_amount: number;
-      next_reward_unclaimed_epoch: number;
-      validator_address: SuiAddress;
-      info: {
-        id: string;
-        version: number;
-      };
-      coin_locked_until_epoch: Option<SuiMoveObject>;
-      ending_epoch: Option<number>;
+export type DelegationData = SuiMoveObject & {
+  dataType: 'moveObject';
+  type: '0x2::delegation::Delegation';
+  fields: {
+    active_delegation: Option<number>;
+    delegate_amount: number;
+    next_reward_unclaimed_epoch: number;
+    validator_address: SuiAddress;
+    info: {
+      id: string;
+      version: number;
     };
+    coin_locked_until_epoch: Option<SuiMoveObject>;
+    ending_epoch: Option<number>;
   };
+};
 
 export type DelegationSuiObject = Omit<SuiObject, 'data'> & {
   data: DelegationData;

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -13,7 +13,6 @@ import {
   optional,
   record,
   string,
-  type,
   union,
 } from 'superstruct';
 import { ObjectId, ObjectOwner, TransactionDigest } from './common';
@@ -47,8 +46,7 @@ export type ObjectContentFields = Infer<typeof ObjectContentFields>;
 export const MovePackageContent = record(string(), string());
 export type MovePackageContent = Infer<typeof MovePackageContent>;
 
-// NOTE: SuiMoveObject uses `type` to skip extra property checking, making ergonomics for type assertion easier.
-export const SuiMoveObject = type({
+export const SuiMoveObject = object({
   /** Move type (e.g., "0x2::coin::Coin<0x2::sui::SUI>") */
   type: string(),
   /** Fields and values stored inside the Move object */
@@ -64,8 +62,8 @@ export const SuiMovePackage = object({
 export type SuiMovePackage = Infer<typeof SuiMovePackage>;
 
 export const SuiData = union([
-  assign(SuiMoveObject, object({ dataType: ObjectType })),
-  assign(SuiMovePackage, object({ dataType: ObjectType })),
+  assign(SuiMoveObject, object({ dataType: literal('moveObject') })),
+  assign(SuiMovePackage, object({ dataType: literal('package') })),
 ]);
 export type SuiData = Infer<typeof SuiData>;
 

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -44,6 +44,7 @@ export const MovePackageContent = record(string(), string());
 export type MovePackageContent = Infer<typeof MovePackageContent>;
 
 export const SuiMoveObject = object({
+  dataType: string(),
   /** Move type (e.g., "0x2::coin::Coin<0x2::sui::SUI>") */
   type: string(),
   /** Fields and values stored inside the Move object */

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -4,6 +4,7 @@
 import {
   any,
   array,
+  assign,
   boolean,
   Infer,
   literal,
@@ -12,6 +13,7 @@ import {
   optional,
   record,
   string,
+  type,
   union,
 } from 'superstruct';
 import { ObjectId, ObjectOwner, TransactionDigest } from './common';
@@ -29,12 +31,14 @@ export const SuiObjectRef = object({
 });
 export type SuiObjectRef = Infer<typeof SuiObjectRef>;
 
-export const SuiObjectInfo = object({
-  ...SuiObjectRef.schema,
-  type: string(),
-  owner: ObjectOwner,
-  previousTransaction: TransactionDigest,
-});
+export const SuiObjectInfo = assign(
+  SuiObjectRef,
+  object({
+    type: string(),
+    owner: ObjectOwner,
+    previousTransaction: TransactionDigest,
+  })
+);
 export type SuiObjectInfo = Infer<typeof SuiObjectInfo>;
 
 export const ObjectContentFields = record(string(), any());
@@ -43,8 +47,8 @@ export type ObjectContentFields = Infer<typeof ObjectContentFields>;
 export const MovePackageContent = record(string(), string());
 export type MovePackageContent = Infer<typeof MovePackageContent>;
 
-export const SuiMoveObject = object({
-  dataType: string(),
+// NOTE: SuiMoveObject uses `type` to skip extra property checking, making ergonomics for type assertion easier.
+export const SuiMoveObject = type({
   /** Move type (e.g., "0x2::coin::Coin<0x2::sui::SUI>") */
   type: string(),
   /** Fields and values stored inside the Move object */
@@ -60,11 +64,8 @@ export const SuiMovePackage = object({
 export type SuiMovePackage = Infer<typeof SuiMovePackage>;
 
 export const SuiData = union([
-  object({
-    dataType: ObjectType,
-    ...SuiMoveObject.schema,
-  }),
-  object({ dataType: ObjectType, ...SuiMovePackage.schema }),
+  assign(SuiMoveObject, object({ dataType: ObjectType })),
+  assign(SuiMovePackage, object({ dataType: ObjectType })),
 ]);
 export type SuiData = Infer<typeof SuiData>;
 


### PR DESCRIPTION
This was causing bugs because `dataType` is missing, so instead of using `is`, we can narrow through a discriminated union off `dataType`.