### PR TITLE
[wallet-standard] Add deeplink feature

### DIFF
--- a/sdk/wallet-adapter/wallet-standard/src/detect.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/detect.ts
@@ -8,14 +8,18 @@ import {
   Wallet,
   WalletWithFeatures,
 } from "@wallet-standard/core";
-import { SuiSignAndExecuteTransactionFeature } from "./features";
+import {
+  SuiDeeplinkFeature,
+  SuiSignAndExecuteTransactionFeature,
+} from "./features";
 
 export type StandardWalletAdapterWallet = WalletWithFeatures<
   ConnectFeature &
     EventsFeature &
     SuiSignAndExecuteTransactionFeature &
-    // Disconnect is an optional feature:
-    Partial<DisconnectFeature>
+    // Optional Features:
+    Partial<DisconnectFeature> &
+    Partial<SuiDeeplinkFeature>
 >;
 
 export function isStandardWalletAdapterCompatibleWallet(

--- a/sdk/wallet-adapter/wallet-standard/src/features/index.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/index.ts
@@ -3,12 +3,15 @@
 
 import type { WalletWithFeatures } from "@wallet-standard/core";
 import type { SuiSignAndExecuteTransactionFeature } from "./suiSignAndExecuteTransaction";
+import type { SuiDeeplinkFeature } from "./suiDeeplink";
 
 /**
  * Wallet Standard features that are unique to Sui, and that all Sui wallets are expected to implement.
  */
-export type SuiFeatures = SuiSignAndExecuteTransactionFeature;
+export type SuiFeatures = SuiSignAndExecuteTransactionFeature &
+  SuiDeeplinkFeature;
 
 export type WalletWithSuiFeatures = WalletWithFeatures<SuiFeatures>;
 
 export * from "./suiSignAndExecuteTransaction";
+export * from "./suiDeeplink";

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiDeeplink.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiDeeplink.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/** The latest API version of the deeplink API. */
+export type SuiDeeplinkVersion = "0.0.1";
+
+/**
+ * TODO: Docs.
+ */
+export type SuiDeeplinkFeature = {
+  /** Namespace for the feature. */
+  "sui:deeplink": {
+    /** Version of the feature API. */
+    version: SuiDeeplinkVersion;
+    deeplink: SuiDeeplinkMethod;
+  };
+};
+
+export type SuiDeeplinkMethod = (
+  input: SuiDeeplinkInput
+) => Promise<SuiDeeplinkOutput>;
+
+export type SuiDeeplinkType = "stake";
+
+export interface SuiDeeplinkInput {
+  type: SuiDeeplinkType;
+}
+
+export interface SuiDeeplinkOutput {}
+
+export interface SuiDeeplinkOptions {}


### PR DESCRIPTION
We want the ability to deeplink into different views in a wallet within dapps, and we think this is a generic enough use-case to warrant a new wallet standard feature. I don't have a solid idea quite yet about what the deeplinkable views are going to be, right now we just know staking is going to be one of them, but just putting this up to get early feedback.