### PR TITLE
crypto: Add multisig to sui

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -19,13 +19,14 @@ use sui_storage::mutex_table::LockGuard;
 use sui_storage::write_ahead_log::{DBWriteAheadLog, TxGuard, WriteAheadLog};
 use sui_types::base_types::{AuthorityName, EpochId, ObjectID, SequenceNumber, TransactionDigest};
 use sui_types::committee::Committee;
-use sui_types::crypto::{AuthoritySignInfo, Signature};
+use sui_types::crypto::AuthoritySignInfo;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     CertifiedTransaction, ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind,
     SenderSignedData, SharedInputObject, TransactionEffects, TrustedCertificate,
     TrustedSignedTransactionEffects, VerifiedCertificate, VerifiedSignedTransaction,
 };
+use sui_types::signature::GenericSignature;
 use tracing::{debug, info, trace, warn};
 use typed_store::rocks::{DBBatch, DBMap, DBOptions, MetricConf, TypedStoreError};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
@@ -214,7 +215,7 @@ pub struct AuthorityEpochTables {
 
     /// When we see certificate through consensus for the first time, we record
     /// user signature for this transaction here. This will be included in the checkpoint later.
-    user_signatures_for_checkpoints: DBMap<TransactionDigest, Signature>,
+    user_signatures_for_checkpoints: DBMap<TransactionDigest, GenericSignature>,
 
     /// Maps sequence number to checkpoint summary, used by CheckpointBuilder to build checkpoint within epoch
     builder_checkpoint_summary: DBMap<CheckpointSequenceNumber, CheckpointSummary>,
@@ -799,7 +800,7 @@ impl AuthorityPerEpochStore {
     pub async fn user_signatures_for_checkpoint(
         &self,
         digests: &[TransactionDigest],
-    ) -> SuiResult<Vec<Signature>> {
+    ) -> SuiResult<Vec<GenericSignature>> {
         // todo - use NotifyRead::register_all might be faster
         for digest in digests {
             self.consensus_message_processed_notify(ConsensusTransactionKey::Certificate(*digest))
@@ -1093,7 +1094,11 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    pub fn test_insert_user_signature(&self, digest: TransactionDigest, signature: &Signature) {
+    pub fn test_insert_user_signature(
+        &self,
+        digest: TransactionDigest,
+        signature: &GenericSignature,
+    ) {
         self.tables
             .user_signatures_for_checkpoints
             .insert(&digest, signature)

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1250,7 +1250,7 @@ mod tests {
         }
         let all_digests: Vec<_> = store.iter().map(|(k, _v)| *k).collect();
         for digest in all_digests {
-            let signature = Signature::Ed25519SuiSignature(Default::default());
+            let signature = Signature::Ed25519SuiSignature(Default::default()).into();
             state
                 .epoch_store_for_testing()
                 .test_insert_user_signature(digest, &signature);

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -142,20 +142,21 @@ impl SuiTxValidatorMetrics {
 
 #[cfg(test)]
 mod tests {
-    use fastcrypto::traits::KeyPair;
-    use narwhal_types::Batch;
-    use narwhal_worker::TransactionValidator;
-    use sui_types::{base_types::AuthorityName, messages::ConsensusTransaction};
-
-    use super::*;
     use crate::{
         authority::authority_tests::init_state_with_objects_and_committee,
         consensus_adapter::consensus_tests::{test_certificates, test_gas_objects},
+        consensus_validator::{SuiTxValidator, SuiTxValidatorMetrics},
+    };
+    use fastcrypto::traits::KeyPair;
+    use narwhal_types::Batch;
+    use narwhal_worker::TransactionValidator;
+    use sui_types::{
+        base_types::AuthorityName, messages::ConsensusTransaction, signature::GenericSignature,
     };
 
     use sui_macros::sim_test;
+    use sui_types::crypto::Ed25519SuiSignature;
     use sui_types::object::Object;
-
     #[sim_test]
     async fn accept_valid_transaction() {
         // Initialize an authority with a (owned) gas object and a shared object; then
@@ -208,7 +209,11 @@ mod tests {
         let bogus_transaction_bytes: Vec<_> = certificates
             .into_iter()
             .map(|mut cert| {
-                cert.tx_signature.as_mut()[2] = cert.tx_signature.as_mut()[2].wrapping_add(1);
+                // set it to an all-zero user signature
+                cert.tx_signature =
+                    GenericSignature::Signature(sui_types::crypto::Signature::Ed25519SuiSignature(
+                        Ed25519SuiSignature::default(),
+                    ));
                 bincode::serialize(&ConsensusTransaction::new_certificate_message(&name1, cert))
                     .unwrap()
             })

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -805,7 +805,7 @@ async fn test_handle_transfer_transaction_bad_signature() {
     bad_signature_transfer_transaction
         .data_mut_for_testing()
         .tx_signature =
-        Signature::new_secure(&transfer_transaction.data().intent_message, &unknown_key);
+        Signature::new_secure(&transfer_transaction.data().intent_message, &unknown_key).into();
 
     assert!(client
         .handle_transaction(bad_signature_transfer_transaction)

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -35,7 +35,7 @@ use sui_types::base_types::{
 };
 use sui_types::coin::CoinMetadata;
 use sui_types::committee::EpochId;
-use sui_types::crypto::{Signature, SuiAuthorityStrongQuorumSignInfo};
+use sui_types::crypto::SuiAuthorityStrongQuorumSignInfo;
 use sui_types::dynamic_field::DynamicFieldInfo;
 use sui_types::error::{ExecutionError, SuiError};
 use sui_types::event::{BalanceChangeType, Event, EventID};
@@ -55,6 +55,7 @@ use sui_types::move_package::{disassemble_modules, MovePackage};
 use sui_types::object::{
     Data, MoveObject, Object, ObjectFormatOptions, ObjectRead, Owner, PastObjectRead,
 };
+use sui_types::signature::GenericSignature;
 use sui_types::{parse_sui_struct_tag, parse_sui_type_tag};
 use tracing::warn;
 
@@ -1809,7 +1810,7 @@ pub struct SuiCertifiedTransaction {
     pub transaction_digest: TransactionDigest,
     pub data: SuiTransactionData,
     /// tx_signature is signed by the transaction sender, committing to the intent message containing the transaction data and intent.
-    pub tx_signature: Signature,
+    pub tx_signature: GenericSignature,
     /// authority signature information, if available, is signed by an authority, applied on `data`.
     pub auth_sign_info: SuiAuthorityStrongQuorumSignInfo,
 }

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -18,9 +18,9 @@ use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_json_rpc_types::SuiExecuteTransactionResponse;
 use sui_open_rpc::Module;
 use sui_types::intent::Intent;
+use sui_types::messages::Transaction;
 use sui_types::messages::{ExecuteTransactionRequest, ExecuteTransactionRequestType};
-use sui_types::{crypto, messages::Transaction};
-
+use sui_types::signature::GenericSignature;
 pub struct FullNodeTransactionExecutionApi {
     pub transaction_orchestrator: Arc<TransactiondOrchestrator<NetworkAuthorityClient>>,
     pub module_cache: Arc<SyncModuleCache<ResolverWrapper<AuthorityStore>>>,
@@ -48,10 +48,9 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
     ) -> RpcResult<SuiExecuteTransactionResponse> {
         let tx_data =
             bcs::from_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?).map_err(|e| anyhow!(e))?;
-        let signature = crypto::Signature::from_bytes(&signature.to_vec().map_err(|e| anyhow!(e))?)
+        let signature = GenericSignature::from_bytes(&signature.to_vec().map_err(|e| anyhow!(e))?)
             .map_err(|e| anyhow!(e))?;
-
-        let txn = Transaction::from_data(tx_data, Intent::default(), signature);
+        let txn = Transaction::from_generic_sig_data(tx_data, Intent::default(), signature);
 
         let transaction_orchestrator = self.transaction_orchestrator.clone();
         let response = spawn_monitored_task!(transaction_orchestrator.execute_transaction(
@@ -79,11 +78,9 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
     ) -> RpcResult<SuiExecuteTransactionResponse> {
         let tx_data =
             bcs::from_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?).map_err(|e| anyhow!(e))?;
-        let signature = crypto::Signature::from_bytes(&signature.to_vec().map_err(|e| anyhow!(e))?)
+        let signature = GenericSignature::from_bytes(&signature.to_vec().map_err(|e| anyhow!(e))?)
             .map_err(|e| anyhow!(e))?;
-
-        let txn = Transaction::from_data(tx_data, Intent::default(), signature);
-
+        let txn = Transaction::from_generic_sig_data(tx_data, Intent::default(), signature);
         let transaction_orchestrator = self.transaction_orchestrator.clone();
         let response = spawn_monitored_task!(transaction_orchestrator.execute_transaction(
             ExecuteTransactionRequest {

--- a/crates/sui-keys/src/key_derive.rs
+++ b/crates/sui-keys/src/key_derive.rs
@@ -61,9 +61,11 @@ pub fn derive_key_pair_from_path(
             );
             Ok((kp.public().into(), SuiKeyPair::Secp256r1(kp)))
         }
-        SignatureScheme::BLS12381 => Err(SuiError::UnsupportedFeatureError {
-            error: "BLS12381 key derivation is currently not supported".to_string(),
-        }),
+        SignatureScheme::BLS12381 | SignatureScheme::MultiSig => {
+            Err(SuiError::UnsupportedFeatureError {
+                error: format!("key derivation not supported {:?}", key_scheme),
+            })
+        }
     }
 }
 
@@ -156,9 +158,11 @@ pub fn validate_path(
                 .map_err(|_| SuiError::SignatureKeyGenError("Cannot parse path".to_string()))?),
             }
         }
-        SignatureScheme::BLS12381 => Err(SuiError::UnsupportedFeatureError {
-            error: "BLS12381 key derivation is currently not supported".to_string(),
-        }),
+        SignatureScheme::BLS12381 | SignatureScheme::MultiSig => {
+            Err(SuiError::UnsupportedFeatureError {
+                error: format!("key derivation not supported {:?}", key_scheme),
+            })
+        }
     }
 }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2862,7 +2862,7 @@
             "description": "tx_signature is signed by the transaction sender, committing to the intent message containing the transaction data and intent.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/Signature"
+                "$ref": "#/components/schemas/GenericSignature"
               }
             ]
           }
@@ -2886,7 +2886,7 @@
             "description": "This field 'pins' user signatures for the checkpoint:\n\n* For normal checkpoint this field will contain same number of elements as transactions. * Genesis checkpoint has transactions but this field is empty. * Last checkpoint in the epoch will have (last)extra system transaction in the transactions list not covered in the signatures list",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Signature"
+              "$ref": "#/components/schemas/GenericSignature"
             }
           }
         }
@@ -3055,6 +3055,47 @@
             "$ref": "#/components/schemas/ProtocolVersion"
           }
         }
+      },
+      "CompressedSignature": {
+        "description": "Unlike `enum Signature`, `enum CompressedSignature` does not contain public key.",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "Ed25519"
+            ],
+            "properties": {
+              "Ed25519": {
+                "$ref": "#/components/schemas/Base64"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Secp256k1"
+            ],
+            "properties": {
+              "Secp256k1": {
+                "$ref": "#/components/schemas/Base64"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Secp256r1"
+            ],
+            "properties": {
+              "Secp256r1": {
+                "$ref": "#/components/schemas/Base64"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "Data": {
         "oneOf": [
@@ -4241,6 +4282,35 @@
           }
         }
       },
+      "GenericSignature": {
+        "description": "Due to the incompatibility of [enum Signature] (which dispatches a trait that assumes signature and pubkey bytes for verification), here we add a wrapper enum where member can just implement a lightweight [trait AuthenticatorTrait]. This way MultiSig (and future Authenticators) can implement its own `verify`.",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "MultiSig"
+            ],
+            "properties": {
+              "MultiSig": {
+                "$ref": "#/components/schemas/MultiSig"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Signature"
+            ],
+            "properties": {
+              "Signature": {
+                "$ref": "#/components/schemas/Signature"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
       "Hex": {
         "description": "Hex string encoding.",
         "type": "string"
@@ -4521,6 +4591,75 @@
             ]
           }
         ]
+      },
+      "MultiSig": {
+        "description": "The struct that contains signatures and public keys necessary for authenticating a MultiSig.",
+        "type": "object",
+        "required": [
+          "bitmap",
+          "multisig_pk",
+          "sigs"
+        ],
+        "properties": {
+          "bitmap": {
+            "description": "A bitmap that indicates the position of which public key the signature should be authenticated with.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Base64"
+              }
+            ]
+          },
+          "multisig_pk": {
+            "description": "The public key encoded with each public key with its signature scheme used along with the corresponding weight.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MultiSigPublicKey"
+              }
+            ]
+          },
+          "sigs": {
+            "description": "The plain signature encoded with signature scheme.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompressedSignature"
+            }
+          }
+        }
+      },
+      "MultiSigPublicKey": {
+        "description": "The struct that contains the public key used for authenticating a MultiSig.",
+        "type": "object",
+        "required": [
+          "pk_map",
+          "threshold"
+        ],
+        "properties": {
+          "pk_map": {
+            "description": "A list of public key and its corresponding weight.",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/components/schemas/PublicKey"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "threshold": {
+            "description": "If the total weight of the public keys corresponding to verified signatures is larger than threshold, the MultiSig is verified.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
       },
       "Object": {
         "type": "object",
@@ -4974,6 +5113,46 @@
         "type": "integer",
         "format": "uint64",
         "minimum": 0.0
+      },
+      "PublicKey": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "Ed25519"
+            ],
+            "properties": {
+              "Ed25519": {
+                "$ref": "#/components/schemas/Base64"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Secp256k1"
+            ],
+            "properties": {
+              "Secp256k1": {
+                "$ref": "#/components/schemas/Base64"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Secp256r1"
+            ],
+            "properties": {
+              "Secp256r1": {
+                "$ref": "#/components/schemas/Base64"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "RPCTransactionRequestParams": {
         "oneOf": [

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use std::ops::Range;
 use std::str::FromStr;
 
-use fastcrypto::encoding::Base64;
 use fastcrypto::traits::AggregateAuthenticator;
+use fastcrypto::traits::EncodeDecodeBase64;
 use fastcrypto::traits::KeyPair;
 use move_core_types::identifier::Identifier;
 use rand::rngs::StdRng;
@@ -31,7 +31,7 @@ use sui_types::base_types::{
 use sui_types::crypto::AuthorityQuorumSignInfo;
 use sui_types::crypto::{
     get_key_pair_from_rng, AccountKeyPair, AggregateAuthoritySignature, AuthorityKeyPair,
-    AuthorityPublicKeyBytes, AuthoritySignature, Signature, SuiAuthorityStrongQuorumSignInfo,
+    AuthorityPublicKeyBytes, AuthoritySignature, SuiAuthorityStrongQuorumSignInfo,
 };
 use sui_types::event::EventID;
 use sui_types::gas_coin::GasCoin;
@@ -42,6 +42,7 @@ use sui_types::messages::{
 use sui_types::object::Owner;
 use sui_types::query::EventQuery;
 use sui_types::query::TransactionQuery;
+use sui_types::signature::GenericSignature;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 
@@ -172,7 +173,7 @@ impl RpcExampleProvider {
                 "Execute an transaction with serialized signature",
                 vec![
                     ("tx_bytes", json!(tx_bytes.tx_bytes)),
-                    ("signature", json!(Base64::from_bytes(signature.as_ref()))),
+                    ("signature", json!(signature.encode_base64())),
                     (
                         "request_type",
                         json!(ExecuteTransactionRequestType::WaitForLocalExecution),
@@ -386,7 +387,7 @@ impl RpcExampleProvider {
         &mut self,
     ) -> (
         TransactionData,
-        Signature,
+        GenericSignature,
         SuiAddress,
         ObjectID,
         SuiTransactionResponse,

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -4,9 +4,9 @@
 use axum::{Extension, Json};
 use fastcrypto::encoding::{Encoding, Hex};
 use sui_types::base_types::SuiAddress;
-use sui_types::crypto;
 use sui_types::crypto::{SignatureScheme, ToFromBytes};
 use sui_types::messages::{ExecuteTransactionRequestType, Transaction, TransactionData};
+use sui_types::signature::GenericSignature;
 
 use crate::errors::Error;
 use crate::types::{
@@ -93,10 +93,10 @@ pub async fn combine(
     }
     .flag()];
 
-    let signed_tx = Transaction::from_data(
+    let signed_tx = Transaction::from_generic_sig_data(
         intent_msg.value,
         Intent::default(),
-        crypto::Signature::from_bytes(&[&*flag, &*sig_bytes, &*pub_key].concat())?,
+        GenericSignature::from_bytes(&[&*flag, &*sig_bytes, &*pub_key].concat())?,
     );
     signed_tx.verify_signature()?;
     let signed_tx_bytes = bcs::to_bytes(&signed_tx)?;

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -19,13 +19,15 @@ use std::str::FromStr;
 
 pub use crate::committee::EpochId;
 use crate::crypto::{
-    AuthorityPublicKey, AuthorityPublicKeyBytes, KeypairTraits, PublicKey, SuiPublicKey,
+    AuthorityPublicKey, AuthorityPublicKeyBytes, KeypairTraits, PublicKey, SignatureScheme,
+    SuiPublicKey,
 };
 pub use crate::digests::{ObjectDigest, TransactionDigest, TransactionEffectsDigest};
 use crate::error::ExecutionError;
 use crate::error::ExecutionErrorKind;
 use crate::error::SuiError;
 use crate::gas_coin::GasCoin;
+use crate::multisig::MultiSigPublicKey;
 use crate::object::{Object, Owner};
 use crate::sui_serde::Readable;
 use fastcrypto::encoding::{Encoding, Hex};
@@ -249,6 +251,28 @@ impl From<&PublicKey> for SuiAddress {
         let mut hasher = Sha3_256::default();
         hasher.update([pk.flag()]);
         hasher.update(pk);
+        let g_arr = hasher.finalize();
+
+        let mut res = [0u8; SUI_ADDRESS_LENGTH];
+        // OK to access slice because Sha3_256 should never be shorter than SUI_ADDRESS_LENGTH.
+        res.copy_from_slice(&AsRef::<[u8]>::as_ref(&g_arr)[..SUI_ADDRESS_LENGTH]);
+        SuiAddress(res)
+    }
+}
+
+/// A MultiSig address is the first 20 bytes of the hash of
+/// `flag_MultiSig || threshold || flag_1 || pk_1 || weight_1 || ... || flag_n || pk_n || weight_n`
+/// of all participating public keys and its weight.  
+impl From<MultiSigPublicKey> for SuiAddress {
+    fn from(multisig_pk: MultiSigPublicKey) -> Self {
+        let mut hasher = Sha3_256::default();
+        hasher.update([SignatureScheme::MultiSig.flag()]);
+        hasher.update(multisig_pk.threshold().to_le_bytes());
+        multisig_pk.pubkeys().iter().for_each(|(pk, w)| {
+            hasher.update([pk.flag()]);
+            hasher.update(pk.as_ref());
+            hasher.update(w.to_le_bytes());
+        });
         let g_arr = hasher.finalize();
 
         let mut res = [0u8; SUI_ADDRESS_LENGTH];

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -31,6 +31,7 @@ pub mod crypto;
 pub mod digests;
 pub mod dynamic_field;
 pub mod event;
+pub mod filter;
 pub mod gas;
 pub mod gas_coin;
 pub mod governance;
@@ -41,16 +42,16 @@ pub mod message_envelope;
 pub mod messages;
 pub mod messages_checkpoint;
 pub mod move_package;
+pub mod multisig;
 pub mod object;
 pub mod query;
 pub mod quorum_driver_types;
+pub mod signature;
 pub mod signature_seed;
 pub mod storage;
 pub mod sui_serde;
 pub mod sui_system_state;
 pub mod temporary_store;
-
-pub mod filter;
 
 #[path = "./unit_tests/utils.rs"]
 pub mod utils;

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -7,17 +7,17 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::base_types::ExecutionDigests;
 use crate::committee::{EpochId, ProtocolVersion, StakeUnit};
-use crate::crypto::{
-    AuthoritySignInfo, AuthoritySignInfoTrait, AuthorityStrongQuorumSignInfo, Signature, Signer,
-};
+use crate::crypto::{AuthoritySignInfo, AuthoritySignInfoTrait, AuthorityStrongQuorumSignInfo};
 use crate::error::SuiResult;
 use crate::gas::GasCostSummary;
+use crate::signature::GenericSignature;
 use crate::{
     base_types::AuthorityName,
     committee::Committee,
     crypto::{sha3_hash, AuthoritySignature, VerificationObligation},
     error::SuiError,
 };
+use fastcrypto::traits::Signer;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -405,7 +405,7 @@ pub struct CheckpointContents {
     /// * Genesis checkpoint has transactions but this field is empty.
     /// * Last checkpoint in the epoch will have (last)extra system transaction
     /// in the transactions list not covered in the signatures list
-    user_signatures: Vec<Signature>,
+    user_signatures: Vec<GenericSignature>,
 }
 
 impl CheckpointSignatureMessage {
@@ -427,7 +427,7 @@ impl CheckpointContents {
 
     pub fn new_with_causally_ordered_transactions_and_signatures<T>(
         contents: T,
-        signatures: Vec<Signature>,
+        signatures: Vec<GenericSignature>,
     ) -> Self
     where
         T: IntoIterator<Item = ExecutionDigests>,

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -1,0 +1,270 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    crypto::{CompressedSignature, SignatureScheme},
+    signature::AuthenticatorTrait,
+    sui_serde::SuiBitmap,
+};
+pub use enum_dispatch::enum_dispatch;
+use fastcrypto::{
+    ed25519::Ed25519PublicKey,
+    encoding::Base64,
+    error::FastCryptoError,
+    secp256k1::Secp256k1PublicKey,
+    secp256r1::Secp256r1PublicKey,
+    traits::{ToFromBytes, VerifyingKey},
+};
+use once_cell::sync::OnceCell;
+use roaring::RoaringBitmap;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use std::hash::{Hash, Hasher};
+
+use crate::{
+    base_types::SuiAddress,
+    crypto::{PublicKey, Signature},
+    error::SuiError,
+    intent::IntentMessage,
+};
+
+#[cfg(test)]
+#[path = "unit_tests/multisig_tests.rs"]
+mod multisig_tests;
+
+pub type WeightUnit = u8;
+pub type ThresholdUnit = u16;
+pub const MAX_SIGNER_IN_MULTISIG: usize = 10;
+
+/// This initialize the underlying bytes representation of MultiSig. It encodes
+/// [struct MultiSig] as the MultiSig flag (0x03) concat with the bcs bytes
+/// of [struct MultiSig] i.e. `flag || bcs_bytes(MultiSig)`.
+impl AsRef<[u8]> for MultiSig {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+            .get_or_try_init::<_, eyre::Report>(|| {
+                let mut bytes = Vec::new();
+                bytes.push(SignatureScheme::MultiSig.flag());
+                bytes.extend_from_slice(
+                    bcs::to_bytes(self)
+                        .expect("BCS serialization should not fail")
+                        .as_slice(),
+                );
+                Ok(bytes)
+            })
+            .expect("OnceCell invariant violated")
+    }
+}
+
+/// The struct that contains signatures and public keys necessary for authenticating a MultiSig.
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct MultiSig {
+    /// The plain signature encoded with signature scheme.
+    sigs: Vec<CompressedSignature>,
+    /// A bitmap that indicates the position of which public key the signature should be authenticated with.
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "SuiBitmap")]
+    bitmap: RoaringBitmap,
+    /// The public key encoded with each public key with its signature scheme used along with the corresponding weight.
+    multisig_pk: MultiSigPublicKey,
+    /// A bytes representation of [struct MultiSig]. This helps with implementing [trait AsRef<[u8]>].
+    #[serde(skip)]
+    bytes: OnceCell<Vec<u8>>,
+}
+
+/// Necessary trait for [struct SenderSignedData].
+impl PartialEq for MultiSig {
+    fn eq(&self, other: &Self) -> bool {
+        self.sigs == other.sigs
+            && self.bitmap == other.bitmap
+            && self.multisig_pk == other.multisig_pk
+    }
+}
+
+/// Necessary trait for [struct SenderSignedData].
+impl Eq for MultiSig {}
+
+/// Necessary trait for [struct SenderSignedData].
+impl Hash for MultiSig {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
+    }
+}
+
+impl AuthenticatorTrait for MultiSig {
+    fn verify_secure_generic<T>(
+        &self,
+        value: &IntentMessage<T>,
+        author: SuiAddress,
+    ) -> Result<(), SuiError>
+    where
+        T: Serialize,
+    {
+        if self.multisig_pk.pk_map.len() > MAX_SIGNER_IN_MULTISIG {
+            return Err(SuiError::InvalidSignature {
+                error: "Invalid number of public keys".to_string(),
+            });
+        }
+
+        if <SuiAddress as From<MultiSigPublicKey>>::from(self.multisig_pk.clone()) != author {
+            return Err(SuiError::InvalidSignature {
+                error: "Invalid address".to_string(),
+            });
+        }
+        let mut weight_sum: u16 = 0;
+        let message = bcs::to_bytes(&value).expect("Message serialization should not fail");
+
+        // Verify each signature against its corresponding signature scheme and public key.
+        // TODO: further optimization can be done because multiple Ed25519 signatures can be batch verified.
+        for (sig, i) in self.sigs.iter().zip(&self.bitmap) {
+            let pk_map =
+                self.multisig_pk
+                    .pk_map
+                    .get(i as usize)
+                    .ok_or(SuiError::InvalidSignature {
+                        error: "Invalid public keys index".to_string(),
+                    })?;
+            let res = match sig {
+                CompressedSignature::Ed25519(s) => {
+                    let pk = Ed25519PublicKey::from_bytes(pk_map.0.as_ref()).map_err(|_| {
+                        SuiError::InvalidSignature {
+                            error: "Invalid public key".to_string(),
+                        }
+                    })?;
+                    pk.verify(&message, s)
+                }
+                CompressedSignature::Secp256k1(s) => {
+                    let pk = Secp256k1PublicKey::from_bytes(pk_map.0.as_ref()).map_err(|_| {
+                        SuiError::InvalidSignature {
+                            error: "Invalid public key".to_string(),
+                        }
+                    })?;
+                    pk.verify(&message, s)
+                }
+                CompressedSignature::Secp256r1(s) => {
+                    let pk = Secp256r1PublicKey::from_bytes(pk_map.0.as_ref()).map_err(|_| {
+                        SuiError::InvalidSignature {
+                            error: "Invalid public key".to_string(),
+                        }
+                    })?;
+                    pk.verify(&message, s)
+                }
+            };
+            if res.is_ok() {
+                weight_sum += pk_map.1 as u16;
+            } else {
+                return Err(SuiError::InvalidSignature {
+                    error: format!("Invalid signature for pk={:?}", pk_map.0),
+                });
+            }
+        }
+
+        if weight_sum >= self.multisig_pk.threshold {
+            Ok(())
+        } else {
+            Err(SuiError::InvalidSignature {
+                error: format!("Insufficient weight {:?}", weight_sum),
+            })
+        }
+    }
+}
+
+impl MultiSig {
+    /// This combines a list of [enum Signature] `flag || signature || pk` to a MultiSig.
+    pub fn combine(
+        full_sigs: Vec<Signature>,
+        multisig_pk: MultiSigPublicKey,
+    ) -> Result<Self, SuiError> {
+        if full_sigs.len() > multisig_pk.pk_map.len()
+            || multisig_pk.pk_map.len() > MAX_SIGNER_IN_MULTISIG
+            || full_sigs.is_empty()
+            || multisig_pk.pk_map.is_empty()
+        {
+            return Err(SuiError::InvalidSignature {
+                error: "Invalid number of signatures".to_string(),
+            });
+        }
+        let mut bitmap = RoaringBitmap::new();
+        let mut sigs = Vec::new();
+        for s in full_sigs {
+            bitmap.insert(multisig_pk.get_index(s.to_public_key()?).ok_or(
+                SuiError::IncorrectSigner {
+                    error: "pk does not exist".to_string(),
+                },
+            )?);
+            sigs.push(s.to_compressed()?);
+        }
+        Ok(MultiSig {
+            sigs,
+            bitmap,
+            multisig_pk,
+            bytes: OnceCell::new(),
+        })
+    }
+
+    pub fn validate(&self) -> Result<(), FastCryptoError> {
+        if self.sigs.len() > self.multisig_pk.pk_map.len() || self.sigs.is_empty() {
+            return Err(FastCryptoError::InvalidInput);
+        }
+        self.multisig_pk.validate()?;
+        Ok(())
+    }
+}
+
+/// The struct that contains the public key used for authenticating a MultiSig.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MultiSigPublicKey {
+    /// A list of public key and its corresponding weight.
+    pk_map: Vec<(PublicKey, WeightUnit)>,
+    /// If the total weight of the public keys corresponding to verified signatures is larger than threshold, the MultiSig is verified.
+    threshold: ThresholdUnit,
+}
+
+impl MultiSigPublicKey {
+    pub fn new(
+        pks: Vec<PublicKey>,
+        weights: Vec<WeightUnit>,
+        threshold: ThresholdUnit,
+    ) -> Result<Self, SuiError> {
+        if pks.is_empty()
+            || weights.is_empty()
+            || threshold == 0
+            || pks.len() != weights.len()
+            || pks.len() > MAX_SIGNER_IN_MULTISIG
+            || weights.iter().any(|w| w == &0)
+        {
+            return Err(SuiError::InvalidSignature {
+                error: "Invalid number of public keys".to_string(),
+            });
+        }
+        Ok(MultiSigPublicKey {
+            pk_map: pks.into_iter().zip(weights.into_iter()).collect(),
+            threshold,
+        })
+    }
+
+    pub fn get_index(&self, pk: PublicKey) -> Option<u32> {
+        self.pk_map.iter().position(|x| x.0 == pk).map(|x| x as u32)
+    }
+
+    pub fn threshold(&self) -> &ThresholdUnit {
+        &self.threshold
+    }
+
+    pub fn pubkeys(&self) -> &Vec<(PublicKey, WeightUnit)> {
+        &self.pk_map
+    }
+
+    pub fn validate(&self) -> Result<(), FastCryptoError> {
+        if self.threshold == 0
+            || self.pubkeys().is_empty()
+            || self.pubkeys().len() > MAX_SIGNER_IN_MULTISIG
+            || self.pubkeys().iter().any(|pk_weight| pk_weight.1 == 0)
+        {
+            return Err(FastCryptoError::InvalidInput);
+        }
+        Ok(())
+    }
+}

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    base_types::SuiAddress, crypto::Signature, error::SuiError, intent::IntentMessage,
+    multisig::MultiSig,
+};
+use crate::{
+    crypto::{SignatureScheme, SuiSignature},
+    serde_to_from_bytes,
+};
+pub use enum_dispatch::enum_dispatch;
+use fastcrypto::{
+    error::FastCryptoError,
+    traits::{EncodeDecodeBase64, ToFromBytes},
+};
+use schemars::JsonSchema;
+use serde::Serialize;
+use std::hash::Hash;
+
+/// A lightweight trait that all members of [enum GenericSignature] implement.
+#[enum_dispatch]
+pub trait AuthenticatorTrait {
+    fn verify_secure_generic<T>(
+        &self,
+        value: &IntentMessage<T>,
+        author: SuiAddress,
+    ) -> Result<(), SuiError>
+    where
+        T: Serialize;
+}
+
+/// Due to the incompatibility of [enum Signature] (which dispatches a trait that
+/// assumes signature and pubkey bytes for verification), here we add a wrapper
+/// enum where member can just implement a lightweight [trait AuthenticatorTrait].
+/// This way MultiSig (and future Authenticators) can implement its own `verify`.
+#[enum_dispatch(AuthenticatorTrait)]
+#[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Hash)]
+pub enum GenericSignature {
+    MultiSig,
+    Signature,
+}
+
+/// GenericSignature encodes a single signature [enum Signature] as is `flag || signature || pubkey`.
+/// It encodes [struct MultiSig] as the MultiSig flag (0x03) concat with the bcs serializedbytes
+/// of [struct MultiSig] i.e. `flag || bcs_bytes(MultiSig)`.
+impl ToFromBytes for GenericSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        match SignatureScheme::from_flag_byte(
+            bytes.first().ok_or(FastCryptoError::InputTooShort(0))?,
+        ) {
+            Ok(x) => match x {
+                SignatureScheme::ED25519
+                | SignatureScheme::Secp256k1
+                | SignatureScheme::Secp256r1 => Ok(GenericSignature::Signature(
+                    Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidSignature)?,
+                )),
+                SignatureScheme::MultiSig => {
+                    let multisig: MultiSig =
+                        bcs::from_bytes(bytes.get(1..).ok_or(FastCryptoError::InvalidInput)?)
+                            .map_err(|_| FastCryptoError::InvalidSignature)?;
+                    multisig.validate()?;
+                    Ok(GenericSignature::MultiSig(multisig))
+                }
+                _ => Err(FastCryptoError::InvalidInput),
+            },
+            Err(_) => Err(FastCryptoError::InvalidInput),
+        }
+    }
+}
+
+/// Trait useful to get the bytes reference for [enum GenericSignature].
+impl AsRef<[u8]> for GenericSignature {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            GenericSignature::MultiSig(s) => s.as_ref(),
+            GenericSignature::Signature(s) => s.as_ref(),
+        }
+    }
+}
+
+// A macro to implement [trait Serialize] and [trait Deserialize] for [enum GenericSignature] using its bytes representation.
+serde_to_from_bytes!(GenericSignature);
+
+/// This ports the wrapper trait to the verify_secure defined on [enum Signature].
+impl AuthenticatorTrait for Signature {
+    fn verify_secure_generic<T>(
+        &self,
+        value: &IntentMessage<T>,
+        author: SuiAddress,
+    ) -> Result<(), SuiError>
+    where
+        T: Serialize,
+    {
+        self.verify_secure(value, author)
+    }
+}

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -1,0 +1,358 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use fastcrypto::traits::ToFromBytes;
+use once_cell::sync::OnceCell;
+use rand::{rngs::StdRng, SeedableRng};
+use roaring::RoaringBitmap;
+
+use crate::{
+    base_types::SuiAddress,
+    crypto::{
+        get_key_pair, get_key_pair_from_rng, Ed25519SuiSignature, Signature, SuiKeyPair,
+        SuiSignatureInner,
+    },
+    intent::{Intent, IntentMessage, PersonalMessage},
+    multisig::{MultiSig, MAX_SIGNER_IN_MULTISIG},
+    signature::{AuthenticatorTrait, GenericSignature},
+};
+
+use super::{MultiSigPublicKey, ThresholdUnit, WeightUnit};
+
+pub fn keys() -> Vec<SuiKeyPair> {
+    let mut seed = StdRng::from_seed([0; 32]);
+    let kp1: SuiKeyPair = SuiKeyPair::Ed25519(get_key_pair_from_rng(&mut seed).1);
+    let kp2: SuiKeyPair = SuiKeyPair::Secp256k1(get_key_pair_from_rng(&mut seed).1);
+    let kp3: SuiKeyPair = SuiKeyPair::Secp256r1(get_key_pair_from_rng(&mut seed).1);
+    vec![kp1, kp2, kp3]
+}
+
+#[test]
+fn multisig_scenarios() {
+    let keys = keys();
+    let pk1 = keys[0].public();
+    let pk2 = keys[1].public();
+    let pk3 = keys[2].public();
+
+    let multisig_pk = MultiSigPublicKey::new(
+        vec![pk1.clone(), pk2.clone(), pk3.clone()],
+        vec![1, 1, 1],
+        2,
+    )
+    .unwrap();
+    let addr = SuiAddress::from(multisig_pk.clone());
+    let msg = IntentMessage::new(
+        Intent::default(),
+        PersonalMessage {
+            message: "Hello".as_bytes().to_vec(),
+        },
+    );
+    let sig1 = Signature::new_secure(&msg, &keys[0]);
+    let sig2 = Signature::new_secure(&msg, &keys[1]);
+    let sig3 = Signature::new_secure(&msg, &keys[2]);
+
+    // Any 2 of 3 signatures verifies ok.
+    let multi_sig1 =
+        MultiSig::combine(vec![sig1.clone(), sig2.clone()], multisig_pk.clone()).unwrap();
+    assert!(multi_sig1.verify_secure_generic(&msg, addr).is_ok());
+
+    let multi_sig2 =
+        MultiSig::combine(vec![sig1.clone(), sig3.clone()], multisig_pk.clone()).unwrap();
+    assert!(multi_sig2.verify_secure_generic(&msg, addr).is_ok());
+
+    let multi_sig3 =
+        MultiSig::combine(vec![sig2.clone(), sig3.clone()], multisig_pk.clone()).unwrap();
+    assert!(multi_sig3.verify_secure_generic(&msg, addr).is_ok());
+
+    // 1 of 3 signature verify fails.
+    let multi_sig4 = MultiSig::combine(vec![sig2.clone()], multisig_pk).unwrap();
+    assert!(multi_sig4.verify_secure_generic(&msg, addr).is_err());
+
+    // Incorrect address fails.
+    let kp4: SuiKeyPair = SuiKeyPair::Secp256r1(get_key_pair().1);
+    let pk4 = kp4.public();
+    let multisig_pk_1 = MultiSigPublicKey::new(
+        vec![pk1.clone(), pk2.clone(), pk3.clone(), pk4],
+        vec![1, 1, 1, 1],
+        1,
+    )
+    .unwrap();
+    let multisig5 = MultiSig::combine(vec![sig1.clone(), sig2.clone()], multisig_pk_1).unwrap();
+    assert!(multisig5.verify_secure_generic(&msg, addr).is_err());
+
+    // Create a MultiSig pubkey of pk1 (weight = 1), pk2 (weight = 2), pk3 (weight = 3), threshold 3.
+    let multisig_pk_2 = MultiSigPublicKey::new(
+        vec![pk1.clone(), pk2.clone(), pk3.clone()],
+        vec![1, 2, 3],
+        3,
+    )
+    .unwrap();
+    let addr_2 = SuiAddress::from(multisig_pk_2.clone());
+
+    // sig1 and sig2 (3 of 6) verifies ok.
+    let multi_sig_6 =
+        MultiSig::combine(vec![sig1.clone(), sig2.clone()], multisig_pk_2.clone()).unwrap();
+    assert!(multi_sig_6.verify_secure_generic(&msg, addr_2).is_ok());
+
+    // providing the same sig twice fails.
+    let multi_sig_6 =
+        MultiSig::combine(vec![sig1.clone(), sig1.clone()], multisig_pk_2.clone()).unwrap();
+    assert!(multi_sig_6.verify_secure_generic(&msg, addr_2).is_err());
+
+    // Change position for sig2 and sig1 fails.
+    let multi_sig_7 =
+        MultiSig::combine(vec![sig2.clone(), sig1.clone()], multisig_pk_2.clone()).unwrap();
+    assert!(multi_sig_7.verify_secure_generic(&msg, addr_2).is_err());
+
+    // sig3 itself (3 of 6) verifies ok.
+    let multi_sig_8 = MultiSig::combine(vec![sig3.clone()], multisig_pk_2.clone()).unwrap();
+    assert!(multi_sig_8.verify_secure_generic(&msg, addr_2).is_ok());
+
+    // sig2 itself (2 of 6) verifies fail.
+    let multi_sig_9 = MultiSig::combine(vec![sig2.clone()], multisig_pk_2.clone()).unwrap();
+    assert!(multi_sig_9.verify_secure_generic(&msg, addr_2).is_err());
+
+    // A bad sig in the multisig fails, even though sig2 and sig3 verifies and weights meets threshold.
+    let bad_sig = Signature::new_secure(
+        &IntentMessage::new(
+            Intent::default(),
+            PersonalMessage {
+                message: "Bad message".as_bytes().to_vec(),
+            },
+        ),
+        &keys[0],
+    );
+    let multi_sig_9 = MultiSig::combine(vec![bad_sig, sig2, sig3], multisig_pk_2).unwrap();
+    assert!(multi_sig_9.verify_secure_generic(&msg, addr_2).is_err());
+
+    // Wrong bitmap verifies fail.
+    let mut bitmap = RoaringBitmap::new();
+    bitmap.insert(1);
+    let multi_sig_10 = MultiSig {
+        sigs: vec![sig1.to_compressed().unwrap()], // sig1 has index 0
+        bitmap,
+        multisig_pk: MultiSigPublicKey::new(vec![pk1, pk2, pk3], vec![1, 2, 3], 3).unwrap(),
+        bytes: OnceCell::new(),
+    };
+    assert!(multi_sig_10.verify_secure_generic(&msg, addr_2).is_err());
+}
+
+#[test]
+fn test_combine_sigs() {
+    let kp1: SuiKeyPair = SuiKeyPair::Ed25519(get_key_pair().1);
+    let kp2: SuiKeyPair = SuiKeyPair::Secp256k1(get_key_pair().1);
+    let kp3: SuiKeyPair = SuiKeyPair::Secp256r1(get_key_pair().1);
+
+    let pk1 = kp1.public();
+    let pk2 = kp2.public();
+
+    let multisig_pk = MultiSigPublicKey::new(vec![pk1, pk2], vec![1, 1], 2).unwrap();
+
+    let msg = IntentMessage::new(
+        Intent::default(),
+        PersonalMessage {
+            message: "Hello".as_bytes().to_vec(),
+        },
+    );
+    let sig1 = Signature::new_secure(&msg, &kp1);
+    let sig2 = Signature::new_secure(&msg, &kp2);
+    let sig3 = Signature::new_secure(&msg, &kp3);
+
+    // MultiSigPublicKey contains only 2 public key but 3 signatures are passed, fails to combine.
+    assert!(MultiSig::combine(vec![sig1, sig2, sig3], multisig_pk.clone()).is_err());
+
+    // Cannot create malformed MultiSig.
+    assert!(MultiSig::combine(vec![], multisig_pk).is_err());
+}
+#[test]
+fn test_serde_roundtrip() {
+    let msg = IntentMessage::new(
+        Intent::default(),
+        PersonalMessage {
+            message: "Hello".as_bytes().to_vec(),
+        },
+    );
+
+    for kp in keys() {
+        let pk = kp.public();
+        let multisig_pk = MultiSigPublicKey::new(vec![pk], vec![1], 1).unwrap();
+        let sig = Signature::new_secure(&msg, &kp);
+        let multisig = MultiSig::combine(vec![sig], multisig_pk).unwrap();
+        let plain_bytes = bcs::to_bytes(&multisig).unwrap();
+
+        let generic_sig = GenericSignature::MultiSig(multisig);
+        let generic_sig_bytes = generic_sig.as_bytes();
+        let generic_sig_roundtrip = GenericSignature::from_bytes(generic_sig_bytes).unwrap();
+        assert_eq!(generic_sig, generic_sig_roundtrip);
+
+        // A MultiSig flag 0x03 is appended before the bcs serialized bytes.
+        assert_eq!(plain_bytes.len() + 1, generic_sig_bytes.len());
+        assert_eq!(generic_sig_bytes.first().unwrap(), &0x03);
+    }
+
+    // Malformed multisig cannot be serialized
+    let multisig_pk = MultiSigPublicKey {
+        pk_map: vec![(keys()[0].public(), 1)],
+        threshold: 1,
+    };
+    let multisig = MultiSig {
+        sigs: vec![], // No sigs
+        bitmap: RoaringBitmap::new(),
+        multisig_pk,
+        bytes: OnceCell::new(),
+    };
+
+    let generic_sig = GenericSignature::MultiSig(multisig);
+    let generic_sig_bytes = generic_sig.as_bytes();
+    assert!(GenericSignature::from_bytes(generic_sig_bytes).is_err());
+
+    // Malformed multisig_pk cannot be serialized
+    let multisig_pk_1 = MultiSigPublicKey {
+        pk_map: vec![],
+        threshold: 0,
+    };
+
+    let multisig_1 = MultiSig {
+        sigs: vec![],
+        bitmap: RoaringBitmap::new(),
+        multisig_pk: multisig_pk_1,
+        bytes: OnceCell::new(),
+    };
+
+    let generic_sig_1 = GenericSignature::MultiSig(multisig_1);
+    let generic_sig_bytes = generic_sig_1.as_bytes();
+    assert!(GenericSignature::from_bytes(generic_sig_bytes).is_err());
+
+    // Single sig serialization unchanged.
+    let sig = Ed25519SuiSignature::default();
+    let single_sig = GenericSignature::Signature(sig.clone().into());
+    let single_sig_bytes = single_sig.as_bytes();
+    let single_sig_roundtrip = GenericSignature::from_bytes(single_sig_bytes).unwrap();
+    assert_eq!(single_sig, single_sig_roundtrip);
+    assert_eq!(single_sig_bytes.len(), Ed25519SuiSignature::LENGTH);
+    assert_eq!(
+        single_sig_bytes.first().unwrap(),
+        &Ed25519SuiSignature::SCHEME.flag()
+    );
+    assert_eq!(sig.as_bytes().len(), single_sig_bytes.len());
+}
+
+#[test]
+fn single_sig_port_works() {
+    let kp: SuiKeyPair = SuiKeyPair::Ed25519(get_key_pair().1);
+    let addr = SuiAddress::from(&kp.public());
+    let msg = IntentMessage::new(
+        Intent::default(),
+        PersonalMessage {
+            message: "Hello".as_bytes().to_vec(),
+        },
+    );
+    let sig = Signature::new_secure(&msg, &kp);
+    assert!(sig.verify_secure_generic(&msg, addr).is_ok());
+}
+
+#[test]
+fn test_multisig_pk_failure() {
+    let keys = keys();
+    let pk1 = keys[0].public();
+    let pk2 = keys[1].public();
+    let pk3 = keys[2].public();
+
+    // Fails on weight 0.
+    assert!(MultiSigPublicKey::new(
+        vec![pk1.clone(), pk2.clone(), pk3.clone()],
+        vec![0, 1, 1],
+        2
+    )
+    .is_err());
+
+    // Fails on threshold 0.
+    assert!(MultiSigPublicKey::new(
+        vec![pk1.clone(), pk2.clone(), pk3.clone()],
+        vec![0, 1, 1],
+        0
+    )
+    .is_err());
+
+    // Fails on incorrect array length.
+    assert!(
+        MultiSigPublicKey::new(vec![pk1.clone(), pk2.clone(), pk3.clone()], vec![1], 2).is_err()
+    );
+
+    // Fails on empty array length.
+    assert!(MultiSigPublicKey::new(vec![pk1, pk2, pk3], vec![], 2).is_err());
+}
+
+#[test]
+fn test_multisig_address() {
+    // Pin an hardcoded multisig address generation here. If this fails, the address
+    // generation logic may have changed. If this is intended, update the hardcoded value below.
+    let keys = keys();
+    let pk1 = keys[0].public();
+    let pk2 = keys[1].public();
+    let pk3 = keys[2].public();
+
+    let threshold: ThresholdUnit = 2;
+    let w1: WeightUnit = 1;
+    let w2: WeightUnit = 2;
+    let w3: WeightUnit = 3;
+
+    let multisig_pk =
+        MultiSigPublicKey::new(vec![pk1, pk2, pk3], vec![w1, w2, w3], threshold).unwrap();
+    let address: SuiAddress = multisig_pk.into();
+    assert_eq!(
+        SuiAddress::from_str("0x43247fc96101763052ccc4f0417257a4270a537c").unwrap(),
+        address
+    );
+}
+
+#[test]
+fn test_max_sig() {
+    let msg = IntentMessage::new(
+        Intent::default(),
+        PersonalMessage {
+            message: "Hello".as_bytes().to_vec(),
+        },
+    );
+    let mut seed = StdRng::from_seed([0; 32]);
+    let mut keys: Vec<SuiKeyPair> = Vec::new();
+    for _ in 0..10 {
+        keys.push(SuiKeyPair::Ed25519(get_key_pair_from_rng(&mut seed).1));
+    }
+
+    // multisig_pk with larger that max number of pks fails.
+    assert!(MultiSigPublicKey::new(
+        vec![keys[0].public(); MAX_SIGNER_IN_MULTISIG + 1],
+        vec![WeightUnit::MAX; MAX_SIGNER_IN_MULTISIG + 1],
+        ThresholdUnit::MAX
+    )
+    .is_err());
+
+    // multisig_pk with max weights for each pk and max threshold is ok.
+    let high_threshold_pk = MultiSigPublicKey::new(
+        vec![keys[0].public(); MAX_SIGNER_IN_MULTISIG],
+        vec![WeightUnit::MAX; 10],
+        ThresholdUnit::MAX,
+    )
+    .unwrap();
+    let address: SuiAddress = high_threshold_pk.clone().into();
+    let sig = Signature::new_secure(&msg, &keys[0]);
+
+    // But max threshold cannot be met, fails to verify.
+    let multisig = MultiSig::combine(vec![sig; MAX_SIGNER_IN_MULTISIG], high_threshold_pk).unwrap();
+    assert!(multisig.verify_secure_generic(&msg, address).is_err());
+
+    // multisig_pk with max weights for each pk with threshold is 1x max weight verifies ok.
+    let low_threshold_pk = MultiSigPublicKey::new(
+        vec![keys[0].public(); MAX_SIGNER_IN_MULTISIG],
+        vec![WeightUnit::MAX; 10],
+        WeightUnit::MAX.into(),
+    )
+    .unwrap();
+    let address: SuiAddress = low_threshold_pk.clone().into();
+    let sig = Signature::new_secure(&msg, &keys[0]);
+    let multisig = MultiSig::combine(vec![sig; 1], low_threshold_pk).unwrap();
+    assert!(multisig.verify_secure_generic(&msg, address).is_ok());
+}

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -37,9 +37,11 @@ use sui_json_rpc_types::{
 use sui_json_rpc_types::{GetRawObjectDataResponse, SuiData};
 use sui_json_rpc_types::{SuiCertifiedTransaction, SuiExecutionStatus, SuiTransactionEffects};
 use sui_keys::keystore::AccountKeystore;
+use sui_sdk::SuiClient;
 use sui_sdk::TransactionExecutionResult;
 use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::intent::Intent;
+use sui_types::signature::GenericSignature;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     gas_coin::GasCoin,
@@ -47,14 +49,9 @@ use sui_types::{
     object::Owner,
     parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS,
 };
-use sui_types::{
-    crypto::{Signature, SignatureScheme},
-    intent::IntentMessage,
-};
+use sui_types::{crypto::SignatureScheme, intent::IntentMessage};
 use tokio::sync::RwLock;
 use tracing::{info, warn};
-
-use sui_sdk::SuiClient;
 
 pub const EXAMPLE_NFT_NAME: &str = "Example NFT";
 pub const EXAMPLE_NFT_DESCRIPTION: &str = "An NFT created by the Sui Command Line Tool";
@@ -951,15 +948,14 @@ impl SuiClientCommands {
                         .to_vec()
                         .map_err(|e| anyhow!(e))?,
                 )?;
-                let signature = Signature::from_bytes(
-                    &Base64::try_from(signature)
-                        .map_err(|e| anyhow!(e))?
-                        .to_vec()
-                        .map_err(|e| anyhow!(e))?,
-                )?;
-                let verified =
-                    Transaction::from_data(data, Intent::default(), signature).verify()?;
+                let bytes = &Base64::try_from(signature)
+                    .map_err(|e| anyhow!(e))?
+                    .to_vec()
+                    .map_err(|e| anyhow!(e))?;
 
+                let sig = GenericSignature::from_bytes(bytes)?;
+                let verified =
+                    Transaction::from_generic_sig_data(data, Intent::default(), sig).verify()?;
                 let response = context.execute_transaction(verified).await?;
                 SuiClientCommandResult::ExecuteSignedTx(response)
             }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -1,21 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
-use std::fs;
-use std::path::{Path, PathBuf};
-
 use anyhow::anyhow;
 use bip32::DerivationPath;
 use clap::*;
 use fastcrypto::encoding::{decode_bytes_hex, Base64, Encoding};
 use fastcrypto::traits::KeyPair;
+use std::fs;
+use std::path::{Path, PathBuf};
 use sui_keys::key_derive::generate_new_key;
 use sui_keys::keypair_file::{
     read_authority_keypair_from_file, read_keypair_from_file, write_authority_keypair_to_file,
     write_keypair_to_file,
 };
+use sui_types::crypto::{PublicKey, Signature};
 use sui_types::intent::{Intent, IntentMessage};
 use sui_types::messages::TransactionData;
+use sui_types::multisig::{MultiSig, MultiSigPublicKey, ThresholdUnit, WeightUnit};
+use sui_types::signature::GenericSignature;
 use tracing::info;
 
 use sui_keys::keystore::{AccountKeystore, Keystore};
@@ -78,6 +79,31 @@ pub enum KeyToolCommand {
     /// (Base64 encoded `privkey`). This prints out the account keypair as Base64 encoded `flag || privkey`,
     /// the network keypair, worker keypair, protocol keypair as Base64 encoded `privkey`.
     LoadKeypair { file: PathBuf },
+
+    /// To MultiSig Sui Address. Pass in a list of all public keys `flag || pk` in Base64.
+    /// See `keytool list` for example public keys.
+    MultiSigAddress {
+        #[clap(long)]
+        threshold: ThresholdUnit,
+        #[clap(long, multiple_occurrences = false, multiple_values = true)]
+        pks: Vec<PublicKey>,
+        #[clap(long, multiple_occurrences = false, multiple_values = true)]
+        weights: Vec<WeightUnit>,
+    },
+
+    /// Provides a list of signatures (`flag || sig || pk` encoded in Base64), threshold, a list of public keys.
+    /// Returns a valid MultiSig and its sender address. The result can be used as signature field for `sui client execute-signed-tx`.
+    /// The number of sigs must be greater than the threshold. The number of sigs must be smaller than the number of pks.
+    MultiSigCombinePartialSig {
+        #[clap(long, multiple_occurrences = false, multiple_values = true)]
+        sigs: Vec<Signature>,
+        #[clap(long, multiple_occurrences = false, multiple_values = true)]
+        pks: Vec<PublicKey>,
+        #[clap(long, multiple_occurrences = false, multiple_values = true)]
+        weights: Vec<WeightUnit>,
+        #[clap(long)]
+        threshold: ThresholdUnit,
+    },
 }
 
 impl KeyToolCommand {
@@ -200,6 +226,44 @@ impl KeyToolCommand {
                         }
                     }
                 }
+            }
+            KeyToolCommand::MultiSigAddress {
+                threshold,
+                pks,
+                weights,
+            } => {
+                let multisig_pk = MultiSigPublicKey::new(pks.clone(), weights.clone(), threshold)?;
+                let address: SuiAddress = multisig_pk.into();
+                println!("MultiSig address: {address}");
+
+                println!("Participating parties:");
+                println!(
+                    " {0: ^42} | {1: ^50} | {2: ^6}",
+                    "Sui Address", "Public Key (Base64)", "Weight"
+                );
+                println!("{}", ["-"; 100].join(""));
+                for (pk, w) in pks.into_iter().zip(weights.into_iter()) {
+                    println!(
+                        " {0: ^42} | {1: ^45} | {2: ^6}",
+                        Into::<SuiAddress>::into(&pk),
+                        pk.encode_base64(),
+                        w
+                    );
+                }
+            }
+            KeyToolCommand::MultiSigCombinePartialSig {
+                sigs,
+                pks,
+                weights,
+                threshold,
+            } => {
+                let multisig_pk = MultiSigPublicKey::new(pks, weights, threshold)?;
+                let address: SuiAddress = multisig_pk.clone().into();
+                let multisig = MultiSig::combine(sigs, multisig_pk)?;
+                let generic_sig: GenericSignature = multisig.into();
+                println!("MultiSig address: {address}");
+                println!("MultiSig parsed: {:?}", generic_sig);
+                println!("MultiSig serialized: {:?}", generic_sig.encode_base64());
             }
         }
 


### PR DESCRIPTION
Multisig support in Sui: Now sui accepts Multisig signatures. [enum GenericSignature] now replaced all [enum Signature] for user signature verification logics. 

Keytool command now supports 1) Generate multisig address 2) Combine single signatures to a multisig.

Design: https://github.com/MystenLabs/sui/issues/7187
PR: https://github.com/MystenLabs/sui/pull/7110

Step by step testing in localnet: https://gist.github.com/joyqvq/5febd8deb5cacc6f47afa1253224b7da

Main changes are in `multisig.rs`, `signature.rs` `crypto.rs`

Next step: 
- [ ] Typescript util to compute multisig address
- [ ] Typescript util to combine partial sigs
- [ ] Explorer rendering of multisig