### PR TITLE
fix: Recover fullnode-template.yaml

### DIFF
--- a/crates/sui-config/data/fullnode-template-with-path.yaml
+++ b/crates/sui-config/data/fullnode-template-with-path.yaml
@@ -10,3 +10,11 @@ enable-event-processing: true
 genesis:
   # Update this to the location of where the genesis file is stored
   genesis-file-location: "genesis.blob"
+protocol-key-pair:
+  path: "protocol.key"
+network-key-pair: 
+  path: "network.key"
+account-key-pair: 
+  path: "account.key"
+worker-key-pair: 
+  path: "worker.key"

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -656,7 +656,7 @@ mod tests {
         .unwrap();
         write_keypair_to_file(&account_key_pair, &PathBuf::from("account.key")).unwrap();
 
-        const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
+        const TEMPLATE: &str = include_str!("../data/fullnode-template-with-path.yaml");
         let template: NodeConfig = serde_yaml::from_str(TEMPLATE).unwrap();
         assert_eq!(
             template.protocol_key_pair().public(),


### PR DESCRIPTION
turns out this yaml template is not only used for testing but also for docker config. added a new template for file path and maintain the old template. fixes https://github.com/MystenLabs/sui/issues/7079