### PR TITLE
Reduce sqlite wal cleanup process frequency to every two hour 

### DIFF
--- a/crates/sui-core/src/event_handler.rs
+++ b/crates/sui-core/src/event_handler.rs
@@ -52,8 +52,8 @@ impl EventHandler {
         tokio::spawn(async move {
             match store_copy.as_ref() {
                 EventStoreType::SqlEventStore(db) => {
-                    // Start periodic task to clean up WAL
-                    db.wal_cleanup_thread(Some(Duration::from_secs(300))).await;
+                    // Start periodic task to clean up WAL every 2 hour
+                    db.wal_cleanup_thread(Some(Duration::from_secs(7200))).await;
                 }
             }
         });


### PR DESCRIPTION
We saw that each cleanup takes longer than 5 minutes. This impacts the read serve-ability. Reduce the frequency to 2 hours.