### PR TITLE
[TypeScript SDK] Add method for DevInspectMoveCall

### DIFF
--- a/.changeset/nasty-rocks-itch.md
+++ b/.changeset/nasty-rocks-itch.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Add devInspectMoveCall, which is similar to devInspectTransaction, but lets you call any Move function without a gas object and budget

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -63,6 +63,7 @@ import { requestSuiFromFaucet } from '../rpc/faucet-client';
 import { lt } from '@suchipi/femver';
 import { Base64DataBuffer } from '../serialization/base64';
 import { any, number } from 'superstruct';
+import { RawMoveCall } from '../signers/txn-data-serializers/txn-data-serializer';
 
 /**
  * Configuration options for the JsonRpcProvider. If the value of a field is not provided,
@@ -713,6 +714,30 @@ export class JsonRpcProvider extends Provider {
       throw new Error(
         `Error dev inspect transaction with request type: ${err}`
       );
+    }
+  }
+
+  async devInspectMoveCall(
+    sender: SuiAddress,
+    moveCall: RawMoveCall
+  ): Promise<DevInspectResults> {
+    try {
+      const resp = await this.client.requestWithType(
+        'sui_devInspectMoveCall',
+        [
+          sender,
+          moveCall.packageObjectId,
+          moveCall.module,
+          moveCall.function,
+          moveCall.typeArguments,
+          moveCall.arguments,
+        ],
+        DevInspectResults,
+        this.options.skipDataValidation
+      );
+      return resp;
+    } catch (err) {
+      throw new Error(`Error dev inspect move call with request type: ${err}`);
     }
   }
 

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -4,6 +4,7 @@
 import { PublicKey, SignatureScheme } from '../cryptography/publickey';
 import { HttpHeaders } from '../rpc/client';
 import { Base64DataBuffer } from '../serialization/base64';
+import { RawMoveCall } from '../signers/txn-data-serializers/txn-data-serializer';
 import {
   GetObjectDataResponse,
   SuiObjectInfo,
@@ -249,8 +250,26 @@ export abstract class Provider {
    */
   abstract unsubscribeEvent(id: SubscriptionId): Promise<boolean>;
 
+  /**
+   * Similar to dryRunTransaction, but lets you call any Move function(including non-entry function)
+   * with arbitrary values.
+   */
   abstract devInspectTransaction(txBytes: string): Promise<DevInspectResults>;
 
+  /**
+   * Similar to devInspectTransaction, but lets you call any Move function without a gas object and
+   * budget
+   */
+  abstract devInspectMoveCall(
+    sender: SuiAddress,
+    moveCall: RawMoveCall
+  ): Promise<DevInspectResults>;
+
+  /**
+   * Execute the transaction without committing any state changes on chain. This is useful for estimating
+   * gas budget and the transaction effects
+   * @param txBytes
+   */
   abstract dryRunTransaction(txBytes: string): Promise<TransactionEffects>;
   // TODO: add more interface methods
 }

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -4,6 +4,7 @@
 import { PublicKey, SignatureScheme } from '../cryptography/publickey';
 import { HttpHeaders } from '../rpc/client';
 import { Base64DataBuffer } from '../serialization/base64';
+import { RawMoveCall } from '../signers/txn-data-serializers/txn-data-serializer';
 import {
   CertifiedTransaction,
   TransactionDigest,
@@ -34,7 +35,7 @@ import {
   Order,
   TransactionEffects,
   CoinMetadata,
-  DevInspectResults
+  DevInspectResults,
 } from '../types';
 import { Provider } from './provider';
 
@@ -119,6 +120,13 @@ export class VoidProvider extends Provider {
 
   devInspectTransaction(_txBytes: string): Promise<DevInspectResults> {
     throw this.newError('devInspectTransaction');
+  }
+
+  async devInspectMoveCall(
+    _sender: SuiAddress,
+    _moveCall: RawMoveCall
+  ): Promise<DevInspectResults> {
+    throw this.newError('devInspectMoveCall');
   }
 
   dryRunTransaction(_txBytes: string): Promise<TransactionEffects> {

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -95,6 +95,14 @@ export interface MoveCallTransaction {
   gasBudget: number;
 }
 
+export interface RawMoveCall {
+  packageObjectId: ObjectId;
+  module: string;
+  function: string;
+  typeArguments: string[];
+  arguments: SuiJsonValue[];
+}
+
 export type UnserializedSignableTransaction =
   | {
       kind: 'moveCall';

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -8,6 +8,9 @@ import {
   LocalTxnDataSerializer,
   SignableTransaction,
   RawSigner,
+  JsonRpcProvider,
+  SuiAddress,
+  RawMoveCall,
 } from '../../src';
 import {
   DEFAULT_GAS_BUDGET,
@@ -91,6 +94,13 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
         kind: 'moveCall',
         data: moveCall,
       });
+
+      await validateDevInspectMoveCall(
+        toolbox.provider,
+        await signer.getAddress(),
+        moveCall,
+        'success'
+      );
     });
 
     it('Move Call that aborts', async () => {
@@ -110,6 +120,12 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
         kind: 'moveCall',
         data: moveCall,
       });
+      await validateDevInspectMoveCall(
+        toolbox.provider,
+        await signer.getAddress(),
+        moveCall,
+        'failure'
+      );
     });
   }
 );
@@ -121,4 +137,14 @@ async function validateDevInspectTransaction(
   const localDigest = await signer.getTransactionDigest(txn);
   const result = await signer.devInspectTransaction(txn);
   expect(localDigest).toEqual(result.effects.transactionDigest);
+}
+
+async function validateDevInspectMoveCall(
+  provider: JsonRpcProvider,
+  address: SuiAddress,
+  moveCall: RawMoveCall,
+  status: 'success' | 'failure'
+) {
+  const result = await provider.devInspectMoveCall(address, moveCall);
+  expect(result.effects.status.status).toEqual(status);
 }


### PR DESCRIPTION
Corresponding change on the SDK side for the newly RPC endpoint added in https://github.com/MystenLabs/sui/pull/7096