### PR TITLE
wallet-ext: revert react-router update

### DIFF
--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -135,7 +135,7 @@
         "react-intl": "^6.0.5",
         "react-number-format": "^4.9.3",
         "react-redux": "^8.0.2",
-        "react-router-dom": "^6.5.0",
+        "react-router-dom": "6.3.0",
         "react-textarea-autosize": "^8.3.4",
         "rxjs": "^7.5.6",
         "semver": "^7.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,7 +259,7 @@ importers:
       react-intl: ^6.0.5
       react-number-format: ^4.9.3
       react-redux: ^8.0.2
-      react-router-dom: ^6.5.0
+      react-router-dom: 6.3.0
       react-textarea-autosize: ^8.3.4
       rxjs: ^7.5.6
       sass: ^1.53.0
@@ -319,7 +319,7 @@ importers:
       react-intl: 6.0.8_n4upredruleo7vrbwztywbpoxq
       react-number-format: 4.9.3_biqbaboplfbrettd7655fr4n2y
       react-redux: 8.0.2_yqqa5ithnjtlkxisuaub7c4kpa
-      react-router-dom: 6.6.1_biqbaboplfbrettd7655fr4n2y
+      react-router-dom: 6.3.0_biqbaboplfbrettd7655fr4n2y
       react-textarea-autosize: 8.3.4_kzbn2opkn2327fwg5yzwzya5o4
       rxjs: 7.5.6
       semver: 7.3.8
@@ -12147,6 +12147,12 @@ packages:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
     dev: false
 
+  /history/5.3.0:
+    resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
+    dependencies:
+      '@babel/runtime': 7.20.6
+    dev: false
+
   /hoist-non-react-statics/3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -16061,6 +16067,18 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /react-router-dom/6.3.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      history: 5.3.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-router: 6.3.0_react@18.2.0
+    dev: false
+
   /react-router-dom/6.6.1_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-u+8BKUtelStKbZD5UcY0NY90WOzktrkJJhyhNg7L0APn9t1qJNLowzrM9CHdpB6+rcPt6qQrlkIXsTvhuXP68g==}
     engines: {node: '>=14'}
@@ -16072,6 +16090,15 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-router: 6.6.1_react@18.2.0
+    dev: false
+
+  /react-router/6.3.0_react@18.2.0:
+    resolution: {integrity: sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      history: 5.3.0
+      react: 18.2.0
     dev: false
 
   /react-router/6.6.1_react@18.2.0:


### PR DESCRIPTION
* seems that we were taking advantage of a bug which was fixed in 6.4.0 and useLocation after that version returns the provided location of the routes. This breaks how the menu links where constructed.
* revert the update until we fix the actual problem

quick fix for APPS-315 until we have a proper fix