### PR TITLE
[Narwhal] Do not retry InvalidEpoch error

### DIFF
--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -901,6 +901,7 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
                     match e {
                         // Report unretriable errors as 400 Bad Request.
                         DagError::InvalidSignature
+                        | DagError::InvalidEpoch { .. }
                         | DagError::InvalidHeaderDigest
                         | DagError::HeaderHasBadWorkerIds(_)
                         | DagError::HeaderHasInvalidParentRoundNumbers(_)


### PR DESCRIPTION
This does not fix the InvalidEpoch errors, but just something I found while reading code.

An invalid epoch response is not retriable at the RPC layer, or even at the level of Narwhal.

In future, maybe we can refactor to assume an error is not retriable by default.