### PR TITLE
[epoch] Pass epoch store to TransactionManager

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1100,7 +1100,7 @@ impl AuthorityPerEpochStore {
         {
             // The certificate has already been inserted into the pending_certificates table by
             // process_consensus_transaction() above.
-            transaction_manager.enqueue(vec![certificate])?;
+            transaction_manager.enqueue(vec![certificate], self)?;
         }
         Ok(())
     }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -581,7 +581,7 @@ async fn execute_transactions(
     }
     epoch_store.insert_pending_certificates(&synced_txns)?;
 
-    transaction_manager.enqueue(synced_txns)?;
+    transaction_manager.enqueue(synced_txns, &epoch_store)?;
 
     // Once synced_txns have been awaited, all txns should have effects committed.
     let mut periods = 1;

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -98,7 +98,7 @@ pub async fn execution_process(
             }
 
             // Remove the certificate that finished execution from the pending_certificates table.
-            authority.certificate_executed(&digest);
+            authority.certificate_executed(&digest, &epoch_store);
 
             authority
                 .metrics


### PR DESCRIPTION
TransactionManager runs passively, which means we could pass epoch store to every call to it.