### PR TITLE
[epoch] Move epoch store out of AuthorityStore

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -265,7 +265,6 @@ pub struct CheckpointAggregator {
     notify: Arc<Notify>,
     exit: watch::Receiver<()>,
     current: Option<CheckpointSignatureAggregator>,
-    state: Arc<AuthorityState>,
     output: Box<dyn CertifiedCheckpointOutput>,
     metrics: Arc<CheckpointMetrics>,
 }
@@ -559,7 +558,6 @@ impl CheckpointAggregator {
         epoch_store: Arc<AuthorityPerEpochStore>,
         notify: Arc<Notify>,
         exit: watch::Receiver<()>,
-        state: Arc<AuthorityState>,
         output: Box<dyn CertifiedCheckpointOutput>,
         metrics: Arc<CheckpointMetrics>,
     ) -> Self {
@@ -570,7 +568,6 @@ impl CheckpointAggregator {
             notify,
             exit,
             current,
-            state,
             output,
             metrics,
         }
@@ -612,7 +609,7 @@ impl CheckpointAggregator {
                     next_index: 0,
                     digest: summary.digest(),
                     summary,
-                    signatures: StakeAggregator::new(self.state.clone_committee()),
+                    signatures: StakeAggregator::new(self.epoch_store.committee().clone()),
                 });
                 self.current.as_mut().unwrap()
             };
@@ -762,7 +759,7 @@ impl CheckpointService {
         let (exit_snd, exit_rcv) = watch::channel(());
 
         let builder = CheckpointBuilder::new(
-            state.clone(),
+            state,
             checkpoint_store.clone(),
             epoch_store.clone(),
             notify_builder.clone(),
@@ -781,7 +778,6 @@ impl CheckpointService {
             epoch_store.clone(),
             notify_aggregator.clone(),
             exit_rcv,
-            state,
             certified_checkpoint_output,
             metrics,
         );

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::AuthorityStore;
 use std::collections::HashSet;
 use sui_types::base_types::ObjectRef;
@@ -96,6 +97,7 @@ pub(crate) fn check_dev_inspect_input_objects(
 
 pub async fn check_certificate_input(
     store: &AuthorityStore,
+    epoch_store: &AuthorityPerEpochStore,
     cert: &VerifiedCertificate,
 ) -> SuiResult<(SuiGasStatus<'static>, InputObjects)> {
     let gas_status = get_gas_status(store, &cert.data().intent_message.value).await?;
@@ -106,7 +108,7 @@ pub async fn check_certificate_input(
         // through sequencing, so we must bypass the sequence checks here.
         store.check_input_objects(&input_object_kinds)?
     } else {
-        store.check_sequenced_input_objects(cert.digest(), &input_object_kinds)?
+        store.check_sequenced_input_objects(cert.digest(), &input_object_kinds, epoch_store)?
     };
     let input_objects = check_objects(
         &cert.data().intent_message.value,

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -79,7 +79,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
         let certificate = CertifiedTransaction::new(
             transaction.into_message(),
             vec![vote.auth_sig().clone()],
-            &authority.clone_committee(),
+            &authority.clone_committee_for_testing(),
         )
         .unwrap();
         certificates.push(certificate);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -149,6 +149,8 @@ impl SuiNode {
             )
             .await?,
         );
+        let epoch_store =
+            AuthorityPerEpochStore::new(genesis_committee, &config.db_path().join("store"), None);
 
         let checkpoint_store = CheckpointStore::new(&config.db_path().join("checkpoints"));
         let state_sync_store = RocksDbStore::new(
@@ -199,6 +201,7 @@ impl SuiNode {
             config.protocol_public_key(),
             secret,
             store,
+            epoch_store,
             committee_store.clone(),
             index_store.clone(),
             event_store,


### PR DESCRIPTION
This PR moves epoch store out of AuthorityStore to fully prevent accidental access.
In order to do so, some notable refactorings:
1. CheckpointAggregator doesn't need a dependency to AuthorityState. Removing it.
2. Move a bunch of functions out of AuthorityStore that require access to both stores.
3. Remove clone_committee() from AuthorityState, to avoid accidental access to the epoch store.

After this PR, we still have a few calls to epoch_store() and epoch(). We will need to follow up and audit all the callsites to eventually minimize them.