### PR TITLE
[gas] encapsulating object.storage_rebate to avoid accidental minting…

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -89,7 +89,7 @@ pub fn execute_transaction_to_effects<
     debug!(
         computation_gas_cost = gas_cost_summary.computation_cost,
         storage_gas_cost = gas_cost_summary.storage_cost,
-        storage_gas_rebate = gas_cost_summary.storage_rebate,
+        storage_gas_rebate = gas_cost_summary.storage_rebate(),
         "Finished execution of transaction with status {:?}",
         status
     );
@@ -333,12 +333,7 @@ fn execution_loop<
                 for genesis_object in objects {
                     match genesis_object {
                         sui_types::messages::GenesisObject::RawObject { data, owner } => {
-                            let object = Object {
-                                data,
-                                owner,
-                                previous_transaction: tx_ctx.digest(),
-                                storage_rebate: 0,
-                            };
+                            let object = Object::new(data, owner, tx_ctx.digest());
                             temporary_store.write_object(
                                 &SingleTxContext::genesis(),
                                 object,

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -474,10 +474,7 @@ impl Builder {
         // checkpoint created from genesis.
         let objects = objects
             .into_iter()
-            .map(|object| Object {
-                previous_transaction: TransactionDigest::genesis(),
-                ..object
-            })
+            .map(|object| Object::new(object.data, object.owner, TransactionDigest::genesis()))
             .collect::<Vec<_>>();
 
         let genesis = Genesis {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2301,14 +2301,14 @@ impl AuthorityState {
             ?next_epoch,
             computation_cost=?gas_cost_summary.computation_cost,
             storage_cost=?gas_cost_summary.storage_cost,
-            storage_rebase=?gas_cost_summary.storage_rebate,
+            storage_rebase=?gas_cost_summary.storage_rebate(),
             "Creating advance epoch transaction"
         );
         let tx = VerifiedTransaction::new_change_epoch(
             next_epoch,
             gas_cost_summary.storage_cost,
             gas_cost_summary.computation_cost,
-            gas_cost_summary.storage_rebate,
+            gas_cost_summary.storage_rebate(),
         );
         // If we fail to sign the transaction locally for whatever reason, it's not recoverable.
         self.handle_transaction_impl(tx.clone(), epoch_store)

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -480,7 +480,7 @@ impl CheckpointBuilder {
             GasCostSummary::new(
                 previous_gas_costs.computation_cost + current_gas_costs.computation_cost,
                 previous_gas_costs.storage_cost + current_gas_costs.storage_cost,
-                previous_gas_costs.storage_rebate + current_gas_costs.storage_rebate,
+                previous_gas_costs.storage_rebate() + current_gas_costs.storage_rebate(),
             )
         } else {
             current_gas_costs

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -121,11 +121,7 @@ pub fn create_fake_cert_and_effect_digest<'a>(
 pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
     TransactionEffects {
         status: ExecutionStatus::Success,
-        gas_used: GasCostSummary {
-            computation_cost: 0,
-            storage_cost: 0,
-            storage_rebate: 0,
-        },
+        gas_used: GasCostSummary::empty(),
         modified_at_versions: Vec::new(),
         shared_objects: Vec::new(),
         transaction_digest: *tx.digest(),

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -562,12 +562,12 @@ impl TryInto<Object> for SuiObject<SuiRawData> {
             }
             SuiRawData::Package(p) => Data::Package(MovePackage::new(p.id, &p.module_map)?),
         };
-        Ok(Object {
+        Ok(Object::new_unsafe(
             data,
-            owner: self.owner,
-            previous_transaction: self.previous_transaction,
-            storage_rebate: self.storage_rebate,
-        })
+            self.owner,
+            self.previous_transaction,
+            self.storage_rebate,
+        ))
     }
 }
 
@@ -661,6 +661,7 @@ impl<T: SuiData> SuiObject<T> {
 
     pub fn try_from(o: Object, layout: Option<MoveStructLayout>) -> Result<Self, anyhow::Error> {
         let oref = o.compute_object_reference();
+        let storage_rebate = o.storage_rebate();
         let data = match o.data {
             Data::Move(m) => {
                 let layout = layout.ok_or(SuiError::ObjectSerializationError {
@@ -674,7 +675,7 @@ impl<T: SuiData> SuiObject<T> {
             data,
             owner: o.owner,
             previous_transaction: o.previous_transaction,
-            storage_rebate: o.storage_rebate,
+            storage_rebate,
             reference: oref.into(),
         })
     }
@@ -2112,7 +2113,7 @@ impl From<GasCostSummary> for SuiGasCostSummary {
         Self {
             computation_cost: s.computation_cost,
             storage_cost: s.storage_cost,
-            storage_rebate: s.storage_rebate,
+            storage_rebate: s.storage_rebate(),
         }
     }
 }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1933,11 +1933,7 @@ impl Default for TransactionEffects {
     fn default() -> Self {
         TransactionEffects {
             status: ExecutionStatus::Success,
-            gas_used: GasCostSummary {
-                computation_cost: 0,
-                storage_cost: 0,
-                storage_rebate: 0,
-            },
+            gas_used: GasCostSummary::empty(),
             modified_at_versions: Vec::new(),
             shared_objects: Vec::new(),
             transaction_digest: TransactionDigest::random(),


### PR DESCRIPTION
…/burning

`Object.storage_rebate` is a particularly sensitive field because it corresponds directly to SUI that the user can claim. This was previously a public field, which made it a bit too easy to make mistakes when updating this field. Made the field private, and forced the API's for accessing it to provide the old version of the object, or insist that no object size change is occurring.