### PR TITLE
[move] Implement Boogie native function for address module

### DIFF
--- a/crates/sui-framework/docs/address_spec.md
+++ b/crates/sui-framework/docs/address_spec.md
@@ -1,0 +1,146 @@
+
+<a name="0x0_address_spec"></a>
+
+# Module `0x0::address_spec`
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `from_bytes`](#0x0_address_spec_from_bytes)
+-  [Function `to_u256`](#0x0_address_spec_to_u256)
+-  [Function `from_u256`](#0x0_address_spec_from_u256)
+
+
+<pre><code><b>use</b> <a href="address.md#0x2_address">0x2::address</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x0_address_spec_MAX"></a>
+
+
+
+<pre><code><b>const</b> <a href="address_spec.md#0x0_address_spec_MAX">MAX</a>: u256 = 1461501637330902918203684832716283019655932542975;
+</code></pre>
+
+
+
+<a name="0x0_address_spec_from_bytes"></a>
+
+## Function `from_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_spec.md#0x0_address_spec_from_bytes">from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_spec.md#0x0_address_spec_from_bytes">from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <b>address</b> {
+    <a href="address.md#0x2_address_from_bytes">address::from_bytes</a>(bytes)
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> len(bytes) != 20;
+<b>ensures</b> result == <a href="address.md#0x2_address_from_bytes">address::from_bytes</a>(bytes);
+<b>let</b> addr = @0x89b9f9d1fadc027cf9532d6f99041522;
+<b>let</b> expected_output = x"0000000089b9f9d1fadc027cf9532d6f99041522";
+<b>aborts_if</b> len(expected_output) != 20;
+<b>aborts_if</b> <a href="address.md#0x2_address_from_bytes">address::from_bytes</a>(expected_output) != addr;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_address_spec_to_u256"></a>
+
+## Function `to_u256`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_spec.md#0x0_address_spec_to_u256">to_u256</a>(a: <b>address</b>): u256
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_spec.md#0x0_address_spec_to_u256">to_u256</a>(a: <b>address</b>): u256 {
+    <a href="address.md#0x2_address_to_u256">address::to_u256</a>(a)
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+<b>ensures</b> <a href="address.md#0x2_address_from_u256">address::from_u256</a>(result) == a;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_address_spec_from_u256"></a>
+
+## Function `from_u256`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_spec.md#0x0_address_spec_from_u256">from_u256</a>(n: u256): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_spec.md#0x0_address_spec_from_u256">from_u256</a>(n: u256): <b>address</b> {
+    <a href="address.md#0x2_address_from_u256">address::from_u256</a>(n)
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> n &gt; <a href="address_spec.md#0x0_address_spec_MAX">MAX</a>;
+<b>ensures</b> <a href="address.md#0x2_address_to_u256">address::to_u256</a>(result) == n;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework/docs/object.md
+++ b/crates/sui-framework/docs/object.md
@@ -196,10 +196,10 @@ Make an <code><a href="object.md#0x2_object_ID">ID</a></code> from raw bytes.
 <details>
 <summary>Specification</summary>
 
-Specify the calling of native function <code><a href="address.md#0x2_address_from_bytes">address::from_bytes</a></code>
 
 
 <pre><code><b>aborts_if</b> len(bytes) != 20;
+<b>ensures</b> <a href="address.md#0x2_address_from_bytes">address::from_bytes</a>(bytes) == result.bytes;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/object.md
+++ b/crates/sui-framework/docs/object.md
@@ -193,6 +193,19 @@ Make an <code><a href="object.md#0x2_object_ID">ID</a></code> from raw bytes.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+Specify the calling of native function <code><a href="address.md#0x2_address_from_bytes">address::from_bytes</a></code>
+
+
+<pre><code><b>aborts_if</b> len(bytes) != 20;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_object_id_from_address"></a>
 
 ## Function `id_from_address`

--- a/crates/sui-framework/sources/address_spec.move
+++ b/crates/sui-framework/sources/address_spec.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::address_spec {
+    use sui::address;
+
+    const MAX: u256 = 1461501637330902918203684832716283019655932542975;
+
+    public fun from_bytes(bytes: vector<u8>): address {
+        address::from_bytes(bytes)
+    }
+
+    spec from_bytes {
+        aborts_if len(bytes) != 20;
+        ensures result == address::from_bytes(bytes);
+
+        let addr = @0x89b9f9d1fadc027cf9532d6f99041522; //$t1
+        let expected_output = x"0000000089b9f9d1fadc027cf9532d6f99041522"; //$t2
+
+        aborts_if len(expected_output) != 20;
+        aborts_if address::from_bytes(expected_output) != addr;
+    }
+
+    public fun to_u256(a: address): u256 {
+        address::to_u256(a)
+    }
+
+    spec to_u256 {
+        aborts_if false;
+        ensures address::from_u256(result) == a;
+    }
+
+    public fun from_u256(n: u256): address {
+        address::from_u256(n)
+    }
+
+    spec from_u256 {
+        aborts_if n > MAX;
+        ensures address::to_u256(result) == n;
+    }
+}

--- a/crates/sui-framework/sources/address_spec.move
+++ b/crates/sui-framework/sources/address_spec.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module sui::address_spec {
+module 0x0::address_spec {
     use sui::address;
 
     const MAX: u256 = 1461501637330902918203684832716283019655932542975;

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -59,6 +59,12 @@ module sui::object {
         id_from_address(address::from_bytes(bytes))
     }
 
+    /// Specify the calling of native function `address::from_bytes`
+    spec id_from_bytes {
+        aborts_if len(bytes) != 20;
+        ensures address::from_bytes(bytes) == result.bytes;
+    }
+
     /// Make an `ID` from an address.
     public fun id_from_address(bytes: address): ID {
         ID { bytes }

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -59,7 +59,6 @@ module sui::object {
         id_from_address(address::from_bytes(bytes))
     }
 
-    /// Specify the calling of native function `address::from_bytes`
     spec id_from_bytes {
         aborts_if len(bytes) != 20;
         ensures address::from_bytes(bytes) == result.bytes;

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -29,7 +29,7 @@ procedure {:inline 1} $2_address_from_bytes(bytes: Vec (int)) returns (res: int)
 {
     var len: int;
     len := LenVec(bytes);
-    if (len != 20) {
+    if (len != $ADRESS_LENGTH) {
         call $ExecFailureAbort();
         return;
     }

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -5,11 +5,90 @@
 // Native address
 
 
-procedure {:inline 1} $2_address_from_bytes(bytes: Vec (int)) returns (res: int);
+const $MAX_ADDRESS: int;
+axiom $MAX_ADDRESS == 1461501637330902918203684832716283019655932542975;
 
-procedure {:inline 1} $2_address_to_u256(addr: int) returns (res: int);
+const $ADRESS_LENGTH: int;
+axiom $ADRESS_LENGTH == 20;
 
-procedure {:inline 1} $2_address_from_u256(num: int) returns (res: int);
+// helper function for converting vector to address.
+function $2_peel_vector_to_address(bytes: Vec (int), len: int): int
+{
+    if len > 0 then 256 * $2_peel_vector_to_address(bytes, len-1) + ReadVec(bytes, len-1)
+    else 0
+}
+
+axiom (forall v1, v2: Vec (int) :: {$2_peel_vector_to_address(v1, $ADRESS_LENGTH), $2_peel_vector_to_address(v2, $ADRESS_LENGTH)}
+   $IsEqual'vec'u8''(v1, v2) <==> $IsEqual'address'($2_peel_vector_to_address(v1, $ADRESS_LENGTH), $2_peel_vector_to_address(v2, $ADRESS_LENGTH)));
+
+axiom (forall v: Vec (int) :: {$2_peel_vector_to_address(v, $ADRESS_LENGTH)}
+     ( var r := $2_peel_vector_to_address(v, $ADRESS_LENGTH); $IsValid'address'(r) ));
+
+// procedure that check abort condition, and converting bytes to address.
+procedure {:inline 1} $2_address_from_bytes(bytes: Vec (int)) returns (res: int)
+{
+    var len: int;
+    len := LenVec(bytes);
+    if (len != 20) {
+        call $ExecFailureAbort();
+        return;
+    }
+    res := $2_peel_vector_to_address(bytes, $ADRESS_LENGTH);
+}
+
+function {:inline} $2_address_$from_bytes(bytes: Vec (int)): int {
+    $2_peel_vector_to_address(bytes, $ADRESS_LENGTH)
+}
+
+function $2_u256_from_address(addr: int): int
+{
+    addr
+}
+
+axiom (forall a1, a2: int :: {$2_u256_from_address(a1), $2_u256_from_address(a2)}
+   $IsEqual'address'(a1, a2) <==> $IsEqual'u256'($2_u256_from_address(a1), $2_u256_from_address(a2)));
+
+axiom (forall a: int :: {$2_u256_from_address(a)}
+     ( var r := $2_u256_from_address(a); $IsValid'u256'(r) ));
+
+// procedure that check abort condition, and converting address to u256.
+procedure {:inline 1} $2_address_to_u256(addr: int) returns (res: int)
+{
+    if ( !$IsValid'address'(addr) ) {
+        call $ExecFailureAbort();
+        return;
+    }
+    res := $2_u256_from_address(addr);
+}
+
+function {:inline} $2_address_$to_u256(addr: int): int {
+    $2_u256_from_address(addr)
+}
+
+function $2_u256_to_address(num: int): int
+{
+    num
+}
+
+axiom (forall n1, n2: int :: {$2_u256_to_address(n1), $2_u256_to_address(n2)}
+   $IsEqual'u256'(n1, n2) <==> $IsEqual'address'($2_u256_to_address(n1), $2_u256_to_address(n2)));
+
+axiom (forall n: int :: {$2_u256_to_address(n)}
+     ( var r := $2_u256_to_address(n); $IsValid'address'(r) ));
+
+// procedure that check abort condition, and converting u256 to address.
+procedure {:inline 1} $2_address_from_u256(num: int) returns (res: int)
+{
+    if ( !$IsValid'u256'(num) || num > $MAX_ADDRESS ) {
+        call $ExecFailureAbort();
+        return;
+    }
+    res := $2_u256_to_address(num);
+}
+
+function {:inline} $2_address_$from_u256(num: int): int {
+    $2_u256_to_address(num)
+}
 
 // ==================================================================================
 // Native transfer


### PR DESCRIPTION
## Summary
This PR implements calls of native function of the `address` module in the prover.
This enables specifications to functions containing calls of native functions of the `address` module.
Also this PR adds prover specs to the `object` module, and test spec code of `address` module.

## Motivation
- Previous code in `sui-natives.bpl` is just a skeleton, so this PR implements boogie side of native functions in `address` module.
```move
module 0x0::address_spec {
    use sui::address;

    public fun from_bytes(bytes: vector<u8>): address {
        address::from_bytes(bytes)
    }

	spec from_bytes {
	    aborts_if len(bytes) != 20;
	}
}
```
- Running prover through `sui move prove -- --verify-only from_bytes` command on above specification returns "error: function does not abort under this condition".
```move
module 0x0::address_spec {
    use sui::address;

    public fun from_bytes(bytes: vector<u8>): address {
        address::from_bytes(bytes)
    }

	spec from_bytes {
	    ensures result == address::from_bytes(bytes);
	}
}
```
- Running prover through `sui move prove -- --verify-only from_bytes` command on above specification returns "Error: use of undeclared function: $2_address_$from_bytes".

## Key Changes
- `aborts_if len(bytes) != 20;` specification pass the prover, and other false `aborts_if` conditions will return errors.
- Implements native function calls of `address` module (eg. `address::from_bytes()`) in `spec` block.
- Prover fails when post-conditions at specification are false and passes when post-conditions are true.

I'm a noob sui contributor, so I would appreciate it if you could point out any mistakes.