### PR TITLE
wallet-ext: fix menu redirecting to home page

### DIFF
--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -135,7 +135,7 @@
         "react-intl": "^6.0.5",
         "react-number-format": "^4.9.3",
         "react-redux": "^8.0.2",
-        "react-router-dom": "^6.5.0",
+        "react-router-dom": "6.6.1",
         "react-textarea-autosize": "^8.3.4",
         "rxjs": "^7.5.6",
         "semver": "^7.3.8",

--- a/apps/wallet/src/ui/app/components/menu/content/index.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/index.tsx
@@ -3,13 +3,20 @@
 
 import cl from 'classnames';
 import { useCallback } from 'react';
-import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
+import {
+    Navigate,
+    Route,
+    Routes,
+    useLocation,
+    useNavigate,
+} from 'react-router-dom';
 
 import Account from './account';
 import MenuList from './menu-list';
 import Network from './network';
 import { ErrorBoundary } from '_components/error-boundary';
 import {
+    MainLocationContext,
     useMenuIsOpen,
     useMenuUrl,
     useNextMenuUrl,
@@ -23,6 +30,7 @@ import st from './MenuContent.module.scss';
 const CLOSE_KEY_CODES: string[] = ['Escape'];
 
 function MenuContent() {
+    const mainLocation = useLocation();
     const isOpen = useMenuIsOpen();
     const menuUrl = useMenuUrl();
     const menuHomeUrl = useNextMenuUrl(true, '/');
@@ -47,17 +55,19 @@ function MenuContent() {
             <div className={st.backdrop} onClick={handleOnCloseMenu} />
             <div className={cl(st.content, { [st.expanded]: expanded })}>
                 <ErrorBoundary>
-                    <Routes location={menuUrl || ''}>
-                        <Route path="/" element={<MenuList />} />
-                        <Route path="/account" element={<Account />} />
-                        <Route path="/network" element={<Network />} />
-                        <Route
-                            path="*"
-                            element={
-                                <Navigate to={menuHomeUrl} replace={true} />
-                            }
-                        />
-                    </Routes>
+                    <MainLocationContext.Provider value={mainLocation}>
+                        <Routes location={menuUrl || ''}>
+                            <Route path="/" element={<MenuList />} />
+                            <Route path="/account" element={<Account />} />
+                            <Route path="/network" element={<Network />} />
+                            <Route
+                                path="*"
+                                element={
+                                    <Navigate to={menuHomeUrl} replace={true} />
+                                }
+                            />
+                        </Routes>
+                    </MainLocationContext.Provider>
                 </ErrorBoundary>
             </div>
         </div>

--- a/apps/wallet/src/ui/app/components/menu/hooks.ts
+++ b/apps/wallet/src/ui/app/components/menu/hooks.ts
@@ -1,10 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 
+import type { Location } from 'react-router-dom';
+
 const MENU_PARAM = 'menu';
+
+export const MainLocationContext = createContext<Location | null>(null);
 
 export function useMenuUrl() {
     const [searchParams] = useSearchParams();
@@ -26,8 +30,18 @@ export function useMenuIsOpen() {
  * @param nextMenuLocation The location within the menu
  */
 export function useNextMenuUrl(isOpen: boolean, nextMenuLocation = '/') {
-    const [searchParams] = useSearchParams();
-    const { pathname } = useLocation();
+    const mainLocationContext = useContext(MainLocationContext);
+    const location = useLocation();
+    // here we assume that if MainLocationContext is not defined
+    // we are not within the menu routes and location is the main one.
+    // if it's defined then we use that because useLocation returns the
+    // location from the menu Routes that is not what we need here.
+    const finalLocation = mainLocationContext || location;
+    const { pathname, search } = finalLocation;
+    const searchParams = useMemo(
+        () => new URLSearchParams(search.replace('?', '')),
+        [search]
+    );
     return useMemo(() => {
         if (isOpen) {
             searchParams.set(MENU_PARAM, nextMenuLocation);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,7 +259,7 @@ importers:
       react-intl: ^6.0.5
       react-number-format: ^4.9.3
       react-redux: ^8.0.2
-      react-router-dom: ^6.5.0
+      react-router-dom: 6.6.1
       react-textarea-autosize: ^8.3.4
       rxjs: ^7.5.6
       sass: ^1.53.0
@@ -324,7 +324,7 @@ importers:
       rxjs: 7.5.6
       semver: 7.3.8
       stream-browserify: 3.0.0
-      tailwindcss: 3.2.4_ts-node@10.9.1
+      tailwindcss: 3.2.4_v776zzvn44o7tpgzieipaairwm
       throttle-debounce: 5.0.0
       tweetnacl: 1.0.3
       uuid: 8.3.2
@@ -17901,10 +17901,12 @@ packages:
       - ts-node
     dev: true
 
-  /tailwindcss/3.2.4_ts-node@10.9.1:
+  /tailwindcss/3.2.4_v776zzvn44o7tpgzieipaairwm:
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3


### PR DESCRIPTION
* after updating `react-router` using `useLocation` returns the location from menu Routes (the inner Routes) and this breaks the menu since we expect the main location of the app
* this fix uses react context to pass the main location to menu so it can create the correct urls

Before


https://user-images.githubusercontent.com/10210143/210827801-218ea58e-de37-4282-8438-df6dabe8820a.mov



After

https://user-images.githubusercontent.com/10210143/210827111-90d49b12-05c6-46f4-b531-a8aefaaeb94e.mov

closes APPS-315