### PR TITLE
[QD Reconfig] 5. reconfig stress

### DIFF
--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -20,8 +20,7 @@ use sui_benchmark::workloads::{
 use sui_benchmark::FullNodeProxy;
 use sui_benchmark::LocalValidatorAggregatorProxy;
 use sui_benchmark::ValidatorProxy;
-use sui_core::authority_aggregator::reconfig_from_genesis;
-use sui_core::authority_aggregator::AuthorityAggregatorBuilder;
+use sui_config::utils;
 use sui_node::metrics;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
@@ -29,8 +28,8 @@ use sui_types::crypto::{deterministic_random_account_key, AccountKeyPair};
 use tokio::time::sleep;
 
 use sui_types::object::generate_test_gas_objects_with_owner;
-use test_utils::authority::spawn_test_authorities;
 use test_utils::authority::test_and_configure_authority_configs;
+use test_utils::authority::{spawn_fullnode, spawn_test_authorities};
 use tokio::runtime::Builder;
 use tokio::sync::Barrier;
 use tracing::info;
@@ -75,11 +74,16 @@ struct Opts {
     /// genesis_blob_path, keypair_path and primary_gas_id
     #[clap(long, parse(try_from_str), default_value = "true", global = true)]
     pub local: bool,
-    /// If provided, use FullNodeProxy to submit transactions and read data.
+    /// Required in remote benchmark, namely when local = false
+    #[clap(long)]
+    pub fullnode_rpc_address: Option<String>,
+    /// Whether to submit transactions to a fullnode.
+    /// If true, use FullNodeProxy.
+    /// Otherwise, use LocalValidatorAggregatorProxy.
     /// This param only matters when local = false, namely local runs always
     /// use a LocalValidatorAggregatorProxy.
-    #[clap(long, global = true)]
-    pub fullnode_rpc_address: Option<String>,
+    #[clap(long, parse(try_from_str), default_value = "false", global = true)]
+    pub use_fullnode_for_execution: bool,
     /// Default workload is 100% transfer object
     #[clap(subcommand)]
     run_spec: RunSpec,
@@ -202,7 +206,7 @@ async fn main() -> Result<()> {
             .parse()
             .unwrap(),
     );
-    let registry: Arc<Registry> = Arc::new(registry_service.default_registry());
+    let registry: Registry = registry_service.default_registry();
 
     let barrier = Arc::new(Barrier::new(2));
     let cloned_barrier = barrier.clone();
@@ -227,15 +231,8 @@ async fn main() -> Result<()> {
         // Make the client runtime wait until we are done creating genesis objects
         let cloned_config = configs.clone();
         let cloned_gas = primary_gas;
-
-        let (aggregator, _) = AuthorityAggregatorBuilder::from_network_config(&configs)
-            .with_registry(registry.clone())
-            .build()
-            .unwrap();
-
-        let proxy: Arc<dyn ValidatorProxy + Send + Sync> = Arc::new(
-            LocalValidatorAggregatorProxy::from_auth_agg(Arc::new(aggregator)),
-        );
+        let fullnode_ip = format!("{}", utils::get_local_ip_for_tests());
+        let fullnode_rpc_port = utils::get_available_port(&fullnode_ip);
 
         // spawn a thread to spin up sui nodes on the multi-threaded server runtime.
         // running forever
@@ -249,7 +246,9 @@ async fn main() -> Result<()> {
                 .unwrap();
             server_runtime.block_on(async move {
                 // Setup the network
-                let _nodes: Vec<_> = spawn_test_authorities(cloned_gas, &cloned_config).await;
+                let _validators: Vec<_> = spawn_test_authorities(cloned_gas, &cloned_config).await;
+                let _fullnode = spawn_fullnode(&cloned_config, Some(fullnode_rpc_port)).await;
+
                 cloned_barrier.wait().await;
 
                 // This thread cannot exit, otherwise validators will shutdown.
@@ -258,6 +257,19 @@ async fn main() -> Result<()> {
                 }
             });
         });
+
+        // Let fullnode be created.
+        sleep(Duration::from_secs(5)).await;
+        let fullnode_rpc_url = format!("http://{fullnode_ip}:{fullnode_rpc_port}");
+        eprintln!("Fullnode rpc url: {fullnode_rpc_url}");
+        let proxy: Arc<dyn ValidatorProxy + Send + Sync> = Arc::new(
+            LocalValidatorAggregatorProxy::from_network_config(
+                &configs,
+                &registry,
+                &fullnode_rpc_url,
+            )
+            .await,
+        );
         (primary_gas_id, owner, Arc::new(keypair), proxy)
     } else {
         info!("Configuring remote benchmark..");
@@ -270,23 +282,21 @@ async fn main() -> Result<()> {
                 });
         });
 
-        let proxy: Arc<dyn ValidatorProxy + Send + Sync> =
-            if let Some(fullnode_url) = opts.fullnode_rpc_address {
-                info!("Using Full node: {fullnode_url}..");
-                Arc::new(FullNodeProxy::from_url(&fullnode_url).await.unwrap())
-            } else {
-                let genesis = sui_config::node::Genesis::new_from_file(&opts.genesis_blob_path);
-                let genesis = genesis.genesis()?;
-                let (aggregator, _) = AuthorityAggregatorBuilder::from_genesis(genesis)
-                    .with_registry(registry.clone())
-                    .build()
-                    .unwrap();
-
-                let aggregator = reconfig_from_genesis(aggregator).await?;
-                Arc::new(LocalValidatorAggregatorProxy::from_auth_agg(Arc::new(
-                    aggregator,
-                )))
-            };
+        let fullnode_rpc_url = opts
+            .fullnode_rpc_address
+            .expect("Remote benchmark requires fullnode-rpc-url");
+            info!("Fullnode rpc url: {fullnode_rpc_url}");
+        let proxy: Arc<dyn ValidatorProxy + Send + Sync> = if opts.use_fullnode_for_execution {
+            info!("Using FullNodeProxy: {fullnode_rpc_url}..");
+            Arc::new(FullNodeProxy::from_url(&fullnode_rpc_url).await.unwrap())
+        } else {
+            let genesis = sui_config::node::Genesis::new_from_file(&opts.genesis_blob_path);
+            let genesis = genesis.genesis()?;
+            Arc::new(
+                LocalValidatorAggregatorProxy::from_genesis(genesis, &registry, &fullnode_rpc_url)
+                    .await,
+            )
+        };
         info!(
             "Reconfiguration - Reconfiguration to epoch {} is done",
             proxy.get_current_epoch(),

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -261,7 +261,7 @@ async fn main() -> Result<()> {
         // Let fullnode be created.
         sleep(Duration::from_secs(5)).await;
         let fullnode_rpc_url = format!("http://{fullnode_ip}:{fullnode_rpc_port}");
-        eprintln!("Fullnode rpc url: {fullnode_rpc_url}");
+        info!("Fullnode rpc url: {fullnode_rpc_url}");
         let proxy: Arc<dyn ValidatorProxy + Send + Sync> = Arc::new(
             LocalValidatorAggregatorProxy::from_network_config(
                 &configs,
@@ -285,7 +285,7 @@ async fn main() -> Result<()> {
         let fullnode_rpc_url = opts
             .fullnode_rpc_address
             .expect("Remote benchmark requires fullnode-rpc-url");
-            info!("Fullnode rpc url: {fullnode_rpc_url}");
+        info!("Fullnode rpc url: {fullnode_rpc_url}");
         let proxy: Arc<dyn ValidatorProxy + Send + Sync> = if opts.use_fullnode_for_execution {
             info!("Using FullNodeProxy: {fullnode_rpc_url}..");
             Arc::new(FullNodeProxy::from_url(&fullnode_rpc_url).await.unwrap())

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -224,6 +224,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
         show_progress: bool,
         run_duration: Interval,
     ) -> Result<BenchmarkStats, anyhow::Error> {
+        eprintln!("Running BenchDriver");
         let mut tasks = Vec::new();
         let (tx, mut rx) = tokio::sync::mpsc::channel(100);
         let mut bench_workers = vec![];

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -224,7 +224,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
         show_progress: bool,
         run_duration: Interval,
     ) -> Result<BenchmarkStats, anyhow::Error> {
-        eprintln!("Running BenchDriver");
+        info!("Running BenchDriver");
         let mut tasks = Vec::new();
         let (tx, mut rx) = tokio::sync::mpsc::channel(100);
         let mut bench_workers = vec![];

--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -1,0 +1,119 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use sui_core::{
+    authority_aggregator::{AuthAggMetrics, AuthorityAggregator},
+    authority_client::NetworkAuthorityClient,
+    epoch::committee_store::CommitteeStore,
+    quorum_driver::{reconfig_observer::ReconfigObserver, QuorumDriver},
+    safe_client::SafeClientMetricsBase,
+};
+use sui_sdk::SuiClient;
+use sui_types::committee::Committee;
+use tracing::{debug, error, trace};
+
+/// A ReconfigObserver that polls FullNode periodically
+/// to get new epoch information.
+/// Caveat: it does not guarantee to insert every commitee
+/// into committee store. This is fine in scenarios such
+/// as stress, but may not be suitable in some other cases.
+#[derive(Clone)]
+pub struct FullNodeReconfigObserver {
+    pub fullnode_client: SuiClient,
+    committee_store: Arc<CommitteeStore>,
+    safe_client_metrics_base: SafeClientMetricsBase,
+    auth_agg_metrics: AuthAggMetrics,
+}
+
+impl FullNodeReconfigObserver {
+    pub async fn new(
+        fullnode_rpc_url: &str,
+        committee_store: Arc<CommitteeStore>,
+        safe_client_metrics_base: SafeClientMetricsBase,
+        auth_agg_metrics: AuthAggMetrics,
+    ) -> Self {
+        Self {
+            fullnode_client: SuiClient::new(fullnode_rpc_url, None, None)
+                .await
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Can't create SuiClient with rpc url {fullnode_rpc_url}: {:?}",
+                        e
+                    )
+                }),
+            committee_store,
+            safe_client_metrics_base,
+            auth_agg_metrics,
+        }
+    }
+}
+
+#[async_trait]
+impl ReconfigObserver<NetworkAuthorityClient> for FullNodeReconfigObserver {
+    fn clone_boxed(&self) -> Box<dyn ReconfigObserver<NetworkAuthorityClient> + Send + Sync> {
+        Box::new(self.clone())
+    }
+
+    async fn run(&mut self, quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>) {
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+            match self.fullnode_client.read_api().get_sui_system_state().await {
+                Ok(sui_system_state) => {
+                    let epoch_id = sui_system_state.epoch;
+                    if epoch_id > quorum_driver.current_epoch() {
+                        debug!(
+                            chain_id=?sui_system_state.chain_id,
+                            epoch_id,
+                            "Got SuiSystemState in newer epoch"
+                        );
+                        let new_committee = match self
+                            .fullnode_client
+                            .read_api()
+                            .get_committee_info(Some(epoch_id))
+                            .await
+                        {
+                            Ok(committee) if committee.committee_info.is_some() => {
+                                // Safe to unwrap, checked above
+                                Committee::new(committee.epoch, BTreeMap::from_iter(committee.committee_info.unwrap().into_iter())).unwrap_or_else(
+                                    |e| panic!("Can't create a valid Committee given info returned from Full Node: {:?}", e)
+                                )
+                            }
+                            other => {
+                                error!(
+                                    "Can't get CommitteeInfo {} from Full Node: {:?}",
+                                    epoch_id, other
+                                );
+                                continue;
+                            }
+                        };
+                        let _ = self.committee_store.insert_new_committee(&new_committee);
+                        match AuthorityAggregator::new_from_system_state(
+                            &sui_system_state,
+                            &self.committee_store,
+                            self.safe_client_metrics_base.clone(),
+                            self.auth_agg_metrics.clone(),
+                        ) {
+                            Ok(auth_agg) => {
+                                quorum_driver.update_validators(Arc::new(auth_agg)).await
+                            }
+                            Err(err) => error!(
+                                "Can't create AuthorityAggregator from SuiSystemState: {:?}",
+                                err
+                            ),
+                        }
+                    } else {
+                        trace!(
+                            chain_id=?sui_system_state.chain_id,
+                            epoch_id,
+                            "Ignored SystemState from a previous or current epoch",
+                        );
+                    }
+                }
+                Err(err) => error!("Can't get SuiSystemState from Full Node: {:?}", err,),
+            }
+        }
+    }
+}

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -8,7 +8,6 @@ mod test {
     use std::sync::Arc;
     use std::time::Duration;
     use sui_config::SUI_KEYSTORE_FILENAME;
-    use sui_core::authority_aggregator::AuthorityAggregatorBuilder;
     use test_utils::{messages::get_gas_object_with_wallet_context, network::TestClusterBuilder};
 
     use sui_benchmark::{
@@ -57,6 +56,7 @@ mod test {
         let swarm = &test_cluster.swarm;
         let context = &test_cluster.wallet;
         let sender = test_cluster.get_address_0();
+        let fullnode_rpc_url = &test_cluster.fullnode_handle.rpc_url;
 
         let keystore_path = swarm.dir().join(SUI_KEYSTORE_FILENAME);
         let ed25519_keypair = get_ed25519_keypair_from_keystore(keystore_path, &sender).unwrap();
@@ -78,12 +78,14 @@ mod test {
             1,  // shared_counter_weight
             1,  // transfer_object_weight
         )];
-
-        let (aggregator, _) = AuthorityAggregatorBuilder::from_network_config(swarm.config())
-            .build()
-            .unwrap();
+        let registry = prometheus::Registry::new();
         let proxy: Arc<dyn ValidatorProxy + Send + Sync> = Arc::new(
-            LocalValidatorAggregatorProxy::from_auth_agg(Arc::new(aggregator)),
+            LocalValidatorAggregatorProxy::from_network_config(
+                swarm.config(),
+                &registry,
+                fullnode_rpc_url,
+            )
+            .await,
         );
 
         for w in workloads.iter_mut() {
@@ -96,7 +98,6 @@ mod test {
         }
 
         let driver = BenchDriver::new(5);
-        let registry = prometheus::Registry::new();
 
         // Use 0 for unbounded
         let test_duration_secs = get_var("SIM_STRESS_TEST_DURATION_SECS", 10);

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -72,6 +72,7 @@ impl OnsiteReconfigObserver {
 
 #[async_trait]
 impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
+<<<<<<< HEAD
     fn clone_boxed(&self) -> Box<dyn ReconfigObserver<NetworkAuthorityClient> + Send + Sync> {
         Box::new(Self {
             reconfig_rx: self.reconfig_rx.resubscribe(),
@@ -82,6 +83,8 @@ impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
         })
     }
 
+=======
+>>>>>>> 3c6f11a74 (add reconfig observer)
     async fn run(&mut self, quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>) {
         // A tiny optimization: when a very stale node just starts, the
         // channel may fill up committees quickly. Here we skip directly to
@@ -116,7 +119,6 @@ impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
         }
     }
 }
-
 /// A dummy ReconfigObserver for testing.
 pub struct DummyReconfigObserver;
 

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -53,7 +53,7 @@ impl OnsiteReconfigObserver {
     async fn create_authority_aggregator_from_system_state(
         &self,
     ) -> AuthorityAggregator<NetworkAuthorityClient> {
-        AuthorityAggregator::new_from_system_state(
+        AuthorityAggregator::new_from_local_system_state(
             &self.authority_store,
             &self.committee_store,
             self.safe_client_metrics_base.clone(),
@@ -72,7 +72,6 @@ impl OnsiteReconfigObserver {
 
 #[async_trait]
 impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
-<<<<<<< HEAD
     fn clone_boxed(&self) -> Box<dyn ReconfigObserver<NetworkAuthorityClient> + Send + Sync> {
         Box::new(Self {
             reconfig_rx: self.reconfig_rx.resubscribe(),
@@ -83,8 +82,6 @@ impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
         })
     }
 
-=======
->>>>>>> 3c6f11a74 (add reconfig observer)
     async fn run(&mut self, quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>) {
         // A tiny optimization: when a very stale node just starts, the
         // channel may fill up committees quickly. Here we skip directly to

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -63,7 +63,7 @@ impl TransactiondOrchestrator<NetworkAuthorityClient> {
     ) -> anyhow::Result<Self> {
         let safe_client_metrics_base = SafeClientMetricsBase::new(prometheus_registry);
         let auth_agg_metrics = AuthAggMetrics::new(prometheus_registry);
-        let validators = AuthorityAggregator::new_from_system_state(
+        let validators = AuthorityAggregator::new_from_local_system_state(
             &validator_state.db(),
             validator_state.committee_store(),
             safe_client_metrics_base.clone(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -47,6 +47,7 @@ use sui_storage::{
     IndexStore,
 };
 use sui_types::committee::Committee;
+use sui_types::committee::EpochId;
 use sui_types::crypto::KeypairTraits;
 use sui_types::messages::QuorumDriverResponse;
 use tokio::sync::mpsc::channel;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -47,7 +47,6 @@ use sui_storage::{
     IndexStore,
 };
 use sui_types::committee::Committee;
-use sui_types::committee::EpochId;
 use sui_types::crypto::KeypairTraits;
 use sui_types::messages::QuorumDriverResponse;
 use tokio::sync::mpsc::channel;

--- a/crates/sui/tests/checkpoint_tests.rs
+++ b/crates/sui/tests/checkpoint_tests.rs
@@ -32,7 +32,7 @@ async fn basic_checkpoints_integration_test() {
         sender,
         &keypair,
     );
-    let net = AuthorityAggregator::new_from_system_state(
+    let net = AuthorityAggregator::new_from_local_system_state(
         &authorities[0].with(|node| node.state().db()),
         &authorities[0].with(|node| node.state().committee_store().clone()),
         SafeClientMetricsBase::new(&registry),

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -134,7 +134,7 @@ async fn reconfig_with_revert_end_to_end_test() {
         sender,
         &keypair,
     );
-    let net = AuthorityAggregator::new_from_system_state(
+    let net = AuthorityAggregator::new_from_local_system_state(
         &authorities[0].with(|node| node.state().db()),
         &authorities[0].with(|node| node.state().committee_store().clone()),
         SafeClientMetricsBase::new(&registry),
@@ -271,7 +271,7 @@ async fn test_validator_resign_effects() {
         &keypair,
     );
     let registry = Registry::new();
-    let mut net = AuthorityAggregator::new_from_system_state(
+    let mut net = AuthorityAggregator::new_from_local_system_state(
         &authorities[0].with(|node| node.state().db()),
         &authorities[0].with(|node| node.state().committee_store().clone()),
         SafeClientMetricsBase::new(&registry),


### PR DESCRIPTION
This is the last PR in the stack with which we have reconfigurability in stress.
This PR adds FullNodeReconfigObserver that can be used in stress to reconfig QuorumDriver.

New commands to run stress:
```
RUST_BACKTRACE=1 RUST_LOG=error,sui_benchmark=info,sui=info ./target/release/stress --fullnode-rpc-address http://127.0.0.1:9000 --num-client-threads 10 --num-server-threads 1 --num-transfer-accounts 2 --primary-gas-id 0x59931dcac57ba20d75321acaf55e8eb5a2c47e9f --genesis-blob-path ~/.sui/sui_config/genesis.blob --keystore-path ~/.sui/sui_config/sui.keystore  bench --target-qps 100 --in-flight-ratio 5 --num-workers 3 --shared-counter 25 --local=false
```