### PR TITLE
[Temp Fix] - warn if can't find previous version owner instead of returning error

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1127,11 +1127,14 @@ impl AuthorityState {
                 error!("Error processing object owner index for tx [{}], cannot find modified at version for deleted object [{id}].", effects.transaction_digest);
                 continue;
             };
-            match self.get_owner_at_version(id, *old_version)? {
-                Owner::AddressOwner(addr) => deleted_owners.push((addr, *id)),
-                Owner::ObjectOwner(object_id) => {
+            match self.get_owner_at_version(id, *old_version) {
+                Ok(Owner::AddressOwner(addr)) => deleted_owners.push((addr, *id)),
+                Ok(Owner::ObjectOwner(object_id)) => {
                     deleted_dynamic_fields.push((ObjectID::from(object_id), *id))
                 }
+                Err(e) => warn!(
+                    "Cannot find object owner for [{id}] at version [{old_version}], cause: {e}"
+                ),
                 _ => {}
             }
         }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1133,7 +1133,8 @@ impl AuthorityState {
                     deleted_dynamic_fields.push((ObjectID::from(object_id), *id))
                 }
                 Err(e) => warn!(
-                    "Cannot find object owner for [{id}] at version [{old_version}], cause: {e}"
+                    "Cannot find object owner for [{id}] at version [{old_version}], tx digest: [{}], cause: {e}",
+                    effects.transaction_digest
                 ),
                 _ => {}
             }


### PR DESCRIPTION
`process_object_index` is crashing the node because of incorrect `modified_at_versions` data in the TransactionEffects, temporarily change the Error to warning until we find the root cause.