### PR TITLE
[json rpc] add gas price to txn data type

### DIFF
--- a/.changeset/afraid-rabbits-cheat.md
+++ b/.changeset/afraid-rabbits-cheat.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Add gas price field to RPC transaction data type

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -588,6 +588,16 @@ impl SuiObjectRef {
     }
 }
 
+impl Display for SuiObjectRef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Object ID: {}, version: {}, digest: {}",
+            self.object_id, self.version, self.digest
+        )
+    }
+}
+
 impl From<ObjectRef> for SuiObjectRef {
     fn from(oref: ObjectRef) -> Self {
         Self {
@@ -1512,6 +1522,7 @@ pub struct SuiTransactionData {
     pub transactions: Vec<SuiTransactionKind>,
     pub sender: SuiAddress,
     pub gas_payment: SuiObjectRef,
+    pub gas_price: u64,
     pub gas_budget: u64,
 }
 
@@ -1527,6 +1538,10 @@ impl Display for SuiTransactionData {
                 writeln!(writer, "{}", kind)?;
             }
         }
+        writeln!(writer, "Sender: {}", self.sender)?;
+        writeln!(writer, "Gas Payment: {}", self.gas_payment)?;
+        writeln!(writer, "Gas Price: {}", self.gas_price)?;
+        writeln!(writer, "Gas Budget: {}", self.gas_budget)?;
         write!(f, "{}", writer)
     }
 }
@@ -1548,6 +1563,7 @@ impl TryFrom<TransactionData> for SuiTransactionData {
             transactions,
             sender: data.signer(),
             gas_payment: data.gas().into(),
+            gas_price: data.gas_price,
             gas_budget: data.gas_budget,
         })
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -381,6 +381,7 @@
                     "version": 2,
                     "digest": "YTUjbD51qSXhx3rDQSfIuu++oJOfFSRxK003oCCyjN0="
                   },
+                  "gasPrice": 1,
                   "gasBudget": 1000
                 },
                 "txSignature": "AGSIdPE6TiZpK8SYSgDee0v/nYra7zakdS70Mf7f44u95qbqwnNUX8J3LemofDeLFjBEKCG4NWOMJbK26RNPcwFx+rEBAzFCR9EqZuZwy6ymxQFHAR2C/1SDkX9nq7wm2w==",
@@ -545,6 +546,7 @@
                     "version": 2,
                     "digest": "wsHZkAgLQVgjWMbUFXCCHtL4i9yTTujRYs1wXaHfoM0="
                   },
+                  "gasPrice": 1,
                   "gasBudget": 1000
                 },
                 "txSignature": "AEYFlSNOs3VXTafbryAH3/ZKoqy907QU+pP9oSkiOtmix/LsiwY4EjCHwj+ICLkIHNTGXx7LHGbKu++PomyH1QZrcsROTZwfkUDdbwRmvqkE8UTLidenb8PFiZSW/zoONw==",
@@ -1627,6 +1629,7 @@
                     "version": 2,
                     "digest": "ARL4CGSLNu+/je6KGoLeRtlQTpahEIoXjvdvVsOZYzo="
                   },
+                  "gasPrice": 1,
                   "gasBudget": 1000
                 },
                 "txSignature": "ANMM5DC9TGa+L9jh25Bo6zR88WVklxXfpPGGyR/mid9bd1wTs6hHhl2W1PvNYXnf5fGRkrzdnnRtkdX8kio0CAGk8MuV4Ujxl9xtOeYgzm8Jf2BS6d0xIUr4jebbcPvoqQ==",
@@ -5513,6 +5516,7 @@
         "required": [
           "gasBudget",
           "gasPayment",
+          "gasPrice",
           "sender",
           "transactions"
         ],
@@ -5524,6 +5528,11 @@
           },
           "gasPayment": {
             "$ref": "#/components/schemas/ObjectRef"
+          },
+          "gasPrice": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "sender": {
             "$ref": "#/components/schemas/SuiAddress"

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -106,6 +106,7 @@ export const SuiTransactionData = object({
   transactions: array(SuiTransactionKind),
   sender: SuiAddress,
   gasPayment: SuiObjectRef,
+  gasPrice: number(),
   gasBudget: number(),
 });
 export type SuiTransactionData = Infer<typeof SuiTransactionData>;
@@ -380,6 +381,10 @@ export function getTransactionGasObject(
   tx: CertifiedTransaction
 ): SuiObjectRef {
   return tx.data.gasPayment;
+}
+
+export function getTransactionGasPrice(tx: CertifiedTransaction): number {
+  return tx.data.gasPrice;
 }
 
 export function getTransactionGasBudget(tx: CertifiedTransaction): number {


### PR DESCRIPTION
The `gas_price` field is needed for wave 2 analytics