### PR TITLE
Minor improvements to stress

### DIFF
--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -33,6 +33,7 @@ use test_utils::authority::spawn_test_authorities;
 use test_utils::authority::test_and_configure_authority_configs;
 use tokio::runtime::Builder;
 use tokio::sync::Barrier;
+use tracing::info;
 
 #[derive(Parser)]
 #[clap(name = "Stress Testing Framework")]
@@ -206,7 +207,7 @@ async fn main() -> Result<()> {
     let barrier = Arc::new(Barrier::new(2));
     let cloned_barrier = barrier.clone();
     let (primary_gas_id, owner, keypair, aggregator) = if opts.local {
-        eprintln!("Configuring local benchmark..");
+        info!("Configuring local benchmark..");
         let configs = {
             let mut configs = test_and_configure_authority_configs(opts.committee_size as usize);
             let mut metric_port = opts.server_metric_port;
@@ -259,7 +260,7 @@ async fn main() -> Result<()> {
         });
         (primary_gas_id, owner, Arc::new(keypair), proxy)
     } else {
-        eprintln!("Configuring remote benchmark..");
+        info!("Configuring remote benchmark..");
         std::thread::spawn(move || {
             Builder::new_multi_thread()
                 .build()
@@ -271,7 +272,7 @@ async fn main() -> Result<()> {
 
         let proxy: Arc<dyn ValidatorProxy + Send + Sync> =
             if let Some(fullnode_url) = opts.fullnode_rpc_address {
-                eprintln!("Using Full node: {fullnode_url}..");
+                info!("Using Full node: {fullnode_url}..");
                 Arc::new(FullNodeProxy::from_url(&fullnode_url).await.unwrap())
             } else {
                 let genesis = sui_config::node::Genesis::new_from_file(&opts.genesis_blob_path);
@@ -286,7 +287,7 @@ async fn main() -> Result<()> {
                     aggregator,
                 )))
             };
-        eprintln!(
+        info!(
             "Reconfiguration - Reconfiguration to epoch {} is done",
             proxy.get_current_epoch(),
         );

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -33,7 +33,7 @@ use sui_types::messages::VerifiedTransaction;
 use tokio::sync::Barrier;
 use tokio::time;
 use tokio::time::Instant;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use super::BenchmarkStats;
 use super::Interval;
@@ -127,7 +127,7 @@ enum NextOp {
 async fn print_and_start_benchmark() -> &'static Instant {
     static ONCE: OnceCell<Instant> = OnceCell::const_new();
     ONCE.get_or_init(|| async move {
-        eprintln!("Starting benchmark!");
+        info!("Starting benchmark!");
         Instant::now()
     })
     .await
@@ -241,7 +241,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
         let stat_delay_micros = 1_000_000 * self.stat_collection_interval;
         let metrics = Arc::new(BenchMetrics::new(registry));
         let barrier = Arc::new(Barrier::new(num_workers as usize));
-        eprintln!("Setting up workers...");
+        info!("Setting up workers...");
         let progress = Arc::new(match run_duration {
             Interval::Count(count) => ProgressBar::new(count)
                 .with_prefix("Running benchmark(count):")


### PR DESCRIPTION
This PR improves stress in two ways:
1. Change a bunch of eprintln to info! for proper logging and easier search in grafana.
2. `transfer_sui_for_testing` should not return None, which is very confusing. If it ever fails, we allow it to retry and in the end we just panic.