### PR TITLE
[adapter] Ignore deletions for objects that are always wrapped

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
@@ -13,4 +13,4 @@ written: object(106)
 
 task 3 'run'. lines 43-43:
 written: object(108)
-deleted: object(_), object(107)
+deleted: object(107)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
@@ -27,7 +27,7 @@ written: object(111)
 
 task 6 'run'. lines 52-52:
 written: object(112), object(114)
-deleted: object(_), object(113)
+deleted: object(113)
 
 task 7 'run'. lines 55-55:
 created: object(116), object(117)

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -628,10 +628,9 @@ fn process_successful_execution<S: Storage + ParentSync>(
             None => match state_view.get_latest_parent_entry_ref(id) {
                 Ok(Some((_, previous_version, _))) => previous_version,
                 Ok(None) => {
-                    // TODO we don't really need to mark this as deleted, as the object was not
-                    // created this txn but has never existed in storage. We just need a better
-                    // way of detecting this rather than relying on the parent sync
-                    SequenceNumber::new()
+                    // This object was not created this transaction but has never existed in
+                    // storage, skip it.
+                    continue;
                 }
                 _ => {
                     return Err(ExecutionError::new_with_source(

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -21,7 +21,7 @@ use sui_types::{
     messages::ExecutionStatus,
 };
 
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 use std::{env, str::FromStr};
 
 const MAX_GAS: u64 = 10000;
@@ -540,16 +540,27 @@ async fn test_create_then_delete_parent_child_wrap() {
     .await
     .unwrap();
     assert!(effects.status.is_ok());
+    // Modifies the gas object
+    assert_eq!(effects.mutated.len(), 1);
     // Creates 3 objects, the parent, a field, and the child
     assert_eq!(effects.created.len(), 2);
     // not wrapped as it wasn't first created
     assert_eq!(effects.wrapped.len(), 0);
     assert_eq!(effects.events.len(), 3);
 
+    let gas_ref = effects.mutated[0].0;
+
     let parent = effects
         .created
         .iter()
         .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
+        .unwrap()
+        .0;
+
+    let field = effects
+        .created
+        .iter()
+        .find(|((id, _, _), _)| id != &parent.0)
         .unwrap()
         .0;
 
@@ -568,9 +579,24 @@ async fn test_create_then_delete_parent_child_wrap() {
     .await
     .unwrap();
     assert!(effects.status.is_ok());
-    // Check that both objects were deleted.
-    assert_eq!(effects.deleted.len(), 3);
-    assert_eq!(effects.events.len(), 4);
+
+    // The parent and field are considered deleted, the child doesn't count because it wasn't
+    // considered created in the first place.
+    assert_eq!(effects.deleted.len(), 2);
+    assert_eq!(effects.events.len(), 3);
+
+    assert_eq!(
+        effects
+            .modified_at_versions
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>(),
+        HashSet::from([
+            (gas_ref.0, gas_ref.1),
+            (parent.0, parent.1),
+            (field.0, field.1)
+        ]),
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
If an object has always existed in a wrapped state and is eventually deleted, don't included it among the deleted (and therefore modified) objects in the effects for the transaction that deletes its ID.

## Test Plan

Updated an existing unit test to confirm the values for `modified_at_versions` after deleting an object that was always wrapped