### PR TITLE
[consensus] Verify certificate user signature

### DIFF
--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -688,6 +688,15 @@ impl AsRef<[u8]> for Signature {
         }
     }
 }
+impl AsMut<[u8]> for Signature {
+    fn as_mut(&mut self) -> &mut [u8] {
+        match self {
+            Signature::Ed25519SuiSignature(sig) => sig.as_mut(),
+            Signature::Secp256k1SuiSignature(sig) => sig.as_mut(),
+            Signature::Secp256r1SuiSignature(sig) => sig.as_mut(),
+        }
+    }
+}
 
 impl signature::Signature for Signature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
@@ -761,6 +770,12 @@ impl AsRef<[u8]> for Ed25519SuiSignature {
     }
 }
 
+impl AsMut<[u8]> for Ed25519SuiSignature {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
 impl signature::Signature for Ed25519SuiSignature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
         if bytes.len() != Self::LENGTH {
@@ -808,6 +823,12 @@ impl AsRef<[u8]> for Secp256k1SuiSignature {
     }
 }
 
+impl AsMut<[u8]> for Secp256k1SuiSignature {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
 impl signature::Signature for Secp256k1SuiSignature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
         if bytes.len() != Self::LENGTH {
@@ -852,6 +873,12 @@ impl SuiPublicKey for Secp256r1PublicKey {
 impl AsRef<[u8]> for Secp256r1SuiSignature {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for Secp256r1SuiSignature {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
     }
 }
 

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -12,7 +12,7 @@ use crate::error::SuiResult;
 use once_cell::sync::OnceCell;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 pub trait Message {
     type DigestType: Clone + Debug;
@@ -288,6 +288,12 @@ impl<T: Message, S> Deref for Envelope<T, S> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.data
+    }
+}
+
+impl<T: Message, S> DerefMut for Envelope<T, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
     }
 }
 


### PR DESCRIPTION
Seems like we did not address TODO in consensus_validator when unpinning user signatures from certificate, those exposed vulnerability that allowed validators to submit certificates with incorrect user signatures.