### PR TITLE
[explorer] New text/header variant api

### DIFF
--- a/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -121,10 +121,10 @@ function StakeColumn({ stake }: { stake: bigint }) {
     const [amount, symbol] = useFormatCoin(stake, SUI_TYPE_ARG);
     return (
         <div className="flex items-end gap-0.5">
-            <Text variant="bodySmall" color="steel-darker">
+            <Text variant="bodySmall/medium" color="steel-darker">
                 {amount}
             </Text>
-            <Text variant="captionSmall" color="steel-dark">
+            <Text variant="captionSmall/medium" color="steel-dark">
                 {symbol}
             </Text>
         </div>
@@ -173,17 +173,13 @@ const validatorsTable = (validatorsData: ValidatorState, limit?: number) => {
         data: validatorsItems.map((validator) => {
             return {
                 name: (
-                    <Text
-                        variant="bodySmall"
-                        color="steel-darker"
-                        weight="medium"
-                    >
+                    <Text variant="bodySmall/medium" color="steel-darker">
                         {validator.name}
                     </Text>
                 ),
                 stake: <StakeColumn stake={validator.stake} />,
                 delegation: (
-                    <Text variant="bodySmall" color="steel-darker">
+                    <Text variant="bodySmall/medium" color="steel-darker">
                         {validator.stake.toString()}
                     </Text>
                 ),

--- a/apps/explorer/src/pages/object-result/views/PkgView.tsx
+++ b/apps/explorer/src/pages/object-result/views/PkgView.tsx
@@ -80,7 +80,7 @@ function PkgView({ data }: { data: DataType }) {
                 </TabGroup>
 
                 <div className="mb-3">
-                    <Heading as="h2" variant="heading4" weight="semibold">
+                    <Heading as="h2" variant="heading4/semibold">
                         Modules
                     </Heading>
                 </div>

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -254,16 +254,16 @@ function GasAmount({
     return (
         <div className="flex h-full items-center gap-1">
             <div className="flex items-baseline gap-0.5 text-gray-90">
-                <Text variant="body">{formattedAmount}</Text>
-                <Text variant="subtitleSmall">{symbol}</Text>
+                <Text variant="body/medium">{formattedAmount}</Text>
+                <Text variant="subtitleSmall/medium">{symbol}</Text>
             </div>
 
-            <Text variant="bodySmall">
+            <Text variant="bodySmall/medium">
                 <div className="flex items-center text-steel">
                     (
                     <div className="flex items-baseline gap-0.5">
                         <div>{amount?.toLocaleString()}</div>
-                        <Text variant="subtitleSmall">MIST</Text>
+                        <Text variant="subtitleSmall/medium">MIST</Text>
                     </div>
                     )
                 </div>
@@ -575,8 +575,7 @@ function TransactionView({
                                 <DescriptionItem
                                     title={
                                         <Text
-                                            variant="body"
-                                            weight="semibold"
+                                            variant="body/semibold"
                                             color="steel-darker"
                                         >
                                             Total Gas Fee

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -9,7 +9,7 @@ import { Heading } from '~/ui/Heading';
 function ValidatorPageResult() {
     return (
         <div>
-            <Heading as="h1" variant="heading2" weight="bold">
+            <Heading as="h1" variant="heading2/bold">
                 Validators
             </Heading>
             <div className="mt-8">

--- a/apps/explorer/src/ui/Amount.tsx
+++ b/apps/explorer/src/ui/Amount.tsx
@@ -3,15 +3,10 @@
 import { CoinFormat, formatBalance } from '~/hooks/useFormatCoin';
 import { Heading } from '~/ui/Heading';
 
-const SIZE_FORMAT = {
-    lg: 'heading2',
-    md: 'heading6',
-} as const;
-
 export type AmountProps = {
     amount: number | string | bigint;
     symbol?: string | null;
-    size?: keyof typeof SIZE_FORMAT;
+    size?: 'md' | 'lg';
     format?: CoinFormat;
 };
 
@@ -30,8 +25,7 @@ export function Amount({ amount, symbol, size = 'md', format }: AmountProps) {
     return (
         <div className="flex items-end gap-1 break-words">
             <Heading
-                variant={SIZE_FORMAT[size]}
-                weight={isLarge ? 'bold' : 'semibold'}
+                variant={isLarge ? 'heading2/bold' : 'heading6/semibold'}
                 color="gray-90"
             >
                 {formattedAmount}

--- a/apps/explorer/src/ui/DateCard.tsx
+++ b/apps/explorer/src/ui/DateCard.tsx
@@ -23,7 +23,7 @@ export function DateCard({ date }: DateCardProps) {
     }
 
     return (
-        <Text variant="bodySmall" weight="semibold" color="steel-dark">
+        <Text variant="bodySmall/semibold" color="steel-dark">
             <time dateTime={new Date(date).toISOString()}>{dateStr}</time>
         </Text>
     );

--- a/apps/explorer/src/ui/Heading.tsx
+++ b/apps/explorer/src/ui/Heading.tsx
@@ -4,6 +4,8 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import { type ReactNode } from 'react';
 
+import { parseVariant, type SizeAndWeightVariant } from './utils/sizeAndWeight';
+
 const headingStyles = cva(
     [
         // TODO: Remove when CSS reset is applied.
@@ -13,10 +15,10 @@ const headingStyles = cva(
         variants: {
             /**
              * The size of the heading that will be displayed.
-             * The variant is expressed in the desktop size, and will automatically adjust for mobile.
+             * The size is expressed in the desktop size, and will automatically adjust for mobile.
              * Set the `fixed` property to disable responsive sizing.
              */
-            variant: {
+            size: {
                 heading1: 'text-heading1',
                 heading2: 'md:text-heading2 text-heading3',
                 heading3: 'text-heading3',
@@ -49,35 +51,42 @@ const headingStyles = cva(
             /** Fix the header size, and disable responsive sizing of the heading. */
             fixed: { true: '', false: '' },
         },
-        defaultVariants: {
-            variant: 'heading1',
-            weight: 'semibold',
-        },
-        // Use the empty `fixed` variant to force text size to a set value:
+        // Use the empty `fixed` size to force text size to a set value:
         compoundVariants: [
-            { fixed: true, variant: 'heading1', class: '!text-heading1' },
-            { fixed: true, variant: 'heading2', class: '!text-heading2' },
-            { fixed: true, variant: 'heading3', class: '!text-heading3' },
-            { fixed: true, variant: 'heading4', class: '!text-heading4' },
-            { fixed: true, variant: 'heading5', class: '!text-heading5' },
-            { fixed: true, variant: 'heading6', class: '!text-heading6' },
+            { fixed: true, size: 'heading1', class: '!text-heading1' },
+            { fixed: true, size: 'heading2', class: '!text-heading2' },
+            { fixed: true, size: 'heading3', class: '!text-heading3' },
+            { fixed: true, size: 'heading4', class: '!text-heading4' },
+            { fixed: true, size: 'heading5', class: '!text-heading5' },
+            { fixed: true, size: 'heading6', class: '!text-heading6' },
         ],
     }
 );
 
-export interface HeadingProps extends VariantProps<typeof headingStyles> {
+type HeadingStylesProps = VariantProps<typeof headingStyles>;
+
+export interface HeadingProps
+    extends Omit<HeadingStylesProps, 'size' | 'weight'> {
     /**
      * The HTML element that will be rendered.
      * By default, we render a "div" in order to separate presentational styles from semantic markup.
      */
     as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'div';
     children: ReactNode;
+    variant: SizeAndWeightVariant<HeadingStylesProps>;
 }
 
 export function Heading({
     as: Tag = 'div',
     children,
+    variant,
     ...styleProps
 }: HeadingProps) {
-    return <Tag className={headingStyles(styleProps)}>{children}</Tag>;
+    const [size, weight] = parseVariant<HeadingStylesProps>(variant);
+
+    return (
+        <Tag className={headingStyles({ size, weight, ...styleProps })}>
+            {children}
+        </Tag>
+    );
 }

--- a/apps/explorer/src/ui/PageHeader.tsx
+++ b/apps/explorer/src/ui/PageHeader.tsx
@@ -62,11 +62,7 @@ export function PageHeader({ title, subtitle, type, status }: PageHeaderProps) {
         <div data-testid="pageheader">
             <div className="mb-3 flex items-center gap-2">
                 <Icon className="text-steel" />
-                <Heading
-                    variant="heading4"
-                    weight="semibold"
-                    color="steel-darker"
-                >
+                <Heading variant="heading4/semibold" color="steel-darker">
                     {type}
                 </Heading>
             </div>
@@ -75,8 +71,7 @@ export function PageHeader({ title, subtitle, type, status }: PageHeaderProps) {
                     <div className="min-w-0 break-words">
                         <Heading
                             as="h2"
-                            variant="heading2"
-                            weight="semibold"
+                            variant="heading2/semibold"
                             color="gray-90"
                             mono
                         >
@@ -104,11 +99,7 @@ export function PageHeader({ title, subtitle, type, status }: PageHeaderProps) {
             </div>
             {subtitle && (
                 <div className="mt-2 break-words">
-                    <Heading
-                        variant="heading4"
-                        weight="semibold"
-                        color="gray-75"
-                    >
+                    <Heading variant="heading4/semibold" color="gray-75">
                         {subtitle}
                     </Heading>
                 </div>

--- a/apps/explorer/src/ui/SenderRecipient.tsx
+++ b/apps/explorer/src/ui/SenderRecipient.tsx
@@ -38,7 +38,7 @@ export function SenderRecipient({
 
     return (
         <div className="flex flex-col justify-start gap-4">
-            <Heading variant="heading4" weight="semibold" color="gray-90">
+            <Heading variant="heading4/semibold" color="gray-90">
                 {singleTransferCoin ? 'Sender & Recipient' : 'Sender'}
             </Heading>
             <div className="relative flex flex-col justify-center gap-[15px]">
@@ -57,8 +57,7 @@ export function SenderRecipient({
                     <div className="mt-3.5 flex flex-col gap-2.5">
                         <div className="mb-2.5">
                             <Heading
-                                variant="heading4"
-                                weight="semibold"
+                                variant="heading4/semibold"
                                 color="gray-90"
                             >
                                 {multipleRecipientsList.length > 1

--- a/apps/explorer/src/ui/StatAmount.tsx
+++ b/apps/explorer/src/ui/StatAmount.tsx
@@ -19,8 +19,7 @@ export function StatAmount({ dollarAmount, date, ...props }: StatAmountProps) {
                 <div className="flex flex-col items-baseline gap-2.5">
                     <Heading
                         as="h4"
-                        variant="heading4"
-                        weight="semibold"
+                        variant="heading4/semibold"
                         color="gray-90"
                         fixed
                     >

--- a/apps/explorer/src/ui/StatAmount.tsx
+++ b/apps/explorer/src/ui/StatAmount.tsx
@@ -31,7 +31,7 @@ export function StatAmount({ dollarAmount, date, ...props }: StatAmountProps) {
                 </div>
             </div>
             {dollarAmount && (
-                <Text variant="bodySmall" weight="semibold" color="steel-dark">
+                <Text variant="bodySmall/semibold" color="steel-dark">
                     {new Intl.NumberFormat(undefined, {
                         style: 'currency',
                         currency: 'USD',

--- a/apps/explorer/src/ui/TableHeader.tsx
+++ b/apps/explorer/src/ui/TableHeader.tsx
@@ -14,12 +14,7 @@ export function TableHeader({ as = 'h3', children, after }: TableHeaderProps) {
     return (
         <div className="flex items-center border-0 border-b border-solid border-gray-45 pb-5">
             <div className="flex-1">
-                <Heading
-                    as={as}
-                    variant="heading4"
-                    weight="semibold"
-                    color="gray-90"
-                >
+                <Heading as={as} variant="heading4/semibold" color="gray-90">
                     {children}
                 </Heading>
             </div>

--- a/apps/explorer/src/ui/Text.tsx
+++ b/apps/explorer/src/ui/Text.tsx
@@ -6,12 +6,7 @@ import { type ReactNode } from 'react';
 
 const textStyles = cva([], {
     variants: {
-        weight: {
-            medium: 'font-medium',
-            semibold: 'font-semibold',
-            bold: 'font-bold',
-        },
-        variant: {
+        size: {
             body: 'text-body',
             bodySmall: 'text-bodySmall',
             subtitle: 'text-subtitle',
@@ -19,6 +14,11 @@ const textStyles = cva([], {
             subtitleSmallExtra: 'text-subtitleSmallExtra',
             caption: 'uppercase text-caption',
             captionSmall: 'uppercase text-captionSmall ',
+        },
+        weight: {
+            medium: 'font-medium',
+            semibold: 'font-semibold',
+            bold: 'font-bold',
         },
         color: {
             'gray-100': 'text-gray-100',
@@ -42,16 +42,29 @@ const textStyles = cva([], {
             false: 'font-sans',
         },
     },
-    defaultVariants: {
-        weight: 'medium',
-        variant: 'body',
-    },
 });
 
-export interface TextProps extends VariantProps<typeof textStyles> {
+type TextStylesProps = VariantProps<typeof textStyles>;
+type Variant = `${TextStylesProps['size']}/${TextStylesProps['weight']}`;
+
+export interface TextProps extends Omit<TextStylesProps, 'size' | 'weight'> {
+    variant: Variant;
     children: ReactNode;
 }
 
-export function Text({ children, ...styleProps }: TextProps) {
-    return <div className={textStyles(styleProps)}>{children}</div>;
+export function Text({
+    children,
+    variant = 'body/medium',
+    ...styleProps
+}: TextProps) {
+    const [size, weight] = variant.split('/') as [
+        TextStylesProps['size'],
+        TextStylesProps['weight']
+    ];
+
+    return (
+        <div className={textStyles({ size, weight, ...styleProps })}>
+            {children}
+        </div>
+    );
 }

--- a/apps/explorer/src/ui/Text.tsx
+++ b/apps/explorer/src/ui/Text.tsx
@@ -4,6 +4,8 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import { type ReactNode } from 'react';
 
+import { parseVariant, type SizeAndWeightVariant } from './utils/sizeAndWeight';
+
 const textStyles = cva([], {
     variants: {
         size: {
@@ -45,10 +47,9 @@ const textStyles = cva([], {
 });
 
 type TextStylesProps = VariantProps<typeof textStyles>;
-type Variant = `${TextStylesProps['size']}/${TextStylesProps['weight']}`;
 
 export interface TextProps extends Omit<TextStylesProps, 'size' | 'weight'> {
-    variant: Variant;
+    variant: SizeAndWeightVariant<TextStylesProps>;
     children: ReactNode;
 }
 
@@ -57,10 +58,7 @@ export function Text({
     variant = 'body/medium',
     ...styleProps
 }: TextProps) {
-    const [size, weight] = variant.split('/') as [
-        TextStylesProps['size'],
-        TextStylesProps['weight']
-    ];
+    const [size, weight] = parseVariant<TextStylesProps>(variant);
 
     return (
         <div className={textStyles({ size, weight, ...styleProps })}>

--- a/apps/explorer/src/ui/stories/DescriptionList.stories.tsx
+++ b/apps/explorer/src/ui/stories/DescriptionList.stories.tsx
@@ -32,7 +32,9 @@ export const Default: StoryObj<DescriptionListProps> = {
                     0xb758af2061e7c0e55df23de52c51968f6efbc959
                 </Link>
             </DescriptionItem>
-            <DescriptionItem title={<Text variant="bodySmall">Owner</Text>}>
+            <DescriptionItem
+                title={<Text variant="bodySmall/medium">Owner</Text>}
+            >
                 Value 1
             </DescriptionItem>
         </DescriptionList>

--- a/apps/explorer/src/ui/stories/Heading.stories.tsx
+++ b/apps/explorer/src/ui/stories/Heading.stories.tsx
@@ -9,59 +9,74 @@ export default {
     component: Heading,
 } as Meta;
 
-export const Heading1: StoryObj<HeadingProps> = {
-    render: (props) => {
+interface StoryProps {
+    as: HeadingProps['as'];
+    variants: HeadingProps['variant'][];
+}
+
+export const Heading1: StoryObj<StoryProps> = {
+    render: ({ as, variants }) => {
         return (
             <div className="space-y-2">
                 <div>
-                    <Heading {...props} weight="bold">
-                        This is a sample heading.
-                    </Heading>
-                    <Heading {...props} weight="semibold">
-                        This is a sample heading.
-                    </Heading>
-                    <Heading {...props} weight="medium">
-                        This is a sample heading.
-                    </Heading>
+                    {variants.map((variant) => (
+                        <Heading key={variant} as={as} variant={variant}>
+                            This is a sample heading.
+                        </Heading>
+                    ))}
                 </div>
                 <div>
-                    <Heading {...props} weight="bold" fixed>
-                        This is a sample heading. (fixed)
-                    </Heading>
-                    <Heading {...props} weight="semibold" fixed>
-                        This is a sample heading. (fixed)
-                    </Heading>
-                    <Heading {...props} weight="medium" fixed>
-                        This is a sample heading. (fixed)
-                    </Heading>
+                    {variants.map((variant) => (
+                        <Heading key={variant} as={as} variant={variant} fixed>
+                            This is a sample heading. (fixed)
+                        </Heading>
+                    ))}
                 </div>
             </div>
         );
     },
-    args: { as: 'h1', variant: 'heading1' },
+    args: {
+        as: 'h1',
+        variants: ['heading1/bold', 'heading1/semibold', 'heading1/medium'],
+    },
 };
 
-export const Heading2: StoryObj<HeadingProps> = {
+export const Heading2: StoryObj<StoryProps> = {
     ...Heading1,
-    args: { as: 'h2', variant: 'heading2' },
+    args: {
+        as: 'h2',
+        variants: ['heading2/bold', 'heading2/semibold', 'heading2/medium'],
+    },
 };
 
-export const Heading3: StoryObj<HeadingProps> = {
+export const Heading3: StoryObj<StoryProps> = {
     ...Heading1,
-    args: { as: 'h3', variant: 'heading3' },
+    args: {
+        as: 'h3',
+        variants: ['heading3/bold', 'heading3/semibold', 'heading3/medium'],
+    },
 };
 
-export const Heading4: StoryObj<HeadingProps> = {
+export const Heading4: StoryObj<StoryProps> = {
     ...Heading1,
-    args: { as: 'h4', variant: 'heading4' },
+    args: {
+        as: 'h4',
+        variants: ['heading4/bold', 'heading4/semibold', 'heading4/medium'],
+    },
 };
 
-export const Heading5: StoryObj<HeadingProps> = {
+export const Heading5: StoryObj<StoryProps> = {
     ...Heading1,
-    args: { as: 'h5', variant: 'heading5' },
+    args: {
+        as: 'h5',
+        variants: ['heading5/bold', 'heading5/semibold', 'heading5/medium'],
+    },
 };
 
-export const Heading6: StoryObj<HeadingProps> = {
+export const Heading6: StoryObj<StoryProps> = {
     ...Heading1,
-    args: { as: 'h6', variant: 'heading6' },
+    args: {
+        as: 'h6',
+        variants: ['heading6/bold', 'heading6/semibold', 'heading6/medium'],
+    },
 };

--- a/apps/explorer/src/ui/stories/Text.stories.tsx
+++ b/apps/explorer/src/ui/stories/Text.stories.tsx
@@ -12,20 +12,17 @@ export default {
 
 interface StoryProps {
     variants: TextProps['variant'][];
-    weights?: TextProps['weight'][];
     italic?: boolean;
 }
 
 export const Body: StoryObj<StoryProps> = {
-    render: ({ variants, weights = ['medium', 'semibold'], italic }) => (
+    render: ({ variants, italic }) => (
         <div>
             {variants.map((variant) => (
                 <Fragment key={variant}>
-                    {weights.map((weight) => (
-                        <Text key={weight} variant={variant} weight={weight}>
-                            {variant} - {weight}
-                        </Text>
-                    ))}
+                    <Text key={variant} variant={variant}>
+                        {variant}
+                    </Text>
 
                     {italic && (
                         <Text variant={variant} italic>
@@ -37,7 +34,12 @@ export const Body: StoryObj<StoryProps> = {
         </div>
     ),
     args: {
-        variants: ['body', 'bodySmall'],
+        variants: [
+            'body/medium',
+            'body/semibold',
+            'bodySmall/medium',
+            'bodySmall/semibold',
+        ],
         italic: true,
     },
 };
@@ -45,14 +47,27 @@ export const Body: StoryObj<StoryProps> = {
 export const Subtitle: StoryObj<StoryProps> = {
     ...Body,
     args: {
-        variants: ['subtitle', 'subtitleSmall', 'subtitleSmallExtra'],
+        variants: [
+            'subtitle/medium',
+            'subtitle/semibold',
+            'subtitleSmall/medium',
+            'subtitleSmall/semibold',
+            'subtitleSmallExtra/medium',
+            'subtitleSmallExtra/semibold',
+        ],
     },
 };
 
 export const Caption: StoryObj<StoryProps> = {
     ...Body,
     args: {
-        variants: ['caption', 'captionSmall'],
-        weights: ['medium', 'semibold', 'bold'],
+        variants: [
+            'caption/medium',
+            'caption/semibold',
+            'caption/bold',
+            'captionSmall/medium',
+            'captionSmall/semibold',
+            'captionSmall/bold',
+        ],
     },
 };

--- a/apps/explorer/src/ui/utils/sizeAndWeight.ts
+++ b/apps/explorer/src/ui/utils/sizeAndWeight.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+interface SizeAndWeightProps {
+    size?: string | null;
+    weight?: string | null;
+}
+export type SizeAndWeightVariant<T extends SizeAndWeightProps> = `${NonNullable<
+    T['size']
+>}/${NonNullable<T['weight']>}`;
+
+export function parseVariant<T extends SizeAndWeightProps>(variant: string) {
+    return variant.split('/') as [T['size'], T['weight']];
+}


### PR DESCRIPTION
This reworks the API for `variant` on the text / header components, so that `size` and `weight` are combined into a single prop. This aligns more with the figma, and also forces developers to set both of these values together (which makes sense given they are both really required). This also is still fully typed, with auto-complete as well.