### PR TITLE
Fix reconfig_with_revert_end_to_end_test to always use the longest-waiting validator as the revert target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4889,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=d9a8a1dce46ac5c0c3e85986a94f2cb3ca0e1367#d9a8a1dce46ac5c0c3e85986a94f2cb3ca0e1367"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=dbbbbddf35408f8c5cfefe450f6a731e97b258c3#dbbbbddf35408f8c5cfefe450f6a731e97b258c3"
 dependencies = [
  "ahash 0.7.6",
  "async-task",
@@ -4918,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=d9a8a1dce46ac5c0c3e85986a94f2cb3ca0e1367#d9a8a1dce46ac5c0c3e85986a94f2cb3ca0e1367"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=dbbbbddf35408f8c5cfefe450f6a731e97b258c3#dbbbbddf35408f8c5cfefe450f6a731e97b258c3"
 dependencies = [
  "darling",
  "proc-macro2 1.0.49",

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -171,11 +171,18 @@ impl<'a> FullnodeConfigBuilder<'a> {
         let listen_ip = self.listen_ip.unwrap_or_else(utils::get_local_ip_for_tests);
         let listen_ip_str = format!("{}", listen_ip);
 
+        let get_available_port = |public_port| {
+            if listen_ip.is_loopback() {
+                utils::get_available_port(&listen_ip_str)
+            } else {
+                public_port
+            }
+        };
+
         let network_address = format!(
             "/ip4/{}/tcp/{}/http",
             listen_ip,
-            self.port
-                .unwrap_or_else(|| utils::get_available_port(&listen_ip_str))
+            self.port.unwrap_or_else(|| get_available_port(8080))
         )
         .parse()
         .unwrap();
@@ -183,8 +190,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
         let p2p_config = {
             let address = SocketAddr::new(
                 listen_ip,
-                self.p2p_port
-                    .unwrap_or_else(|| utils::get_available_port(&listen_ip_str)),
+                self.p2p_port.unwrap_or_else(|| get_available_port(8084)),
             );
             let seed_peers = validator_configs
                 .iter()
@@ -204,9 +210,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             }
         };
 
-        let rpc_port = self
-            .rpc_port
-            .unwrap_or_else(|| utils::get_available_port(&listen_ip_str));
+        let rpc_port = self.rpc_port.unwrap_or_else(|| get_available_port(9000));
         let jsonrpc_server_url = format!("{}:{}", listen_ip, rpc_port);
         let json_rpc_address: SocketAddr = jsonrpc_server_url.parse().unwrap();
 
@@ -221,9 +225,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             metrics_address: utils::available_local_socket_address(),
             // TODO: admin server is hard coded to start on 127.0.0.1 - we should probably
             // provide the entire socket address here to avoid confusion.
-            admin_interface_port: self
-                .admin_port
-                .unwrap_or_else(|| utils::get_available_port("127.0.0.1")),
+            admin_interface_port: self.admin_port.unwrap_or_else(|| get_available_port(8888)),
             json_rpc_address,
             consensus_config: None,
             enable_event_processing: self.enable_event_store,

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -172,7 +172,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
         let listen_ip_str = format!("{}", listen_ip);
 
         let get_available_port = |public_port| {
-            if listen_ip.is_loopback() {
+            if listen_ip.is_loopback() || listen_ip == utils::get_local_ip_for_tests() {
                 utils::get_available_port(&listen_ip_str)
             } else {
                 public_port

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -443,6 +443,13 @@ impl CheckpointBuilder {
             .as_ref()
             .map(|(_, c)| c.sequence_number + 1)
             .unwrap_or_default();
+        if last_checkpoint_of_epoch {
+            info!(
+                ?sequence_number,
+                "creating last checkpoint of epoch {}",
+                self.epoch_store.epoch()
+            );
+        }
         let summary = CheckpointSummary::new(
             self.epoch_store.epoch(),
             sequence_number,

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -234,31 +234,12 @@ impl ConsensusAdapter {
         ourselves: &AuthorityName,
         tx_digest: &TransactionDigest,
     ) -> Duration {
-        let position = Self::position_submit_certificate(committee, ourselves, tx_digest);
+        let position = position_submit_certificate(committee, ourselves, tx_digest);
         const MAX_DELAY_MUL: usize = 10;
         // DELAY_STEP is chosen as 1.5 * mean consensus delay
         // In the future we can actually use information about consensus rounds instead of this delay
         const DELAY_STEP: Duration = Duration::from_secs(7);
         DELAY_STEP * std::cmp::min(position, MAX_DELAY_MUL) as u32
-    }
-
-    /// Returns a position of the current validator in ordered list of validator to submit transaction
-    fn position_submit_certificate(
-        committee: &Committee,
-        ourselves: &AuthorityName,
-        tx_digest: &TransactionDigest,
-    ) -> usize {
-        // the 32 is as requirement of the deault StdRng::from_seed choice
-        let digest_bytes = tx_digest.into_bytes();
-
-        // permute the validators deterministically, based on the digest
-        let mut rng = StdRng::from_seed(digest_bytes);
-        let validators = committee.shuffle_by_stake_with_rng(None, None, &mut rng);
-        let (position, _) = validators
-            .into_iter()
-            .find_position(|a| a == ourselves)
-            .expect("Could not find ourselves in shuffled committee");
-        position
     }
 
     /// This method blocks until transaction is persisted in local database
@@ -410,6 +391,25 @@ impl ConsensusAdapter {
     }
 }
 
+/// Returns a position of the current validator in ordered list of validator to submit transaction
+pub fn position_submit_certificate(
+    committee: &Committee,
+    ourselves: &AuthorityName,
+    tx_digest: &TransactionDigest,
+) -> usize {
+    // the 32 is as requirement of the deault StdRng::from_seed choice
+    let digest_bytes = tx_digest.into_bytes();
+
+    // permute the validators deterministically, based on the digest
+    let mut rng = StdRng::from_seed(digest_bytes);
+    let validators = committee.shuffle_by_stake_with_rng(None, None, &mut rng);
+    let (position, _) = validators
+        .into_iter()
+        .find_position(|a| a == ourselves)
+        .expect("Could not find ourselves in shuffled committee");
+    position
+}
+
 impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
     /// This method is called externally to begin reconfiguration
     /// It transition reconfig state to reject new certificates from user
@@ -536,7 +536,7 @@ mod adapter_tests {
 
             let mut zero_found = false;
             for (name, _) in authorities.iter() {
-                let f = ConsensusAdapter::position_submit_certificate(&committee, name, &tx_digest);
+                let f = position_submit_certificate(&committee, name, &tx_digest);
                 assert!(f < committee.num_members());
                 if f == 0 {
                     // One and only one validator gets position 0

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -498,7 +498,7 @@ impl SubmitToConsensus for Arc<ConsensusAdapter> {
 
 #[cfg(test)]
 mod adapter_tests {
-    use super::ConsensusAdapter;
+    use super::position_submit_certificate;
     use fastcrypto::traits::KeyPair;
     use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
     use sui_types::{

--- a/crates/sui-proc-macros/Cargo.toml
+++ b/crates/sui-proc-macros/Cargo.toml
@@ -16,4 +16,4 @@ syn = "1.0.104"
 workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d9a8a1dce46ac5c0c3e85986a94f2cb3ca0e1367", package = "msim-macros" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "dbbbbddf35408f8c5cfefe450f6a731e97b258c3", package = "msim-macros" }

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -19,4 +19,4 @@ telemetry-subscribers.workspace = true
 tower = "0.4.13"
 
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d9a8a1dce46ac5c0c3e85986a94f2cb3ca0e1367", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "dbbbbddf35408f8c5cfefe450f6a731e97b258c3", package = "msim" }

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -54,9 +54,9 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "d9a8a1dce46ac5c0c3e85986a94f2cb3ca0e1367"'
+    --config 'patch.crates-io.tokio.rev = "dbbbbddf35408f8c5cfefe450f6a731e97b258c3"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "d9a8a1dce46ac5c0c3e85986a94f2cb3ca0e1367"'
+    --config 'patch.crates-io.futures-timer.rev = "dbbbbddf35408f8c5cfefe450f6a731e97b258c3"'
   )
 fi
 


### PR DESCRIPTION
This improves a basic source of flakiness in the test - this ensures (or at least makes it very likely) that the to-be-reverted tx in the test is not submitted to consensus before the end-of-epoch messages are sent by the other 3 validators. Previously, the order was a matter of random chance, so the test would fail if we happened to pick the most eager validator to be the reverter.