### PR TITLE
api: Use serialized signature for execute_transaction endpoint

### DIFF
--- a/.changeset/rare-shoes-sell.md
+++ b/.changeset/rare-shoes-sell.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Deprecate sui_executeTransaction in favor of sui_executeTransactionSerializedSig

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -23,7 +23,6 @@ use sui_types::base_types::{
     ObjectID, SequenceNumber, SuiAddress, TransactionDigest, TxSequenceNumber,
 };
 use sui_types::committee::EpochId;
-use sui_types::crypto::SignatureScheme;
 use sui_types::event::EventID;
 use sui_types::governance::DelegatedStake;
 use sui_types::messages::CommitteeInfoResponse;
@@ -639,13 +638,9 @@ pub trait TransactionExecutionApi {
         &self,
         /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
         tx_bytes: Base64,
-        /// Flag of the signature scheme that is used.
-        sig_scheme: SignatureScheme,
-        /// Signature committed to the intent message of the transaction data, as base-64 encoded string.
+        /// `flag || signature || pubkey` bytes, as base-64 encoded string, signature is committed to the intent message of the transaction data, as base-64 encoded string.
         signature: Base64,
-        /// Signer's public key, as base-64 encoded string.
-        pub_key: Base64,
-        /// The request type.
+        /// The request type
         request_type: ExecuteTransactionRequestType,
     ) -> RpcResult<SuiExecuteTransactionResponse>;
 

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -73,7 +73,7 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let dryrun_response = http_client.dry_run_transaction(tx_bytes).await?;
 
     let tx_response: SuiExecuteTransactionResponse = http_client
-        .execute_transaction_serialized_sig(
+        .execute_transaction(
             tx_bytes1,
             signature_bytes,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -111,7 +111,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
 
     let tx_response = http_client
-        .execute_transaction_serialized_sig(
+        .execute_transaction(
             tx_bytes,
             signature_bytes,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -162,7 +162,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
 
     let tx_response = http_client
-        .execute_transaction_serialized_sig(
+        .execute_transaction(
             tx_bytes,
             signature_bytes,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -266,14 +266,12 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
-    let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
+    let (tx_bytes, signature) = tx.to_tx_bytes_and_signature();
 
     let tx_response = http_client
         .execute_transaction(
             tx_bytes,
-            sig_scheme,
-            signature_bytes,
-            pub_key,
+            signature,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -327,14 +325,12 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
-    let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
+    let (tx_bytes, signature) = tx.to_tx_bytes_and_signature();
 
     let tx_response = http_client
         .execute_transaction(
             tx_bytes,
-            sig_scheme,
-            signature_bytes,
-            pub_key,
+            signature,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -407,14 +403,12 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let tx = transaction_bytes.to_data()?;
 
     let tx = to_sender_signed_transaction(tx, keystore.get_key(address)?);
-    let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
+    let (tx_bytes, signature) = tx.to_tx_bytes_and_signature();
 
     let tx_response = http_client
         .execute_transaction(
             tx_bytes,
-            sig_scheme,
-            signature_bytes,
-            pub_key,
+            signature,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -452,7 +446,7 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
         let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
 
         let response = http_client
-            .execute_transaction_serialized_sig(
+            .execute_transaction(
                 tx_bytes,
                 signature_bytes,
                 ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -784,7 +778,7 @@ async fn test_locked_sui() -> Result<(), anyhow::Error> {
     let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
 
     http_client
-        .execute_transaction_serialized_sig(
+        .execute_transaction(
             tx_bytes,
             signature_bytes,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -838,7 +832,7 @@ async fn test_delegation() -> Result<(), anyhow::Error> {
     let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
 
     http_client
-        .execute_transaction_serialized_sig(
+        .execute_transaction(
             tx_bytes,
             signature_bytes,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -897,7 +891,7 @@ async fn test_delegation_multiple_coins() -> Result<(), anyhow::Error> {
     let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
 
     http_client
-        .execute_transaction_serialized_sig(
+        .execute_transaction(
             tx_bytes,
             signature_bytes,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -964,7 +958,7 @@ async fn test_delegation_with_locked_sui() -> Result<(), anyhow::Error> {
     let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
 
     http_client
-        .execute_transaction_serialized_sig(
+        .execute_transaction(
             tx_bytes,
             signature_bytes,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -995,7 +989,7 @@ async fn test_delegation_with_locked_sui() -> Result<(), anyhow::Error> {
     let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
 
     http_client
-        .execute_transaction_serialized_sig(
+        .execute_transaction(
             tx_bytes,
             signature_bytes,
             ExecuteTransactionRequestType::WaitForLocalExecution,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -293,24 +293,8 @@
           }
         },
         {
-          "name": "sig_scheme",
-          "description": "Flag of the signature scheme that is used.",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/SignatureScheme"
-          }
-        },
-        {
           "name": "signature",
-          "description": "Signature committed to the intent message of the transaction data, as base-64 encoded string.",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/Base64"
-          }
-        },
-        {
-          "name": "pub_key",
-          "description": "Signer's public key, as base-64 encoded string.",
+          "description": "`flag || signature || pubkey` bytes, as base-64 encoded string, signature is committed to the intent message of the transaction data, as base-64 encoded string.",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/Base64"
@@ -318,7 +302,7 @@
         },
         {
           "name": "request_type",
-          "description": "The request type.",
+          "description": "The request type",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/ExecuteTransactionRequestType"
@@ -334,23 +318,15 @@
       },
       "examples": [
         {
-          "name": "Execute an object transfer transaction",
+          "name": "Execute an transaction with serialized signature",
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AABDbOepJUsw0lPkVnzK+l82zoTICqi8m+ZODVrnlohCdK7zAFrmczgJAgAAAAAAAAAgMhOK400i5jl686mnHk76H7rRbLDPr95bKISFjoP6QUYRIEQC0XqEFTihtL+27+QoUEIaCsjsHVuE3WKJ4ZO5+I3kqZQ1jJ+FAgAAAAAAAAAgYTUjbD51qSXhx3rDQSfIuu++oJOfFSRxK003oCCyjN0BAAAAAAAAAOgDAAAAAAAA"
-            },
-            {
-              "name": "sig_scheme",
-              "value": "ED25519"
+              "value": "AABu/ETttc09/jL0v2w+isQu7xOF4BQD5JpLKWrcsi6ifTyS5M4iVqxkAgAAAAAAAAAg4/KC+kiz4BA7qbvtagYVO5/EhuEB8OnicDrIZm0Grsy1FgS1GDdd/f3bXfUkeP8IXSFaC1y6vcNs8bny7ISBomyn2BFpVZeUAgAAAAAAAAAgAouPAuQwKlWV2IiaZ8bTHGyXDlZ/A+9n2BGk+ENmW40BAAAAAAAAAOgDAAAAAAAA"
             },
             {
               "name": "signature",
-              "value": "ZIh08TpOJmkrxJhKAN57S/+ditrvNqR1LvQx/t/ji73mpurCc1Rfwnct6ah8N4sWMEQoIbg1Y4wlsrbpE09zAQ=="
-            },
-            {
-              "name": "pub_key",
-              "value": "cfqxAQMxQkfRKmbmcMuspsUBRwEdgv9Ug5F/Z6u8Jts="
+              "value": "AG+IXPpjofhGMG9roBEk00xzpNPsBOM6JtTgRKRY8zyvWcwIyrU4qhHVesKT0Pon0W0xP0b6SqIFneWxTvDC4gMETxNsaJH6UBKN/GfiZ46X8iMV/dyLU/zHwVMrBp9VTQ=="
             },
             {
               "name": "request_type",
@@ -361,30 +337,30 @@
             "name": "Result",
             "value": {
               "certificate": {
-                "transactionDigest": "SmRMvZAcnjxMtasU6NP6wvY2Uw42uUno8C5AfRY6b3c",
+                "transactionDigest": "BEq7zDLoAQYesW7napSoEwAaurhRRuzJ5hfjaHcsGi63",
                 "data": {
                   "transactions": [
                     {
                       "TransferObject": {
-                        "recipient": "0x436ce7a9254b30d253e4567ccafa5f36ce84c80a",
+                        "recipient": "0x6efc44edb5cd3dfe32f4bf6c3e8ac42eef1385e0",
                         "objectRef": {
-                          "objectId": "0xa8bc9be64e0d5ae796884274aef3005ae6733809",
+                          "objectId": "0x1403e49a4b296adcb22ea27d3c92e4ce2256ac64",
                           "version": 2,
-                          "digest": "MhOK400i5jl686mnHk76H7rRbLDPr95bKISFjoP6QUY="
+                          "digest": "4/KC+kiz4BA7qbvtagYVO5/EhuEB8OnicDrIZm0Grsw="
                         }
                       }
                     }
                   ],
-                  "sender": "0x11204402d17a841538a1b4bfb6efe42850421a0a",
+                  "sender": "0xb51604b518375dfdfddb5df52478ff085d215a0b",
                   "gasPayment": {
-                    "objectId": "0xc8ec1d5b84dd6289e193b9f88de4a994358c9f85",
+                    "objectId": "0x5cbabdc36cf1b9f2ec8481a26ca7d81169559794",
                     "version": 2,
-                    "digest": "YTUjbD51qSXhx3rDQSfIuu++oJOfFSRxK003oCCyjN0="
+                    "digest": "AouPAuQwKlWV2IiaZ8bTHGyXDlZ/A+9n2BGk+ENmW40="
                   },
                   "gasPrice": 1,
                   "gasBudget": 1000
                 },
-                "txSignature": "AGSIdPE6TiZpK8SYSgDee0v/nYra7zakdS70Mf7f44u95qbqwnNUX8J3LemofDeLFjBEKCG4NWOMJbK26RNPcwFx+rEBAzFCR9EqZuZwy6ymxQFHAR2C/1SDkX9nq7wm2w==",
+                "txSignature": "AG+IXPpjofhGMG9roBEk00xzpNPsBOM6JtTgRKRY8zyvWcwIyrU4qhHVesKT0Pon0W0xP0b6SqIFneWxTvDC4gMETxNsaJH6UBKN/GfiZ46X8iMV/dyLU/zHwVMrBp9VTQ==",
                 "authSignInfo": {
                   "epoch": 0,
                   "signature": "",
@@ -409,37 +385,37 @@
                   "storageCost": 100,
                   "storageRebate": 10
                 },
-                "transactionDigest": "E9PkcTxb6bdMCGcP5DP67UNkXaUhEzQSTehkYdEsYKJ1",
+                "transactionDigest": "6Ez41t7shkB8LUjE3owq2QcEyrDYhsZZYuQZQrJPpJDx",
                 "mutated": [
                   {
                     "owner": {
-                      "AddressOwner": "0x11204402d17a841538a1b4bfb6efe42850421a0a"
+                      "AddressOwner": "0xb51604b518375dfdfddb5df52478ff085d215a0b"
                     },
                     "reference": {
-                      "objectId": "0xc8ec1d5b84dd6289e193b9f88de4a994358c9f85",
+                      "objectId": "0x5cbabdc36cf1b9f2ec8481a26ca7d81169559794",
                       "version": 2,
-                      "digest": "YTUjbD51qSXhx3rDQSfIuu++oJOfFSRxK003oCCyjN0="
+                      "digest": "AouPAuQwKlWV2IiaZ8bTHGyXDlZ/A+9n2BGk+ENmW40="
                     }
                   },
                   {
                     "owner": {
-                      "AddressOwner": "0x436ce7a9254b30d253e4567ccafa5f36ce84c80a"
+                      "AddressOwner": "0x6efc44edb5cd3dfe32f4bf6c3e8ac42eef1385e0"
                     },
                     "reference": {
-                      "objectId": "0xa8bc9be64e0d5ae796884274aef3005ae6733809",
+                      "objectId": "0x1403e49a4b296adcb22ea27d3c92e4ce2256ac64",
                       "version": 2,
-                      "digest": "MhOK400i5jl686mnHk76H7rRbLDPr95bKISFjoP6QUY="
+                      "digest": "4/KC+kiz4BA7qbvtagYVO5/EhuEB8OnicDrIZm0Grsw="
                     }
                   }
                 ],
                 "gasObject": {
                   "owner": {
-                    "ObjectOwner": "0x11204402d17a841538a1b4bfb6efe42850421a0a"
+                    "ObjectOwner": "0xb51604b518375dfdfddb5df52478ff085d215a0b"
                   },
                   "reference": {
-                    "objectId": "0xc8ec1d5b84dd6289e193b9f88de4a994358c9f85",
+                    "objectId": "0x5cbabdc36cf1b9f2ec8481a26ca7d81169559794",
                     "version": 2,
-                    "digest": "YTUjbD51qSXhx3rDQSfIuu++oJOfFSRxK003oCCyjN0="
+                    "digest": "AouPAuQwKlWV2IiaZ8bTHGyXDlZ/A+9n2BGk+ENmW40="
                   }
                 },
                 "events": [
@@ -447,12 +423,12 @@
                     "transferObject": {
                       "packageId": "0x0000000000000000000000000000000000000002",
                       "transactionModule": "native",
-                      "sender": "0x11204402d17a841538a1b4bfb6efe42850421a0a",
+                      "sender": "0xb51604b518375dfdfddb5df52478ff085d215a0b",
                       "recipient": {
-                        "AddressOwner": "0x436ce7a9254b30d253e4567ccafa5f36ce84c80a"
+                        "AddressOwner": "0x6efc44edb5cd3dfe32f4bf6c3e8ac42eef1385e0"
                       },
                       "objectType": "0x2::example::Object",
-                      "objectId": "0xa8bc9be64e0d5ae796884274aef3005ae6733809",
+                      "objectId": "0x1403e49a4b296adcb22ea27d3c92e4ce2256ac64",
                       "version": 2
                     }
                   }
@@ -504,131 +480,7 @@
         "schema": {
           "$ref": "#/components/schemas/SuiExecuteTransactionResponse"
         }
-      },
-      "examples": [
-        {
-          "name": "Execute an transaction with serialized signature",
-          "params": [
-            {
-              "name": "tx_bytes",
-              "value": "AACpM7iJnvsgc1pPauyCE27/c+aBnHN3fSsxRAWdEJYzYFOryNDoQ3EiAgAAAAAAAAAg6mjskM8fdWdamzhfR5/qfC3a0Ld7dYA2p0/bb9vqRqPiYZUZQgIZpwo6bh/2u2CqPUJSt6cnFPvxDrwXAzxbTJGYkm3c1gMNAgAAAAAAAAAgwsHZkAgLQVgjWMbUFXCCHtL4i9yTTujRYs1wXaHfoM0BAAAAAAAAAOgDAAAAAAAA"
-            },
-            {
-              "name": "signature",
-              "value": "AEYFlSNOs3VXTafbryAH3/ZKoqy907QU+pP9oSkiOtmix/LsiwY4EjCHwj+ICLkIHNTGXx7LHGbKu++PomyH1QZrcsROTZwfkUDdbwRmvqkE8UTLidenb8PFiZSW/zoONw=="
-            },
-            {
-              "name": "request_type",
-              "value": "WaitForLocalExecution"
-            }
-          ],
-          "result": {
-            "name": "Result",
-            "value": {
-              "certificate": {
-                "transactionDigest": "H8kJj83i5eYpr7agBtrjAohLQ7rYGCBMz14KRETq834o",
-                "data": {
-                  "transactions": [
-                    {
-                      "TransferObject": {
-                        "recipient": "0xa933b8899efb20735a4f6aec82136eff73e6819c",
-                        "objectRef": {
-                          "objectId": "0x73777d2b3144059d1096336053abc8d0e8437122",
-                          "version": 2,
-                          "digest": "6mjskM8fdWdamzhfR5/qfC3a0Ld7dYA2p0/bb9vqRqM="
-                        }
-                      }
-                    }
-                  ],
-                  "sender": "0xe2619519420219a70a3a6e1ff6bb60aa3d4252b7",
-                  "gasPayment": {
-                    "objectId": "0xa72714fbf10ebc17033c5b4c9198926ddcd6030d",
-                    "version": 2,
-                    "digest": "wsHZkAgLQVgjWMbUFXCCHtL4i9yTTujRYs1wXaHfoM0="
-                  },
-                  "gasPrice": 1,
-                  "gasBudget": 1000
-                },
-                "txSignature": "AEYFlSNOs3VXTafbryAH3/ZKoqy907QU+pP9oSkiOtmix/LsiwY4EjCHwj+ICLkIHNTGXx7LHGbKu++PomyH1QZrcsROTZwfkUDdbwRmvqkE8UTLidenb8PFiZSW/zoONw==",
-                "authSignInfo": {
-                  "epoch": 0,
-                  "signature": "",
-                  "signers_map": [
-                    58,
-                    48,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                  ]
-                }
-              },
-              "effects": {
-                "status": {
-                  "status": "success"
-                },
-                "gasUsed": {
-                  "computationCost": 100,
-                  "storageCost": 100,
-                  "storageRebate": 10
-                },
-                "transactionDigest": "GsPDh3rJZzPJ8977gZEf9a5QZo2h7eup7v2ioNk9kvZX",
-                "mutated": [
-                  {
-                    "owner": {
-                      "AddressOwner": "0xe2619519420219a70a3a6e1ff6bb60aa3d4252b7"
-                    },
-                    "reference": {
-                      "objectId": "0xa72714fbf10ebc17033c5b4c9198926ddcd6030d",
-                      "version": 2,
-                      "digest": "wsHZkAgLQVgjWMbUFXCCHtL4i9yTTujRYs1wXaHfoM0="
-                    }
-                  },
-                  {
-                    "owner": {
-                      "AddressOwner": "0xa933b8899efb20735a4f6aec82136eff73e6819c"
-                    },
-                    "reference": {
-                      "objectId": "0x73777d2b3144059d1096336053abc8d0e8437122",
-                      "version": 2,
-                      "digest": "6mjskM8fdWdamzhfR5/qfC3a0Ld7dYA2p0/bb9vqRqM="
-                    }
-                  }
-                ],
-                "gasObject": {
-                  "owner": {
-                    "ObjectOwner": "0xe2619519420219a70a3a6e1ff6bb60aa3d4252b7"
-                  },
-                  "reference": {
-                    "objectId": "0xa72714fbf10ebc17033c5b4c9198926ddcd6030d",
-                    "version": 2,
-                    "digest": "wsHZkAgLQVgjWMbUFXCCHtL4i9yTTujRYs1wXaHfoM0="
-                  }
-                },
-                "events": [
-                  {
-                    "transferObject": {
-                      "packageId": "0x0000000000000000000000000000000000000002",
-                      "transactionModule": "native",
-                      "sender": "0xe2619519420219a70a3a6e1ff6bb60aa3d4252b7",
-                      "recipient": {
-                        "AddressOwner": "0xa933b8899efb20735a4f6aec82136eff73e6819c"
-                      },
-                      "objectType": "0x2::example::Object",
-                      "objectId": "0x73777d2b3144059d1096336053abc8d0e8437122",
-                      "version": 2
-                    }
-                  }
-                ]
-              },
-              "timestamp_ms": null,
-              "parsed_data": null
-            }
-          }
-        }
-      ]
+      }
     },
     {
       "name": "sui_getAllBalances",
@@ -995,7 +847,7 @@
             {
               "name": "query",
               "value": {
-                "Transaction": "BEq7zDLoAQYesW7napSoEwAaurhRRuzJ5hfjaHcsGi63"
+                "Transaction": "FBPTp2FqjT3NbK85GFTDtKTTU5qJpBqEX44GE9CfUQor"
               }
             },
             {
@@ -1020,7 +872,7 @@
               "data": [
                 {
                   "timestamp": 0,
-                  "txDigest": "BEq7zDLoAQYesW7napSoEwAaurhRRuzJ5hfjaHcsGi63",
+                  "txDigest": "FBPTp2FqjT3NbK85GFTDtKTTU5qJpBqEX44GE9CfUQor",
                   "id": {
                     "txSeq": 0,
                     "eventSeq": 0
@@ -1029,12 +881,12 @@
                     "transferObject": {
                       "packageId": "0x0000000000000000000000000000000000000002",
                       "transactionModule": "native",
-                      "sender": "0xb51604b518375dfdfddb5df52478ff085d215a0b",
+                      "sender": "0xc9f373e51a0a03bfd8b1a861fb7e220b6617e575",
                       "recipient": {
-                        "AddressOwner": "0x6efc44edb5cd3dfe32f4bf6c3e8ac42eef1385e0"
+                        "AddressOwner": "0xc677ed804f82f1c8587b98d64c00bfb46c3843bd"
                       },
                       "objectType": "0x2::example::Object",
-                      "objectId": "0x1403e49a4b296adcb22ea27d3c92e4ce2256ac64",
+                      "objectId": "0x8bf6ccfa7c65a86138698cd1fdcac3dce8d8c7ce",
                       "version": 2
                     }
                   }
@@ -1260,7 +1112,7 @@
           "params": [
             {
               "name": "object_id",
-              "value": "0x686464524a876b463d1297603568c40e814d9d53"
+              "value": "0x2ea0d7117b30c8c8436ce7a9254b30d253e4567c"
             }
           ],
           "result": {
@@ -1275,19 +1127,19 @@
                   "fields": {
                     "balance": "10000",
                     "id": {
-                      "id": "0x686464524a876b463d1297603568c40e814d9d53"
+                      "id": "0x2ea0d7117b30c8c8436ce7a9254b30d253e4567c"
                     }
                   }
                 },
                 "owner": {
-                  "AddressOwner": "0x96d23087a0fd641e91e0e00df6c012cded9ef9ba"
+                  "AddressOwner": "0xcafa5f36ce84c80aa8bc9be64e0d5ae796884274"
                 },
-                "previousTransaction": "7MLdoNgkZnWKQeAfdAAdJsoQX86VPDfvJFV7ERfZ2v7t",
+                "previousTransaction": "CmvrMzn3qVkwJtZfkCNAQEDN11pV6t8mR8zdDPaayAn7",
                 "storageRebate": 100,
                 "reference": {
-                  "objectId": "0x686464524a876b463d1297603568c40e814d9d53",
+                  "objectId": "0x2ea0d7117b30c8c8436ce7a9254b30d253e4567c",
                   "version": 1,
-                  "digest": "2hzaTkK0FFsm+jXqGdJYsRPY4+EryiqmErME7OWyWYg="
+                  "digest": "PnWpJeHHesNBJ8i6776gk58VJHErTTegILKM3TITiuM="
                 }
               }
             }
@@ -1329,51 +1181,51 @@
           "params": [
             {
               "name": "address",
-              "value": "0xd885442b44972526c4e8ce25a0416c3955d818bb"
+              "value": "0x464b5ca6488b897c005b2e17f00fc0bc8e7ed3f2"
             }
           ],
           "result": {
             "name": "Result",
             "value": [
               {
-                "objectId": "0x1ab0e832877d628233e3e1d64f76b71a80ec4f33",
+                "objectId": "0xab59d607b0e3586bda1cda4e42b4145b26fa35ea",
                 "version": 0,
-                "digest": "L00aZ0LFN/K7Mkc7AbHcscqslCcipHh7sYXkeRkWkm4=",
+                "digest": "GdJYsRPY4+EryiqmErME7OWyWYiBjdcjTgSZEyM+uRg=",
                 "type": "0x2::coin::Coin<0x2::sui::SUI>",
                 "owner": {
-                  "AddressOwner": "0xd885442b44972526c4e8ce25a0416c3955d818bb"
+                  "AddressOwner": "0x464b5ca6488b897c005b2e17f00fc0bc8e7ed3f2"
                 },
-                "previousTransaction": "7TBYiUPthxZ2LNvMk5kwtqHpw1e3casThSHZfqkKrXZh"
+                "previousTransaction": "DzjLdREM8DovYxjmAVA6noZguRsQ5hXrX1aRdN9EiHRx"
               },
               {
-                "objectId": "0x827ec0818e00de4b297f047c3beda43d6e9f9b1b",
+                "objectId": "0x12bea9ffe04748d6696c30631735193aea95b8f9",
                 "version": 0,
-                "digest": "G8RM3841dOf38LLeIyOgbrw1a61hRyazE9gRAS1L5yM=",
+                "digest": "CCwQYgwNbj/JWWtFONDcJL7Dcbs+RjRWH4iS5gQCGrk=",
                 "type": "0x2::coin::Coin<0x2::sui::SUI>",
                 "owner": {
-                  "AddressOwner": "0xd885442b44972526c4e8ce25a0416c3955d818bb"
+                  "AddressOwner": "0x464b5ca6488b897c005b2e17f00fc0bc8e7ed3f2"
                 },
-                "previousTransaction": "8u3E7cQUSuo96NwJ9mYS4hMGCs48CEjreQPGrKGsVTMV"
+                "previousTransaction": "8ECLnHkuLMea3g54k2KRaDGAqKAj39SGUs5CB5165v4Z"
               },
               {
-                "objectId": "0x564da689e9da76e1430d191fbc937d42f74104aa",
+                "objectId": "0x877d628233e3e1d64f76b71a80ec4f332f4d1a67",
                 "version": 0,
-                "digest": "KRhx9LnRIPdlg6HaXREj8rigrGBrlApm5C79eCr1IDE=",
+                "digest": "QsU38rsyRzsBsdyxyqyUJyKkeHuxheR5GRaSbl/bJd0=",
                 "type": "0x2::coin::Coin<0x2::sui::SUI>",
                 "owner": {
-                  "AddressOwner": "0xd885442b44972526c4e8ce25a0416c3955d818bb"
+                  "AddressOwner": "0x464b5ca6488b897c005b2e17f00fc0bc8e7ed3f2"
                 },
-                "previousTransaction": "2E3Y69NXfHQxMHoNupkwpv3RmADKQz4Lpka5fa6PjU2g"
+                "previousTransaction": "9tznME4gjDKFGpBL3HhGv1YNVzV9WFnaxoywoocrKmmS"
               },
               {
-                "objectId": "0xd1e09be8e451cd3c364076623c0231898be0722c",
+                "objectId": "0x8e00de4b297f047c3beda43d6e9f9b1b1bc44cdf",
                 "version": 0,
-                "digest": "COTrIpxEy5V9Kc9zcK+KG5xULUmzyDz7nGg/t9BSbik=",
+                "digest": "zjV05/fwst4jI6BuvDVrrWFHJrMT2BEBLUvnI3VWhxI=",
                 "type": "0x2::coin::Coin<0x2::sui::SUI>",
                 "owner": {
-                  "AddressOwner": "0xd885442b44972526c4e8ce25a0416c3955d818bb"
+                  "AddressOwner": "0x464b5ca6488b897c005b2e17f00fc0bc8e7ed3f2"
                 },
-                "previousTransaction": "FWCZrdzxmfk7zogPwBu3tZHForssh8VMqJXkixrLGQCr"
+                "previousTransaction": "hw88uCsQbCGQJDpK2V9nJV4UFQeyTXCsVrAYLg7Ktek"
               }
             ]
           }
@@ -1414,51 +1266,51 @@
           "params": [
             {
               "name": "object_id",
-              "value": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9"
+              "value": "0xe9da76e1430d191fbc937d42f74104aa291871f4"
             }
           ],
           "result": {
             "name": "Result",
             "value": [
               {
-                "objectId": "0xa14c6b812b94fe613c5bcebb5eeb1d449e251616",
+                "objectId": "0xb9d120f76583a1da5d1123f2b8a0ac606b940a66",
                 "version": 0,
-                "digest": "bVfXH96xVNDcns23swBX0KkyaEysNSzcGj6JgCnQJO4=",
+                "digest": "5C79eCr1IDESMxrcLtb0Atyjlr/m36OsilfqCIYIcP0=",
                 "type": "0x2::coin::Coin<0x2::sui::SUI>",
                 "owner": {
-                  "ObjectOwner": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9"
+                  "ObjectOwner": "0xe9da76e1430d191fbc937d42f74104aa291871f4"
                 },
-                "previousTransaction": "E3dSj5imFCTb5QUaaM2RKkmM2FUszD99qvfcNiUVqBBv"
+                "previousTransaction": "6UcFCc9ZCLJ8fdJb2uKKh2yNFbCAFXXsW5AFQLu6EQph"
               },
               {
-                "objectId": "0x8b0cbf377792e206e6b80d4d5eea64e2e70563b1",
+                "objectId": "0x9c44cb957d29cf7370af8a1b9c542d49b3c83cfb",
                 "version": 0,
-                "digest": "WJAmxON/lBpFHvggmg+/vxtUmyuya46u4IiVFG3ye8M=",
+                "digest": "nGg/t9BSbinXfonnv+/U9zraPRmsh9RTUfAZaogLlcM=",
                 "type": "0x2::coin::Coin<0x2::sui::SUI>",
                 "owner": {
-                  "ObjectOwner": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9"
+                  "ObjectOwner": "0xe9da76e1430d191fbc937d42f74104aa291871f4"
                 },
-                "previousTransaction": "Ewd4QWcfAnZXdQ5MAnrRtkuDweHQQECrX6beY65yXHXj"
+                "previousTransaction": "GkzWWDBnTYo9FBhJpGzJNbsg9KfJreyGWMSAPTaiBy2g"
               },
               {
-                "objectId": "0x8bc160c74cd844f922623fa58cdd6ef2d0531ce3",
+                "objectId": "0x2b94fe613c5bcebb5eeb1d449e2516166d57d71f",
                 "version": 0,
-                "digest": "WfMui9DNX54cTteFYCsUTXmIN9uwFHTINWbFsqU1QQ0=",
+                "digest": "3rFU0NyezbezAFfQqTJoTKw1LNwaPomAKdAk7sHUTGo=",
                 "type": "0x2::coin::Coin<0x2::sui::SUI>",
                 "owner": {
-                  "ObjectOwner": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9"
+                  "ObjectOwner": "0xe9da76e1430d191fbc937d42f74104aa291871f4"
                 },
-                "previousTransaction": "FiT2qZx7vs4Gqy5o4hkiAdcLrX5dWgC2VBxse5gjwupS"
+                "previousTransaction": "HYqdRSAaRoWGEpUJhUe1hNPxrLVtZn9GJ14WztqzLWBQ"
               },
               {
-                "objectId": "0xd3dbd682f600d1f62dc0921f7f7dbfca95055adc",
+                "objectId": "0x7792e206e6b80d4d5eea64e2e70563b1589026c4",
                 "version": 0,
-                "digest": "XhR6Hu4u3SNxRHRERonJRvaaWFkkuRxLiubUzW4eAvY=",
+                "digest": "43+UGkUe+CCaD7+/G1SbK7Jrjq7giJUUbfJ7w88mEME=",
                 "type": "0x2::coin::Coin<0x2::sui::SUI>",
                 "owner": {
-                  "ObjectOwner": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9"
+                  "ObjectOwner": "0xe9da76e1430d191fbc937d42f74104aa291871f4"
                 },
-                "previousTransaction": "7qQzifR67pNVyi1MDvA4VMKS76fKwov222kg6vh2Gv27"
+                "previousTransaction": "64UQ3a7m1mjWuzgyGoH8RnMyPGDN4XYTC9dS4qiSfdK4"
               }
             ]
           }
@@ -1496,7 +1348,7 @@
           "params": [
             {
               "name": "object_id",
-              "value": "0x7d2ff374c3f870f36fb728ab4187831206d15181"
+              "value": "0x4cd844f922623fa58cdd6ef2d0531ce359f32e8b"
             }
           ],
           "result": {
@@ -1509,17 +1361,17 @@
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "has_public_transfer": true,
                   "version": 1,
-                  "bcs_bytes": "fS/zdMP4cPNvtyirQYeDEgbRUYEQJwAAAAAAAA=="
+                  "bcs_bytes": "TNhE+SJiP6WM3W7y0FMc41nzLosQJwAAAAAAAA=="
                 },
                 "owner": {
-                  "AddressOwner": "0xff7c50772417586a93633829fcba6d6e0ccb13d3"
+                  "AddressOwner": "0xd0cd5f9e1c4ed785602b144d798837dbb01474c8"
                 },
-                "previousTransaction": "FomLHyaFXekRw2wdCcQqn9EvUaQhruUv3sH4FQYZEVoo",
+                "previousTransaction": "4bTW1xuz9VBmMryJQDc3mMvHEkgUye59fxvChc12QnHp",
                 "storageRebate": 100,
                 "reference": {
-                  "objectId": "0x7d2ff374c3f870f36fb728ab4187831206d15181",
+                  "objectId": "0x4cd844f922623fa58cdd6ef2d0531ce359f32e8b",
                   "version": 1,
-                  "digest": "8jJSXNzuo1pDOnsPUOjfsuIbpJfFSrMKPZrcB8FCnE0="
+                  "digest": "fxpOPcex5//T29aC9gDR9i3Akh9/fb/KlQVa3F4Ueh4="
                 }
               }
             }
@@ -1630,37 +1482,37 @@
           "params": [
             {
               "name": "digest",
-              "value": "G49Sw2YCRHSjapehH6dKpQqnAgsWhxHLf3HYBuEaXa7a"
+              "value": "3AEp1zzNUB8jUx1vXnsWcmgTR193aFEE9V6Kbqe2iJ5o"
             }
           ],
           "result": {
             "name": "Result",
             "value": {
               "certificate": {
-                "transactionDigest": "G49Sw2YCRHSjapehH6dKpQqnAgsWhxHLf3HYBuEaXa7a",
+                "transactionDigest": "3AEp1zzNUB8jUx1vXnsWcmgTR193aFEE9V6Kbqe2iJ5o",
                 "data": {
                   "transactions": [
                     {
                       "TransferObject": {
-                        "recipient": "0x7a91f631760853934d383634bcf7c32655009a61",
+                        "recipient": "0x4689c946f69a585924b91c4b8ae6d4cd6e1e02f6",
                         "objectRef": {
-                          "objectId": "0xf1de0eae420a2e4ae1bb772ab2dd5d5a7dfa949c",
+                          "objectId": "0x658d21bce9b88bdceee1294144eec47cf39388bb",
                           "version": 2,
-                          "digest": "LrMQvKkSTl8vOM5znqrLtmAGiIBOB4RIn5D3+GbMKd8="
+                          "digest": "2/52FLgep2slXl1DUDLNhZXzfrj8AP/NoAr8XqnjnLI="
                         }
                       }
                     }
                   ],
-                  "sender": "0x1d6911910920c621a975743e49382f8db9c1c05d",
+                  "sender": "0x5f3ff5d763a77666ce443e6ed0802cf4991d6069",
                   "gasPayment": {
-                    "objectId": "0x0ef06908e7a54900f279be4c6a101e9a3af5c807",
+                    "objectId": "0x680f69b7426bc52929692fdc7d2ff374c3f870f3",
                     "version": 2,
-                    "digest": "ARL4CGSLNu+/je6KGoLeRtlQTpahEIoXjvdvVsOZYzo="
+                    "digest": "b7coq0GHgxIG0VGB/3xQdyQXWGqTYzgp/LptbgzLE9M="
                   },
                   "gasPrice": 1,
                   "gasBudget": 1000
                 },
-                "txSignature": "ANMM5DC9TGa+L9jh25Bo6zR88WVklxXfpPGGyR/mid9bd1wTs6hHhl2W1PvNYXnf5fGRkrzdnnRtkdX8kio0CAGk8MuV4Ujxl9xtOeYgzm8Jf2BS6d0xIUr4jebbcPvoqQ==",
+                "txSignature": "AGByrNPNX8XcfZpqbzGkBmwlWFJmkPRthbjEleR/MRadhudsaGF+6p6MMw0mjPvsQ+fuSb/O0vTp+2eLhekupQTlSWjlOED/V6Eca5zv6KJs5sFfQMs6XCZi8IwJleWjPw==",
                 "authSignInfo": {
                   "epoch": 0,
                   "signature": "",
@@ -1685,37 +1537,37 @@
                   "storageCost": 100,
                   "storageRebate": 10
                 },
-                "transactionDigest": "CyGJmgvA8He9m1TNHdQYzZPKeQy9r8FVtJ5amhc88wnw",
+                "transactionDigest": "HJSAiyhRGdVoPxS8xWnaEdH7MYZDZqqVfVgg8dfFKGw6",
                 "mutated": [
                   {
                     "owner": {
-                      "AddressOwner": "0x1d6911910920c621a975743e49382f8db9c1c05d"
+                      "AddressOwner": "0x5f3ff5d763a77666ce443e6ed0802cf4991d6069"
                     },
                     "reference": {
-                      "objectId": "0x0ef06908e7a54900f279be4c6a101e9a3af5c807",
+                      "objectId": "0x680f69b7426bc52929692fdc7d2ff374c3f870f3",
                       "version": 2,
-                      "digest": "ARL4CGSLNu+/je6KGoLeRtlQTpahEIoXjvdvVsOZYzo="
+                      "digest": "b7coq0GHgxIG0VGB/3xQdyQXWGqTYzgp/LptbgzLE9M="
                     }
                   },
                   {
                     "owner": {
-                      "AddressOwner": "0x7a91f631760853934d383634bcf7c32655009a61"
+                      "AddressOwner": "0x4689c946f69a585924b91c4b8ae6d4cd6e1e02f6"
                     },
                     "reference": {
-                      "objectId": "0xf1de0eae420a2e4ae1bb772ab2dd5d5a7dfa949c",
+                      "objectId": "0x658d21bce9b88bdceee1294144eec47cf39388bb",
                       "version": 2,
-                      "digest": "LrMQvKkSTl8vOM5znqrLtmAGiIBOB4RIn5D3+GbMKd8="
+                      "digest": "2/52FLgep2slXl1DUDLNhZXzfrj8AP/NoAr8XqnjnLI="
                     }
                   }
                 ],
                 "gasObject": {
                   "owner": {
-                    "ObjectOwner": "0x1d6911910920c621a975743e49382f8db9c1c05d"
+                    "ObjectOwner": "0x5f3ff5d763a77666ce443e6ed0802cf4991d6069"
                   },
                   "reference": {
-                    "objectId": "0x0ef06908e7a54900f279be4c6a101e9a3af5c807",
+                    "objectId": "0x680f69b7426bc52929692fdc7d2ff374c3f870f3",
                     "version": 2,
-                    "digest": "ARL4CGSLNu+/je6KGoLeRtlQTpahEIoXjvdvVsOZYzo="
+                    "digest": "b7coq0GHgxIG0VGB/3xQdyQXWGqTYzgp/LptbgzLE9M="
                   }
                 },
                 "events": [
@@ -1723,12 +1575,12 @@
                     "transferObject": {
                       "packageId": "0x0000000000000000000000000000000000000002",
                       "transactionModule": "native",
-                      "sender": "0x1d6911910920c621a975743e49382f8db9c1c05d",
+                      "sender": "0x5f3ff5d763a77666ce443e6ed0802cf4991d6069",
                       "recipient": {
-                        "AddressOwner": "0x7a91f631760853934d383634bcf7c32655009a61"
+                        "AddressOwner": "0x4689c946f69a585924b91c4b8ae6d4cd6e1e02f6"
                       },
                       "objectType": "0x2::example::Object",
-                      "objectId": "0xf1de0eae420a2e4ae1bb772ab2dd5d5a7dfa949c",
+                      "objectId": "0x658d21bce9b88bdceee1294144eec47cf39388bb",
                       "version": 2
                     }
                   }
@@ -1772,7 +1624,7 @@
           "params": [
             {
               "name": "digest",
-              "value": "9sJ77aD6M1qSTpxLYTjeGSFhiMPBHP9Abgr8YjXFJkwG"
+              "value": "G49Sw2YCRHSjapehH6dKpQqnAgsWhxHLf3HYBuEaXa7a"
             }
           ],
           "result": {
@@ -1843,12 +1695,12 @@
             {
               "name": "query",
               "value": {
-                "InputObject": "0xe293c08cec0f40783d9ac4bf4abb4d7f820647fd"
+                "InputObject": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c74"
               }
             },
             {
               "name": "cursor",
-              "value": "A1NZtyS73EN5N4jBA8Q7fMcvmJ3voaGkUEuFnjyXA5HC"
+              "value": "DyjSAx3jU1ERs8zFG1cQvQzdXLMeKgDoVj366MrkRjG"
             },
             {
               "name": "limit",
@@ -1863,11 +1715,11 @@
             "name": "Result",
             "value": {
               "data": [
-                "9WajtNQhL2AebUmv6oYdVHaBKNG8C3PtphwjRD6PaKRh",
-                "6xQBrrbMRvhvpM6UTwYZvxDsqmt2qq9vGBsWvJk7ZVpy",
-                "A33X7MrgZcuFULczA8RDiECvwKTG9bBCEDKjVM3iP5jf"
+                "GD9ggktpmg7emKWoWvK9mjHY3XuaR9dmdhBiCPCyABZT",
+                "2EL37wRGHvRyT6q4nZYMDm8AsKmYG4todK6QH6Hftrys",
+                "79WsaYhq5UEkgKg5SGQBXb8BA6A4ZDQiprDPyKC1GAY9"
               ],
-              "nextCursor": "BvSKESccKJFyFXpY9yVZ3LSwGU2ckzjv8QuHr2crndK"
+              "nextCursor": "2dnpKMuvbtsQSofMivyT1AdcA4WJanK8C5aSfJHt3Tya"
             }
           }
         }
@@ -2880,7 +2732,7 @@
           "params": [
             {
               "name": "object_id",
-              "value": "0x818dd7234e049913233eb918c11638af89d575be"
+              "value": "0x4d22e6397af3a9a71e4efa1fbad16cb0cfafde5b"
             },
             {
               "name": "version",
@@ -2899,19 +2751,19 @@
                   "fields": {
                     "balance": "10000",
                     "id": {
-                      "id": "0x818dd7234e049913233eb918c11638af89d575be"
+                      "id": "0x4d22e6397af3a9a71e4efa1fbad16cb0cfafde5b"
                     }
                   }
                 },
                 "owner": {
-                  "AddressOwner": "0xb99003d30a245ac74a02e26e45cb80ee1b9c00a9"
+                  "AddressOwner": "0x2884858e83fa4146c34e4d5ca8f7f7dfaa083b1c"
                 },
-                "previousTransaction": "4T9XiCXVjtBsf5zLoYmHQMLF4G8ewKvBkLagbzApGBta",
+                "previousTransaction": "2C2xqKAT9RFdZAKSRm7uFcRMQ6AF1TLnkhe9ZQnnz2xo",
                 "storageRebate": 100,
                 "reference": {
-                  "objectId": "0x818dd7234e049913233eb918c11638af89d575be",
+                  "objectId": "0x4d22e6397af3a9a71e4efa1fbad16cb0cfafde5b",
                   "version": 4,
-                  "digest": "yVlrRTjQ3CS+w3G7PkY0Vh+IkuYEAhq5a2Mur6Ip7D0="
+                  "digest": "NWjEDoFNnVOW0jCHoP1kHpHg4A32wBLN7Z75ul5b8EI="
                 }
               }
             }
@@ -4978,15 +4830,6 @@
             },
             "additionalProperties": false
           }
-        ]
-      },
-      "SignatureScheme": {
-        "type": "string",
-        "enum": [
-          "ED25519",
-          "Secp256k1",
-          "Secp256r1",
-          "BLS12381"
         ]
       },
       "StakeSubsidy": {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -27,10 +27,10 @@ use sui_open_rpc::ExamplePairing;
 use sui_types::base_types::{
     ObjectDigest, ObjectID, ObjectType, SequenceNumber, SuiAddress, TransactionDigest,
 };
+use sui_types::crypto::AuthorityQuorumSignInfo;
 use sui_types::crypto::{
     get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, Signature,
 };
-use sui_types::crypto::{AuthorityQuorumSignInfo, SuiSignature};
 use sui_types::event::EventID;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
@@ -71,7 +71,6 @@ impl RpcExampleProvider {
     pub fn examples(&mut self) -> BTreeMap<String, Vec<ExamplePairing>> {
         [
             self.batch_transaction_examples(),
-            self.execute_transaction_example(),
             self.get_object_example(),
             self.get_past_object_example(),
             self.get_objects_owned_by_address(),
@@ -82,7 +81,7 @@ impl RpcExampleProvider {
             self.get_transaction_auth_signers(),
             self.get_transactions(),
             self.get_events(),
-            self.execute_transaction_serialized_sig_example(),
+            self.execute_transaction_example(),
         ]
         .into_iter()
         .map(|example| (example.function_name, example.examples))
@@ -168,41 +167,10 @@ impl RpcExampleProvider {
 
     fn execute_transaction_example(&mut self) -> Examples {
         let (data, signature, _, _, result, _) = self.get_transfer_data_response();
-
-        Examples::new(
-            "sui_executeTransaction",
-            vec![ExamplePairing::new(
-                "Execute an object transfer transaction",
-                vec![
-                    (
-                        "tx_bytes",
-                        json!(Base64::from_bytes(bcs::to_bytes(&data).unwrap().as_slice())),
-                    ),
-                    ("sig_scheme", json!(signature.scheme())),
-                    (
-                        "signature",
-                        json!(Base64::from_bytes(signature.signature_bytes())),
-                    ),
-                    (
-                        "pub_key",
-                        json!(Base64::from_bytes(signature.public_key_bytes())),
-                    ),
-                    (
-                        "request_type",
-                        json!(ExecuteTransactionRequestType::WaitForLocalExecution),
-                    ),
-                ],
-                json!(result),
-            )],
-        )
-    }
-
-    fn execute_transaction_serialized_sig_example(&mut self) -> Examples {
-        let (data, signature, _, _, result, _) = self.get_transfer_data_response();
         let tx_bytes = TransactionBytes::from_data(data).unwrap();
 
         Examples::new(
-            "sui_executeTransactionSerializedSig",
+            "sui_executeTransaction",
             vec![ExamplePairing::new(
                 "Execute an transaction with serialized signature",
                 vec![

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -349,15 +349,13 @@ impl QuorumDriver {
         tx: VerifiedTransaction,
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> SuiRpcResult<TransactionExecutionResult> {
-        let (tx_bytes, flag, signature, pub_key) = tx.to_network_data_for_execution();
+        let (tx_bytes, signature) = tx.to_tx_bytes_and_signature();
         let request_type =
             request_type.unwrap_or(ExecuteTransactionRequestType::WaitForLocalExecution);
-        let resp = TransactionExecutionApiClient::execute_transaction(
+        let resp = TransactionExecutionApiClient::execute_transaction_serialized_sig(
             &self.api.http,
             tx_bytes,
-            flag,
             signature,
-            pub_key,
             request_type.clone(),
         )
         .await?;

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -6,8 +6,7 @@ use crate::certificate_proof::CertificateProof;
 use crate::committee::{EpochId, StakeUnit};
 use crate::crypto::{
     sha3_hash, AuthoritySignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo,
-    Ed25519SuiSignature, EmptySignInfo, Signature, SignatureScheme, SuiSignature,
-    SuiSignatureInner, ToFromBytes,
+    Ed25519SuiSignature, EmptySignInfo, Signature, SuiSignature, SuiSignatureInner, ToFromBytes,
 };
 use crate::gas::GasCostSummary;
 use crate::intent::{Intent, IntentMessage};
@@ -958,20 +957,7 @@ impl Transaction {
         Self::new(SenderSignedData::new(data, intent, signature))
     }
 
-    // TODO(joyqvq): remove and prefer to_tx_bytes_and_signature()
-    pub fn to_network_data_for_execution(&self) -> (Base64, SignatureScheme, Base64, Base64) {
-        (
-            Base64::from_bytes(
-                bcs::to_bytes(&self.intent_message.value)
-                    .unwrap()
-                    .as_slice(),
-            ),
-            self.tx_signature.scheme(),
-            Base64::from_bytes(self.tx_signature.signature_bytes()),
-            Base64::from_bytes(self.tx_signature.public_key_bytes()),
-        )
-    }
-
+    /// Returns the Base64 encoded tx_bytes and the Base64 encoded serialized signature (`flag || sig || pk`).
     pub fn to_tx_bytes_and_signature(&self) -> (Base64, Base64) {
         (
             Base64::from_bytes(&bcs::to_bytes(&self.data().intent_message.value).unwrap()),

--- a/crates/sui/offline_signing.md
+++ b/crates/sui/offline_signing.md
@@ -1,29 +1,31 @@
 # Offline Signing
 
 This is a guide for users who wish to sign a transaction using an offline device without relying on sui keystore. Here are the steps to:
- 1. Serialize the data for signing;
- 2. Take the serialized data elsewhere to sign (wallet of your choice, or tools in other languages) to produce a signature and the corresponding public key.
- 3. Execute the signed transaction.
+1. Serialize the data for signing;
+2. Take the serialized data elsewhere to sign (wallet of your choice, or tools in other languages) to produce a signature and the corresponding public key.
+3. Execute the signed transaction.
 
 ## Step 1: Serialize a Transfer
 
 A transaction data must be serialized according to [BCS](https://crates.io/crates/bcs). It is supported in [other languages](https://github.com/zefchain/serde-reflection#language-interoperability).
 
-Here an example is provided to serialize a transfer data in CLI. This outputs a serialized transaction data in Base64.
-
+Here an example is provided to serialize a transfer data in CLI. This outputs a serialized transaction data in Base64. The intent message to sign is what the signature commits to. The raw transaction to execute is what is submitted as tx_bytes
+ 
 ```shell
-sui client serialize-transfer-sui --to 0x581a119a6576d3b502b5dc47c5de497b774e68ca --sui-coin-object-id 0x0599b794da39169f7c75d34eba06ae105fedc61b --gas-budget 1000
-VHJhbnNhY3Rpb25EYXRhOjoAA1gaEZpldtO1ArXcR8XeSXt3TmjKAFgaEZpldtO1ArXcR8XeSXt3TmjKBZm3lNo5Fp98ddNOugauEF/txhsCAAAAAAAAACC0knjIoZEdbQBQuqg3feG/GA0L2v9gLDfH2uX8iGf5SwEAAAAAAAAA6AMAAAAAAAA=
+target/debug/sui client serialize-transfer-sui --to 0xfdf3a56d8ac390499c611fd338036e3139a0e9a5 --sui-coin-object-id 0x14808dbfbb3efd6fa09624fd18d7f40958679fa1 --gas-budget 1000
+
+Intent message to sign: $DATA_TO_SIGN
+Raw transaction to execute: $TX_BYTES
 ```
 
 ## Step 2: Sign the data
-This can be done elsewhere in your signing device or implemented in languages of your choice. Sui accepts signature for both ECDSA Secp256k1 and pure Ed25519. 
+This can be done elsewhere in your signing device or implemented in languages of your choice. Sui accepts signatures for ECDSA Secp256k1, ECDSA Secp256r1 and pure Ed25519.
 
 An accepted ECDSA Secp256k1 signature follows:
-1. The signature must be of length 65 bytes in the form of `[r, s, v]` where the first 32 bytes are `r`, the second 32 bytes are `s` and the last byte is `v`. 
-2. The `r` value can be between 0x1 and 0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364140 (inclusive). 
-3. The `s` value must be in the lower half of the curve order, i.e. between 0x1 and 0x7FFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF 5D576E73 57A4501D DFE92F46 681B20A0 (inclusive). 
-4. The `v` represents the recovery ID, which must be normalized to 0, 1, 2 or 3. Note that unlike [EIP-155](https://eips.ethereum.org/EIPS/eip-155) chain ID is not used to calculate the `v` value. 
+1. The signature must be of length 65 bytes in the form of `[r, s, v]` where the first 32 bytes are `r`, the second 32 bytes are `s` and the last byte is `v`.
+2. The `r` value can be between 0x1 and 0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364140 (inclusive).
+3. The `s` value must be in the lower half of the curve order, i.e. between 0x1 and 0x7FFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF 5D576E73 57A4501D DFE92F46 681B20A0 (inclusive).
+4. The `v` represents the recovery ID, which must be normalized to 0, 1, 2 or 3. Note that unlike [EIP-155](https://eips.ethereum.org/EIPS/eip-155) chain ID is not used to calculate the `v` value.
 5. Ideally, the signature must be generated with deterministic nonce according to [RFC6979](https://www.rfc-editor.org/rfc/rfc6979).
 
 An accepted pure Ed25519 signature follows:
@@ -31,22 +33,21 @@ An accepted pure Ed25519 signature follows:
 2. The signature must be valid according to [ZIP215](https://github.com/zcash/zips/blob/main/zip-0215.rst).
 
 Here we use the keytool command to sign as an example, using the Ed25519 key corresponding to the provided address stored in `sui.keystore`. This commands outputs the signature, the public key and the flag encoded in Base64. This command is backed by [fastcrypto](https://crates.io/crates/fastcrypto).
-
+ 
 ```shell
-sui keytool sign --address 0x581a119a6576d3b502b5dc47c5de497b774e68ca --data VHJhbnNhY3Rpb25EYXRhOjoAA1gaEZpldtO1ArXcR8XeSXt3TmjKAFgaEZpldtO1ArXcR8XeSXt3TmjKBZm3lNo5Fp98ddNOugauEF/txhsCAAAAAAAAACC0knjIoZEdbQBQuqg3feG/GA0L2v9gLDfH2uX8iGf5SwEAAAAAAAAA6AMAAAAAAAA=
-2022-10-18T03:30:39.510775Z  INFO sui::keytool: Data to sign : VHJhbnNhY3Rpb25EYXRhOjoAA1gaEZpldtO1ArXcR8XeSXt3TmjKAFgaEZpldtO1ArXcR8XeSXt3TmjKBZm3lNo5Fp98ddNOugauEF/txhsCAAAAAAAAACC0knjIoZEdbQBQuqg3feG/GA0L2v9gLDfH2uX8iGf5SwEAAAAAAAAA6AMAAAAAAAA=
-2022-10-18T03:30:39.510838Z  INFO sui::keytool: Address : 0x581a119a6576d3b502b5dc47c5de497b774e68ca
-2022-10-18T03:30:39.511304Z  INFO sui::keytool: Flag Base64: AA==
-2022-10-18T03:30:39.511318Z  INFO sui::keytool: Public Key Base64: rJzjxQ+FCK9m8YDU8Dq1Yx931HkIArhcw33kUPL9P8c=
-2022-10-18T03:30:39.511326Z  INFO sui::keytool: Signature : epIttAjg4OBOzVBQQuMflR9sJwh12XiBFwDV9gmiBxomKJ0YyjcbhLONdvA1xs2NXy8xdagwHR/uRVdI6z+LAg==
+target/debug/sui keytool sign --address 0xb59ce11ef3ad15b6c247dda9890dce1b781f99df --data $DATA_TO_SIGN
+
+Intent message to sign: AAAAAAP986VtisOQSZxhH9M4A24xOaDppQDue7TlY/36sS2HyepBJa2PjB3RkxSAjb+7Pv1voJYk/RjX9AlYZ5+hAgAAAAAAAAAgghpx3ucYetjUIHnaFCho6iaUXnt4hczdAeLlgIw0GqsBAAAAAAAAAOgDAAAAAAAA
+Signer address: 0xb59ce11ef3ad15b6c247dda9890dce1b781f99df
+Serialized signature (`flag || sig || pk` in Base64): $SERIALIZED_SIG
 ```
 
 ## Step 3: Execute the signed transaction
 
-Now that you had obtained the signature, signing scheme flag, and public key, you can submit using the execution transaction command. This command takes in the unsigned transaction data in Base64, the scheme flag for which the signature is produced wutg (can be `ed25519` or `secp256k1`), the public key in Base64, and the corresponding signature in Base64. This executes the signed transaction and returns the certificate and transaction effects if successful. 
+Now that you have obtained the serialized signature, you can submit using the execution transaction command. This command takes `--tx-bytes` as the raw transaction bytes to execute (see output of `sui client serialize-transfer-sui`) and the serialized signature (see output of `sui keytool sign`). This executes the signed transaction and returns the certificate and transaction effects if successful.
 
 ```shell
-sui client execute-signed-tx --tx-data VHJhbnNhY3Rpb25EYXRhOjoAA1gaEZpldtO1ArXcR8XeSXt3TmjKAFgaEZpldtO1ArXcR8XeSXt3TmjKBZm3lNo5Fp98ddNOugauEF/txhsCAAAAAAAAACC0knjIoZEdbQBQuqg3feG/GA0L2v9gLDfH2uX8iGf5SwEAAAAAAAAA6AMAAAAAAAA= --scheme ed25519 --pubkey rJzjxQ+FCK9m8YDU8Dq1Yx931HkIArhcw33kUPL9P8c= --signature epIttAjg4OBOzVBQQuMflR9sJwh12XiBFwDV9gmiBxomKJ0YyjcbhLONdvA1xs2NXy8xdagwHR/uRVdI6z+LAg==
+sui client execute-signed-tx --tx-bytes $TX_BYTES --signature $SERIALIZED_SIG
 ----- Certificate ----
 Transaction Hash: wnk9u71q8mhPgEOrDZJacVyqAzNBAmsMOPM4rNoS0LE=
 Transaction Signature: AA==@epIttAjg4OBOzVBQQuMflR9sJwh12XiBFwDV9gmiBxomKJ0YyjcbhLONdvA1xs2NXy8xdagwHR/uRVdI6z+LAg==@rJzjxQ+FCK9m8YDU8Dq1Yx931HkIArhcw33kUPL9P8c=
@@ -58,5 +59,5 @@ Amount: Full Balance
 ----- Transaction Effects ----
 Status : Success
 Mutated Objects:
-  - ID: 0x0599b794da39169f7c75d34eba06ae105fedc61b , Owner: Account Address ( 0x581a119a6576d3b502b5dc47c5de497b774e68ca )
+ - ID: 0x0599b794da39169f7c75d34eba06ae105fedc61b , Owner: Account Address ( 0x581a119a6576d3b502b5dc47c5de497b774e68ca )
 ```

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -896,13 +896,10 @@ impl SuiClientCommands {
                     .await?;
                 let data1 = data.clone();
                 let intent_msg = IntentMessage::new(Intent::default(), data);
-                info!(
-                    "Transaction bytes : {}",
-                    Base64::encode(&bcs::to_bytes(&data1).unwrap())
-                );
-                SuiClientCommandResult::SerializeTransferSui(Base64::encode(
-                    bcs::to_bytes(&intent_msg)?.as_slice(),
-                ))
+                SuiClientCommandResult::SerializeTransferSui(
+                    Base64::encode(bcs::to_bytes(&intent_msg)?.as_slice()),
+                    Base64::encode(&bcs::to_bytes(&data1).unwrap()),
+                )
             }
 
             SuiClientCommands::ExecuteSignedTx {
@@ -1318,8 +1315,9 @@ impl Display for SuiClientCommandResult {
                     writeln!(writer, "{}", parsed_resp)?;
                 }
             }
-            SuiClientCommandResult::SerializeTransferSui(res) => {
-                write!(writer, "Data to sign: {}", res)?;
+            SuiClientCommandResult::SerializeTransferSui(data_to_sign, data_to_execute) => {
+                writeln!(writer, "Intent message to sign: {}", data_to_sign)?;
+                writeln!(writer, "Raw transaction to execute: {}", data_to_execute)?;
             }
             SuiClientCommandResult::ActiveEnv(env) => {
                 write!(writer, "{}", env.as_deref().unwrap_or("None"))?;
@@ -1478,7 +1476,7 @@ pub enum SuiClientCommandResult {
     ActiveEnv(Option<String>),
     Envs(Vec<SuiEnv>, Option<String>),
     CreateExampleNFT(GetObjectDataResponse),
-    SerializeTransferSui(String),
+    SerializeTransferSui(String, String),
     ExecuteSignedTx(SuiTransactionResponse),
     NewEnv(SuiEnv),
 }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -13,7 +13,7 @@ use sui_keys::keypair_file::{
     read_authority_keypair_from_file, read_keypair_from_file, write_authority_keypair_to_file,
     write_keypair_to_file,
 };
-use sui_types::intent::Intent;
+use sui_types::intent::IntentMessage;
 use sui_types::messages::TransactionData;
 use tracing::info;
 
@@ -120,27 +120,16 @@ impl KeyToolCommand {
                 }
             }
             KeyToolCommand::Sign { address, data } => {
-                info!("Data to sign : {}", data);
-                info!("Address : {}", address);
+                println!("Intent message to sign: {}", data);
+                println!("Signer address: {}", address);
                 let message = Base64::decode(&data).map_err(|e| anyhow!(e))?;
-                let tx_data: TransactionData = bcs::from_bytes(&message).map_err(|e| anyhow!(e))?;
-                let sui_signature = keystore.sign_secure(&address, &tx_data, Intent::default())?;
-                // Separate pub key and signature string, signature and pub key are concatenated with an '@' symbol.
-                let signature_string = format!("{:?}", sui_signature);
-                let sig_split = signature_string.split('@').collect::<Vec<_>>();
-                let flag = sig_split
-                    .first()
-                    .ok_or_else(|| anyhow!("Error creating signature."))?;
-                let signature = sig_split
-                    .get(1)
-                    .ok_or_else(|| anyhow!("Error creating signature."))?;
-                let pub_key = sig_split
-                    .last()
-                    .ok_or_else(|| anyhow!("Error creating signature."))?;
-                info!("Flag Base64: {}", flag);
-                info!("Public Key Base64: {}", pub_key);
-                info!("Signature : {}", signature);
-                info!("Serialized signature Base64: {:?}", sui_signature);
+                let intent_msg: IntentMessage<TransactionData> = bcs::from_bytes(&message)?;
+                let sui_signature =
+                    keystore.sign_secure(&address, &intent_msg.value, intent_msg.intent)?;
+                println!(
+                    "Serialized signature (`flag || sig || pk` in Base64): {:?}",
+                    sui_signature.encode_base64()
+                );
             }
             KeyToolCommand::Import {
                 mnemonic_phrase,

--- a/doc/src/build/json-rpc.md
+++ b/doc/src/build/json-rpc.md
@@ -83,7 +83,7 @@ sui keytool sign --address <owner_address> --data <tx_bytes>
 The keytool creates a key and then returns the signature and public key information.
 
 
-#### Execute a transaction with a signature and a public key
+#### Execute a transaction with a serialized signature
 
 ```shell
 curl --location --request POST $SUI_RPC_HOST \
@@ -91,16 +91,15 @@ curl --location --request POST $SUI_RPC_HOST \
 --data-raw '{
   "jsonrpc": "2.0",
   "id": 1,
-  "method": "sui_executeTransaction",
+  "method": "sui_executeTransactionSerializedSig",
   "params": [ 
     "{{tx_bytes}}",
-    "{{sig_scheme}}",
     "{{signature}}",
-    "{{pub_key}}",
     "{{request_type}}"
   ]
 }' | json_pp
 ```
+`signature` is a Base64 encoded `flag || signature || pubkey`. 
 
 Native transfer by `sui_transferObject` supports any object that allows for public transfers. Some objects cannot be transferred natively and require a [Move call](#sui_movecall). See [Transactions](../learn/transactions.md#native-transaction) for more information about native transfers.
 

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -582,22 +582,7 @@ export class JsonRpcProvider extends Provider {
   ): Promise<SuiExecuteTransactionResponse> {
     try {
       let resp;
-      let version = await this.getRpcApiVersion();
-      if (version?.major === 0 && version?.minor < 18) {
-        resp = await this.client.requestWithType(
-          'sui_executeTransaction',
-          [
-            txnBytes.toString(),
-            signatureScheme,
-            signature.toString(),
-            pubkey.toString(),
-            requestType,
-          ],
-          SuiExecuteTransactionResponse,
-          this.options.skipDataValidation
-        );
-      } else {
-        // Serialize sigature field as: `flag || signature || pubkey`
+      // Serialize sigature field as: `flag || signature || pubkey`
         const serialized_sig = new Uint8Array(
           1 + signature.getLength() + pubkey.toBytes().length
         );
@@ -615,7 +600,6 @@ export class JsonRpcProvider extends Provider {
           SuiExecuteTransactionResponse,
           this.options.skipDataValidation
         );
-      }
       return resp;
     } catch (err) {
       throw new Error(`Error executing transaction with request type: ${err}`);


### PR DESCRIPTION
## What

Make `sui_executeTransaction` API the same as `sui_executeTransactionSerializedSig`. 

This `sui_executeTransaction` now requires the client to be responsible to serialize `flag || signature || pubkey` in one field and submit in the `signature` field. Instead of sending three separate fields previously (scheme, pubkey, signature). 

## Why
This simplifies future use cases for multisig and multi agent execute transaction.

## How to use

In Rust: 
```
let serialized_sig = crypto::Signature::from_bytes(&[&*flag, &*sig_bytes, &*pub_key].concat()).unwrap();
```

In CLI: See usage of `sui keytool sign`. 

```shell
target/debug/sui keytool sign --address 0xb59ce11ef3ad15b6c247dda9890dce1b781f99df --data $DATA_TO_SIGN

Intent message to sign: AAAAAAP986VtisOQSZxhH9M4A24xOaDppQDue7TlY/36sS2HyepBJa2PjB3RkxSAjb+7Pv1voJYk/RjX9AlYZ5+hAgAAAAAAAAAgghpx3ucYetjUIHnaFCho6iaUXnt4hczdAeLlgIw0GqsBAAAAAAAAAOgDAAAAAAAA
Signer address: 0xb59ce11ef3ad15b6c247dda9890dce1b781f99df
Serialized signature (`flag || sig || pk` in Base64): $SERIALIZED_SIG
```
In Typescript: 
```
      // Serialize signature field as: `flag || sig || pk`
        const serialized_sig = new Uint8Array(
          1 + signature.getLength() + pubkey.toBytes().length
        );
        serialized_sig.set([SIGNATURE_SCHEME_TO_FLAG[signatureScheme]]);
        serialized_sig.set(signature.getData(), 1);
        serialized_sig.set(pubkey.toBytes(), 1 + signature.getLength());
```

Also fixed some ergonomics and bugs of keytool and offline signing docs. 