### PR TITLE
[Rosetta] - Use dry run to estimation transaction budget

### DIFF
--- a/crates/sui-rosetta/resources/sui.ros
+++ b/crates/sui-rosetta/resources/sui.ros
@@ -39,14 +39,6 @@ transfer(10){
           "value":{{sender_amount}},
           "currency":{{currency}}
         }
-      },
-      {
-        "operation_identifier":{"index":2},
-        "type":"GasBudget",
-        "account":{{sender.account_identifier}},
-        "metadata":{
-          "budget": "1000"
-        }
       }];
   }
 }

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -202,7 +202,7 @@ pub async fn metadata(
             let sender_coins = context
                 .client
                 .coin_read_api()
-                .select_coins(*sender, None, amount + 1000, false)
+                .select_coins(*sender, None, amount + 1000, None, vec![])
                 .await?
                 .into_iter()
                 .map(|coin| coin.object_ref())

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -6,8 +6,6 @@ use std::future;
 use axum::{Extension, Json};
 use fastcrypto::encoding::{Encoding, Hex};
 use futures::StreamExt;
-use sui_sdk::SUI_COIN_TYPE;
-
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto;
 use sui_types::crypto::{SignatureScheme, ToFromBytes};
@@ -15,13 +13,13 @@ use sui_types::messages::{ExecuteTransactionRequestType, Transaction, Transactio
 
 use crate::errors::Error;
 use crate::types::{
-    ConstructionCombineRequest, ConstructionCombineResponse, ConstructionDeriveRequest,
+    Amount, ConstructionCombineRequest, ConstructionCombineResponse, ConstructionDeriveRequest,
     ConstructionDeriveResponse, ConstructionHashRequest, ConstructionMetadata,
     ConstructionMetadataRequest, ConstructionMetadataResponse, ConstructionParseRequest,
     ConstructionParseResponse, ConstructionPayloadsRequest, ConstructionPayloadsResponse,
     ConstructionPreprocessRequest, ConstructionPreprocessResponse, ConstructionSubmitRequest,
-    MetadataOptions, SignatureType, SigningPayload, TransactionIdentifier,
-    TransactionIdentifierResponse,
+    InternalOperation, MetadataOptions, SignatureType, SigningPayload, TransactionIdentifier,
+    TransactionIdentifierResponse, TransactionMetadata,
 };
 use crate::{OnlineServerContext, SuiEnv};
 use anyhow::anyhow;
@@ -56,9 +54,9 @@ pub async fn payloads(
 ) -> Result<ConstructionPayloadsResponse, Error> {
     env.check_network_identifier(&request.network_identifier)?;
     let metadata = request.metadata.ok_or(Error::MissingMetadata)?;
+    let address = metadata.sender;
 
-    let data = request.operations.into_transaction_data(metadata)?;
-    let address = data.signer();
+    let data = request.operations.into_internal()?.into_data(metadata);
     let intent_msg = IntentMessage::new(Intent::default(), data);
     let intent_msg_bytes = bcs::to_bytes(&intent_msg)?;
 
@@ -150,30 +148,11 @@ pub async fn preprocess(
 ) -> Result<ConstructionPreprocessResponse, Error> {
     env.check_network_identifier(&request.network_identifier)?;
 
-    let (sender, amount) = request
-        .operations
-        .iter()
-        .find_map(|op| match (&op.account, &op.amount) {
-            (Some(acc), Some(amount)) => {
-                if amount.value.is_negative() {
-                    Some((acc.address, amount.value.abs()))
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        })
-        .ok_or_else(|| {
-            Error::MalformedOperationError(
-                "Cannot extract sender's address from operations.".to_string(),
-            )
-        })?;
+    let internal_operation = request.operations.into_internal()?;
+    let sender = internal_operation.sender();
 
     Ok(ConstructionPreprocessResponse {
-        options: Some(MetadataOptions {
-            sender,
-            amount: amount as u128,
-        }),
+        options: Some(MetadataOptions { internal_operation }),
         required_public_keys: vec![sender.into()],
     })
 }
@@ -209,36 +188,57 @@ pub async fn metadata(
     WithRejection(Json(request), _): WithRejection<Json<ConstructionMetadataRequest>, Error>,
 ) -> Result<ConstructionMetadataResponse, Error> {
     env.check_network_identifier(&request.network_identifier)?;
+    let option = request.options.ok_or(Error::MissingMetadata)?;
+    let sender = option.internal_operation.sender();
+    let (tx_metadata, gas) = match &option.internal_operation {
+        InternalOperation::PaySui {
+            sender, amounts, ..
+        } => {
+            let amount = amounts.iter().sum::<u64>() as u128;
+            let mut total = 0u128;
+            let sender_coins = context
+                .client
+                .coin_read_api()
+                .get_coins_stream(*sender, None)
+                .take_while(|coin| {
+                    let ready = future::ready(total < amount);
+                    total += coin.balance as u128;
+                    ready
+                })
+                .map(|c| c.object_ref())
+                .collect::<Vec<_>>()
+                .await;
 
-    let sender_coins = if let Some(option) = request.options {
-        let mut total = 0u128;
-        let coins = context
-            .client
-            .coin_read_api()
-            .get_coins_stream(option.sender, Some(SUI_COIN_TYPE.to_string()))
-            .take_while(|coin| {
-                let ready = future::ready(total < option.amount);
-                total += coin.balance as u128;
-                ready
-            })
-            .map(|c| c.object_ref())
-            .collect::<Vec<_>>()
-            .await;
-
-        if total < option.amount {
-            return Err(Error::InsufficientFund {
-                address: option.sender,
-                amount: option.amount,
-            });
+            if total < amount {
+                return Err(Error::InsufficientFund {
+                    address: *sender,
+                    amount,
+                });
+            }
+            let gas = sender_coins[0];
+            (TransactionMetadata::PaySui(sender_coins), gas)
         }
-        coins
-    } else {
-        Default::default()
     };
+    // get gas estimation from dry-run, this will also return any tx error.
+    let data = option.internal_operation.into_data(ConstructionMetadata {
+        tx_metadata: tx_metadata.clone(),
+        sender,
+        gas,
+        budget: 1000,
+    });
+    let dry_run = context.client.read_api().dry_run_transaction(data).await?;
+
+    let budget = dry_run.gas_used.computation_cost + dry_run.gas_used.storage_cost
+        - dry_run.gas_used.storage_rebate;
 
     Ok(ConstructionMetadataResponse {
-        metadata: ConstructionMetadata { sender_coins },
-        suggested_fee: vec![],
+        metadata: ConstructionMetadata {
+            tx_metadata,
+            sender,
+            gas,
+            budget,
+        },
+        suggested_fee: vec![Amount::new(budget as i128)],
     })
 }
 

--- a/crates/sui-rosetta/src/errors.rs
+++ b/crates/sui-rosetta/src/errors.rs
@@ -56,6 +56,9 @@ pub enum Error {
     #[error("Public key deserialization error: {0:?}")]
     PublicKeyDeserializationError(PublicKey),
 
+    #[error("Error executing transaction: {0}")]
+    TransactionExecutionError(String),
+
     #[error(transparent)]
     InternalError(#[from] anyhow::Error),
     #[error(transparent)]

--- a/crates/sui-rosetta/src/errors.rs
+++ b/crates/sui-rosetta/src/errors.rs
@@ -14,7 +14,6 @@ use serde_json::{json, Value};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
-use sui_types::base_types::SuiAddress;
 use sui_types::error::SuiError;
 
 use crate::types::{BlockHash, OperationType, PublicKey, SuiEnv};
@@ -56,8 +55,6 @@ pub enum Error {
     },
     #[error("Public key deserialization error: {0:?}")]
     PublicKeyDeserializationError(PublicKey),
-    #[error("Insufficient fund for address [{address}], requested amount: {amount}")]
-    InsufficientFund { address: SuiAddress, amount: u128 },
 
     #[error(transparent)]
     InternalError(#[from] anyhow::Error),
@@ -68,7 +65,7 @@ pub enum Error {
     #[error(transparent)]
     SuiError(#[from] SuiError),
     #[error(transparent)]
-    SuiRpcError(#[from] sui_sdk::error::RpcError),
+    SuiRpcError(#[from] sui_sdk::error::Error),
     #[error(transparent)]
     EncodingError(#[from] eyre::Report),
     #[error(transparent)]

--- a/crates/sui-rosetta/src/unit_tests/operations_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/operations_tests.rs
@@ -5,7 +5,7 @@ use sui_types::base_types::{ObjectDigest, ObjectID, SequenceNumber, SuiAddress};
 use sui_types::messages::TransactionData;
 
 use crate::operations::Operations;
-use crate::types::ConstructionMetadata;
+use crate::types::{ConstructionMetadata, TransactionMetadata};
 
 #[tokio::test]
 async fn test_operation_data_parsing() -> Result<(), anyhow::Error> {
@@ -28,10 +28,12 @@ async fn test_operation_data_parsing() -> Result<(), anyhow::Error> {
 
     let ops: Operations = data.clone().try_into()?;
     let metadata = ConstructionMetadata {
-        sender_coins: vec![gas],
+        tx_metadata: TransactionMetadata::PaySui(vec![gas]),
+        sender,
+        gas,
+        budget: 1000,
     };
-
-    let parsed_data = ops.into_transaction_data(metadata)?;
+    let parsed_data = ops.into_internal()?.into_data(metadata);
     assert_eq!(data, parsed_data);
 
     Ok(())

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -31,7 +31,9 @@ sui-keys =  { path = "../sui-keys" }
 move-core-types.workspace = true
 move-bytecode-utils.workspace = true
 move-binary-format.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+fastcrypto.workspace = true
+
+workspace-hack= { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 clap = { version = "3.2.17", features = ["derive"] }

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -256,16 +256,21 @@ impl CoinReadApi {
         address: SuiAddress,
         coin_type: Option<String>,
         amount: u128,
-        include_locked_coins: bool,
+        locked_until_epoch: Option<EpochId>,
+        exclude: Vec<ObjectID>,
     ) -> SuiRpcResult<Vec<Coin>> {
         let mut total = 0u128;
         let coins = self
             .get_coins_stream(address, coin_type)
-            .take_while(|coin| {
+            .filter(|coin: &Coin| {
+                future::ready(
+                    locked_until_epoch == coin.locked_until_epoch
+                        && !exclude.contains(&coin.coin_object_id),
+                )
+            })
+            .take_while(|coin: &Coin| {
                 let ready = future::ready(total < amount);
-                if !include_locked_coins || coin.locked_until_epoch.is_none() {
-                    total += coin.balance as u128;
-                }
+                total += coin.balance as u128;
                 ready
             })
             .collect::<Vec<_>>()

--- a/crates/sui-sdk/src/error.rs
+++ b/crates/sui-sdk/src/error.rs
@@ -10,6 +10,8 @@ pub type SuiRpcResult<T = ()> = Result<T, RpcError>;
 pub enum RpcError {
     #[error(transparent)]
     RpcError(#[from] jsonrpsee::core::Error),
+    #[error(transparent)]
+    PcsSerialisationError(#[from] bcs::Error),
     #[error("Subscription error : {0}")]
     Subscription(String),
     #[error("Encountered error when confirming tx status for {0:?}, err: {1:?}")]

--- a/crates/sui-sdk/src/error.rs
+++ b/crates/sui-sdk/src/error.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_types::base_types::TransactionDigest;
+use sui_types::base_types::{SuiAddress, TransactionDigest};
 use thiserror::Error;
 
-pub type SuiRpcResult<T = ()> = Result<T, RpcError>;
+pub type SuiRpcResult<T = ()> = Result<T, Error>;
 
 #[derive(Error, Debug)]
-pub enum RpcError {
+pub enum Error {
     #[error(transparent)]
     RpcError(#[from] jsonrpsee::core::Error),
     #[error(transparent)]
@@ -25,4 +25,6 @@ pub enum RpcError {
         client_version: String,
         server_version: String,
     },
+    #[error("Insufficient fund for address [{address}], requested amount: {amount}")]
+    InsufficientFund { address: SuiAddress, amount: u128 },
 }

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -108,9 +108,7 @@ impl RpcClient {
             .pointer("/info/version")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
-                Error::DataError(
-                    "Fail parsing server version from rpc.discover endpoint.".into(),
-                )
+                Error::DataError("Fail parsing server version from rpc.discover endpoint.".into())
             })?;
         let rpc_methods = Self::parse_methods(&rpc_spec)?;
 

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -12,7 +12,7 @@ use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 
-use crate::error::{RpcError, SuiRpcResult};
+use crate::error::{Error, SuiRpcResult};
 use rpc_types::{SuiCertifiedTransaction, SuiParsedTransactionResponse, SuiTransactionEffects};
 use serde_json::Value;
 use sui_adapter::execution_mode::Normal;
@@ -78,7 +78,7 @@ impl RpcClient {
         http: &str,
         ws: Option<&str>,
         request_timeout: Option<Duration>,
-    ) -> Result<Self, RpcError> {
+    ) -> Result<Self, Error> {
         let mut http_builder = HttpClientBuilder::default();
         if let Some(request_timeout) = request_timeout {
             http_builder = http_builder.request_timeout(request_timeout);
@@ -102,13 +102,13 @@ impl RpcClient {
     async fn get_server_info(
         http: &HttpClient,
         ws: &Option<WsClient>,
-    ) -> Result<ServerInfo, RpcError> {
+    ) -> Result<ServerInfo, Error> {
         let rpc_spec: Value = http.request("rpc.discover", rpc_params![]).await?;
         let version = rpc_spec
             .pointer("/info/version")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
-                RpcError::DataError(
+                Error::DataError(
                     "Fail parsing server version from rpc.discover endpoint.".into(),
                 )
             })?;
@@ -127,12 +127,12 @@ impl RpcClient {
         })
     }
 
-    fn parse_methods(server_spec: &Value) -> Result<Vec<String>, RpcError> {
+    fn parse_methods(server_spec: &Value) -> Result<Vec<String>, Error> {
         let methods = server_spec
             .pointer("/methods")
             .and_then(|methods| methods.as_array())
             .ok_or_else(|| {
-                RpcError::DataError(
+                Error::DataError(
                     "Fail parsing server information from rpc.discover endpoint.".into(),
                 )
             })?;
@@ -150,7 +150,7 @@ impl SuiClient {
         http_url: &str,
         ws_url: Option<&str>,
         request_timeout: Option<Duration>,
-    ) -> Result<Self, RpcError> {
+    ) -> Result<Self, Error> {
         let rpc = RpcClient::new(http_url, ws_url, request_timeout).await?;
         let api = Arc::new(rpc);
         let read_api = Arc::new(ReadApi::new(api.clone()));
@@ -187,7 +187,7 @@ impl SuiClient {
         let server_version = self.api_version();
         let client_version = env!("CARGO_PKG_VERSION");
         if server_version != client_version {
-            return Err(RpcError::ServerVersionMismatch {
+            return Err(Error::ServerVersionMismatch {
                 client_version: client_version.to_string(),
                 server_version: server_version.to_string(),
             });

--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -10,7 +10,7 @@ use move_core_types::account_address::AccountAddress;
 use move_package::compilation::compiled_package::CompiledPackage;
 use move_symbol_pool::Symbol;
 use sui_sdk::apis::ReadApi;
-use sui_sdk::error::RpcError;
+use sui_sdk::error::Error;
 
 use sui_sdk::rpc_types::{SuiRawData, SuiRawMoveObject, SuiRawMovePackage};
 use sui_types::{base_types::ObjectID, error::SuiError};
@@ -21,7 +21,7 @@ mod tests;
 #[derive(Debug, Error)]
 pub enum SourceVerificationError {
     #[error("Could not read a dependency's on-chain object: {0:?}")]
-    DependencyObjectReadFailure(RpcError),
+    DependencyObjectReadFailure(Error),
 
     #[error("Dependency object does not exist or was deleted: {0:?}")]
     SuiObjectRefFailure(SuiError),

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -569,6 +569,10 @@ impl TransactionKind {
         )
     }
 
+    pub fn is_single_tx(&self) -> bool {
+        matches!(self, TransactionKind::Single(_))
+    }
+
     pub fn is_system_tx(&self) -> bool {
         matches!(
             self,
@@ -791,7 +795,7 @@ impl TransactionData {
     pub fn input_objects(&self) -> SuiResult<Vec<InputObjectKind>> {
         let mut inputs = self.kind.input_objects()?;
 
-        if !self.kind.is_system_tx() && !self.kind.is_pay_sui_tx() {
+        if !self.kind.is_system_tx() && !self.kind.is_pay_sui_tx() && !self.kind.is_single_tx() {
             inputs.push(InputObjectKind::ImmOrOwnedMoveObject(
                 *self.gas_payment_object_ref(),
             ));

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -569,10 +569,6 @@ impl TransactionKind {
         )
     }
 
-    pub fn is_single_tx(&self) -> bool {
-        matches!(self, TransactionKind::Single(_))
-    }
-
     pub fn is_system_tx(&self) -> bool {
         matches!(
             self,
@@ -795,7 +791,7 @@ impl TransactionData {
     pub fn input_objects(&self) -> SuiResult<Vec<InputObjectKind>> {
         let mut inputs = self.kind.input_objects()?;
 
-        if !self.kind.is_system_tx() && !self.kind.is_pay_sui_tx() && !self.kind.is_single_tx() {
+        if !self.kind.is_system_tx() && !self.kind.is_pay_sui_tx() {
             inputs.push(InputObjectKind::ImmOrOwnedMoveObject(
                 *self.gas_payment_object_ref(),
             ));


### PR DESCRIPTION
Fixes https://github.com/MystenLabs/sui/issues/6425

We need to return a estimated fee for rosetta response, this PR contain some refactoring to make dry_run possible in the `metadata` endpoint.
