### PR TITLE
[TypeScript SDK] Fix superstruct validation

### DIFF
--- a/.changeset/many-dolphins-bake.md
+++ b/.changeset/many-dolphins-bake.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Fix schema validation bug in Coin.newPayTransaction

--- a/sdk/typescript/src/types/framework.ts
+++ b/sdk/typescript/src/types/framework.ts
@@ -15,7 +15,7 @@ import { normalizeSuiObjectId, ObjectId, SuiAddress } from './common';
 import { getOption, Option } from './option';
 import { StructTag } from './sui-bcs';
 import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
-import { Infer, is, literal, number, object, string, union } from 'superstruct';
+import { Infer, literal, number, object, string, union } from 'superstruct';
 
 export const SUI_FRAMEWORK_ADDRESS = '0x2';
 export const MOVE_STDLIB_ADDRESS = '0x1';
@@ -82,7 +82,7 @@ export class Coin {
   }
 
   public static getID(obj: ObjectData): ObjectId {
-    if (is(obj, SuiMoveObject)) {
+    if ('fields' in obj) {
       return obj.fields.id.id;
     }
     return getObjectId(obj);


### PR DESCRIPTION
@Jibz1 reported a bug where transfer SUI in Sui wallet throws the following error

```

Encountered error when calling RpcTxnDataSerialize for a paySui transaction for address 30dee5a84762ee9b2d2a487cf147e7689abf1e35 for transaction { "kind": "paySui", "data": { "inputCoins": [ null ], "recipients": [ "0xa444d4ee0a8b9f6855d922a97b6b2f79dae34705" ], "amounts": [ 1000000 ], "gasBudget": 300 } }: Error: RPC Error: invalid type: null, expected a string at line 1 column 5

```



This is because 

https://github.com/MystenLabs/sui/blob/bd3c646e621e4fca8fceb1f9a5797c85550e87ad/sdk/typescript/src/types/framework.ts#L279

is returning `undefined` since 

https://github.com/MystenLabs/sui/blob/bd3c646e621e4fca8fceb1f9a5797c85550e87ad/sdk/typescript/src/types/framework.ts#L85 returns `false` because the object contains an extra `dataType: "moveObject"` field. 

One alternative fix is to move the `dataType` from `SuiData` to `SuiMoveObject` and `SuiMovePackage`
https://github.com/MystenLabs/sui/blob/bd3c646e621e4fca8fceb1f9a5797c85550e87ad/sdk/typescript/src/types/objects.ts#L64-L67. However, doing so breaks a few e2e tests since `SuiMovePackage` is also used in https://github.com/MystenLabs/sui/blob/bd3c646e621e4fca8fceb1f9a5797c85550e87ad/sdk/typescript/src/types/transactions.ts#L95 without the `dataType` field.

Therefore, this PR relaxes the validation from `object` to https://docs.superstructjs.org/api-reference/types#type
