### PR TITLE
rpc: checkpoint content read APIs

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -57,6 +57,9 @@ use sui_types::crypto::{AuthorityKeyPair, NetworkKeyPair};
 use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldType};
 use sui_types::event::{Event, EventID};
 use sui_types::gas::{GasCostSummary, SuiGasStatus};
+use sui_types::messages_checkpoint::{
+    CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, CheckpointSummary,
+};
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::{Owner, PastObjectRead};
 use sui_types::query::{EventQuery, TransactionQuery};
@@ -80,6 +83,7 @@ use crate::authority::authority_notify_read::NotifyRead;
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::authority_store::{ExecutionLockReadGuard, ObjectLockStatus};
 use crate::authority_aggregator::TransactionCertifier;
+use crate::checkpoints::CheckpointStore;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::execution_driver::execution_process;
 use crate::module_cache_gauge::ModuleCacheGauge;
@@ -409,6 +413,7 @@ pub struct AuthorityState {
 
     pub event_handler: Option<Arc<EventHandler>>,
     pub transaction_streamer: Option<Arc<TransactionStreamer>>,
+    checkpoint_store: Arc<CheckpointStore>,
 
     committee_store: Arc<CommitteeStore>,
 
@@ -1528,6 +1533,7 @@ impl AuthorityState {
         indexes: Option<Arc<IndexStore>>,
         event_store: Option<Arc<EventStoreType>>,
         transaction_streamer: Option<Arc<TransactionStreamer>>,
+        checkpoint_store: Arc<CheckpointStore>,
         prometheus_registry: &Registry,
     ) -> Arc<Self> {
         let native_functions =
@@ -1564,6 +1570,7 @@ impl AuthorityState {
             module_cache,
             event_handler,
             transaction_streamer,
+            checkpoint_store,
             committee_store,
             transaction_manager,
             metrics,
@@ -1630,6 +1637,7 @@ impl AuthorityState {
             None,
         ));
 
+        let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
         let index_store = Some(Arc::new(IndexStore::new(path.join("indexes"))));
 
         // add the object_basics module
@@ -1642,6 +1650,7 @@ impl AuthorityState {
             index_store,
             None,
             None,
+            checkpoint_store,
             &Registry::new(),
         )
         .await;
@@ -2062,6 +2071,69 @@ impl AuthorityState {
     ) -> Result<Vec<TransactionDigest>, anyhow::Error> {
         self.get_indexes()?
             .get_transactions(query, cursor, limit, reverse)
+    }
+
+    fn get_checkpoint_store(&self) -> Arc<CheckpointStore> {
+        self.checkpoint_store.clone()
+    }
+
+    pub fn get_latest_checkpoint_sequence_number(
+        &self,
+    ) -> Result<CheckpointSequenceNumber, anyhow::Error> {
+        self.get_checkpoint_store()
+            .get_highest_executed_checkpoint_seq_number()?
+            .ok_or_else(|| anyhow!("Latest checkpoint sequence number not found"))
+    }
+
+    pub fn get_checkpoint_summary(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Result<CheckpointSummary, anyhow::Error> {
+        let verified_checkpoint = self
+            .get_checkpoint_store()
+            .get_checkpoint_by_sequence_number(sequence_number)?;
+        match verified_checkpoint {
+            Some(verified_checkpoint) => Ok(verified_checkpoint.into_inner().summary),
+            None => Err(anyhow!(
+                "Verified checkpoint not found for sequence number {}",
+                sequence_number
+            )),
+        }
+    }
+
+    pub fn get_checkpoint_contents(
+        &self,
+        digest: CheckpointContentsDigest,
+    ) -> Result<CheckpointContents, anyhow::Error> {
+        self.get_checkpoint_store()
+            .get_checkpoint_contents(&digest)?
+            .ok_or_else(|| anyhow!("Checkpoint contents not found for digest: {:?}", digest))
+    }
+
+    pub fn get_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Result<CheckpointContents, anyhow::Error> {
+        let verified_checkpoint = self
+            .get_checkpoint_store()
+            .get_checkpoint_by_sequence_number(sequence_number)?;
+        match verified_checkpoint {
+            Some(verified_checkpoint) => {
+                let content_digest = verified_checkpoint.into_inner().content_digest();
+                self.get_checkpoint_store()
+                    .get_checkpoint_contents(&content_digest)?
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "Checkpoint contents not found for sequence number: {}",
+                            sequence_number
+                        )
+                    })
+            }
+            None => Err(anyhow!(
+                "Verified checkpoint not found for sequence number {}",
+                sequence_number
+            )),
+        }
     }
 
     pub async fn get_timestamp_ms(

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2433,6 +2433,10 @@ async fn test_authority_persist() {
         fs::create_dir(&epoch_store_path).unwrap();
         let epoch_store = AuthorityPerEpochStore::new(committee, &epoch_store_path, None);
 
+        let checkpoint_store_path = dir.join(format!("DB_{:?}", ObjectID::random()));
+        fs::create_dir(&checkpoint_store_path).unwrap();
+        let checkpoint_store = CheckpointStore::new(&checkpoint_store_path);
+
         AuthorityState::new(
             name,
             secrete,
@@ -2442,6 +2446,7 @@ async fn test_authority_persist() {
             None,
             None,
             None,
+            checkpoint_store,
             &prometheus::Registry::new(),
         )
         .await

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -28,6 +28,9 @@ use sui_types::event::EventID;
 use sui_types::governance::DelegatedStake;
 use sui_types::messages::CommitteeInfoResponse;
 use sui_types::messages::ExecuteTransactionRequestType;
+use sui_types::messages_checkpoint::{
+    CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, CheckpointSummary,
+};
 use sui_types::query::{EventQuery, TransactionQuery};
 use sui_types::sui_system_state::{SuiSystemState, ValidatorMetadata};
 
@@ -281,6 +284,31 @@ pub trait RpcFullNodeReadApi {
         /// the version of the queried object. If None, default to the latest known version
         version: SequenceNumber,
     ) -> RpcResult<GetPastObjectDataResponse>;
+
+    /// Return the sequence number of the latest checkpoint that has been executed
+    #[method(name = "getLatestCheckpointSequenceNumber")]
+    fn get_latest_checkpoint_sequence_number(&self) -> RpcResult<CheckpointSequenceNumber>;
+
+    /// Return a checkpoint summary based on a checkpoint sequence number
+    #[method(name = "getCheckpointSummary")]
+    fn get_checkpoint_summary(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> RpcResult<CheckpointSummary>;
+
+    /// Return contents of a checkpoint, namely a list of execution digests
+    #[method(name = "getCheckpointContents")]
+    fn get_checkpoint_contents(
+        &self,
+        digest: CheckpointContentsDigest,
+    ) -> RpcResult<CheckpointContents>;
+
+    /// Return contents of a checkpoint based on its sequence number
+    #[method(name = "getCheckpointContentsBySequenceNumber")]
+    fn get_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> RpcResult<CheckpointContents>;
 }
 
 #[open_rpc(namespace = "sui", tag = "Governance Read API")]

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -28,6 +28,9 @@ use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest, TxSequenceNumber};
 use sui_types::crypto::sha3_hash;
 use sui_types::messages::TransactionData;
+use sui_types::messages_checkpoint::{
+    CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, CheckpointSummary,
+};
 use sui_types::move_package::normalize_modules;
 use sui_types::object::{Data, ObjectRead};
 use sui_types::query::TransactionQuery;
@@ -406,6 +409,46 @@ impl RpcFullNodeReadApiServer for FullNodeApi {
             .await
             .map_err(|e| anyhow!("{e}"))?
             .try_into()?)
+    }
+
+    fn get_latest_checkpoint_sequence_number(&self) -> RpcResult<CheckpointSequenceNumber> {
+        Ok(self
+            .state
+            .get_latest_checkpoint_sequence_number()
+            .map_err(|e| {
+                anyhow!("Latest checkpoint sequence number was not found with error :{e}")
+            })?)
+    }
+
+    fn get_checkpoint_summary(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> RpcResult<CheckpointSummary> {
+        Ok(self.state.get_checkpoint_summary(sequence_number)
+        .map_err(|e| anyhow!("Checkpoint summary based on sequence number: {sequence_number} was not found with error :{e}"))?)
+    }
+
+    fn get_checkpoint_contents(
+        &self,
+        digest: CheckpointContentsDigest,
+    ) -> RpcResult<CheckpointContents> {
+        Ok(self.state.get_checkpoint_contents(digest).map_err(|e| {
+            anyhow!(
+                "Checkpoint contents based on digest: {:?} were not found with error: {}",
+                digest,
+                e
+            )
+        })?)
+    }
+
+    fn get_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> RpcResult<CheckpointContents> {
+        Ok(self
+            .state
+            .get_checkpoint_contents_by_sequence_number(sequence_number)
+            .map_err(|e| anyhow!("Checkpoint contents based on seq number: {sequence_number} were not found with error: {e}"))?)
     }
 }
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -196,6 +196,7 @@ impl SuiNode {
             index_store.clone(),
             event_store,
             transaction_streamer,
+            checkpoint_store.clone(),
             &prometheus_registry,
         )
         .await;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -735,6 +735,85 @@
       }
     },
     {
+      "name": "sui_getCheckpointContents",
+      "tags": [
+        {
+          "name": "Full Node API"
+        }
+      ],
+      "description": "Return contents of a checkpoint, namely a list of execution digests",
+      "params": [
+        {
+          "name": "digest",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/CheckpointContentsDigest"
+          }
+        }
+      ],
+      "result": {
+        "name": "CheckpointContents",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/CheckpointContents"
+        }
+      }
+    },
+    {
+      "name": "sui_getCheckpointContentsBySequenceNumber",
+      "tags": [
+        {
+          "name": "Full Node API"
+        }
+      ],
+      "description": "Return contents of a checkpoint based on its sequence number",
+      "params": [
+        {
+          "name": "sequence_number",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "CheckpointContents",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/CheckpointContents"
+        }
+      }
+    },
+    {
+      "name": "sui_getCheckpointSummary",
+      "tags": [
+        {
+          "name": "Full Node API"
+        }
+      ],
+      "description": "Return a checkpoint summary based on a checkpoint sequence number",
+      "params": [
+        {
+          "name": "sequence_number",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "CheckpointSummary",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/CheckpointSummary"
+        }
+      }
+    },
+    {
       "name": "sui_getCoinMetadata",
       "tags": [
         {
@@ -1048,6 +1127,25 @@
           }
         }
       ]
+    },
+    {
+      "name": "sui_getLatestCheckpointSequenceNumber",
+      "tags": [
+        {
+          "name": "Full Node API"
+        }
+      ],
+      "description": "Return the sequence number of the latest checkpoint that has been executed",
+      "params": [],
+      "result": {
+        "name": "CheckpointSequenceNumber",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
     },
     {
       "name": "sui_getMoveFunctionArgTypes",
@@ -3044,6 +3142,98 @@
         "format": "uint8",
         "minimum": 0.0
       },
+      "CheckpointContents": {
+        "description": "CheckpointContents are the transactions included in an upcoming checkpoint. They must have already been causally ordered. Since the causal order algorithm is the same among validators, we expect all honest validators to come up with the same order for each checkpoint content.",
+        "type": "object",
+        "required": [
+          "transactions"
+        ],
+        "properties": {
+          "transactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExecutionDigests"
+            }
+          }
+        }
+      },
+      "CheckpointContentsDigest": {
+        "$ref": "#/components/schemas/Base58"
+      },
+      "CheckpointDigest": {
+        "$ref": "#/components/schemas/Base58"
+      },
+      "CheckpointSummary": {
+        "type": "object",
+        "required": [
+          "content_digest",
+          "epoch",
+          "epoch_rolling_gas_cost_summary",
+          "network_total_transactions",
+          "sequence_number"
+        ],
+        "properties": {
+          "content_digest": {
+            "$ref": "#/components/schemas/CheckpointContentsDigest"
+          },
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "epoch_rolling_gas_cost_summary": {
+            "description": "The running total gas costs of all transactions included in the current epoch so far until this checkpoint.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GasCostSummary"
+              }
+            ]
+          },
+          "network_total_transactions": {
+            "description": "Total number of transactions committed since genesis, including those in this checkpoint.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "next_epoch_committee": {
+            "description": "If this checkpoint is the last checkpoint of the epoch, we also include the committee of the next epoch. This allows anyone receiving this checkpoint know that the epoch will change after this checkpoint, as well as what the new committee is. The committee is stored as a vector of validator pub key and stake pairs. The vector should be sorted based on the Committee data structure. TODO: If desired, we could also commit to the previous last checkpoint cert so that they form a hash chain.",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/components/schemas/AuthorityPublicKeyBytes"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "previous_digest": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CheckpointDigest"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sequence_number": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      },
       "Coin": {
         "type": "object",
         "required": [
@@ -4129,6 +4319,21 @@
           "WaitForEffectsCert",
           "WaitForLocalExecution"
         ]
+      },
+      "ExecutionDigests": {
+        "type": "object",
+        "required": [
+          "effects",
+          "transaction"
+        ],
+        "properties": {
+          "effects": {
+            "$ref": "#/components/schemas/TransactionEffectsDigest"
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/TransactionDigest"
+          }
+        }
       },
       "ExecutionStatus": {
         "oneOf": [

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use fastcrypto::encoding::{Encoding, Hex};
+use fastcrypto::encoding::{Base58, Encoding, Hex};
 use std::fmt::{Debug, Display, Formatter};
 use std::slice::Iter;
 
@@ -10,14 +10,17 @@ use crate::committee::{EpochId, StakeUnit};
 use crate::crypto::{AuthoritySignInfo, AuthoritySignInfoTrait, AuthorityWeakQuorumSignInfo};
 use crate::error::SuiResult;
 use crate::gas::GasCostSummary;
+use crate::sui_serde::Readable;
 use crate::{
     base_types::AuthorityName,
     committee::Committee,
     crypto::{sha3_hash, AuthoritySignature, VerificationObligation},
     error::SuiError,
 };
+use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, Bytes};
 
 pub type CheckpointSequenceNumber = u64;
 
@@ -96,8 +99,15 @@ impl AuthenticatedCheckpoint {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct CheckpointDigest(pub [u8; 32]);
+#[serde_as]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub struct CheckpointDigest(
+    #[schemars(with = "Base58")]
+    #[serde_as(as = "Readable<Base58, Bytes>")]
+    pub [u8; 32],
+);
 
 impl AsRef<[u8]> for CheckpointDigest {
     fn as_ref(&self) -> &[u8] {
@@ -111,8 +121,15 @@ impl AsRef<[u8; 32]> for CheckpointDigest {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct CheckpointContentsDigest(pub [u8; 32]);
+#[serde_as]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub struct CheckpointContentsDigest(
+    #[schemars(with = "Base58")]
+    #[serde_as(as = "Readable<Base58, Bytes>")]
+    pub [u8; 32],
+);
 
 impl AsRef<[u8]> for CheckpointContentsDigest {
     fn as_ref(&self) -> &[u8] {
@@ -128,7 +145,7 @@ impl AsRef<[u8; 32]> for CheckpointContentsDigest {
 
 // The constituent parts of checkpoints, signed and certified
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 pub struct CheckpointSummary {
     pub epoch: EpochId,
     pub sequence_number: CheckpointSequenceNumber,
@@ -437,7 +454,7 @@ pub struct CheckpointSignatureMessage {
 /// They must have already been causally ordered. Since the causal order algorithm
 /// is the same among validators, we expect all honest validators to come up with
 /// the same order for each checkpoint content.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CheckpointContents {
     transactions: Vec<ExecutionDigests>,
 }


### PR DESCRIPTION
Today new checkpoints can only be accessed internally. This PR adds CheckpointStore to AuthorityState such that it can be accessed externally via RPC.

Testing via local RPC and local txns
```
curl --location --request POST http://127.0.0.1:9000 \
--header 'Content-Type: application/json' \
--data-raw '{ "jsonrpc":"2.0", "id":1, "method":"sui_getCheckpointContentsBySequenceNumber", "params":[158]}'
{"jsonrpc":"2.0","result":{"transactions":[{"transaction":"C3Bz9oQkSUiUMqFMBykMNinHmQDGy3AUkDHrAdBLAyAr","effects":"rYIw9fV0zPcOdOw3yXiWBuUSy7eaHPZIIDcnVDegKFU="}]},"id":1}%  


curl --location --request POST http://127.0.0.1:9000 \
--header 'Content-Type: application/json' \
--data-raw '{ "jsonrpc":"2.0", "id":1, "method":"sui_getLatestCheckpointSequenceNumber", "params":[]}'
{"jsonrpc":"2.0","result":242,"id":1}%   

```