### PR TITLE
[dev-inspect] Make epoch a parameter. Limit to fullnode

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1018,7 +1018,7 @@ impl AuthorityState {
         transaction: TransactionData,
         transaction_digest: TransactionDigest,
     ) -> Result<SuiTransactionEffects, anyhow::Error> {
-        if !self.is_fullnode() && !cfg!(test) {
+        if !self.is_fullnode() {
             return Err(anyhow!("dry-exec is only support on fullnodes"));
         }
 
@@ -1051,7 +1051,7 @@ impl AuthorityState {
         transaction_digest: TransactionDigest,
         epoch: EpochId,
     ) -> Result<DevInspectResults, anyhow::Error> {
-        if !self.is_fullnode() && !cfg!(test) {
+        if !self.is_fullnode() {
             return Err(anyhow!("dev-inspect is only supported on fullnodes"));
         }
 
@@ -1084,7 +1084,7 @@ impl AuthorityState {
         move_call: MoveCall,
         epoch: EpochId,
     ) -> Result<DevInspectResults, anyhow::Error> {
-        if !self.is_fullnode() && !cfg!(test) {
+        if !self.is_fullnode() {
             return Err(anyhow!("dev-inspect is only supported on fullnodes"));
         }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1018,6 +1018,10 @@ impl AuthorityState {
         transaction: TransactionData,
         transaction_digest: TransactionDigest,
     ) -> Result<SuiTransactionEffects, anyhow::Error> {
+        if !self.is_fullnode() && !cfg!(test) {
+            return Err(anyhow!("dry-exec is only support on fullnodes"));
+        }
+
         let (gas_status, input_objects) =
             transaction_input_checker::check_transaction_input(&self.database, &transaction)
                 .await?;
@@ -1045,7 +1049,12 @@ impl AuthorityState {
         &self,
         transaction: TransactionData,
         transaction_digest: TransactionDigest,
+        epoch: EpochId,
     ) -> Result<DevInspectResults, anyhow::Error> {
+        if !self.is_fullnode() && !cfg!(test) {
+            return Err(anyhow!("dev-inspect is only supported on fullnodes"));
+        }
+
         let (gas_status, input_objects) =
             transaction_input_checker::check_dev_inspect_input(&self.database, &transaction)
                 .await?;
@@ -1064,7 +1073,7 @@ impl AuthorityState {
                 &self.move_vm,
                 &self._native_functions,
                 gas_status,
-                self.epoch(),
+                epoch,
             );
         DevInspectResults::new(effects, execution_result, self.module_cache.as_ref())
     }
@@ -1073,7 +1082,12 @@ impl AuthorityState {
         &self,
         sender: SuiAddress,
         move_call: MoveCall,
+        epoch: EpochId,
     ) -> Result<DevInspectResults, anyhow::Error> {
+        if !self.is_fullnode() && !cfg!(test) {
+            return Err(anyhow!("dev-inspect is only supported on fullnodes"));
+        }
+
         let input_objects = move_call.input_objects();
         let input_objects = transaction_input_checker::check_dev_inspect_input_objects(
             &self.database,
@@ -1104,7 +1118,7 @@ impl AuthorityState {
                 transaction_dependencies,
                 &self.move_vm,
                 gas_status,
-                self.epoch(),
+                epoch,
             );
 
         DevInspectResults::new(effects, execution_result, self.module_cache.as_ref())

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -85,7 +85,11 @@ pub(crate) fn check_dev_inspect_input_objects(
             fp_ensure!(
                 used_objects.insert(object.id().into()),
                 SuiError::InvalidBatchTransaction {
-                    error: format!("Mutable object {} cannot appear in more than one single transactions in a batch", object.id()),
+                    error: format!(
+                        "Mutable object {} cannot appear in more than one single \
+                        transactions in a batch",
+                        object.id()
+                    ),
                 }
             );
         }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -28,7 +28,7 @@ use std::fs;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use sui_json_rpc_types::SuiExecutionResult;
+use sui_json_rpc_types::{SuiExecutionResult, SuiExecutionStatus};
 use sui_types::utils::to_sender_signed_transaction;
 
 use std::{convert::TryInto, env};
@@ -124,40 +124,69 @@ fn compare_transaction_info_responses(
 }
 
 async fn construct_shared_object_transaction_with_sequence_number(
-    sequence_number: SequenceNumber,
-) -> (Arc<AuthorityState>, VerifiedTransaction, ObjectID, ObjectID) {
+    initial_shared_version_override: Option<SequenceNumber>,
+) -> (
+    Arc<AuthorityState>,
+    Arc<AuthorityState>,
+    VerifiedTransaction,
+    ObjectID,
+    ObjectID,
+) {
     let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
 
     // Initialize an authority with a (owned) gas object and a shared object.
     let gas_object_id = ObjectID::random();
-    let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-    let gas_object_ref = gas_object.compute_object_reference();
-
-    let shared_object_id = ObjectID::random();
-    let shared_object = {
-        use sui_types::object::MoveObject;
-        let obj = MoveObject::new_gas_coin(sequence_number, shared_object_id, 10);
-        Object::new_move(
-            obj,
-            Owner::Shared {
-                initial_shared_version: sequence_number,
-            },
-            TransactionDigest::genesis(),
+    let (shared_object_id, shared_object) = {
+        let (authority, package) =
+            init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+        let effects = call_move_(
+            &authority,
+            None,
+            &gas_object_id,
+            &sender,
+            &keypair,
+            &package,
+            "object_basics",
+            "share",
+            vec![],
+            vec![],
+            true,
         )
+        .await
+        .unwrap();
+        let shared_object_id = effects.created[0].0 .0;
+        let mut shared_object = authority
+            .get_object(&shared_object_id)
+            .await
+            .unwrap()
+            .unwrap();
+        if let Some(initial_shared_version) = initial_shared_version_override {
+            shared_object
+                .data
+                .try_as_move_mut()
+                .unwrap()
+                .increment_version_to(initial_shared_version);
+            shared_object.owner = Owner::Shared {
+                initial_shared_version,
+            };
+        }
+        shared_object.previous_transaction = TransactionDigest::genesis();
+        (shared_object_id, shared_object)
     };
     let initial_shared_version = shared_object.version();
-    let authority = init_state_with_objects(vec![gas_object, shared_object]).await;
 
     // Make a sample transaction.
-    let module = "object_basics";
-    let function = "create";
-    let package_object_ref = authority.get_framework_object_ref().await.unwrap();
-
+    let (validator, fullnode, package) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
+    validator.insert_genesis_object(shared_object.clone()).await;
+    fullnode.insert_genesis_object(shared_object).await;
+    let gas_object = validator.get_object(&gas_object_id).await.unwrap();
+    let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let data = TransactionData::new_move_call(
         sender,
-        package_object_ref,
-        ident_str!(module).to_owned(),
-        ident_str!(function).to_owned(),
+        package,
+        ident_str!("object_basics").to_owned(),
+        ident_str!("set_value").to_owned(),
         /* type_args */ vec![],
         gas_object_ref,
         /* args */
@@ -167,12 +196,12 @@ async fn construct_shared_object_transaction_with_sequence_number(
                 initial_shared_version,
             }),
             CallArg::Pure(16u64.to_le_bytes().to_vec()),
-            CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
         ],
         MAX_GAS,
     );
     (
-        authority,
+        validator,
+        fullnode,
         to_sender_signed_transaction(data, &keypair),
         gas_object_id,
         shared_object_id,
@@ -181,46 +210,53 @@ async fn construct_shared_object_transaction_with_sequence_number(
 
 #[tokio::test]
 async fn test_dry_run_transaction() {
-    let (authority, transaction, gas_object_id, shared_object_id) =
-        construct_shared_object_transaction_with_sequence_number(SequenceNumber::MIN).await;
+    let (validator, fullnode, transaction, gas_object_id, shared_object_id) =
+        construct_shared_object_transaction_with_sequence_number(None).await;
+    let initial_shared_object_version = validator
+        .get_object(&shared_object_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .version();
 
     let transaction_digest = *transaction.digest();
 
-    let response = authority
+    let response = fullnode
         .dry_exec_transaction(
             transaction.data().intent_message.value.clone(),
             transaction_digest,
         )
-        .await;
-    assert!(response.is_ok());
+        .await
+        .unwrap();
+    assert_eq!(response.status, SuiExecutionStatus::Success);
 
     // Make sure that objects are not mutated after dry run.
-    let gas_object_version = authority
+    let gas_object_version = fullnode
         .get_object(&gas_object_id)
         .await
         .unwrap()
         .unwrap()
         .version();
     assert_eq!(gas_object_version, OBJECT_START_VERSION);
-    let shared_object_version = authority
+    let shared_object_version = fullnode
         .get_object(&shared_object_id)
         .await
         .unwrap()
         .unwrap()
         .version();
-    assert_eq!(shared_object_version, SequenceNumber::MIN);
+    assert_eq!(shared_object_version, initial_shared_object_version);
 }
 
 #[tokio::test]
 async fn test_dev_inspect_object_by_bytes() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas_object_id = ObjectID::random();
-    let (authority_state, object_basics) =
-        init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+    let (validator, fullnode, object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
 
     // test normal call
     let DevInspectResults { effects, results } = call_dev_inspect(
-        &authority_state,
+        &fullnode,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -251,8 +287,9 @@ async fn test_dev_inspect_object_by_bytes() {
     assert!(return_values.is_empty());
 
     // actually make the call to make an object
-    let effects = call_move(
-        &authority_state,
+    let effects = call_move_(
+        &validator,
+        Some(&fullnode),
         &gas_object_id,
         &sender,
         &sender_key,
@@ -264,11 +301,12 @@ async fn test_dev_inspect_object_by_bytes() {
             TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
             TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
         ],
+        false,
     )
     .await
     .unwrap();
     let created_object_id = effects.created[0].0 .0;
-    let created_object = authority_state
+    let created_object = validator
         .get_object(&created_object_id)
         .await
         .unwrap()
@@ -282,7 +320,7 @@ async fn test_dev_inspect_object_by_bytes() {
 
     // use the created object directly, via its bytes
     let DevInspectResults { effects, results } = call_dev_inspect(
-        &authority_state,
+        &fullnode,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -316,8 +354,9 @@ async fn test_dev_inspect_object_by_bytes() {
     let updated_reference_bytes = &mutable_reference_outputs[0].1;
 
     // make the same call with the object id
-    let effects = call_move(
-        &authority_state,
+    let effects = call_move_(
+        &validator,
+        Some(&fullnode),
         &gas_object_id,
         &sender,
         &sender_key,
@@ -329,6 +368,7 @@ async fn test_dev_inspect_object_by_bytes() {
             TestCallArg::Object(created_object_id),
             TestCallArg::Pure(bcs::to_bytes(&100_u64).unwrap()),
         ],
+        false,
     )
     .await
     .unwrap();
@@ -337,7 +377,7 @@ async fn test_dev_inspect_object_by_bytes() {
     assert!(effects.deleted.is_empty());
 
     // compare the bytes
-    let updated_object = authority_state
+    let updated_object = validator
         .get_object(&created_object_id)
         .await
         .unwrap()
@@ -350,13 +390,13 @@ async fn test_dev_inspect_object_by_bytes() {
 async fn test_dev_inspect_unowned_gas() {
     let (alice, _alice_key): (_, AccountKeyPair) = get_key_pair();
     let alice_gas_id = ObjectID::random();
-    let (authority_state, object_basics) =
-        init_state_with_ids_and_object_basics(vec![(alice, alice_gas_id)]).await;
+    let (_validator, full_node, object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![(alice, alice_gas_id)]).await;
     let (bob, bob_key): (_, AccountKeyPair) = get_key_pair();
 
     // bob uses dev inspect with alice's gas
     let DevInspectResults { effects, results } = call_dev_inspect(
-        &authority_state,
+        &full_node,
         &alice_gas_id,
         &bob,
         &bob_key,
@@ -391,13 +431,14 @@ async fn test_dev_inspect_unowned_gas() {
 async fn test_dev_inspect_unowned_object() {
     let (alice, alice_key): (_, AccountKeyPair) = get_key_pair();
     let alice_gas_id = ObjectID::random();
-    let (authority_state, object_basics) =
-        init_state_with_ids_and_object_basics(vec![(alice, alice_gas_id)]).await;
+    let (validator, fullnode, object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![(alice, alice_gas_id)]).await;
     let (bob, _bob_key): (_, AccountKeyPair) = get_key_pair();
 
     // make an object, send it to bob
-    let effects = call_move(
-        &authority_state,
+    let effects = call_move_(
+        &validator,
+        Some(&fullnode),
         &alice_gas_id,
         &alice,
         &alice_key,
@@ -409,11 +450,12 @@ async fn test_dev_inspect_unowned_object() {
             TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
             TestCallArg::Pure(bcs::to_bytes(&bob).unwrap()),
         ],
+        false,
     )
     .await
     .unwrap();
     let created_object_id = effects.created[0].0 .0;
-    let created_object = authority_state
+    let created_object = validator
         .get_object(&created_object_id)
         .await
         .unwrap()
@@ -423,7 +465,7 @@ async fn test_dev_inspect_unowned_object() {
 
     // alice uses the object with dev inspect, despite not being the owner
     let DevInspectResults { effects, results } = call_dev_inspect(
-        &authority_state,
+        &fullnode,
         &alice_gas_id,
         &alice,
         &alice_key,
@@ -463,12 +505,14 @@ async fn test_dev_inspect_dynamic_field() {
     let (test_object1_bytes, test_object2_bytes) = {
         let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
         let gas_object_id = ObjectID::random();
-        let (authority_state, object_basics) =
-            init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+        let (validator, fullnode, object_basics) =
+            init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)])
+                .await;
         macro_rules! mk_obj {
             () => {{
-                let effects = call_move(
-                    &authority_state,
+                let effects = call_move_(
+                    &validator,
+                    Some(&fullnode),
                     &gas_object_id,
                     &sender,
                     &sender_key,
@@ -480,11 +524,12 @@ async fn test_dev_inspect_dynamic_field() {
                         TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
                         TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
                     ],
+                    false,
                 )
                 .await
                 .unwrap();
                 let created_object_id = effects.created[0].0 .0;
-                let created_object = authority_state
+                let created_object = validator
                     .get_object(&created_object_id)
                     .await
                     .unwrap()
@@ -502,12 +547,12 @@ async fn test_dev_inspect_dynamic_field() {
 
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas_object_id = ObjectID::random();
-    let (authority_state, object_basics) =
-        init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+    let (_validator, fullnode, object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
 
     // add a dynamic field to itself
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &authority_state,
+        &fullnode,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -527,7 +572,7 @@ async fn test_dev_inspect_dynamic_field() {
 
     // add a dynamic field to an object
     let DevInspectResults { effects, results } = call_dev_inspect(
-        &authority_state,
+        &fullnode,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -562,13 +607,14 @@ async fn test_dev_inspect_dynamic_field() {
 async fn test_dev_inspect_return_values() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas_object_id = ObjectID::random();
-    let (authority_state, object_basics) =
-        init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+    let (validator, fullnode, object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
 
     // make an object
     let init_value = 16_u64;
-    let effects = call_move(
-        &authority_state,
+    let effects = call_move_(
+        &validator,
+        Some(&fullnode),
         &gas_object_id,
         &sender,
         &sender_key,
@@ -580,11 +626,12 @@ async fn test_dev_inspect_return_values() {
             TestCallArg::Pure(bcs::to_bytes(&(init_value)).unwrap()),
             TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
         ],
+        false,
     )
     .await
     .unwrap();
     let created_object_id = effects.created[0].0 .0;
-    let created_object = authority_state
+    let created_object = validator
         .get_object(&created_object_id)
         .await
         .unwrap()
@@ -598,7 +645,7 @@ async fn test_dev_inspect_return_values() {
 
     // mutably borrow a value from it's bytes
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &authority_state,
+        &fullnode,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -628,7 +675,7 @@ async fn test_dev_inspect_return_values() {
 
     // borrow a value from it's bytes
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &authority_state,
+        &fullnode,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -658,7 +705,7 @@ async fn test_dev_inspect_return_values() {
 
     // read one value from it's bytes
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &authority_state,
+        &fullnode,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -688,7 +735,7 @@ async fn test_dev_inspect_return_values() {
 
     // read two values from it's bytes
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &authority_state,
+        &fullnode,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -721,13 +768,14 @@ async fn test_dev_inspect_return_values() {
 async fn test_dev_inspect_move_call() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas_object_id = ObjectID::random();
-    let (authority_state, object_basics) =
-        init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+    let (validator, fullnode, object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
 
     // make an object
     let init_value = 16_u64;
-    let effects = call_move(
-        &authority_state,
+    let effects = call_move_(
+        &validator,
+        Some(&fullnode),
         &gas_object_id,
         &sender,
         &sender_key,
@@ -739,11 +787,12 @@ async fn test_dev_inspect_move_call() {
             TestCallArg::Pure(bcs::to_bytes(&(init_value)).unwrap()),
             TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
         ],
+        false,
     )
     .await
     .unwrap();
     let created_object_id = effects.created[0].0 .0;
-    let created_object = authority_state
+    let created_object = validator
         .get_object(&created_object_id)
         .await
         .unwrap()
@@ -757,7 +806,7 @@ async fn test_dev_inspect_move_call() {
 
     // borrow a value from it's bytes via a direct move call
     let DevInspectResults { results, effects } = call_dev_inspect_move_call(
-        &authority_state,
+        &fullnode,
         sender,
         &object_basics,
         "object_basics",
@@ -796,7 +845,7 @@ async fn test_dev_inspect_move_call() {
 
     // read two values from it's bytes via direct move call
     let DevInspectResults { results, .. } = call_dev_inspect_move_call(
-        &authority_state,
+        &fullnode,
         sender,
         &object_basics,
         "object_basics",
@@ -824,7 +873,7 @@ async fn test_dev_inspect_move_call() {
 
     // read two values from it's bytes via a normal transaction
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &authority_state,
+        &fullnode,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -846,6 +895,9 @@ async fn test_dev_inspect_move_call() {
     // check the value is the same as via the direct move call
     assert_eq!(return_value_3, return_value_2);
 }
+
+#[tokio::test]
+async fn test_developer_call_on_validator() {}
 
 #[tokio::test]
 async fn test_handle_transfer_transaction_bad_signature() {
@@ -968,8 +1020,8 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
 
 #[tokio::test]
 async fn test_handle_shared_object_with_max_sequence_number() {
-    let (authority, transaction, _, _) =
-        construct_shared_object_transaction_with_sequence_number(SequenceNumber::MAX).await;
+    let (authority, _fullnode, transaction, _, _) =
+        construct_shared_object_transaction_with_sequence_number(Some(SequenceNumber::MAX)).await;
     // Submit the transaction and assemble a certificate.
     let response = authority.handle_transaction(transaction.clone()).await;
     assert!(response.is_err());
@@ -1243,16 +1295,18 @@ pub async fn send_and_confirm_transaction(
     authority: &AuthorityState,
     transaction: VerifiedTransaction,
 ) -> Result<SignedTransactionEffects, SuiError> {
-    send_and_confirm_transaction_with_shared(
+    send_and_confirm_transaction_(
         authority,
+        None, /* no fullnode_key_pair */
         transaction,
         false, /* no shared objects */
     )
     .await
 }
 
-pub async fn send_and_confirm_transaction_with_shared(
+pub async fn send_and_confirm_transaction_(
     authority: &AuthorityState,
+    fullnode: Option<&AuthorityState>,
     transaction: VerifiedTransaction,
     with_shared: bool, // transaction includes shared objects
 ) -> Result<SignedTransactionEffects, SuiError> {
@@ -1277,7 +1331,11 @@ pub async fn send_and_confirm_transaction_with_shared(
 
     // Submit the confirmation. *Now* execution actually happens, and it should fail when we try to look up our dummy module.
     // we unfortunately don't get a very descriptive error message, but we can at least see that something went wrong inside the VM
-    authority.try_execute_for_test(&certificate).await
+    let result = authority.try_execute_for_test(&certificate).await?;
+    if let Some(fullnode) = fullnode {
+        fullnode.try_execute_for_test(&certificate).await?;
+    }
+    Ok(result)
 }
 
 /// Create a `CompiledModule` that depends on `m`
@@ -3219,6 +3277,23 @@ pub async fn init_state() -> Arc<AuthorityState> {
 }
 
 #[cfg(test)]
+pub async fn init_state_validator_with_fullnode() -> (Arc<AuthorityState>, Arc<AuthorityState>) {
+    use sui_types::crypto::get_authority_key_pair;
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let network_config = sui_config::builder::ConfigBuilder::new(&dir).build();
+    let genesis = network_config.genesis;
+    let keypair = network_config.validator_configs[0]
+        .protocol_key_pair()
+        .copy();
+
+    let validator = init_state_with_committee(&genesis, &keypair).await;
+    let fullnode_key_pair = get_authority_key_pair().1;
+    let fullnode = init_state_with_committee(&genesis, &fullnode_key_pair).await;
+    (validator, fullnode)
+}
+
+#[cfg(test)]
 pub async fn init_state_with_committee(
     genesis: &Genesis,
     authority_key: &AuthorityKeyPair,
@@ -3267,6 +3342,38 @@ pub async fn init_state_with_ids_and_object_basics<
     let pkg_ref = pkg.compute_object_reference();
     state.insert_genesis_object(pkg).await;
     (state, pkg_ref)
+}
+
+#[cfg(test)]
+pub async fn init_state_with_ids_and_object_basics_with_fullnode<
+    I: IntoIterator<Item = (SuiAddress, ObjectID)>,
+>(
+    objects: I,
+) -> (Arc<AuthorityState>, Arc<AuthorityState>, ObjectRef) {
+    use sui_framework_build::compiled_package::BuildConfig;
+
+    let (validator, fullnode) = init_state_validator_with_fullnode().await;
+    for (address, object_id) in objects {
+        let obj = Object::with_id_owner_for_testing(object_id, address);
+        validator.insert_genesis_object(obj.clone()).await;
+        fullnode.insert_genesis_object(obj).await;
+    }
+
+    // add object_basics package object to genesis, since lots of test use it
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/unit_tests/data/object_basics");
+    let modules = BuildConfig::default()
+        .build(path)
+        .unwrap()
+        .get_modules()
+        .into_iter()
+        .cloned()
+        .collect();
+    let pkg = Object::new_package(modules, TransactionDigest::genesis()).unwrap();
+    let pkg_ref = pkg.compute_object_reference();
+    validator.insert_genesis_object(pkg.clone()).await;
+    fullnode.insert_genesis_object(pkg).await;
+    (validator, fullnode, pkg_ref)
 }
 
 #[cfg(test)]
@@ -3424,8 +3531,9 @@ pub async fn call_move(
     type_args: Vec<TypeTag>,
     test_args: Vec<TestCallArg>,
 ) -> SuiResult<TransactionEffects> {
-    call_move_with_shared(
+    call_move_(
         authority,
+        None,
         gas_object_id,
         sender,
         sender_key,
@@ -3439,8 +3547,9 @@ pub async fn call_move(
     .await
 }
 
-pub async fn call_move_with_shared(
+pub async fn call_move_(
     authority: &AuthorityState,
+    fullnode: Option<&AuthorityState>,
     gas_object_id: &ObjectID,
     sender: &SuiAddress,
     sender_key: &AccountKeyPair,
@@ -3470,7 +3579,7 @@ pub async fn call_move_with_shared(
 
     let transaction = to_sender_signed_transaction(data, sender_key);
     let signed_effects =
-        send_and_confirm_transaction_with_shared(authority, transaction, with_shared).await?;
+        send_and_confirm_transaction_(authority, fullnode, transaction, with_shared).await?;
     Ok(signed_effects.into_data())
 }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3580,6 +3580,7 @@ pub async fn call_dev_inspect(
         .dev_inspect_transaction(
             transaction.data().intent_message.value.clone(),
             transaction_digest,
+            authority.epoch(),
         )
         .await
 }
@@ -3604,7 +3605,9 @@ pub async fn call_dev_inspect_move_call(
         type_arguments,
         arguments,
     };
-    authority.dev_inspect_move_call(sender, move_call).await
+    authority
+        .dev_inspect_move_call(sender, move_call, authority.epoch())
+        .await
 }
 
 #[cfg(test)]

--- a/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
+++ b/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
@@ -30,6 +30,10 @@ module examples::object_basics {
         )
     }
 
+    public entry fun share(ctx: &mut TxContext) {
+        transfer::share_object(Object { id: object::new(ctx), value: 0 })
+    }
+
     public entry fun transfer(o: Object, recipient: address) {
         transfer::transfer(o, recipient)
     }

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -4,8 +4,7 @@
 
 use super::*;
 use crate::authority::authority_tests::{
-    call_move, call_move_with_shared, init_state_with_ids, send_and_confirm_transaction,
-    TestCallArg,
+    call_move, call_move_, init_state_with_ids, send_and_confirm_transaction, TestCallArg,
 };
 use sui_types::utils::to_sender_signed_transaction;
 
@@ -1048,8 +1047,9 @@ async fn test_entry_point_vector_error() {
     );
     let (shared_obj_id, _, _) = effects.created[0].0;
     // call a function with a vector containing one shared object
-    let effects = call_move_with_shared(
+    let effects = call_move_(
         &authority,
+        None,
         &gas,
         &sender,
         &sender_key,
@@ -1429,8 +1429,9 @@ async fn test_entry_point_vector_any_error() {
     );
     let (shared_obj_id, _, _) = effects.created[0].0;
     // call a function with a vector containing one shared object
-    let effects = call_move_with_shared(
+    let effects = call_move_(
         &authority,
+        None,
         &gas,
         &sender,
         &sender_key,

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -187,14 +187,17 @@ pub trait RpcFullNodeReadApi {
     /// Return dev-inpsect results of the transaction, including both the transaction
     /// effects and return values of the transaction.
     #[method(name = "devInspectTransaction")]
-    async fn dev_inspect_transaction(&self, tx_bytes: Base64) -> RpcResult<DevInspectResults>;
+    async fn dev_inspect_transaction(
+        &self,
+        tx_bytes: Base64,
+        /// The epoch to perform the call. Will be set from the system state object if not provided
+        epoch: Option<EpochId>,
+    ) -> RpcResult<DevInspectResults>;
 
     /// Similar to `dev_inspect_transaction` but do not require gas object and budget
     #[method(name = "devInspectMoveCall")]
     async fn dev_inspect_move_call(
         &self,
-        /// The epoch to perform the call
-        epoch: EpochId,
         /// the caller's Sui address
         sender_address: SuiAddress,
         /// the Move package ID, e.g. `0x2`
@@ -207,6 +210,8 @@ pub trait RpcFullNodeReadApi {
         type_arguments: Vec<SuiTypeTag>,
         /// the arguments to be passed into the Move function, in [SuiJson](https://docs.sui.io/build/sui-json) format
         arguments: Vec<SuiJsonValue>,
+        /// The epoch to perform the call. Will be set from the system state object if not provided
+        epoch: Option<EpochId>,
     ) -> RpcResult<DevInspectResults>;
 
     /// Return transaction execution effects including the gas cost summary,

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -193,6 +193,8 @@ pub trait RpcFullNodeReadApi {
     #[method(name = "devInspectMoveCall")]
     async fn dev_inspect_move_call(
         &self,
+        /// The epoch to perform the call
+        epoch: EpochId,
         /// the caller's Sui address
         sender_address: SuiAddress,
         /// the Move package ID, e.g. `0x2`
@@ -265,7 +267,7 @@ pub trait RpcFullNodeReadApi {
         cursor: Option<TransactionDigest>,
         /// Maximum item returned per page, default to [QUERY_MAX_RESULT_LIMIT] if not specified.
         limit: Option<usize>,
-        /// query result ordering, default to false (ascending order), oldest record first.  
+        /// query result ordering, default to false (ascending order), oldest record first.
         descending_order: Option<bool>,
     ) -> RpcResult<TransactionsPage>;
 
@@ -616,7 +618,7 @@ pub trait EventReadApi {
         cursor: Option<EventID>,
         /// maximum number of items per page, default to [QUERY_MAX_RESULT_LIMIT] if not specified.
         limit: Option<usize>,
-        /// query result ordering, default to false (ascending order), oldest record first.  
+        /// query result ordering, default to false (ascending order), oldest record first.
         descending_order: Option<bool>,
     ) -> RpcResult<EventPage>;
 }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use sui_adapter::execution_mode;
 use sui_json::SuiJsonValue;
 use sui_transaction_builder::TransactionBuilder;
+use sui_types::committee::EpochId;
 use sui_types::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
 use tap::TapFallible;
 
@@ -230,12 +231,13 @@ impl RpcFullNodeReadApiServer for FullNodeApi {
         let (txn_data, txn_digest) = get_transaction_data_and_digest(tx_bytes)?;
         Ok(self
             .state
-            .dev_inspect_transaction(txn_data, txn_digest)
+            .dev_inspect_transaction(txn_data, txn_digest, 0)
             .await?)
     }
 
     async fn dev_inspect_move_call(
         &self,
+        epoch: EpochId,
         sender_address: SuiAddress,
         package_object_id: ObjectID,
         module: String,
@@ -255,7 +257,7 @@ impl RpcFullNodeReadApiServer for FullNodeApi {
             .await?;
         Ok(self
             .state
-            .dev_inspect_move_call(sender_address, move_call)
+            .dev_inspect_move_call(sender_address, move_call, epoch)
             .await?)
     }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -215,6 +215,15 @@
               "$ref": "#/components/schemas/SuiJsonValue"
             }
           }
+        },
+        {
+          "name": "epoch",
+          "description": "The epoch to perform the call. Will be set from the system state object if not provided",
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
         }
       ],
       "result": {
@@ -239,6 +248,15 @@
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/Base64"
+          }
+        },
+        {
+          "name": "epoch",
+          "description": "The epoch to perform the call. Will be set from the system state object if not provided",
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         }
       ],
@@ -975,7 +993,7 @@
         },
         {
           "name": "descending_order",
-          "description": "query result ordering, default to false (ascending order), oldest record first.  ",
+          "description": "query result ordering, default to false (ascending order), oldest record first.",
           "schema": {
             "type": "boolean"
           }
@@ -1823,7 +1841,7 @@
         },
         {
           "name": "descending_order",
-          "description": "query result ordering, default to false (ascending order), oldest record first.  ",
+          "description": "query result ordering, default to false (ascending order), oldest record first.",
           "schema": {
             "type": "boolean"
           }


### PR DESCRIPTION
- Make epoch a provided parameter instead of taking from the authority.
- Limit the call to full nodes (should not be run on validators)