### PR TITLE
genesis: use checkpoint from genesis

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -32,7 +32,7 @@ use sui_types::messages::{CallArg, TransactionEffects};
 use sui_types::messages::{CertifiedTransaction, Transaction};
 use sui_types::messages::{InputObjects, SignedTransaction};
 use sui_types::messages_checkpoint::{
-    CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary,
+    CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary, VerifiedCheckpoint,
 };
 use sui_types::object::Owner;
 use sui_types::sui_system_state::SuiSystemState;
@@ -83,12 +83,24 @@ impl Genesis {
         &self.objects
     }
 
+    pub fn object(&self, id: ObjectID) -> Option<Object> {
+        self.objects.iter().find(|o| o.id() == id).cloned()
+    }
+
     pub fn transaction(&self) -> &CertifiedTransaction {
         &self.transaction
     }
 
     pub fn effects(&self) -> &TransactionEffects {
         &self.effects
+    }
+
+    pub fn checkpoint(&self) -> VerifiedCheckpoint {
+        VerifiedCheckpoint::new(self.checkpoint.clone(), &self.committee().unwrap()).unwrap()
+    }
+
+    pub fn checkpoint_contents(&self) -> &CheckpointContents {
+        &self.checkpoint_contents
     }
 
     pub fn epoch(&self) -> EpochId {
@@ -469,16 +481,6 @@ impl Builder {
 
         // Ensure we have signatures from all validators
         assert_eq!(checkpoint.auth_signature.len(), validators.len() as u64);
-
-        // TODO(bmwill) remove this and don't override previous txn digest once we actually use the
-        // checkpoint created from genesis.
-        let objects = objects
-            .into_iter()
-            .map(|object| Object {
-                previous_transaction: TransactionDigest::genesis(),
-                ..object
-            })
-            .collect::<Vec<_>>();
 
         let genesis = Genesis {
             checkpoint,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2234,13 +2234,6 @@ impl AuthorityState {
             .expect("Cannot insert genesis object")
     }
 
-    pub async fn insert_genesis_objects_bulk_unsafe(&self, objects: &[&Object]) {
-        self.database
-            .bulk_object_insert(objects)
-            .await
-            .expect("Cannot bulk insert genesis objects")
-    }
-
     /// Make an information response for a transaction
     pub async fn make_transaction_info(
         &self,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -615,7 +615,7 @@ impl AuthorityState {
 
     /// Executes a certificate for its effects.
     #[instrument(level = "trace", skip_all)]
-    pub(crate) async fn execute_certificate(
+    pub async fn execute_certificate(
         &self,
         certificate: &VerifiedCertificate,
         epoch_store: &Arc<AuthorityPerEpochStore>,

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -496,7 +496,7 @@ impl AuthorityStore {
     /// Insert an object directly into the store, and also update relevant tables
     /// NOTE: does not handle transaction lock.
     /// This is used to insert genesis objects
-    pub async fn insert_object_direct(&self, object_ref: ObjectRef, object: &Object) -> SuiResult {
+    async fn insert_object_direct(&self, object_ref: ObjectRef, object: &Object) -> SuiResult {
         let mut write_batch = self.perpetual_tables.objects.batch();
 
         // Insert object
@@ -532,10 +532,8 @@ impl AuthorityStore {
         Ok(())
     }
 
-    /// This function is used by the bench.rs script, and should not be used in other contexts
-    /// In particular it does not check the old locks before inserting new ones, so the objects
-    /// must be new.
-    pub async fn bulk_object_insert(&self, objects: &[&Object]) -> SuiResult<()> {
+    /// This function should only be used for initializing genesis and should remain private.
+    async fn bulk_object_insert(&self, objects: &[&Object]) -> SuiResult<()> {
         let mut batch = self.perpetual_tables.objects.batch();
         let ref_and_objects: Vec<_> = objects
             .iter()

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -73,6 +73,19 @@ impl CheckpointStore {
         Arc::new(Self::open_tables_read_write(path.to_path_buf(), None, None))
     }
 
+    pub fn insert_genesis_checkpoint(
+        &self,
+        checkpoint: VerifiedCheckpoint,
+        contents: CheckpointContents,
+    ) {
+        self.insert_verified_checkpoint(checkpoint.clone()).unwrap();
+        self.insert_checkpoint_contents(contents).unwrap();
+        self.update_highest_synced_checkpoint(&checkpoint).unwrap();
+        self.checkpoint_summary
+            .insert(&checkpoint.sequence_number(), checkpoint.summary())
+            .unwrap();
+    }
+
     pub fn get_checkpoint_by_digest(
         &self,
         digest: &CheckpointDigest,

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -21,7 +21,6 @@ use sui_types::{
         TransactionInfoRequest, TransactionInfoResponse,
     },
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
-    object::Object,
 };
 use sui_types::{error::SuiResult, messages::HandleCertificateResponse};
 
@@ -133,21 +132,6 @@ impl LocalAuthorityClient {
             state,
             fault_config: LocalAuthorityClientFaultConfig::default(),
         }
-    }
-
-    pub async fn new_with_objects(
-        committee: Committee,
-        secret: AuthorityKeyPair,
-        objects: Vec<Object>,
-        genesis: &Genesis,
-    ) -> Self {
-        let client = Self::new(committee, secret, genesis).await;
-
-        for object in objects {
-            client.state.insert_genesis_object(object).await;
-        }
-
-        client
     }
 
     pub fn new_from_authority(state: Arc<AuthorityState>) -> Self {

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -166,7 +166,7 @@ async fn init_genesis(
         .cloned()
         .collect();
     let pkg = Object::new_package(modules, TransactionDigest::genesis()).unwrap();
-    let pkg_ref = pkg.compute_object_reference();
+    let pkg_id = pkg.id();
     genesis_objects.push(pkg);
 
     let mut builder = sui_config::genesis::Builder::new().add_objects(genesis_objects);
@@ -201,6 +201,12 @@ async fn init_genesis(
         builder = builder.add_validator_signature(key);
     }
     let genesis = builder.build();
+    let pkg_ref = genesis
+        .objects()
+        .iter()
+        .find(|o| o.id() == pkg_id)
+        .unwrap()
+        .compute_object_reference();
     (genesis, key_pairs, pkg_ref)
 }
 
@@ -210,11 +216,12 @@ pub async fn init_local_authorities(
 ) -> (
     AuthorityAggregator<LocalAuthorityClient>,
     Vec<Arc<AuthorityState>>,
+    Genesis,
     ObjectRef,
 ) {
     let (genesis, key_pairs, pkg_ref) = init_genesis(committee_size, genesis_objects).await;
     let (aggregator, authorities) = init_local_authorities_with_genesis(&genesis, key_pairs).await;
-    (aggregator, authorities, pkg_ref)
+    (aggregator, authorities, genesis, pkg_ref)
 }
 
 pub async fn init_local_authorities_with_genesis(
@@ -230,13 +237,7 @@ pub async fn init_local_authorities_with_genesis(
     let mut clients = BTreeMap::new();
     let mut states = Vec::new();
     for (authority_name, secret) in key_pairs {
-        let client = LocalAuthorityClient::new_with_objects(
-            committee.clone(),
-            secret,
-            genesis.objects().to_owned(),
-            genesis,
-        )
-        .await;
+        let client = LocalAuthorityClient::new(committee.clone(), secret, genesis).await;
         states.push(client.state.clone());
         clients.insert(authority_name, client);
     }

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -249,7 +249,9 @@ async fn check_objects(
     if !errors.is_empty() {
         return Err(SuiError::TransactionInputObjectsErrors { errors });
     }
-    fp_ensure!(!all_objects.is_empty(), SuiError::ObjectInputArityViolation);
+    if !transaction.kind.is_genesis_tx() && all_objects.is_empty() {
+        return Err(SuiError::ObjectInputArityViolation);
+    }
 
     Ok(InputObjects::new(all_objects))
 }

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -295,7 +295,7 @@ async fn test_transaction_manager() {
         .collect_vec();
     let all_gas_objects = gas_objects.clone().into_iter().flatten().collect_vec();
 
-    let (aggregator, authorities, framework_obj_ref) =
+    let (aggregator, authorities, _genesis, framework_obj_ref) =
         init_local_authorities(4, all_gas_objects.clone()).await;
     let authority_clients: Vec<_> = authorities
         .iter()

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -466,8 +466,7 @@ async fn execute_pay_all_sui(
             input_coin_objects
                 .clone()
                 .into_iter()
-                .map(ToOwned::to_owned)
-                .collect(),
+                .map(ToOwned::to_owned),
         )
         .build();
     let genesis = network_config.genesis;

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -457,7 +457,7 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
     }
     // test get_transactions_in_range
     let tx: Vec<TransactionDigest> = http_client.get_transactions_in_range(0, 10).await?;
-    assert_eq!(4, tx.len());
+    assert_eq!(5, tx.len());
 
     // test get_transactions_in_range with smaller range
     let tx: Vec<TransactionDigest> = http_client.get_transactions_in_range(1, 3).await?;
@@ -538,7 +538,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
         .get_transactions(TransactionQuery::All, first_page.next_cursor, None, false)
         .await
         .unwrap();
-    assert_eq!(15, second_page.data.len());
+    assert_eq!(16, second_page.data.len());
     assert!(second_page.next_cursor.is_none());
 
     let mut all_txs_rev = first_page.data.clone();
@@ -667,7 +667,7 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
         .get_events(EventQuery::All, Some((5, 0).into()), Some(20), false)
         .await
         .unwrap();
-    assert_eq!(15, page2.data.len());
+    assert_eq!(16, page2.data.len());
     assert_eq!(None, page2.next_cursor);
 
     // test get all events descending
@@ -677,7 +677,7 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
         .await
         .unwrap();
     assert_eq!(3, page1.data.len());
-    assert_eq!(Some((16, 0).into()), page1.next_cursor);
+    assert_eq!(Some((17, 0).into()), page1.next_cursor);
     let page2 = client
         .event_api()
         .get_events(EventQuery::All, Some((16, 0).into()), None, true)
@@ -710,7 +710,7 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
         )
         .await
         .unwrap();
-    assert_eq!(4, page.data.len());
+    assert_eq!(9, page.data.len());
 
     let object = client
         .read_api()
@@ -727,7 +727,7 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
         .get_events(EventQuery::Object(object), None, Some(10), false)
         .await
         .unwrap();
-    assert_eq!(4, page.data.len());
+    assert_eq!(5, page.data.len());
 
     Ok(())
 }

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -376,6 +376,12 @@ where
 
             self.spawn_notify_peers_of_checkpoint(checkpoint);
         } else {
+            // Ensure that if consensus sends us a checkpoint that we expect to be the next one,
+            // that it isn't on a fork
+            if checkpoint.sequence_number() == next_sequence_number {
+                assert_eq!(checkpoint.previous_digest(), previous_digest);
+            }
+
             // Otherwise stick it with the other unprocessed checkpoints and we can try to sync the missing
             // ones
             self.peer_heights

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -583,6 +583,13 @@ impl TransactionKind {
             TransactionKind::Single(SingleTransactionKind::ChangeEpoch(_))
         )
     }
+
+    pub fn is_genesis_tx(&self) -> bool {
+        matches!(
+            self,
+            TransactionKind::Single(SingleTransactionKind::Genesis(_))
+        )
+    }
 }
 
 impl Display for TransactionKind {

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -195,8 +195,8 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
         None,
         false,
     )?;
-    assert_eq!(txes.len(), 1);
-    assert_eq!(txes[0], digest);
+    assert_eq!(txes.len(), 2);
+    assert_eq!(txes[1], digest);
 
     let txes =
         node.state()
@@ -207,16 +207,16 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     let txes =
         node.state()
             .get_transactions(TransactionQuery::ToAddress(receiver), None, None, false)?;
-    assert_eq!(txes.len(), 1);
-    assert_eq!(txes[0], digest);
+    assert_eq!(txes.len(), 2);
+    assert_eq!(txes[1], digest);
 
     // Note that this is also considered a tx to the sender, because it mutated
     // one or more of the sender's objects.
     let txes =
         node.state()
             .get_transactions(TransactionQuery::ToAddress(sender), None, None, false)?;
-    assert_eq!(txes.len(), 1);
-    assert_eq!(txes[0], digest);
+    assert_eq!(txes.len(), 2);
+    assert_eq!(txes[1], digest);
 
     // No transactions have originated from the receiver
     let txes = node.state().get_transactions(
@@ -280,14 +280,15 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
                 end_time: ts.unwrap() + HOUR_MS,
             },
             None,
-            10,
+            100,
             false,
         )
         .await?;
+    let all_events = &all_events[all_events.len() - 3..];
     assert_eq!(all_events[0].1.tx_digest.unwrap(), digest);
     let all_events = all_events
-        .into_iter()
-        .map(|(_, envelope)| envelope.event)
+        .iter()
+        .map(|(_, envelope)| envelope.event.clone())
         .collect::<Vec<_>>();
     assert_eq!(all_events.len(), 3);
     assert_eq!(
@@ -345,23 +346,22 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
         .get_events(
             EventQuery::Recipient(Owner::AddressOwner(receiver)),
             None,
-            10,
+            100,
             false,
         )
         .await?;
-    assert_eq!(events_by_recipient[0].1.tx_digest.unwrap(), digest);
-    let events_by_recipient = events_by_recipient
-        .into_iter()
-        .map(|(_, envelope)| envelope.event)
-        .collect::<Vec<_>>();
-    assert_eq!(events_by_recipient.len(), 1);
-    assert_eq!(events_by_recipient, vec![recipient_event.clone()]);
+    assert_eq!(
+        events_by_recipient.last().unwrap().1.tx_digest.unwrap(),
+        digest
+    );
+    assert_eq!(events_by_recipient.last().unwrap().1.event, recipient_event,);
 
     // query by object
-    let events_by_object = node
+    let mut events_by_object = node
         .state()
-        .get_events(EventQuery::Object(transferred_object), None, 10, false)
+        .get_events(EventQuery::Object(transferred_object), None, 100, false)
         .await?;
+    let events_by_object = events_by_object.split_off(events_by_object.len() - 2);
     assert_eq!(events_by_object[0].1.tx_digest.unwrap(), digest);
     let events_by_object = events_by_object
         .into_iter()
@@ -813,14 +813,16 @@ async fn test_full_node_event_read_api_ok() {
         .request("sui_getEvents", params)
         .await
         .unwrap();
-    assert_eq!(events_by_recipient.data[0].tx_digest.unwrap(), digest);
+    assert_eq!(
+        events_by_recipient.data.last().unwrap().tx_digest.unwrap(),
+        digest
+    );
     let events_by_recipient = events_by_recipient
         .data
         .into_iter()
         .map(|envelope| envelope.event)
         .collect::<Vec<_>>();
-    assert_eq!(events_by_recipient.len(), 1);
-    assert_eq!(events_by_recipient, vec![recipient_event.clone()]);
+    assert_eq!(events_by_recipient.last().unwrap(), &recipient_event);
 
     // query by object
     let params = rpc_params![
@@ -833,17 +835,18 @@ async fn test_full_node_event_read_api_ok() {
         .request("sui_getEvents", params)
         .await
         .unwrap();
-    assert_eq!(events_by_object.data[0].tx_digest.unwrap(), digest);
+    assert_eq!(
+        events_by_object.data.last().unwrap().tx_digest.unwrap(),
+        digest
+    );
     let events_by_object = events_by_object
         .data
         .into_iter()
         .map(|envelope| envelope.event)
         .collect::<Vec<_>>();
-    assert_eq!(events_by_object.len(), 2);
-    assert_eq!(
-        events_by_object,
-        vec![sender_event.clone(), recipient_event.clone()]
-    );
+    assert_eq!(events_by_object.len(), 3);
+    assert_eq!(events_by_object[1], sender_event);
+    assert_eq!(events_by_object[2], recipient_event);
 
     // query by transaction module
     let params = rpc_params![
@@ -875,7 +878,7 @@ async fn test_full_node_event_read_api_ok() {
     wait_for_tx(digest2, node.state().clone()).await;
 
     // Add a delay to ensure event processing is done after transaction commits.
-    sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(5)).await;
 
     // query by move event struct name
     let struct_tag_str = sui_framework_address_concat_string("::devnet_nft::MintNFTEvent");
@@ -900,16 +903,16 @@ async fn test_full_node_event_read_api_ok() {
             end_time: ts2.unwrap() + HOUR_MS
         },
         None::<u64>,
-        10,
+        100,
         false
     ];
     let all_events: EventPage = jsonrpc_client
         .request("sui_getEvents", params)
         .await
         .unwrap();
+    // genesis txn
     // The first txn emits TransferObject(sender), TransferObject(recipient), Gas
     // The second txn emits MoveEvent, NewObject and Gas
-    assert_eq!(all_events.data.len(), 6);
     let tx_digests: Vec<TransactionDigest> = all_events
         .data
         .iter()
@@ -917,7 +920,7 @@ async fn test_full_node_event_read_api_ok() {
         .collect();
     // Sorted in ascending time
     assert_eq!(
-        tx_digests,
+        tx_digests[tx_digests.len() - 6..],
         vec![digest, digest, digest, digest2, digest2, digest2]
     );
 }

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -36,7 +36,7 @@ async fn local_advance_epoch_tx_test() {
     // 2. The timeout in the API works as expected.
     // 3. The certificate can be executed by each validator.
     // Uses local clients.
-    let (net, states, _) = init_local_authorities(4, vec![]).await;
+    let (net, states, _, _) = init_local_authorities(4, vec![]).await;
 
     // Make sure that validators do not accept advance epoch sent externally.
     let tx = VerifiedTransaction::new_change_epoch(1, 0, 0, 0);

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -12,7 +12,10 @@ use sui_types::messages::{
 use sui_types::object::generate_test_gas_objects_with_owner;
 use sui_types::quorum_driver_types::QuorumDriverError;
 use sui_types::utils::to_sender_signed_transaction;
-use test_utils::authority::{spawn_fullnode, spawn_test_authorities, test_authority_configs};
+use test_utils::authority::{
+    spawn_fullnode, spawn_test_authorities, test_authority_configs,
+    test_authority_configs_with_objects,
+};
 use test_utils::messages::make_transactions_with_wallet_context;
 use test_utils::network::wait_for_nodes_transition_to_epoch;
 use test_utils::network::TestClusterBuilder;
@@ -202,8 +205,8 @@ async fn test_tx_across_epoch_boundaries() {
     let (result_tx, mut result_rx) =
         tokio::sync::mpsc::channel::<CertifiedTransaction>(total_tx_cnt);
 
-    let config = test_authority_configs();
-    let authorities = spawn_test_authorities(gas_objects.clone(), &config).await;
+    let (config, gas_objects) = test_authority_configs_with_objects(gas_objects);
+    let authorities = spawn_test_authorities([], &config).await;
     let fullnode = spawn_fullnode(&config, None).await;
 
     let txes = gas_objects


### PR DESCRIPTION
This PR finishes the work from https://github.com/MystenLabs/sui/pull/7105 and actually uses the checkpoint from genesis by inserting it into the node's storage at startup, before any other services startup.

After this PR lands we should be able to simplify some parts of state-sync and maybe even checkpoint construction given we'll now guarantee that we'll always at least have 1 checkpoint in our storage at startup.