### PR TITLE
update next epoch metadata in a few places

### DIFF
--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,13 +4,13 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
-    "computation_cost": 6814,
-    "storage_cost": 9768,
+    "computation_cost": 6817,
+    "storage_cost": 9772,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 7619,
-    "storage_cost": 10891,
+    "computation_cost": 7622,
+    "storage_cost": 10895,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
@@ -29,8 +29,8 @@ expression: common_costs_estimate
     "storage_rebate": 0
   },
   "SplitCoin": {
-    "computation_cost": 6792,
-    "storage_cost": 9736,
+    "computation_cost": 6795,
+    "storage_cost": 9740,
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -531,6 +531,7 @@ process them in <code>advance_epoch</code> by calling <code>process_pending_dele
     <b>let</b> validator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
     <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
     <a href="validator.md#0x2_validator_request_set_gas_price">validator::request_set_gas_price</a>(<a href="validator.md#0x2_validator">validator</a>, new_gas_price);
+    self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
 }
 </code></pre>
 
@@ -561,6 +562,7 @@ process them in <code>advance_epoch</code> by calling <code>process_pending_dele
     <b>let</b> validator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
     <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
     <a href="validator.md#0x2_validator_request_set_commission_rate">validator::request_set_commission_rate</a>(<a href="validator.md#0x2_validator">validator</a>, new_commission_rate);
+    self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
 }
 </code></pre>
 

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -245,6 +245,7 @@ module sui::validator_set {
         let validator_address = tx_context::sender(ctx);
         let validator = get_validator_mut(&mut self.active_validators, validator_address);
         validator::request_set_gas_price(validator, new_gas_price);
+        self.next_epoch_validators = derive_next_epoch_validators(self);
     }
 
     public(friend) fun request_set_commission_rate(
@@ -255,6 +256,7 @@ module sui::validator_set {
         let validator_address = tx_context::sender(ctx);
         let validator = get_validator_mut(&mut self.active_validators, validator_address);
         validator::request_set_commission_rate(validator, new_commission_rate);
+        self.next_epoch_validators = derive_next_epoch_validators(self);
     }
 
 


### PR DESCRIPTION
`request_set_gas_price` and `request_set_commission_rate` both update the validator's metadata for the next epoch so the next epoch metadata should be properly updated via `derive_next_epoch_validators`. Not a big deal right now since these two functions don't affect validator membership or stake distribution but will be a bug later if we try to derive the next epoch reference gas price or something.