### PR TITLE
Allow reconfiguration in stress test

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -49,7 +49,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load() {
         let mut builder = TestClusterBuilder::new()
-            .with_num_validators(get_var("SIM_STRESS_TEST_NUM_VALIDATORS", 4));
+            .with_num_validators(get_var("SIM_STRESS_TEST_NUM_VALIDATORS", 7));
 
         let checkpoints_per_epoch = get_var("CHECKPOINTS_PER_EPOCH", 0);
         if checkpoints_per_epoch > 0 {

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -48,11 +48,16 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load() {
-        let test_cluster = TestClusterBuilder::new()
-            .with_num_validators(get_var("SIM_STRESS_TEST_NUM_VALIDATORS", 4))
-            .build()
-            .await
-            .unwrap();
+        let mut builder = TestClusterBuilder::new()
+            .with_num_validators(get_var("SIM_STRESS_TEST_NUM_VALIDATORS", 4));
+
+        let checkpoints_per_epoch = get_var("CHECKPOINTS_PER_EPOCH", 0);
+        if checkpoints_per_epoch > 0 {
+            builder = builder.with_checkpoints_per_epoch(30);
+        }
+
+        let test_cluster = builder.build().await.unwrap();
+
         let swarm = &test_cluster.swarm;
         let context = &test_cluster.wallet;
         let sender = test_cluster.get_address_0();


### PR DESCRIPTION
This allows running reconfig during simulated stress test. Recommended usage:

`$ USE_MOCK_CRYPTO=1 SIM_STRESS_TEST_DURATION_SECS=120 CHECKPOINTS_PER_EPOCH=30 cargo simtest test_simulated_load`

The `USE_MOCK_CRYPTO=1` is not necessary but makes the test run much faster.

This immediately produces the following failure:

```
thread '<unnamed>' panicked at 'Older object version not found', /Users/mlogan/dev/sui/crates/sui-core/src/authority/authority_store.rs:1061:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Other failures can likely be found with different seeds.