### PR TITLE
`execution_mode` shouldn't leak into SDK client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8402,7 +8402,6 @@ dependencies = [
  "serde_yaml",
  "shell-words",
  "signature",
- "sui-adapter",
  "sui-config",
  "sui-core",
  "sui-framework",

--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -47,7 +47,7 @@ pub trait ExecutionMode {
     );
 }
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct Normal;
 
 impl ExecutionMode for Normal {

--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -46,6 +46,7 @@ pub trait ExecutionMode {
         result: Self::ExecutionResult,
     );
 }
+
 #[derive(Clone)]
 pub struct Normal;
 

--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -46,7 +46,7 @@ pub trait ExecutionMode {
         result: Self::ExecutionResult,
     );
 }
-
+#[derive(Clone)]
 pub struct Normal;
 
 impl ExecutionMode for Normal {

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -8,7 +8,6 @@ use move_binary_format::normalized::{Module as NormalizedModule, Type};
 use move_core_types::identifier::Identifier;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use sui_adapter::execution_mode;
 use sui_json::SuiJsonValue;
 use sui_transaction_builder::TransactionBuilder;
 use sui_types::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
@@ -35,6 +34,7 @@ use sui_types::move_package::normalize_modules;
 use sui_types::object::{Data, ObjectRead};
 use sui_types::query::TransactionQuery;
 
+use sui_adapter::execution_mode::DevInspect;
 use tracing::debug;
 
 use crate::api::RpcFullNodeReadApiServer;
@@ -50,7 +50,7 @@ pub struct ReadApi {
 
 pub struct FullNodeApi {
     pub state: Arc<AuthorityState>,
-    builder: TransactionBuilder,
+    dev_inspect_builder: TransactionBuilder<DevInspect>,
 }
 
 impl FullNodeApi {
@@ -58,7 +58,7 @@ impl FullNodeApi {
         let reader = Arc::new(AuthorityStateDataReader::new(state.clone()));
         Self {
             state,
-            builder: TransactionBuilder(reader),
+            dev_inspect_builder: TransactionBuilder::new(reader, DevInspect),
         }
     }
 }
@@ -247,8 +247,8 @@ impl RpcFullNodeReadApiServer for FullNodeApi {
         arguments: Vec<SuiJsonValue>,
     ) -> RpcResult<DevInspectResults> {
         let move_call = self
-            .builder
-            .single_move_call::<execution_mode::DevInspect>(
+            .dev_inspect_builder
+            .single_move_call(
                 package_object_id,
                 &module,
                 &function,

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -58,7 +58,7 @@ impl FullNodeApi {
         let reader = Arc::new(AuthorityStateDataReader::new(state.clone()));
         Self {
             state,
-            dev_inspect_builder: TransactionBuilder::new(reader, DevInspect),
+            dev_inspect_builder: TransactionBuilder::new(reader),
         }
     }
 }

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -34,8 +34,8 @@ impl FullNodeTransactionBuilderApi {
     pub fn new(state: Arc<AuthorityState>) -> Self {
         let reader = Arc::new(AuthorityStateDataReader::new(state));
         Self {
-            builder: TransactionBuilder::new(reader.clone(), Normal),
-            dev_inspect_builder: TransactionBuilder::new(reader, DevInspect),
+            builder: TransactionBuilder::new(reader.clone()),
+            dev_inspect_builder: TransactionBuilder::new(reader),
         }
     }
 }

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -6,7 +6,6 @@ use crate::SuiRpcModule;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use std::sync::Arc;
-use sui_adapter::execution_mode;
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::{
     GetRawObjectDataResponse, SuiObjectInfo, SuiTransactionBuilderMode, SuiTypeTag,
@@ -21,19 +20,22 @@ use sui_types::{
 
 use fastcrypto::encoding::Base64;
 use jsonrpsee::RpcModule;
+use sui_adapter::execution_mode::{DevInspect, Normal};
 
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::RPCTransactionRequestParams;
 
 pub struct FullNodeTransactionBuilderApi {
-    builder: TransactionBuilder,
+    builder: TransactionBuilder<Normal>,
+    dev_inspect_builder: TransactionBuilder<DevInspect>,
 }
 
 impl FullNodeTransactionBuilderApi {
     pub fn new(state: Arc<AuthorityState>) -> Self {
         let reader = Arc::new(AuthorityStateDataReader::new(state));
         Self {
-            builder: TransactionBuilder(reader),
+            builder: TransactionBuilder::new(reader.clone(), Normal),
+            dev_inspect_builder: TransactionBuilder::new(reader, DevInspect),
         }
     }
 }
@@ -225,8 +227,8 @@ impl RpcTransactionBuilderServer for FullNodeTransactionBuilderApi {
         let mode = txn_builder_mode.unwrap_or(SuiTransactionBuilderMode::Commit);
         let data: TransactionData = match mode {
             SuiTransactionBuilderMode::DevInspect => {
-                self.builder
-                    .move_call::<execution_mode::DevInspect>(
+                self.dev_inspect_builder
+                    .move_call(
                         signer,
                         package_object_id,
                         &module,
@@ -240,7 +242,7 @@ impl RpcTransactionBuilderServer for FullNodeTransactionBuilderApi {
             }
             SuiTransactionBuilderMode::Commit => {
                 self.builder
-                    .move_call::<execution_mode::Normal>(
+                    .move_call(
                         signer,
                         package_object_id,
                         &module,
@@ -267,15 +269,13 @@ impl RpcTransactionBuilderServer for FullNodeTransactionBuilderApi {
         let mode = txn_builder_mode.unwrap_or(SuiTransactionBuilderMode::Commit);
         let data = match mode {
             SuiTransactionBuilderMode::DevInspect => {
-                self.builder
-                    .batch_transaction::<execution_mode::DevInspect>(
-                        signer, params, gas, gas_budget,
-                    )
+                self.dev_inspect_builder
+                    .batch_transaction(signer, params, gas, gas_budget)
                     .await?
             }
             SuiTransactionBuilderMode::Commit => {
                 self.builder
-                    .batch_transaction::<execution_mode::Normal>(signer, params, gas, gas_budget)
+                    .batch_transaction(signer, params, gas, gas_budget)
                     .await?
             }
         };

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -13,7 +13,6 @@ use clap::Parser;
 use clap::Subcommand;
 use serde::Deserialize;
 
-use sui_adapter::execution_mode;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_sdk::{
     json::SuiJsonValue,
@@ -75,7 +74,7 @@ impl TicTacToe {
         let create_game_call = self
             .client
             .transaction_builder()
-            .move_call::<execution_mode::Normal>(
+            .move_call(
                 player_x,
                 self.game_package_id,
                 "shared_tic_tac_toe",
@@ -171,7 +170,7 @@ impl TicTacToe {
             let place_mark_call = self
                 .client
                 .transaction_builder()
-                .move_call::<execution_mode::Normal>(
+                .move_call(
                     my_identity,
                     self.game_package_id,
                     "shared_tic_tac_toe",

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -156,7 +156,7 @@ impl SuiClient {
         let read_api = Arc::new(ReadApi::new(api.clone()));
         let quorum_driver = QuorumDriver::new(api.clone());
         let event_api = EventApi::new(api.clone());
-        let transaction_builder = TransactionBuilder::new(read_api.clone(), Normal);
+        let transaction_builder = TransactionBuilder::new(read_api.clone());
         let coin_read_api = CoinReadApi::new(api.clone());
         let governance_api = GovernanceApi::new(api.clone());
 

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -15,6 +15,7 @@ use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use crate::error::{RpcError, SuiRpcResult};
 use rpc_types::{SuiCertifiedTransaction, SuiParsedTransactionResponse, SuiTransactionEffects};
 use serde_json::Value;
+use sui_adapter::execution_mode::Normal;
 pub use sui_json as json;
 
 use crate::apis::{CoinReadApi, EventApi, GovernanceApi, QuorumDriver, ReadApi};
@@ -42,7 +43,7 @@ pub struct TransactionExecutionResult {
 #[derive(Clone)]
 pub struct SuiClient {
     api: Arc<RpcClient>,
-    transaction_builder: TransactionBuilder,
+    transaction_builder: TransactionBuilder<Normal>,
     read_api: Arc<ReadApi>,
     coin_read_api: CoinReadApi,
     event_api: EventApi,
@@ -155,7 +156,7 @@ impl SuiClient {
         let read_api = Arc::new(ReadApi::new(api.clone()));
         let quorum_driver = QuorumDriver::new(api.clone());
         let event_api = EventApi::new(api.clone());
-        let transaction_builder = TransactionBuilder(read_api.clone());
+        let transaction_builder = TransactionBuilder::new(read_api.clone(), Normal);
         let coin_read_api = CoinReadApi::new(api.clone());
         let governance_api = GovernanceApi::new(api.clone());
 
@@ -196,7 +197,7 @@ impl SuiClient {
 }
 
 impl SuiClient {
-    pub fn transaction_builder(&self) -> &TransactionBuilder {
+    pub fn transaction_builder(&self) -> &TransactionBuilder<Normal> {
         &self.transaction_builder
     }
     pub fn read_api(&self) -> &ReadApi {

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
+use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -53,11 +54,14 @@ pub trait DataReader {
 }
 
 #[derive(Clone)]
-pub struct TransactionBuilder<Mode: ExecutionMode>(Arc<dyn DataReader + Sync + Send>, Mode);
+pub struct TransactionBuilder<Mode: ExecutionMode>(
+    Arc<dyn DataReader + Sync + Send>,
+    PhantomData<Mode>,
+);
 
 impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
-    pub fn new(data_reader: Arc<dyn DataReader + Sync + Send>, mode: Mode) -> Self {
-        Self(data_reader, mode)
+    pub fn new(data_reader: Arc<dyn DataReader + Sync + Send>) -> Self {
+        Self(data_reader, PhantomData)
     }
 
     async fn select_gas(

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -53,9 +53,13 @@ pub trait DataReader {
 }
 
 #[derive(Clone)]
-pub struct TransactionBuilder(pub Arc<dyn DataReader + Sync + Send>);
+pub struct TransactionBuilder<Mode: ExecutionMode>(Arc<dyn DataReader + Sync + Send>, Mode);
 
-impl TransactionBuilder {
+impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
+    pub fn new(data_reader: Arc<dyn DataReader + Sync + Send>, mode: Mode) -> Self {
+        Self(data_reader, mode)
+    }
+
     async fn select_gas(
         &self,
         signer: SuiAddress,
@@ -223,7 +227,7 @@ impl TransactionBuilder {
         ))
     }
 
-    pub async fn move_call<Mode: ExecutionMode>(
+    pub async fn move_call(
         &self,
         signer: SuiAddress,
         package_object_id: ObjectID,
@@ -235,14 +239,8 @@ impl TransactionBuilder {
         gas_budget: u64,
     ) -> anyhow::Result<TransactionData> {
         let single_move_call = SingleTransactionKind::Call(
-            self.single_move_call::<Mode>(
-                package_object_id,
-                module,
-                function,
-                type_args,
-                call_args,
-            )
-            .await?,
+            self.single_move_call(package_object_id, module, function, type_args, call_args)
+                .await?,
         );
         let input_objects = single_move_call
             .input_objects()?
@@ -265,7 +263,7 @@ impl TransactionBuilder {
         ))
     }
 
-    pub async fn single_move_call<Mode: ExecutionMode>(
+    pub async fn single_move_call(
         &self,
         package_object_id: ObjectID,
         module: &str,
@@ -283,7 +281,7 @@ impl TransactionBuilder {
             .collect::<Result<Vec<_>, _>>()?;
 
         let call_args = self
-            .resolve_and_checks_json_args::<Mode>(
+            .resolve_and_checks_json_args(
                 package_object_id,
                 &module,
                 &function,
@@ -324,7 +322,7 @@ impl TransactionBuilder {
         })
     }
 
-    async fn resolve_and_checks_json_args<Mode: ExecutionMode>(
+    async fn resolve_and_checks_json_args(
         &self,
         package_id: ObjectID,
         module: &Identifier,
@@ -493,7 +491,7 @@ impl TransactionBuilder {
         ))
     }
 
-    pub async fn batch_transaction<Mode: ExecutionMode>(
+    pub async fn batch_transaction(
         &self,
         signer: SuiAddress,
         single_transaction_params: Vec<RPCTransactionRequestParams>,
@@ -516,7 +514,7 @@ impl TransactionBuilder {
                 }
                 RPCTransactionRequestParams::MoveCallRequestParams(param) => {
                     SingleTransactionKind::Call(
-                        self.single_move_call::<Mode>(
+                        self.single_move_call(
                             param.package_object_id,
                             &param.module,
                             &param.function,

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -22,7 +22,6 @@ clap = { version = "3.2.17", features = ["derive"] }
 bip32 = "0.4.0"
 prettytable-rs = "0.10.0"
 
-sui-adapter = { path = "../sui-adapter" }
 sui-core = { path = "../sui-core" }
 sui-framework = { path = "../sui-framework" }
 sui-framework-build = { path = "../sui-framework-build" }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -27,6 +27,9 @@ use serde::Serialize;
 use serde_json::json;
 use sui_adapter::execution_mode;
 use sui_framework::build_move_package;
+use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
+use sui_types::error::SuiError;
+
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
@@ -36,9 +39,7 @@ use sui_json_rpc_types::{GetRawObjectDataResponse, SuiData};
 use sui_json_rpc_types::{SuiCertifiedTransaction, SuiExecutionStatus, SuiTransactionEffects};
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::TransactionExecutionResult;
-use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 use sui_types::dynamic_field::DynamicFieldType;
-use sui_types::error::SuiError;
 use sui_types::intent::Intent;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
@@ -1413,7 +1414,7 @@ pub async fn call_move(
     let client = context.get_client().await?;
     let data = client
         .transaction_builder()
-        .move_call::<execution_mode::Normal>(
+        .move_call(
             sender,
             package,
             module,

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -25,7 +25,6 @@ use prettytable::Table;
 use prettytable::{row, table};
 use serde::Serialize;
 use serde_json::json;
-use sui_adapter::execution_mode;
 use sui_framework::build_move_package;
 use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 use sui_types::error::SuiError;

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -8,7 +8,6 @@ use tracing::{debug, info};
 
 use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
-use sui_adapter::execution_mode;
 use sui_config::ValidatorInfo;
 use sui_core::authority_client::AuthorityAPI;
 pub use sui_core::test_utils::{compile_basics_package, wait_for_all_txes, wait_for_tx};
@@ -143,7 +142,7 @@ pub async fn submit_move_transaction(
     let client = context.get_client().await.unwrap();
     let data = client
         .transaction_builder()
-        .move_call::<execution_mode::Normal>(
+        .move_call(
             sender,
             package_ref.0,
             module,


### PR DESCRIPTION
`execution_mode` is leaking in to SDK via TransactionBuilder, this PR fixes that.