### PR TITLE
[reconfiguration] Do not revert transactions executed via state sync

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2469,6 +2469,10 @@ impl AuthorityState {
             pending_certificates.len()
         );
         for digest in pending_certificates {
+            if epoch_store.is_transaction_executed_in_checkpoint(&digest)? {
+                debug!("Not reverting pending consensus transaction {:?} - it was included in checkpoint", digest);
+                continue;
+            }
             debug!("Reverting {:?} at the end of epoch", digest);
             self.database.revert_state_update(&digest).await?;
         }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -527,7 +527,10 @@ impl CheckpointBuilder {
             let mut pending = HashSet::new();
             for effect in roots {
                 let digest = effect.transaction_digest;
-                if self.epoch_store.tx_checkpointed_in_current_epoch(&digest)? {
+                if self
+                    .epoch_store
+                    .builder_included_transaction_in_checkpoint(&digest)?
+                {
                     continue;
                 }
                 for dependency in effect.dependencies.iter() {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -298,11 +298,13 @@ impl SuiNode {
             .close_epoch(&self.state.epoch_store())
     }
 
-    pub fn tx_checkpointed_in_current_epoch(&self, digest: &TransactionDigest) -> SuiResult<bool> {
-        Ok(self
-            .state
+    pub fn is_transaction_executed_in_checkpoint_this_epoch(
+        &self,
+        digest: &TransactionDigest,
+    ) -> SuiResult<bool> {
+        self.state
             .epoch_store()
-            .tx_checkpointed_in_current_epoch(digest)?)
+            .is_transaction_executed_in_checkpoint(digest)
     }
 
     fn create_p2p_network(

--- a/crates/sui/tests/checkpoint_tests.rs
+++ b/crates/sui/tests/checkpoint_tests.rs
@@ -47,7 +47,10 @@ async fn basic_checkpoints_integration_test() {
 
     for _ in 0..600 {
         let all_included = authorities.iter().all(|handle| {
-            handle.with(|node| node.tx_checkpointed_in_current_epoch(tx.digest()).unwrap())
+            handle.with(|node| {
+                node.is_transaction_executed_in_checkpoint_this_epoch(tx.digest())
+                    .unwrap()
+            })
         });
         if all_included {
             // success


### PR DESCRIPTION
There is a condition where we can attempt to revert final transaction: we can have transaction that we proposed to consensus, but epoch ended via state sync before we reached end of consensus stream. In that case we might attempt to revert transaction that is actually final.

This PR fixes this problem by recording all executed transactions in the epoch table and then verifying that only transactions that were not executed as part of checkpoint process are reverted.

This diff works under assumption that all checkpoints(both for checkpoints that are locally created and synchronized from remote) go through checkpoint executor.