### PR TITLE
Ignore RUSTSEC-2023-0001

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -52,7 +52,9 @@ ignore = [
     # potential segfault in the time crate, brought by chrono et al.
     "RUSTSEC-2020-0071",
     # potential segfault in localtime_r, brought by chrono et al.
-    "RUSTSEC-2020-0159"
+    "RUSTSEC-2020-0159",
+    # On Windows, configuring a named pipe server with [pipe_mode] will force [ServerOptions]::[reject_remote_clients] as `false`.
+    "RUSTSEC-2023-0001"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/narwhal/deny.toml
+++ b/narwhal/deny.toml
@@ -49,6 +49,8 @@ notice = "warn"
 # output a note when they are encountered.
 ignore = [
     #"RUSTSEC-0000-0000",
+    # On Windows, configuring a named pipe server with [pipe_mode] will force [ServerOptions]::[reject_remote_clients] as `false`.
+    "RUSTSEC-2023-0001"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
Sui does not use named pipes (on Windows or otherwise)