### PR TITLE
wallet-ext,wallet-adapters,wallet-kit-core: handle disconnecting dapp using wallet

### DIFF
--- a/.changeset/fuzzy-comics-leave.md
+++ b/.changeset/fuzzy-comics-leave.md
@@ -1,0 +1,6 @@
+---
+"@mysten/wallet-kit-core": minor
+---
+
+- Disconnect wallet kit when selected wallet disconnects
+- Make disconnect async

--- a/.changeset/nine-weeks-arrive.md
+++ b/.changeset/nine-weeks-arrive.md
@@ -1,0 +1,7 @@
+---
+"@mysten/wallet-adapter-wallet-standard": minor
+"@mysten/wallet-adapter-unsafe-burner": minor
+"@mysten/wallet-adapter-base": minor
+---
+
+- Support wallet adapter events

--- a/apps/wallet/src/background/index.ts
+++ b/apps/wallet/src/background/index.ts
@@ -44,6 +44,10 @@ Permissions.permissionReply.subscribe((permission) => {
     }
 });
 
+Permissions.on('connectedAccountsChanged', ({ origin, accounts }) => {
+    connections.notifyWalletStatusChange(origin, { accounts });
+});
+
 Keyring.on('lockedStatusUpdate', (isLocked: boolean) => {
     connections.notifyForLockedStatusUpdate(isLocked);
 });

--- a/apps/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
@@ -22,7 +22,8 @@ export type PayloadType =
     | 'disconnect-app'
     | 'done'
     | 'keyring'
-    | 'stake-request';
+    | 'stake-request'
+    | 'wallet-status-changed';
 
 export interface BasePayload {
     type: PayloadType;

--- a/apps/wallet/src/shared/messaging/messages/payloads/wallet-status-change/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/wallet-status-change/index.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { SuiAddress } from '@mysten/sui.js/src';
+import type { BasePayload, Payload } from '_payloads';
+
+export type WalletStatusChange = {
+    accounts?: SuiAddress[];
+};
+
+export interface WalletStatusChangePayload
+    extends BasePayload,
+        WalletStatusChange {
+    type: 'wallet-status-changed';
+}
+
+export function isWalletStatusChangePayload(
+    payload: Payload
+): payload is WalletStatusChangePayload {
+    return isBasePayload(payload) && payload.type === 'wallet-status-changed';
+}

--- a/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
+++ b/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  MoveCallTransaction,
   SignableTransaction,
   SuiAddress,
   SuiTransactionResponse,
 } from "@mysten/sui.js";
+
+export interface WalletAdapterEvents {
+  changed(changes: { connected?: boolean; accounts?: SuiAddress[] }): void;
+}
 
 export interface WalletAdapter {
   // Metadata
@@ -18,7 +21,10 @@ export interface WalletAdapter {
   // Connection Management
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
-
+  on: <E extends keyof WalletAdapterEvents>(
+    event: E,
+    callback: WalletAdapterEvents[E]
+  ) => () => void;
   /**
    * Suggest a transaction for the user to sign. Supports all valid transaction types.
    */

--- a/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
+++ b/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from "@mysten/sui.js";
 
 export interface WalletAdapterEvents {
-  changed(changes: { connected?: boolean; accounts?: SuiAddress[] }): void;
+  change(changes: { connected?: boolean; accounts?: SuiAddress[] }): void;
 }
 
 export interface WalletAdapter {

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -11,7 +11,10 @@ import {
   RawSigner,
   SignableTransaction,
 } from "@mysten/sui.js";
-import { WalletAdapter } from "@mysten/wallet-adapter-base";
+import {
+  WalletAdapter,
+  WalletAdapterEvents,
+} from "@mysten/wallet-adapter-base";
 
 export class UnsafeBurnerWalletAdapter implements WalletAdapter {
   name = "Unsafe Burner Wallet";
@@ -74,4 +77,11 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
     this.connecting = false;
     this.connected = false;
   }
+
+  on: <E extends keyof WalletAdapterEvents>(
+    event: E,
+    callback: WalletAdapterEvents[E]
+  ) => () => void = () => {
+    return () => {};
+  };
 }

--- a/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
+++ b/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
@@ -105,7 +105,7 @@ export class StandardWalletAdapter implements WalletAdapter {
   };
 
   async #notifyChanged() {
-    this.#events.emit("changed", {
+    this.#events.emit("change", {
       connected: this.connected,
       accounts: await this.getAccounts(),
     });

--- a/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
+++ b/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
@@ -2,18 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SignableTransaction } from "@mysten/sui.js";
-import { WalletAdapter } from "@mysten/wallet-adapter-base";
+import {
+  WalletAdapter,
+  WalletAdapterEvents,
+} from "@mysten/wallet-adapter-base";
 import { StandardWalletAdapterWallet } from "@mysten/wallet-standard";
+import mitt from "mitt";
 
 export interface StandardWalletAdapterConfig {
   wallet: StandardWalletAdapterWallet;
 }
 
+type WalletAdapterEventsMap = {
+  [E in keyof WalletAdapterEvents]: Parameters<WalletAdapterEvents[E]>[0];
+};
+
 export class StandardWalletAdapter implements WalletAdapter {
   connected = false;
   connecting = false;
 
+  readonly #events = mitt<WalletAdapterEventsMap>();
   #wallet: StandardWalletAdapterWallet;
+  #walletEventUnsubscribe: (() => void) | null = null;
 
   constructor({ wallet }: StandardWalletAdapterConfig) {
     this.#wallet = wallet;
@@ -40,6 +50,15 @@ export class StandardWalletAdapter implements WalletAdapter {
       if (this.connected || this.connecting) return;
       this.connecting = true;
 
+      this.#walletEventUnsubscribe = this.#wallet.features[
+        "standard:events"
+      ].on("change", async ({ accounts }) => {
+        if (accounts) {
+          this.connected = accounts.length > 0;
+          await this.#notifyChanged();
+        }
+      });
+
       if (!this.#wallet.accounts.length) {
         await this.#wallet.features["standard:connect"].connect();
       }
@@ -49,16 +68,21 @@ export class StandardWalletAdapter implements WalletAdapter {
       }
 
       this.connected = true;
+      await this.#notifyChanged();
     } finally {
       this.connecting = false;
     }
   }
 
   async disconnect() {
-    this.connected = false;
-    this.connecting = false;
     if (this.#wallet.features["standard:disconnect"]) {
       await this.#wallet.features["standard:disconnect"].disconnect();
+    }
+    this.connected = false;
+    this.connecting = false;
+    if (this.#walletEventUnsubscribe) {
+      this.#walletEventUnsubscribe();
+      this.#walletEventUnsubscribe = null;
     }
   }
 
@@ -67,6 +91,23 @@ export class StandardWalletAdapter implements WalletAdapter {
       "sui:signAndExecuteTransaction"
     ].signAndExecuteTransaction({
       transaction,
+    });
+  }
+
+  on: <E extends keyof WalletAdapterEvents>(
+    event: E,
+    callback: WalletAdapterEvents[E]
+  ) => () => void = (event, callback) => {
+    this.#events.on(event, callback);
+    return () => {
+      this.#events.off(event, callback);
+    };
+  };
+
+  async #notifyChanged() {
+    this.#events.emit("changed", {
+      connected: this.connected,
+      accounts: await this.getAccounts(),
     });
   }
 }

--- a/sdk/wallet-adapter/wallet-kit-core/src/index.ts
+++ b/sdk/wallet-adapter/wallet-kit-core/src/index.ts
@@ -44,7 +44,7 @@ export interface WalletKitCore {
   getState(): WalletKitCoreState;
   subscribe(handler: SubscribeHandler): Unsubscribe;
   connect(walletName: string): Promise<void>;
-  disconnect(): void;
+  disconnect(): Promise<void>;
   signAndExecuteTransaction(
     transaction: SignableTransaction
   ): Promise<SuiTransactionResponse>;
@@ -76,6 +76,7 @@ export function createWalletKitCore({
   preferredWallets = [SUI_WALLET_NAME],
 }: WalletKitCoreOptions): WalletKitCore {
   const subscriptions: Set<(state: WalletKitCoreState) => void> = new Set();
+  let walletEventUnsubscribe: (() => void) | null = null;
 
   let internalState: InternalWalletKitCoreState = {
     accounts: [],
@@ -106,6 +107,19 @@ export function createWalletKitCore({
       try {
         handler(state);
       } catch {}
+    });
+  }
+
+  function disconnected() {
+    if (walletEventUnsubscribe) {
+      walletEventUnsubscribe();
+      walletEventUnsubscribe = null;
+    }
+    setState({
+      status: WalletKitCoreConnectionStatus.DISCONNECTED,
+      accounts: [],
+      currentAccount: null,
+      currentWallet: null,
     });
   }
 
@@ -143,11 +157,22 @@ export function createWalletKitCore({
       const currentWallet =
         internalState.wallets.find((wallet) => wallet.name === walletName) ??
         null;
-
       // TODO: Should the current wallet actually be set before we successfully connect to it?
       setState({ currentWallet });
 
       if (currentWallet && !currentWallet.connecting) {
+        if (walletEventUnsubscribe) {
+          walletEventUnsubscribe();
+        }
+        walletEventUnsubscribe = currentWallet.on(
+          "changed",
+          ({ connected }) => {
+            // when undefined connected hasn't changed
+            if (connected === false) {
+              disconnected();
+            }
+          }
+        );
         try {
           setState({ status: WalletKitCoreConnectionStatus.CONNECTING });
           await currentWallet.connect();
@@ -167,19 +192,13 @@ export function createWalletKitCore({
       }
     },
 
-    disconnect() {
+    async disconnect() {
       if (!internalState.currentWallet) {
         console.warn("Attempted to `disconnect` but no wallet was connected.");
         return;
       }
-
-      internalState.currentWallet.disconnect();
-      setState({
-        status: WalletKitCoreConnectionStatus.DISCONNECTED,
-        accounts: [],
-        currentAccount: null,
-        currentWallet: null,
-      });
+      await internalState.currentWallet.disconnect();
+      disconnected();
     },
 
     signAndExecuteTransaction(transaction) {

--- a/sdk/wallet-adapter/wallet-kit-core/src/index.ts
+++ b/sdk/wallet-adapter/wallet-kit-core/src/index.ts
@@ -164,15 +164,12 @@ export function createWalletKitCore({
         if (walletEventUnsubscribe) {
           walletEventUnsubscribe();
         }
-        walletEventUnsubscribe = currentWallet.on(
-          "changed",
-          ({ connected }) => {
-            // when undefined connected hasn't changed
-            if (connected === false) {
-              disconnected();
-            }
+        walletEventUnsubscribe = currentWallet.on("change", ({ connected }) => {
+          // when undefined connected hasn't changed
+          if (connected === false) {
+            disconnected();
           }
-        );
+        });
         try {
           setState({ status: WalletKitCoreConnectionStatus.CONNECTING });
           await currentWallet.connect();


### PR DESCRIPTION
fix the case where user disconnects from a dapp using the wallet and wallet-kit was staying in connected state

* wallet-ext: emit events when connected accounts change
* wallet-adapters: emit events when connected status changes
* wallet-kit-core: listen for connection status events and update state


https://user-images.githubusercontent.com/10210143/211874732-a677b30b-3b87-42aa-87a8-82311e9a5f4c.mov

part of APPS-308