### PR TITLE
indexer: hardcode RPC client URL

### DIFF
--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -9,7 +9,7 @@ use backoff::ExponentialBackoff;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
-use tracing::info;
+use tracing::{info, warn};
 
 pub mod errors;
 pub mod models;
@@ -21,11 +21,14 @@ pub type PgPoolConnection = PooledConnection<ConnectionManager<PgConnection>>;
 
 use errors::IndexerError;
 
+pub const RPC_CLIENT_URL: &str = "https://fullnode.devnet.sui.io:443";
+
 pub async fn new_rpc_client(http_url: String) -> Result<SuiClient, IndexerError> {
-    info!("Getting new rpc client...");
+    info!("Getting new RPC client...");
     SuiClient::new(http_url.as_str(), None, None)
         .await
         .map_err(|e| {
+            warn!("Failed to get new RPC client with error: {:?}", e);
             IndexerError::RpcClientInitError(format!(
                 "Failed to initialize fullnode RPC client with error: {:?}",
                 e

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -3,7 +3,7 @@
 
 use std::env;
 use sui_indexer::errors::IndexerError;
-use sui_indexer::{new_pg_connection_pool, new_rpc_client};
+use sui_indexer::{new_pg_connection_pool, new_rpc_client, RPC_CLIENT_URL};
 
 use backoff::future::retry;
 use backoff::ExponentialBackoff;
@@ -27,7 +27,7 @@ async fn main() -> Result<(), IndexerError> {
 
     let indexer_config = IndexerConfig::parse();
     retry(ExponentialBackoff::default(), || async {
-        let rpc_client = new_rpc_client(indexer_config.rpc_client_url.clone()).await?;
+        let rpc_client = new_rpc_client(RPC_CLIENT_URL.into()).await?;
         let pg_connection_pool = new_pg_connection_pool(indexer_config.db_url.clone()).await?;
         // NOTE: Each handler is responsible for one type of data from nodes,like transactions and events;
         // Handler orchestrator runs these handlers in parallel and manage them upon errors etc.
@@ -63,6 +63,4 @@ async fn main() -> Result<(), IndexerError> {
 struct IndexerConfig {
     #[clap(long)]
     db_url: String,
-    #[clap(long)]
-    rpc_client_url: String,
 }


### PR DESCRIPTION
The context is https://mysten-labs.slack.com/archives/C03GKUEA5PF/p1673307642213839
It's not great but will hardcode the URL for now to unblock, also added logging for RPC client connection err.

Tested locally to make sure that the RPC connection succeeds and tables are populated.