### PR TITLE
[Narwhal] Add a wait after certificate fetching fails against all peers

### DIFF
--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -100,6 +100,9 @@ pub enum DagError {
         local_time: TimestampMs,
     },
 
+    #[error("No peer can be reached for fetching certificates! Check if network is healthy.")]
+    NoCertificateFetched,
+
     #[error("Too many certificates in the FetchCertificatesResponse {0} > {1}")]
     TooManyFetchedCertificatesReturned(usize, usize),
 


### PR DESCRIPTION
It is possible for certificate fetching to fail against all peers immediately. So a delay is needed before fetching is retried.

There should be no issues of increasing latencies, because it is rare to have all peers unavailable. Most likely there is a local issue.

Passed test at 05c39cdba with
```
MSIM_TEST_SEED=12827887558300077306 USE_MOCK_CRYPTO=1 RUST_LOG=sui=debug,msim=error,narwhal=debug,info cargo simtest --test reconfiguration_tests test_passive_reconfig --run-ignored all
```