### PR TITLE
[move] A prototype of Sui memory model support in the Prover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4200,7 +4200,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4217,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -4230,12 +4230,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4274,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "difference",
@@ -4354,7 +4354,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4402,7 +4402,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4440,7 +4440,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4458,7 +4458,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4472,7 +4472,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4491,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4510,7 +4510,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "hex",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "hex",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4563,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4664,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4675,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "hex",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "once_cell",
  "serde 1.0.151",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "better_any",
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -4864,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7020,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
+source = "git+https://github.com/move-language/move?rev=84dfb01e00e7778e6fd035335290ad156e6caac0#84dfb01e00e7778e6fd035335290ad156e6caac0"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4200,7 +4200,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4217,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -4230,12 +4230,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4274,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "difference",
@@ -4354,7 +4354,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4402,7 +4402,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4440,7 +4440,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4458,7 +4458,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4472,7 +4472,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4491,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4510,7 +4510,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "hex",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "hex",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4563,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4664,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4675,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "hex",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "once_cell",
  "serde 1.0.151",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "better_any",
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -4864,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7020,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=a8e95cbae69564d8928c9873b8acfabc50e642cf#a8e95cbae69564d8928c9873b8acfabc50e642cf"
+source = "git+https://github.com/move-language/move?rev=c109370befdea189e43cd796ddfb5ede44cccb70#c109370befdea189e43cd796ddfb5ede44cccb70"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,26 +104,26 @@ opt-level = 1
 tokio = "1.22.0"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-cli = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", features = ["address20"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-package = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-prover = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-cli = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["address20"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-package = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-prover = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "f64e36ceed674ccd46938cfd9645a2d32a923656" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "f64e36ceed674ccd46938cfd9645a2d32a923656", package = "fastcrypto-zkp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,26 +104,26 @@ opt-level = 1
 tokio = "1.22.0"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-cli = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["address20"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-package = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-prover = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-cli = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", features = ["address20"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-package = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-prover = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "f64e36ceed674ccd46938cfd9645a2d32a923656" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "f64e36ceed674ccd46938cfd9645a2d32a923656", package = "fastcrypto-zkp" }

--- a/crates/sui-framework/docs/dynamic_field.md
+++ b/crates/sui-framework/docs/dynamic_field.md
@@ -161,6 +161,18 @@ Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExist
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> intrinsic;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_dynamic_field_borrow"></a>
 
 ## Function `borrow`

--- a/crates/sui-framework/docs/prover.md
+++ b/crates/sui-framework/docs/prover.md
@@ -5,14 +5,110 @@
 
 
 
--  [Module Specification](#@Module_Specification_0)
+-  [Resource `Ownership`](#0x2_prover_Ownership)
+-  [Resource `DynamicFields`](#0x2_prover_DynamicFields)
+-  [Constants](#@Constants_0)
+-  [Module Specification](#@Module_Specification_1)
 
 
-<pre><code></code></pre>
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+</code></pre>
 
 
 
-<a name="@Module_Specification_0"></a>
+<a name="0x2_prover_Ownership"></a>
+
+## Resource `Ownership`
+
+
+
+<pre><code><b>struct</b> <a href="prover.md#0x2_prover_Ownership">Ownership</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>owner: <a href="_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>status: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_prover_DynamicFields"></a>
+
+## Resource `DynamicFields`
+
+
+
+<pre><code><b>struct</b> <a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K: <b>copy</b>, drop, store&gt; <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>names: <a href="">vector</a>&lt;K&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_prover_IMMUTABLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="prover.md#0x2_prover_IMMUTABLE">IMMUTABLE</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_prover_OWNED"></a>
+
+
+
+<pre><code><b>const</b> <a href="prover.md#0x2_prover_OWNED">OWNED</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_prover_SHARED"></a>
+
+
+
+<pre><code><b>const</b> <a href="prover.md#0x2_prover_SHARED">SHARED</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
@@ -21,7 +117,12 @@
 <a name="0x2_prover_owned"></a>
 
 
-<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_owned">owned</a>(memory: <b>address</b>, owner_map: <b>address</b>, id: <b>address</b>): bool;
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_owned">owned</a>&lt;T: key&gt;(obj: T): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
+   <a href="_is_some">option::is_some</a>(<b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner) &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a>
+}
 </code></pre>
 
 
@@ -30,7 +131,12 @@
 <a name="0x2_prover_owned_by"></a>
 
 
-<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_owned_by">owned_by</a>(memory: <b>address</b>, owner_map: <b>address</b>, id: <b>address</b>, owner: <b>address</b>): bool;
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_owned_by">owned_by</a>&lt;T: key&gt;(obj: T, owner: <b>address</b>): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner == <a href="_spec_some">option::spec_some</a>(owner) &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a>
+}
 </code></pre>
 
 
@@ -39,5 +145,81 @@
 <a name="0x2_prover_shared"></a>
 
 
-<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_shared">shared</a>(memory: <b>address</b>, owner_map: <b>address</b>, id: <b>address</b>): bool;
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_shared">shared</a>&lt;T: key&gt;(obj: T): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
+   <a href="_is_none">option::is_none</a>(<b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner) &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_SHARED">SHARED</a>
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_immutable"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_immutable">immutable</a>&lt;T: key&gt;(obj: T): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
+   <a href="_is_none">option::is_none</a>(<b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner) &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_IMMUTABLE">IMMUTABLE</a>
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_has_field"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_has_field">has_field</a>&lt;T: key, K: <b>copy</b> + drop + store&gt;(obj: T, name: K): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K&gt;(addr, name)
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_num_fields"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_num_fields">num_fields</a>&lt;T: key, K: <b>copy</b> + drop + store&gt;(obj: T): u64 {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>if</b> (!<b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr)) {
+       0
+   } <b>else</b> {
+       len(<b>global</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr).names)
+   }
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_uid_has_field"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K: <b>copy</b> + drop + store&gt;(addr: <b>address</b>, name: K): bool {
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr) && contains(<b>global</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr).names, name)
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_vec_remove"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_vec_remove">vec_remove</a>&lt;T&gt;(v: <a href="">vector</a>&lt;T&gt;, elem_idx: u64, current_idx: u64) : <a href="">vector</a>&lt;T&gt; {
+   <b>let</b> len = len(v);
+   <b>if</b> (current_idx != len) {
+       vec()
+   } <b>else</b> <b>if</b> (current_idx != elem_idx) {
+       concat(vec(v[current_idx]), <a href="prover.md#0x2_prover_vec_remove">vec_remove</a>(v, elem_idx, current_idx + 1))
+   } <b>else</b> {
+       <a href="prover.md#0x2_prover_vec_remove">vec_remove</a>(v, elem_idx, current_idx + 1)
+   }
+}
 </code></pre>

--- a/crates/sui-framework/docs/prover.md
+++ b/crates/sui-framework/docs/prover.md
@@ -1,0 +1,25 @@
+
+<a name="0x2_prover"></a>
+
+# Module `0x2::prover`
+
+
+
+-  [Module Specification](#@Module_Specification_0)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Module_Specification_0"></a>
+
+## Module Specification
+
+
+
+<a name="0x2_prover_owned"></a>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_owned">owned</a>(memory: <b>address</b>, id: <b>address</b>): bool;
+</code></pre>

--- a/crates/sui-framework/docs/prover.md
+++ b/crates/sui-framework/docs/prover.md
@@ -23,3 +23,21 @@
 
 <pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_owned">owned</a>(memory: <b>address</b>, id: <b>address</b>): bool;
 </code></pre>
+
+
+
+
+<a name="0x2_prover_owned_by"></a>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_owned_by">owned_by</a>(memory: <b>address</b>, id: <b>address</b>, owner: <b>address</b>): bool;
+</code></pre>
+
+
+
+
+<a name="0x2_prover_shared"></a>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_shared">shared</a>(memory: <b>address</b>, id: <b>address</b>): bool;
+</code></pre>

--- a/crates/sui-framework/docs/prover.md
+++ b/crates/sui-framework/docs/prover.md
@@ -21,7 +21,7 @@
 <a name="0x2_prover_owned"></a>
 
 
-<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_owned">owned</a>(memory: <b>address</b>, id: <b>address</b>): bool;
+<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_owned">owned</a>(memory: <b>address</b>, owner_map: <b>address</b>, id: <b>address</b>): bool;
 </code></pre>
 
 
@@ -30,7 +30,7 @@
 <a name="0x2_prover_owned_by"></a>
 
 
-<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_owned_by">owned_by</a>(memory: <b>address</b>, id: <b>address</b>, owner: <b>address</b>): bool;
+<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_owned_by">owned_by</a>(memory: <b>address</b>, owner_map: <b>address</b>, id: <b>address</b>, owner: <b>address</b>): bool;
 </code></pre>
 
 
@@ -39,5 +39,5 @@
 <a name="0x2_prover_shared"></a>
 
 
-<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_shared">shared</a>(memory: <b>address</b>, id: <b>address</b>): bool;
+<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_shared">shared</a>(memory: <b>address</b>, owner_map: <b>address</b>, id: <b>address</b>): bool;
 </code></pre>

--- a/crates/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/sources/dynamic_field.move
@@ -56,6 +56,10 @@ public fun add<Name: copy + drop + store, Value: store>(
     add_child_object(object_addr, field)
 }
 
+spec add {
+    pragma intrinsic;
+}
+
 /// Immutably borrows the `object`s dynamic field with the name specified by `name: Name`.
 /// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
 /// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -160,7 +160,7 @@ module sui::object {
     public fun calibrate_address_from_bytes(bytes: vector<u8>) {
         sui::address::from_bytes(bytes);
     }
-    
+
     #[test_only]
     public fun calibrate_address_from_bytes_nop(bytes: vector<u8>) {
         let _ = bytes;

--- a/crates/sui-framework/sources/prover.move
+++ b/crates/sui-framework/sources/prover.move
@@ -3,10 +3,96 @@
 
 module sui::prover {
 
-    spec native fun owned(memory: address, owner_map: address, id: address): bool;
+    use std::option;
+    use std::vector;
+    use sui::object;
 
-    spec native fun owned_by(memory: address, owner_map: address, id: address, owner: address): bool;
+    const OWNED: u64 = 1;
+    const SHARED: u64 = 2;
+    const IMMUTABLE: u64 = 3;
 
-    spec native fun shared(memory: address, owner_map: address, id: address): bool;
+
+    #[verify_only]
+    struct Ownership has key {
+        owner: option::Option<address>,
+        status: u64,
+    }
+
+    #[verify_only]
+    struct DynamicFields<K: copy + drop + store> has key {
+        names: vector<K>,
+    }
+
+    // "public" functions to be used in specs as an equivalent of core Prover's builtins
+
+    spec fun owned<T: key>(obj: T): bool {
+        let addr = object::id(obj).bytes;
+        exists<Ownership>(addr) &&
+        option::is_some(global<Ownership>(addr).owner) &&
+        global<Ownership>(addr).status == OWNED
+    }
+
+    spec fun owned_by<T: key>(obj: T, owner: address): bool {
+        let addr = object::id(obj).bytes;
+        exists<Ownership>(addr) &&
+        global<Ownership>(addr).owner == option::spec_some(owner) &&
+        global<Ownership>(addr).status == OWNED
+    }
+
+        /*
+    spec fun is_field_of<T: key>(obj: T, owner: sui::object::UID): bool {
+        let addr = object::id(obj).bytes;
+        exists<Ownership>(addr) &&
+        global<Ownership>(addr).owner == option::spec_some(owner) &&
+        global<Ownership>(addr).status == OWNED
+}
+        */
+
+    spec fun shared<T: key>(obj: T): bool {
+        let addr = object::id(obj).bytes;
+        exists<Ownership>(addr) &&
+        option::is_none(global<Ownership>(addr).owner) &&
+        global<Ownership>(addr).status == SHARED
+    }
+
+    spec fun immutable<T: key>(obj: T): bool {
+        let addr = object::id(obj).bytes;
+        exists<Ownership>(addr) &&
+        option::is_none(global<Ownership>(addr).owner) &&
+        global<Ownership>(addr).status == IMMUTABLE
+    }
+
+    spec fun has_field<T: key, K: copy + drop + store>(obj: T, name: K): bool {
+        let addr = object::id(obj).bytes;
+        uid_has_field<K>(addr, name)
+    }
+
+    spec fun num_fields<T: key, K: copy + drop + store>(obj: T): u64 {
+        let addr = object::id(obj).bytes;
+        if (!exists<DynamicFields<K>>(addr)) {
+            0
+        } else {
+            len(global<DynamicFields<K>>(addr).names)
+        }
+    }
+
+    // "helper" function - may also be used in specs but mostly opaque ones defining behavior of key
+    // framework functions
+
+    spec fun uid_has_field<K: copy + drop + store>(addr: address, name: K): bool {
+        exists<DynamicFields<K>>(addr) && contains(global<DynamicFields<K>>(addr).names, name)
+    }
+
+    // remove an element at index from a vector and return the resulting vector
+    spec fun vec_remove<T>(v: vector<T>, elem_idx: u64, current_idx: u64) : vector<T> {
+        let len = len(v);
+        if (current_idx != len) {
+            vec()
+        } else if (current_idx != elem_idx) {
+            concat(vec(v[current_idx]), vec_remove(v, elem_idx, current_idx + 1))
+        } else {
+            vec_remove(v, elem_idx, current_idx + 1)
+        }
+    }
 
 }

--- a/crates/sui-framework/sources/prover.move
+++ b/crates/sui-framework/sources/prover.move
@@ -3,10 +3,10 @@
 
 module sui::prover {
 
-    spec native fun owned(memory: address, id: address): bool;
+    spec native fun owned(memory: address, owner_map: address, id: address): bool;
 
-    spec native fun owned_by(memory: address, id: address, owner: address): bool;
+    spec native fun owned_by(memory: address, owner_map: address, id: address, owner: address): bool;
 
-    spec native fun shared(memory: address, id: address): bool;
+    spec native fun shared(memory: address, owner_map: address, id: address): bool;
 
 }

--- a/crates/sui-framework/sources/prover.move
+++ b/crates/sui-framework/sources/prover.move
@@ -5,4 +5,8 @@ module sui::prover {
 
     spec native fun owned(memory: address, id: address): bool;
 
+    spec native fun owned_by(memory: address, id: address, owner: address): bool;
+
+    spec native fun shared(memory: address, id: address): bool;
+
 }

--- a/crates/sui-framework/sources/prover.move
+++ b/crates/sui-framework/sources/prover.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::prover {
+
+    spec native fun owned(memory: address, id: address): bool;
+
+}

--- a/crates/sui-framework/sources/test_scenario.move
+++ b/crates/sui-framework/sources/test_scenario.move
@@ -229,7 +229,7 @@ module sui::test_scenario {
     public fun return_to_address<T: key>(account: address, t: T) {
         let id = object::id(&t);
         assert!(was_taken_from_address(account, id), ECantReturnObject);
-        sui::transfer::transfer(t, account)
+        sui::transfer::transfer(t, account);
     }
 
     /// Returns true if the object with `ID` id was in the inventory for `account`

--- a/crates/sui/src/sui_move/prove.rs
+++ b/crates/sui/src/sui_move/prove.rs
@@ -81,8 +81,6 @@ impl Prove {
             ),
         );
 
-        options.model_builder.globals_access = vec!["owner".to_string()];
-
         let prover_result = std::thread::spawn(move || {
             prove::run_move_prover(
                 build_config,

--- a/crates/sui/src/sui_move/prove.rs
+++ b/crates/sui/src/sui_move/prove.rs
@@ -80,6 +80,7 @@ impl Prove {
                 "UpdateDynField".to_string(),
             ),
         );
+        options.backend.memory_type = Some("$SuiMemory".to_string());
 
         let prover_result = std::thread::spawn(move || {
             prove::run_move_prover(

--- a/crates/sui/src/sui_move/prove.rs
+++ b/crates/sui/src/sui_move/prove.rs
@@ -80,7 +80,8 @@ impl Prove {
                 "UpdateDynField".to_string(),
             ),
         );
-        options.backend.memory_type = Some("$SuiMemory".to_string());
+
+        options.model_builder.globals_access = vec!["owner".to_string()];
 
         let prover_result = std::thread::spawn(move || {
             prove::run_move_prover(

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -14,6 +14,10 @@ procedure {:inline 1} $2_address_from_u256(num: int) returns (res: int);
 // ==================================================================================
 // Native transfer
 
+function {:inline} ownership_update<T>(m: $Memory T, id: int, v: T): $Memory T {
+    $Memory(domain#$Memory(m)[id := true], contents#$Memory(m)[id := v])
+}
+
 {%- for instance in transfer_instances %}
 
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
@@ -23,27 +27,40 @@ procedure {:inline 1} $2_address_from_u256(num: int) returns (res: int);
 // Native transfer implementation for object type `{{instance.suffix}}`
 
 
-//procedure {:inline 1} $2_transfer_transfer_internal{{S}}(obj: {{T}}, recipient: int);
 
 procedure {:inline 1} $2_transfer_transfer_internal{{S}}(obj: {{T}}, recipient: int) {
     var id: int;
-    id := $bytes#$2_object_ID($id#$2_object_UID($id#{{T}}(obj)));
-    owner[id] := $ObjState(false, recipient);
-    {{T}}_$memory := transfer({{T}}_$memory, id, obj, recipient);
+    var v: $2_prover_Ownership;
+    id := $bytes#$2_object_ID($2_object_$id{{S}}(obj));
+    v := $2_prover_Ownership($1_option_spec_some'address'(recipient), 1);
+    $2_prover_Ownership_$memory := ownership_update($2_prover_Ownership_$memory, id, v);
 }
 
 procedure {:inline 1} $2_transfer_share_object{{S}}(obj: {{T}}) {
     var id: int;
-    id := $bytes#$2_object_ID($id#$2_object_UID($id#{{T}}(obj)));
-    if ($2_prover_owned({{T}}_$memory, owner, id)) {
+    var v: $2_prover_Ownership;
+    if ($2_prover_owned{{S}}($2_prover_Ownership_$memory, obj)) {
         call $ExecFailureAbort();
         return;
     }
-    owner[id] := $ObjState(true, 0);
-    {{T}}_$memory := share({{T}}_$memory, id, obj);
+    
+    id := $bytes#$2_object_ID($2_object_$id{{S}}(obj));
+    v := $2_prover_Ownership($1_option_Option'address'(EmptyVec()), 2);
+    $2_prover_Ownership_$memory := ownership_update($2_prover_Ownership_$memory, id, v);
 }
 
-procedure {:inline 1} $2_transfer_freeze_object{{S}}(obj: {{T}});
+procedure {:inline 1} $2_transfer_freeze_object{{S}}(obj: {{T}}) {
+    var id: int;
+    var v: $2_prover_Ownership;
+    if ($2_prover_owned{{S}}($2_prover_Ownership_$memory, obj)) {
+        call $ExecFailureAbort();
+        return;
+    }
+    
+    id := $bytes#$2_object_ID($2_object_$id{{S}}(obj));
+    v := $2_prover_Ownership($1_option_Option'address'(EmptyVec()), 3);
+    $2_prover_Ownership_$memory := ownership_update($2_prover_Ownership_$memory, id, v);
+}
 
 {%- endfor %}
 
@@ -65,6 +82,11 @@ procedure {:inline 1} $2_object_record_new_uid(id: int);
 procedure {:inline 1} $2_object_borrow_uid{{S}}(obj: {{T}}) returns (res: $2_object_UID) {
     res := $id#{{T}}(obj);
 }
+
+function $2_object_$borrow_uid{{S}}(obj: {{T}}): $2_object_UID {
+    $id#{{T}}(obj)
+}
+
 
 {%- endfor %}
 
@@ -110,8 +132,35 @@ procedure {:inline 1} $2_types_is_one_time_witness{{S}}(_: {{T}}) returns (res: 
 
 procedure {:inline 1} $2_dynamic_field_has_child_object(parent: int, id: int) returns (res: bool);
 
-{%- for instance in dynamic_field_instances %}
+{%- for instance_0 in dynamic_field_instances %}
+{%- for instance_1 in dynamic_field_instances %}
+{%- set S = "'" ~ instance_0.suffix ~ "'" -%}
+{%- set T = instance_0.name -%}
+{%- set K = "'" ~ instance_0.suffix ~ "_" ~ instance_1.suffix ~ "'" -%}
 
+// ----------------------------------------------------------------------------------
+// Native dynamic field implementation for object type `{{instance_0.suffix}}_{{instance_1.suffix}}
+// This may be suboptimal as this template will be expanded for all combinations of concrete types
+// but handling it probelry would require non-trivial changes to prelude generation code in the core Move repo 
+
+procedure {:inline 1} $2_dynamic_field_add{{K}}(parent: $Mutation $2_object_UID, name: {{T}}, value: {{T}}) returns (res: $Mutation $2_object_UID) {
+    var id: int;
+    var v: $2_prover_DynamicFields{{S}};
+    id := $bytes#$2_object_ID($id#$2_object_UID($Dereference(parent)));
+    if ($2_prover_uid_has_field{{S}}($2_prover_DynamicFields{{S}}_$memory, id, name)) {
+        call $ExecFailureAbort();
+        return;
+    }
+    v := $2_prover_DynamicFields{{S}}(ExtendVec($names#$2_prover_DynamicFields{{S}}($ResourceValue($2_prover_DynamicFields{{S}}_$memory, id)), name));
+    $2_prover_DynamicFields{{S}}_$memory := ownership_update($2_prover_DynamicFields{{S}}_$memory, id, v);
+    res := parent;    
+}
+
+{%- endfor %}
+{%- endfor %}
+
+
+{%- for instance in dynamic_field_instances %}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
 {%- set T = instance.name -%}
 
@@ -138,48 +187,6 @@ procedure {:inline 1} $2_dynamic_field_has_child_object_with_ty{{S}}(parent: int
 function GetDynField<T, V>(o: T, addr: int): V;
 
 function UpdateDynField<T, V>(o: T, addr: int, v: V): T;
-
-// ==================================================================================
-// Spec native functions to be used in specs to tap into Sui storage model
-
-
-// Representation of object state. The owner value is meaningless if object is shared,
-// otherwise itcontains address of the object owner
-
-type {:datatype} $ObjState;
-function {:constructor} $ObjState(shared: bool, owner: int): $ObjState;
-
-
-// Representation of memory for a given type.
-//type {:datatype} $SuiMemory _;
-
-//function {:constructor} $SuiMemory<T>(domain: [int]bool, contents: [int]T): $SuiMemory T;
-
-var owner: [int]$ObjState;
-
-// Functions to change memory state used in in native function Boogie implementations
-
-function {:inline} transfer<T>(m: $Memory T, id: int, v: T, recipient: int): $Memory T {
-    $Memory(domain#$Memory(m)[id := true], contents#$Memory(m)[id := v])
-}
-
-function {:inline} share<T>(m: $Memory T, id: int, v: T): $Memory T {
-    $Memory(domain#$Memory(m)[id := true], contents#$Memory(m)[id := v])
-}
-
-// Functions to query memory state
-
-function {:inline} $2_prover_owned<T>(m: $Memory T, o: [int]$ObjState, id: int): bool {
-    domain#$Memory(m)[id] && !shared#$ObjState(o[id])
-}
-
-function {:inline} $2_prover_owned_by<T>(m: $Memory T, o: [int]$ObjState, id: int, owner: int): bool {
-    domain#$Memory(m)[id] && !shared#$ObjState(o[id]) && owner#$ObjState(o[id]) == owner
-}
-
-function {:inline} $2_prover_shared<T>(m: $Memory T, o: [int]$ObjState, id: int): bool {
-    domain#$Memory(m)[id] && shared#$ObjState(o[id])
-}
 
 
 

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -27,13 +27,13 @@ procedure {:inline 1} $2_address_from_u256(num: int) returns (res: int);
 
 procedure {:inline 1} $2_transfer_transfer_internal{{S}}(obj: {{T}}, recipient: int) {
     var id: int;
-    call id := $2_object_id_address{{S}}(obj);
+    id := $bytes#$2_object_ID($id#$2_object_UID($id#{{T}}(obj)));
     {{T}}_$memory := transfer({{T}}_$memory, id, obj, recipient);
 }
 
 procedure {:inline 1} $2_transfer_share_object{{S}}(obj: {{T}}) {
     var id: int;
-    call id := $2_object_id_address{{S}}(obj);
+    id := $bytes#$2_object_ID($id#$2_object_UID($id#{{T}}(obj)));
     if ($2_prover_owned({{T}}_$memory, id)) {
         call $ExecFailureAbort();
         return;

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -28,10 +28,14 @@ procedure {:inline 1} $2_address_from_u256(num: int) returns (res: int);
 procedure {:inline 1} $2_transfer_transfer_internal{{S}}(obj: {{T}}, recipient: int) {
     var id: int;
     call id := $2_object_id_address{{S}}(obj);
-    {{T}}_$memory := transfer({{T}}_$memory, id, obj);
+    {{T}}_$memory := transfer({{T}}_$memory, id, obj, recipient);
 }
 
-procedure {:inline 1} $2_transfer_share_object{{S}}(obj: {{T}});
+procedure {:inline 1} $2_transfer_share_object{{S}}(obj: {{T}}) {
+    var id: int;
+    call id := $2_object_id_address{{S}}(obj);
+    {{T}}_$memory := share({{T}}_$memory, id, obj);
+}
 
 procedure {:inline 1} $2_transfer_freeze_object{{S}}(obj: {{T}});
 
@@ -133,18 +137,44 @@ function UpdateDynField<T, V>(o: T, addr: int, v: V): T;
 // Spec native functions to be used in specs to tap into Sui storage model
 
 
+// Representation of object state. The owner value is meaningless if object is shared,
+// otherwise itcontains address of the object owner
+
+type {:datatype} $ObjState;
+function {:constructor} $ObjState(shared: bool, owner: int): $ObjState;
+
+
 // Representation of memory for a given type.
 type {:datatype} $SuiMemory _;
 
-function {:constructor} $SuiMemory<T>(domain: [int]bool, contents: [int]T): $SuiMemory T;
+function {:constructor} $SuiMemory<T>(domain: [int]bool, contents: [int]T, owner: [int]$ObjState): $SuiMemory T;
+
+
+// Functions to change memory state used in in native function Boogie implementations
+
+function {:inline} transfer<T>(m: $SuiMemory T, id: int, v: T, recipient: int): $SuiMemory T {
+    $SuiMemory(domain#$SuiMemory(m)[id := true], contents#$SuiMemory(m)[id := v], owner#$SuiMemory(m)[id := $ObjState(false, recipient)])
+}
+
+function {:inline} share<T>(m: $SuiMemory T, id: int, v: T): $SuiMemory T {
+    $SuiMemory(domain#$SuiMemory(m)[id := true], contents#$SuiMemory(m)[id := v], owner#$SuiMemory(m)[id := $ObjState(true, 0)])
+}
+
+// Functions to query memory state
 
 function {:inline} $2_prover_owned<T>(m: $SuiMemory T, id: int): bool {
-    domain#$SuiMemory(m)[id]
+    domain#$SuiMemory(m)[id] && !shared#$ObjState(owner#$SuiMemory(m)[id])
 }
 
-function {:inline} transfer<T>(m: $SuiMemory T, id: int, v: T): $SuiMemory T {
-    $SuiMemory(domain#$SuiMemory(m)[id := true], contents#$SuiMemory(m)[id := v])
+function {:inline} $2_prover_owned_by<T>(m: $SuiMemory T, id: int, owner: int): bool {
+    domain#$SuiMemory(m)[id] && !shared#$ObjState(owner#$SuiMemory(m)[id]) && owner#$ObjState(owner#$SuiMemory(m)[id]) == owner
 }
+
+function {:inline} $2_prover_shared<T>(m: $SuiMemory T, id: int): bool {
+    domain#$SuiMemory(m)[id] && shared#$ObjState(owner#$SuiMemory(m)[id])
+}
+
+
 
 
 

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -34,6 +34,10 @@ procedure {:inline 1} $2_transfer_transfer_internal{{S}}(obj: {{T}}, recipient: 
 procedure {:inline 1} $2_transfer_share_object{{S}}(obj: {{T}}) {
     var id: int;
     call id := $2_object_id_address{{S}}(obj);
+    if ($2_prover_owned({{T}}_$memory, id)) {
+        call $ExecFailureAbort();
+        return;
+    }
     {{T}}_$memory := share({{T}}_$memory, id, obj);
 }
 

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -93,7 +93,7 @@ bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2", default-features = 
 bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", features = ["alloc", "std", "unicode"] }
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
 byte-slice-cast = { version = "1", features = ["std"] }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", features = ["fiat"] }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
@@ -319,41 +319,41 @@ miniz_oxide = { version = "0.6", default-features = false, features = ["with-all
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-cli = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-cli = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
 multiaddr = { version = "0.17", features = ["url"] }
 multibase = { version = "0.9", features = ["std"] }
 multihash = { version = "0.17", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
@@ -458,8 +458,8 @@ rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen-93f6ce9d446188ac = { package = "rcgen", version = "0.10", features = ["pem", "x509-parser"] }
 rcgen-274715c4dabd11b0 = { package = "rcgen", version = "0.9", features = ["pem"] }
-read-write-set = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", features = ["regex-syntax", "std"] }
@@ -738,7 +738,7 @@ bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", features = ["alloc", 
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
 bumpalo = { version = "3" }
 byte-slice-cast = { version = "1", features = ["std"] }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", features = ["fiat"] }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
@@ -997,41 +997,41 @@ mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "o
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-cli = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-cli = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0" }
 multiaddr = { version = "0.17", features = ["url"] }
 multibase = { version = "0.9", features = ["std"] }
 multihash = { version = "0.17", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
@@ -1161,8 +1161,8 @@ rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen-93f6ce9d446188ac = { package = "rcgen", version = "0.10", features = ["pem", "x509-parser"] }
 rcgen-274715c4dabd11b0 = { package = "rcgen", version = "0.9", features = ["pem"] }
-read-write-set = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "84dfb01e00e7778e6fd035335290ad156e6caac0", default-features = false }
 readonly = { version = "0.2", default-features = false }
 ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -93,7 +93,7 @@ bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2", default-features = 
 bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", features = ["alloc", "std", "unicode"] }
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
 byte-slice-cast = { version = "1", features = ["std"] }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["fiat"] }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
@@ -319,41 +319,41 @@ miniz_oxide = { version = "0.6", default-features = false, features = ["with-all
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-cli = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-cli = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
 multiaddr = { version = "0.17", features = ["url"] }
 multibase = { version = "0.9", features = ["std"] }
 multihash = { version = "0.17", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
@@ -458,8 +458,8 @@ rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen-93f6ce9d446188ac = { package = "rcgen", version = "0.10", features = ["pem", "x509-parser"] }
 rcgen-274715c4dabd11b0 = { package = "rcgen", version = "0.9", features = ["pem"] }
-read-write-set = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", features = ["regex-syntax", "std"] }
@@ -738,7 +738,7 @@ bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", features = ["alloc", 
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
 bumpalo = { version = "3" }
 byte-slice-cast = { version = "1", features = ["std"] }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["fiat"] }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
@@ -997,41 +997,41 @@ mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "o
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-cli = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-cli = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70" }
 multiaddr = { version = "0.17", features = ["url"] }
 multibase = { version = "0.9", features = ["std"] }
 multihash = { version = "0.17", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
@@ -1161,8 +1161,8 @@ rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen-93f6ce9d446188ac = { package = "rcgen", version = "0.10", features = ["pem", "x509-parser"] }
 rcgen-274715c4dabd11b0 = { package = "rcgen", version = "0.9", features = ["pem"] }
-read-write-set = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "a8e95cbae69564d8928c9873b8acfabc50e642cf", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "c109370befdea189e43cd796ddfb5ede44cccb70", default-features = false }
 readonly = { version = "0.2", default-features = false }
 ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }


### PR DESCRIPTION
**Please note that this is very much a draft at this point.**

This PR taps into generalization of the Prover to allow it to reason about custom memory models (https://github.com/move-language/move/pull/810). The model defined here is just an example to test some early ideas on how low-level integration with the Prover (e.g., how we can query a memory model defined in Boogie from function specs)  would look like (it's a no-goal of this PR to define an actual full-fledged Sui memory model).

The goal is to use this integration to start prototyping and/or discuss how to modify/extend Prover support to better suit Sui needs.

With this PR we can reason about ownership in a very simple way. In particular, the following code and its spec would be correctly handed by the prover (in that it would be proven to be correct):

```
    struct Obj has key, store {
        id: UID
    }

    public fun foo(o: Obj, recipient: address) {
        let _ = sui::object::id_address(&o);
        sui::transfer::transfer(o, recipient);
    }

    spec foo {
        ensures sui::prover::owned_by(memory<Obj>(), o.id.id.bytes, recipient);
        aborts_if false;
    }

    public fun bar(o: Obj) {
        let _ = sui::object::id_address(&o);
        sui::transfer::share_object(o)
    }

    spec bar {
        ensures sui::prover::shared(memory<Obj>(), o.id.id.bytes);
        aborts_if sui::prover::owned(memory<Obj>(), o.id.id.bytes);
    }
```

This is accomplished by fleshing out Boogie model for the `transfer_internal` and `share_object` functions (to update the memory map for an `ID` of an object being transferred/shared) and by defining a new native spec functions that can query the memory map with the help of the new prover built-in defined in https://github.com/move-language/move/pull/810

Some limitation of this approach are probably immediately apparent and part of the task is to decide if we can or cannot live with them (at least for the time being).

The first one is super annoying and I don't know how to get around it, but hopefully it's easy fixable by someone in the know. You may have noticed the `et _ = sui::object::id_address(&o);` statement in the example above - without it, Boogie does not pull the definition of the `sui::object::id_address` function and reports it as "unknown".

Also, it's not ideal that in the spec we need to use field access (`o.id.id.bytes`) to get to the `ID` of an object in question. Not only is it not pretty but also does not allow reasoning about generic types in specs. The reason for it is that while in the function itself (more concretely in Boogie translation of the `transfer::transfer_internal` and `transfer::share_object` functions) we can (indirectly via `object::id_address`) call  `object::borrow_uid` native function (which in Boogie is translated into a procedure), we cannot do the same in the spec where all Move code is translated into Boogie functions (and NOT procedures) which makes calling `object::borrow_uid` impossible.
