### PR TITLE
chore: Update codeowners for crypto related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
-/crates/sui-types/src/crypto.rs @huitseeker
-/crates/sui-sdk/src/crypto.rs @huitseeker @patrickkuo
+/crates/sui-types/src/crypto.rs @joyqvq @kchalkias @benr-ml
+/crates/sui-types/src/base_types.rs @joyqvq
+/crates/sui-keys/ @joyqvq @patrickkuo
 
 *.md @randall-Mysten @ronny-mysten
 # Omit auto-generated changelogs and changesets from docs review:
@@ -10,7 +11,7 @@ CHANGELOG.md
 /crates/sui-config/tests/snapshot_tests.rs @tharbert @huitseeker
 
 # Notify Narwhal changes to interested folks.
-/narwhal/crypto/ @huitseeker @kchalkias
+/narwhal/crypto/ @joyqvq @kchalkias
 /narwhal/executor/ @asonnino @akichidis
 /narwhal/examples/ @arun-koshy
 /narwhal/network/ @bmwill


### PR DESCRIPTION
change/deprecate some codeowners based on my understanding on some of the recent workstreams. 