### PR TITLE
[wallet-ext]  Add custom `suiWallet:stake` feature

### DIFF
--- a/apps/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/apps/wallet/src/background/connections/ContentScriptConnection.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import Browser from 'webextension-polyfill';
+
+import { Window } from '../Window';
 import { Connection } from './Connection';
 import { createMessage } from '_messages';
 import { isGetAccount } from '_payloads/account/GetAccount';
@@ -8,7 +11,10 @@ import {
     isAcquirePermissionsRequest,
     isHasPermissionRequest,
 } from '_payloads/permissions';
-import { isExecuteTransactionRequest } from '_payloads/transactions';
+import {
+    isExecuteTransactionRequest,
+    isStakeRequest,
+} from '_payloads/transactions';
 import Permissions from '_src/background/Permissions';
 import Transactions from '_src/background/Transactions';
 
@@ -120,6 +126,15 @@ export class ContentScriptConnection extends Connection {
             } else {
                 this.sendNotAllowedError(msg.id);
             }
+        } else if (isStakeRequest(payload)) {
+            // TODO: Should this check permissions?
+            const window = new Window(
+                Browser.runtime.getURL('ui.html') +
+                    `#/stake/new?address=${encodeURIComponent(
+                        payload.validatorAddress
+                    )}`
+            );
+            await window.show();
         }
     }
 

--- a/apps/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/apps/wallet/src/background/connections/ContentScriptConnection.ts
@@ -127,7 +127,6 @@ export class ContentScriptConnection extends Connection {
                 this.sendNotAllowedError(msg.id);
             }
         } else if (isStakeRequest(payload)) {
-            // TODO: Should this check permissions?
             const window = new Window(
                 Browser.runtime.getURL('ui.html') +
                     `#/stake/new?address=${encodeURIComponent(

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -31,6 +31,7 @@ import {
 import type { GetAccount } from '_payloads/account/GetAccount';
 import type { GetAccountResponse } from '_payloads/account/GetAccountResponse';
 import type {
+    StakeRequest,
     ExecuteTransactionRequest,
     ExecuteTransactionResponse,
 } from '_payloads/transactions';
@@ -41,6 +42,14 @@ type WalletEventsMap = {
 
 // NOTE: Because this runs in a content script, we can't fetch the manifest.
 const name = process.env.APP_NAME || 'Sui Wallet';
+
+type StakeInput = { validatorAddress: string };
+type SuiWalletStakeFeature = {
+    'suiWallet:stake': {
+        version: '0.0.1';
+        stake: (input: StakeInput) => Promise<void>;
+    };
+};
 
 export class SuiWallet implements Wallet {
     readonly #events: Emitter<WalletEventsMap>;
@@ -68,7 +77,8 @@ export class SuiWallet implements Wallet {
 
     get features(): ConnectFeature &
         EventsFeature &
-        SuiSignAndExecuteTransactionFeature {
+        SuiSignAndExecuteTransactionFeature &
+        SuiWalletStakeFeature {
         return {
             'standard:connect': {
                 version: '1.0.0',
@@ -81,6 +91,10 @@ export class SuiWallet implements Wallet {
             'sui:signAndExecuteTransaction': {
                 version: '1.0.0',
                 signAndExecuteTransaction: this.#signAndExecuteTransaction,
+            },
+            'suiWallet:stake': {
+                version: '0.0.1',
+                stake: this.#stake,
             },
         };
     }
@@ -164,6 +178,16 @@ export class SuiWallet implements Wallet {
                 },
             }),
             (response) => response.result
+        );
+    };
+
+    #stake = async (input: StakeInput) => {
+        await mapToPromise<void, void>(
+            this.#send<StakeRequest, void>({
+                type: 'stake-request',
+                validatorAddress: input.validatorAddress,
+            }),
+            (response) => response
         );
     };
 

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -182,13 +182,10 @@ export class SuiWallet implements Wallet {
     };
 
     #stake = async (input: StakeInput) => {
-        await mapToPromise<void, void>(
-            this.#send<StakeRequest, void>({
-                type: 'stake-request',
-                validatorAddress: input.validatorAddress,
-            }),
-            (response) => response
-        );
+        this.#send<StakeRequest, void>({
+            type: 'stake-request',
+            validatorAddress: input.validatorAddress,
+        });
     };
 
     #hasPermissions(permissions: HasPermissionsRequest['permissions']) {

--- a/apps/wallet/src/dapp-interface/utils.ts
+++ b/apps/wallet/src/dapp-interface/utils.ts
@@ -5,7 +5,7 @@ import { lastValueFrom, map, take, type Observable } from 'rxjs';
 
 import { isErrorPayload, type Payload } from '_payloads';
 
-export function mapToPromise<T extends Payload, R>(
+export function mapToPromise<T extends Payload | void, R>(
     stream: Observable<T>,
     project: (value: T) => R
 ) {
@@ -13,7 +13,7 @@ export function mapToPromise<T extends Payload, R>(
         stream.pipe(
             take<T>(1),
             map<T, R>((response) => {
-                if (isErrorPayload(response)) {
+                if (response && isErrorPayload(response)) {
                     // TODO: throw proper error
                     throw new Error(response.message);
                 }

--- a/apps/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
@@ -21,7 +21,8 @@ export type PayloadType =
     | 'update-active-origin'
     | 'disconnect-app'
     | 'done'
-    | 'keyring';
+    | 'keyring'
+    | 'stake-request';
 
 export interface BasePayload {
     type: PayloadType;

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/Staking.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/Staking.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { BasePayload, Payload } from '_payloads';
+
+export interface StakeRequest extends BasePayload {
+    type: 'stake-request';
+    validatorAddress: string;
+}
+
+export function isStakeRequest(payload: Payload): payload is StakeRequest {
+    return isBasePayload(payload) && payload.type === 'stake-request';
+}

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/index.ts
@@ -4,3 +4,4 @@
 export * from './ExecuteTransactionRequest';
 export * from './ExecuteTransactionResponse';
 export * from './TransactionRequest';
+export * from './Staking';

--- a/sdk/wallet-adapter/example/src/App.tsx
+++ b/sdk/wallet-adapter/example/src/App.tsx
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import "./App.css";
-import { WalletKitProvider, ConnectButton } from "@mysten/wallet-kit";
+import { WalletKitProvider, ConnectButton, useWalletKit } from "@mysten/wallet-kit";
 
 function App() {
+  const { currentWallet } = useWalletKit();
+  console.log(currentWallet);
   return (
     <div className="App">
-      <WalletKitProvider>
-        <ConnectButton />
-      </WalletKitProvider>
+      <ConnectButton />
     </div>
   );
 }

--- a/sdk/wallet-adapter/example/src/App.tsx
+++ b/sdk/wallet-adapter/example/src/App.tsx
@@ -2,11 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import "./App.css";
-import { WalletKitProvider, ConnectButton, useWalletKit } from "@mysten/wallet-kit";
+import { ConnectButton, useWalletKit } from "@mysten/wallet-kit";
+import { useEffect } from "react";
 
 function App() {
   const { currentWallet } = useWalletKit();
-  console.log(currentWallet);
+
+  useEffect(() => {
+    // You can do something with `currentWallet` here.
+  }, [currentWallet]);
+
   return (
     <div className="App">
       <ConnectButton />

--- a/sdk/wallet-adapter/example/src/index.tsx
+++ b/sdk/wallet-adapter/example/src/index.tsx
@@ -5,12 +5,15 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { WalletKitProvider } from "@mysten/wallet-kit";
 
 export const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <WalletKitProvider>
+      <App />
+    </WalletKitProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
This adds a custom `suiWallet:stake` feature to the Sui Wallet, which opens the wallet in the middle of the validator onboarding staking flow. Right now it doesn't require permissions, since there's no return value out of it (it just opens a window), but we can address that later if we want.