### PR TITLE
[checkpoints] Fix bug with including transactions from previous epoch

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2537,7 +2537,10 @@ impl AuthorityState {
             pending_certificates.len()
         );
         for digest in pending_certificates {
-            if epoch_store.is_transaction_executed_in_checkpoint(&digest)? {
+            if self
+                .database
+                .is_transaction_executed_in_checkpoint(&digest)?
+            {
                 debug!("Not reverting pending consensus transaction {:?} - it was included in checkpoint", digest);
                 continue;
             }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -197,9 +197,6 @@ pub struct AuthorityEpochTables {
     /// Checkpoint builder maintains internal list of transactions it included in checkpoints here
     builder_digest_to_checkpoint: DBMap<TransactionDigest, CheckpointSequenceNumber>,
 
-    /// When transaction is executed via checkpoint executor, we store association here
-    executed_transactions_to_checkpoint: DBMap<TransactionDigest, CheckpointSequenceNumber>,
-
     /// Stores pending signatures
     /// The key in this table is checkpoint sequence number and an arbitrary integer
     pending_checkpoint_signatures:
@@ -358,30 +355,6 @@ impl AuthorityPerEpochStore {
     #[cfg(test)]
     pub fn delete_signed_transaction_for_test(&self, transaction: &TransactionDigest) {
         self.tables.transactions.remove(transaction).unwrap();
-    }
-
-    pub fn insert_executed_transactions(
-        &self,
-        digests: &[TransactionDigest],
-        sequence: CheckpointSequenceNumber,
-    ) -> SuiResult {
-        let batch = self.tables.executed_transactions_to_checkpoint.batch();
-        let batch = batch.insert_batch(
-            &self.tables.executed_transactions_to_checkpoint,
-            digests.iter().map(|d| (*d, sequence)),
-        )?;
-        batch.write()?;
-        Ok(())
-    }
-
-    pub fn is_transaction_executed_in_checkpoint(
-        &self,
-        digest: &TransactionDigest,
-    ) -> SuiResult<bool> {
-        Ok(self
-            .tables
-            .executed_transactions_to_checkpoint
-            .contains_key(digest)?)
     }
 
     pub fn get_signed_transaction(

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -71,6 +71,10 @@ pub struct AuthorityPerpetualTables {
     pub(crate) effects: DBMap<TransactionEffectsDigest, TransactionEffects>,
     pub(crate) synced_transactions: DBMap<TransactionDigest, TrustedCertificate>,
 
+    /// When transaction is executed via checkpoint executor, we store association here
+    pub(crate) executed_transactions_to_checkpoint:
+        DBMap<TransactionDigest, (EpochId, CheckpointSequenceNumber)>,
+
     /// A singleton table that stores the current epoch number. This is used only for the purpose of
     /// crash recovery so that when we restart we know which epoch we are at. This is needed because
     /// there will be moments where the on-chain epoch doesn't match with the per-epoch table epoch.

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -645,7 +645,11 @@ async fn execute_transactions(
             }
             Ok(Err(err)) => return Err(err),
             Ok(Ok(_)) => {
-                epoch_store.insert_executed_transactions(&all_tx_digests, checkpoint_sequence)?;
+                authority_store.insert_executed_transactions(
+                    &all_tx_digests,
+                    epoch_store.epoch(),
+                    checkpoint_sequence,
+                )?;
                 return Ok(());
             }
         }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -552,6 +552,17 @@ impl CheckpointBuilder {
                 {
                     continue;
                 }
+                let executed_epoch = self.state.database.transaction_executed_in_epoch(&digest)?;
+                if let Some(executed_epoch) = executed_epoch {
+                    // Skip here if transaction was executed in previous epoch
+                    //
+                    // Do not skip if transaction was executed in this epoch -
+                    // we rely on builder_included_transaction_in_checkpoint instead for current epoch
+                    // because execution can run ahead checkpoint builder
+                    if executed_epoch < self.epoch_store.epoch() {
+                        continue;
+                    }
+                }
                 for dependency in effect.dependencies.iter() {
                     if seen.insert(*dependency) {
                         pending.insert(*dependency);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -304,12 +304,12 @@ impl SuiNode {
             .close_epoch(&self.state.epoch_store())
     }
 
-    pub fn is_transaction_executed_in_checkpoint_this_epoch(
+    pub fn is_transaction_executed_in_checkpoint(
         &self,
         digest: &TransactionDigest,
     ) -> SuiResult<bool> {
         self.state
-            .epoch_store()
+            .database
             .is_transaction_executed_in_checkpoint(digest)
     }
 

--- a/crates/sui/tests/checkpoint_tests.rs
+++ b/crates/sui/tests/checkpoint_tests.rs
@@ -48,7 +48,7 @@ async fn basic_checkpoints_integration_test() {
     for _ in 0..600 {
         let all_included = authorities.iter().all(|handle| {
             handle.with(|node| {
-                node.is_transaction_executed_in_checkpoint_this_epoch(tx.digest())
+                node.is_transaction_executed_in_checkpoint(tx.digest())
                     .unwrap()
             })
         });


### PR DESCRIPTION
When we moved checkpoint builder transaction index into per epoch store, we introduced a bug where checkpoints will start including transactions from previous epoch.

This PR fixes the bug by maintaining permanent index of executed transactions in authority store.