### PR TITLE
[tokenomics] Disable a few framework move functions

### DIFF
--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -48,7 +48,6 @@ pub async fn check_transaction_input(
     transaction: &TransactionData,
 ) -> SuiResult<(SuiGasStatus<'static>, InputObjects)> {
     transaction.validity_check()?;
-    transaction.kind.validity_check()?;
     let gas_status = get_gas_status(store, transaction).await?;
     let input_objects = transaction.input_objects()?;
     let objects = store.check_input_objects(&input_objects)?;
@@ -64,7 +63,6 @@ pub(crate) async fn check_dev_inspect_input(
     transaction: &TransactionData,
 ) -> SuiResult<(SuiGasStatus<'static>, InputObjects)> {
     transaction.validity_check()?;
-    transaction.kind.validity_check()?;
     let gas_status = get_gas_status(store, transaction).await?;
     let input_objects = transaction.input_objects()?;
     let input_objects = check_dev_inspect_input_objects(store, input_objects)?;

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -554,6 +554,9 @@ pub enum SuiError {
     #[error("Index store not available on this Fullnode.")]
     IndexStoreNotAvailable,
 
+    #[error("This Move function is currently disabled and not available for call")]
+    BlockedMoveFunction,
+
     #[error("unknown error: {0}")]
     Unknown(String),
 }


### PR DESCRIPTION
We won't open up validator join and exit until the next wave.