### PR TITLE
[Checkpoint Executor] Make a per-epoch component

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::node::{default_checkpoints_per_epoch, AuthorityKeyPairWithPath, KeyPairWithPath};
+use crate::node::{
+    default_checkpoints_per_epoch, default_end_of_epoch_broadcast_channel_capacity,
+    AuthorityKeyPairWithPath, KeyPairWithPath,
+};
 use crate::{
     genesis,
     genesis_config::{GenesisConfig, ValidatorConfigInfo, ValidatorGenesisInfo},
@@ -370,6 +373,8 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     grpc_concurrency_limit: initial_accounts_config.grpc_concurrency_limit,
                     p2p_config,
                     authority_store_pruning_config: AuthorityStorePruningConfig::validator_config(),
+                    end_of_epoch_broadcast_channel_capacity:
+                        default_end_of_epoch_broadcast_channel_capacity(),
                     checkpoint_executor_config: Default::default(),
                 }
             })

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -81,6 +81,12 @@ pub struct NodeConfig {
     #[serde(default = "default_authority_store_pruning_config")]
     pub authority_store_pruning_config: AuthorityStorePruningConfig,
 
+    /// Size of the broadcast channel used for notifying other systems of end of epoch.
+    ///
+    /// If unspecified, this will default to `128`.
+    #[serde(default = "default_end_of_epoch_broadcast_channel_capacity")]
+    pub end_of_epoch_broadcast_channel_capacity: usize,
+
     #[serde(default)]
     pub checkpoint_executor_config: CheckpointExecutorConfig,
 }
@@ -131,6 +137,10 @@ pub fn default_concurrency_limit() -> Option<usize> {
 pub fn default_checkpoints_per_epoch() -> Option<u64> {
     // Currently a checkpoint is ~3 seconds, 3000 checkpoints is 9000s, which is about 2.5 hours.
     Some(3000)
+}
+
+pub fn default_end_of_epoch_broadcast_channel_capacity() -> usize {
+    128
 }
 
 pub fn bool_true() -> bool {
@@ -227,12 +237,6 @@ pub struct CheckpointExecutorConfig {
     #[serde(default = "default_checkpoint_execution_max_concurrency")]
     pub checkpoint_execution_max_concurrency: usize,
 
-    /// Size of the broadcast channel use for notifying other systems of end of epoch.
-    ///
-    /// If unspecified, this will default to `128`.
-    #[serde(default = "default_end_of_epoch_broadcast_channel_capacity")]
-    pub end_of_epoch_broadcast_channel_capacity: usize,
-
     /// Number of seconds to wait for effects of a batch of transactions
     /// before logging a warning. Note that we will continue to retry
     /// indefinitely
@@ -246,10 +250,6 @@ fn default_checkpoint_execution_max_concurrency() -> usize {
     100
 }
 
-fn default_end_of_epoch_broadcast_channel_capacity() -> usize {
-    128
-}
-
 fn default_local_execution_timeout_sec() -> u64 {
     10
 }
@@ -258,8 +258,6 @@ impl Default for CheckpointExecutorConfig {
     fn default() -> Self {
         Self {
             checkpoint_execution_max_concurrency: default_checkpoint_execution_max_concurrency(),
-            end_of_epoch_broadcast_channel_capacity:
-                default_end_of_epoch_broadcast_channel_capacity(),
             local_execution_timeout_sec: default_local_execution_timeout_sec(),
         }
     }

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::node::AuthorityStorePruningConfig;
-use crate::node::{default_checkpoints_per_epoch, AuthorityKeyPairWithPath, KeyPairWithPath};
+use crate::node::{
+    default_checkpoints_per_epoch, default_end_of_epoch_broadcast_channel_capacity,
+    AuthorityKeyPairWithPath, KeyPairWithPath,
+};
 use crate::p2p::{P2pConfig, SeedPeer};
 use crate::{builder, genesis, utils, Config, NodeConfig, ValidatorInfo};
 use fastcrypto::traits::KeyPair;
@@ -235,6 +238,8 @@ impl<'a> FullnodeConfigBuilder<'a> {
             grpc_concurrency_limit: None,
             p2p_config,
             authority_store_pruning_config: AuthorityStorePruningConfig::fullnode_config(),
+            end_of_epoch_broadcast_channel_capacity:
+                default_end_of_epoch_broadcast_channel_capacity(),
             checkpoint_executor_config: Default::default(),
         })
     }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -58,9 +58,9 @@ validator_configs:
       objects-num-latest-versions-to-retain: 2
       objects-pruning-period-secs: 86400
       objects-pruning-initial-delay-secs: 3600
+    end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 100
-      end-of-epoch-broadcast-channel-capacity: 128
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
@@ -117,9 +117,9 @@ validator_configs:
       objects-num-latest-versions-to-retain: 2
       objects-pruning-period-secs: 86400
       objects-pruning-initial-delay-secs: 3600
+    end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 100
-      end-of-epoch-broadcast-channel-capacity: 128
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
@@ -176,9 +176,9 @@ validator_configs:
       objects-num-latest-versions-to-retain: 2
       objects-pruning-period-secs: 86400
       objects-pruning-initial-delay-secs: 3600
+    end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 100
-      end-of-epoch-broadcast-channel-capacity: 128
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
@@ -235,9 +235,9 @@ validator_configs:
       objects-num-latest-versions-to-retain: 2
       objects-pruning-period-secs: 86400
       objects-pruning-initial-delay-secs: 3600
+    end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 100
-      end-of-epoch-broadcast-channel-capacity: 128
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
@@ -294,9 +294,9 @@ validator_configs:
       objects-num-latest-versions-to-retain: 2
       objects-pruning-period-secs: 86400
       objects-pruning-initial-delay-secs: 3600
+    end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 100
-      end-of-epoch-broadcast-channel-capacity: 128
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
@@ -353,9 +353,9 @@ validator_configs:
       objects-num-latest-versions-to-retain: 2
       objects-pruning-period-secs: 86400
       objects-pruning-initial-delay-secs: 3600
+    end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 100
-      end-of-epoch-broadcast-channel-capacity: 128
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
@@ -412,9 +412,9 @@ validator_configs:
       objects-num-latest-versions-to-retain: 2
       objects-pruning-period-secs: 86400
       objects-pruning-initial-delay-secs: 3600
+    end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 100
-      end-of-epoch-broadcast-channel-capacity: 128
       local-execution-timeout-sec: 10
 account_keys:
   - 10wECHkYvXqL5/CY6WhjbfFPotZb5tjEbpmumqbRxuk=

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1474,7 +1474,7 @@ impl AuthorityPerEpochStore {
             .set(stats.total_gas_reward as i64);
     }
 
-    pub(crate) fn record_epoch_reconfig_start_time_metric(&self) {
+    pub fn record_epoch_reconfig_start_time_metric(&self) {
         if let Some(epoch_close_time) = *self.epoch_close_time.read() {
             self.metrics
                 .epoch_reconfig_start_time_since_epoch_close_ms

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -23,100 +23,77 @@ pub async fn test_checkpoint_executor_crash_recovery() {
     let tempdir = tempdir().unwrap();
     let checkpoint_store = CheckpointStore::new(tempdir.path());
 
-    // new Node (syncing from checkpoint 0)
-    let cold_start_checkpoints = {
-        let (_state, executor, checkpoint_sender, committee): (
-            Arc<AuthorityState>,
-            CheckpointExecutor,
-            Sender<VerifiedCheckpoint>,
-            CommitteeFixture,
-        ) = init_executor_test(buffer_size, checkpoint_store.clone()).await;
+    let (state, mut executor, checkpoint_sender, committee): (
+        Arc<AuthorityState>,
+        CheckpointExecutor,
+        Sender<VerifiedCheckpoint>,
+        CommitteeFixture,
+    ) = init_executor_test(buffer_size, checkpoint_store.clone()).await;
 
-        assert!(matches!(
-            checkpoint_store
-                .get_highest_executed_checkpoint_seq_number()
-                .unwrap(),
-            None,
-        ));
-        let checkpoints = sync_new_checkpoints(
-            &checkpoint_store,
-            &checkpoint_sender,
-            2 * buffer_size,
-            None,
-            &committee,
-        );
-        let (executor_handle, _reconfig_channel) = executor.start().unwrap();
-        tokio::time::sleep(Duration::from_secs(5)).await;
+    assert!(matches!(
+        checkpoint_store
+            .get_highest_executed_checkpoint_seq_number()
+            .unwrap(),
+        None,
+    ));
+    let checkpoints = sync_new_checkpoints(
+        &checkpoint_store,
+        &checkpoint_sender,
+        2 * buffer_size,
+        None,
+        &committee,
+    );
 
-        // dropping the channel will cause the checkpoint executor process to exit (gracefully)
-        drop(checkpoint_sender);
-        timeout(Duration::from_secs(1), async {
-            executor_handle
-                .join()
-                .await
-                .expect("Should exit gracefully");
-        })
-        .await
-        .unwrap();
+    let epoch_store = state.epoch_store().clone();
+    let executor_handle =
+        spawn_monitored_task!(async move { executor.run_epoch(epoch_store).await });
+    tokio::time::sleep(Duration::from_secs(5)).await;
 
-        assert!(matches!(
-            checkpoint_store.get_highest_executed_checkpoint_seq_number().unwrap(),
-            Some(highest) if highest == 2 * (buffer_size as u64) - 1,
-        ));
+    // ensure we executed all synced checkpoints
+    let highest_executed = checkpoint_store
+        .get_highest_executed_checkpoint_seq_number()
+        .unwrap()
+        .expect("Expected highest executed to not be None");
+    assert_eq!(highest_executed, 2 * (buffer_size as u64) - 1,);
 
-        checkpoints
-    };
+    // Simulate node restart
+    executor_handle.abort();
 
-    // Node shutdown, syncing from checkpoint > 0
-    {
-        let last_executed_checkpoint = cold_start_checkpoints.last().cloned().unwrap();
+    // sync more checkpoints in the meantime
+    let _ = sync_new_checkpoints(
+        &checkpoint_store,
+        &checkpoint_sender,
+        2 * buffer_size,
+        Some(checkpoints.last().cloned().unwrap()),
+        &committee,
+    );
 
-        let (_state, executor, checkpoint_sender, committee): (
-            Arc<AuthorityState>,
-            CheckpointExecutor,
-            Sender<VerifiedCheckpoint>,
-            CommitteeFixture,
-        ) = init_executor_test(buffer_size, checkpoint_store.clone()).await;
+    // restart checkpoint executor and ensure that it picks
+    // up where it left off
+    let mut executor = CheckpointExecutor::new_for_tests(
+        checkpoint_sender.subscribe(),
+        checkpoint_store.clone(),
+        state.database.clone(),
+        state.transaction_manager().clone(),
+    );
 
-        assert!(matches!(
-            checkpoint_store
-                .get_highest_executed_checkpoint_seq_number()
-                .unwrap(),
-            Some(seq_num) if seq_num == last_executed_checkpoint.sequence_number(),
-        ));
-        // Start syncing new checkpoints from the last checkpoint before
-        // previous shutdown
-        let _ = sync_new_checkpoints(
-            &checkpoint_store,
-            &checkpoint_sender,
-            2 * buffer_size,
-            Some(last_executed_checkpoint),
-            &committee,
-        );
-        let (executor_handle, _reconfig_channel) = executor.start().unwrap();
-        tokio::time::sleep(Duration::from_secs(5)).await;
+    let epoch_store = state.epoch_store().clone();
+    let executor_handle =
+        spawn_monitored_task!(async move { executor.run_epoch(epoch_store).await });
+    tokio::time::sleep(Duration::from_secs(5)).await;
 
-        // dropping the channel will cause the checkpoint executor process to exit (gracefully)
-        drop(checkpoint_sender);
-        timeout(Duration::from_secs(1), async {
-            executor_handle
-                .join()
-                .await
-                .expect("Should exit gracefully");
-        })
-        .await
-        .unwrap();
+    let highest_executed = checkpoint_store
+        .get_highest_executed_checkpoint_seq_number()
+        .unwrap()
+        .expect("Expected highest executed to not be None");
+    assert_eq!(highest_executed, 4 * (buffer_size as u64) - 1);
 
-        assert!(matches!(
-            checkpoint_store.get_highest_executed_checkpoint_seq_number().unwrap(),
-            Some(highest) if highest == 4 * (buffer_size as u64) - 1,
-        ));
-    }
+    executor_handle.abort();
 }
 
 /// Test that checkpoint execution correctly signals end of epoch after
-/// receiving last checkpoint of epoch, pauses execution until reconfig,
-/// then resumes checkpoint execution after reconfig.
+/// receiving last checkpoint of epoch, then resumes executing cehckpoints
+/// from the next epoch if called after reconfig
 #[tokio::test]
 pub async fn test_checkpoint_executor_cross_epoch() {
     let buffer_size = 10;
@@ -124,7 +101,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
     let tempdir = tempdir().unwrap();
     let checkpoint_store = CheckpointStore::new(tempdir.path());
 
-    let (authority_state, executor, checkpoint_sender, first_committee): (
+    let (authority_state, mut executor, checkpoint_sender, first_committee): (
         Arc<AuthorityState>,
         CheckpointExecutor,
         Sender<VerifiedCheckpoint>,
@@ -157,7 +134,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
     );
 
     // sync 20 more checkpoints
-    let _next_epoch_checkpoints = sync_new_checkpoints(
+    let next_epoch_checkpoints = sync_new_checkpoints(
         &checkpoint_store,
         &checkpoint_sender,
         num_to_sync_per_epoch,
@@ -165,8 +142,23 @@ pub async fn test_checkpoint_executor_cross_epoch() {
         &second_committee,
     );
 
-    let (_handle, mut reconfig_channel) = executor.start().unwrap();
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    // sync end of epoch checkpoint
+    let last_executed_checkpoint = next_epoch_checkpoints.last().cloned().unwrap();
+    let (_end_of_epoch_checkpoint, _third_committee) = sync_end_of_epoch_checkpoint(
+        &checkpoint_store,
+        &checkpoint_sender,
+        last_executed_checkpoint,
+        &second_committee,
+    );
+
+    // Ensure executor reaches end of epoch in a timely manner
+    timeout(Duration::from_secs(5), async {
+        executor
+            .run_epoch(authority_state.epoch_store().clone())
+            .await;
+    })
+    .await
+    .unwrap();
 
     // We should have synced up to epoch boundary
     assert!(matches!(
@@ -174,20 +166,24 @@ pub async fn test_checkpoint_executor_cross_epoch() {
         Some(highest) if highest == (num_to_sync_per_epoch as u64),
     ));
 
-    // Ensure we have end of epoch notification
-    let next_committee = reconfig_channel.recv().await.unwrap();
-    assert_eq!(second_committee.committee(), &next_committee);
-
     authority_state
         .reconfigure(second_committee.committee().clone())
         .await
         .unwrap();
 
-    // checkpoint execution should resume
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    // checkpoint execution should resume starting at checkpoints
+    // of next epoch
+    timeout(Duration::from_secs(5), async {
+        executor
+            .run_epoch(authority_state.epoch_store().clone())
+            .await;
+    })
+    .await
+    .unwrap();
+
     assert!(matches!(
         checkpoint_store.get_highest_executed_checkpoint_seq_number().unwrap(),
-        Some(highest) if highest == (2 * num_to_sync_per_epoch as u64),
+        Some(highest) if highest == (2 * num_to_sync_per_epoch as u64) + 1,
     ));
 }
 
@@ -199,7 +195,7 @@ pub async fn test_reconfig_crash_recovery() {
     let checkpoint_store = CheckpointStore::new(tempdir.path());
 
     // new Node (syncing from checkpoint 0)
-    let (authority_state, executor, checkpoint_sender, first_committee): (
+    let (authority_state, mut executor, checkpoint_sender, first_committee): (
         Arc<AuthorityState>,
         CheckpointExecutor,
         Sender<VerifiedCheckpoint>,
@@ -244,10 +240,15 @@ pub async fn test_reconfig_crash_recovery() {
         &second_committee,
     );
 
-    let (executor_handle, mut reconfig_channel) = executor.start().unwrap();
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    timeout(Duration::from_secs(1), async {
+        executor
+            .run_epoch(authority_state.epoch_store().clone())
+            .await;
+    })
+    .await
+    .unwrap();
 
-    // Check that we paused execution at epoch boundary
+    // Check that we stopped execution at epoch boundary
     assert_eq!(
         checkpoint_store
             .get_highest_executed_checkpoint_seq_number()
@@ -256,56 +257,33 @@ pub async fn test_reconfig_crash_recovery() {
         end_of_epoch_checkpoint.sequence_number(),
     );
 
-    // Check that we have end of epoch notification - this will trigger reconfig
-    let next_committee = reconfig_channel.recv().await.unwrap();
-    assert_eq!(second_committee.committee(), &next_committee);
-
-    // Simulate reconfig crash by dropping the channel and aborting the executor task,
-    // causing checkpoint executor to exit ungracefully.
-    // TODO drop won't work here because we are paused for reconfig and thus are no longer
-    // polling the recv channel. Instead abort() the task
-    drop(checkpoint_sender);
-    executor_handle.event_loop_handle().abort();
-
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
-    // Node restart
-    let (checkpoint_sender, _): (Sender<VerifiedCheckpoint>, Receiver<VerifiedCheckpoint>) =
-        broadcast::channel(10);
-    let executor = CheckpointExecutor::new_for_tests(
+    // Drop and re-istantiate checkpoint executor without performing reconfig. This
+    // is logically equivalent to reconfig crashing and the node restarting, in which
+    // case executor should be able to infer that, rather than beginning execution of
+    // the next epoch, we should immediately exit so that reconfig can be reattempted.
+    drop(executor);
+    let mut executor = CheckpointExecutor::new_for_tests(
         checkpoint_sender.subscribe(),
         checkpoint_store.clone(),
-        authority_state.clone(),
+        authority_state.database.clone(),
+        authority_state.transaction_manager().clone(),
     );
-    let (_handle, mut reconfig_channel) = executor.start().unwrap();
 
-    // Check that post-startup, we remain paused for reconfig
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    timeout(Duration::from_millis(200), async {
+        executor
+            .run_epoch(authority_state.epoch_store().clone())
+            .await;
+    })
+    .await
+    .unwrap();
+
+    // Check that we have still not gone beyond epoch boundary
     assert_eq!(
         checkpoint_store
             .get_highest_executed_checkpoint_seq_number()
             .unwrap()
             .unwrap(),
         end_of_epoch_checkpoint.sequence_number(),
-    );
-
-    // Check that end of epoch is re-signaled so that we re-attempt reconfig
-    let next_committee = reconfig_channel.recv().await.unwrap();
-    assert_eq!(second_committee.committee(), &next_committee);
-
-    authority_state
-        .reconfigure(second_committee.committee().clone())
-        .await
-        .unwrap();
-
-    // checkpoint execution should resume
-    tokio::time::sleep(Duration::from_secs(5)).await;
-    assert_eq!(
-        checkpoint_store
-            .get_highest_executed_checkpoint_seq_number()
-            .unwrap()
-            .unwrap(),
-        end_of_epoch_checkpoint.sequence_number() + 1,
     );
 }
 
@@ -334,7 +312,8 @@ async fn init_executor_test(
     let executor = CheckpointExecutor::new_for_tests(
         checkpoint_sender.subscribe(),
         store.clone(),
-        state.clone(),
+        state.database.clone(),
+        state.transaction_manager().clone(),
     );
     (state, executor, checkpoint_sender, committee)
 }


### PR DESCRIPTION
* Make `CheckpointExecutor` exit after it reaches end of epoch
* Enforce the invariant that clean exit can only happen if we reach end of epoch (this means we now panic if the statesync channel is closed, rather than exit gracefully)
* Move end of epoch send channel to `SuiNode`, which will alert all listeners once `CheckpointExecutor` exits
* Fix `TransactionOrchestrator` to subscribe to `SuiNode` end of epoch channel, which we are guaranteed should never close