### PR TITLE
indexer: add basic prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8792,6 +8792,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "narwhal-network",
+ "prometheus",
  "serde 1.0.152",
  "serde_json",
  "sui",

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -20,6 +20,7 @@ diesel = { version = "2.0.0", features = ["chrono", "postgres", "r2d2", "serde_j
 futures = "0.3.23"
 jsonrpsee = { git="https://github.com/patrickkuo/jsonrpsee.git", rev= "adc19a124ed7045744442ca67f084ddfba4ba177", features = ["full"] }
 serde = { version = "1.0.144", features = ["derive"] }
+prometheus = "0.13.3"
 serde_json = "1.0.83"
 thiserror = "1.0.34"
 tracing = "0.1.36"

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -12,6 +12,7 @@ use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use tracing::{info, warn};
 
 pub mod errors;
+pub mod metrics;
 pub mod models;
 pub mod schema;
 pub mod utils;
@@ -20,8 +21,6 @@ pub type PgConnectionPool = Pool<ConnectionManager<PgConnection>>;
 pub type PgPoolConnection = PooledConnection<ConnectionManager<PgConnection>>;
 
 use errors::IndexerError;
-
-pub const RPC_CLIENT_URL: &str = "https://fullnode.devnet.sui.io:443";
 
 pub async fn new_rpc_client(http_url: String) -> Result<SuiClient, IndexerError> {
     info!("Getting new RPC client...");

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -1,0 +1,192 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::{register_int_counter_with_registry, IntCounter, Registry};
+
+/// Prometheus metrics for sui-indexer.
+
+#[derive(Clone, Debug)]
+pub struct IndexerTransactionHandlerMetrics {
+    pub total_transactions_received: IntCounter,
+    pub total_transactions_processed: IntCounter,
+
+    pub total_transaction_page_fetch_attempt: IntCounter,
+    pub total_transaction_page_received: IntCounter,
+    pub total_transaction_page_committed: IntCounter,
+
+    pub total_transaction_handler_error: IntCounter,
+}
+
+impl IndexerTransactionHandlerMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            total_transactions_received: register_int_counter_with_registry!(
+                "total_transactions_received",
+                "Total number of transactions received",
+                registry,
+            )
+            .unwrap(),
+            total_transactions_processed: register_int_counter_with_registry!(
+                "total_transactions_processed",
+                "Total number of transactions processed",
+                registry,
+            )
+            .unwrap(),
+            total_transaction_page_fetch_attempt: register_int_counter_with_registry!(
+                "total_transaction_page_fetch_attempt",
+                "Total number of transaction page fetch attempt",
+                registry,
+            )
+            .unwrap(),
+            total_transaction_page_received: register_int_counter_with_registry!(
+                "total_transaction_page_received",
+                "Total number of transaction page received",
+                registry,
+            )
+            .unwrap(),
+            total_transaction_page_committed: register_int_counter_with_registry!(
+                "total_transaction_page_committed",
+                "Total number of transaction page committed",
+                registry,
+            )
+            .unwrap(),
+            total_transaction_handler_error: register_int_counter_with_registry!(
+                "total_transaction_handler_error",
+                "Total number of transaction handler error",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexerEventHandlerMetrics {
+    pub total_events_received: IntCounter,
+    pub total_events_processed: IntCounter,
+
+    pub total_event_page_fetch_attempt: IntCounter,
+    pub total_event_page_received: IntCounter,
+    pub total_event_page_committed: IntCounter,
+
+    pub total_event_handler_error: IntCounter,
+}
+
+impl IndexerEventHandlerMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            total_events_received: register_int_counter_with_registry!(
+                "total_events_received",
+                "Total number of events received",
+                registry,
+            )
+            .unwrap(),
+            total_events_processed: register_int_counter_with_registry!(
+                "total_events_processed",
+                "Total number of events processed",
+                registry,
+            )
+            .unwrap(),
+            total_event_page_fetch_attempt: register_int_counter_with_registry!(
+                "total_event_page_fetch_attempt",
+                "Total number of event page fetch attempt",
+                registry,
+            )
+            .unwrap(),
+            total_event_page_received: register_int_counter_with_registry!(
+                "total_event_page_received",
+                "Total number of event page received",
+                registry,
+            )
+            .unwrap(),
+            total_event_page_committed: register_int_counter_with_registry!(
+                "total_event_page_committed",
+                "Total number of event page committed",
+                registry,
+            )
+            .unwrap(),
+            total_event_handler_error: register_int_counter_with_registry!(
+                "total_event_handler_error",
+                "Total number of event handler error",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+/// derivative data processor related metrics
+#[derive(Clone, Debug)]
+pub struct IndexerAddressProcessorMetrics {
+    pub total_address_batch_processed: IntCounter,
+    pub total_address_processor_error: IntCounter,
+}
+
+impl IndexerAddressProcessorMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            total_address_batch_processed: register_int_counter_with_registry!(
+                "total_address_batch_processed",
+                "Total number of address batches processed",
+                registry,
+            )
+            .unwrap(),
+            total_address_processor_error: register_int_counter_with_registry!(
+                "total_address_processor_error",
+                "Total number of address processor error",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexerObjectProcessorMetrics {
+    pub total_object_batch_processed: IntCounter,
+    pub total_object_processor_error: IntCounter,
+}
+
+impl IndexerObjectProcessorMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            total_object_batch_processed: register_int_counter_with_registry!(
+                "total_object_batch_processed",
+                "Total number of object batches processed",
+                registry,
+            )
+            .unwrap(),
+            total_object_processor_error: register_int_counter_with_registry!(
+                "total_object_processor_error",
+                "Total number of object processor error",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexerPackageProcessorMetrics {
+    pub total_package_batch_processed: IntCounter,
+    pub total_package_processor_error: IntCounter,
+}
+
+impl IndexerPackageProcessorMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            total_package_batch_processed: register_int_counter_with_registry!(
+                "total_package_batch_processed",
+                "Total number of package batches processed",
+                registry,
+            )
+            .unwrap(),
+            total_package_processor_error: register_int_counter_with_registry!(
+                "total_package_processor_error",
+                "Total number of package processor error",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}

--- a/crates/sui-indexer/src/processors/address_processor.rs
+++ b/crates/sui-indexer/src/processors/address_processor.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use prometheus::Registry;
 use std::sync::Arc;
-use sui_indexer::errors::IndexerError;
 use tracing::info;
 
+use sui_indexer::errors::IndexerError;
+use sui_indexer::metrics::IndexerAddressProcessorMetrics;
 use sui_indexer::models::address_logs::{commit_address_log, read_address_log};
 use sui_indexer::models::addresses::{commit_addresses, transaction_to_address, NewAddress};
 use sui_indexer::models::transactions::read_transactions;
@@ -14,11 +16,19 @@ const TRANSACTION_BATCH_SIZE: usize = 100;
 
 pub struct AddressProcessor {
     pg_connection_pool: Arc<PgConnectionPool>,
+    pub address_processor_metrics: IndexerAddressProcessorMetrics,
 }
 
 impl AddressProcessor {
-    pub fn new(pg_connection_pool: Arc<PgConnectionPool>) -> AddressProcessor {
-        Self { pg_connection_pool }
+    pub fn new(
+        pg_connection_pool: Arc<PgConnectionPool>,
+        prometheus_registry: &Registry,
+    ) -> AddressProcessor {
+        let address_processor_metrics = IndexerAddressProcessorMetrics::new(prometheus_registry);
+        Self {
+            pg_connection_pool,
+            address_processor_metrics,
+        }
     }
 
     pub async fn start(&self) -> Result<(), IndexerError> {
@@ -38,6 +48,9 @@ impl AddressProcessor {
 
             commit_addresses(&mut pg_pool_conn, addr_vec)?;
             commit_address_log(&mut pg_pool_conn, last_processed_id)?;
+            self.address_processor_metrics
+                .total_address_batch_processed
+                .inc();
         }
     }
 }


### PR DESCRIPTION
besides title, this PR also reverts changes in #7271 which was a hack and we do not need it any more with Brad's instructions on sui-operations.

Tested locally
1. run local validator
2. run indexer with local validator and clean local DB
```
cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost/gegao" --rpc-client-url "http://127.0.0.1:9000"
```

3. saw metrics on http://localhost:8081/metrics (the default address and port)
```
# HELP total_address_batch_processed Total number of address batches processed
# TYPE total_address_batch_processed counter
total_address_batch_processed 210948
# HELP total_address_processor_error Total number of address processor error
# TYPE total_address_processor_error counter
total_address_processor_error 0
# HELP total_event_handler_error Total number of event handler error
# TYPE total_event_handler_error counter
total_event_handler_error 0
# HELP total_event_page_committed Total number of event page committed
# TYPE total_event_page_committed counter
total_event_page_committed 544
# HELP total_event_page_fetch_attempt Total number of event page fetch attempt
# TYPE total_event_page_fetch_attempt counter
total_event_page_fetch_attempt 545
# HELP total_event_page_received Total number of event page received
# TYPE total_event_page_received counter
total_event_page_received 545
# HELP total_events_processed Total number of events processed
# TYPE total_events_processed counter
total_events_processed 8853
# HELP total_events_received Total number of events received
# TYPE total_events_received counter
total_events_received 8910
# HELP total_object_batch_processed Total number of object batches processed
# TYPE total_object_batch_processed counter
total_object_batch_processed 574
# HELP total_object_processor_error Total number of object processor error
# TYPE total_object_processor_error counter
total_object_processor_error 0
# HELP total_package_batch_processed Total number of package batches processed
# TYPE total_package_batch_processed counter
total_package_batch_processed 574
# HELP total_package_processor_error Total number of package processor error
# TYPE total_package_processor_error counter
total_package_processor_error 0
# HELP total_transaction_handler_error Total number of transaction handler error
# TYPE total_transaction_handler_error counter
total_transaction_handler_error 0
# HELP total_transaction_page_committed Total number of transaction page committed
# TYPE total_transaction_page_committed counter
total_transaction_page_committed 542
# HELP total_transaction_page_fetch_attempt Total number of transaction page fetch attempt
# TYPE total_transaction_page_fetch_attempt counter
total_transaction_page_fetch_attempt 542
# HELP total_transaction_page_received Total number of transaction page received
# TYPE total_transaction_page_received counter
total_transaction_page_received 542
# HELP total_transactions_processed Total number of transactions processed
# TYPE total_transactions_processed counter
total_transactions_processed 2920
# HELP total_transactions_received Total number of transactions received
# TYPE total_transactions_received counter
total_transactions_received 2920
# HELP uptime uptime of the node service in seconds
# TYPE uptime counter
uptime{version="0.21.0-704c671be"} 58
```