### PR TITLE
[narwhal] narwhal manager blocking start/shutdown & admin refactor

### DIFF
--- a/crates/sui-core/src/narwhal_manager/mod.rs
+++ b/crates/sui-core/src/narwhal_manager/mod.rs
@@ -8,7 +8,7 @@ pub mod narwhal_manager_tests;
 use arc_swap::ArcSwap;
 use fastcrypto::bls12381;
 use fastcrypto::traits::KeyPair;
-use mysten_metrics::RegistryService;
+use mysten_metrics::{monitored_scope, RegistryService};
 use narwhal_config::{Committee, Parameters, SharedWorkerCache, WorkerId};
 use narwhal_executor::ExecutionState;
 use narwhal_node::primary_node::PrimaryNode;
@@ -86,6 +86,8 @@ impl<TxValidator: TransactionValidator> NarwhalManager<TxValidator> {
             return;
         }
 
+        let _guard = monitored_scope("NarwhalManagerStart");
+
         // Create a new store
         let mut store_path = self.storage_base_path.clone();
         store_path.push(format!("epoch{}", committee.epoch()));
@@ -141,6 +143,8 @@ impl<TxValidator: TransactionValidator> NarwhalManager<TxValidator> {
     // Shuts down whole Narwhal (primary & worker(s)) and waits until nodes
     // have shutdown.
     pub async fn shutdown(&self) {
+        let _guard = monitored_scope("NarwhalManagerShutdown");
+
         let mut running = self.running.lock().await;
 
         let now = Instant::now();

--- a/crates/sui-core/src/narwhal_manager/mod.rs
+++ b/crates/sui-core/src/narwhal_manager/mod.rs
@@ -15,32 +15,11 @@ use narwhal_node::primary_node::PrimaryNode;
 use narwhal_node::worker_node::WorkerNodes;
 use narwhal_node::NodeStorage;
 use narwhal_worker::TransactionValidator;
-use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 use sui_types::crypto::NetworkKeyPair;
-use tokio::sync::mpsc::{Receiver, Sender};
-use tokio::task::JoinHandle;
-use tracing::instrument;
-
-pub struct NarwhalStartMessage<State> {
-    pub committee: Arc<Committee>,
-    pub shared_worker_cache: SharedWorkerCache,
-    pub execution_state: Arc<State>,
-}
-
-impl<State> Debug for NarwhalStartMessage<State> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.committee.fmt(f)?;
-        self.shared_worker_cache.fmt(f)
-    }
-}
-
-pub struct NarwhalManager<State> {
-    pub join_handle: JoinHandle<()>,
-    pub tx_start: Sender<NarwhalStartMessage<State>>,
-    pub tx_stop: Sender<()>,
-}
+use tokio::sync::Mutex;
 
 pub struct NarwhalConfiguration<TxValidator: TransactionValidator> {
     pub primary_keypair: bls12381::min_sig::BLS12381KeyPair,
@@ -54,128 +33,127 @@ pub struct NarwhalConfiguration<TxValidator: TransactionValidator> {
     pub registry_service: RegistryService,
 }
 
-pub async fn run_narwhal_manager<State, TxValidator>(
-    config: NarwhalConfiguration<TxValidator>,
-    mut tr_start: Receiver<NarwhalStartMessage<State>>,
-    mut tr_stop: Receiver<()>,
-) where
-    State: ExecutionState + Send + Sync + 'static,
-    TxValidator: TransactionValidator,
-{
-    // Create the Narwhal Primary with configuration
-    let primary_node = PrimaryNode::new(
-        config.parameters.clone(),
-        true,
-        config.registry_service.clone(),
-    );
+pub struct NarwhalManager<TxValidator> {
+    storage_base_path: PathBuf,
+    primary_keypair: bls12381::min_sig::BLS12381KeyPair,
+    network_keypair: NetworkKeyPair,
+    worker_ids_and_keypairs: Vec<(WorkerId, NetworkKeyPair)>,
+    primary_node: PrimaryNode,
+    worker_nodes: WorkerNodes,
+    tx_validator: TxValidator,
+    running: Mutex<bool>,
+}
 
-    // Create Narwhal Workers with configuration
-    let worker_nodes = WorkerNodes::new(config.registry_service.clone(), config.parameters.clone());
+impl<TxValidator: TransactionValidator> NarwhalManager<TxValidator> {
+    pub fn new(config: NarwhalConfiguration<TxValidator>) -> Self {
+        // Create the Narwhal Primary with configuration
+        let primary_node = PrimaryNode::new(
+            config.parameters.clone(),
+            true,
+            config.registry_service.clone(),
+        );
 
-    loop {
-        // Copy the config for this iteration of the loop
-        let mut id_keypair_copy = Vec::new();
-        for (id, keypair) in &config.worker_ids_and_keypairs {
-            id_keypair_copy.push((*id, keypair.copy()));
+        // Create Narwhal Workers with configuration
+        let worker_nodes =
+            WorkerNodes::new(config.registry_service.clone(), config.parameters.clone());
+
+        Self {
+            primary_node,
+            worker_nodes,
+            tx_validator: config.tx_validator,
+            primary_keypair: config.primary_keypair,
+            network_keypair: config.network_keypair,
+            worker_ids_and_keypairs: config.worker_ids_and_keypairs,
+            storage_base_path: config.storage_base_path,
+            running: Mutex::new(false),
+        }
+    }
+
+    // Starts the Narwhal (primary & worker(s)) - if not already running.
+    pub async fn start<State>(
+        &self,
+        committee: Arc<Committee>,
+        shared_worker_cache: SharedWorkerCache,
+        execution_state: Arc<State>,
+    ) where
+        State: ExecutionState + Send + Sync + 'static,
+    {
+        let mut running = self.running.lock().await;
+        if *running {
+            tracing::warn!(
+                "Narwhal node is already running - need to shutdown first before starting again"
+            );
+            return;
         }
 
-        // Wait for instruction to start an instance of narwhal
-        let NarwhalStartMessage {
-            committee,
-            shared_worker_cache,
-            execution_state,
-        } = match tr_start.recv().await {
-            Some(m) => m,
-            None => break,
-        };
+        // Create a new store
+        let mut store_path = self.storage_base_path.clone();
+        store_path.push(format!("epoch{}", committee.epoch()));
+        let store = NodeStorage::reopen(store_path);
 
-        tracing::info!("Received start signal for epoch {}", committee.epoch);
+        let name = self.primary_keypair.public().clone();
 
-        let config_copy = NarwhalConfiguration {
-            primary_keypair: config.primary_keypair.copy(),
-            network_keypair: config.network_keypair.copy(),
-            worker_ids_and_keypairs: id_keypair_copy,
-            storage_base_path: config.storage_base_path.clone(),
-            parameters: config.parameters.clone(),
-            tx_validator: config.tx_validator.clone(),
-            registry_service: config.registry_service.clone(),
-        };
+        let now = Instant::now();
+        tracing::info!("Starting up Narwhal for epoch {}", committee.epoch());
 
-        start_narwhal(
-            config_copy,
-            committee,
-            shared_worker_cache,
-            execution_state,
-            &primary_node,
-            &worker_nodes,
-        )
-        .await;
+        // start primary
+        self.primary_node
+            .start(
+                self.primary_keypair.copy(),
+                self.network_keypair.copy(),
+                Arc::new(ArcSwap::new(committee.clone())),
+                shared_worker_cache.clone(),
+                &store,
+                execution_state,
+            )
+            .await
+            .expect("Unable to start Narwhal Primary");
 
-        // Wait for instruction to stop the instance of narwhal
-        match tr_stop.recv().await {
-            Some(_) => shutdown_narwhal(&primary_node, &worker_nodes).await,
-            None => break,
-        };
+        // Start Narwhal Workers with configuration
+        // Copy the config for this iteration of the loop
+        let id_keypair_copy = self
+            .worker_ids_and_keypairs
+            .iter()
+            .map(|(id, keypair)| (*id, keypair.copy()))
+            .collect();
+
+        self.worker_nodes
+            .start(
+                name,
+                id_keypair_copy,
+                Arc::new(ArcSwap::new(committee.clone())),
+                shared_worker_cache,
+                &store,
+                self.tx_validator.clone(),
+            )
+            .await
+            .expect("Unable to start Narwhal Worker");
+
+        tracing::info!(
+            "Starting up Narwhal for epoch {} is complete - took {} seconds",
+            committee.epoch(),
+            now.elapsed().as_secs_f64()
+        );
+
+        *running = true
     }
-}
 
-#[instrument(level = "info", skip_all)]
-async fn shutdown_narwhal(primary_node: &PrimaryNode, worker_nodes: &WorkerNodes) {
-    tracing::info!("Shutting down narwhal");
+    // Shuts down whole Narwhal (primary & worker(s)) and waits until nodes
+    // have shutdown.
+    pub async fn shutdown(&self) {
+        let mut running = self.running.lock().await;
 
-    primary_node.shutdown().await;
-    worker_nodes.shutdown().await;
+        let now = Instant::now();
+        tracing::info!("Shutting down Narwhal");
 
-    tracing::info!("Narwhal shutdown is complete");
-    // TODO: clean up previous storage disk as is no longer needed
-}
+        self.primary_node.shutdown().await;
+        self.worker_nodes.shutdown().await;
 
-#[instrument(level = "info", skip_all)]
-async fn start_narwhal<State, TxValidator>(
-    config: NarwhalConfiguration<TxValidator>,
-    committee: Arc<Committee>,
-    worker_cache: SharedWorkerCache,
-    execution_state: Arc<State>,
-    primary_node: &PrimaryNode,
-    worker_nodes: &WorkerNodes,
-) where
-    State: ExecutionState + Send + Sync + 'static,
-    TxValidator: TransactionValidator,
-{
-    // Create a new store
-    let mut store_path = config.storage_base_path.clone();
-    store_path.push(format!("epoch{}", committee.epoch()));
-    let store = NodeStorage::reopen(store_path);
+        tracing::info!(
+            "Narwhal shutdown is complete - took {} seconds",
+            now.elapsed().as_secs_f64()
+        );
 
-    let name = config.primary_keypair.public().clone();
-
-    tracing::info!("Starting up narwhal");
-
-    // Start Narwhal Primary with configuration
-    primary_node
-        .start(
-            config.primary_keypair.copy(),
-            config.network_keypair.copy(),
-            Arc::new(ArcSwap::new(committee.clone())),
-            worker_cache.clone(),
-            &store,
-            execution_state,
-        )
-        .await
-        .expect("Unable to start Narwhal Primary");
-
-    // Start Narwhal Workers with configuration
-    worker_nodes
-        .start(
-            name,
-            config.worker_ids_and_keypairs,
-            Arc::new(ArcSwap::new(committee.clone())),
-            worker_cache,
-            &store,
-            config.tx_validator.clone(),
-        )
-        .await
-        .expect("Unable to start Narwhal Worker");
-
-    tracing::info!("Starting up narwhal is complete");
+        *running = false
+    }
 }

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -163,6 +163,10 @@ async fn test_narwhal_manager() {
         // stop narwhal instance
         narwhal_manager.shutdown().await;
 
+        // ensure that no primary or worker node is running
+        assert_eq!(narwhal_manager.primary_node.is_running().await, false);
+        assert!(narwhal_manager.worker_nodes.workers_running().await.is_empty());
+
         let system_state = state
             .get_sui_system_state_object()
             .expect("Reading Sui system state object cannot fail");

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -164,8 +164,12 @@ async fn test_narwhal_manager() {
         narwhal_manager.shutdown().await;
 
         // ensure that no primary or worker node is running
-        assert_eq!(narwhal_manager.primary_node.is_running().await, false);
-        assert!(narwhal_manager.worker_nodes.workers_running().await.is_empty());
+        assert!(!narwhal_manager.primary_node.is_running().await);
+        assert!(narwhal_manager
+            .worker_nodes
+            .workers_running()
+            .await
+            .is_empty());
 
         let system_state = state
             .get_sui_system_state_object()

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority::AuthorityState;
-use crate::narwhal_manager::{
-    run_narwhal_manager, NarwhalConfiguration, NarwhalManager, NarwhalStartMessage,
-};
+use crate::narwhal_manager::{NarwhalConfiguration, NarwhalManager};
 use bytes::Bytes;
 use fastcrypto::bls12381;
 use fastcrypto::traits::KeyPair;
@@ -18,7 +16,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use test_utils::authority::test_and_configure_authority_configs;
 use tokio::sync::broadcast;
-use tokio::sync::mpsc::channel;
 use tokio::time::{interval, sleep};
 
 #[derive(Clone)]
@@ -122,27 +119,17 @@ async fn test_narwhal_manager() {
             registry_service,
         };
 
-        let (tx_start, tr_start) = channel(1);
-        let (tx_stop, tr_stop) = channel(1);
-        let join_handle = tokio::spawn(run_narwhal_manager(narwhal_config, tr_start, tr_stop));
-
-        let narwhal_manager = NarwhalManager {
-            join_handle,
-            tx_start,
-            tx_stop,
-        };
+        let narwhal_manager = NarwhalManager::new(narwhal_config);
 
         // start narwhal
         let shared_worker_cache = SharedWorkerCache::from(worker_cache.clone());
-        assert!(narwhal_manager
-            .tx_start
-            .send(NarwhalStartMessage {
-                committee: Arc::new(narwhal_committee.clone()),
-                shared_worker_cache: shared_worker_cache.clone(),
-                execution_state: Arc::new(execution_state.clone())
-            })
-            .await
-            .is_ok());
+        narwhal_manager
+            .start(
+                Arc::new(narwhal_committee.clone()),
+                shared_worker_cache.clone(),
+                Arc::new(execution_state.clone()),
+            )
+            .await;
 
         let name = config.protocol_key_pair().public().clone();
         narwhal_managers.push((
@@ -153,7 +140,7 @@ async fn test_narwhal_manager() {
         ));
 
         // Send some transactions
-        let (tr_shutdown, rx_shutdown) = broadcast::channel(1);
+        let (tx_shutdown, rx_shutdown) = broadcast::channel(1);
         tokio::spawn(async move {
             send_transactions(
                 &name,
@@ -163,7 +150,7 @@ async fn test_narwhal_manager() {
             )
             .await
         });
-        shutdown_senders.push(tr_shutdown);
+        shutdown_senders.push(tx_shutdown);
     }
 
     sleep(Duration::from_secs(1)).await;
@@ -174,7 +161,7 @@ async fn test_narwhal_manager() {
 
     for (narwhal_manager, state, transactions_addr, name) in narwhal_managers {
         // stop narwhal instance
-        assert!(narwhal_manager.tx_stop.send(()).await.is_ok());
+        narwhal_manager.shutdown().await;
 
         let system_state = state
             .get_sui_system_state_object()
@@ -194,15 +181,13 @@ async fn test_narwhal_manager() {
 
         // start narwhal with advanced epoch
         let shared_worker_cache = SharedWorkerCache::from(worker_cache.clone());
-        assert!(narwhal_manager
-            .tx_start
-            .send(NarwhalStartMessage {
-                committee: Arc::new(narwhal_committee.clone()),
-                shared_worker_cache: shared_worker_cache.clone(),
-                execution_state: Arc::new(execution_state.clone())
-            })
-            .await
-            .is_ok());
+        narwhal_manager
+            .start(
+                Arc::new(narwhal_committee.clone()),
+                shared_worker_cache.clone(),
+                Arc::new(execution_state.clone()),
+            )
+            .await;
 
         // Send some transactions
         let (tr_shutdown, rx_shutdown) = broadcast::channel(1);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -49,7 +49,6 @@ use sui_storage::{
 use sui_types::committee::Committee;
 use sui_types::crypto::KeypairTraits;
 use sui_types::messages::QuorumDriverResponse;
-use tokio::sync::mpsc::channel;
 use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
 use tower::ServiceBuilder;
@@ -71,16 +70,14 @@ use sui_core::consensus_handler::ConsensusHandler;
 use sui_core::consensus_validator::SuiTxValidator;
 use sui_core::epoch::epoch_metrics::EpochMetrics;
 use sui_core::epoch::reconfiguration::ReconfigurationInitiator;
-use sui_core::narwhal_manager::{
-    run_narwhal_manager, NarwhalConfiguration, NarwhalManager, NarwhalStartMessage,
-};
+use sui_core::narwhal_manager::{NarwhalConfiguration, NarwhalManager};
 use sui_json_rpc::coin_api::CoinReadApi;
 use sui_types::base_types::{EpochId, TransactionDigest};
 use sui_types::error::{SuiError, SuiResult};
 
 pub struct ValidatorComponents {
     validator_server_handle: tokio::task::JoinHandle<Result<()>>,
-    narwhal_manager: NarwhalManager<ConsensusHandler<Arc<AuthorityStore>>>,
+    narwhal_manager: NarwhalManager<SuiTxValidator>,
     consensus_adapter: Arc<ConsensusAdapter>,
     // dropping this will eventually stop checkpoint tasks. The receiver side of this channel
     // is copied into each checkpoint service task, and they are listening to any change to this
@@ -441,7 +438,7 @@ impl SuiNode {
         )
         .await?;
 
-        let narwhal_manager = Self::construct_and_run_narwhal_manager(
+        let narwhal_manager = Self::construct_narwhal_manager(
             config,
             consensus_config,
             state.clone(),
@@ -470,7 +467,7 @@ impl SuiNode {
         checkpoint_store: Arc<CheckpointStore>,
         epoch_store: Arc<AuthorityPerEpochStore>,
         state_sync_handle: state_sync::Handle,
-        narwhal_manager: NarwhalManager<ConsensusHandler<Arc<AuthorityStore>>>,
+        narwhal_manager: NarwhalManager<SuiTxValidator>,
         validator_server_handle: JoinHandle<Result<()>>,
         checkpoint_metrics: Arc<CheckpointMetrics>,
     ) -> Result<ValidatorComponents> {
@@ -504,14 +501,13 @@ impl SuiNode {
             .address;
         let worker_cache = system_state.get_current_epoch_narwhal_worker_cache(transactions_addr);
 
-        let msg = NarwhalStartMessage {
-            committee: committee.clone(),
-            shared_worker_cache: SharedWorkerCache::from(worker_cache),
-            execution_state: consensus_handler,
-        };
-        info!("Sending start signal to Narwhal");
-        narwhal_manager.tx_start.send(msg).await?;
-        // TODO: (Laura) wait for start complete signal
+        narwhal_manager
+            .start(
+                committee.clone(),
+                SharedWorkerCache::from(worker_cache),
+                consensus_handler,
+            )
+            .await;
 
         Ok(ValidatorComponents {
             validator_server_handle,
@@ -558,12 +554,12 @@ impl SuiNode {
         )
     }
 
-    fn construct_and_run_narwhal_manager(
+    fn construct_narwhal_manager(
         config: &NodeConfig,
         consensus_config: &ConsensusConfig,
         state: Arc<AuthorityState>,
         registry_service: &RegistryService,
-    ) -> Result<NarwhalManager<ConsensusHandler<Arc<AuthorityStore>>>> {
+    ) -> Result<NarwhalManager<SuiTxValidator>> {
         let narwhal_config = NarwhalConfiguration {
             primary_keypair: config.protocol_key_pair().copy(),
             network_keypair: config.network_key_pair().copy(),
@@ -574,18 +570,7 @@ impl SuiNode {
             registry_service: registry_service.clone(),
         };
 
-        let (tx_start, tr_start) = channel(1);
-        let (tx_stop, tr_stop) = channel(1);
-        let join_handle =
-            spawn_monitored_task!(run_narwhal_manager(narwhal_config, tr_start, tr_stop));
-
-        let narwhal_manager = NarwhalManager {
-            join_handle,
-            tx_start,
-            tx_stop,
-        };
-
-        Ok(narwhal_manager)
+        Ok(NarwhalManager::new(narwhal_config))
     }
 
     fn construct_consensus_adapter(
@@ -706,9 +691,7 @@ impl SuiNode {
                 // Stop the old checkpoint service.
                 drop(checkpoint_service_exit);
 
-                info!("Sending shutdown signal to Narwhal");
-                narwhal_manager.tx_stop.send(()).await?;
-                // TODO: (Laura) wait for stop complete signal
+                narwhal_manager.shutdown().await;
 
                 self.reconfigure_state(next_epoch).await;
 

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -248,9 +248,8 @@ async fn reconfig_with_revert_end_to_end_test() {
 }
 
 // This test just starts up a cluster that reconfigures itself under 0 load.
-//#[sim_test]
-//#[ignore] // test is flaky right now
-#[tokio::test]
+#[sim_test]
+#[ignore] // test is flaky right now
 async fn test_passive_reconfig() {
     telemetry_subscribers::init_for_testing();
 

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -248,9 +248,12 @@ async fn reconfig_with_revert_end_to_end_test() {
 }
 
 // This test just starts up a cluster that reconfigures itself under 0 load.
-#[sim_test]
-#[ignore] // test is flaky right now
+//#[sim_test]
+//#[ignore] // test is flaky right now
+#[tokio::test]
 async fn test_passive_reconfig() {
+    telemetry_subscribers::init_for_testing();
+
     let _test_cluster = TestClusterBuilder::new()
         .with_checkpoints_per_epoch(10)
         .build()

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -278,7 +278,7 @@ async fn test_tx_across_epoch_boundaries() {
     // Will all transactions finish in epoch 0?  Local testing results say
     // unlikely with total_tx_size = 180.
     loop {
-        match tokio::time::timeout(tokio::time::Duration::from_secs(5), result_rx.recv()).await {
+        match tokio::time::timeout(tokio::time::Duration::from_secs(60), result_rx.recv()).await {
             Ok(Some(tx_cert)) => {
                 if tx_cert.auth_sig().epoch == 1 {
                     return;

--- a/narwhal/network/src/admin.rs
+++ b/narwhal/network/src/admin.rs
@@ -70,6 +70,7 @@ pub fn start_admin_server(
                     }
                     Err(err) => {
                         if total_retries == 0 {
+                            error!("{}", err);
                             panic!("Failed to boot admin {}: {}", socket_address, err);
                         }
 

--- a/narwhal/network/src/admin.rs
+++ b/narwhal/network/src/admin.rs
@@ -4,9 +4,11 @@
 use axum::routing::post;
 use axum::{extract::Extension, http::StatusCode, routing::get, Json, Router};
 use mysten_metrics::{spawn_logged_monitored_task, spawn_monitored_task};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+use std::time::Duration;
 use tokio::task::JoinHandle;
-use tracing::info;
+use tokio::time::sleep;
+use tracing::{error, info};
 use types::metered_channel::Sender;
 use types::{ConditionalBroadcastReceiver, ReconfigureNotification};
 
@@ -48,11 +50,39 @@ pub fn start_admin_server(
 
     handles.push(spawn_logged_monitored_task!(
         async move {
-            axum_server::bind(socket_address)
-                .handle(shutdown_handle)
-                .serve(router.into_make_service())
-                .await
-                .unwrap();
+            // retry a few times before quiting
+            let mut total_retries = 10;
+
+            loop {
+                total_retries -= 1;
+
+                match TcpListener::bind(socket_address) {
+                    Ok(listener) => {
+                        axum_server::from_tcp(listener)
+                            .handle(shutdown_handle)
+                            .serve(router.into_make_service())
+                            .await
+                            .unwrap_or_else(|err| {
+                                panic!("Failed to boot admin {}: {err}", socket_address)
+                            });
+
+                        return;
+                    }
+                    Err(err) => {
+                        if total_retries == 0 {
+                            panic!("Failed to boot admin {}: {}", socket_address, err);
+                        }
+
+                        error!("{}", err);
+
+                        // just sleep for a bit before retrying in case the port
+                        // has not been de-allocated
+                        sleep(Duration::from_secs(1)).await;
+
+                        continue;
+                    }
+                }
+            }
         },
         "AdminServerTask"
     ));

--- a/narwhal/node/src/metrics.rs
+++ b/narwhal/node/src/metrics.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use axum::{http::StatusCode, routing::get, Extension, Router};
-use config::WorkerId;
+use config::{Epoch, WorkerId};
 use crypto::PublicKey;
 use multiaddr::Multiaddr;
 use mysten_metrics::spawn_logged_monitored_task;
@@ -13,6 +13,12 @@ use tokio::task::JoinHandle;
 const METRICS_ROUTE: &str = "/metrics";
 const PRIMARY_METRICS_PREFIX: &str = "narwhal_primary";
 const WORKER_METRICS_PREFIX: &str = "narwhal_worker";
+
+pub fn new_registry(epoch: Epoch) -> Registry {
+    let mut labels = HashMap::new();
+    labels.insert("epoch".to_string(), epoch.to_string());
+    Registry::new_custom(None, Some(labels)).unwrap()
+}
 
 pub fn primary_metrics_registry(name: PublicKey) -> Registry {
     let mut labels = HashMap::new();

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use crate::metrics::new_registry;
 use crate::{try_join_all, FuturesUnordered, NodeError};
 use config::{Parameters, SharedCommittee, SharedWorkerCache};
 use consensus::bullshark::Bullshark;
@@ -70,7 +71,7 @@ impl PrimaryNodeInner {
         }
 
         // create a new registry
-        let registry = Registry::new();
+        let registry = new_registry(committee.load().epoch);
 
         // create the channel to send the shutdown signal
         let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -13,6 +13,7 @@ use mysten_metrics::{RegistryID, RegistryService};
 use primary::{NetworkModel, Primary, PrimaryChannelMetrics, NUM_SHUTDOWN_RECEIVERS};
 use prometheus::{IntGauge, Registry};
 use std::sync::Arc;
+use std::time::Instant;
 use storage::NodeStorage;
 use tokio::sync::{oneshot, watch, RwLock};
 use tokio::task::JoinHandle;
@@ -110,6 +111,7 @@ impl PrimaryNodeInner {
         }
 
         // send the shutdown signal to the node
+        let now = Instant::now();
         info!("Sending shutdown message to primary node");
 
         if let Some(tx_shutdown) = self.tx_shutdown.as_ref() {
@@ -124,7 +126,10 @@ impl PrimaryNodeInner {
 
         self.swap_registry(None);
 
-        info!("Narwhal primary shutdown is complete");
+        info!(
+            "Narwhal primary shutdown is complete - took {} seconds",
+            now.elapsed().as_secs_f64()
+        );
     }
 
     // Helper method useful to wait on the execution of the primary node

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use storage::NodeStorage;
 use tokio::sync::{oneshot, watch, RwLock};
 use tokio::task::JoinHandle;
-use tracing::{debug, info};
+use tracing::{debug, info, instrument};
 use types::{
     metered_channel, Certificate, ConditionalBroadcastReceiver, PreSubscribedBroadcastSender, Round,
 };
@@ -46,6 +46,7 @@ impl PrimaryNodeInner {
 
     // Starts the primary node with the provided info. If the node is already running then this
     // method will return an error instead.
+    #[instrument(level = "info", skip_all)]
     async fn start<State>(
         &mut self, // The private-public key pair of this authority.
         keypair: KeyPair,
@@ -102,13 +103,14 @@ impl PrimaryNodeInner {
     // Will shutdown the primary node and wait until the node has shutdown by waiting on the
     // underlying components handles. If the node was not already running then the
     // method will return immediately.
+    #[instrument(level = "info", skip_all)]
     async fn shutdown(&mut self) {
         if !self.is_running().await {
             return;
         }
 
         // send the shutdown signal to the node
-        info!("Sending shutdown message to narwhal");
+        info!("Sending shutdown message to primary node");
 
         if let Some(tx_shutdown) = self.tx_shutdown.as_ref() {
             tx_shutdown

--- a/narwhal/node/src/worker_node.rs
+++ b/narwhal/node/src/worker_node.rs
@@ -330,7 +330,7 @@ impl WorkerNodes {
     }
 
     // returns the worker ids that are currently running
-    async fn workers_running(&self) -> Vec<WorkerId> {
+    pub async fn workers_running(&self) -> Vec<WorkerId> {
         let mut worker_ids = Vec::new();
 
         for (id, worker) in self.workers.load_full().as_ref() {

--- a/narwhal/node/src/worker_node.rs
+++ b/narwhal/node/src/worker_node.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use storage::NodeStorage;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
-use tracing::info;
+use tracing::{info, instrument};
 use types::PreSubscribedBroadcastSender;
 use worker::metrics::{initialise_metrics, Metrics};
 use worker::{TransactionValidator, Worker, NUM_SHUTDOWN_RECEIVERS};
@@ -35,6 +35,7 @@ pub struct WorkerNodeInner {
 impl WorkerNodeInner {
     // Starts the worker node with the provided info. If the node is already running then this
     // method will return an error instead.
+    #[instrument(level = "info", skip_all)]
     async fn start(
         &mut self,
         // The primary's public key
@@ -97,6 +98,7 @@ impl WorkerNodeInner {
     // Will shutdown the worker node and wait until the node has shutdown by waiting on the
     // underlying components handles. If the node was not already running then the
     // method will return immediately.
+    #[instrument(level = "info", skip_all)]
     async fn shutdown(&mut self) {
         if !self.is_running().await {
             return;
@@ -234,6 +236,7 @@ impl WorkerNodes {
         }
     }
 
+    #[instrument(level = "info", skip_all)]
     pub async fn start(
         &self,
         // The primary's public key of this authority.
@@ -302,6 +305,7 @@ impl WorkerNodes {
     }
 
     // Shuts down all the workers
+    #[instrument(level = "info", skip_all)]
     pub async fn shutdown(&self) {
         for (key, worker) in self.workers.load_full().as_ref() {
             info!("Shutting down worker {}", key);

--- a/narwhal/node/src/worker_node.rs
+++ b/narwhal/node/src/worker_node.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::metrics::new_registry;
 use crate::{try_join_all, FuturesUnordered, NodeError};
 use arc_swap::{ArcSwap, ArcSwapOption};
 use config::{Parameters, SharedCommittee, SharedWorkerCache, WorkerId};
@@ -63,7 +64,7 @@ impl WorkerNodeInner {
             (metrics, None)
         } else {
             // create a new registry
-            let registry = Registry::new();
+            let registry = new_registry(committee.load().epoch);
 
             (initialise_metrics(&registry), Some(registry))
         };
@@ -264,7 +265,7 @@ impl WorkerNodes {
         }
 
         // create the registry first
-        let registry = Registry::new();
+        let registry = new_registry(committee.load().epoch);
 
         let metrics = initialise_metrics(&registry);
 

--- a/narwhal/node/src/worker_node.rs
+++ b/narwhal/node/src/worker_node.rs
@@ -9,6 +9,7 @@ use mysten_metrics::{RegistryID, RegistryService};
 use prometheus::Registry;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 use storage::NodeStorage;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
@@ -104,6 +105,7 @@ impl WorkerNodeInner {
             return;
         }
 
+        let now = Instant::now();
         if let Some(tx_shutdown) = self.tx_shutdown.as_ref() {
             tx_shutdown
                 .send()
@@ -116,7 +118,11 @@ impl WorkerNodeInner {
 
         self.swap_registry(None);
 
-        info!("Narwhal worker {} shutdown is complete", self.id);
+        info!(
+            "Narwhal worker {} shutdown is complete - took {} seconds",
+            self.id,
+            now.elapsed().as_secs_f64()
+        );
     }
 
     // If any of the underlying handles haven't still finished, then this method will return


### PR DESCRIPTION
This PR is addressing the following:

* refactors the `narwhal_manager` to support blocking `start` & `shutdown` methods. Instead of using channels now we use pure methods directly on the `narwhal_manager` . The `shutdown` method is blocking and returns only when Narwhal (primary + workers) has shutdown allowing us to proceed to the rest of SUI reconfig.
* refactors the admin server to make a few retries when trying to bootstrap. That gives some grace period for the port to get unbinded - assuming is not done directly - and avoid any relevant errors.
* adds the `epoch` label in every Narwhal metric  for primary/worker nodes

**Note:**  I expected now the node actual reconfiguration time to increase as we'll wait for Narwhal to complete the shutdown process before we continue. On the one hand this has the pro that we perform things sequentially and make things easier to reasonate about and ensure we don't have Narwhal running on previous epoch while we reconfigure SUI node. The con is that it will increase the reconfiguration time per node.