### PR TITLE
[load test] add delegation transactions

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -352,7 +352,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
                                                 }
                                                 NextOp::Response(Some((
                                                     latency,
-                                                    b.1.make_new_payload(new_version, effects.gas_object().0),
+                                                    b.1.make_new_payload(new_version, effects.gas_object().0, &effects),
                                                 ),
                                                 ))
                                             }
@@ -398,7 +398,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
                                             if let Some(sig_info) = effects.quorum_sig() { sig_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_effects_cert.with_label_values(&[&name.unwrap().to_string()]).inc()) }
                                             NextOp::Response(Some((
                                                 latency,
-                                                payload.make_new_payload(new_version, effects.gas_object().0),
+                                                payload.make_new_payload(new_version, effects.gas_object().0, &effects),
                                             )))
                                         }
                                         Err(err) => {

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -132,6 +132,9 @@ pub enum RunSpec {
         // transactions in the benchmark workload
         #[clap(long, default_value = "1")]
         transfer_object: u32,
+        // relative weight of delegation transactions in the benchmark workload
+        #[clap(long, default_value = "0")]
+        delegation: u32,
         // Target qps
         #[clap(long, default_value = "1000", global = true)]
         target_qps: u64,

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -193,6 +193,7 @@ pub async fn generate_all_gas_for_test(
             .iter()
             .cloned(),
     );
+    coin_configs.extend(workload_gas_config.delegation_gas_configs.iter().cloned());
 
     let (_updated_primary_gas, mut new_gas_coins) = split_coin_and_pay(
         proxy.clone(),
@@ -249,6 +250,18 @@ pub async fn generate_all_gas_for_test(
         })
         .collect();
 
+    let delegation_payload_gas = workload_gas_config
+        .delegation_gas_configs
+        .iter()
+        .map(|c| {
+            let (index, _) = new_gas_coins
+                .iter()
+                .find_position(|g| g.1.get_owner_address().unwrap() == c.address)
+                .unwrap();
+            new_gas_coins.remove(index)
+        })
+        .collect();
+
     let workload_init_config = WorkloadInitGas {
         shared_counter_init_gas,
     };
@@ -257,6 +270,7 @@ pub async fn generate_all_gas_for_test(
         transfer_tokens,
         transfer_object_payload_gas,
         shared_counter_payload_gas,
+        delegation_payload_gas,
     };
 
     Ok((workload_init_config, workload_payload_config))

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::workloads::payload::Payload;
+use crate::workloads::workload::{Workload, WorkloadType, MAX_GAS_FOR_TESTING};
+use crate::workloads::{GasCoinConfig, WorkloadInitGas, WorkloadPayloadGas};
+use crate::{ExecutionEffects, ValidatorProxy};
+use async_trait::async_trait;
+use rand::seq::IteratorRandom;
+use std::sync::Arc;
+use sui_core::test_utils::make_transfer_sui_transaction;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::crypto::{get_key_pair, AccountKeyPair};
+use sui_types::messages::VerifiedTransaction;
+use sui_types::SUI_FRAMEWORK_OBJECT_ID;
+use test_utils::messages::make_delegation_transaction;
+
+pub struct DelegationTestPayload {
+    system_package_ref: ObjectRef,
+    coin: Option<ObjectRef>,
+    gas: ObjectRef,
+    validator: SuiAddress,
+    sender: SuiAddress,
+    keypair: Arc<AccountKeyPair>,
+}
+
+impl Payload for DelegationTestPayload {
+    /// delegation flow is split into two phases
+    /// first `make_transaction` call creates separate coin object for future delegation
+    /// followup call creates delegation transaction itself
+    fn make_transaction(&self) -> VerifiedTransaction {
+        match self.coin {
+            Some(coin) => make_delegation_transaction(
+                self.gas,
+                coin,
+                self.system_package_ref,
+                self.validator,
+                self.sender,
+                &self.keypair,
+            ),
+            None => make_transfer_sui_transaction(
+                self.gas,
+                self.sender,
+                Some(1),
+                self.sender,
+                &self.keypair,
+            ),
+        }
+    }
+
+    fn make_new_payload(
+        self: Box<Self>,
+        _: ObjectRef,
+        new_gas: ObjectRef,
+        effects: &ExecutionEffects,
+    ) -> Box<dyn Payload> {
+        let coin = match self.coin {
+            None => Some(effects.created().get(0).unwrap().0),
+            Some(_) => None,
+        };
+        Box::new(DelegationTestPayload {
+            system_package_ref: self.system_package_ref,
+            coin,
+            gas: new_gas,
+            validator: self.validator,
+            sender: self.sender,
+            keypair: self.keypair,
+        })
+    }
+
+    fn get_object_id(&self) -> ObjectID {
+        self.gas.0
+    }
+
+    fn get_workload_type(&self) -> WorkloadType {
+        WorkloadType::Delegation
+    }
+}
+
+pub struct DelegationWorkload;
+
+impl DelegationWorkload {
+    pub fn new_boxed() -> Box<dyn Workload<dyn Payload>> {
+        Box::<dyn Workload<dyn Payload>>::from(Box::new(DelegationWorkload))
+    }
+
+    pub fn generate_gas_config_for_payloads(count: u64) -> Vec<GasCoinConfig> {
+        (0..count)
+            .map(|_| {
+                let (address, keypair) = get_key_pair();
+                GasCoinConfig {
+                    amount: MAX_GAS_FOR_TESTING,
+                    address,
+                    keypair: Arc::new(keypair),
+                }
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl Workload<dyn Payload> for DelegationWorkload {
+    async fn init(&mut self, _: WorkloadInitGas, _: Arc<dyn ValidatorProxy + Sync + Send>) {}
+
+    async fn make_test_payloads(
+        &self,
+        _num_payloads: u64,
+        gas_config: WorkloadPayloadGas,
+        proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+    ) -> Vec<Box<dyn Payload>> {
+        let system_package = proxy.get_object(SUI_FRAMEWORK_OBJECT_ID).await;
+        let system_package_ref = system_package.unwrap().compute_object_reference();
+        let validators = proxy
+            .get_validators()
+            .await
+            .expect("failed to fetch validators");
+
+        gas_config
+            .delegation_payload_gas
+            .into_iter()
+            .map(|(gas, owner, keypair)| {
+                let validator = *validators.iter().choose(&mut rand::thread_rng()).unwrap();
+                Box::new(DelegationTestPayload {
+                    system_package_ref,
+                    coin: None,
+                    gas,
+                    validator,
+                    sender: owner.get_owner_address().unwrap(),
+                    keypair,
+                })
+            })
+            .map(|b| Box::<dyn Payload>::from(b))
+            .collect()
+    }
+
+    fn get_workload_type(&self) -> WorkloadType {
+        WorkloadType::Delegation
+    }
+}

--- a/crates/sui-benchmark/src/workloads/payload.rs
+++ b/crates/sui-benchmark/src/workloads/payload.rs
@@ -5,6 +5,7 @@ use sui_types::base_types::{ObjectID, ObjectRef};
 
 use sui_types::messages::VerifiedTransaction;
 
+use crate::ExecutionEffects;
 use rand::{prelude::*, rngs::OsRng};
 use rand_distr::WeightedAliasIndex;
 
@@ -15,6 +16,7 @@ pub trait Payload: Send + Sync {
         self: Box<Self>,
         new_object: ObjectRef,
         new_gas: ObjectRef,
+        effects: &ExecutionEffects,
     ) -> Box<dyn Payload>;
     fn make_transaction(&self) -> VerifiedTransaction;
     fn get_object_id(&self) -> ObjectID;
@@ -33,11 +35,12 @@ impl Payload for CombinationPayload {
         self: Box<Self>,
         new_object: ObjectRef,
         new_gas: ObjectRef,
+        effects: &ExecutionEffects,
     ) -> Box<dyn Payload> {
         let mut new_payloads = vec![];
         for (pos, e) in self.payloads.into_iter().enumerate() {
             if pos == self.curr_index {
-                let updated = e.make_new_payload(new_object, new_gas);
+                let updated = e.make_new_payload(new_object, new_gas, effects);
                 new_payloads.push(updated);
             } else {
                 new_payloads.push(e);

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -7,7 +7,7 @@ use crate::workloads::Gas;
 use crate::workloads::payload::Payload;
 use crate::workloads::workload::MAX_GAS_FOR_TESTING;
 use crate::workloads::{GasCoinConfig, WorkloadInitGas, WorkloadPayloadGas};
-use crate::ValidatorProxy;
+use crate::{ExecutionEffects, ValidatorProxy};
 use async_trait::async_trait;
 use futures::future::join_all;
 use rand::seq::SliceRandom;
@@ -32,7 +32,12 @@ pub struct SharedCounterTestPayload {
 }
 
 impl Payload for SharedCounterTestPayload {
-    fn make_new_payload(self: Box<Self>, _: ObjectRef, new_gas: ObjectRef) -> Box<dyn Payload> {
+    fn make_new_payload(
+        self: Box<Self>,
+        _: ObjectRef,
+        new_gas: ObjectRef,
+        _: &ExecutionEffects,
+    ) -> Box<dyn Payload> {
         Box::new(SharedCounterTestPayload {
             package_ref: self.package_ref,
             counter_id: self.counter_id,

--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -16,7 +16,7 @@ use sui_types::{
 
 use crate::workloads::payload::Payload;
 use crate::workloads::{Gas, GasCoinConfig, WorkloadInitGas, WorkloadPayloadGas};
-use crate::ValidatorProxy;
+use crate::{ExecutionEffects, ValidatorProxy};
 use sui_core::test_utils::make_transfer_object_transaction;
 
 use super::workload::{Workload, WorkloadType, MAX_GAS_FOR_TESTING};
@@ -33,6 +33,7 @@ impl Payload for TransferObjectTestPayload {
         self: Box<Self>,
         new_object: ObjectRef,
         new_gas: ObjectRef,
+        _: &ExecutionEffects,
     ) -> Box<dyn Payload> {
         let recipient = self
             .gas

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -21,6 +21,7 @@ pub enum WorkloadType {
     SharedCounter,
     TransferObject,
     Combination,
+    Delegation,
 }
 
 impl fmt::Display for WorkloadType {
@@ -29,6 +30,7 @@ impl fmt::Display for WorkloadType {
             WorkloadType::SharedCounter => write!(f, "shared_counter"),
             WorkloadType::TransferObject => write!(f, "transfer_object"),
             WorkloadType::Combination => write!(f, "combination"),
+            WorkloadType::Delegation => write!(f, "delegation"),
         }
     }
 }

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -8,6 +8,7 @@ mod test {
     use std::sync::Arc;
     use std::time::Duration;
     use sui_benchmark::util::generate_all_gas_for_test;
+    use sui_benchmark::workloads::delegation::DelegationWorkload;
     use sui_benchmark::workloads::shared_counter::SharedCounterWorkload;
     use sui_benchmark::workloads::transfer_object::TransferObjectWorkload;
     use sui_benchmark::workloads::WorkloadGasConfig;
@@ -111,6 +112,7 @@ mod test {
 
         let (transfer_object_workload_tokens, transfer_object_workload_payload_gas_config) =
             TransferObjectWorkload::generate_coin_config_for_payloads(max_ops, 2, max_ops);
+        let delegation_gas_configs = DelegationWorkload::generate_gas_config_for_payloads(max_ops);
         let (workload_init_gas, workload_payload_gas) = generate_all_gas_for_test(
             proxy.clone(),
             primary_gas,
@@ -121,6 +123,7 @@ mod test {
                 shared_counter_workload_payload_gas_config,
                 transfer_object_workload_tokens,
                 transfer_object_workload_payload_gas_config,
+                delegation_gas_configs,
             },
         )
         .await
@@ -132,6 +135,7 @@ mod test {
             2, // num transfer accounts
             1, // shared_counter_weight
             1, // transfer_object_weight
+            1, // delegation_weight
             workload_payload_gas,
         );
         combination_workload


### PR DESCRIPTION
adding delegation transactions to load test
it already allows to stress test the scenario where multiple delegation requests are sent (i.e. how system in such case will behave after reconfiguration) 

*note that PR doesn't support undelegate functionality*
