### PR TITLE
[checkpoints] Pin user signatures in the checkpoint contents.

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -19,7 +19,7 @@ use sui_storage::mutex_table::LockGuard;
 use sui_storage::write_ahead_log::{DBWriteAheadLog, TxGuard, WriteAheadLog};
 use sui_types::base_types::{AuthorityName, EpochId, ObjectID, SequenceNumber, TransactionDigest};
 use sui_types::committee::Committee;
-use sui_types::crypto::AuthoritySignInfo;
+use sui_types::crypto::{AuthoritySignInfo, Signature};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     CertifiedTransaction, ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind,
@@ -203,6 +203,10 @@ pub struct AuthorityEpochTables {
     /// The key in this table is checkpoint sequence number and an arbitrary integer
     pending_checkpoint_signatures:
         DBMap<(CheckpointSequenceNumber, u64), CheckpointSignatureMessage>,
+
+    /// When we see certificate through consensus for the first time, we record
+    /// user signature for this transaction here. This will be included in the checkpoint later.
+    user_signatures_for_checkpoints: DBMap<TransactionDigest, Signature>,
 }
 
 impl AuthorityEpochTables {
@@ -716,6 +720,31 @@ impl AuthorityPerEpochStore {
             .contains_key(authority))
     }
 
+    /// Note: this is async function as it waits for certificates to be processed by
+    /// consensus before returning
+    pub async fn user_signatures_for_checkpoint(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Signature>> {
+        // todo - use NotifyRead::register_all might be faster
+        for digest in digests {
+            self.consensus_message_processed_notify(ConsensusTransactionKey::Certificate(*digest))
+                .await?;
+        }
+        let signatures = self
+            .tables
+            .user_signatures_for_checkpoints
+            .multi_get(digests)?;
+        let mut result = Vec::with_capacity(digests.len());
+        for (signature, digest) in signatures.into_iter().zip(digests.iter()) {
+            let Some(signature) = signature else {
+                return Err(SuiError::from(format!("Can not find user signature for checkpoint for transaction {:?}", digest).as_str()));
+            };
+            result.push(signature);
+        }
+        Ok(result)
+    }
+
     /// Returns Ok(true) if 2f+1 end of publish messages were recorded at this point
     pub fn record_end_of_publish(
         &self,
@@ -914,6 +943,19 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
+    pub fn test_insert_user_signature(&self, digest: TransactionDigest, signature: &Signature) {
+        self.tables
+            .user_signatures_for_checkpoints
+            .insert(&digest, signature)
+            .unwrap();
+        let key = ConsensusTransactionKey::Certificate(digest);
+        self.tables
+            .consensus_message_processed
+            .insert(&key, &true)
+            .unwrap();
+        self.consensus_notify_read.notify(&key, &());
+    }
+
     fn finish_consensus_certificate_process_with_batch(
         &self,
         batch: DBBatch,
@@ -929,6 +971,16 @@ impl AuthorityPerEpochStore {
         let batch = batch.insert_batch(
             &self.tables.pending_certificates,
             [(*certificate.digest(), certificate.clone().serializable())],
+        )?;
+        // User signatures are written in the same batch as consensus certificate processed flag,
+        // which means we won't attempt to insert this twice for the same tx digest
+        debug_assert!(!self
+            .tables
+            .user_signatures_for_checkpoints
+            .contains_key(certificate.digest())?);
+        let batch = batch.insert_batch(
+            &self.tables.user_signatures_for_checkpoints,
+            [(*certificate.digest(), certificate.tx_signature.clone())],
         )?;
         self.finish_consensus_transaction_process_with_batch(batch, key, consensus_index)
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2976,13 +2976,21 @@
         "description": "CheckpointContents are the transactions included in an upcoming checkpoint. They must have already been causally ordered. Since the causal order algorithm is the same among validators, we expect all honest validators to come up with the same order for each checkpoint content.",
         "type": "object",
         "required": [
-          "transactions"
+          "transactions",
+          "user_signatures"
         ],
         "properties": {
           "transactions": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ExecutionDigests"
+            }
+          },
+          "user_signatures": {
+            "description": "This field 'pins' user signatures for the checkpoint:\n\n* For normal checkpoint this field will contain same number of elements as transactions. * Genesis checkpoint has transactions but this field is empty. * Last checkpoint in the epoch will have (last)extra system transaction in the transactions list not covered in the signatures list",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Signature"
             }
           }
         }

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -755,6 +755,13 @@ pub struct Ed25519SuiSignature(
     [u8; Ed25519PublicKey::LENGTH + Ed25519Signature::LENGTH + 1],
 );
 
+// Implementation useful for simplify testing when mock signature is needed
+impl Default for Ed25519SuiSignature {
+    fn default() -> Self {
+        Self([0; Ed25519PublicKey::LENGTH + Ed25519Signature::LENGTH + 1])
+    }
+}
+
 impl SuiSignatureInner for Ed25519SuiSignature {
     type Sig = Ed25519Signature;
     type PubKey = Ed25519PublicKey;

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -7,7 +7,9 @@ use std::slice::Iter;
 
 use crate::base_types::ExecutionDigests;
 use crate::committee::{EpochId, StakeUnit};
-use crate::crypto::{AuthoritySignInfo, AuthoritySignInfoTrait, AuthorityWeakQuorumSignInfo};
+use crate::crypto::{
+    AuthoritySignInfo, AuthoritySignInfoTrait, AuthorityWeakQuorumSignInfo, Signature,
+};
 use crate::error::SuiResult;
 use crate::gas::GasCostSummary;
 use crate::sui_serde::Readable;
@@ -399,6 +401,13 @@ pub struct CheckpointSignatureMessage {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CheckpointContents {
     transactions: Vec<ExecutionDigests>,
+    /// This field 'pins' user signatures for the checkpoint:
+    ///
+    /// * For normal checkpoint this field will contain same number of elements as transactions.
+    /// * Genesis checkpoint has transactions but this field is empty.
+    /// * Last checkpoint in the epoch will have (last)extra system transaction
+    /// in the transactions list not covered in the signatures list
+    user_signatures: Vec<Signature>,
 }
 
 impl CheckpointSignatureMessage {
@@ -414,6 +423,20 @@ impl CheckpointContents {
     {
         Self {
             transactions: contents.into_iter().collect(),
+            user_signatures: vec![],
+        }
+    }
+
+    pub fn new_with_causally_ordered_transactions_and_signatures<T>(
+        contents: T,
+        signatures: Vec<Signature>,
+    ) -> Self
+    where
+        T: IntoIterator<Item = ExecutionDigests>,
+    {
+        Self {
+            transactions: contents.into_iter().collect(),
+            user_signatures: signatures,
         }
     }
 


### PR DESCRIPTION
This PR adds `CheckpointContents::signatures` field that contains user signatures submitted for the transaction.

This is needed because otherwise we do not have any record of the user signatures in the checkpoints history, because we no longer commit to the transaction signature in the TransactionDigest.