### PR TITLE
[explorer] Remove vercel silent for explorer

### DIFF
--- a/apps/explorer/vercel.json
+++ b/apps/explorer/vercel.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://openapi.vercel.sh/vercel.json",
     "rewrites": [{ "source": "/(.*)", "destination": "/" }],
-    "github": {
-        "silent": true
-    },
     "headers": [
         {
             "source": "/assets/(.*)",


### PR DESCRIPTION
This was added back when we only had one vercel project. Now we have several, and we don't use silent for the others, so let's just remove this for the explorer as well so that things are consistent.