### PR TITLE
[wallet-kit] Add support for preferred wallets in wallet kit

### DIFF
--- a/.changeset/rotten-donkeys-call.md
+++ b/.changeset/rotten-donkeys-call.md
@@ -1,0 +1,6 @@
+---
+"@mysten/wallet-kit-core": patch
+"@mysten/wallet-kit": patch
+---
+
+Add support for preferred wallets.

--- a/sdk/wallet-adapter/wallet-kit/src/WalletKitContext.tsx
+++ b/sdk/wallet-adapter/wallet-kit/src/WalletKitContext.tsx
@@ -22,6 +22,7 @@ export const WalletKitContext = createContext<WalletKitCore | null>(null);
 
 interface WalletKitProviderProps {
   adapters?: WalletAdapterList;
+  preferredWallets?: string[];
   /** Enable the development-only unsafe burner wallet, which is can be useful for testing. */
   enableUnsafeBurner?: boolean;
   children: ReactNode;
@@ -29,6 +30,7 @@ interface WalletKitProviderProps {
 
 export function WalletKitProvider({
   adapters: configuredAdapters,
+  preferredWallets,
   children,
   enableUnsafeBurner,
 }: WalletKitProviderProps) {
@@ -43,7 +45,7 @@ export function WalletKitProvider({
 
   const walletKitRef = useRef<WalletKitCore | null>(null);
   if (!walletKitRef.current) {
-    walletKitRef.current = createWalletKitCore({ adapters });
+    walletKitRef.current = createWalletKitCore({ adapters, preferredWallets });
   }
 
   return (


### PR DESCRIPTION
This adds a configurable list of "preferred wallets" to Wallet Kit, which will change the sort order of wallets within wallet kit (preferred wallets ordered to the top). This defaults to the Sui Wallet, but is entirely configurable. 