### PR TITLE
[checkpoint] Remove authenticated checkpoint

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -110,6 +110,14 @@ impl CheckpointStore {
             .map(|maybe_checkpoint| maybe_checkpoint.map(VerifiedCheckpoint::new_unchecked))
     }
 
+    pub fn get_latest_certified_checkpoint(&self) -> Option<VerifiedCheckpoint> {
+        self.certified_checkpoints
+            .iter()
+            .skip_to_last()
+            .next()
+            .map(|(_, v)| VerifiedCheckpoint::new_unchecked(v))
+    }
+
     pub fn multi_get_checkpoint_by_sequence_number(
         &self,
         sequence_numbers: &[CheckpointSequenceNumber],

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -10,8 +10,7 @@ use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry
 use std::sync::Arc;
 use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::messages_checkpoint::{
-    AuthenticatedCheckpoint, CheckpointRequest, CheckpointRequestType, CheckpointResponse,
-    CheckpointSequenceNumber,
+    CertifiedCheckpointSummary, CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber,
 };
 use sui_types::{base_types::*, committee::*, fp_ensure};
 use sui_types::{
@@ -624,7 +623,7 @@ where
     fn verify_checkpoint_sequence(
         &self,
         expected_seq: Option<CheckpointSequenceNumber>,
-        checkpoint: &Option<AuthenticatedCheckpoint>,
+        checkpoint: &Option<CertifiedCheckpointSummary>,
     ) -> SuiResult {
         let observed_seq = checkpoint.as_ref().map(|c| c.summary().sequence_number);
 
@@ -661,24 +660,20 @@ where
         response: &CheckpointResponse,
     ) -> SuiResult {
         // Verify response data was correct for request
-        match &request.request_type {
-            CheckpointRequestType::AuthenticatedCheckpoint(seq) => {
-                let CheckpointResponse::AuthenticatedCheckpoint {
-                    checkpoint,
-                    contents,
-                } = &response;
-                // Checks that the sequence number is correct.
-                self.verify_checkpoint_sequence(*seq, checkpoint)?;
-                self.verify_contents_exist(request.detail, checkpoint, contents)?;
-                // Verify signature.
-                match checkpoint {
-                    Some(c) => {
-                        let epoch_id = c.summary().epoch;
-                        c.verify(&self.get_committee(&epoch_id)?, contents.as_ref())
-                    }
-                    None => Ok(()),
-                }
+        let CheckpointResponse {
+            checkpoint,
+            contents,
+        } = &response;
+        // Checks that the sequence number is correct.
+        self.verify_checkpoint_sequence(request.sequence_number, checkpoint)?;
+        self.verify_contents_exist(request.request_content, checkpoint, contents)?;
+        // Verify signature.
+        match checkpoint {
+            Some(c) => {
+                let epoch_id = c.summary().epoch;
+                c.verify(&self.get_committee(&epoch_id)?, contents.as_ref())
             }
+            None => Ok(()),
         }
     }
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -11,9 +11,7 @@ use crate::crypto::{
 use crate::gas::GasCostSummary;
 use crate::intent::{Intent, IntentMessage};
 use crate::message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope};
-use crate::messages_checkpoint::{
-    AuthenticatedCheckpoint, CheckpointSequenceNumber, CheckpointSignatureMessage,
-};
+use crate::messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage};
 use crate::object::{MoveObject, Object, ObjectFormatOptions, Owner, PACKAGE_VERSION};
 use crate::storage::{DeleteKind, WriteKind};
 use crate::{
@@ -1055,33 +1053,6 @@ pub type TrustedCertificate = TrustedEnvelope<SenderSignedData, AuthorityStrongQ
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct AccountInfoRequest {
     pub account: SuiAddress,
-}
-
-/// Subscribe to notifications when new checkpoint certificates are available.
-///
-/// Note that there is no start field necessary, because checkpoint sequence numbers are
-/// contiguous. Therefore the client is always immediately sent the highest available checkpoint
-/// number, from which they can deduce if they are missing any checkpoints.
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct CheckpointStreamRequest {
-    // No request fields are currently necessary, but tonic errors when the request struct has size
-    // 0.
-    _ignored: u64,
-}
-
-impl CheckpointStreamRequest {
-    pub fn new() -> Self {
-        Default::default()
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CheckpointStreamResponseItem {
-    /// The first available checkpoint sequence on this validator. Currently this is always 0.
-    /// When snapshots are implemented, this may change to become the first checkpoint after the
-    /// most recent snapshot.
-    pub first_available_sequence: CheckpointSequenceNumber,
-    pub checkpoint: AuthenticatedCheckpoint,
 }
 
 impl From<SuiAddress> for AccountInfoRequest {

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -26,77 +26,19 @@ pub type CheckpointSequenceNumber = u64;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointRequest {
-    // Type of checkpoint request
-    pub request_type: CheckpointRequestType,
-    // A flag, if true also return the contents of the
-    // checkpoint besides the meta-data.
-    pub detail: bool,
-}
-
-impl CheckpointRequest {
-    pub fn authenticated(seq: Option<CheckpointSequenceNumber>, detail: bool) -> CheckpointRequest {
-        CheckpointRequest {
-            request_type: CheckpointRequestType::AuthenticatedCheckpoint(seq),
-            detail,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum CheckpointRequestType {
-    /// Request a stored authenticated checkpoint.
     /// if a sequence number is specified, return the checkpoint with that sequence number;
     /// otherwise if None returns the latest authenticated checkpoint stored.
-    AuthenticatedCheckpoint(Option<CheckpointSequenceNumber>),
+    pub sequence_number: Option<CheckpointSequenceNumber>,
+    // A flag, if true also return the contents of the
+    // checkpoint besides the meta-data.
+    pub request_content: bool,
 }
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum CheckpointResponse {
-    AuthenticatedCheckpoint {
-        checkpoint: Option<AuthenticatedCheckpoint>,
-        contents: Option<CheckpointContents>,
-    },
-}
-
-// TODO: Rename to AuthenticatedCheckpointSummary
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum AuthenticatedCheckpoint {
-    // The checkpoint with just a single authority
-    // signature.
-    Signed(SignedCheckpointSummary),
-    // The checkpoint with a quorum of signatures.
-    Certified(CertifiedCheckpointSummary),
-}
-
-impl AuthenticatedCheckpoint {
-    pub fn summary(&self) -> &CheckpointSummary {
-        match self {
-            Self::Signed(s) => &s.summary,
-            Self::Certified(c) => &c.summary,
-        }
-    }
-
-    pub fn verify(&self, committee: &Committee, detail: Option<&CheckpointContents>) -> SuiResult {
-        match self {
-            Self::Signed(s) => s.verify(committee, detail),
-            Self::Certified(c) => c.verify(committee, detail),
-        }
-    }
-
-    pub fn sequence_number(&self) -> CheckpointSequenceNumber {
-        match self {
-            Self::Signed(s) => s.summary.sequence_number,
-            Self::Certified(c) => c.summary.sequence_number,
-        }
-    }
-
-    pub fn epoch(&self) -> EpochId {
-        match self {
-            Self::Signed(s) => s.summary.epoch,
-            Self::Certified(c) => c.summary.epoch,
-        }
-    }
+pub struct CheckpointResponse {
+    pub checkpoint: Option<CertifiedCheckpointSummary>,
+    pub contents: Option<CheckpointContents>,
 }
 
 #[serde_as]


### PR DESCRIPTION
This PR removes authenticated checkpoint which is no longer needed.
Also removes the checkpoint query method from authority aggregator, which is also no longer needed.
Also re-enables the handle_checkpoint API on validators. We don't need this in our normal operation, but it could be useful for debugging purposes.