### PR TITLE
[checkpoints] Insert genesis transactions in the checkpoint builder index

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1288,6 +1288,19 @@ impl AuthorityPerEpochStore {
         batch.write()
     }
 
+    /// Register genesis transaction in builder DB so that it does not include transaction
+    /// in future checkpoints
+    pub fn put_genesis_transaction_in_builder_digest_to_checkpoint(
+        &self,
+        digest: TransactionDigest,
+        sequence: CheckpointSequenceNumber,
+    ) -> SuiResult<()> {
+        Ok(self
+            .tables
+            .builder_digest_to_checkpoint
+            .insert(&digest, &sequence)?)
+    }
+
     pub fn builder_included_transaction_in_checkpoint(
         &self,
         digest: &TransactionDigest,

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -83,7 +83,20 @@ impl CheckpointStore {
         &self,
         checkpoint: VerifiedCheckpoint,
         contents: CheckpointContents,
+        epoch_store: &AuthorityPerEpochStore,
     ) {
+        for transaction in contents.iter() {
+            debug!(
+                "Manually inserting genesis transaction in checkpoint DB: {:?}",
+                transaction.transaction
+            );
+            epoch_store
+                .put_genesis_transaction_in_builder_digest_to_checkpoint(
+                    transaction.transaction,
+                    checkpoint.sequence_number(),
+                )
+                .unwrap();
+        }
         self.insert_verified_checkpoint(checkpoint.clone()).unwrap();
         self.insert_checkpoint_contents(contents).unwrap();
         self.update_highest_synced_checkpoint(&checkpoint).unwrap();

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -159,8 +159,11 @@ impl SuiNode {
         );
 
         let checkpoint_store = CheckpointStore::new(&config.db_path().join("checkpoints"));
-        checkpoint_store
-            .insert_genesis_checkpoint(genesis.checkpoint(), genesis.checkpoint_contents().clone());
+        checkpoint_store.insert_genesis_checkpoint(
+            genesis.checkpoint(),
+            genesis.checkpoint_contents().clone(),
+            &epoch_store,
+        );
         let state_sync_store = RocksDbStore::new(
             store.clone(),
             committee_store.clone(),


### PR DESCRIPTION
This is needed so that CheckpointBuilder does not attempt to include genesis transaction in the future checkpoints.