### PR TITLE
Minor changes to txn api

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -482,10 +482,7 @@ impl AuthorityPerEpochStore {
         retry_transaction_forever!({
             // This code may still be correct without using a transaction snapshot, but I couldn't
             // convince myself of that.
-            let db_transaction = self
-                .tables
-                .next_shared_object_versions
-                .transaction_with_snapshot()?;
+            let db_transaction = self.tables.next_shared_object_versions.transaction()?;
 
             let next_versions = db_transaction.multi_get(
                 &self.tables.next_shared_object_versions,

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -565,5 +565,5 @@ TypedStoreError:
     4:
       MetricsReporting: UNIT
     5:
-      TransactionWriteConflict: UNIT
+      RetryableTransactionError: UNIT
 

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -21,8 +21,8 @@ pub enum TypedStoreError {
     CrossDBBatch,
     #[error("Metric reporting thread failed with error")]
     MetricsReporting,
-    #[error("Conflicting write detected")]
-    TransactionWriteConflict,
+    #[error("Transaction should be retried")]
+    RetryableTransactionError,
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, Error)]


### PR DESCRIPTION
It might be a better idea to provide stronger isolation guarantee with transaction api by default. This is the premise of this PR. It changes a few small things:
1. By default the `rocksdb.transaction` will open the transaction with set_snapshot set to true. If the user knows what they are doing, they can use `rocksdb.transaction_without_snapshot` where they can choose to call `get_for_update()` or set snapshot by themselves as part of the transaction body. This makes the default mode run with stronger isolation b/w concurrent transactions.
2. Renamed `TransactionWriteConflict` as `RetryableTransactionException` which is returned on tx conflict i.e. `Busy` and when `TryAgain` is returned from the db (as both are perfectly retryable situations). `TryAgain` is returned when memtable history is not enough (because it got flushed) to check for tx conflict and retrying a transaction is most likely going to fix it.