### PR TITLE
Add move event emitting staking and rewards info during epoch change

### DIFF
--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,13 +4,13 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
-    "computation_cost": 6942,
-    "storage_cost": 9958,
+    "computation_cost": 7073,
+    "storage_cost": 10152,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 7802,
-    "storage_cost": 11161,
+    "computation_cost": 7932,
+    "storage_cost": 11355,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
@@ -29,8 +29,8 @@ expression: common_costs_estimate
     "storage_rebate": 0
   },
   "SplitCoin": {
-    "computation_cost": 6921,
-    "storage_cost": 9926,
+    "computation_cost": 7051,
+    "storage_cost": 10119,
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -6,6 +6,7 @@
 
 
 -  [Struct `StakingPool`](#0x2_staking_pool_StakingPool)
+-  [Struct `PoolTokenExchangeRate`](#0x2_staking_pool_PoolTokenExchangeRate)
 -  [Resource `InactiveStakingPool`](#0x2_staking_pool_InactiveStakingPool)
 -  [Struct `DelegationToken`](#0x2_staking_pool_DelegationToken)
 -  [Struct `PendingDelegationEntry`](#0x2_staking_pool_PendingDelegationEntry)
@@ -31,6 +32,7 @@
 -  [Function `validator_address`](#0x2_staking_pool_validator_address)
 -  [Function `staked_sui_amount`](#0x2_staking_pool_staked_sui_amount)
 -  [Function `delegation_token_amount`](#0x2_staking_pool_delegation_token_amount)
+-  [Function `pool_token_exchange_rate`](#0x2_staking_pool_pool_token_exchange_rate)
 -  [Function `new_pending_withdraw_entry`](#0x2_staking_pool_new_pending_withdraw_entry)
 -  [Function `withdraw_from_principal_impl`](#0x2_staking_pool_withdraw_from_principal_impl)
 -  [Function `get_sui_amount`](#0x2_staking_pool_get_sui_amount)
@@ -114,6 +116,40 @@ A staking pool embedded in each validator struct in the system state object.
 <dd>
  Delegation withdraws requested during the current epoch. Similar to new delegation, the withdraws are processed
  at epoch boundaries. Rewards are withdrawn and distributed after the rewards for the current epoch have come in.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_staking_pool_PoolTokenExchangeRate"></a>
+
+## Struct `PoolTokenExchangeRate`
+
+Struct representing the exchange rate of the delegation pool token to SUI.
+
+
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>sui_amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>pool_token_amount: u64</code>
+</dt>
+<dd>
+
 </dd>
 </dl>
 
@@ -1096,6 +1132,33 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_token_amount">delegation_token_amount</a>(delegation: &<a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>): u64 { <a href="balance.md#0x2_balance_value">balance::value</a>(&delegation.pool_tokens) }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_pool_token_exchange_rate"></a>
+
+## Function `pool_token_exchange_rate`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate">pool_token_exchange_rate</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate">pool_token_exchange_rate</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> {
+    <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> {
+        sui_amount: pool.sui_balance,
+        pool_token_amount: <a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(&pool.delegation_token_supply),
+    }
+}
 </code></pre>
 
 

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -31,6 +31,7 @@
 -  [Function `pending_withdraw`](#0x2_validator_pending_withdraw)
 -  [Function `gas_price`](#0x2_validator_gas_price)
 -  [Function `commission_rate`](#0x2_validator_commission_rate)
+-  [Function `pool_token_exchange_rate`](#0x2_validator_pool_token_exchange_rate)
 -  [Function `is_duplicate`](#0x2_validator_is_duplicate)
 
 
@@ -906,6 +907,30 @@ Return the total amount staked with this validator, including both validator sta
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_commission_rate">commission_rate</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
     self.commission_rate
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_pool_token_exchange_rate"></a>
+
+## Function `pool_token_exchange_rate`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pool_token_exchange_rate">pool_token_exchange_rate</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pool_token_exchange_rate">pool_token_exchange_rate</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): PoolTokenExchangeRate {
+    <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate">staking_pool::pool_token_exchange_rate</a>(&self.delegation_staking_pool)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -8,6 +8,7 @@
 -  [Struct `ValidatorSet`](#0x2_validator_set_ValidatorSet)
 -  [Struct `ValidatorPair`](#0x2_validator_set_ValidatorPair)
 -  [Struct `DelegationRequestEvent`](#0x2_validator_set_DelegationRequestEvent)
+-  [Struct `ValidatorEpochInfo`](#0x2_validator_set_ValidatorEpochInfo)
 -  [Constants](#@Constants_0)
 -  [Function `new`](#0x2_validator_set_new)
 -  [Function `request_add_validator`](#0x2_validator_set_request_add_validator)
@@ -42,6 +43,7 @@
 -  [Function `compute_reward_distribution`](#0x2_validator_set_compute_reward_distribution)
 -  [Function `distribute_reward`](#0x2_validator_set_distribute_reward)
 -  [Function `derive_next_epoch_validators`](#0x2_validator_set_derive_next_epoch_validators)
+-  [Function `emit_validator_epoch_events`](#0x2_validator_set_emit_validator_epoch_events)
 -  [Function `active_validators`](#0x2_validator_set_active_validators)
 
 
@@ -210,6 +212,89 @@ Event emitted when a new delegation request is received.
 </dd>
 <dt>
 <code>amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_validator_set_ValidatorEpochInfo"></a>
+
+## Struct `ValidatorEpochInfo`
+
+Event containing staking and rewards related information of
+each validator, emitted during epoch advancement.
+
+
+<pre><code><b>struct</b> <a href="validator_set.md#0x2_validator_set_ValidatorEpochInfo">ValidatorEpochInfo</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>validator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>reference_gas_survey_quote: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>validator_stake: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delegated_stake: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>commission_rate: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>stake_rewards: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>pool_token_exchange_rate: <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>tallying_rule_reporters: <a href="">vector</a>&lt;<b>address</b>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>tallying_rule_global_score: u64</code>
 </dt>
 <dd>
 
@@ -641,7 +726,7 @@ It does the following things:
 5. At the end, we calculate the total stake for the new epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, delegator_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, _validator_report_records: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_advance_epoch">advance_epoch</a>(new_epoch: u64, self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, delegator_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, validator_report_records: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -651,11 +736,12 @@ It does the following things:
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_advance_epoch">advance_epoch</a>(
+    new_epoch: u64,
     self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
     validator_reward: &<b>mut</b> Balance&lt;SUI&gt;,
     delegator_reward: &<b>mut</b> Balance&lt;SUI&gt;,
     storage_fund_reward: &<b>mut</b> Balance&lt;SUI&gt;,
-    _validator_report_records: &VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
+    validator_report_records: &VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
     ctx: &<b>mut</b> TxContext,
 ) {
     // `compute_reward_distribution` must be called before `distribute_reward` and `adjust_stake_and_gas_price` <b>to</b>
@@ -690,6 +776,9 @@ It does the following things:
     <a href="validator_set.md#0x2_validator_set_process_pending_delegation_switches">process_pending_delegation_switches</a>(self, ctx);
 
     <a href="validator_set.md#0x2_validator_set_process_pending_delegations_and_withdraws">process_pending_delegations_and_withdraws</a>(&<b>mut</b> self.active_validators, ctx);
+
+    // Emit events after we have processed all the rewards distribution and pending delegations.
+    <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(new_epoch, &self.active_validators, &validator_reward_amounts, validator_report_records);
 
     <a href="validator_set.md#0x2_validator_set_process_pending_validators">process_pending_validators</a>(&<b>mut</b> self.active_validators, &<b>mut</b> self.pending_validators);
 
@@ -1480,6 +1569,64 @@ TODO: If we want to enforce a % on stake threshold, this is the function to do i
         i = i + 1;
     };
     result
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_emit_validator_epoch_events"></a>
+
+## Function `emit_validator_epoch_events`
+
+Emit events containing information of each validator for the epoch,
+including stakes, rewards, performance, etc.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(new_epoch: u64, vs: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, reward_amounts: &<a href="">vector</a>&lt;u64&gt;, report_records: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(
+    new_epoch: u64,
+    vs: &<a href="">vector</a>&lt;Validator&gt;,
+    reward_amounts: &<a href="">vector</a>&lt;u64&gt;,
+    report_records: &VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
+) {
+    <b>let</b> num_validators = <a href="_length">vector::length</a>(vs);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; num_validators) {
+        <b>let</b> v = <a href="_borrow">vector::borrow</a>(vs, i);
+        <b>let</b> validator_address = <a href="validator.md#0x2_validator_sui_address">validator::sui_address</a>(v);
+        <b>let</b> tallying_rule_reporters =
+            <b>if</b> (<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(report_records, &validator_address)) {
+                <a href="vec_set.md#0x2_vec_set_into_keys">vec_set::into_keys</a>(*<a href="vec_map.md#0x2_vec_map_get">vec_map::get</a>(report_records, &validator_address))
+            } <b>else</b> {
+                <a href="">vector</a>[]
+            };
+        <a href="event.md#0x2_event_emit">event::emit</a>(
+            <a href="validator_set.md#0x2_validator_set_ValidatorEpochInfo">ValidatorEpochInfo</a> {
+                epoch: new_epoch,
+                validator_address,
+                reference_gas_survey_quote: <a href="validator.md#0x2_validator_gas_price">validator::gas_price</a>(v),
+                validator_stake: <a href="validator.md#0x2_validator_stake_amount">validator::stake_amount</a>(v),
+                delegated_stake: <a href="validator.md#0x2_validator_delegate_amount">validator::delegate_amount</a>(v),
+                commission_rate: <a href="validator.md#0x2_validator_commission_rate">validator::commission_rate</a>(v),
+                stake_rewards: *<a href="_borrow">vector::borrow</a>(reward_amounts, i),
+                pool_token_exchange_rate: <a href="validator.md#0x2_validator_pool_token_exchange_rate">validator::pool_token_exchange_rate</a>(v),
+                tallying_rule_reporters,
+                // TODO: placeholder <b>global</b> score
+                tallying_rule_global_score: 1,
+            }
+        );
+        i = i + 1;
+    }
 }
 </code></pre>
 

--- a/crates/sui-framework/sources/governance/staking_pool.move
+++ b/crates/sui-framework/sources/governance/staking_pool.move
@@ -49,6 +49,12 @@ module sui::staking_pool {
         pending_withdraws: TableVec<PendingWithdrawEntry>,
     }
 
+    /// Struct representing the exchange rate of the delegation pool token to SUI.
+    struct PoolTokenExchangeRate has copy, drop {
+        sui_amount: u64,
+        pool_token_amount: u64,
+    }
+
     /// An inactive staking pool associated with an inactive validator.
     /// Only withdraws can be made from this pool.
     struct InactiveStakingPool has key {
@@ -415,6 +421,12 @@ module sui::staking_pool {
 
     public fun delegation_token_amount(delegation: &Delegation): u64 { balance::value(&delegation.pool_tokens) }
 
+    public fun pool_token_exchange_rate(pool: &StakingPool): PoolTokenExchangeRate {
+        PoolTokenExchangeRate {
+            sui_amount: pool.sui_balance,
+            pool_token_amount: balance::supply_value(&pool.delegation_token_supply),
+        }
+    }
     /// Create a new pending withdraw entry.
     public(friend) fun new_pending_withdraw_entry(
         delegator: address, 

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -14,7 +14,7 @@ module sui::validator {
     use sui::epoch_time_lock::EpochTimeLock;
     use std::option::Option;
     use sui::bls12381::bls12381_min_sig_verify_with_domain;
-    use sui::staking_pool::{Self, Delegation, StakedSui, StakingPool};
+    use sui::staking_pool::{Self, Delegation, PoolTokenExchangeRate, StakedSui, StakingPool};
 
     friend sui::genesis;
     friend sui::sui_system;
@@ -301,6 +301,10 @@ module sui::validator {
 
     public fun commission_rate(self: &Validator): u64 {
         self.commission_rate
+    }
+
+    public fun pool_token_exchange_rate(self: &Validator): PoolTokenExchangeRate {
+        staking_pool::pool_token_exchange_rate(&self.delegation_staking_pool)
     }
 
     public fun is_duplicate(self: &Validator, other: &Validator): bool {

--- a/crates/sui-framework/tests/validator_set_tests.move
+++ b/crates/sui-framework/tests/validator_set_tests.move
@@ -203,6 +203,7 @@ module sui::validator_set_tests {
         let dummy_storage_fund_reward = balance::zero();
 
         validator_set::advance_epoch(
+            1, // dummy new epoch number
             validator_set, 
             &mut dummy_validator_reward, 
             &mut dummy_delegator_reward, 


### PR DESCRIPTION
This PR implements event emission during epoch changes.
One system level event `SystemEpochInfo` is emitted, and one validator level event `ValidatorEpochInfo` is emitted per validator.