### PR TITLE
refactor authority aggregator's process tx/cert

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -270,6 +270,7 @@ impl EffectsStakeMap {
     errors
 )]
 pub struct QuorumExecuteCertificateError {
+    pub total_stake: StakeUnit,
     pub errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
 }
 
@@ -1707,6 +1708,7 @@ where
 
         // If none has, fail.
         Err(QuorumExecuteCertificateError {
+            total_stake: self.committee.total_votes,
             errors: state.errors,
         })
     }

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -9,7 +9,6 @@ use crate::authority_client::{
 use crate::safe_client::{SafeClient, SafeClientMetrics, SafeClientMetricsBase};
 use crate::test_authority_clients::LocalAuthorityClient;
 use crate::validator_info::make_committee;
-
 use async_trait::async_trait;
 use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
@@ -17,12 +16,14 @@ use move_core_types::value::MoveStructLayout;
 use mysten_metrics::monitored_future;
 use mysten_network::config::Config;
 use std::convert::AsRef;
+use std::fmt::Display;
 use sui_config::genesis::Genesis;
 use sui_config::NetworkConfig;
 use sui_network::{
     default_mysten_network_config, DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_REQUEST_TIMEOUT_SEC,
 };
 use sui_types::crypto::{AuthorityPublicKeyBytes, AuthoritySignInfo};
+use sui_types::message_envelope::Message;
 use sui_types::object::{Object, ObjectFormatOptions, ObjectRead};
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::{
@@ -32,6 +33,7 @@ use sui_types::{
     messages::*,
 };
 use sui_types::{fp_ensure, SUI_SYSTEM_STATE_OBJECT_ID};
+use thiserror::Error;
 use tracing::{debug, error, info, trace, warn, Instrument};
 
 use prometheus::{
@@ -180,7 +182,25 @@ struct EffectsStakeInfo {
 #[derive(Default)]
 struct EffectsStakeMap {
     effects_map: HashMap<(EpochId, TransactionEffectsDigest), EffectsStakeInfo>,
-    effects_cert: Option<CertifiedTransactionEffects>,
+    effects_cert: Option<VerifiedCertifiedTransactionEffects>,
+}
+
+#[derive(Error, Debug)]
+struct EffectsCertError {
+    error: SuiError,
+    effect_digest: TransactionEffectsDigest,
+    authorities: Vec<AuthorityName>,
+    total_stake: StakeUnit,
+}
+
+impl Display for EffectsCertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "effect_digest: {:?}, error: {:?}, authorities: {:?}, total_stake: {:?}",
+            self.effect_digest, self.error, self.authorities, self.total_stake,
+        )
+    }
 }
 
 impl EffectsStakeMap {
@@ -189,7 +209,7 @@ impl EffectsStakeMap {
         effects: SignedTransactionEffects,
         weight: StakeUnit,
         committee: &Committee,
-    ) -> bool {
+    ) -> Result<bool, EffectsCertError> {
         let epoch = effects.epoch();
         let digest = *effects.digest();
         let (effects, sig) = effects.into_data_and_sig();
@@ -204,32 +224,83 @@ impl EffectsStakeMap {
         entry.stake += weight;
         entry.signatures.push(sig);
 
-        if entry.stake >= committee.quorum_threshold() {
-            self.effects_cert = CertifiedTransactionEffects::new(
-                entry.effects.clone(),
-                entry.signatures.clone(),
-                committee,
-            )
-            .tap_err(|err| {
-                error!(
-                    "A quorum of effects are available but failed to form a certificate: {:?}",
-                    err
-                );
-            })
-            .ok();
-            self.effects_cert.is_some()
-        } else {
-            false
+        if entry.stake < committee.quorum_threshold() {
+            return Ok(false);
         }
+        let cte = CertifiedTransactionEffects::new(
+            entry.effects.clone(),
+            entry.signatures.clone(),
+            committee,
+        )
+        .tap_err(|err| {
+            error!(
+                "A quorum of effects are available but failed to form a certificate: {:?}",
+                err
+            );
+        })
+        .map_err(|e| EffectsCertError {
+            error: e,
+            effect_digest: entry.effects.digest(),
+            authorities: entry.signatures.iter().map(|s| s.authority).collect(),
+            total_stake: entry.stake,
+        })?
+        .verify(committee)
+        .map_err(|e| EffectsCertError {
+            error: e,
+            effect_digest: entry.effects.digest(),
+            authorities: entry.signatures.iter().map(|s| s.authority).collect(),
+            total_stake: entry.stake,
+        })?;
+        self.effects_cert = Some(cte);
+        Ok(true)
     }
 
     pub fn len(&self) -> usize {
         self.effects_map.len()
     }
 
-    pub fn get_cert(&self) -> Option<CertifiedTransactionEffects> {
+    pub fn get_cert(&self) -> Option<VerifiedCertifiedTransactionEffects> {
         self.effects_cert.clone()
     }
+}
+
+#[derive(Error, Debug)]
+#[error(
+    "Failed to execute certificate on a quorum of validators. Validator errors: {:?}",
+    errors
+)]
+pub struct QuorumExecuteCertificateError {
+    errors: BTreeMap<String, (Vec<AuthorityName>, StakeUnit)>,
+}
+
+#[derive(Error, Debug)]
+#[error(
+    "Failed to execute transaction on a quorum of validators to form a transaction certificate. Locked objects: {:?}. Validator errors: {:?}",
+    conflicting_tx_digests,
+    errors,
+)]
+pub struct QuorumExecuteTransactionError {
+    pub good_stake: StakeUnit,
+    pub errors: BTreeMap<String, (Vec<AuthorityName>, StakeUnit)>,
+    pub conflicting_tx_digests:
+        BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
+}
+
+#[derive(Default)]
+struct ProcessTransactionState {
+    // The list of signatures gathered at any point
+    signatures: Vec<AuthoritySignInfo>,
+    // A certificate if we manage to make or find one
+    certificate: Option<VerifiedCertificate>,
+    effects_map: EffectsStakeMap,
+    // The list of errors gathered at any point
+    errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
+    // Tally of stake for good vs bad responses.
+    good_stake: StakeUnit,
+    bad_stake: StakeUnit,
+    // If there are conflicting transactions, we note them down and may attempt to retry
+    conflicting_tx_digests:
+        BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
 }
 
 #[derive(Clone)]
@@ -1181,7 +1252,7 @@ where
     pub async fn process_transaction(
         &self,
         transaction: VerifiedTransaction,
-    ) -> Result<VerifiedCertificate, SuiError> {
+    ) -> Result<VerifiedCertificate, QuorumExecuteTransactionError> {
         // Now broadcast the transaction to all authorities.
         let threshold = self.committee.quorum_threshold();
         let validity = self.committee.validity_threshold();
@@ -1196,23 +1267,6 @@ where
             "Transaction data: {:?}",
             transaction.data().intent_message.value
         );
-
-        #[derive(Default)]
-        struct ProcessTransactionState {
-            // The list of signatures gathered at any point
-            signatures: Vec<AuthoritySignInfo>,
-            // A certificate if we manage to make or find one
-            certificate: Option<VerifiedCertificate>,
-            effects_map: EffectsStakeMap,
-            // The list of errors gathered at any point
-            errors: Vec<SuiError>,
-            // Tally of stake for good vs bad responses.
-            good_stake: StakeUnit,
-            bad_stake: StakeUnit,
-            // If there are conflicting transactions, we note them down and may attempt to retry
-            conflicting_tx_digests:
-                BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
-        }
 
         let state = ProcessTransactionState::default();
 
@@ -1233,54 +1287,14 @@ where
                                 signed_effects: Some(inner_effects),
                                 ..
                             }) => {
-                                // If we get a certificate in the same epoch, then we use it.
-                                // A certificate in a past epoch does not guaranteee finality
-                                // and validators may reject to process it.
-                                if inner_certificate.epoch() == self.committee.epoch {
-                                    debug!(tx_digest = ?tx_digest, name=?name.concise(), weight, "Received prev certificate from validator handle_transaction");
-                                    state.certificate = Some(inner_certificate);
-                                } else if inner_effects.epoch() == self.committee.epoch {
-                                    // If we get 2f+1 effects, it's an proof that the transaction
-                                    // has already been finalized in a different epoch. Regardless
-                                    // of the cert's epoch, we can accept it.
-                                    // This is safe when the signed-effects's epoch is equal to
-                                    // the local epoch because validators re-sign effects that are
-                                    // committed in past epochs. However it's not safe when the
-                                    // signed effects comes from the future because the stake
-                                    // distribution may have changed.
-                                    // Theoretically, the signed effects could be in a previous
-                                    // epoch from a stale validator, but in `effects_map` we try to
-                                    // form a CertifiedTransactionEffects which requires all sigs
-                                    // in the same epoch, this is not necessary but not a big deal
-                                    // anyways.
-                                    // TODO: we may return a CertifiedTransactionEffects directly here
-                                    if state.effects_map.add(inner_effects, weight, &self.committee) {
-                                        debug!(
-                                            tx_digest = ?tx_digest,
-                                            "Got quorum for effects for certs that are from previous epochs handle_transaction"
-                                        );
-                                        state.certificate = Some(inner_certificate);
-                                    }
-                                } else {
-                                    // We reach here when
-                                    // inner_certificate and inner_effects.epoch() > self.committee.epoch
-                                    // and the shared committee store in SafeClient is updated. In this case
-                                    // we record a transient error.
-                                    debug!(
-                                        tx_digest = ?tx_digest,
-                                        name=?name.concise(),
-                                        weight,
-                                        actual_epoch = inner_certificate.epoch(),
-                                        expected_epoch = self.committee.epoch,
-                                        "Received epoch-mismatched transaction cert from validator handle_transaction",
-                                    );
-                                    state.errors.push(
-                                        SuiError::WrongEpoch { expected_epoch: self.committee.epoch, actual_epoch: inner_certificate.epoch() }
-                                    );
-                                    state.bad_stake += weight;
+                                if let Err(err) = self.handle_response_with_certified_transaction(&mut state, name, weight, tx_digest, inner_certificate, inner_effects) {
+                                    // The error means we fail to verify a TransactionEffectsCertificate
+                                    // with a quorum. This shouldn't happen in theory but when it does,
+                                    // we exit
+                                    state.errors.push((err.error, err.authorities, err.total_stake));
+                                    return Ok(ReduceOutput::End(state));
                                 }
                             }
-
                             // If we get back a signed transaction, then we aggregate the
                             // new signature and check whether we have enough to form
                             // a certificate.
@@ -1288,60 +1302,10 @@ where
                                 signed_transaction: Some(inner_signed_transaction),
                                 ..
                             }) => {
-                                // If the signed transaction's epoch is older, than the validator is falling behind.
-                                // If it's newer than we need a reconfig. Either way, we return a transient error.
-                                if inner_signed_transaction.epoch() != self.committee.epoch {
-                                    debug!(
-                                        tx_digest = ?tx_digest,
-                                        name=?name.concise(),
-                                        weight,
-                                        actual_epoch = inner_signed_transaction.epoch(),
-                                        expected_epoch = self.committee.epoch,
-                                        "Received epoch-mismatched signed transaction from validator handle_transaction"
-                                    );
-                                    state.errors.push(
-                                        SuiError::WrongEpoch { expected_epoch: self.committee.epoch, actual_epoch: inner_signed_transaction.epoch() }
-                                    );
-                                    state.bad_stake += weight;
-                                } else {
-                                    let tx_digest = inner_signed_transaction.digest();
-                                    debug!(tx_digest = ?tx_digest, name=?name.concise(), weight, "Received signed transaction from validator handle_transaction");
-                                    state.signatures.push(inner_signed_transaction.into_inner().into_data_and_sig().1);
-                                    state.good_stake += weight;
-                                    if state.good_stake >= threshold {
-                                        self.metrics
-                                            .num_signatures
-                                            .observe(state.signatures.len() as f64);
-                                        self.metrics.num_good_stake.observe(state.good_stake as f64);
-                                        self.metrics.num_bad_stake.observe(state.bad_stake as f64);
-                                        state.certificate =
-                                            Some(CertifiedTransaction::new(
-                                                transaction_ref.data().clone(),
-                                                state.signatures.clone(),
-                                                &self.committee,
-                                            )?.verify(&self.committee)?);
-                                    }
-                                }
+                                self.handle_response_with_signed_transaction(&mut state, name, weight, tx_digest, inner_signed_transaction, transaction_ref, threshold);
                             }
                             Err(err) => {
-                                let concise_name = name.concise();
-                                debug!(tx_digest = ?tx_digest, name=?concise_name, weight, "Failed to let validator sign transaction by handle_transaction: {:?}", err);
-                                self.metrics.process_tx_errors.with_label_values(&[&concise_name.to_string(), err.as_ref()]).inc();
-
-                                if let SuiError::ObjectLockConflict {
-                                    obj_ref,
-                                    pending_transaction,
-                                } = err {
-                                    let (lock_records, total_stake) = state.conflicting_tx_digests
-                                        .entry(pending_transaction)
-                                        .or_insert((Vec::new(), 0));
-                                    lock_records.push((name, obj_ref));
-                                    *total_stake += weight;
-                                }
-
-                                // Append to the list of errors
-                                state.errors.push(err);
-                                state.bad_stake += weight; // This is the bad stake counter
+                                self.handle_response_with_err(&mut state, name, weight, tx_digest, err);
                             }
                             // In case we don't get an error but also don't get a valid value:
                             // the response contains either signed transaction or transaction certificate.
@@ -1355,15 +1319,24 @@ where
                                 );
                                 error!(?tx_digest, name=?name.concise(), error_msg);
 
-                                state.errors.push(
+                                state.errors.push((
                                     SuiError::ByzantineAuthoritySuspicion {
                                         authority: name,
                                         reason: error_msg,
-                                    }
-                                );
+                                    },
+                                    vec![name],
+                                    weight,
+                                ));
                                 state.bad_stake += weight; // This is the bad stake counter
                             }
                         };
+
+                        // When we have good stake, we end the processing:
+                        // we either have a certificate or have trouble in forming
+                        // a cert, which shouldn't happen.
+                        if state.good_stake >= threshold {
+                            return Ok(ReduceOutput::End(state));
+                        }
 
                         if state.bad_stake > validity {
                             self.metrics
@@ -1385,11 +1358,14 @@ where
                 // A long timeout before we hear back from a quorum
                 self.timeouts.pre_quorum_timeout,
             )
-            .await?;
+            .await
+            // The reduction above shouldn't return error
+            .unwrap();
 
         debug!(
             ?tx_digest,
-            num_errors = state.errors.len(),
+            num_errors = state.errors.iter().map(|e| e.1.len()).sum::<usize>(),
+            num_unique_errors = state.errors.len(),
             good_stake = state.good_stake,
             bad_stake = state.bad_stake,
             num_signatures = state.signatures.len(),
@@ -1400,54 +1376,231 @@ where
             debug!(?tx_digest, "Errors received: {:?}", state.errors);
         }
 
-        if state.certificate.is_none() && !state.effects_map.effects_map.is_empty() {
+        state = Self::record_non_quorum_effects_maybe(tx_digest, state);
+
+        // If we have some certificate return it, or return an error.
+        state.certificate.ok_or(QuorumExecuteTransactionError {
+            good_stake: state.good_stake,
+            errors: aggregate_errors(&state.errors),
+            conflicting_tx_digests: state.conflicting_tx_digests,
+        })
+    }
+
+    fn handle_response_with_err(
+        &self,
+        state: &mut ProcessTransactionState,
+        name: AuthorityName,
+        weight: StakeUnit,
+        tx_digest: &TransactionDigest,
+        err: SuiError,
+    ) {
+        let concise_name = name.concise();
+        debug!(tx_digest = ?tx_digest, name=?concise_name, weight, "Failed to let validator sign transaction by handle_transaction: {:?}", err);
+        self.metrics
+            .process_tx_errors
+            .with_label_values(&[&concise_name.to_string(), err.as_ref()])
+            .inc();
+
+        if let SuiError::ObjectLockConflict {
+            obj_ref,
+            pending_transaction,
+        } = err
+        {
+            let (lock_records, total_stake) = state
+                .conflicting_tx_digests
+                .entry(pending_transaction)
+                .or_insert((Vec::new(), 0));
+            lock_records.push((name, obj_ref));
+            *total_stake += weight;
+        }
+
+        // Append to the list of errors
+        state.errors.push((err, vec![name], weight));
+        state.bad_stake += weight; // This is the bad stake counter
+    }
+
+    /// This function could return Error when signature verification
+    /// or certification forming fails. This only happens when we have
+    /// a quorum of good stake, so if the we see such an error, we
+    /// should exit handling this transaction.
+    fn handle_response_with_signed_transaction(
+        &self,
+        state: &mut ProcessTransactionState,
+        name: AuthorityName,
+        weight: StakeUnit,
+        tx_digest: &TransactionDigest,
+        signed_transaction: VerifiedSignedTransaction,
+        transaction_ref: &VerifiedTransaction,
+        threshold: StakeUnit,
+    ) {
+        // If the signed transaction's epoch is older, than the validator is falling behind.
+        // If it's newer than we need a reconfig. Either way, we return a transient error.
+        if signed_transaction.epoch() != self.committee.epoch {
             debug!(
+                ?tx_digest,
+                name=?name.concise(),
+                weight,
+                actual_epoch = signed_transaction.epoch(),
+                expected_epoch = self.committee.epoch,
+                "Received epoch-mismatched signed transaction from validator handle_transaction"
+            );
+            state.errors.push((
+                SuiError::WrongEpoch {
+                    expected_epoch: self.committee.epoch,
+                    actual_epoch: signed_transaction.epoch(),
+                },
+                vec![name],
+                weight,
+            ));
+            state.bad_stake += weight;
+        } else {
+            let tx_digest = *signed_transaction.digest();
+            debug!(tx_digest = ?tx_digest, name=?name.concise(), weight, "Received signed transaction from validator handle_transaction");
+            state
+                .signatures
+                .push(signed_transaction.into_inner().into_data_and_sig().1);
+            state.good_stake += weight;
+            if state.good_stake >= threshold {
+                self.metrics
+                    .num_signatures
+                    .observe(state.signatures.len() as f64);
+                self.metrics.num_good_stake.observe(state.good_stake as f64);
+                self.metrics.num_bad_stake.observe(state.bad_stake as f64);
+
+                let ct = CertifiedTransaction::new(
+                    transaction_ref.data().clone(),
+                    state.signatures.clone(),
+                    &self.committee,
+                )
+                .and_then(|ct| ct.verify(&self.committee));
+                match ct {
+                    Ok(ct) => {
+                        state.certificate = Some(ct);
+                    }
+                    Err(error) => {
+                        error!(?tx_digest, "Failed to form CertifiedTransaction even with quorum, this shouldn't happen");
+                        state.errors.push((
+                            error,
+                            state.signatures.iter().map(|s| s.authority).collect(),
+                            state.good_stake,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_response_with_certified_transaction(
+        &self,
+        state: &mut ProcessTransactionState,
+        name: AuthorityName,
+        weight: StakeUnit,
+        tx_digest: &TransactionDigest,
+        certificate: VerifiedCertificate,
+        signed_effects: SignedTransactionEffects,
+    ) -> Result<(), EffectsCertError> {
+        // If we get a certificate in the same epoch, then we use it.
+        // A certificate in a past epoch does not guaranteee finality
+        // and validators may reject to process it.
+        if certificate.epoch() == self.committee.epoch {
+            debug!(tx_digest = ?tx_digest, name=?name.concise(), weight, "Received prev certificate from validator handle_transaction");
+            state.certificate = Some(certificate);
+        } else if signed_effects.epoch() == self.committee.epoch {
+            // If we get 2f+1 effects, it's an proof that the transaction
+            // has already been finalized in a different epoch. Regardless
+            // of the cert's epoch, we can accept it.
+            // This is safe when the signed-effects's epoch is equal to
+            // the local epoch because validators re-sign effects that are
+            // committed in past epochs. However it's not safe when the
+            // signed effects comes from the future because the stake
+            // distribution may have changed.
+            // Theoretically, the signed effects could be in a previous
+            // epoch from a stale validator, but in `effects_map` we try to
+            // form a CertifiedTransactionEffects which requires all sigs
+            // in the same epoch, this is not necessary but not a big deal
+            // anyways.
+            // TODO: we may return a CertifiedTransactionEffects directly here
+            if state
+                .effects_map
+                .add(signed_effects, weight, &self.committee)?
+            {
+                debug!(
+                    tx_digest = ?tx_digest,
+                    "Got quorum for effects for certs that are from previous epochs handle_transaction"
+                );
+                state.certificate = Some(certificate);
+            }
+        } else {
+            // We reach here when response's epoch > self.committee.epoch
+            // and the shared committee store in SafeClient is already updated.
+            // In this case we record a transient error.
+            debug!(
+                tx_digest = ?tx_digest,
+                name=?name.concise(),
+                weight,
+                actual_epoch = certificate.epoch(),
+                expected_epoch = self.committee.epoch,
+                "Received epoch-mismatched transaction cert from validator handle_transaction",
+            );
+            state.errors.push((
+                SuiError::WrongEpoch {
+                    expected_epoch: self.committee.epoch,
+                    actual_epoch: certificate.epoch(),
+                },
+                vec![name],
+                weight,
+            ));
+            state.bad_stake += weight;
+        }
+        Ok(())
+    }
+
+    /// Check if we have some signed TransactionEffects but not a quorum
+    fn record_non_quorum_effects_maybe(
+        tx_digest: &TransactionDigest,
+        mut state: ProcessTransactionState,
+    ) -> ProcessTransactionState {
+        if state.certificate.is_none() && !state.effects_map.effects_map.is_empty() {
+            warn!(
                 ?tx_digest,
                 "Received signed Effects but not with a quorum {:?}", state.effects_map.effects_map
             );
-            state.errors.push(
-                SuiError::QuorumFailedToFormEffectsCertWhenProcessingTransaction {
-                    effects_map: state
-                        .effects_map
-                        .effects_map
-                        .into_iter()
-                        .map(|(k, v)| {
-                            (
-                                k,
-                                (
-                                    v.signatures
-                                        .into_iter()
-                                        .map(|s| s.authority)
-                                        .collect::<Vec<_>>(),
-                                    v.stake,
-                                ),
-                            )
-                        })
-                        .collect(),
+            let non_quorum_effects = state
+                .effects_map
+                .effects_map
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        *k,
+                        (
+                            v.signatures.iter().map(|s| s.authority).collect::<Vec<_>>(),
+                            v.stake,
+                        ),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+            let mut involved_validators = Vec::new();
+            let mut total_stake = 0;
+            for (validators, stake) in non_quorum_effects.values() {
+                involved_validators.extend_from_slice(validators);
+                total_stake += stake;
+            }
+            state.errors.push((
+                SuiError::QuorumFailedToGetEffectsQuorumWhenProcessingTransaction {
+                    effects_map: non_quorum_effects,
                 },
-            );
+                involved_validators,
+                total_stake,
+            ));
         }
-
-        // If we have some certificate return it, or return an error.
         state
-            .certificate
-            .ok_or(SuiError::QuorumFailedToProcessTransaction {
-                good_stake: state.good_stake,
-                errors: state.errors,
-                conflicting_tx_digests: state.conflicting_tx_digests,
-            })
     }
 
-    /// Process a certificate assuming that 2f+1 authorities already are up to date.
-    ///
-    /// This call is meant to be called after `process_transaction` returns a certificate.
-    /// At that point (and after) enough authorities are up to date with all objects
-    /// needed to process the certificate that a submission should succeed. However,
-    /// in case an authority returns an error, we do try to bring it up to speed.
+    /// Process a certificate
     pub async fn process_certificate(
         &self,
         certificate: CertifiedTransaction,
-    ) -> Result<VerifiedCertifiedTransactionEffects, SuiError> {
+    ) -> Result<VerifiedCertifiedTransactionEffects, QuorumExecuteCertificateError> {
         #[derive(Default)]
         struct ProcessCertificateState {
             // Different authorities could return different effects.  We want at least one effect to come
@@ -1455,7 +1608,7 @@ where
             // The map here allows us to count the stake for each unique effect.
             effects_map: EffectsStakeMap,
             bad_stake: StakeUnit,
-            errors: Vec<SuiError>,
+            errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
         }
 
         let state = ProcessCertificateState::default();
@@ -1497,19 +1650,29 @@ where
                                     "Validator handled certificate successfully",
                                 );
                                 // Note: here we aggregate votes by the hash of the effects structure
-                                if state.effects_map.add(signed_effects, weight, &self.committee) {
-                                    debug!(
-                                        tx_digest = ?tx_digest,
-                                        "Got quorum for validators handle_certificate."
-                                    );
-                                    return Ok(ReduceOutput::End(state));
+                                match state.effects_map.add(signed_effects, weight, &self.committee) {
+                                    Err(err) => {
+                                        // The error means we fail to verify a TransactionEffectsCertificate
+                                        // with a quorum. This shouldn't happen in theory but when it does,
+                                        // we exit
+                                        state.errors.push((err.error, err.authorities, err.total_stake));
+                                        return Ok(ReduceOutput::End(state));
+                                    }
+                                    Ok(true) => {
+                                        debug!(
+                                            tx_digest = ?tx_digest,
+                                            "Got quorum for validators handle_certificate."
+                                        );
+                                        return Ok(ReduceOutput::End(state));
+                                    }
+                                    _ => ()
                                 }
                             }
                             Err(err) => {
                                 let concise_name = name.concise();
                                 debug!(tx_digest = ?tx_digest, name=?name.concise(), weight, "Failed to get signed effects from validator handle_certificate: {:?}", err);
                                 self.metrics.process_cert_errors.with_label_values(&[&concise_name.to_string(), err.as_ref()]).inc();
-                                state.errors.push(err);
+                                state.errors.push((err, vec![name], weight));
                                 state.bad_stake += weight;
                                 if state.bad_stake > validity {
                                     return Ok(ReduceOutput::End(state));
@@ -1522,7 +1685,9 @@ where
                 // A long timeout before we hear back from a quorum
                 self.timeouts.pre_quorum_timeout,
             )
-            .await?;
+            .await
+            // The reduction above shouldn't return error
+            .unwrap();
 
         debug!(
             tx_digest = ?tx_digest,
@@ -1538,12 +1703,12 @@ where
                 tx_digest = ?tx_digest,
                 "Found an effect with good stake over threshold"
             );
-            return cert.verify(&self.committee);
+            return Ok(cert);
         }
 
         // If none has, fail.
-        Err(SuiError::QuorumFailedToExecuteCertificate {
-            errors: state.errors,
+        Err(QuorumExecuteCertificateError {
+            errors: aggregate_errors(&state.errors),
         })
     }
 
@@ -1871,6 +2036,20 @@ where
             }
         }
     }
+}
+
+fn aggregate_errors(
+    errors: &Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
+) -> BTreeMap<String, (Vec<AuthorityName>, StakeUnit)> {
+    let mut aggregated_errors = BTreeMap::<String, (Vec<AuthorityName>, StakeUnit)>::new();
+    for (error, names, weight) in errors {
+        let entry = aggregated_errors
+            .entry(error.as_ref().to_string())
+            .or_default();
+        entry.0.extend_from_slice(names);
+        entry.1 += weight;
+    }
+    aggregated_errors
 }
 
 /// Given an AuthorityAggregator on genesis (epoch 0), catch up to the latest epoch and fill in

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -180,8 +180,8 @@ async fn test_quorum_driver_update_validators_and_max_retry_times() {
         let ticket = quorum_driver.submit_transaction(tx).await.unwrap();
         // We have a timeout here to make the test fail fast if fails
         match tokio::time::timeout(Duration::from_secs(20), ticket).await {
-            Ok(Err(QuorumDriverError::FailedAfterMaximumAttempts { total_attempts })) => assert_eq!(total_attempts, 4),
-            _ => panic!("The transaction should err on SafeClient epoch check mismatch, be retried 3 times and raise QuorumDriverError::FailedAfterMaximumAttempts error"),
+            Ok(Err(QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { total_attempts })) => assert_eq!(total_attempts, 4),
+            _ => panic!("The transaction should err on SafeClient epoch check mismatch, be retried 3 times and raise QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts error"),
         };
     });
 

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -23,7 +23,7 @@ use tracing::{debug, error};
 macro_rules! check_error {
     ($address:expr, $cond:expr, $msg:expr) => {
         $cond.tap_err(|err| {
-            if err.indicates_epoch_change() {
+            if err.individual_error_indicates_epoch_change() {
                 debug!(?err, authority=?$address, "Not a real client error");
             } else {
                 error!(?err, authority=?$address, $msg);

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1194,11 +1194,11 @@ async fn test_handle_transaction_response() {
         .unwrap();
 
     assert_resp_err(
-            &agg,
-            tx.clone(),
-            |e| matches!(e, SuiError::WrongEpoch { expected_epoch, actual_epoch } if *expected_epoch == 0 && *actual_epoch == 1)
-        )
-        .await;
+        &agg,
+        tx.clone(),
+        |e| matches!(e, SuiError::WrongEpoch { expected_epoch, actual_epoch } if *expected_epoch == 0 && *actual_epoch == 1)
+    )
+    .await;
 }
 
 async fn assert_resp_err<F>(

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -220,7 +220,7 @@ impl Committee {
     pub fn validity_threshold(&self) -> StakeUnit {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (N + 2) / 3 = f + 1 + k/3 = f + 1
-        (self.total_votes + 2) / 3
+        validity_threshold(self.total_votes)
     }
 
     #[inline]
@@ -351,6 +351,12 @@ impl Display for Committee {
             self.epoch, voting_rights
         )
     }
+}
+
+pub fn validity_threshold(total_stake: StakeUnit) -> StakeUnit {
+    // If N = 3f + 1 + k (0 <= k < 3)
+    // then (N + 2) / 3 = f + 1 + k/3 = f + 1
+    (total_stake + 2) / 3
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -404,7 +404,7 @@ where {
     // this is probably derivable, but we'd rather have it explicitly laid out for instructional purposes,
     // see [#34](https://github.com/MystenLabs/narwhal/issues/34)
     #[allow(dead_code)]
-    fn default() -> Self {
+    pub fn default() -> Self {
         Self([0u8; AuthorityPublicKey::LENGTH])
     }
 }

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -18,8 +18,12 @@ pub type QuorumDriverResult = Result<QuorumDriverResponse, QuorumDriverError>;
 /// Every invariant needs detailed documents to instruct client handling.
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash, AsRefStr)]
 pub enum QuorumDriverError {
+    #[error("QuorumDriver internal error: {0:?}.")]
+    QuorumDriverInternalError(SuiError),
+    #[error("Invalid user signature: {0:?}.")]
+    InvalidUserSignature(SuiError),
     #[error(
-        "Failed to process transaction on a quorum of validators to form a transaction certificate because of locked objects: {:?}, retried a conflicting transaction {:?}, success: {:?}",
+        "Failed to sign transaction by a quorum of validators because of locked objects: {:?}, retried a conflicting transaction {:?}, success: {:?}",
         conflicting_txes,
         retried_tx,
         retried_tx_success
@@ -30,17 +34,11 @@ pub enum QuorumDriverError {
         retried_tx_success: Option<bool>,
     },
     #[error("Transaction timed out before reaching finality")]
-    TimeoutBeforeReachFinality,
-    #[error("Transaction failed to reach finality after {total_attempts} attempts.")]
-    FailedAfterMaximumAttempts { total_attempts: u8 },
-    // We expect this occrus very rarely. For any common error types,
-    // we should represent as a QuorumDriverError variant instead.
-    #[error("Transaction encountered uncategorized SuiError: {:?}", error)]
-    UncategorizedSuiError { error: SuiError },
-}
-
-impl From<SuiError> for QuorumDriverError {
-    fn from(error: SuiError) -> Self {
-        QuorumDriverError::UncategorizedSuiError { error }
-    }
+    TimeoutBeforeFinality,
+    #[error("Transaction failed to reach finality with transient error after {total_attempts} attempts.")]
+    FailedWithTransientErrorAfterMaximumAttempts { total_attempts: u8 },
+    #[error("Transaction has non recoverable errors from at least 1/3 of validators: {errors:?}.")]
+    NonRecoverableTransactionError {
+        errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
+    },
 }

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -247,7 +247,7 @@ async fn test_tx_across_epoch_boundaries() {
                         result_tx.send(tx_cert).await.unwrap();
                         break;
                     }
-                    Err(QuorumDriverError::TimeoutBeforeReachFinality) => {
+                    Err(QuorumDriverError::TimeoutBeforeFinality) => {
                         info!(?tx_digest, "tx result: timeout and will retry")
                     }
                     Err(other) => panic!("unexpected error: {:?}", other),


### PR DESCRIPTION
Today it's very hard to categorize errors returned from `AuthorityAggregator::process_transaction/certificate` because of the variety of potential `SuiError`s. It prevents us from telling precisely which failed transactions to retry and what to discard. This PR refactors the relevant code with the following major changes:
(meat in `authority_aggregator.rs`)
1. break down `process_transaction` into several smaller functions to make it more readable and less error-prone
2. let `process_transaction` return `QuorumExecuteTransactionError` and `process_certificate` return `QuorumExecuteCertificateError`, rather than `SuiError::xyz`
3. aggregate `SuiErrors` by error type before returning them, for easier categorization in the following PRs
4. corresponding changes in quorum driver code