### PR TITLE
[refactor] remove epoch label from metrics

### DIFF
--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -330,7 +330,7 @@ async fn trigger_reconfiguration(authorities: &[SuiNodeHandle]) {
         })
         .collect();
 
-    timeout(Duration::from_secs(20), join_all(handles))
+    timeout(Duration::from_secs(60), join_all(handles))
         .await
         .expect("timed out waiting for reconfiguration to complete");
 }

--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -265,11 +265,7 @@ impl CertificateFetcher {
         self.fetch_certificates_task
             .spawn(monitored_future!(async move {
                 let _scope = monitored_scope("CertificatesFetching");
-                state
-                    .metrics
-                    .certificate_fetcher_inflight_fetch
-                    .with_label_values(&[&committee.epoch.to_string()])
-                    .inc();
+                state.metrics.certificate_fetcher_inflight_fetch.inc();
 
                 let now = Instant::now();
                 match run_fetch_task(state.clone(), committee.clone(), gc_round, written_rounds)
@@ -286,11 +282,7 @@ impl CertificateFetcher {
                     }
                 };
 
-                state
-                    .metrics
-                    .certificate_fetcher_inflight_fetch
-                    .with_label_values(&[&committee.epoch.to_string()])
-                    .dec();
+                state.metrics.certificate_fetcher_inflight_fetch.dec();
             }));
     }
 
@@ -325,7 +317,6 @@ async fn run_fetch_task(
     state
         .metrics
         .certificate_fetcher_num_certificates_processed
-        .with_label_values(&[&committee.epoch().to_string()])
         .add(num_certs_fetched as i64);
 
     debug!("Successfully fetched and processed {num_certs_fetched} certificates");

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -313,39 +313,37 @@ impl PrimaryChannelMetrics {
 #[derive(Clone)]
 pub struct PrimaryMetrics {
     /// count number of headers that the node proposed
-    pub headers_proposed: IntCounterVec,
+    pub headers_proposed: IntCounter,
     /// the current proposed header round
-    pub proposed_header_round: IntGaugeVec,
+    pub proposed_header_round: IntGauge,
     /// The number of received votes for the proposed last round
     pub votes_received_last_round: IntGauge,
     /// The round of the latest created certificate by our node
-    pub certificate_created_round: IntGaugeVec,
+    pub certificate_created_round: IntGauge,
     /// count number of certificates that the node created
-    pub certificates_created: IntCounterVec,
+    pub certificates_created: IntCounter,
     /// count number of certificates that the node processed (others + own)
     pub certificates_processed: IntCounterVec,
     /// count number of certificates that the node suspended their processing
     pub certificates_suspended: IntCounterVec,
     /// count number of duplicate certificates that the node processed (others + own)
-    pub duplicate_certificates_processed: IntCounterVec,
+    pub duplicate_certificates_processed: IntCounter,
     /// Latency to perform a garbage collection in core module
-    pub gc_core_latency: HistogramVec,
+    pub gc_core_latency: Histogram,
     /// The current Narwhal round in proposer
-    pub current_round: IntGaugeVec,
-    /// The last received Narwhal round.
-    pub last_parent_missing_round: IntGaugeVec,
+    pub current_round: IntGauge,
     /// The highest Narwhal round that has been received.
     pub highest_received_round: IntGaugeVec,
     /// The highest Narwhal round that has been processed.
     pub highest_processed_round: IntGaugeVec,
     /// 0 if there is no inflight certificates fetching, 1 otherwise.
-    pub certificate_fetcher_inflight_fetch: IntGaugeVec,
+    pub certificate_fetcher_inflight_fetch: IntGauge,
     /// Number of fetched certificates successfully processed by core.
-    pub certificate_fetcher_num_certificates_processed: IntGaugeVec,
+    pub certificate_fetcher_num_certificates_processed: IntGauge,
     /// Number of votes that were requested but not sent due to previously having voted differently
-    pub votes_dropped_equivocation_protection: IntCounterVec,
+    pub votes_dropped_equivocation_protection: IntCounter,
     /// Number of pending batches in proposer
-    pub num_of_pending_batches_in_proposer: IntGaugeVec,
+    pub num_of_pending_batches_in_proposer: IntGauge,
     /// A histogram to track the number of batches included
     /// per header.
     pub num_of_batch_digests_in_header: HistogramVec,
@@ -356,23 +354,21 @@ pub struct PrimaryMetrics {
     /// created and until it has been included to a header proposal.
     pub proposer_batch_latency: Histogram,
     /// Time it takes for a header to be materialised to a certificate
-    pub header_to_certificate_latency: HistogramVec,
+    pub header_to_certificate_latency: Histogram,
 }
 
 impl PrimaryMetrics {
     pub fn new(registry: &Registry) -> Self {
         Self {
-            headers_proposed: register_int_counter_vec_with_registry!(
+            headers_proposed: register_int_counter_with_registry!(
                 "headers_proposed",
                 "Number of headers that node proposed",
-                &["epoch"],
                 registry
             )
             .unwrap(),
-            proposed_header_round: register_int_gauge_vec_with_registry!(
+            proposed_header_round: register_int_gauge_with_registry!(
                 "proposed_header_round",
                 "The current proposed header round",
-                &["epoch"],
                 registry
             ).unwrap(),
             votes_received_last_round: register_int_gauge_with_registry!(
@@ -380,106 +376,90 @@ impl PrimaryMetrics {
                 "The number of received votes for the proposed last round",
                 registry
             ).unwrap(),
-            certificate_created_round: register_int_gauge_vec_with_registry!(
+            certificate_created_round: register_int_gauge_with_registry!(
                 "certificate_created_round",
                 "The round of the latest created certificate by our node",
-                &["epoch"],
                 registry
             ).unwrap(),
-            certificates_created: register_int_counter_vec_with_registry!(
+            certificates_created: register_int_counter_with_registry!(
                 "certificates_created",
                 "Number of certificates that node created",
-                &["epoch"],
                 registry
             )
             .unwrap(),
             certificates_processed: register_int_counter_vec_with_registry!(
                 "certificates_processed",
                 "Number of certificates that node processed (others + own)",
-                &["epoch", "source"],
+                &["source"],
                 registry
             )
             .unwrap(),
             certificates_suspended: register_int_counter_vec_with_registry!(
                 "certificates_suspended",
                 "Number of certificates that node suspended processing of",
-                &["epoch", "reason"],
+                &["reason"],
                 registry
             )
             .unwrap(),
-            duplicate_certificates_processed: register_int_counter_vec_with_registry!(
+            duplicate_certificates_processed: register_int_counter_with_registry!(
                 "duplicate_certificates_processed",
                 "Number of certificates that node processed (others + own)",
-                &["epoch"],
                 registry
             )
             .unwrap(),
-            gc_core_latency: register_histogram_vec_with_registry!(
+            gc_core_latency: register_histogram_with_registry!(
                 "gc_core_latency",
                 "Latency of a the garbage collection process for core module",
-                &["epoch"],
                 registry
             )
             .unwrap(),
-            current_round: register_int_gauge_vec_with_registry!(
+            current_round: register_int_gauge_with_registry!(
                 "current_round",
                 "Current round the node will propose",
-                &["epoch"],
-                registry
-            )
-            .unwrap(),
-            last_parent_missing_round: register_int_gauge_vec_with_registry!(
-                "last_parent_missing_round",
-                "The round of the last certificate which misses parent",
-                &["epoch"],
                 registry
             )
             .unwrap(),
             highest_received_round: register_int_gauge_vec_with_registry!(
                 "highest_received_round",
                 "Highest round received by the primary",
-                &["epoch", "source"],
+                &["source"],
                 registry
             )
             .unwrap(),
             highest_processed_round: register_int_gauge_vec_with_registry!(
                 "highest_processed_round",
                 "Highest round processed (stored) by the primary",
-                &["epoch", "source"],
+                &["source"],
                 registry
             )
             .unwrap(),
-            certificate_fetcher_inflight_fetch: register_int_gauge_vec_with_registry!(
+            certificate_fetcher_inflight_fetch: register_int_gauge_with_registry!(
                 "certificate_fetcher_inflight_fetch",
                 "0 if there is no inflight certificates fetching, 1 otherwise.",
-                &["epoch"],
                 registry
             )
             .unwrap(),
-            certificate_fetcher_num_certificates_processed: register_int_gauge_vec_with_registry!(
+            certificate_fetcher_num_certificates_processed: register_int_gauge_with_registry!(
                 "certificate_fetcher_num_certificates_processed",
                 "Number of fetched certificates successfully processed by core.",
-                &["epoch"],
                 registry
             )
             .unwrap(),
-            votes_dropped_equivocation_protection: register_int_counter_vec_with_registry!(
+            votes_dropped_equivocation_protection: register_int_counter_with_registry!(
                 "votes_dropped_equivocation_protection",
                 "Number of votes that were requested but not sent due to previously having voted differently",
-                &["epoch"],
                 registry
             )
             .unwrap(),
-            num_of_pending_batches_in_proposer: register_int_gauge_vec_with_registry!(
+            num_of_pending_batches_in_proposer: register_int_gauge_with_registry!(
                 "num_of_pending_batches_in_proposer",
                 "Number of batch digests pending in proposer for next header proposal",
-                &["epoch"],
                 registry
             ).unwrap(),
             num_of_batch_digests_in_header: register_histogram_vec_with_registry!(
                 "num_of_batch_digests_in_header",
                 "The number of batch digests included in a proposed header. A reason label is included.",
-                &["epoch", "reason"],
+                &["reason"],
                 // buckets in number of digests
                 vec![0.0, 5.0, 10.0, 15.0, 32.0, 50.0, 100.0, 200.0, 500.0, 1000.0],
                 registry
@@ -487,7 +467,7 @@ impl PrimaryMetrics {
             proposer_ready_to_advance: register_int_counter_vec_with_registry!(
                 "proposer_ready_to_advance",
                 "The number of times where the proposer is ready/not ready to advance.",
-                &["epoch", "ready", "round"],
+                &["ready", "round"],
                 registry
             ).unwrap(),
             proposer_batch_latency: register_histogram_with_registry!(
@@ -496,10 +476,9 @@ impl PrimaryMetrics {
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             ).unwrap(),
-            header_to_certificate_latency: register_histogram_vec_with_registry!(
+            header_to_certificate_latency: register_histogram_with_registry!(
                 "header_to_certificate_latency",
                 "Time it takes for a header to be materialised to a certificate",
-                &["epoch"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             ).unwrap()

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -813,10 +813,7 @@ impl PrimaryReceiverHandler {
                         "Authority {} submitted duplicate header for votes at epoch {}, round {}",
                         header.author, header.epoch, header.round
                     );
-                    self.metrics
-                        .votes_dropped_equivocation_protection
-                        .with_label_values(&[&header.epoch.to_string()])
-                        .inc();
+                    self.metrics.votes_dropped_equivocation_protection.inc();
                     return Err(DagError::AlreadyVoted(vote_info.vote_digest, header.round));
                 }
             }

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -406,10 +406,7 @@ impl Proposer {
                 // Advance to the next round.
                 self.round += 1;
                 let _ = self.tx_narwhal_round_updates.send(self.round);
-                self.metrics
-                    .current_round
-                    .with_label_values(&[&self.committee.epoch.to_string()])
-                    .set(self.round as i64);
+                self.metrics.current_round.set(self.round as i64);
                 debug!("Dag moved to round {}", self.round);
 
                 // Make a new header.
@@ -429,7 +426,7 @@ impl Proposer {
 
                         self.metrics
                             .num_of_batch_digests_in_header
-                            .with_label_values(&[&self.committee.epoch.to_string(), reason])
+                            .with_label_values(&[reason])
                             .observe(digests as f64);
                     }
                 }
@@ -552,7 +549,7 @@ impl Proposer {
 
                     self.metrics
                     .proposer_ready_to_advance
-                    .with_label_values(&[&self.committee.epoch.to_string(), &advance.to_string(), round_type])
+                    .with_label_values(&[&advance.to_string(), round_type])
                     .inc();
                 }
 
@@ -587,7 +584,6 @@ impl Proposer {
             // update metrics
             self.metrics
                 .num_of_pending_batches_in_proposer
-                .with_label_values(&[&self.committee.epoch.to_string()])
                 .set(self.digests.len() as i64);
         }
     }

--- a/narwhal/primary/src/tests/core_tests.rs
+++ b/narwhal/primary/src/tests/core_tests.rs
@@ -325,7 +325,6 @@ async fn process_certificates() {
     }
 
     let mut m = HashMap::new();
-    m.insert("epoch", "0");
     m.insert("source", "other");
     assert_eq!(
         metrics
@@ -464,7 +463,6 @@ async fn recover_core() {
     }
 
     let mut m = HashMap::new();
-    m.insert("epoch", "0");
     m.insert("source", "other");
     assert_eq!(
         metrics

--- a/narwhal/worker/src/metrics.rs
+++ b/narwhal/worker/src/metrics.rs
@@ -69,7 +69,7 @@ impl WorkerMetrics {
             created_batch_size: register_histogram_vec_with_registry!(
                 "created_batch_size",
                 "Size in bytes of the created batches",
-                &["epoch", "reason"],
+                &["reason"],
                 // buckets with size in bytes
                 vec![
                     100.0,
@@ -90,7 +90,7 @@ impl WorkerMetrics {
             created_batch_latency: register_histogram_vec_with_registry!(
                 "created_batch_latency",
                 "The latency of creating (sealing) a batch",
-                &["epoch", "reason"],
+                &["reason"],
                 // buckets in seconds
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -6,7 +6,7 @@ use super::*;
 use crate::NUM_SHUTDOWN_RECEIVERS;
 use prometheus::Registry;
 use store::rocks;
-use test_utils::{temp_dir, transaction, CommitteeFixture};
+use test_utils::{temp_dir, transaction};
 use types::PreSubscribedBroadcastSender;
 
 fn create_batches_store() -> Store<BatchDigest, Batch> {
@@ -16,8 +16,6 @@ fn create_batches_store() -> Store<BatchDigest, Batch> {
 
 #[tokio::test]
 async fn make_batch() {
-    let fixture = CommitteeFixture::builder().build();
-    let committee = fixture.committee();
     let store = create_batches_store();
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let (tx_batch_maker, rx_batch_maker) = test_utils::test_channel!(1);
@@ -29,7 +27,6 @@ async fn make_batch() {
     let id = 0;
     let _batch_maker_handle = BatchMaker::spawn(
         id,
-        committee,
         /* max_batch_size */ 200,
         /* max_batch_delay */
         Duration::from_millis(1_000_000), // Ensure the timer is not triggered.
@@ -76,8 +73,6 @@ async fn make_batch() {
 
 #[tokio::test]
 async fn batch_timeout() {
-    let fixture = CommitteeFixture::builder().build();
-    let committee = fixture.committee();
     let store = create_batches_store();
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let (tx_batch_maker, rx_batch_maker) = test_utils::test_channel!(1);
@@ -89,7 +84,6 @@ async fn batch_timeout() {
     let id = 0;
     let _batch_maker_handle = BatchMaker::spawn(
         id,
-        committee,
         /* max_batch_size */ 200,
         /* max_batch_delay */
         Duration::from_millis(50), // Ensure the timer is triggered.

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -446,7 +446,6 @@ impl Worker {
         // gathers the 'cancel handlers' of the messages and send them to the `QuorumWaiter`.
         let batch_maker_handle = BatchMaker::spawn(
             self.id,
-            (*(*(*self.committee).load()).clone()).clone(),
             self.parameters.batch_size,
             self.parameters.max_batch_delay,
             shutdown_receivers.pop().unwrap(),


### PR DESCRIPTION
As we now add the `epoch` label by default when [we create the prometheus Registry](https://github.com/MystenLabs/sui/blob/bae8bafc62914983156d038840f6f1575c328da7/narwhal/node/src/metrics.rs#L19) , there is no need to have those separately added in the metrics - and in fact we should remove them as they are not deduped and could create potential issues