### PR TITLE
wallet-ext: move feature gating to bg service

### DIFF
--- a/apps/wallet/src/background/FeatureGating.ts
+++ b/apps/wallet/src/background/FeatureGating.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GrowthBook } from '@growthbook/growthbook';
+
+const GROWTHBOOK_API_KEY =
+    process.env.NODE_ENV === 'production'
+        ? 'key_prod_ac59fe325855eb5f'
+        : 'key_dev_dc2872e15e0c5f95';
+
+class FeatureGating {
+    #growthBook = new GrowthBook();
+    #ready = this.loadFeatures();
+
+    async getGrowthBook() {
+        await this.#ready;
+        return this.#growthBook;
+    }
+
+    async getLoadedFeatures() {
+        return (await this.getGrowthBook()).getFeatures();
+    }
+
+    private async loadFeatures() {
+        try {
+            const res = await fetch(
+                `https://cdn.growthbook.io/api/features/${GROWTHBOOK_API_KEY}`
+            );
+            if (!res.ok) {
+                throw new Error(res.statusText);
+            }
+            const data = await res.json();
+            this.#growthBook.setFeatures(data.features);
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                'Failed to fetch feature definitions from Growthbook',
+                e
+            );
+        }
+    }
+}
+
+export default new FeatureGating();

--- a/apps/wallet/src/background/connections/UiConnection.ts
+++ b/apps/wallet/src/background/connections/UiConnection.ts
@@ -3,6 +3,7 @@
 
 import { BehaviorSubject, filter, switchMap, takeUntil } from 'rxjs';
 
+import FeatureGating from '../FeatureGating';
 import { Connection } from './Connection';
 import { createMessage } from '_messages';
 import { isBasePayload } from '_payloads';
@@ -20,6 +21,7 @@ import Keyring from '_src/background/keyring';
 
 import type { Message } from '_messages';
 import type { PortChannelName } from '_messaging/PortChannelName';
+import type { LoadedFeaturesPayload } from '_payloads/feature-gating';
 import type { KeyringPayload } from '_payloads/keyring';
 import type { Permission, PermissionRequests } from '_payloads/permissions';
 import type { UpdateActiveOrigin } from '_payloads/tabs/updateActiveOrigin';
@@ -92,6 +94,19 @@ export class UiConnection extends Connection {
                 this.send(createMessage({ type: 'done' }, id));
             } else if (isBasePayload(payload) && payload.type === 'keyring') {
                 await Keyring.handleUiMessage(msg, this);
+            } else if (
+                isBasePayload(payload) &&
+                payload.type === 'get-features'
+            ) {
+                this.send(
+                    createMessage<LoadedFeaturesPayload>(
+                        {
+                            type: 'features-response',
+                            features: await FeatureGating.getLoadedFeatures(),
+                        },
+                        id
+                    )
+                );
             }
         } catch (e) {
             // just in case

--- a/apps/wallet/src/shared/experimentation/features.ts
+++ b/apps/wallet/src/shared/experimentation/features.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * This is a list of feature keys that are used in
- * in https://docs.growthbook.io/app/features#feature-keys
+ * This is a list of feature keys that are used in wallet
+ * https://docs.growthbook.io/app/features#feature-keys
  */
 export enum FEATURES {
     USE_LOCAL_TXN_SERIALIZER = 'use-local-txn-serializer',

--- a/apps/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
@@ -23,7 +23,9 @@ export type PayloadType =
     | 'done'
     | 'keyring'
     | 'stake-request'
-    | 'wallet-status-changed';
+    | 'wallet-status-changed'
+    | 'get-features'
+    | 'features-response';
 
 export interface BasePayload {
     type: PayloadType;

--- a/apps/wallet/src/shared/messaging/messages/payloads/feature-gating/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/feature-gating/index.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { GrowthBook } from '@growthbook/growthbook';
+import type { BasePayload, Payload } from '_payloads';
+
+export type LoadedFeatures = Parameters<GrowthBook['setFeatures']>['0'];
+
+export interface LoadedFeaturesPayload extends BasePayload {
+    type: 'features-response';
+    features: LoadedFeatures;
+}
+
+export function isLoadedFeaturesPayload(
+    payload: Payload
+): payload is LoadedFeaturesPayload {
+    return isBasePayload(payload) && payload.type === 'features-response';
+}

--- a/apps/wallet/src/ui/app/ApiProvider.ts
+++ b/apps/wallet/src/ui/app/ApiProvider.ts
@@ -7,9 +7,9 @@ import {
     LocalTxnDataSerializer,
 } from '@mysten/sui.js';
 
-import { growthbook } from './experimentation/feature-gating';
-import { FEATURES } from './experimentation/features';
 import { queryClient } from './helpers/queryClient';
+import { growthbook } from '_app/experimentation/feature-gating';
+import { FEATURES } from '_src/shared/experimentation/features';
 
 import type { Keypair } from '@mysten/sui.js';
 

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -3,8 +3,11 @@
 
 import { lastValueFrom, map, take } from 'rxjs';
 
+import { growthbook } from '../experimentation/feature-gating';
 import { createMessage } from '_messages';
 import { PortStream } from '_messaging/PortStream';
+import { type BasePayload } from '_payloads';
+import { isLoadedFeaturesPayload } from '_payloads/feature-gating';
 import { isKeyringPayload } from '_payloads/keyring';
 import { isPermissionRequests } from '_payloads/permissions';
 import { isUpdateActiveOrigin } from '_payloads/tabs/updateActiveOrigin';
@@ -50,6 +53,7 @@ export class BackgroundClient {
             this.sendGetPermissionRequests(),
             this.sendGetTransactionRequests(),
             this.getWalletStatus(),
+            this.loadFeatures(),
         ]).then(() => undefined);
     }
 
@@ -227,6 +231,16 @@ export class BackgroundClient {
         );
     }
 
+    private async loadFeatures() {
+        return await lastValueFrom(
+            this.sendMessage(
+                createMessage<BasePayload>({
+                    type: 'get-features',
+                })
+            ).pipe(take(1))
+        );
+    }
+
     private handleIncomingMessage(msg: Message) {
         if (!this._initialized || !this._dispatch) {
             throw new Error(
@@ -249,6 +263,8 @@ export class BackgroundClient {
             payload.return
         ) {
             action = setKeyringStatus(payload.return);
+        } else if (isLoadedFeaturesPayload(payload)) {
+            growthbook.setFeatures(payload.features);
         }
         if (action) {
             this._dispatch(action);

--- a/apps/wallet/src/ui/app/experimentation/feature-gating.ts
+++ b/apps/wallet/src/ui/app/experimentation/feature-gating.ts
@@ -3,28 +3,4 @@
 
 import { GrowthBook } from '@growthbook/growthbook';
 
-const GROWTHBOOK_API_KEY =
-    process.env.NODE_ENV === 'production'
-        ? 'key_prod_ac59fe325855eb5f'
-        : 'key_dev_dc2872e15e0c5f95';
-
 export const growthbook = new GrowthBook();
-
-export async function loadFeatures() {
-    try {
-        const res = await fetch(
-            `https://cdn.growthbook.io/api/features/${GROWTHBOOK_API_KEY}`
-        );
-
-        if (!res.ok) {
-            throw new Error(res.statusText);
-        }
-
-        const data = await res.json();
-
-        growthbook.setFeatures(data.features);
-    } catch (e) {
-        // eslint-disable-next-line no-console
-        console.warn('Failed to fetch feature definitions from Growthbook', e);
-    }
-}

--- a/apps/wallet/src/ui/app/index.tsx
+++ b/apps/wallet/src/ui/app/index.tsx
@@ -5,7 +5,6 @@ import { useFeature } from '@growthbook/growthbook-react';
 import { useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
-import { FEATURES } from './experimentation/features';
 import { AppType } from './redux/slices/app/AppType';
 import StakeHome from './staking/home';
 import StakeNew from './staking/stake';
@@ -33,6 +32,7 @@ import SelectPage from '_pages/initialize/select';
 import SiteConnectPage from '_pages/site-connect';
 import WelcomePage from '_pages/welcome';
 import { setNavVisibility } from '_redux/slices/app';
+import { FEATURES } from '_src/shared/experimentation/features';
 
 const HIDDEN_MENU_PATHS = [
     '/stake',

--- a/apps/wallet/src/ui/app/pages/home/tokens/TokensDetails.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/TokensDetails.tsx
@@ -17,7 +17,7 @@ import { SuiIcons } from '_font-icons/output/sui-icons';
 import { useAppSelector, useObjectsState } from '_hooks';
 import { accountAggregateBalancesSelector } from '_redux/slices/account';
 import { GAS_TYPE_ARG, Coin } from '_redux/slices/sui-objects/Coin';
-import { FEATURES } from '_src/ui/app/experimentation/features';
+import { FEATURES } from '_src/shared/experimentation/features';
 
 import st from './TokensPage.module.scss';
 

--- a/apps/wallet/src/ui/app/staking/home/index.tsx
+++ b/apps/wallet/src/ui/app/staking/home/index.tsx
@@ -4,7 +4,6 @@
 import { useFeature } from '@growthbook/growthbook-react';
 import cl from 'classnames';
 
-import { FEATURES } from '../../experimentation/features';
 import { usePendingDelegation } from '../usePendingDelegation';
 import { ActiveDelegation } from './ActiveDelegation';
 import { DelegationCard, DelegationState } from './DelegationCard';
@@ -25,6 +24,7 @@ import Icon, { SuiIcons } from '_components/icon';
 import Loading from '_components/loading';
 import { useAppSelector, useObjectsState } from '_hooks';
 import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
+import { FEATURES } from '_src/shared/experimentation/features';
 
 import st from './StakeHome.module.scss';
 

--- a/apps/wallet/src/ui/index.tsx
+++ b/apps/wallet/src/ui/index.tsx
@@ -9,7 +9,7 @@ import { Provider } from 'react-redux';
 import { HashRouter } from 'react-router-dom';
 
 import App from './app';
-import { growthbook, loadFeatures } from './app/experimentation/feature-gating';
+import { growthbook } from './app/experimentation/feature-gating';
 import { queryClient } from './app/helpers/queryClient';
 import { ErrorBoundary } from '_components/error-boundary';
 import { initAppType, initNetworkFromStorage } from '_redux/slices/app';
@@ -28,10 +28,9 @@ async function init() {
     if (process.env.NODE_ENV === 'development') {
         Object.defineProperty(window, 'store', { value: store });
     }
-    await loadFeatures();
     store.dispatch(initAppType(getFromLocationSearch(window.location.search)));
-    await store.dispatch(initNetworkFromStorage()).unwrap();
     await thunkExtras.background.init(store.dispatch);
+    await store.dispatch(initNetworkFromStorage()).unwrap();
 }
 
 function renderApp() {


### PR DESCRIPTION
* move loading features to bg service to be able to use growthbook there
* ui now uses the bg service to get the list of features instead of loading them again

This is needed in order to move network env handling to bg service and make UI instances use the same API env

part of APPS-308