### PR TITLE
explorer: ignore tx errors when executing a module method

### DIFF
--- a/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
+++ b/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
@@ -94,7 +94,9 @@ export function ModuleFunction({
         <DisclosureBox defaultOpen={defaultOpen} title={functionName}>
             <form
                 onSubmit={handleSubmit((formData) =>
-                    execute.mutateAsync(formData)
+                    execute.mutateAsync(formData).catch(() => {
+                        /* ignore tx execution errors */
+                    })
                 )}
                 autoComplete="off"
                 className="flex flex-col flex-nowrap items-stretch gap-4"


### PR DESCRIPTION
* stop logging errors to sentry if a transaction fails