### PR TITLE
indexer: use standard address and port for metrics

### DIFF
--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -88,8 +88,8 @@ struct IndexerConfig {
     db_url: String,
     #[clap(long)]
     rpc_client_url: String,
-    #[clap(long, default_value = "127.0.0.1", global = true)]
+    #[clap(long, default_value = "0.0.0.0", global = true)]
     pub client_metric_host: String,
-    #[clap(long, default_value = "8081", global = true)]
+    #[clap(long, default_value = "9184", global = true)]
     pub client_metric_port: u16,
 }


### PR DESCRIPTION
Per Allan's instructions, this PR changes the default addr and port to the standard one
> It shouldn’t be listening on localhost (127.0.0.1), it should be on 0.0.0.0 for the metrics port 9184.

