### PR TITLE
Update simulator pointer, increase reconfiguration timeout, add logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4998,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=f591ab0b1e56435fe7b354f02131fe104bd825e7#f591ab0b1e56435fe7b354f02131fe104bd825e7"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=030cd3036f35d9625bf733d0ef33bc7316c32001#030cd3036f35d9625bf733d0ef33bc7316c32001"
 dependencies = [
  "ahash 0.7.6",
  "async-task",
@@ -5018,6 +5018,7 @@ dependencies = [
  "real_tokio",
  "serde 1.0.152",
  "socket2",
+ "tap",
  "tokio-util 0.7.4 (git+https://github.com/mystenmark/tokio-madsim-fork.git?rev=8b166d79d8b7d81ce9b6db87c3aa8ab53b2d3082)",
  "toml",
  "tracing",
@@ -5027,7 +5028,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=f591ab0b1e56435fe7b354f02131fe104bd825e7#f591ab0b1e56435fe7b354f02131fe104bd825e7"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=030cd3036f35d9625bf733d0ef33bc7316c32001#030cd3036f35d9625bf733d0ef33bc7316c32001"
 dependencies = [
  "darling",
  "proc-macro2 1.0.49",

--- a/crates/sui-proc-macros/Cargo.toml
+++ b/crates/sui-proc-macros/Cargo.toml
@@ -16,4 +16,4 @@ syn = "1.0.104"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "f591ab0b1e56435fe7b354f02131fe104bd825e7", package = "msim-macros" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "030cd3036f35d9625bf733d0ef33bc7316c32001", package = "msim-macros" }

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -19,4 +19,4 @@ telemetry-subscribers.workspace = true
 tower = "0.4.13"
 
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "f591ab0b1e56435fe7b354f02131fe104bd825e7", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "030cd3036f35d9625bf733d0ef33bc7316c32001", package = "msim" }

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -54,9 +54,9 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "f591ab0b1e56435fe7b354f02131fe104bd825e7"'
+    --config 'patch.crates-io.tokio.rev = "030cd3036f35d9625bf733d0ef33bc7316c32001"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "f591ab0b1e56435fe7b354f02131fe104bd825e7"'
+    --config 'patch.crates-io.futures-timer.rev = "030cd3036f35d9625bf733d0ef33bc7316c32001"'
   )
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/MystenLabs/mysten-sim/pull/27, which allows grpc to correctly handle connection failure / reconnection after reconfig, and causes reconfig tests to be pretty much stable.

Additionally, I increased the reconfiguration timeout at Tasos's recommendation, as narwhal reconfig is now blocking.