### PR TITLE
[quorum-driver] DependentPackageNotFound is not a retryable error

### DIFF
--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -4,7 +4,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::base_types::{AuthorityName, ObjectRef, TransactionDigest};
+use crate::base_types::{AuthorityName, ObjectID, ObjectRef, TransactionDigest};
 use crate::committee::StakeUnit;
 use crate::error::SuiError;
 use crate::messages::QuorumDriverResponse;
@@ -28,6 +28,8 @@ pub enum QuorumDriverError {
         retried_tx: Option<TransactionDigest>,
         retried_tx_success: Option<bool>,
     },
+    #[error("Package {package_id:?} cannot be found.")]
+    DependentPackageNotFound { package_id: ObjectID },
     #[error("Transaction timed out before reaching finality")]
     TimeoutBeforeReachFinality,
     #[error("Transaction failed to reach finality after {total_attempts} attempts.")]


### PR DESCRIPTION
Fixes an issue where this error would trigger a retry, causing a publish where the dependency was not found to timeout, rather than produce the actual error.

## Test Plan

```
$ cargo simtest
```

- Publish a package with a non-existent dependency (e.g. at 0x0).
- Before this change, this would timeout.
- After it would produce a more informative error message (and finish sooner):

```
Failed to execute transaction 6ZYokTj4TpN7n1JXVczJUkoNE7B6gSZVFrA2nYnn2ox2 with error RpcError(Call(Custom(ErrorObject { code: ServerError(-32000), message: "Package 0x0000000000000000000000000000000000000000 cannot be found.", data: None })))
```