### PR TITLE
[checkpoints] Correctly read last checkpoint on epoch boundary.

### DIFF
--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -389,6 +389,10 @@ impl VerifiedCheckpoint {
     pub fn into_inner(self) -> CertifiedCheckpointSummary {
         self.0
     }
+
+    pub fn into_summary_and_sequence(self) -> (CheckpointSequenceNumber, CheckpointSummary) {
+        (self.summary.sequence_number, self.0.summary)
+    }
 }
 
 impl std::ops::Deref for VerifiedCheckpoint {


### PR DESCRIPTION
This PR changes how last checkpoint is read on epoch boundary. Previously we relied on internal builder table, `checkpoint_summary` to read last checkpoint. This is not correct however, since on the checkpoint boundary this might not be updated fully, also this table will be empty if new validator joins in the epoch.

In this PR we change it:
(1) `checkpoint_summary` is renamed and move to epoch store
(2) Across epoch boundary `certified_checkpoint` table is used to get last checkpoint of previous epoch.