### PR TITLE
consolidate tx input errors into `TransactionInputObjectsErrors`

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -63,11 +63,11 @@ created: object(127)
 written: object(126)
 
 task 16 'run'. lines 163-166:
-Error: The transaction inputs contain duplicates ObjectRef's
+Error: Error checking transaction input objects: [DuplicateObjectRefInput]
 
 task 17 'run'. lines 168-168:
 created: object(130)
 written: object(129)
 
 task 18 'run'. lines 170-170:
-Error: The transaction inputs contain duplicates ObjectRef's
+Error: Error checking transaction input objects: [DuplicateObjectRefInput]

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
@@ -60,11 +60,11 @@ created: object(126)
 written: object(125)
 
 task 15 'run'. lines 160-163:
-Error: The transaction inputs contain duplicates ObjectRef's
+Error: Error checking transaction input objects: [DuplicateObjectRefInput]
 
 task 16 'run'. lines 165-165:
 created: object(129)
 written: object(128)
 
 task 17 'run'. lines 167-167:
-Error: The transaction inputs contain duplicates ObjectRef's
+Error: Error checking transaction input objects: [DuplicateObjectRefInput]

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -24,7 +24,6 @@ mod test {
     use sui_types::object::Owner;
     use test_utils::messages::get_sui_gas_object_with_wallet_context;
     use test_utils::network::TestClusterBuilder;
-    use tracing::log::error;
 
     fn test_config() -> SimConfig {
         env_config(

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -289,6 +289,7 @@ impl AuthorityStore {
         Ok(result)
     }
 
+    // Transaction input errors should be aggregated in TransactionInputObjectsErrors
     pub fn check_input_objects(
         &self,
         objects: &[InputObjectKind],

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -275,7 +275,7 @@ impl AuthorityStore {
             .contains_key(&ObjectKey(*object_id, version))?)
     }
 
-    /// Read an object and return it, or Err(ObjectNotFound) if the object was not found.
+    /// Read an object and return it, or Ok(None) if the object was not found.
     pub fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         self.perpetual_tables.get_object(object_id)
     }

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -95,7 +95,7 @@ impl AuthorityPerpetualTables {
         Self::get_read_only_handle(Self::path(parent_path), None, None)
     }
 
-    /// Read an object and return it, or Err(ObjectNotFound) if the object was not found.
+    /// Read an object and return it, or Ok(None) if the object was not found.
     pub fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         let obj_entry = self
             .objects

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -40,16 +40,19 @@ async fn get_gas_status(
         extra_gas_object_refs,
     )
     .await
+    .map_err(SuiError::into_transaction_input_error)
 }
 
-// Note: errors returned from this function should aggregated into
-// Sui::TransactionInputObjectsErrors
+// Note: Transaction Input related errors returned from this function
+// should be aggregated into Sui::TransactionInputObjectsErrors
 #[instrument(level = "trace", skip_all)]
 pub async fn check_transaction_input(
     store: &AuthorityStore,
     transaction: &TransactionData,
 ) -> SuiResult<(SuiGasStatus<'static>, InputObjects)> {
-    transaction.validity_check()?;
+    transaction
+        .validity_check()
+        .map_err(SuiError::into_transaction_input_error)?;
     let gas_status = get_gas_status(store, transaction).await?;
     let input_objects = transaction.input_objects()?;
     let objects = store.check_input_objects(&input_objects)?;
@@ -140,11 +143,9 @@ async fn check_gas(
         Ok(SuiGasStatus::new_unmetered())
     } else {
         let gas_object = store.get_object_by_key(&gas_payment.0, gas_payment.1)?;
-        let gas_object = gas_object.ok_or(SuiError::TransactionInputObjectsErrors {
-            errors: vec![SuiError::ObjectNotFound {
-                object_id: gas_payment.0,
-                version: Some(gas_payment.1),
-            }],
+        let gas_object = gas_object.ok_or(SuiError::ObjectNotFound {
+            object_id: gas_payment.0,
+            version: Some(gas_payment.1),
         })?;
 
         // TODO: cache this storage_gas_price in memory
@@ -169,11 +170,9 @@ async fn check_gas(
             let mut additional_objs = vec![];
             for obj_ref in additional_objects_for_gas_payment.iter() {
                 let obj = store.get_object_by_key(&obj_ref.0, obj_ref.1)?;
-                let obj = obj.ok_or(SuiError::TransactionInputObjectsErrors {
-                    errors: vec![SuiError::ObjectNotFound {
-                        object_id: obj_ref.0,
-                        version: Some(obj_ref.1),
-                    }],
+                let obj = obj.ok_or(SuiError::ObjectNotFound {
+                    object_id: obj_ref.0,
+                    version: Some(obj_ref.1),
                 })?;
                 additional_objs.push(obj);
             }
@@ -183,22 +182,18 @@ async fn check_gas(
                 gas_price,
                 extra_amount,
                 additional_objs,
-            )
-            .map_err(|e| SuiError::TransactionInputObjectsErrors { errors: vec![e] })?;
+            )?;
         } else {
-            gas::check_gas_balance(&gas_object, gas_budget, gas_price, extra_amount, vec![])
-                .map_err(|e| SuiError::TransactionInputObjectsErrors { errors: vec![e] })?;
+            gas::check_gas_balance(&gas_object, gas_budget, gas_price, extra_amount, vec![])?;
         }
 
-        let gas_status =
-            gas::start_gas_metering(gas_budget, computation_gas_price, storage_gas_price)
-                .map_err(|e| SuiError::TransactionInputObjectsErrors { errors: vec![e] })?;
-        Ok(gas_status)
+        gas::start_gas_metering(gas_budget, computation_gas_price, storage_gas_price)
     }
 }
 
 /// Check all the objects used in the transaction against the database, and ensure
 /// that they are all the correct version and number.
+// Transaction input errors should be aggregated in TransactionInputObjectsErrors
 #[instrument(level = "trace", skip_all)]
 async fn check_objects(
     transaction: &TransactionData,
@@ -218,9 +213,11 @@ async fn check_objects(
         if !object.is_immutable() {
             fp_ensure!(
                 used_objects.insert(object.id().into()),
-                SuiError::TransactionInputObjectsErrors { errors: vec![SuiError::InvalidBatchTransaction {
-                    error: format!("Mutable object {} cannot appear in more than one single transactions in a batch", object.id()),
-                }]}
+                SuiError::TransactionInputObjectsErrors { errors: vec![
+                    SuiError::InvalidBatchTransaction {
+                        error: format!("Mutable object {} cannot appear in more than one single transactions in a batch", object.id()),
+                    }]
+                }
             );
         }
     }
@@ -256,12 +253,12 @@ async fn check_objects(
     // If any errors with the locks were detected, we return all errors to give the client
     // a chance to update the authority if possible.
     if !errors.is_empty() {
-        return Err(SuiError::TransactionInputObjectsErrors {
-            errors: vec![SuiError::TransactionInputObjectsErrors { errors }],
-        });
+        return Err(SuiError::TransactionInputObjectsErrors { errors });
     }
     if !transaction.kind.is_genesis_tx() && all_objects.is_empty() {
-        return Err(SuiError::ObjectInputArityViolation);
+        return Err(SuiError::TransactionInputObjectsErrors {
+            errors: vec![SuiError::ObjectInputArityViolation],
+        });
     }
 
     Ok(InputObjects::new(all_objects))

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1049,12 +1049,14 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
     let res = authority_state
         .handle_transaction(transfer_transaction)
         .await;
-    assert!(res.is_err());
+
     assert_eq!(
-        res.err(),
-        Some(SuiError::TransactionInputObjectsErrors {
+        res.unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
+        SuiError::TransactionInputObjectsErrors {
             errors: vec![SuiError::InvalidSequenceNumber],
-        })
+        }
     );
 }
 
@@ -1064,12 +1066,14 @@ async fn test_handle_shared_object_with_max_sequence_number() {
         construct_shared_object_transaction_with_sequence_number(Some(SequenceNumber::MAX)).await;
     // Submit the transaction and assemble a certificate.
     let response = authority.handle_transaction(transaction.clone()).await;
-    assert!(response.is_err());
     assert_eq!(
-        response.err(),
-        Some(SuiError::TransactionInputObjectsErrors {
+        response
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
+        SuiError::TransactionInputObjectsErrors {
             errors: vec![SuiError::InvalidSequenceNumber],
-        })
+        }
     );
 }
 
@@ -1297,7 +1301,10 @@ async fn test_immutable_gas() {
         .handle_transaction(transfer_transaction.clone())
         .await;
     assert!(matches!(
-        result.unwrap_err(),
+        result
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasObjectNotOwnedObject { .. }
     ));
 }
@@ -1326,7 +1333,10 @@ async fn test_objected_owned_gas() {
     let transaction = to_sender_signed_transaction(data, &sender_key);
     let result = authority_state.handle_transaction(transaction).await;
     assert!(matches!(
-        result.unwrap_err(),
+        result
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasObjectNotOwnedObject { .. }
     ));
 }
@@ -1758,8 +1768,12 @@ async fn test_handle_transfer_sui_with_amount_insufficient_gas() {
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
     let result = authority_state.handle_transaction(transaction).await;
+
     assert!(matches!(
-        result.unwrap_err(),
+        result
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBalanceTooLowToCoverGasBudget { .. }
     ));
 }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1054,9 +1054,7 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
         res.unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::TransactionInputObjectsErrors {
-            errors: vec![SuiError::InvalidSequenceNumber],
-        }
+        &SuiError::InvalidSequenceNumber,
     );
 }
 
@@ -1071,9 +1069,7 @@ async fn test_handle_shared_object_with_max_sequence_number() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::TransactionInputObjectsErrors {
-            errors: vec![SuiError::InvalidSequenceNumber],
-        }
+        &SuiError::InvalidSequenceNumber,
     );
 }
 
@@ -1301,7 +1297,7 @@ async fn test_immutable_gas() {
         .handle_transaction(transfer_transaction.clone())
         .await;
     assert!(matches!(
-        result
+        *result
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
@@ -1333,7 +1329,7 @@ async fn test_objected_owned_gas() {
     let transaction = to_sender_signed_transaction(data, &sender_key);
     let result = authority_state.handle_transaction(transaction).await;
     assert!(matches!(
-        result
+        *result
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
@@ -1770,7 +1766,7 @@ async fn test_handle_transfer_sui_with_amount_insufficient_gas() {
     let result = authority_state.handle_transaction(transaction).await;
 
     assert!(matches!(
-        result
+        *result
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
@@ -4061,8 +4057,12 @@ async fn test_blocked_move_calls() {
         ),
         &sender_key,
     );
-    assert!(matches!(
-        authority_state.handle_transaction(tx).await,
-        Err(SuiError::BlockedMoveFunction)
-    ));
+    let response = authority_state.handle_transaction(tx).await;
+    assert_eq!(
+        *response
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
+        SuiError::BlockedMoveFunction
+    );
 }

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -161,7 +161,10 @@ async fn test_batch_contains_publish() -> anyhow::Result<()> {
     let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
-        response.unwrap_err(),
+        *response
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::InvalidBatchTransaction { .. }
     ));
     Ok(())
@@ -191,7 +194,10 @@ async fn test_batch_contains_transfer_sui() -> anyhow::Result<()> {
     let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
-        response.unwrap_err(),
+        *response
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::InvalidBatchTransaction { .. }
     ));
     Ok(())
@@ -238,7 +244,7 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
     let response = send_and_confirm_transaction(&authority_state, tx).await;
 
     assert!(matches!(
-        response
+        *response
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -236,8 +236,12 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
 
     let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
+
     assert!(matches!(
-        response.unwrap_err(),
+        response
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBalanceTooLowToCoverGasBudget { .. }
     ));
 

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -27,9 +27,13 @@ async fn test_tx_less_than_minimum_gas_budget() {
     // handling phase.
     let budget = *MIN_GAS_BUDGET - 1;
     let result = execute_transfer(*MAX_GAS_BUDGET, budget, false).await;
-    let err = result.response.unwrap_err();
+
     assert_eq!(
-        err,
+        result
+            .response
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBudgetTooLow {
             gas_budget: budget,
             min_budget: *MIN_GAS_BUDGET
@@ -44,9 +48,13 @@ async fn test_tx_more_than_maximum_gas_budget() {
     // handling phase.
     let budget = *MAX_GAS_BUDGET + 1;
     let result = execute_transfer(*MAX_GAS_BUDGET, budget, false).await;
-    let err = result.response.unwrap_err();
+
     assert_eq!(
-        err,
+        result
+            .response
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBudgetTooHigh {
             gas_budget: budget,
             max_budget: *MAX_GAS_BUDGET
@@ -63,9 +71,12 @@ async fn test_tx_gas_balance_less_than_budget() {
     let budget = *MIN_GAS_BUDGET;
     let gas_price = 1;
     let result = execute_transfer_with_price(gas_balance, budget, gas_price, false).await;
-    let err = result.response.unwrap_err();
     assert_eq!(
-        err,
+        result
+            .response
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: gas_balance as u128,
             gas_budget: (gas_price * budget) as u128,
@@ -140,9 +151,12 @@ async fn test_native_transfer_gas_price_is_used() {
     let gas_budget = *MAX_GAS_BUDGET;
     let gas_price = u64::MAX;
     let result = execute_transfer_with_price(gas_balance, gas_budget, gas_price, true).await;
-    let err = result.response.unwrap_err();
     assert_eq!(
-        err,
+        result
+            .response
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: (gas_balance as u128),
             gas_budget: (gas_budget as u128) * (gas_price as u128),

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -34,7 +34,7 @@ async fn test_tx_less_than_minimum_gas_budget() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::GasBudgetTooLow {
+        &SuiError::GasBudgetTooLow {
             gas_budget: budget,
             min_budget: *MIN_GAS_BUDGET
         }
@@ -55,7 +55,7 @@ async fn test_tx_more_than_maximum_gas_budget() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::GasBudgetTooHigh {
+        &SuiError::GasBudgetTooHigh {
             gas_budget: budget,
             max_budget: *MAX_GAS_BUDGET
         }
@@ -77,7 +77,7 @@ async fn test_tx_gas_balance_less_than_budget() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::GasBalanceTooLowToCoverGasBudget {
+        &SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: gas_balance as u128,
             gas_budget: (gas_price * budget) as u128,
             gas_price
@@ -157,7 +157,7 @@ async fn test_native_transfer_gas_price_is_used() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::GasBalanceTooLowToCoverGasBudget {
+        &SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: (gas_balance as u128),
             gas_budget: (gas_budget as u128) * (gas_price as u128),
             gas_price

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -1112,7 +1112,7 @@ async fn test_entry_point_vector_error() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::DuplicateObjectRefInput { .. }
+        &SuiError::DuplicateObjectRefInput { .. }
     ));
 
     // mint an owned object
@@ -1158,7 +1158,7 @@ async fn test_entry_point_vector_error() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::DuplicateObjectRefInput { .. }
+        &SuiError::DuplicateObjectRefInput { .. }
     ));
 }
 
@@ -1492,7 +1492,7 @@ async fn test_entry_point_vector_any_error() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::DuplicateObjectRefInput { .. }
+        &SuiError::DuplicateObjectRefInput { .. }
     ));
 
     // mint an owned object
@@ -1537,7 +1537,7 @@ async fn test_entry_point_vector_any_error() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::DuplicateObjectRefInput { .. }
+        &SuiError::DuplicateObjectRefInput { .. }
     ));
 }
 

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -1107,14 +1107,13 @@ async fn test_entry_point_vector_error() {
     )
     .await;
     // should fail as we have the same object passed in vector and as a separate by-value argument
-    assert!(
-        matches!(
-            result.clone().err().unwrap(),
-            SuiError::DuplicateObjectRefInput { .. }
-        ),
-        "{:?}",
+    assert!(matches!(
         result
-    );
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
+        SuiError::DuplicateObjectRefInput { .. }
+    ));
 
     // mint an owned object
     let effects = call_move(
@@ -1154,14 +1153,13 @@ async fn test_entry_point_vector_error() {
     )
     .await;
     // should fail as we have the same object passed in vector and as a separate by-reference argument
-    assert!(
-        matches!(
-            result.clone().err().unwrap(),
-            SuiError::DuplicateObjectRefInput { .. }
-        ),
-        "{:?}",
+    assert!(matches!(
         result
-    );
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
+        SuiError::DuplicateObjectRefInput { .. }
+    ));
 }
 
 #[tokio::test]
@@ -1489,14 +1487,13 @@ async fn test_entry_point_vector_any_error() {
     )
     .await;
     // should fail as we have the same object passed in vector and as a separate by-value argument
-    assert!(
-        matches!(
-            result.clone().err().unwrap(),
-            SuiError::DuplicateObjectRefInput { .. }
-        ),
-        "{:?}",
+    assert!(matches!(
         result
-    );
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
+        SuiError::DuplicateObjectRefInput { .. }
+    ));
 
     // mint an owned object
     let effects = call_move(
@@ -1535,14 +1532,13 @@ async fn test_entry_point_vector_any_error() {
         ],
     )
     .await;
-    assert!(
-        matches!(
-            result.clone().err().unwrap(),
-            SuiError::DuplicateObjectRefInput { .. }
-        ),
-        "{:?}",
+    assert!(matches!(
         result
-    );
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
+        SuiError::DuplicateObjectRefInput { .. }
+    ));
 }
 
 #[tokio::test]

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -81,7 +81,7 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::GasBalanceTooLowToCoverGasBudget {
+        &SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 1200,
             gas_price: 1
@@ -111,7 +111,7 @@ async fn test_pay_sui_failure_insufficient_total_balance_one_input_coin() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::GasBalanceTooLowToCoverGasBudget {
+        &SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 100 + 100 + 900,
             gas_price: 1
@@ -142,7 +142,7 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::GasBalanceTooLowToCoverGasBudget {
+        &SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 400,
             gas_budget: 801,
             gas_price: 1
@@ -172,7 +172,7 @@ async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() 
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::GasBalanceTooLowToCoverGasBudget {
+        &SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 400 + 600,
             gas_budget: 400 + 400 + 201,
             gas_price: 1
@@ -339,7 +339,7 @@ async fn test_pay_all_sui_failure_insufficient_gas_one_input_coin() {
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::GasBalanceTooLowToCoverGasBudget {
+        &SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 2000,
             gas_price: 1
@@ -360,7 +360,7 @@ async fn test_pay_all_sui_failure_insufficient_gas_budget_multiple_input_coins()
             .unwrap_err()
             .collapse_if_single_transaction_input_error()
             .unwrap(),
-        SuiError::GasBalanceTooLowToCoverGasBudget {
+        &SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 2500,
             gas_price: 1

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -76,9 +76,11 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
     )
     .await;
 
-    let err = res.txn_result.unwrap_err();
     assert_eq!(
-        err,
+        res.txn_result
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 1200,
@@ -104,9 +106,11 @@ async fn test_pay_sui_failure_insufficient_total_balance_one_input_coin() {
     )
     .await;
 
-    let err = res.txn_result.unwrap_err();
     assert_eq!(
-        err,
+        res.txn_result
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 100 + 100 + 900,
@@ -133,9 +137,11 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
     )
     .await;
 
-    let err = res.txn_result.unwrap_err();
     assert_eq!(
-        err,
+        res.txn_result
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 400,
             gas_budget: 801,
@@ -161,10 +167,11 @@ async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() 
         201,
     )
     .await;
-
-    let err = res.txn_result.unwrap_err();
     assert_eq!(
-        err,
+        res.txn_result
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 400 + 600,
             gas_budget: 400 + 400 + 201,
@@ -327,9 +334,11 @@ async fn test_pay_all_sui_failure_insufficient_gas_one_input_coin() {
 
     let res = execute_pay_all_sui(vec![&coin1], recipient, sender, sender_key, 2000).await;
 
-    let err = res.txn_result.unwrap_err();
     assert_eq!(
-        err,
+        res.txn_result
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 2000,
@@ -346,9 +355,11 @@ async fn test_pay_all_sui_failure_insufficient_gas_budget_multiple_input_coins()
     let recipient = dbg_addr(2);
     let res = execute_pay_all_sui(vec![&coin1, &coin2], recipient, sender, sender_key, 2500).await;
 
-    let err = res.txn_result.unwrap_err();
     assert_eq!(
-        err,
+        res.txn_result
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
         SuiError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 2500,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -641,16 +641,23 @@ impl SuiError {
 
     // Collapse TransactionInputObjectsErrors into a single SuiError
     // if there's exactly one error.
-    pub fn collapse_if_single_transaction_input_error(&self) -> Option<SuiError> {
+    pub fn collapse_if_single_transaction_input_error(&self) -> Option<&SuiError> {
         match self {
             SuiError::TransactionInputObjectsErrors { errors } => {
                 if errors.len() != 1 {
                     None
                 } else {
-                    Some(errors.get(0).unwrap().clone())
+                    // Safe to unwrap, length is checked above
+                    Some(errors.get(0).unwrap())
                 }
             }
             _ => None,
+        }
+    }
+
+    pub fn into_transaction_input_error(error: SuiError) -> SuiError {
+        SuiError::TransactionInputObjectsErrors {
+            errors: vec![error],
         }
     }
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -232,7 +232,7 @@ pub enum SuiError {
     InvalidDecoding,
     #[error("Unexpected message.")]
     UnexpectedMessage,
-    #[error("The transaction inputs contain duplicates ObjectRef's")]
+    #[error("The transaction inputs contain duplicated ObjectRef's")]
     DuplicateObjectRefInput,
     #[error("Network error while querying service: {:?}.", error)]
     ClientIoError { error: String },
@@ -636,6 +636,21 @@ impl SuiError {
             }
             SuiError::ValidatorHaltedAtEpochEnd | SuiError::MissingCommitteeAtEpoch(_) => true,
             _ => false,
+        }
+    }
+
+    // Collapse TransactionInputObjectsErrors into a single SuiError
+    // if there's exactly one error.
+    pub fn collapse_if_single_transaction_input_error(&self) -> Option<SuiError> {
+        match self {
+            SuiError::TransactionInputObjectsErrors { errors } => {
+                if errors.len() != 1 {
+                    None
+                } else {
+                    Some(errors.get(0).unwrap().clone())
+                }
+            }
+            _ => None,
         }
     }
 }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -787,7 +787,10 @@ impl TransactionData {
     }
 
     pub fn input_objects(&self) -> SuiResult<Vec<InputObjectKind>> {
-        let mut inputs = self.kind.input_objects()?;
+        let mut inputs = self
+            .kind
+            .input_objects()
+            .map_err(|e| SuiError::TransactionInputObjectsErrors { errors: vec![e] })?;
 
         if !self.kind.is_system_tx() && !self.kind.is_pay_sui_tx() {
             inputs.push(InputObjectKind::ImmOrOwnedMoveObject(

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -790,7 +790,7 @@ impl TransactionData {
         let mut inputs = self
             .kind
             .input_objects()
-            .map_err(|e| SuiError::TransactionInputObjectsErrors { errors: vec![e] })?;
+            .map_err(SuiError::into_transaction_input_error)?;
 
         if !self.kind.is_system_tx() && !self.kind.is_pay_sui_tx() {
             inputs.push(InputObjectKind::ImmOrOwnedMoveObject(


### PR DESCRIPTION
Today transaction input checking could return 100 types of `SuiError`s. This makes determining if a failure is forgivable (e.g. the txn can be retried) hard. In this PR we make `fn check_transaction_input` only return `TransactionInputObjectsErrors` to simplify the logic.