### PR TITLE
[dev-inspect] Combine to a single end point

### DIFF
--- a/.changeset/empty-baboons-teach.md
+++ b/.changeset/empty-baboons-teach.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Updated to new dev inspect transaction layout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7771,9 +7771,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.2.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
+checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
 dependencies = [
  "darling",
  "proc-macro2 1.0.49",
@@ -8785,6 +8785,7 @@ dependencies = [
  "sui-macros",
  "sui-open-rpc",
  "sui-open-rpc-macros",
+ "sui-protocol-constants",
  "sui-sdk",
  "sui-simulator",
  "sui-transaction-builder",
@@ -9403,9 +9404,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.27.6"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c215311383d25d03753375c53ab9fad8fc0cf46953c409211e065edeabf577ee"
+checksum = "975fe381e0ecba475d4acff52466906d95b153a40324956552e027b2a9eaa89e"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -82,14 +82,10 @@ export const deserializeTxn = createAsyncThunk<
         );
         const localSerializer = new LocalTxnDataSerializer(signer.provider);
         const txnBytes = new Base64DataBuffer(serializedTxn);
-        const version = await api.instance.fullNode.getRpcApiVersion();
 
         //TODO: Error handling - either show the error or use the serialized txn
-        const useIntentSigning =
-            version != null && version.major >= 0 && version.minor > 18;
         const deserializeTx =
             (await localSerializer.deserializeTransactionBytesToSignableTransaction(
-                useIntentSigning,
                 txnBytes
             )) as UnserializedSignableTransaction;
 
@@ -97,7 +93,6 @@ export const deserializeTxn = createAsyncThunk<
 
         const normalized = {
             ...deserializeData,
-            gasBudget: Number(deserializeData.gasBudget.toString(10)),
             gasPayment: '0x' + deserializeData.gasPayment,
             arguments: deserializeData.arguments.map((d) => '0x' + d),
         };

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -6,12 +6,16 @@ use std::{collections::BTreeSet, sync::Arc};
 use crate::execution_mode::{self, ExecutionMode};
 use move_core_types::language_storage::{ModuleId, StructTag};
 use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
-use sui_types::base_types::{ObjectDigest, SequenceNumber};
+use sui_types::base_types::SequenceNumber;
 use tracing::{debug, instrument};
 
 use crate::adapter;
 use sui_protocol_constants::{
+<<<<<<< HEAD
     MAX_TX_GAS, REWARD_SLASHING_RATE, STAKE_SUBSIDY_RATE, STORAGE_FUND_REINVEST_RATE,
+=======
+    REWARD_SLASHING_RATE, REWARD_SLASHING_THRESHOLD_BPS, STORAGE_FUND_REINVEST_RATE,
+>>>>>>> 6d8c886bb (fixup! [dev-inspect] Combine to a single end point)
 };
 use sui_types::coin::{transfer_coin, update_input_coins, Coin};
 use sui_types::committee::EpochId;
@@ -697,12 +701,6 @@ fn transfer_sui<S>(
 
     Ok(())
 }
-
-pub const FAKE_GAS_OBJECT: ObjectRef = (
-    ObjectID::ZERO,
-    SequenceNumber::from_u64(0),
-    ObjectDigest::MIN,
-);
 
 #[test]
 fn test_pay_empty_coins() {

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -11,11 +11,7 @@ use tracing::{debug, instrument};
 
 use crate::adapter;
 use sui_protocol_constants::{
-<<<<<<< HEAD
-    MAX_TX_GAS, REWARD_SLASHING_RATE, STAKE_SUBSIDY_RATE, STORAGE_FUND_REINVEST_RATE,
-=======
-    REWARD_SLASHING_RATE, REWARD_SLASHING_THRESHOLD_BPS, STORAGE_FUND_REINVEST_RATE,
->>>>>>> 6d8c886bb (fixup! [dev-inspect] Combine to a single end point)
+    REWARD_SLASHING_RATE, STAKE_SUBSIDY_RATE, STORAGE_FUND_REINVEST_RATE,
 };
 use sui_types::coin::{transfer_coin, update_input_coins, Coin};
 use sui_types::committee::EpochId;

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -787,6 +787,9 @@ fn create_genesis_transaction(
                 .expect("We defined natives to not fail here"),
         );
 
+        let transaction_data = genesis_transaction.data().intent_message.value.clone();
+        let signer = transaction_data.signer();
+        let gas = transaction_data.gas();
         let (inner_temp_store, effects, _execution_error) =
             sui_adapter::execution_engine::execute_transaction_to_effects::<
                 execution_mode::Normal,
@@ -794,7 +797,9 @@ fn create_genesis_transaction(
             >(
                 vec![],
                 temporary_store,
-                genesis_transaction.data().intent_message.value.clone(),
+                transaction_data.kind,
+                signer,
+                gas,
                 *genesis_transaction.digest(),
                 Default::default(),
                 &move_vm,
@@ -1111,6 +1116,9 @@ mod test {
                 .expect("We defined natives to not fail here"),
         );
 
+        let transaction_data = genesis_transaction.data().intent_message.value.clone();
+        let signer = transaction_data.signer();
+        let gas = transaction_data.gas();
         let (_inner_temp_store, effects, _execution_error) =
             sui_adapter::execution_engine::execute_transaction_to_effects::<
                 execution_mode::Normal,
@@ -1118,7 +1126,9 @@ mod test {
             >(
                 vec![],
                 temporary_store,
-                genesis_transaction.data().intent_message.value.clone(),
+                transaction_data.kind,
+                signer,
+                gas,
                 *genesis_transaction.digest(),
                 Default::default(),
                 &move_vm,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -61,7 +61,7 @@ use sui_types::committee::EpochId;
 use sui_types::crypto::{AuthorityKeyPair, NetworkKeyPair};
 use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldType};
 use sui_types::event::{Event, EventID};
-use sui_types::gas::{GasCostSummary, SuiGasStatus};
+use sui_types::gas::{GasCostSummary, GasPrice, SuiGasStatus};
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
     CheckpointSummary, CheckpointTimestamp,
@@ -99,7 +99,7 @@ use crate::{
     event_handler::EventHandler, transaction_input_checker,
     transaction_manager::TransactionManager, transaction_streamer::TransactionStreamer,
 };
-use sui_adapter::execution_engine;
+use sui_adapter::execution_engine::{self, FAKE_GAS_OBJECT};
 
 #[cfg(test)]
 #[path = "unit_tests/authority_tests.rs"]
@@ -1022,11 +1022,16 @@ impl AuthorityState {
         let transaction_dependencies = input_objects.transaction_dependencies();
         let temporary_store =
             TemporaryStore::new(self.database.clone(), input_objects, *certificate.digest());
+        let transaction_data = certificate.data().intent_message.value.clone();
+        let signer = transaction_data.signer();
+        let gas = transaction_data.gas();
         let (inner_temp_store, effects, _execution_error) =
             execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
                 shared_object_refs,
                 temporary_store,
-                certificate.data().intent_message.value.clone(),
+                transaction_data.kind,
+                signer,
+                gas,
                 *certificate.digest(),
                 transaction_dependencies,
                 &self.move_vm,
@@ -1068,11 +1073,15 @@ impl AuthorityState {
         let transaction_dependencies = input_objects.transaction_dependencies();
         let temporary_store =
             TemporaryStore::new(self.database.clone(), input_objects, transaction_digest);
+        let signer = transaction.signer();
+        let gas = transaction.gas();
         let (_inner_temp_store, effects, _execution_error) =
             execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
                 shared_object_refs,
                 temporary_store,
-                transaction,
+                transaction.kind,
+                signer,
+                gas,
                 transaction_digest,
                 transaction_dependencies,
                 &self.move_vm,
@@ -1085,7 +1094,8 @@ impl AuthorityState {
 
     pub async fn dev_inspect_transaction(
         &self,
-        transaction: TransactionData,
+        sender: SuiAddress,
+        transaction_kind: TransactionKind,
         transaction_digest: TransactionDigest,
         epoch: EpochId,
     ) -> Result<DevInspectResults, anyhow::Error> {
@@ -1093,19 +1103,27 @@ impl AuthorityState {
             return Err(anyhow!("dev-inspect is only supported on fullnodes"));
         }
 
-        let (gas_status, input_objects) =
-            transaction_input_checker::check_dev_inspect_input(&self.database, &transaction)
-                .await?;
+        let gas_object = FAKE_GAS_OBJECT;
+        let input_objects = transaction_input_checker::check_dev_inspect_input(
+            &self.database,
+            &transaction_kind,
+            &gas_object,
+        )
+        .await?;
         let shared_object_refs = input_objects.filter_shared_objects();
 
         let transaction_dependencies = input_objects.transaction_dependencies();
         let temporary_store =
             TemporaryStore::new(self.database.clone(), input_objects, transaction_digest);
+        let gas_status =
+            SuiGasStatus::new_uncharged(MAX_TX_GAS, GasPrice::from(1), STORAGE_GAS_PRICE.into());
         let (_inner_temp_store, effects, execution_result) =
             execution_engine::execute_transaction_to_effects::<execution_mode::DevInspect, _>(
                 shared_object_refs,
                 temporary_store,
-                transaction,
+                transaction_kind,
+                sender,
+                gas_object,
                 transaction_digest,
                 transaction_dependencies,
                 &self.move_vm,
@@ -1113,50 +1131,6 @@ impl AuthorityState {
                 gas_status,
                 epoch,
             );
-        DevInspectResults::new(effects, execution_result, self.module_cache.as_ref())
-    }
-
-    pub async fn dev_inspect_move_call(
-        &self,
-        sender: SuiAddress,
-        move_call: MoveCall,
-        epoch: EpochId,
-    ) -> Result<DevInspectResults, anyhow::Error> {
-        if !self.is_fullnode() {
-            return Err(anyhow!("dev-inspect is only supported on fullnodes"));
-        }
-
-        let input_objects = move_call.input_objects();
-        let input_objects = transaction_input_checker::check_dev_inspect_input_objects(
-            &self.database,
-            input_objects,
-        )?;
-        let shared_object_refs = input_objects.filter_shared_objects();
-
-        let transaction_dependencies = input_objects.transaction_dependencies();
-        let transaction_digest =
-            execution_engine::manual_execute_move_call_fake_txn_digest(sender, move_call.clone());
-        let temporary_store =
-            TemporaryStore::new(self.database.clone(), input_objects, transaction_digest);
-        let gas_status = SuiGasStatus::new_with_budget(
-            MAX_TX_GAS,
-            // TODO: Use proper computation gas price.
-            STORAGE_GAS_PRICE.into(),
-            STORAGE_GAS_PRICE.into(),
-        );
-        let (effects, execution_result) =
-            execution_engine::manual_execute_move_call::<execution_mode::DevInspect, _>(
-                shared_object_refs,
-                temporary_store,
-                sender,
-                move_call,
-                transaction_digest,
-                transaction_dependencies,
-                &self.move_vm,
-                gas_status,
-                epoch,
-            );
-
         DevInspectResults::new(effects, execution_result, self.module_cache.as_ref())
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1133,11 +1133,12 @@ impl AuthorityState {
         let transaction_dependencies = input_objects.transaction_dependencies();
         let temporary_store =
             TemporaryStore::new(self.database.clone(), input_objects, transaction_digest);
-        let gas_status = SuiGasStatus::new_uncharged(
+        let mut gas_status = SuiGasStatus::new_with_budget(
             MAX_TX_GAS,
             GasPrice::from(gas_price),
             STORAGE_GAS_PRICE.into(),
         );
+        gas_status.charge_min_tx_gas()?;
         let (_inner_temp_store, effects, execution_result) =
             execution_engine::execute_transaction_to_effects::<execution_mode::DevInspect, _>(
                 shared_object_refs,

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -66,22 +66,11 @@ pub async fn check_transaction_input(
 /// bypasses many of the normal object checks
 pub(crate) async fn check_dev_inspect_input(
     store: &AuthorityStore,
-    transaction: &TransactionData,
-) -> SuiResult<(SuiGasStatus<'static>, InputObjects)> {
-    transaction.validity_check()?;
-    let gas_status = get_gas_status(store, transaction).await?;
-    let input_objects = transaction.input_objects()?;
-    let input_objects = check_dev_inspect_input_objects(store, input_objects)?;
-    Ok((gas_status, input_objects))
-}
-
-#[instrument(level = "trace", skip_all)]
-/// WARNING! This should only be used for the dev-inspect transaction. This transaction type
-/// bypasses many of the normal object checks
-pub(crate) fn check_dev_inspect_input_objects(
-    store: &AuthorityStore,
-    input_objects: Vec<InputObjectKind>,
+    kind: &TransactionKind,
+    gas_object: &ObjectRef,
 ) -> SuiResult<InputObjects> {
+    TransactionData::validity_check_impl(kind, gas_object)?;
+    let input_objects = kind.input_objects()?;
     let objects = store.check_input_objects(&input_objects)?;
     let mut used_objects: HashSet<SuiAddress> = HashSet::new();
     for object in &objects {

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -28,7 +28,7 @@ use std::fs;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use sui_json_rpc_types::{SuiExecutionResult, SuiExecutionStatus};
+use sui_json_rpc_types::{SuiExecutionResult, SuiExecutionStatus, SuiGasCostSummary};
 use sui_types::utils::{
     make_committee_key, mock_certified_checkpoint, to_sender_signed_transaction,
 };

--- a/crates/sui-core/src/unit_tests/data/depends_on_basics/sources/depends_on_basics.move
+++ b/crates/sui-core/src/unit_tests/data/depends_on_basics/sources/depends_on_basics.move
@@ -5,7 +5,7 @@
 /// along with your own.
 module depends::depends_on_basics {
     use examples::object_basics;
-    use sui::tx_context::{Self, TxContext};
+    use sui::tx_context::TxContext;
 
     public entry fun delegate(ctx: &mut TxContext) {
         object_basics::share(ctx);

--- a/crates/sui-core/src/unit_tests/event_handler_tests.rs
+++ b/crates/sui-core/src/unit_tests/event_handler_tests.rs
@@ -38,7 +38,6 @@ fn test_to_json_value() {
             .unwrap()
             .into();
     let json_value = sui_move_struct.to_json_value().unwrap();
-    dbg!(&json_value);
     assert_eq!(
         Some(&json!("1000000")),
         json_value.pointer("/coins/0/balance")

--- a/crates/sui-cost-tables/src/bytecode_tables.rs
+++ b/crates/sui-cost-tables/src/bytecode_tables.rs
@@ -48,6 +48,7 @@ static ZERO_COST_SCHEDULE: Lazy<CostTable> = Lazy::new(zero_cost_schedule);
 /// Provide all the proper guarantees about gas metering in the Move VM.
 ///
 /// Every client must use an instance of this type to interact with the Move VM.
+#[derive(Debug)]
 pub struct GasStatus<'a> {
     cost_table: &'a CostTable,
     gas_left: InternalGas,

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -38,6 +38,7 @@ sui-open-rpc = { path = "../sui-open-rpc" }
 sui-open-rpc-macros = { path = "../sui-open-rpc-macros" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 sui-transaction-builder = { path = "../sui-transaction-builder" }
+sui-protocol-constants = { path = "../sui-protocol-constants" }
 mysten-metrics = { path = "../mysten-metrics" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -188,8 +188,9 @@ pub trait RpcReadApi {
 #[open_rpc(namespace = "sui", tag = "Full Node API")]
 #[rpc(server, client, namespace = "sui")]
 pub trait RpcFullNodeReadApi {
-    /// Return dev-inpsect results of the transaction, including both the transaction
-    /// effects and return values of the transaction.
+    /// Runs the transaction in dev-inpsect mode. Which allows for nearly any
+    /// transaction (or Move call) with any arguments. Detailed results are
+    /// provided, including both the transaction effects and any return values.
     #[method(name = "devInspectTransaction")]
     async fn dev_inspect_transaction(
         &self,
@@ -197,6 +198,8 @@ pub trait RpcFullNodeReadApi {
         tx_bytes: Base64,
         /// The epoch to perform the call. Will be set from the system state object if not provided
         epoch: Option<EpochId>,
+        /// Gas is not charged, but gas usage is still calculated. The default is 1
+        gas_price: Option<u64>,
     ) -> RpcResult<DevInspectResults>;
 
     /// Return transaction execution effects including the gas cost summary,

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -193,27 +193,8 @@ pub trait RpcFullNodeReadApi {
     #[method(name = "devInspectTransaction")]
     async fn dev_inspect_transaction(
         &self,
-        tx_bytes: Base64,
-        /// The epoch to perform the call. Will be set from the system state object if not provided
-        epoch: Option<EpochId>,
-    ) -> RpcResult<DevInspectResults>;
-
-    /// Similar to `dev_inspect_transaction` but do not require gas object and budget
-    #[method(name = "devInspectMoveCall")]
-    async fn dev_inspect_move_call(
-        &self,
-        /// the caller's Sui address
         sender_address: SuiAddress,
-        /// the Move package ID, e.g. `0x2`
-        package_object_id: ObjectID,
-        /// the Move module name, e.g. `devnet_nft`
-        module: String,
-        /// the move function name, e.g. `mint`
-        function: String,
-        /// the type arguments of the Move function
-        type_arguments: Vec<SuiTypeTag>,
-        /// the arguments to be passed into the Move function, in [SuiJson](https://docs.sui.io/build/sui-json) format
-        arguments: Vec<SuiJsonValue>,
+        tx_bytes: Base64,
         /// The epoch to perform the call. Will be set from the system state object if not provided
         epoch: Option<EpochId>,
     ) -> RpcResult<DevInspectResults>;

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -195,11 +195,12 @@ pub trait RpcFullNodeReadApi {
     async fn dev_inspect_transaction(
         &self,
         sender_address: SuiAddress,
+        /// BCS encoded TransactionKind(as opposed to TransactionData, which include gasBudget and gasPrice)
         tx_bytes: Base64,
+        /// Gas is not charged, but gas usage is still calculated. Default to use reference gas price
+        gas_price: Option<u64>,
         /// The epoch to perform the call. Will be set from the system state object if not provided
         epoch: Option<EpochId>,
-        /// Gas is not charged, but gas usage is still calculated. The default is 1
-        gas_price: Option<u64>,
     ) -> RpcResult<DevInspectResults>;
 
     /// Return transaction execution effects including the gas cost summary,

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -239,7 +239,7 @@ impl RpcFullNodeReadApiServer for FullNodeApi {
     ) -> RpcResult<DevInspectResults> {
         let (mut current_epoch, mut reference_gas_price) = (0, 0);
         // Only fetch from DB if necessary
-        if gas_price == None || epoch == None {
+        if gas_price.is_none() || epoch.is_none() {
             (current_epoch, reference_gas_price) =
                 self.get_sui_system_state_object_epoch_and_gas_price()?
         }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -160,7 +160,7 @@
           "name": "Full Node API"
         }
       ],
-      "description": "Return dev-inpsect results of the transaction, including both the transaction effects and return values of the transaction.",
+      "description": "Runs the transaction in dev-inpsect mode. Which allows for nearly any transaction (or Move call) with any arguments. Detailed results are provided, including both the transaction effects and any return values.",
       "params": [
         {
           "name": "sender_address",
@@ -171,9 +171,19 @@
         },
         {
           "name": "tx_bytes",
+          "description": "BCS encoded TransactionKind(as opposed to TransactionData, which include gasBudget and gasPrice)",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/Base64"
+          }
+        },
+        {
+          "name": "gas_price",
+          "description": "Gas is not charged, but gas usage is still calculated. Default to use reference gas price",
+          "schema": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         },
         {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -154,87 +154,6 @@
       ]
     },
     {
-      "name": "sui_devInspectMoveCall",
-      "tags": [
-        {
-          "name": "Full Node API"
-        }
-      ],
-      "description": "Similar to `dev_inspect_transaction` but do not require gas object and budget",
-      "params": [
-        {
-          "name": "sender_address",
-          "description": "the caller's Sui address",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/SuiAddress"
-          }
-        },
-        {
-          "name": "package_object_id",
-          "description": "the Move package ID, e.g. `0x2`",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/ObjectID"
-          }
-        },
-        {
-          "name": "module",
-          "description": "the Move module name, e.g. `devnet_nft`",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        },
-        {
-          "name": "function",
-          "description": "the move function name, e.g. `mint`",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        },
-        {
-          "name": "type_arguments",
-          "description": "the type arguments of the Move function",
-          "required": true,
-          "schema": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TypeTag"
-            }
-          }
-        },
-        {
-          "name": "arguments",
-          "description": "the arguments to be passed into the Move function, in [SuiJson](https://docs.sui.io/build/sui-json) format",
-          "required": true,
-          "schema": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SuiJsonValue"
-            }
-          }
-        },
-        {
-          "name": "epoch",
-          "description": "The epoch to perform the call. Will be set from the system state object if not provided",
-          "schema": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          }
-        }
-      ],
-      "result": {
-        "name": "DevInspectResults",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/DevInspectResults"
-        }
-      }
-    },
-    {
       "name": "sui_devInspectTransaction",
       "tags": [
         {
@@ -243,6 +162,13 @@
       ],
       "description": "Return dev-inpsect results of the transaction, including both the transaction effects and return values of the transaction.",
       "params": [
+        {
+          "name": "sender_address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        },
         {
           "name": "tx_bytes",
           "required": true,

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -481,6 +481,9 @@ impl<'a> SuiTestAdapter<'a> {
         let shared_object_refs: Vec<_> = input_objects.filter_shared_objects();
         let temporary_store =
             TemporaryStore::new(self.storage.clone(), input_objects, transaction_digest);
+        let transaction_data = transaction.into_inner().into_data().intent_message.value;
+        let signer = transaction_data.signer();
+        let gas = transaction_data.gas();
         let (
             inner,
             TransactionEffects {
@@ -500,7 +503,9 @@ impl<'a> SuiTestAdapter<'a> {
         ) = execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
             shared_object_refs,
             temporary_store,
-            transaction.into_inner().into_data().intent_message.value,
+            transaction_data.kind,
+            signer,
+            gas,
             transaction_digest,
             transaction_dependencies,
             &self.vm,

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -199,6 +199,7 @@ fn to_internal(external_units: GasUnits) -> InternalGas {
     GasUnits::to_unit(external_units)
 }
 
+#[derive(Debug)]
 pub struct SuiGasStatus<'a> {
     gas_status: GasStatus<'a>,
     init_budget: GasUnits,
@@ -221,28 +222,12 @@ impl<'a> SuiGasStatus<'a> {
         computation_gas_unit_price: GasPrice,
         storage_gas_unit_price: GasPrice,
     ) -> SuiGasStatus<'a> {
-        let charge = true;
-        Self::new_with_budget_impl(
+        Self::new(
+            GasStatus::new(&INITIAL_COST_SCHEDULE, GasUnits::new(gas_budget)),
             gas_budget,
+            true,
             computation_gas_unit_price,
-            storage_gas_unit_price,
-            charge,
-        )
-    }
-
-    /// WARNING! This should only be used in tests or in dev inspect and dry run. Gas will still
-    /// be measured, but not charged at the end of execution
-    pub fn new_uncharged(
-        gas_budget: u64,
-        computation_gas_unit_price: GasPrice,
-        storage_gas_unit_price: GasPrice,
-    ) -> SuiGasStatus<'a> {
-        let charge = false;
-        Self::new_with_budget_impl(
-            gas_budget,
-            computation_gas_unit_price,
-            storage_gas_unit_price,
-            charge,
+            storage_gas_unit_price.into(),
         )
     }
 
@@ -365,21 +350,6 @@ impl<'a> SuiGasStatus<'a> {
             storage_gas_units: GasUnits::new(0),
             storage_rebate: 0.into(),
         }
-    }
-
-    fn new_with_budget_impl(
-        gas_budget: u64,
-        computation_gas_unit_price: GasPrice,
-        storage_gas_unit_price: GasPrice,
-        charge: bool,
-    ) -> SuiGasStatus<'a> {
-        Self::new(
-            GasStatus::new(&INITIAL_COST_SCHEDULE, GasUnits::new(gas_budget)),
-            gas_budget,
-            charge,
-            computation_gas_unit_price,
-            storage_gas_unit_price.into(),
-        )
     }
 
     fn deduct_computation_cost(&mut self, cost: &InternalGas) -> Result<(), ExecutionError> {

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -415,8 +415,6 @@ impl SingleTransactionKind {
         // transaction.
         let mut used = HashSet::new();
         if !input_objects.iter().all(|o| used.insert(o.object_id())) {
-            dbg!(input_objects);
-            dbg!(used);
             return Err(SuiError::DuplicateObjectRefInput);
         }
         Ok(input_objects)

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -415,6 +415,8 @@ impl SingleTransactionKind {
         // transaction.
         let mut used = HashSet::new();
         if !input_objects.iter().all(|o| used.insert(o.object_id())) {
+            dbg!(input_objects);
+            dbg!(used);
             return Err(SuiError::DuplicateObjectRefInput);
         }
         Ok(input_objects)
@@ -596,6 +598,17 @@ impl TransactionKind {
             self,
             TransactionKind::Single(SingleTransactionKind::Genesis(_))
         )
+    }
+
+    fn is_blocked_move_function(&self) -> bool {
+        self.single_transactions().any(|tx| match tx {
+            SingleTransactionKind::Call(call) => {
+                let (package, module, func) =
+                    (call.package.0, call.module.as_str(), call.function.as_str());
+                BLOCKED_MOVE_FUNCTIONS.contains(&(package, module, func))
+            }
+            _ => false,
+        })
     }
 }
 
@@ -920,11 +933,15 @@ impl TransactionData {
     }
 
     pub fn validity_check(&self) -> SuiResult {
+        Self::validity_check_impl(&self.kind, &self.gas_payment)
+    }
+
+    pub fn validity_check_impl(kind: &TransactionKind, gas_payment: &ObjectRef) -> SuiResult {
         fp_ensure!(
-            !self.is_blocked_move_function(),
+            !kind.is_blocked_move_function(),
             SuiError::BlockedMoveFunction
         );
-        match &self.kind {
+        match kind {
             TransactionKind::Batch(b) => {
                 fp_ensure!(
                     !b.is_empty(),
@@ -947,7 +964,9 @@ impl TransactionData {
                 fp_ensure!(
                     valid,
                     SuiError::InvalidBatchTransaction {
-                        error: "Batch transaction contains non-batchable transactions. Only Call and TransferObject are allowed".to_string()
+                        error: "Batch transaction contains non-batchable transactions. Only Call \
+                        and TransferObject are allowed"
+                            .to_string()
                     }
                 );
             }
@@ -963,7 +982,7 @@ impl TransactionData {
                     fp_ensure!(!p.coins.is_empty(), SuiError::EmptyInputCoins);
                     fp_ensure!(
                         // unwrap() is safe because coins are not empty.
-                        p.coins.first().unwrap() == &self.gas_payment,
+                        p.coins.first().unwrap() == gas_payment,
                         SuiError::UnexpectedGasPaymentObject
                     );
                 }
@@ -971,24 +990,13 @@ impl TransactionData {
                     fp_ensure!(!pa.coins.is_empty(), SuiError::EmptyInputCoins);
                     fp_ensure!(
                         // unwrap() is safe because coins are not empty.
-                        pa.coins.first().unwrap() == &self.gas_payment,
+                        pa.coins.first().unwrap() == gas_payment,
                         SuiError::UnexpectedGasPaymentObject
                     );
                 }
             },
         }
         Ok(())
-    }
-
-    fn is_blocked_move_function(&self) -> bool {
-        self.kind.single_transactions().any(|tx| match tx {
-            SingleTransactionKind::Call(call) => {
-                let (package, module, func) =
-                    (call.package.0, call.module.as_str(), call.function.as_str());
-                BLOCKED_MOVE_FUNCTIONS.contains(&(package, module, func))
-            }
-            _ => false,
-        })
     }
 }
 

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -53,7 +53,7 @@ import {
   CoinBalance,
   CoinSupply,
 } from '../types';
-import { DynamicFieldPage } from '../types/dynamic_fields'
+import { DynamicFieldPage } from '../types/dynamic_fields';
 import {
   PublicKey,
   SignatureScheme,
@@ -69,7 +69,8 @@ import { requestSuiFromFaucet } from '../rpc/faucet-client';
 import { lt } from '@suchipi/femver';
 import { Base64DataBuffer } from '../serialization/base64';
 import { any, is, number, array } from 'superstruct';
-import { RawMoveCall } from '../signers/txn-data-serializers/txn-data-serializer';
+import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
+import { LocalTxnDataSerializer } from '../signers/txn-data-serializers/local-txn-data-serializer';
 
 /**
  * Configuration options for the JsonRpcProvider. If the value of a field is not provided,
@@ -300,23 +301,15 @@ export class JsonRpcProvider extends Provider {
   }
 
   // RPC endpoint
-  async call(
-    endpoint: string,
-    params: Array<any>
-  ) : Promise<any> {
+  async call(endpoint: string, params: Array<any>): Promise<any> {
     try {
-      const response = await this.client.request(
-        endpoint,
-        params
-      );
+      const response = await this.client.request(endpoint, params);
       if (is(response, ErrorResponse)) {
         throw new Error(`RPC Error: ${response.error.message}`);
       }
       return response.result;
     } catch (err) {
-      throw new Error(
-        `Error calling RPC endpoint ${endpoint}: ${err}`
-      );
+      throw new Error(`Error calling RPC endpoint ${endpoint}: ${err}`);
     }
   }
 
@@ -699,22 +692,22 @@ export class JsonRpcProvider extends Provider {
     try {
       let resp;
       // Serialize sigature field as: `flag || signature || pubkey`
-        const serialized_sig = new Uint8Array(
-          1 + signature.getLength() + pubkey.toBytes().length
-        );
-        serialized_sig.set([SIGNATURE_SCHEME_TO_FLAG[signatureScheme]]);
-        serialized_sig.set(signature.getData(), 1);
-        serialized_sig.set(pubkey.toBytes(), 1 + signature.getLength());
+      const serialized_sig = new Uint8Array(
+        1 + signature.getLength() + pubkey.toBytes().length
+      );
+      serialized_sig.set([SIGNATURE_SCHEME_TO_FLAG[signatureScheme]]);
+      serialized_sig.set(signature.getData(), 1);
+      serialized_sig.set(pubkey.toBytes(), 1 + signature.getLength());
 
-        resp = await this.client.requestWithType(
-          'sui_executeTransactionSerializedSig',
-          [
-            txnBytes.toString(),
-            new Base64DataBuffer(serialized_sig).toString(),
-            requestType,
-          ],
-          SuiExecuteTransactionResponse,
-          this.options.skipDataValidation
+      resp = await this.client.requestWithType(
+        'sui_executeTransactionSerializedSig',
+        [
+          txnBytes.toString(),
+          new Base64DataBuffer(serialized_sig).toString(),
+          requestType,
+        ],
+        SuiExecuteTransactionResponse,
+        this.options.skipDataValidation
       );
       return resp;
     } catch (err) {
@@ -820,11 +813,36 @@ export class JsonRpcProvider extends Provider {
     return this.wsClient.unsubscribeEvent(id);
   }
 
-  async devInspectTransaction(txBytes: string): Promise<DevInspectResults> {
+  async devInspectTransaction(
+    sender: SuiAddress,
+    tx: UnserializedSignableTransaction | string | Base64DataBuffer,
+    gasPrice: number | null = null,
+    epoch: number | null = null
+  ): Promise<DevInspectResults> {
     try {
+      const version = await this.getRpcApiVersion();
+      // TODO: remove after 0.23.0 is deployed in both DevNet and TestNet
+      if (version?.major == 0 && version?.minor < 23) {
+        return this.devInspectTransactionDeprecated(sender, tx, epoch);
+      }
+
+      let devInspectTxBytes;
+      if (typeof tx === 'string') {
+        devInspectTxBytes = tx;
+      } else if (tx instanceof Base64DataBuffer) {
+        devInspectTxBytes = tx.toString();
+      } else {
+        devInspectTxBytes = (
+          await new LocalTxnDataSerializer(this).serializeToBytesWithoutGasInfo(
+            sender,
+            tx
+          )
+        ).toString();
+      }
+
       const resp = await this.client.requestWithType(
         'sui_devInspectTransaction',
-        [txBytes],
+        [sender, devInspectTxBytes, gasPrice, epoch],
         DevInspectResults,
         this.options.skipDataValidation
       );
@@ -836,28 +854,46 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async devInspectMoveCall(
+  async devInspectTransactionDeprecated(
     sender: SuiAddress,
-    moveCall: RawMoveCall
+    tx: UnserializedSignableTransaction | string | Base64DataBuffer,
+    epoch: number | null = null
   ): Promise<DevInspectResults> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_devInspectMoveCall',
-        [
-          sender,
-          moveCall.packageObjectId,
-          moveCall.module,
-          moveCall.function,
-          moveCall.typeArguments,
-          moveCall.arguments,
-        ],
-        DevInspectResults,
-        this.options.skipDataValidation
-      );
-      return resp;
-    } catch (err) {
-      throw new Error(`Error dev inspect move call with request type: ${err}`);
+    let devInspectTxBytes;
+    if (typeof tx === 'string') {
+      devInspectTxBytes = tx;
+    } else if (tx instanceof Base64DataBuffer) {
+      devInspectTxBytes = tx.toString();
+    } else {
+      if (tx.kind === 'moveCall' && tx.data.gasBudget == null) {
+        const moveCall = tx.data;
+        const resp = await this.client.requestWithType(
+          'sui_devInspectMoveCall',
+          [
+            sender,
+            moveCall.packageObjectId,
+            moveCall.module,
+            moveCall.function,
+            moveCall.typeArguments,
+            moveCall.arguments,
+          ],
+          DevInspectResults,
+          this.options.skipDataValidation
+        );
+        return resp;
+      }
+      devInspectTxBytes = (
+        await new LocalTxnDataSerializer(this).serializeToBytes(sender, tx)
+      ).toString();
     }
+
+    const resp = await this.client.requestWithType(
+      'sui_devInspectTransaction',
+      [devInspectTxBytes, epoch],
+      DevInspectResults,
+      this.options.skipDataValidation
+    );
+    return resp;
   }
 
   async dryRunTransaction(txBytes: string): Promise<TransactionEffects> {

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -821,8 +821,8 @@ export class JsonRpcProvider extends Provider {
   ): Promise<DevInspectResults> {
     try {
       const version = await this.getRpcApiVersion();
-      // TODO: remove after 0.23.0 is deployed in both DevNet and TestNet
-      if (version?.major == 0 && version?.minor < 23) {
+      // TODO: remove after 0.24.0 is deployed in both DevNet and TestNet
+      if (version?.major == 0 && version?.minor < 24) {
         return this.devInspectTransactionDeprecated(sender, tx, epoch);
       }
 

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -4,7 +4,7 @@
 import { PublicKey, SignatureScheme } from '../cryptography/publickey';
 import { HttpHeaders } from '../rpc/client';
 import { Base64DataBuffer } from '../serialization/base64';
-import { RawMoveCall } from '../signers/txn-data-serializers/txn-data-serializer';
+import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
 import {
   GetObjectDataResponse,
   SuiObjectInfo,
@@ -67,7 +67,7 @@ export abstract class Provider {
 
   // RPC Endpoint
   /**
-   * Invoke any RPC endpoint 
+   * Invoke any RPC endpoint
    * @param endpoint the endpoint to be invoked
    * @param params the arguments to be passed to the RPC request
    */
@@ -75,10 +75,10 @@ export abstract class Provider {
     endpoint: string,
     params: Array<any>
   ) : Promise<any>;
-  
+
   // Coins
   /**
-   * Get all Coin<`coin_type`> objects owned by an address. 
+   * Get all Coin<`coin_type`> objects owned by an address.
    * @param coinType optional fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC), default to 0x2::sui::SUI if not specified.
    * @param cursor optional paging cursor
    * @param limit maximum number of items per page
@@ -314,18 +314,22 @@ export abstract class Provider {
   abstract unsubscribeEvent(id: SubscriptionId): Promise<boolean>;
 
   /**
-   * Similar to dryRunTransaction, but lets you call any Move function(including non-entry function)
-   * with arbitrary values.
+   * Runs the transaction in dev-inpsect mode. Which allows for nearly any
+   * transaction (or Move call) with any arguments. Detailed results are
+   * provided, including both the transaction effects and any return values.
+   *
+   * @param sender the sender of the transaction
+   * @param txn transaction without gasPayment, gasBudget, and gasPrice specified.
+   * @param gas_price optional. Default to use the network reference gas price stored
+   * in the Sui System State object
+   * @param epoch optional. Default to use the current epoch number stored
+   * in the Sui System State object
    */
-  abstract devInspectTransaction(txBytes: string): Promise<DevInspectResults>;
-
-  /**
-   * Similar to devInspectTransaction, but lets you call any Move function without a gas object and
-   * budget
-   */
-  abstract devInspectMoveCall(
+  abstract devInspectTransaction(
     sender: SuiAddress,
-    moveCall: RawMoveCall
+    txn: UnserializedSignableTransaction | string | Base64DataBuffer,
+    gasPrice: number | null,
+    epoch: number | null
   ): Promise<DevInspectResults>;
 
   /**

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -4,7 +4,7 @@
 import { PublicKey, SignatureScheme } from '../cryptography/publickey';
 import { HttpHeaders } from '../rpc/client';
 import { Base64DataBuffer } from '../serialization/base64';
-import { RawMoveCall } from '../signers/txn-data-serializers/txn-data-serializer';
+import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
 import {
   CertifiedTransaction,
   TransactionDigest,
@@ -64,9 +64,7 @@ export class VoidProvider extends Provider {
   }
 
   // RPC Endpoint
-  call(
-    _endpoint: string, 
-    _params: any[]): Promise<any> {
+  call(_endpoint: string, _params: any[]): Promise<any> {
     throw this.newError('call');
   }
 
@@ -175,15 +173,13 @@ export class VoidProvider extends Provider {
     throw this.newError('executeTransaction with request Type');
   }
 
-  devInspectTransaction(_txBytes: string): Promise<DevInspectResults> {
-    throw this.newError('devInspectTransaction');
-  }
-
-  async devInspectMoveCall(
+  devInspectTransaction(
     _sender: SuiAddress,
-    _moveCall: RawMoveCall
+    _txn: UnserializedSignableTransaction | string | Base64DataBuffer,
+    _gasPrice: number | null = null,
+    _epoch: number | null = null
   ): Promise<DevInspectResults> {
-    throw this.newError('devInspectMoveCall');
+    throw this.newError('devInspectTransaction');
   }
 
   dryRunTransaction(_txBytes: string): Promise<TransactionEffects> {

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -31,6 +31,7 @@ import {
   TxnDataSerializer,
   PublishTransaction,
   SignableTransaction,
+  UnserializedSignableTransaction,
 } from './txn-data-serializers/txn-data-serializer';
 
 // See: sui/crates/sui-types/src/intent.rs
@@ -103,22 +104,14 @@ export abstract class SignerWithProvider implements Signer {
         transaction instanceof Base64DataBuffer
           ? transaction
           : new Base64DataBuffer(transaction.data);
-      const version = await this.provider.getRpcApiVersion();
-      let dataToSign;
-      let txBytesToSubmit;
-      if (version?.major == 0 && version?.minor < 19) {
-        dataToSign = txBytes;
-        txBytesToSubmit = txBytes;
-      } else {
-        const intentMessage = new Uint8Array(
-          INTENT_BYTES.length + txBytes.getLength()
-        );
-        intentMessage.set(INTENT_BYTES);
-        intentMessage.set(txBytes.getData(), INTENT_BYTES.length);
+      const intentMessage = new Uint8Array(
+        INTENT_BYTES.length + txBytes.getLength()
+      );
+      intentMessage.set(INTENT_BYTES);
+      intentMessage.set(txBytes.getData(), INTENT_BYTES.length);
 
-        dataToSign = new Base64DataBuffer(intentMessage);
-        txBytesToSubmit = txBytes;
-      }
+      const dataToSign = new Base64DataBuffer(intentMessage);
+      const txBytesToSubmit = txBytes;
       const sig = await this.signData(dataToSign);
       return await this.provider.executeTransaction(
         txBytesToSubmit,
@@ -153,25 +146,15 @@ export abstract class SignerWithProvider implements Signer {
       );
     }
     const version = await this.provider.getRpcApiVersion();
-    const useIntentSigning =
-      version != null && version.major >= 0 && version.minor > 18;
-    let dataToSign;
-    if (useIntentSigning) {
-      const intentMessage = new Uint8Array(
-        INTENT_BYTES.length + txBytes.getLength()
-      );
-      intentMessage.set(INTENT_BYTES);
-      intentMessage.set(txBytes.getData(), INTENT_BYTES.length);
-      dataToSign = new Base64DataBuffer(intentMessage);
-    } else {
-      dataToSign = txBytes;
-    }
+    const intentMessage = new Uint8Array(
+      INTENT_BYTES.length + txBytes.getLength()
+    );
+    intentMessage.set(INTENT_BYTES);
+    intentMessage.set(txBytes.getData(), INTENT_BYTES.length);
+    const dataToSign = new Base64DataBuffer(intentMessage);
 
     const sig = await this.signData(dataToSign);
-    const data = deserializeTransactionBytesToTransactionData(
-      useIntentSigning,
-      txBytes
-    );
+    const data = deserializeTransactionBytesToTransactionData(txBytes);
     return generateTransactionDigest(
       data,
       sig.signatureScheme,
@@ -183,34 +166,23 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
-   * Similar to DryRunTransaction but will let you call any Move function(including non-entry function)
-   * with any arbitrary values.
+   * Runs the transaction in dev-inpsect mode. Which allows for nearly any
+   * transaction (or Move call) with any arguments. Detailed results are
+   * provided, including both the transaction effects and any return values.
    *
    * @param tx the transaction as SignableTransaction or string (in base64) that will dry run
-   * @returns the transaction effects as well as the Move Call return values
+   * @param gas_price optional. Default to use the network reference gas price stored
+   * in the Sui System State object
+   * @param epoch optional. Default to use the current epoch number stored
+   * in the Sui System State object
    */
   async devInspectTransaction(
-    tx: SignableTransaction | string | Base64DataBuffer
+    tx: UnserializedSignableTransaction | string | Base64DataBuffer,
+    gasPrice: number | null = null,
+    epoch: number | null = null
   ): Promise<DevInspectResults> {
     const address = await this.getAddress();
-    let devInspectTxBytes: string;
-    if (typeof tx === 'string') {
-      devInspectTxBytes = tx;
-    } else if (tx instanceof Base64DataBuffer) {
-      devInspectTxBytes = tx.toString();
-    } else {
-      switch (tx.kind) {
-        case 'bytes':
-          devInspectTxBytes = new Base64DataBuffer(tx.data).toString();
-          break;
-        default:
-          devInspectTxBytes = (
-            await this.serializer.serializeToBytes(address, tx, 'DevInspect')
-          ).toString();
-          break;
-      }
-    }
-    return this.provider.devInspectTransaction(devInspectTxBytes);
+    return this.provider.devInspectTransaction(address, tx, gasPrice, epoch);
   }
 
   /**

--- a/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
@@ -54,6 +54,9 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
   ): Promise<Base64DataBuffer> {
     let endpoint: string;
     let args: Array<any>;
+    if (!unserializedTxn.data.gasBudget) {
+      throw new Error('serializeToBytes requires a valid gas budget');
+    }
     switch (unserializedTxn.kind) {
       case 'transferObject':
         const t = unserializedTxn.data as TransferObjectTransaction;

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -6,16 +6,21 @@ import { ObjectId, SuiAddress, SuiJsonValue, TypeTag } from '../../types';
 
 ///////////////////////////////
 // Exported Types
-export interface TransferObjectTransaction {
-  objectId: ObjectId;
-  gasPayment?: ObjectId;
-  gasBudget: number;
-  recipient: SuiAddress;
+export interface TransactionCommon {
+  /* This field is required for regular transaction but can be omitted for devinspect transaction */
+  gasBudget?: number;
+  /* If omitted, reference gas price fetched from the connected fullnode will be used */
+  gasPrice?: number;
 }
 
-export interface TransferSuiTransaction {
+export interface TransferObjectTransaction extends TransactionCommon {
+  objectId: ObjectId;
+  recipient: SuiAddress;
+  gasPayment?: ObjectId;
+}
+
+export interface TransferSuiTransaction extends TransactionCommon {
   suiObjectId: ObjectId;
-  gasBudget: number;
   recipient: SuiAddress;
   amount: number | null;
 }
@@ -24,7 +29,7 @@ export interface TransferSuiTransaction {
 /// The object specified in the `gas` field will be used to pay the gas fee for the transaction.
 /// The gas object can not appear in `input_coins`. If the gas object is not specified, the RPC server
 /// will auto-select one.
-export interface PayTransaction {
+export interface PayTransaction extends TransactionCommon {
   /**
    * use `provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual` to
    * derive a minimal set of coins with combined balance greater than or
@@ -34,7 +39,6 @@ export interface PayTransaction {
   recipients: SuiAddress[];
   amounts: number[];
   gasPayment?: ObjectId;
-  gasBudget: number;
 }
 
 /// Send SUI coins to a list of addresses, following a list of amounts.
@@ -46,7 +50,7 @@ export interface PayTransaction {
 /// input coin, then use the first input coin as the gas coin object.
 /// 3. the balance of the first input coin after tx is sum(input_coins) - sum(amounts) - actual_gas_cost
 /// 4. all other input coins other than the first one are deleted.
-export interface PaySuiTransaction {
+export interface PaySuiTransaction extends TransactionCommon {
   /**
    * use `provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual` to
    * derive a minimal set of coins with combined balance greater than or
@@ -55,7 +59,6 @@ export interface PaySuiTransaction {
   inputCoins: ObjectId[];
   recipients: SuiAddress[];
   amounts: number[];
-  gasBudget: number;
 }
 
 /// Send all SUI coins to one recipient.
@@ -65,42 +68,30 @@ export interface PaySuiTransaction {
 /// 2. transfer the updated first coin to the recipient and also use this first coin as gas coin object.
 /// 3. the balance of the first input coin after tx is sum(input_coins) - actual_gas_cost.
 /// 4. all other input coins other than the first are deleted.
-export interface PayAllSuiTransaction {
+export interface PayAllSuiTransaction extends TransactionCommon {
   inputCoins: ObjectId[];
   recipient: SuiAddress;
-  gasBudget: number;
 }
 
-export interface MergeCoinTransaction {
+export interface MergeCoinTransaction extends TransactionCommon {
   primaryCoin: ObjectId;
   coinToMerge: ObjectId;
   gasPayment?: ObjectId;
-  gasBudget: number;
 }
 
-export interface SplitCoinTransaction {
+export interface SplitCoinTransaction extends TransactionCommon {
   coinObjectId: ObjectId;
   splitAmounts: number[];
   gasPayment?: ObjectId;
-  gasBudget: number;
 }
 
-export interface MoveCallTransaction {
+export interface MoveCallTransaction extends TransactionCommon {
   packageObjectId: ObjectId;
   module: string;
   function: string;
   typeArguments: string[] | TypeTag[];
   arguments: SuiJsonValue[];
   gasPayment?: ObjectId;
-  gasBudget: number;
-}
-
-export interface RawMoveCall {
-  packageObjectId: ObjectId;
-  module: string;
-  function: string;
-  typeArguments: string[];
-  arguments: SuiJsonValue[];
 }
 
 export type UnserializedSignableTransaction =
@@ -173,10 +164,9 @@ export type SignableTransactionData = SignableTransaction['data'];
  * ```
  *
  */
-export interface PublishTransaction {
+export interface PublishTransaction extends TransactionCommon {
   compiledModules: ArrayLike<string> | ArrayLike<ArrayLike<number>>;
   gasPayment?: ObjectId;
-  gasBudget: number;
 }
 
 export type TransactionBuilderMode = 'Commit' | 'DevInspect';

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -339,17 +339,9 @@ export const TRANSACTION_DATA_TYPE_TAG = Array.from('TransactionData::').map(
 );
 
 export function deserializeTransactionBytesToTransactionData(
-  useIntentSigning: boolean,
   bytes: Base64DataBuffer
 ): TransactionData {
-  if (useIntentSigning) {
-    return bcs.de('TransactionData', bytes.getData());
-  } else {
-    return bcs.de(
-      'TransactionData',
-      bytes.getData().slice(TRANSACTION_DATA_TYPE_TAG.length)
-    );
-  }
+  return bcs.de('TransactionData', bytes.getData());
 }
 
 /**

--- a/sdk/typescript/test/e2e/coin-metadata.test.ts
+++ b/sdk/typescript/test/e2e/coin-metadata.test.ts
@@ -2,21 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import {
-  getEvents,
-  getObjectExistsResponse,
-  getObjectFields,
-  LocalTxnDataSerializer,
-  ObjectId,
-  RawSigner,
-} from '../../src';
+import { LocalTxnDataSerializer, ObjectId, RawSigner } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test Coin Metadata', () => {
   let toolbox: TestToolbox;
   let signer: RawSigner;
   let packageId: ObjectId;
-  let shouldSkip: boolean;
 
   beforeAll(async () => {
     toolbox = await setup();
@@ -25,21 +17,11 @@ describe('Test Coin Metadata', () => {
       toolbox.provider,
       new LocalTxnDataSerializer(toolbox.provider)
     );
-    // TODO: This API is only available under version 0.17.0. Clean
-    // up this once 0.17. is released
-    const version = await toolbox.provider.getRpcApiVersion();
-    if (version?.major === 0 && version?.minor < 17) {
-      shouldSkip = true;
-      return;
-    }
     const packagePath = __dirname + '/./data/coin_metadata';
     packageId = await publishPackage(signer, true, packagePath);
   });
 
   it('Test accessing coin metadata', async () => {
-    if (shouldSkip) {
-      return;
-    }
     const coinMetadata = await signer.provider.getCoinMetadata(
       `${packageId}::test::TEST`
     );

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -6,11 +6,8 @@ import {
   getObjectId,
   getNewlyCreatedCoinRefsAfterSplit,
   LocalTxnDataSerializer,
-  SignableTransaction,
   RawSigner,
-  JsonRpcProvider,
-  SuiAddress,
-  RawMoveCall,
+  UnserializedSignableTransaction,
 } from '../../src';
 import {
   DEFAULT_GAS_BUDGET,
@@ -26,12 +23,10 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
     let toolbox: TestToolbox;
     let signer: RawSigner;
     let packageId: string;
-    let shouldSkip: boolean;
 
     beforeAll(async () => {
       toolbox = await setup();
-      const version = await toolbox.provider.getRpcApiVersion();
-      shouldSkip = version?.major == 0 && version?.minor < 20;
+      //const version = await toolbox.provider.getRpcApiVersion();
       signer = new RawSigner(
         toolbox.keypair,
         toolbox.provider,
@@ -44,9 +39,6 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
     });
 
     it('Dev inspect transaction with PayAllSui', async () => {
-      if (shouldSkip) {
-        return;
-      }
       const gasBudget = 1000;
       const coins =
         await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
@@ -64,20 +56,21 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
         getObjectId(c)
       );
 
-      await validateDevInspectTransaction(signer, {
-        kind: 'payAllSui',
-        data: {
-          inputCoins: splitCoins,
-          recipient: DEFAULT_RECIPIENT,
-          gasBudget: gasBudget,
+      await validateDevInspectTransaction(
+        signer,
+        {
+          kind: 'payAllSui',
+          data: {
+            inputCoins: splitCoins,
+            recipient: DEFAULT_RECIPIENT,
+            gasBudget: gasBudget,
+          },
         },
-      });
+        'success'
+      );
     });
 
     it('Move Call that returns struct', async () => {
-      if (shouldSkip) {
-        return;
-      }
       const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
         toolbox.address()
       );
@@ -90,23 +83,17 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
         gasBudget: DEFAULT_GAS_BUDGET,
       };
 
-      await validateDevInspectTransaction(signer, {
-        kind: 'moveCall',
-        data: moveCall,
-      });
-
-      await validateDevInspectMoveCall(
-        toolbox.provider,
-        await signer.getAddress(),
-        moveCall,
+      await validateDevInspectTransaction(
+        signer,
+        {
+          kind: 'moveCall',
+          data: moveCall,
+        },
         'success'
       );
     });
 
     it('Move Call that aborts', async () => {
-      if (shouldSkip) {
-        return;
-      }
       const moveCall = {
         packageObjectId: packageId,
         module: 'serializer_tests',
@@ -116,14 +103,12 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
         gasBudget: DEFAULT_GAS_BUDGET,
       };
 
-      await validateDevInspectTransaction(signer, {
-        kind: 'moveCall',
-        data: moveCall,
-      });
-      await validateDevInspectMoveCall(
-        toolbox.provider,
-        await signer.getAddress(),
-        moveCall,
+      await validateDevInspectTransaction(
+        signer,
+        {
+          kind: 'moveCall',
+          data: moveCall,
+        },
         'failure'
       );
     });
@@ -132,19 +117,9 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
 
 async function validateDevInspectTransaction(
   signer: RawSigner,
-  txn: SignableTransaction
-) {
-  const localDigest = await signer.getTransactionDigest(txn);
-  const result = await signer.devInspectTransaction(txn);
-  expect(localDigest).toEqual(result.effects.transactionDigest);
-}
-
-async function validateDevInspectMoveCall(
-  provider: JsonRpcProvider,
-  address: SuiAddress,
-  moveCall: RawMoveCall,
+  txn: UnserializedSignableTransaction,
   status: 'success' | 'failure'
 ) {
-  const result = await provider.devInspectMoveCall(address, moveCall);
+  const result = await signer.devInspectTransaction(txn);
   expect(result.effects.status.status).toEqual(status);
 }

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -38,7 +38,7 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
       packageId = await publishPackage(signer, useLocalTxnBuilder, packagePath);
     });
 
-    it('Dev inspect transaction with PayAllSui', async () => {
+    it('Dev inspect transaction with Pay', async () => {
       const gasBudget = 1000;
       const coins =
         await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
@@ -59,10 +59,11 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
       await validateDevInspectTransaction(
         signer,
         {
-          kind: 'payAllSui',
+          kind: 'pay',
           data: {
             inputCoins: splitCoins,
-            recipient: DEFAULT_RECIPIENT,
+            recipients: [DEFAULT_RECIPIENT],
+            amounts: [4000],
             gasBudget: gasBudget,
           },
         },

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -17,28 +17,14 @@ describe('Transaction Reading API', () => {
   });
 
   it('Get Transaction', async () => {
-    const resp = await toolbox.provider.getTransactions(
-      'All',
-      null,
-      1,
-    );
+    const resp = await toolbox.provider.getTransactions('All', null, 1);
     const digest = resp.data[0];
     const txn = await toolbox.provider.getTransactionWithEffects(digest);
     expect(txn.certificate.transactionDigest).toEqual(digest);
   });
 
   it('Get Transaction Auth Signers', async () => {
-    const version = await toolbox.provider.getRpcApiVersion();
-    // This endpoint is only available in 0.18 and above
-    if (version?.major === 0 && version?.minor < 18) { 
-      return;
-    }
-    
-    const resp = await toolbox.provider.getTransactions(
-      'All',
-      null,
-      1,
-    );
+    const resp = await toolbox.provider.getTransactions('All', null, 1);
     const digest = resp.data[0];
     const res = await toolbox.provider.getTransactionAuthSigners(digest);
     expect(res.signers.length).greaterThan(0);
@@ -54,19 +40,19 @@ describe('Transaction Reading API', () => {
     const allTransactions = await toolbox.provider.getTransactions(
       'All',
       null,
-      10,
+      10
     );
     expect(allTransactions.data.length).to.greaterThan(0);
 
     const resp2 = await toolbox.provider.getTransactions(
       { ToAddress: toolbox.address() },
       null,
-      null,
+      null
     );
     const resp3 = await toolbox.provider.getTransactions(
       { FromAddress: toolbox.address() },
       null,
-      null,
+      null
     );
     expect([...resp2.data, ...resp3.data]).toEqual(resp);
   });

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -50,25 +50,22 @@ describe('Transaction Serialization and deserialization', () => {
 
     expect(rpcTxnBytes).toEqual(localTxnBytes);
 
-    const version = await toolbox.provider.getRpcApiVersion();
-    const useIntentSigning = version != null && version.major >= 0 && version.minor > 18;
     const deserialized =
       (await localSerializer.deserializeTransactionBytesToSignableTransaction(
-        useIntentSigning,
         localTxnBytes
       )) as UnserializedSignableTransaction;
     expect(deserialized.kind).toEqual('moveCall');
 
     const deserializedTxnData =
-      deserializeTransactionBytesToTransactionData(useIntentSigning, localTxnBytes);
-    const reserialized = await localSerializer.serializeTransactionData(useIntentSigning,
+      deserializeTransactionBytesToTransactionData(localTxnBytes);
+    const reserialized = await localSerializer.serializeTransactionData(
       deserializedTxnData
     );
     expect(reserialized).toEqual(localTxnBytes);
     if ('moveCall' === deserialized.kind) {
       const normalized = {
         ...deserialized.data,
-        gasBudget: Number(deserialized.data.gasBudget.toString(10)),
+        gasBudget: Number(deserialized.data.gasBudget!.toString(10)),
         gasPayment: '0x' + deserialized.data.gasPayment,
       };
       return normalized;


### PR DESCRIPTION
- Merge the transaction mode and move call only mode. Specifying the gas object isn't really necessary for dev inspect

I am not entirely sure how the `read_api` parts of the code should change. Maybe you can help with that @666lcz :) Thanks in advance! 