### PR TITLE
transaction orchestrator schedules pending txes in wal on start

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -244,7 +244,8 @@ impl SuiNode {
                     checkpoint_executor_handle.subscribe_to_end_of_epoch(),
                     config.db_path(),
                     &prometheus_registry,
-                )?,
+                )
+                .await?,
             ))
         } else {
             None

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -36,6 +36,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
         temp_dir.path(),
         &Registry::new(),
     )
+    .await
     .unwrap();
 
     let txn_count = 4;
@@ -93,6 +94,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
         temp_dir.path(),
         &Registry::new(),
     )
+    .await
     .unwrap();
 
     let txn_count = 2;


### PR DESCRIPTION
test plan: start local cluster and stress (using fullnode). Stop fullnode then restart, see transactions enqueued from wal log