### PR TITLE
[rpc] Add RPC endpoint for getting reference gas price

### DIFF
--- a/.changeset/hungry-islands-press.md
+++ b/.changeset/hungry-islands-press.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Add getReferenceGasPrice

--- a/.changeset/tame-shrimps-impress.md
+++ b/.changeset/tame-shrimps-impress.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Use reference gas price instead of a hardcoded "1" for transaction construction

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -339,6 +339,10 @@ pub trait GovernanceReadApi {
     /// Return [SuiSystemState]
     #[method(name = "getSuiSystemState")]
     async fn get_sui_system_state(&self) -> RpcResult<SuiSystemState>;
+
+    /// Return the reference gas price for the network
+    #[method(name = "getReferenceGasPrice")]
+    async fn get_reference_gas_price(&self) -> RpcResult<u64>;
 }
 
 #[open_rpc(namespace = "sui", tag = "Transaction Builder API")]

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -93,6 +93,10 @@ impl GovernanceReadApiServer for GovernanceReadApi {
             .get_sui_system_state_object()
             .map_err(Error::from)?)
     }
+
+    async fn get_reference_gas_price(&self) -> RpcResult<u64> {
+        Ok(self.get_sui_system_state().await?.reference_gas_price)
+    }
 }
 
 impl SuiRpcModule for GovernanceReadApi {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1496,6 +1496,25 @@
       ]
     },
     {
+      "name": "sui_getReferenceGasPrice",
+      "tags": [
+        {
+          "name": "Governance Read API"
+        }
+      ],
+      "description": "Return the reference gas price for the network",
+      "params": [],
+      "result": {
+        "name": "u64",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    {
       "name": "sui_getSuiSystemState",
       "tags": [
         {

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -180,6 +180,10 @@ impl ReadApi {
         Ok(self.api.http.get_sui_system_state().await?)
     }
 
+    pub async fn get_reference_gas_price(&self) -> SuiRpcResult<u64> {
+        Ok(self.api.http.get_reference_gas_price().await?)
+    }
+
     pub async fn dry_run_transaction(
         &self,
         tx: TransactionData,

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -271,5 +271,10 @@ export abstract class Provider {
    * @param txBytes
    */
   abstract dryRunTransaction(txBytes: string): Promise<TransactionEffects>;
+
+  /**
+   * Getting the reference gas price for the network
+   */
+  abstract getReferenceGasPrice(): Promise<number>;
   // TODO: add more interface methods
 }

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -49,6 +49,11 @@ export class VoidProvider extends Provider {
     throw new Error('getCoinMetadata');
   }
 
+  // Governance
+  async getReferenceGasPrice(): Promise<number> {
+    throw this.newError('getReferenceGasPrice');
+  }
+
   // Faucet
   async requestSuiFromFaucet(
     _recipient: SuiAddress,

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -311,9 +311,8 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
         Single: tx,
       },
       gasPayment: gasPayment!,
-      // Need to keep in sync with
-      // https://github.com/MystenLabs/sui/blob/f32877f2e40d35a008710c232e49b57aab886462/crates/sui-types/src/messages.rs#L338
-      gasPrice: 1,
+      // TODO: Allow people to add tip to the reference gas price
+      gasPrice: await this.provider.getReferenceGasPrice(),
       gasBudget: originalTx.data.gasBudget,
       sender: signerAddress,
     };


### PR DESCRIPTION
- Adding a convenience endpoint for wallets to fetch the reference gas price
- Use reference gas price instead of a hardcoded "1" for transaction construction

TODO: update the RPC transaction builder