### PR TITLE
[rpc] use reference gas price for transaction builder

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -670,7 +670,7 @@ pub fn manual_execute_move_call_fake_txn_digest(
     sender: SuiAddress,
     move_call: MoveCall,
 ) -> TransactionDigest {
-    let txn_data = TransactionData::new(
+    let txn_data = TransactionData::new_with_dummy_gas_price(
         TransactionKind::Single(SingleTransactionKind::Call(move_call)),
         sender,
         FAKE_GAS_OBJECT,

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -47,7 +47,7 @@ pub fn make_split_coin_tx(
     gas: ObjectRef,
     keypair: &AccountKeyPair,
 ) -> Result<VerifiedTransaction> {
-    let split_coin = TransactionData::new_move_call(
+    let split_coin = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
         framework,
         coin::PAY_MODULE_NAME.to_owned(),
@@ -72,7 +72,14 @@ pub fn make_pay_tx(
     gas: ObjectRef,
     keypair: &AccountKeyPair,
 ) -> VerifiedTransaction {
-    let pay = TransactionData::new_pay(sender, input_coins, addresses, split_amounts, gas, 1000000);
+    let pay = TransactionData::new_pay_with_dummy_gas_price(
+        sender,
+        input_coins,
+        addresses,
+        split_amounts,
+        gas,
+        1000000,
+    );
     to_sender_signed_transaction(pay, keypair)
 }
 

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -271,7 +271,9 @@ pub fn make_transfer_sui_transaction(
     sender: SuiAddress,
     keypair: &AccountKeyPair,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_transfer_sui(recipient, sender, amount, gas_object, MAX_GAS);
+    let data = TransactionData::new_transfer_sui_with_dummy_gas_price(
+        recipient, sender, amount, gas_object, MAX_GAS,
+    );
     to_sender_signed_transaction(data, keypair)
 }
 
@@ -282,6 +284,8 @@ pub fn make_transfer_object_transaction(
     keypair: &AccountKeyPair,
     recipient: SuiAddress,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object, MAX_GAS);
+    let data = TransactionData::new_transfer_with_dummy_gas_price(
+        recipient, object_ref, sender, gas_object, MAX_GAS,
+    );
     to_sender_signed_transaction(data, keypair)
 }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -56,7 +56,7 @@ pub fn transfer_coin_transaction(
     gas_object_ref: ObjectRef,
 ) -> VerifiedTransaction {
     to_sender_signed_transaction(
-        TransactionData::new_transfer(
+        TransactionData::new_transfer_with_dummy_gas_price(
             dest,
             object_ref,
             src,
@@ -81,7 +81,7 @@ pub fn transfer_object_move_transaction(
     ];
 
     to_sender_signed_transaction(
-        TransactionData::new_move_call(
+        TransactionData::new_move_call_with_dummy_gas_price(
             src,
             framework_obj_ref,
             ident_str!("object_basics").to_owned(),
@@ -110,7 +110,7 @@ pub fn create_object_move_transaction(
     ];
 
     to_sender_signed_transaction(
-        TransactionData::new_move_call(
+        TransactionData::new_move_call_with_dummy_gas_price(
             src,
             framework_obj_ref,
             ident_str!("object_basics").to_owned(),
@@ -132,7 +132,7 @@ pub fn delete_object_move_transaction(
     gas_object_ref: ObjectRef,
 ) -> VerifiedTransaction {
     to_sender_signed_transaction(
-        TransactionData::new_move_call(
+        TransactionData::new_move_call_with_dummy_gas_price(
             src,
             framework_obj_ref,
             ident_str!("object_basics").to_owned(),
@@ -160,7 +160,7 @@ pub fn set_object_move_transaction(
     ];
 
     to_sender_signed_transaction(
-        TransactionData::new_move_call(
+        TransactionData::new_move_call_with_dummy_gas_price(
             src,
             framework_obj_ref,
             ident_str!("object_basics").to_owned(),

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -50,7 +50,7 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
             ],
         }));
     }
-    let data = TransactionData::new(
+    let data = TransactionData::new_with_dummy_gas_price(
         TransactionKind::Batch(transactions),
         sender,
         authority_state
@@ -114,7 +114,7 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
         type_arguments: vec![],
         arguments: vec![],
     }));
-    let data = TransactionData::new(
+    let data = TransactionData::new_with_dummy_gas_price(
         TransactionKind::Batch(transactions),
         sender,
         authority_state
@@ -148,7 +148,7 @@ async fn test_batch_contains_publish() -> anyhow::Result<()> {
     let transactions = vec![SingleTransactionKind::Publish(MoveModulePublish {
         modules: module_bytes,
     })];
-    let data = TransactionData::new(
+    let data = TransactionData::new_with_dummy_gas_price(
         TransactionKind::Batch(transactions),
         sender,
         authority_state
@@ -177,7 +177,7 @@ async fn test_batch_contains_transfer_sui() -> anyhow::Result<()> {
         recipient: Default::default(),
         amount: None,
     })];
-    let data = TransactionData::new(
+    let data = TransactionData::new_with_dummy_gas_price(
         TransactionKind::Batch(transactions),
         sender,
         authority_state
@@ -227,7 +227,7 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
             ],
         }));
     }
-    let data = TransactionData::new(
+    let data = TransactionData::new_with_dummy_gas_price(
         TransactionKind::Batch(transactions),
         sender,
         gas_object.compute_object_reference(),

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -52,7 +52,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
         let function = "create";
         let package_object_ref = authority.get_framework_object_ref().await.unwrap();
 
-        let data = TransactionData::new_move_call(
+        let data = TransactionData::new_move_call_with_dummy_gas_price(
             sender,
             package_object_ref,
             ident_str!(module).to_owned(),

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -165,7 +165,7 @@ async fn test_transfer_sui_insufficient_gas() {
         recipient,
         amount: None,
     }));
-    let data = TransactionData::new_with_gas_price(kind, sender, gas_object_ref, 110, 1);
+    let data = TransactionData::new(kind, sender, gas_object_ref, 110, 1);
     let tx = to_sender_signed_transaction(data, &sender_key);
 
     let effects = send_and_confirm_transaction(&authority_state, tx)
@@ -379,7 +379,7 @@ async fn test_move_call_gas() -> SuiResult {
         CallArg::Pure(16u64.to_le_bytes().to_vec()),
         CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
     ];
-    let data = TransactionData::new_move_call(
+    let data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
         package_object_ref,
         module.clone(),
@@ -440,7 +440,7 @@ async fn test_move_call_gas() -> SuiResult {
     let prev_storage_cost = gas_cost.storage_cost;
 
     // Execute object deletion, and make sure we have storage rebate.
-    let data = TransactionData::new_move_call(
+    let data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
         package_object_ref,
         module.clone(),
@@ -468,7 +468,7 @@ async fn test_move_call_gas() -> SuiResult {
     // Create a transaction with gas budget that should run out during Move VM execution.
     let gas_object = authority_state.get_object(&gas_object_id).await?.unwrap();
     let budget = gas_used_before_vm_exec + 1;
-    let data = TransactionData::new_move_call(
+    let data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
         package_object_ref,
         module,
@@ -547,8 +547,7 @@ async fn execute_transfer_with_price(
         recipient,
         object_ref: object.compute_object_reference(),
     }));
-    let data =
-        TransactionData::new_with_gas_price(kind, sender, gas_object_ref, gas_budget, gas_price);
+    let data = TransactionData::new(kind, sender, gas_object_ref, gas_budget, gas_price);
     let tx = to_sender_signed_transaction(data, &sender_key);
 
     let response = if run_confirm {

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -1861,7 +1861,12 @@ pub async fn build_and_try_publish_test_package(
     let gas_object = authority.get_object(gas_object_id).await.unwrap();
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
 
-    let data = TransactionData::new_module(*sender, gas_object_ref, all_module_bytes, gas_budget);
+    let data = TransactionData::new_module_with_dummy_gas_price(
+        *sender,
+        gas_object_ref,
+        all_module_bytes,
+        gas_budget,
+    );
     let transaction = to_sender_signed_transaction(data, sender_key);
 
     (

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -443,7 +443,7 @@ async fn execute_pay_sui(
         recipients,
         amounts,
     }));
-    let data = TransactionData::new_with_gas_price(kind, sender, gas_object_ref, gas_budget, 1);
+    let data = TransactionData::new(kind, sender, gas_object_ref, gas_budget, 1);
     let tx = to_sender_signed_transaction(data, &sender_key);
     let txn_result = send_and_confirm_transaction(&authority_state, tx).await;
 
@@ -491,7 +491,7 @@ async fn execute_pay_all_sui(
         coins: input_coins,
         recipient,
     }));
-    let data = TransactionData::new_with_gas_price(kind, sender, gas_object_ref, gas_budget, 1);
+    let data = TransactionData::new(kind, sender, gas_object_ref, gas_budget, 1);
     let tx = to_sender_signed_transaction(data, &sender_key);
     let txn_result = send_and_confirm_transaction(&authority_state, tx).await;
     PaySuiTransactionExecutionResult {

--- a/crates/sui-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/sui-faucet/src/faucet/write_ahead_log.rs
@@ -187,7 +187,14 @@ mod tests {
         let recv = SuiAddress::random_for_testing_only();
         (
             recv,
-            TransactionData::new_pay_sui(send, vec![coin], vec![recv], vec![1000], coin, 1000),
+            TransactionData::new_pay_sui_with_dummy_gas_price(
+                send,
+                vec![coin],
+                vec![recv],
+                vec![1000],
+                coin,
+                1000,
+            ),
         )
     }
 }

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -70,6 +70,10 @@ impl DataReader for AuthorityStateDataReader {
         let result = self.0.get_object_read(&object_id).await?;
         Ok(result.try_into()?)
     }
+
+    async fn get_reference_gas_price(&self) -> Result<u64, anyhow::Error> {
+        Ok(self.0.get_sui_system_state_object()?.reference_gas_price)
+    }
 }
 
 #[async_trait]

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -114,7 +114,7 @@ impl RpcExampleProvider {
             }),
         ];
 
-        let data = TransactionData::new(
+        let data = TransactionData::new_with_dummy_gas_price(
             TransactionKind::Batch(vec![
                 SingleTransactionKind::Call(MoveCall {
                     package: (
@@ -433,7 +433,9 @@ impl RpcExampleProvider {
             ObjectDigest::new(self.rng.gen()),
         );
 
-        let data = TransactionData::new_transfer(recipient, object_ref, signer, gas_ref, 1000);
+        let data = TransactionData::new_transfer_with_dummy_gas_price(
+            recipient, object_ref, signer, gas_ref, 1000,
+        );
         let data1 = data.clone();
         let data2 = data.clone();
 

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -775,7 +775,7 @@ impl InternalOperation {
                 amounts,
             }),
         };
-        TransactionData::new(
+        TransactionData::new_with_dummy_gas_price(
             TransactionKind::Single(single_tx),
             metadata.sender,
             metadata.gas,

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -352,7 +352,12 @@ async fn test_transaction(
         get_random_sui(client, sender, input_objects).await
     };
 
-    let data = TransactionData::new(TransactionKind::Single(tx.clone()), sender, gas, 10000);
+    let data = TransactionData::new_with_dummy_gas_price(
+        TransactionKind::Single(tx.clone()),
+        sender,
+        gas,
+        10000,
+    );
 
     let signature = keystore
         .sign_secure(&data.signer(), &data, Intent::default())

--- a/crates/sui-rosetta/src/unit_tests/operations_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/operations_tests.rs
@@ -17,7 +17,7 @@ async fn test_operation_data_parsing() -> Result<(), anyhow::Error> {
 
     let sender = SuiAddress::random_for_testing_only();
 
-    let data = TransactionData::new_pay_sui(
+    let data = TransactionData::new_pay_sui_with_dummy_gas_price(
         sender,
         vec![gas],
         vec![SuiAddress::random_for_testing_only()],

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -230,4 +230,8 @@ impl DataReader for ReadApi {
     ) -> Result<GetRawObjectDataResponse, anyhow::Error> {
         Ok(self.get_object(object_id).await?)
     }
+
+    async fn get_reference_gas_price(&self) -> Result<u64, anyhow::Error> {
+        Ok(self.get_reference_gas_price().await?)
+    }
 }

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -51,6 +51,8 @@ pub trait DataReader {
         &self,
         object_id: ObjectID,
     ) -> Result<GetRawObjectDataResponse, anyhow::Error>;
+
+    async fn get_reference_gas_price(&self) -> Result<u64, anyhow::Error>;
 }
 
 #[derive(Clone)]
@@ -108,11 +110,13 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let gas = self
             .select_gas(signer, gas, gas_budget, vec![object_id])
             .await?;
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new(
             TransactionKind::Single(single_transfer),
             signer,
             gas,
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -136,8 +140,9 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         amount: Option<u64>,
     ) -> anyhow::Result<TransactionData> {
         let object = self.get_object_ref(sui_object_id).await?;
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new_transfer_sui(
-            recipient, signer, amount, object, gas_budget,
+            recipient, signer, amount, object, gas_budget, gas_price,
         ))
     }
 
@@ -167,8 +172,10 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let gas = self
             .select_gas(signer, gas, gas_budget, input_coins)
             .await?;
-        let data =
-            TransactionData::new_pay(signer, coin_refs, recipients, amounts, gas, gas_budget);
+        let gas_price = self.0.get_reference_gas_price().await?;
+        let data = TransactionData::new_pay(
+            signer, coin_refs, recipients, amounts, gas, gas_budget, gas_price,
+        );
         Ok(data)
     }
 
@@ -192,6 +199,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             .collect::<anyhow::Result<Vec<ObjectRef>>>()?;
         // [0] is safe because input_coins is non-empty and coins are of same length as input_coins.
         let gas_object_ref = coin_refs[0];
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new_pay_sui(
             signer,
             coin_refs,
@@ -199,6 +207,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             amounts,
             gas_object_ref,
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -222,12 +231,14 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             .collect::<anyhow::Result<Vec<ObjectRef>>>()?;
         // [0] is safe because input_coins is non-empty and coins are of same length as input_coins.
         let gas_object_ref = coin_refs[0];
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new_pay_all_sui(
             signer,
             coin_refs,
             recipient,
             gas_object_ref,
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -258,12 +269,13 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let gas = self
             .select_gas(signer, gas, gas_budget, input_objects)
             .await?;
-
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new(
             TransactionKind::Single(single_move_call),
             signer,
             gas,
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -390,11 +402,13 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         gas_budget: u64,
     ) -> anyhow::Result<TransactionData> {
         let gas = self.select_gas(sender, gas, gas_budget, vec![]).await?;
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new_module(
             sender,
             gas,
             compiled_modules,
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -414,7 +428,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let gas = self
             .select_gas(signer, gas, gas_budget, vec![coin_object_id])
             .await?;
-
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new_move_call(
             signer,
             self.get_object_ref(SUI_FRAMEWORK_OBJECT_ID).await?,
@@ -427,6 +441,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 CallArg::Pure(bcs::to_bytes(&split_amounts)?),
             ],
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -446,7 +461,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let gas = self
             .select_gas(signer, gas, gas_budget, vec![coin_object_id])
             .await?;
-
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new_move_call(
             signer,
             self.get_object_ref(SUI_FRAMEWORK_OBJECT_ID).await?,
@@ -459,6 +474,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 CallArg::Pure(bcs::to_bytes(&split_count)?),
             ],
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -479,7 +495,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let gas = self
             .select_gas(signer, gas, gas_budget, vec![primary_coin, coin_to_merge])
             .await?;
-
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new_move_call(
             signer,
             self.get_object_ref(SUI_FRAMEWORK_OBJECT_ID).await?,
@@ -492,6 +508,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(coin_to_merge_ref)),
             ],
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -546,12 +563,13 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             .collect();
 
         let gas = self.select_gas(signer, gas, gas_budget, inputs).await?;
-
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new(
             TransactionKind::Batch(tx_kinds),
             signer,
             gas,
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -598,7 +616,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             ADD_DELEGATION_LOCKED_COIN_FUN_NAME
         }
         .to_owned();
-
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new_move_call(
             signer,
             self.get_object_ref(SUI_FRAMEWORK_OBJECT_ID).await?,
@@ -616,6 +634,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 CallArg::Pure(bcs::to_bytes(&validator)?),
             ],
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -631,7 +650,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let delegation = self.get_object_ref(delegation).await?;
         let staked_sui = self.get_object_ref(staked_sui).await?;
         let gas = self.select_gas(signer, gas, gas_budget, vec![]).await?;
-
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new_move_call(
             signer,
             self.get_object_ref(SUI_FRAMEWORK_OBJECT_ID).await?,
@@ -649,6 +668,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 CallArg::Pure(bcs::to_bytes(&principal_withdraw_amount)?),
             ],
             gas_budget,
+            gas_price,
         ))
     }
 
@@ -665,7 +685,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let delegation = self.get_object_ref(delegation).await?;
         let staked_sui = self.get_object_ref(staked_sui).await?;
         let gas = self.select_gas(signer, gas, gas_budget, vec![]).await?;
-
+        let gas_price = self.0.get_reference_gas_price().await?;
         Ok(TransactionData::new_move_call(
             signer,
             self.get_object_ref(SUI_FRAMEWORK_OBJECT_ID).await?,
@@ -684,6 +704,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 CallArg::Pure(bcs::to_bytes(&switch_pool_token_amount)?),
             ],
             gas_budget,
+            gas_price,
         ))
     }
 

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -212,7 +212,12 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         };
         let gas_budget = gas_budget.unwrap_or(GAS_VALUE_FOR_TESTING);
         let data = |sender, gas_payment| {
-            TransactionData::new_module(sender, gas_payment, vec![module_bytes], gas_budget)
+            TransactionData::new_module_with_dummy_gas_price(
+                sender,
+                gas_payment,
+                vec![module_bytes],
+                gas_budget,
+            )
         };
         let transaction = self.sign_txn(sender, data);
         let summary = self.execute_txn(transaction, gas_budget)?;
@@ -288,7 +293,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
 
         let gas_budget = gas_budget.unwrap_or(GAS_VALUE_FOR_TESTING);
         let data = |sender, gas_payment| {
-            TransactionData::new_move_call(
+            TransactionData::new_move_call_with_dummy_gas_price(
                 sender,
                 package_ref,
                 module_id.name().to_owned(),
@@ -410,7 +415,9 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 };
                 let gas_budget = gas_budget.unwrap_or(GAS_VALUE_FOR_TESTING);
                 let transaction = self.sign_txn(sender, |sender, gas| {
-                    TransactionData::new_transfer(recipient, obj_ref, sender, gas, gas_budget)
+                    TransactionData::new_transfer_with_dummy_gas_price(
+                        recipient, obj_ref, sender, gas, gas_budget,
+                    )
                 });
                 let summary = self.execute_txn(transaction, gas_budget)?;
                 let output = self.object_summary_output(&summary, false);

--- a/crates/sui-types/src/unit_tests/intent_tests.rs
+++ b/crates/sui-types/src/unit_tests/intent_tests.rs
@@ -58,7 +58,7 @@ fn test_authority_signature_intent() {
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
     let object = Object::immutable_with_id_for_testing(object_id);
-    let data = TransactionData::new_transfer_sui(
+    let data = TransactionData::new_transfer_sui_with_dummy_gas_price(
         recipient,
         sender,
         None,

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -42,7 +42,7 @@ fn test_signed_values() {
     let committee = Committee::new(0, authorities).unwrap();
 
     let transaction = Transaction::from_data_and_signer(
-        TransactionData::new_transfer(
+        TransactionData::new_transfer_with_dummy_gas_price(
             _a2,
             random_object_ref(),
             a_sender,
@@ -56,7 +56,7 @@ fn test_signed_values() {
     .unwrap();
 
     let bad_transaction = VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
-        TransactionData::new_transfer(
+        TransactionData::new_transfer_with_dummy_gas_price(
             _a2,
             random_object_ref(),
             a_sender,
@@ -119,7 +119,7 @@ fn test_certificates() {
     let committee = Committee::new(0, authorities).unwrap();
 
     let transaction = Transaction::from_data_and_signer(
-        TransactionData::new_transfer(
+        TransactionData::new_transfer_with_dummy_gas_price(
             a2,
             random_object_ref(),
             a_sender,
@@ -432,7 +432,13 @@ fn test_digest_caching() {
     let committee = Committee::new(0, authorities).unwrap();
 
     let transaction = Transaction::from_data_and_signer(
-        TransactionData::new_transfer(sa1, random_object_ref(), sa2, random_object_ref(), 10000),
+        TransactionData::new_transfer_with_dummy_gas_price(
+            sa1,
+            random_object_ref(),
+            sa2,
+            random_object_ref(),
+            10000,
+        ),
         Intent::default(),
         &ssec2,
     )
@@ -502,7 +508,7 @@ fn test_user_signature_committed_in_transactions() {
     let (a_sender, sender_sec): (_, AccountKeyPair) = get_key_pair();
     let (a_sender2, sender_sec2): (_, AccountKeyPair) = get_key_pair();
 
-    let tx_data = TransactionData::new_transfer(
+    let tx_data = TransactionData::new_transfer_with_dummy_gas_price(
         a_sender2,
         random_object_ref(),
         a_sender,
@@ -550,7 +556,7 @@ fn test_user_signature_committed_in_signed_transactions() {
     let (a_sender, sender_sec): (_, AccountKeyPair) = get_key_pair();
     let (a_sender2, sender_sec2): (_, AccountKeyPair) = get_key_pair();
 
-    let tx_data = TransactionData::new_transfer(
+    let tx_data = TransactionData::new_transfer_with_dummy_gas_price(
         a_sender2,
         random_object_ref(),
         a_sender,
@@ -629,7 +635,7 @@ fn verify_sender_signature_correctly_with_flag() {
     // create a sender keypair with Secp256k1
     let sender_kp = SuiKeyPair::Secp256k1(get_key_pair().1);
     // and creates a corresponding transaction
-    let tx_data = TransactionData::new_transfer(
+    let tx_data = TransactionData::new_transfer_with_dummy_gas_price(
         receiver_address,
         random_object_ref(),
         (&sender_kp.public()).into(),

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -51,7 +51,7 @@ pub fn create_fake_transaction() -> VerifiedTransaction {
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
     let object = Object::immutable_with_id_for_testing(object_id);
-    let data = TransactionData::new_transfer_sui(
+    let data = TransactionData::new_transfer_sui_with_dummy_gas_price(
         recipient,
         sender,
         None,

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -212,7 +212,7 @@ async fn test_tx_across_epoch_boundaries() {
     let txes = gas_objects
         .iter()
         .map(|o| {
-            let data = TransactionData::new_transfer_sui(
+            let data = TransactionData::new_transfer_sui_with_dummy_gas_price(
                 get_key_pair::<AccountKeyPair>().0,
                 sender,
                 None,

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -151,7 +151,7 @@ pub async fn make_transactions_with_wallet_context(
             if res.len() >= max_txn_num {
                 return res;
             }
-            let data = TransactionData::new_transfer_sui(
+            let data = TransactionData::new_transfer_sui_with_dummy_gas_price(
                 recipient,
                 *address,
                 Some(2),
@@ -182,7 +182,7 @@ pub async fn make_counter_increment_transaction_with_wallet_context(
             .await
             .unwrap(),
     };
-    let data = TransactionData::new_move_call(
+    let data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
         package_object_ref,
         "counter".parse().unwrap(),
@@ -224,7 +224,7 @@ pub fn make_transactions_with_pre_genesis_objects(
 
         // Here we assume the object is owned not shared, so it is safe to unwrap.
         let sender = o1.owner.get_owner_address().unwrap();
-        let data = TransactionData::new_transfer(
+        let data = TransactionData::new_transfer_with_dummy_gas_price(
             recipient,
             o1.compute_object_reference(),
             /* sender */ sender,
@@ -252,7 +252,7 @@ pub fn test_shared_object_transactions() -> Vec<VerifiedTransaction> {
     let package_object_ref = genesis::get_framework_object_ref();
 
     for gas_object in generate_test_gas_objects() {
-        let data = TransactionData::new_move_call(
+        let data = TransactionData::new_move_call_with_dummy_gas_price(
             sender,
             package_object_ref,
             ident_str!(module).to_owned(),
@@ -286,7 +286,12 @@ pub fn create_publish_move_package_transaction(
     let all_module_bytes = sui_framework::build_move_package(&path, build_config)
         .unwrap()
         .get_package_bytes();
-    let data = TransactionData::new_module(sender, gas_object_ref, all_module_bytes, MAX_GAS);
+    let data = TransactionData::new_module_with_dummy_gas_price(
+        sender,
+        gas_object_ref,
+        all_module_bytes,
+        MAX_GAS,
+    );
     to_sender_signed_transaction(data, keypair)
 }
 
@@ -297,7 +302,9 @@ pub fn make_transfer_object_transaction_with_wallet_context(
     sender: SuiAddress,
     recipient: SuiAddress,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object, MAX_GAS);
+    let data = TransactionData::new_transfer_with_dummy_gas_price(
+        recipient, object_ref, sender, gas_object, MAX_GAS,
+    );
     to_sender_signed_transaction(data, context.config.keystore.get_key(&sender).unwrap())
 }
 
@@ -309,7 +316,12 @@ pub fn make_publish_basics_transaction(gas_object: ObjectRef) -> VerifiedTransac
     let all_module_bytes = sui_framework::build_move_package(&path, build_config)
         .unwrap()
         .get_package_bytes();
-    let data = TransactionData::new_module(sender, gas_object, all_module_bytes, MAX_GAS);
+    let data = TransactionData::new_module_with_dummy_gas_price(
+        sender,
+        gas_object,
+        all_module_bytes,
+        MAX_GAS,
+    );
     to_sender_signed_transaction(data, &keypair)
 }
 
@@ -334,7 +346,7 @@ pub fn make_counter_create_transaction(
     sender: SuiAddress,
     keypair: &AccountKeyPair,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_move_call(
+    let data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
         package_ref,
         "counter".parse().unwrap(),
@@ -355,7 +367,7 @@ pub fn make_counter_increment_transaction(
     sender: SuiAddress,
     keypair: &AccountKeyPair,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_move_call(
+    let data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
         package_ref,
         "counter".parse().unwrap(),
@@ -379,7 +391,7 @@ pub fn make_delegation_transaction(
     sender: SuiAddress,
     keypair: &AccountKeyPair,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_move_call(
+    let data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
         system_package_ref,
         SUI_SYSTEM_MODULE_NAME.to_owned(),
@@ -422,7 +434,7 @@ pub fn move_transaction_with_type_tags(
     let (sender, keypair) = deterministic_random_account_key();
 
     // Make the transaction.
-    let data = TransactionData::new_move_call(
+    let data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
         package_ref,
         ident_str!(module).to_owned(),

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -371,7 +371,7 @@ pub async fn delete_devnet_nft(
     let gas = get_gas_object_with_wallet_context(context, sender)
         .await
         .unwrap_or_else(|| panic!("Expect {sender} to have at least one gas object"));
-    let data = TransactionData::new_move_call(
+    let data = TransactionData::new_move_call_with_dummy_gas_price(
         *sender,
         package_ref,
         "devnet_nft".parse().unwrap(),


### PR DESCRIPTION
Fo TestNet Wave 2, the reference gas price will not always be 1. Therefore the transaction builder should set the gas price to the reference gas price(for TestNet Wave 2, after which the gas price is provided by the wallets/users) instead of a hardcoded one.