### PR TITLE
indexer: use txn diest for event ID

### DIFF
--- a/crates/sui-indexer/migrations/2022-11-18-220045_events/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-220045_events/up.sql
@@ -1,11 +1,10 @@
 CREATE TABLE EVENTS (
     id BIGSERIAL PRIMARY KEY,
+    -- below 2 are from Event ID, tx_digest and event_seq
     transaction_digest VARCHAR(255),
-    -- below 2 are from Event ID, tx_seq and event_seq
-    transaction_sequence BIGINT NOT NULL,
     event_sequence BIGINT NOT NULL,
     event_time TIMESTAMP,
     event_type VARCHAR NOT NULL,
     event_content VARCHAR NOT NULL,
-    UNIQUE (transaction_sequence, event_sequence)
+    UNIQUE (transaction_digest, event_sequence)
 );

--- a/crates/sui-indexer/migrations/2022-11-22-235415_logs/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-22-235415_logs/up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE event_logs (
     id SERIAL PRIMARY KEY,
-    next_cursor_tx_seq BIGINT,
+    next_cursor_tx_dig TEXT,
     next_cursor_event_seq BIGINT
 );
 
@@ -9,7 +9,7 @@ CREATE TABLE transaction_logs (
     next_cursor_tx_digest TEXT
 );
 
-INSERT INTO event_logs (id, next_cursor_tx_seq, next_cursor_event_seq) VALUES
+INSERT INTO event_logs (id, next_cursor_tx_dig, next_cursor_event_seq) VALUES
 (1, NULL, NULL);
 
 INSERT INTO transaction_logs (id, next_cursor_tx_digest) VALUES

--- a/crates/sui-indexer/src/handlers/transaction_handler.rs
+++ b/crates/sui-indexer/src/handlers/transaction_handler.rs
@@ -19,8 +19,6 @@ use sui_indexer::models::transactions::commit_transactions;
 use sui_indexer::utils::log_errors_to_pg;
 use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
 
-use fastcrypto::encoding::{Base64, Encoding};
-
 const TRANSACTION_PAGE_SIZE: usize = 100;
 
 pub struct TransactionHandler {
@@ -48,20 +46,14 @@ impl TransactionHandler {
 
         let mut next_cursor = None;
         let txn_log = read_transaction_log(&mut pg_pool_conn)?;
-        if let Some(txn_digest) = txn_log.next_cursor_tx_digest {
-            let bytes = Base64::decode(txn_digest.as_str()).map_err(|e| {
-                IndexerError::TransactionDigestParsingError(format!(
-                    "Failed decoding bytes from txn digest string {:?} with error {:?}",
-                    txn_digest, e
-                ))
-            })?;
-            let digest = TransactionDigest::try_from(bytes.as_slice()).map_err(|e| {
+        if let Some(tx_dig) = txn_log.next_cursor_tx_digest {
+            let tx_digest = tx_dig.parse().map_err(|e| {
                 IndexerError::TransactionDigestParsingError(format!(
                     "Failed parsing transaction digest {:?} with error: {:?}",
-                    txn_digest, e
+                    tx_dig, e
                 ))
             })?;
-            next_cursor = Some(digest);
+            next_cursor = Some(tx_digest);
         }
 
         loop {
@@ -103,8 +95,8 @@ impl TransactionHandler {
             // This will cause duplidate run of the current batch, but will not cause duplidate rows
             // b/c of the uniqueness restriction of the table.
             if let Some(next_cursor_val) = page.next_cursor {
-                // canonical txn digest is Base64 encoded
-                commit_transction_log(&mut pg_pool_conn, Some(next_cursor_val.encode()))?;
+                // canonical txn digest is Base58 encoded
+                commit_transction_log(&mut pg_pool_conn, Some(next_cursor_val.base58_encode()))?;
                 self.transaction_handler_metrics
                     .total_transactions_processed
                     .inc_by(txn_count as u64);

--- a/crates/sui-indexer/src/models/events.rs
+++ b/crates/sui-indexer/src/models/events.rs
@@ -4,7 +4,7 @@
 use crate::errors::IndexerError;
 use crate::schema::events;
 use crate::schema::events::dsl::{events as events_table, id};
-use crate::schema::events::{event_sequence, transaction_sequence};
+use crate::schema::events::{event_sequence, transaction_digest};
 use crate::utils::log_errors_to_pg;
 use crate::PgPoolConnection;
 
@@ -17,7 +17,6 @@ use sui_json_rpc_types::{EventPage, SuiEvent, SuiEventEnvelope};
 pub struct Event {
     pub id: i64,
     pub transaction_digest: Option<String>,
-    pub transaction_sequence: i64,
     pub event_sequence: i64,
     pub event_time: Option<NaiveDateTime>,
     pub event_type: String,
@@ -102,7 +101,7 @@ pub fn commit_events(
         .run::<_, Error, _>(|conn| {
         diesel::insert_into(events::table)
             .values(&new_events)
-            .on_conflict((transaction_sequence, event_sequence))
+            .on_conflict((transaction_digest, event_sequence))
             .do_nothing()
             .execute(conn)
     });

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -127,8 +127,8 @@ pub fn transaction_response_to_new_transaction(
             err
         ))
     })?;
-    // canonical txn digest string is Base64 encoded
-    let tx_digest = cer.transaction_digest.encode();
+    // canonical txn digest string is Base58 encoded
+    let tx_digest = cer.transaction_digest.base58_encode();
     let gas_budget = cer.data.gas_budget;
     let sender = cer.data.sender.to_string();
     let txn_kind_iter = cer.data.transactions.iter().map(|k| k.to_string());

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -28,7 +28,7 @@ diesel::table! {
 diesel::table! {
     event_logs (id) {
         id -> Int4,
-        next_cursor_tx_dig -> Nullable<Varchar>,
+        next_cursor_tx_dig -> Nullable<Text>,
         next_cursor_event_seq -> Nullable<Int8>,
     }
 }
@@ -37,7 +37,6 @@ diesel::table! {
     events (id) {
         id -> Int8,
         transaction_digest -> Nullable<Varchar>,
-        transaction_sequence -> Int8,
         event_sequence -> Int8,
         event_time -> Nullable<Timestamp>,
         event_type -> Varchar,

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -475,6 +475,11 @@ impl TransactionDigest {
     pub fn encode(&self) -> String {
         Base64::encode(self.0)
     }
+
+    // TODO: de-dup this
+    pub fn base58_encode(&self) -> String {
+        Base58::encode(self.0)
+    }
 }
 
 impl AsRef<[u8]> for TransactionDigest {


### PR DESCRIPTION
changes in this PR:
- title due to change in #6944 
- change txn digest encoding from Base64 to Base58 in indexer due to change in #6270
- revert event query hack as #7374 is now merged
  - the hack is not working when one txn has more than EVENT_BATCH_SIZE events, which is the case on private testnet, where the first txn has 5k+ events.

tested locally with local validator, indexer and DB to make sure that indexer txns and events can still be populated properly