### PR TITLE
[gas] Move storage gas price from on-chain to rust

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -494,7 +494,6 @@ storage_fund:
 parameters:
   min_validator_stake: 100000000000000
   max_validator_candidate_count: 100
-  storage_gas_price: 1
 reference_gas_price: 1
 validator_report_records:
   contents: []

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -4,6 +4,7 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::AuthorityStore;
 use std::collections::HashSet;
+use sui_protocol_constants::STORAGE_GAS_PRICE;
 use sui_types::base_types::ObjectRef;
 use sui_types::messages::TransactionKind;
 use sui_types::{
@@ -148,12 +149,6 @@ async fn check_gas(
             version: Some(gas_payment.1),
         })?;
 
-        // TODO: cache this storage_gas_price in memory
-        let storage_gas_price = store
-            .get_sui_system_state_object()?
-            .parameters
-            .storage_gas_price;
-
         // If the transaction is TransferSui, we ensure that the gas balance is enough to cover
         // both gas budget and the transfer amount.
         let extra_amount = match tx_kind {
@@ -164,7 +159,7 @@ async fn check_gas(
             _ => 0,
         };
         // TODO: We should revisit how we compute gas price and compare to gas budget.
-        let gas_price = std::cmp::max(computation_gas_price, storage_gas_price);
+        let gas_price = std::cmp::max(computation_gas_price, STORAGE_GAS_PRICE);
 
         if tx_kind.is_pay_sui_tx() {
             let mut additional_objs = vec![];
@@ -187,7 +182,7 @@ async fn check_gas(
             gas::check_gas_balance(&gas_object, gas_budget, gas_price, extra_amount, vec![])?;
         }
 
-        gas::start_gas_metering(gas_budget, computation_gas_price, storage_gas_price)
+        gas::start_gas_metering(gas_budget, computation_gas_price, STORAGE_GAS_PRICE)
     }
 }
 

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,13 +4,13 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
-    "computation_cost": 7480,
-    "storage_cost": 10754,
+    "computation_cost": 7475,
+    "storage_cost": 10747,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 8339,
-    "storage_cost": 11958,
+    "computation_cost": 8334,
+    "storage_cost": 11950,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
@@ -29,8 +29,8 @@ expression: common_costs_estimate
     "storage_rebate": 0
   },
   "SplitCoin": {
-    "computation_cost": 7458,
-    "storage_cost": 10722,
+    "computation_cost": 7453,
+    "storage_cost": 10715,
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -66,16 +66,6 @@ The initial amount of SUI locked in the storage fund.
 
 
 
-<a name="0x2_genesis_INIT_STORAGE_GAS_PRICE"></a>
-
-Initial storage gas price
-
-
-<pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_STORAGE_GAS_PRICE">INIT_STORAGE_GAS_PRICE</a>: u64 = 1;
-</code></pre>
-
-
-
 <a name="0x2_genesis_create"></a>
 
 ## Function `create`
@@ -85,7 +75,7 @@ It will create a singleton SuiSystemState object, which contains
 all the information we need in the system.
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_consensus_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addressess: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_stakes: <a href="">vector</a>&lt;u64&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_consensus_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_stakes: <a href="">vector</a>&lt;u64&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -106,7 +96,7 @@ all the information we need in the system.
     validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_consensus_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
-    validator_worker_addressess: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_stakes: <a href="">vector</a>&lt;u64&gt;,
     validator_gas_prices: <a href="">vector</a>&lt;u64&gt;,
     validator_commission_rates: <a href="">vector</a>&lt;u64&gt;,
@@ -125,7 +115,7 @@ all the information we need in the system.
             && <a href="_length">vector::length</a>(&validator_project_urls) == count
             && <a href="_length">vector::length</a>(&validator_net_addresses) == count
             && <a href="_length">vector::length</a>(&validator_consensus_addresses) == count
-            && <a href="_length">vector::length</a>(&validator_worker_addressess) == count
+            && <a href="_length">vector::length</a>(&validator_worker_addresses) == count
             && <a href="_length">vector::length</a>(&validator_gas_prices) == count
             && <a href="_length">vector::length</a>(&validator_commission_rates) == count,
         1
@@ -143,7 +133,7 @@ all the information we need in the system.
         <b>let</b> project_url = *<a href="_borrow">vector::borrow</a>(&validator_project_urls, i);
         <b>let</b> net_address = *<a href="_borrow">vector::borrow</a>(&validator_net_addresses, i);
         <b>let</b> consensus_address = *<a href="_borrow">vector::borrow</a>(&validator_consensus_addresses, i);
-        <b>let</b> worker_address = *<a href="_borrow">vector::borrow</a>(&validator_worker_addressess, i);
+        <b>let</b> worker_address = *<a href="_borrow">vector::borrow</a>(&validator_worker_addresses, i);
         <b>let</b> <a href="stake.md#0x2_stake">stake</a> = *<a href="_borrow">vector::borrow</a>(&validator_stakes, i);
         <b>let</b> gas_price = *<a href="_borrow">vector::borrow</a>(&validator_gas_prices, i);
         <b>let</b> commission_rate = *<a href="_borrow">vector::borrow</a>(&validator_commission_rates, i);
@@ -174,7 +164,6 @@ all the information we need in the system.
         storage_fund,
         <a href="genesis.md#0x2_genesis_INIT_MAX_VALIDATOR_COUNT">INIT_MAX_VALIDATOR_COUNT</a>,
         <a href="genesis.md#0x2_genesis_INIT_MIN_VALIDATOR_STAKE">INIT_MIN_VALIDATOR_STAKE</a>,
-        <a href="genesis.md#0x2_genesis_INIT_STORAGE_GAS_PRICE">INIT_STORAGE_GAS_PRICE</a>,
         <a href="genesis.md#0x2_genesis_INIT_STAKE_SUBSIDY_AMOUNT">INIT_STAKE_SUBSIDY_AMOUNT</a>,
     );
 }

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -87,12 +87,6 @@ A list of system config parameters.
  Maximum number of validator candidates at any moment.
  We do not allow the number of validators in any epoch to go above this.
 </dd>
-<dt>
-<code>storage_gas_price: u64</code>
-</dt>
-<dd>
- Storage gas price denominated in SUI
-</dd>
 </dl>
 
 
@@ -331,7 +325,7 @@ Create a new SuiSystemState object and make it shared.
 This function will be called only once in genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, sui_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_candidate_count: u64, min_validator_stake: u64, storage_gas_price: u64, initial_stake_subsidy_amount: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, sui_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_candidate_count: u64, min_validator_stake: u64, initial_stake_subsidy_amount: u64)
 </code></pre>
 
 
@@ -346,7 +340,6 @@ This function will be called only once in genesis.
     storage_fund: Balance&lt;SUI&gt;,
     max_validator_candidate_count: u64,
     min_validator_stake: u64,
-    storage_gas_price: u64,
     initial_stake_subsidy_amount: u64,
 ) {
     <b>let</b> validators = <a href="validator_set.md#0x2_validator_set_new">validator_set::new</a>(validators);
@@ -361,7 +354,6 @@ This function will be called only once in genesis.
         parameters: <a href="sui_system.md#0x2_sui_system_SystemParameters">SystemParameters</a> {
             min_validator_stake,
             max_validator_candidate_count,
-            storage_gas_price
         },
         reference_gas_price,
         validator_report_records: <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>(),

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -21,9 +21,6 @@ module sui::genesis {
     /// Initial value of the upper-bound on the number of validators.
     const INIT_MAX_VALIDATOR_COUNT: u64 = 100;
 
-    /// Initial storage gas price
-    const INIT_STORAGE_GAS_PRICE: u64 = 1;
-
     /// Stake subisidy to be given out in the very first epoch. Placeholder value.
     const INIT_STAKE_SUBSIDY_AMOUNT: u64 = 1000000;
 
@@ -42,7 +39,7 @@ module sui::genesis {
         validator_project_urls: vector<vector<u8>>,
         validator_net_addresses: vector<vector<u8>>,
         validator_consensus_addresses: vector<vector<u8>>,
-        validator_worker_addressess: vector<vector<u8>>,
+        validator_worker_addresses: vector<vector<u8>>,
         validator_stakes: vector<u64>,
         validator_gas_prices: vector<u64>,
         validator_commission_rates: vector<u64>,
@@ -61,7 +58,7 @@ module sui::genesis {
                 && vector::length(&validator_project_urls) == count
                 && vector::length(&validator_net_addresses) == count
                 && vector::length(&validator_consensus_addresses) == count
-                && vector::length(&validator_worker_addressess) == count
+                && vector::length(&validator_worker_addresses) == count
                 && vector::length(&validator_gas_prices) == count
                 && vector::length(&validator_commission_rates) == count,
             1
@@ -79,7 +76,7 @@ module sui::genesis {
             let project_url = *vector::borrow(&validator_project_urls, i);
             let net_address = *vector::borrow(&validator_net_addresses, i);
             let consensus_address = *vector::borrow(&validator_consensus_addresses, i);
-            let worker_address = *vector::borrow(&validator_worker_addressess, i);
+            let worker_address = *vector::borrow(&validator_worker_addresses, i);
             let stake = *vector::borrow(&validator_stakes, i);
             let gas_price = *vector::borrow(&validator_gas_prices, i);
             let commission_rate = *vector::borrow(&validator_commission_rates, i);
@@ -110,7 +107,6 @@ module sui::genesis {
             storage_fund,
             INIT_MAX_VALIDATOR_COUNT,
             INIT_MIN_VALIDATOR_STAKE,
-            INIT_STORAGE_GAS_PRICE,
             INIT_STAKE_SUBSIDY_AMOUNT,
         );
     }
@@ -127,7 +123,6 @@ module sui::genesis {
             storage_fund,
             INIT_MAX_VALIDATOR_COUNT,
             INIT_MIN_VALIDATOR_STAKE,
-            INIT_STORAGE_GAS_PRICE,
             INIT_STAKE_SUBSIDY_AMOUNT
         )
     }

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -40,8 +40,6 @@ module sui::sui_system {
         /// Maximum number of validator candidates at any moment.
         /// We do not allow the number of validators in any epoch to go above this.
         max_validator_candidate_count: u64,
-        /// Storage gas price denominated in SUI
-        storage_gas_price: u64,
     }
 
     /// The top-level object containing all information of the Sui system.
@@ -103,7 +101,6 @@ module sui::sui_system {
         storage_fund: Balance<SUI>,
         max_validator_candidate_count: u64,
         min_validator_stake: u64,
-        storage_gas_price: u64,
         initial_stake_subsidy_amount: u64,
     ) {
         let validators = validator_set::new(validators);
@@ -118,7 +115,6 @@ module sui::sui_system {
             parameters: SystemParameters {
                 min_validator_stake,
                 max_validator_candidate_count,
-                storage_gas_price
             },
             reference_gas_price,
             validator_report_records: vec_map::empty(),

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -61,7 +61,6 @@ module sui::governance_test_utils {
             balance::create_for_testing<SUI>(storage_fund_amount), // storage_fund
             1024, // max_validator_candidate_count
             0, // min_validator_stake
-            1, // storage_gas_price
             0, // stake subsidy
         )
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5896,8 +5896,7 @@
         "type": "object",
         "required": [
           "max_validator_candidate_count",
-          "min_validator_stake",
-          "storage_gas_price"
+          "min_validator_stake"
         ],
         "properties": {
           "max_validator_candidate_count": {
@@ -5906,11 +5905,6 @@
             "minimum": 0.0
           },
           "min_validator_stake": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "storage_gas_price": {
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0

--- a/crates/sui-protocol-constants/src/lib.rs
+++ b/crates/sui-protocol-constants/src/lib.rs
@@ -120,3 +120,6 @@ pub const REWARD_SLASHING_RATE: u64 = 5000;
 /// The stake subsidy we mint each epoch is 0.01% of the total stake.
 /// In basis point.
 pub const STAKE_SUBSIDY_RATE: u64 = 1;
+
+/// Unit gas price, Mist per internal gas unit.
+pub const STORAGE_GAS_PRICE: u64 = 1;

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -27,7 +27,6 @@ pub const ADVANCE_EPOCH_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch");
 pub struct SystemParameters {
     pub min_validator_stake: u64,
     pub max_validator_candidate_count: u64,
-    pub storage_gas_price: u64,
 }
 
 /// Rust version of the Move std::option::Option type.

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -92,7 +92,6 @@ pub fn test_sui_system_state(epoch: EpochId, validators: Vec<Validator>) -> SuiS
         parameters: SystemParameters {
             min_validator_stake: 1,
             max_validator_candidate_count: 100,
-            storage_gas_price: 1,
         },
         reference_gas_price: 1,
         validator_report_records: VecMap { contents: vec![] },


### PR DESCRIPTION
Previously we always load the storage gas price from on-chain system object, which is problematic in multiple levels:
1. It's inefficient, obviously, there is no need to do a db read on every transaction just to read the storage gas price, which doesn't change during the epoch.
2. There can be data races. Right now we don't guarantee that the advance epoch transaction to be the last transaction executed in the epoch, so what could happen is that a node catching up and executed the advance epoch transaction would have a new storage gas price, which would affect transaction executed after this.

Since we want storage gas price to be updated through software updates instead of governance, this PR moves it to a software constant.