### PR TITLE
Simplify Container, support node restarts, convert some tests to sim_test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4998,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=030cd3036f35d9625bf733d0ef33bc7316c32001#030cd3036f35d9625bf733d0ef33bc7316c32001"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=bef88159c02fae45d94739f4d380efebf86b2958#bef88159c02fae45d94739f4d380efebf86b2958"
 dependencies = [
  "ahash 0.7.6",
  "async-task",
@@ -5028,7 +5028,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=030cd3036f35d9625bf733d0ef33bc7316c32001#030cd3036f35d9625bf733d0ef33bc7316c32001"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=bef88159c02fae45d94739f4d380efebf86b2958#bef88159c02fae45d94739f4d380efebf86b2958"
 dependencies = [
  "darling",
  "proc-macro2 1.0.49",

--- a/crates/sui-core/src/epoch/committee_store.rs
+++ b/crates/sui-core/src/epoch/committee_store.rs
@@ -19,7 +19,7 @@ use sui_macros::nondeterministic;
 pub struct CommitteeStore {
     /// Map from each epoch ID to the committee information.
     #[default_options_override_fn = "committee_table_default_config"]
-    pub(crate) committee_map: DBMap<EpochId, Committee>,
+    committee_map: DBMap<EpochId, Committee>,
 }
 
 // These functions are used to initialize the DB tables

--- a/crates/sui-proc-macros/Cargo.toml
+++ b/crates/sui-proc-macros/Cargo.toml
@@ -16,4 +16,4 @@ syn = "1.0.104"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "030cd3036f35d9625bf733d0ef33bc7316c32001", package = "msim-macros" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "bef88159c02fae45d94739f4d380efebf86b2958", package = "msim-macros" }

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -19,4 +19,4 @@ telemetry-subscribers.workspace = true
 tower = "0.4.13"
 
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "030cd3036f35d9625bf733d0ef33bc7316c32001", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "bef88159c02fae45d94739f4d380efebf86b2958", package = "msim" }

--- a/crates/sui-swarm/src/memory/container-sim.rs
+++ b/crates/sui-swarm/src/memory/container-sim.rs
@@ -1,50 +1,41 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use futures::FutureExt;
 use prometheus::Registry;
 use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
 use sui_config::NodeConfig;
 use sui_node::SuiNode;
-use tracing::trace;
+use tracing::{info, trace};
 
 use super::node::RuntimeType;
 
 #[derive(Debug)]
 pub(crate) struct Container {
-    join_handle: Option<ContainerJoinHandle>,
-    cancel_sender: Option<tokio::sync::oneshot::Sender<()>>,
+    handle: Option<ContainerHandle>,
+    cancel_sender: Option<tokio::sync::watch::Sender<bool>>,
 }
 
 #[derive(Debug)]
-struct ContainerJoinHandle {
+struct ContainerHandle {
     node_id: sui_simulator::task::NodeId,
-    task_handle: sui_simulator::task::JoinHandle<()>,
 }
 
 /// When dropped, stop and wait for the node running in this Container to completely shutdown.
 impl Drop for Container {
     fn drop(&mut self) {
-        trace!("dropping Container");
-
-        let handle = self.join_handle.take().unwrap();
-
-        tracing::info!("shutting down {}", handle.node_id);
-        handle.task_handle.abort();
-        sui_simulator::runtime::Handle::try_current().map(|h| h.kill(handle.node_id));
-
-        trace!("finished dropping Container");
+        if let Some(handle) = self.handle.take() {
+            tracing::info!("shutting down {}", handle.node_id);
+            sui_simulator::runtime::Handle::try_current().map(|h| h.delete_node(handle.node_id));
+        }
     }
 }
 
 impl Container {
     /// Spawn a new Node.
-    pub fn spawn(
-        config: NodeConfig,
-        _runtime: RuntimeType,
-    ) -> (tokio::sync::oneshot::Receiver<()>, Self) {
-        let (startup_sender, startup_reciever) = tokio::sync::oneshot::channel();
-        let (cancel_sender, cancel_reciever) = tokio::sync::oneshot::channel();
+    pub async fn spawn(config: NodeConfig, _runtime: RuntimeType) -> Self {
+        let (startup_sender, mut startup_reciever) = tokio::sync::watch::channel(false);
+        let (cancel_sender, cancel_reciever) = tokio::sync::watch::channel(false);
 
         let handle = sui_simulator::runtime::Handle::current();
         let builder = handle.create_node();
@@ -56,35 +47,40 @@ impl Container {
             _ => panic!("unsupported protocol"),
         };
 
+        let config = Arc::new(config);
+        let startup_sender = Arc::new(startup_sender);
         let node = builder
             .ip(ip)
             .name(&format!("{:?}", config.protocol_public_key().concise()))
-            .init(|| async {
-                tracing::info!("node restarted");
+            .init(move || {
+                info!("Node restarted");
+                let config = config.clone();
+                let mut cancel_reciever = cancel_reciever.clone();
+                let startup_sender = startup_sender.clone();
+                async move {
+                    let registry_service = mysten_metrics::RegistryService::new(Registry::new());
+                    let _server = SuiNode::start(&config, registry_service).await.unwrap();
+
+                    startup_sender.send(true).ok();
+
+                    // run until canceled
+                    loop {
+                        if cancel_reciever.changed().await.is_err() || *cancel_reciever.borrow() {
+                            break;
+                        }
+                    }
+                    trace!("cancellation received; shutting down thread");
+                }
             })
             .build();
 
-        let task_handle = node.spawn(async move {
-            let registry_service = mysten_metrics::RegistryService::new(Registry::new());
-            let _server = SuiNode::start(&config, registry_service).await.unwrap();
-            // Notify that we've successfully started the node
-            trace!("node started, sending oneshot");
-            let _ = startup_sender.send(());
-            // run until canceled
-            cancel_reciever.map(|_| ()).await;
-            trace!("cancellation received; shutting down thread");
-        });
+        startup_reciever.changed().await.unwrap();
+        assert!(*startup_reciever.borrow());
 
-        (
-            startup_reciever,
-            Self {
-                join_handle: Some(ContainerJoinHandle {
-                    node_id: node.id(),
-                    task_handle,
-                }),
-                cancel_sender: Some(cancel_sender),
-            },
-        )
+        Self {
+            handle: Some(ContainerHandle { node_id: node.id() }),
+            cancel_sender: Some(cancel_sender),
+        }
     }
 
     /// Check to see that the Node is still alive by checking if the receiving side of the
@@ -92,7 +88,7 @@ impl Container {
     ///
     pub fn is_alive(&self) -> bool {
         if let Some(cancel_sender) = &self.cancel_sender {
-            !cancel_sender.is_closed()
+            cancel_sender.receiver_count() > 0
         } else {
             false
         }

--- a/crates/sui-swarm/src/memory/container.rs
+++ b/crates/sui-swarm/src/memory/container.rs
@@ -36,10 +36,7 @@ impl Drop for Container {
 
 impl Container {
     /// Spawn a new Node.
-    pub fn spawn(
-        config: NodeConfig,
-        runtime: RuntimeType,
-    ) -> (tokio::sync::oneshot::Receiver<()>, Self) {
+    pub async fn spawn(config: NodeConfig, runtime: RuntimeType) -> Self {
         let (startup_sender, startup_reciever) = tokio::sync::oneshot::channel();
         let (cancel_sender, cancel_reciever) = tokio::sync::oneshot::channel();
 
@@ -93,13 +90,12 @@ impl Container {
             });
         });
 
-        (
-            startup_reciever,
-            Self {
-                join_handle: Some(thread),
-                cancel_sender: Some(cancel_sender),
-            },
-        )
+        startup_reciever.await.unwrap();
+
+        Self {
+            join_handle: Some(thread),
+            cancel_sender: Some(cancel_sender),
+        }
     }
 
     /// Check to see that the Node is still alive by checking if the receiving side of the

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -224,12 +224,7 @@ impl Swarm {
 
     /// Start all of the Validators associated with this Swarm
     pub async fn launch(&mut self) -> Result<()> {
-        let start_handles = self
-            .nodes_iter_mut()
-            .map(|node| node.spawn())
-            .collect::<Result<Vec<_>>>()?;
-
-        try_join_all(start_handles).await?;
+        try_join_all(self.nodes_iter_mut().map(|node| node.start())).await?;
 
         Ok(())
     }

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -22,7 +22,9 @@ use test_utils::network::TestClusterBuilder;
 use test_utils::transaction::wait_for_tx;
 use tracing::info;
 
-#[tokio::test]
+use sui_macros::sim_test;
+
+#[sim_test]
 async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await?;
     let context = &mut test_cluster.wallet;
@@ -79,7 +81,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[tokio::test]
+#[sim_test]
 async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
     let mut test_cluster = TestClusterBuilder::new().build().await?;
@@ -158,7 +160,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[tokio::test]
+#[sim_test]
 async fn test_transaction_orchestrator_reconfig() {
     telemetry_subscribers::init_for_testing();
     let config = test_authority_configs();
@@ -198,7 +200,7 @@ async fn test_transaction_orchestrator_reconfig() {
     });
 }
 
-#[tokio::test]
+#[sim_test]
 async fn test_tx_across_epoch_boundaries() {
     telemetry_subscribers::init_for_testing();
     let total_tx_cnt = 1800;

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -54,9 +54,9 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "030cd3036f35d9625bf733d0ef33bc7316c32001"'
+    --config 'patch.crates-io.tokio.rev = "bef88159c02fae45d94739f4d380efebf86b2958"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "030cd3036f35d9625bf733d0ef33bc7316c32001"'
+    --config 'patch.crates-io.futures-timer.rev = "bef88159c02fae45d94739f4d380efebf86b2958"'
   )
 fi
 


### PR DESCRIPTION
`test_fullnode_wal_log` was a good test case for this, since it kills and restarts validator. Converting it to simtest hugely speeds up the test, as well.

Before:

```
PASS [  57.640s] sui::transaction_orchestrator_tests test_fullnode_wal_log
```

After

```
PASS [  11.670s] sui::transaction_orchestrator_tests test_fullnode_wal_log
```

(If you set `USE_MOCK_CRYPTO=1` it goes down to about 4 seconds).