### PR TITLE
Add metrics for per-validator and total votes in each epoch

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1637,6 +1637,7 @@ impl AuthorityState {
         genesis: &Genesis,
     ) -> Arc<Self> {
         let secret = Arc::pin(key.copy());
+        let name: AuthorityName = secret.public().into();
         let path = match store_base_path {
             Some(path) => path,
             None => {
@@ -1661,6 +1662,7 @@ impl AuthorityState {
         );
         let registry = Registry::new();
         let epoch_store = AuthorityPerEpochStore::new(
+            name,
             genesis_committee.clone(),
             &path.join("store"),
             None,
@@ -2574,7 +2576,9 @@ impl AuthorityState {
 
     async fn reopen_epoch_db(&self, new_committee: Committee) {
         info!(new_epoch = ?new_committee.epoch, "re-opening AuthorityEpochTables for new epoch");
-        let epoch_tables = self.epoch_store().new_at_next_epoch(new_committee);
+        let epoch_tables = self
+            .epoch_store()
+            .new_at_next_epoch(self.name, new_committee);
         let previous_store = self.epoch_store.swap(epoch_tables);
         previous_store.epoch_terminated().await;
     }

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -8,6 +8,9 @@ pub struct EpochMetrics {
     /// The current epoch ID. This is updated only when the AuthorityState finishes reconfiguration.
     pub current_epoch: IntGauge,
 
+    /// Current voting right of the validator in the protocol. Updated at the start of epochs.
+    pub current_voting_right: IntGauge,
+
     /// Total duration of the epoch. This is measured from when the current epoch store is opened,
     /// until the current epoch store is replaced with the next epoch store.
     pub epoch_total_duration: IntGauge,
@@ -20,6 +23,9 @@ pub struct EpochMetrics {
 
     /// Total amount of gas rewards (i.e. computation gas cost) in the epoch.
     pub epoch_total_gas_reward: IntGauge,
+
+    /// Total amount of stakes in the epoch.
+    pub epoch_total_votes: IntGauge,
 
     // An active validator reconfigures through the following steps:
     // 1. Halt validator (a.k.a. close epoch) and stop accepting user transaction certs.
@@ -79,6 +85,12 @@ impl EpochMetrics {
                 registry
             )
             .unwrap(),
+            current_voting_right: register_int_gauge_with_registry!(
+                "current_voting_right",
+                "Current voting right of the validator",
+                registry
+            )
+            .unwrap(),
             epoch_checkpoint_count: register_int_gauge_with_registry!(
                 "epoch_checkpoint_count",
                 "Number of checkpoints in the epoch",
@@ -97,6 +109,11 @@ impl EpochMetrics {
             epoch_total_gas_reward: register_int_gauge_with_registry!(
                 "epoch_total_gas_reward",
                 "Total amount of gas rewards (i.e. computation gas cost) in the epoch",
+                registry
+            ).unwrap(),
+            epoch_total_votes: register_int_gauge_with_registry!(
+                "epoch_total_votes",
+                "Total amount of votes among validators in the epoch.",
                 registry
             ).unwrap(),
             epoch_pending_certs_processed_time_since_epoch_close_ms: register_int_gauge_with_registry!(

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2524,6 +2524,7 @@ async fn test_authority_persist() {
         fs::create_dir(&epoch_store_path).unwrap();
         let registry = Registry::new();
         let epoch_store = AuthorityPerEpochStore::new(
+            name,
             committee,
             &epoch_store_path,
             None,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -149,6 +149,7 @@ impl SuiNode {
             .get_committee(&cur_epoch)?
             .expect("Committee of the current epoch must exist");
         let epoch_store = AuthorityPerEpochStore::new(
+            config.protocol_public_key(),
             committee,
             &config.db_path().join("store"),
             None,


### PR DESCRIPTION
This allows easier visualizations of stake changes over time.