### PR TITLE
genesis: add step for building unsigned checkpoint

### DIFF
--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -413,7 +413,7 @@ pub struct CheckpointSignatureMessage {
 /// They must have already been causally ordered. Since the causal order algorithm
 /// is the same among validators, we expect all honest validators to come up with
 /// the same order for each checkpoint content.
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct CheckpointContents {
     transactions: Vec<ExecutionDigests>,
     /// This field 'pins' user signatures for the checkpoint:


### PR DESCRIPTION
Add a step to the genesis ceremony to build the unsigned checkpoint in order to add a verification step that all the validators are signing the same checkpoint.