### PR TITLE
Remove epoch label from Narwhal metrics

### DIFF
--- a/narwhal/node/src/metrics.rs
+++ b/narwhal/node/src/metrics.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use axum::{http::StatusCode, routing::get, Extension, Router};
-use config::{Epoch, WorkerId};
+use config::WorkerId;
 use crypto::PublicKey;
 use multiaddr::Multiaddr;
 use mysten_metrics::spawn_logged_monitored_task;
@@ -14,10 +14,8 @@ const METRICS_ROUTE: &str = "/metrics";
 const PRIMARY_METRICS_PREFIX: &str = "narwhal_primary";
 const WORKER_METRICS_PREFIX: &str = "narwhal_worker";
 
-pub fn new_registry(epoch: Epoch) -> Registry {
-    let mut labels = HashMap::new();
-    labels.insert("epoch".to_string(), epoch.to_string());
-    Registry::new_custom(None, Some(labels)).unwrap()
+pub fn new_registry() -> Registry {
+    Registry::new_custom(None, None).unwrap()
 }
 
 pub fn primary_metrics_registry(name: PublicKey) -> Registry {

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -71,7 +71,7 @@ impl PrimaryNodeInner {
         }
 
         // create a new registry
-        let registry = new_registry(committee.load().epoch);
+        let registry = new_registry();
 
         // create the channel to send the shutdown signal
         let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);

--- a/narwhal/node/src/worker_node.rs
+++ b/narwhal/node/src/worker_node.rs
@@ -64,7 +64,7 @@ impl WorkerNodeInner {
             (metrics, None)
         } else {
             // create a new registry
-            let registry = new_registry(committee.load().epoch);
+            let registry = new_registry();
 
             (initialise_metrics(&registry), Some(registry))
         };
@@ -265,7 +265,7 @@ impl WorkerNodes {
         }
 
         // create the registry first
-        let registry = new_registry(committee.load().epoch);
+        let registry = new_registry();
 
         let metrics = initialise_metrics(&registry);
 


### PR DESCRIPTION
This may be causing too much cardinalities. For reading current epoch, the Sui `current_epoch` metric can be used for now. We can add a narwhal specific metric too in future.