### PR TITLE
Use AuthorityKeyPair in narwhal_manager

### DIFF
--- a/crates/sui-core/src/narwhal_manager/mod.rs
+++ b/crates/sui-core/src/narwhal_manager/mod.rs
@@ -6,7 +6,6 @@
 pub mod narwhal_manager_tests;
 
 use arc_swap::ArcSwap;
-use fastcrypto::bls12381;
 use fastcrypto::traits::KeyPair;
 use mysten_metrics::{monitored_scope, RegistryService};
 use narwhal_config::{Committee, Parameters, SharedWorkerCache, WorkerId};
@@ -18,11 +17,11 @@ use narwhal_worker::TransactionValidator;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
-use sui_types::crypto::NetworkKeyPair;
+use sui_types::crypto::{AuthorityKeyPair, NetworkKeyPair};
 use tokio::sync::Mutex;
 
 pub struct NarwhalConfiguration<TxValidator: TransactionValidator> {
-    pub primary_keypair: bls12381::min_sig::BLS12381KeyPair,
+    pub primary_keypair: AuthorityKeyPair,
     pub network_keypair: NetworkKeyPair,
     pub worker_ids_and_keypairs: Vec<(WorkerId, NetworkKeyPair)>,
 
@@ -35,7 +34,7 @@ pub struct NarwhalConfiguration<TxValidator: TransactionValidator> {
 
 pub struct NarwhalManager<TxValidator> {
     storage_base_path: PathBuf,
-    primary_keypair: bls12381::min_sig::BLS12381KeyPair,
+    primary_keypair: AuthorityKeyPair,
     network_keypair: NetworkKeyPair,
     worker_ids_and_keypairs: Vec<(WorkerId, NetworkKeyPair)>,
     primary_node: PrimaryNode,


### PR DESCRIPTION
Narwhal manager uses a hardcoded key pair type (bls12381::min_sig) but should use the type defined in sui-types.