### PR TITLE
do not land: demo address

### DIFF
--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -26,7 +26,7 @@ use sui_types::crypto::SuiSignatureInner;
 use sui_types::intent::Intent;
 use tempfile::TempDir;
 
-const TEST_MNEMONIC: &str = "result crisp session latin must fruit genuine question prevent start coconut brave speak student dismiss";
+const TEST_MNEMONIC: &str = "dish law voice unaware mechanic muffin divorce toilet wonder coil card avocado drip grunt taxi slide suit inhale wife sound speed enable fog brother";
 
 #[test]
 fn test_addresses_command() -> Result<(), anyhow::Error> {
@@ -161,17 +161,18 @@ fn test_mnemonics_ed25519() -> Result<(), anyhow::Error> {
         derivation_path: None,
     }
     .execute(&mut keystore)?;
-    keystore.keys().iter().for_each(|pk| {
-        assert_eq!(
-            Hex::encode(pk.as_ref()),
-            "685b2d6f98784dd763249af21c92f588ca1be80c40a98c55bf7c91b74e5ac1e2"
-        );
-    });
+    // keystore.keys().iter().for_each(|pk| {
+    //     assert_eq!(
+    //         Hex::encode(pk.as_ref()),
+    //         "685b2d6f98784dd763249af21c92f588ca1be80c40a98c55bf7c91b74e5ac1e2"
+    //     );
+    // });
     keystore.addresses().iter().for_each(|addr| {
-        assert_eq!(
-            addr.to_string(),
-            "0x1a4623343cd42be47d67314fce0ad042f3c82685"
-        );
+        println!("address={:?}", addr);
+        // assert_eq!(
+        //     addr.to_string(),
+        //     "0x1a4623343cd42be47d67314fce0ad042f3c82685"
+        // );
     });
     Ok(())
 }

--- a/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
@@ -11,7 +11,7 @@ const VALID_SECRET_KEY =
 const INVALID_SECRET_KEY =
   'mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCgbL0kJbj5dvQ/PqcDAzZLZqzshVEs01d1KZdmLh4uZIG==';
 const TEST_MNEMONIC =
-  'result crisp session latin must fruit genuine question prevent start coconut brave speak student dismiss';
+  'dish law voice unaware mechanic muffin divorce toilet wonder coil card avocado drip grunt taxi slide suit inhale wife sound speed enable fog brother';
 
 describe('ed25519-keypair', () => {
   it('new keypair', () => {
@@ -69,9 +69,9 @@ describe('ed25519-keypair', () => {
   it('derive ed25519 keypair from path and mnemonics', () => {
     // Test case generated against rust: /sui/crates/sui/src/unit_tests/keytool_tests.rs#L149
     const keypair = Ed25519Keypair.deriveKeypair(TEST_MNEMONIC);
-    expect(keypair.getPublicKey().toBase64()).toEqual(
-      'aFstb5h4TddjJJryHJL1iMob6AxAqYxVv3yRt05aweI='
-    );
+    // expect(keypair.getPublicKey().toBase64()).toEqual(
+    //   'aFstb5h4TddjJJryHJL1iMob6AxAqYxVv3yRt05aweI='
+    // );
     expect(keypair.getPublicKey().toSuiAddress()).toEqual(
       '1a4623343cd42be47d67314fce0ad042f3c82685'
     );


### PR DESCRIPTION
from rust test:
```
address=0xa38bc2aa63c34e37821f7abb34dbbe97b7ab2ea2
```

from typescript the same result: 
```
 test/unit/cryptography/ed25519-keypair.test.ts > ed25519-keypair > derive ed25519 keypair from path and mnemonics

  + Received   "a38bc2aa63c34e37821f7abb34dbbe97b7ab2ea2"
```