### PR TITLE
[fix] core not panic when certificate_fetcher has shutdown

### DIFF
--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -703,7 +703,15 @@ impl Core {
                             break;
                         }
                     };
-                    message.done.send(()).expect("Failed to signal back to CertificateFetcher");
+
+                    if let Err(err) = message.done.send(()) {
+                        if self.is_shutting_down() {
+                            return;
+                        } else {
+                            panic!("Failed to signal back to CertificateFetcher {:?}", err);
+                        }
+                    }
+
                     result
                 },
 
@@ -780,5 +788,9 @@ impl Core {
 
             Self::process_result(&result);
         }
+    }
+
+    fn is_shutting_down(&self) -> bool {
+        !self.rx_shutdown.receiver.is_empty()
     }
 }

--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -704,12 +704,8 @@ impl Core {
                         }
                     };
 
-                    if let Err(err) = message.done.send(()) {
-                        if self.is_shutting_down() {
-                            return;
-                        } else {
-                            panic!("Failed to signal back to CertificateFetcher {:?}", err);
-                        }
+                    if message.done.send(()).is_err() {
+                        result = Err(DagError::ShuttingDown);
                     }
 
                     result
@@ -788,9 +784,5 @@ impl Core {
 
             Self::process_result(&result);
         }
-    }
-
-    fn is_shutting_down(&self) -> bool {
-        !self.rx_shutdown.receiver.is_empty()
     }
 }


### PR DESCRIPTION
This PR is fixing a reveal issue in private testnet where some nodes panicking with error:
```
2023-01-16 04:12:38	
thread 'tokio-runtime-worker' panicked at 'Failed to signal back to CertificateFetcher: ()', narwhal/primary/src/core.rs:706:43
2023-01-16 04:12:38	
2023-01-16T04:12:38.104203Z ERROR telemetry_subscribers: panicked at 'Failed to signal back to CertificateFetcher: ()', narwhal/primary/src/core.rs:706:43 panic.file="narwhal/primary/src/core.rs" panic.line=706 panic.column=43
```

this is happening when the shutdown signal is sent and the `certificate_fetcher` has received it and shutdown, but Core is still processing the certificates sent from the certificate fetcher. In this case when we try to message back to `certificate_fetcher` , the receiver is closed and this is making the sender panic. On this PR we simplify and assume that when we can't communicate back to `certificate_fetcher`, then the component shutsdown. Although is not the most robust approach, we have made the similar assumption for other cases/components so that makes us at least consistent on that.