### PR TITLE
Reject transaction if any input object is overloaded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9925,9 +9925,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9925,9 +9925,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3576,7 +3576,7 @@ pub(crate) async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCe
             .await
             .unwrap();
     } else {
-        panic!("Failed to verify certificate: {:?}", cert);
+        warn!("Failed to verify certificate: {:?}", cert);
     }
 }
 
@@ -3605,7 +3605,7 @@ pub(crate) async fn send_consensus_no_execution(
             .await
             .unwrap();
     } else {
-        panic!("Failed to verify certificate: {:?}", cert);
+        warn!("Failed to verify certificate: {:?}", cert);
     }
 }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3575,6 +3575,8 @@ pub(crate) async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCe
             )
             .await
             .unwrap();
+    } else {
+        panic!("Failed to verify certificate: {:?}", cert);
     }
 }
 
@@ -3602,6 +3604,8 @@ pub(crate) async fn send_consensus_no_execution(
             )
             .await
             .unwrap();
+    } else {
+        panic!("Failed to verify certificate: {:?}", cert);
     }
 }
 

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority::authority_tests::{send_consensus, send_consensus_no_execution};
-use crate::authority::{AuthorityState, EffectsNotifyRead};
+use crate::authority::{AuthorityState, EffectsNotifyRead, MAX_PER_OBJECT_EXECUTION_QUEUE_LENGTH};
 use crate::authority_aggregator::authority_aggregator_tests::{
     create_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
     transfer_object_move_transaction,
@@ -18,11 +18,12 @@ use itertools::Itertools;
 use sui_types::base_types::TransactionDigest;
 use sui_types::committee::Committee;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
+use sui_types::error::SuiResult;
 use sui_types::messages::{TransactionEffects, VerifiedCertificate, VerifiedTransaction};
 use sui_types::object::{Object, Owner};
 use test_utils::messages::{make_counter_create_transaction, make_counter_increment_transaction};
 use tokio::sync::mpsc::UnboundedReceiver;
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 
 #[allow(dead_code)]
 async fn wait_for_certs(
@@ -427,4 +428,136 @@ async fn test_transaction_manager() {
         .notify_read_effects(digests)
         .await
         .unwrap();
+}
+
+async fn try_sign_on_first_three_authorities(
+    authority_clients: &[&SafeClient<LocalAuthorityClient>],
+    committee: &Committee,
+    txn: &VerifiedTransaction,
+) -> SuiResult<VerifiedCertificate> {
+    for client in authority_clients.iter().take(3) {
+        client.handle_transaction(txn.clone()).await?;
+    }
+    extract_cert(authority_clients, committee, txn.digest())
+        .await
+        .verify(committee)
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_per_object_overload() {
+    telemetry_subscribers::init_for_testing();
+
+    // Initialize a network with 1 account and 2000 gas objects.
+    let (addr, key) = get_key_pair();
+    const NUM_GAS_OBJECTS_PER_ACCOUNT: usize = 2000;
+    let gas_objects = (0..NUM_GAS_OBJECTS_PER_ACCOUNT)
+        .into_iter()
+        .map(|_| Object::with_owner_for_testing(addr))
+        .collect_vec();
+    let (aggregator, authorities, _genesis, framework_obj_ref) =
+        init_local_authorities(4, gas_objects.clone()).await;
+    let authority_clients: Vec<_> = authorities
+        .iter()
+        .map(|a| &aggregator.authority_clients[&a.name])
+        .collect();
+
+    // Create a shared counter.
+    let gas_ref = get_latest_ref(authority_clients[0], gas_objects[0].id()).await;
+    let create_counter_txn =
+        make_counter_create_transaction(gas_ref, framework_obj_ref, addr, &key);
+    let create_counter_cert = try_sign_on_first_three_authorities(
+        &authority_clients,
+        &aggregator.committee,
+        &create_counter_txn,
+    )
+    .await
+    .unwrap();
+    for authority in authorities.iter().take(3) {
+        send_consensus(authority, &create_counter_cert).await;
+    }
+    for authority in authorities.iter().take(3) {
+        authority
+            .database
+            .notify_read_effects(vec![*create_counter_cert.digest()])
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+    }
+
+    // Signing and executing this transaction on the last authority should succeed.
+    authority_clients[3]
+        .handle_transaction(create_counter_txn.clone())
+        .await
+        .unwrap();
+    send_consensus(&authorities[3], &create_counter_cert).await;
+    let create_counter_effects = authorities[3]
+        .database
+        .notify_read_effects(vec![*create_counter_cert.digest()])
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    let (shared_counter_ref, owner) = create_counter_effects.created[0];
+    let Owner::Shared {
+        initial_shared_version: shared_counter_initial_version
+    } = owner else {
+        panic!("Not a shared object! {:?} {:?}", shared_counter_ref, owner);
+    };
+
+    // Stop execution on the last authority, to simulate having a backlog.
+    authorities[3].shutdown_execution_for_test();
+    // Make sure execution driver has exitted.
+    sleep(Duration::from_secs(1)).await;
+
+    // Sign and try execute 1000 txns on the first three authorities. And enqueue them on the last authority.
+    let mut shared_txns = Vec::new();
+    let mut shared_certs = Vec::new();
+    // First shared counter txn has input object available on authority 3. So to overload authority 3, 1 more
+    // txn is needed.
+    let num_txns = MAX_PER_OBJECT_EXECUTION_QUEUE_LENGTH + 1;
+    for gas_object in gas_objects.iter().take(num_txns) {
+        let gas_ref = get_latest_ref(authority_clients[0], gas_object.id()).await;
+        let shared_txn = make_counter_increment_transaction(
+            gas_ref,
+            framework_obj_ref,
+            shared_counter_ref.0,
+            shared_counter_initial_version,
+            addr,
+            &key,
+        );
+        let shared_cert = try_sign_on_first_three_authorities(
+            &authority_clients,
+            &aggregator.committee,
+            &shared_txn,
+        )
+        .await
+        .unwrap();
+        for authority in authorities.iter().take(3) {
+            send_consensus(authority, &shared_cert).await;
+        }
+        send_consensus(&authorities[3], &shared_cert).await;
+        shared_txns.push(shared_txn);
+        shared_certs.push(shared_cert);
+    }
+
+    // Trying to sign a new transaction would now fail.
+    let gas_ref = get_latest_ref(authority_clients[0], gas_objects[num_txns].id()).await;
+    let shared_txn = make_counter_increment_transaction(
+        gas_ref,
+        framework_obj_ref,
+        shared_counter_ref.0,
+        shared_counter_initial_version,
+        addr,
+        &key,
+    );
+    let sign_result = authority_clients[3]
+        .handle_transaction(shared_txn.clone())
+        .await;
+    let message = format!("{sign_result:?}");
+    assert!(
+        message.contains("TooManyTransactionsPendingOnObject"),
+        "Signing should fail with backlogs on the shared counter: {}",
+        message,
+    );
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -88,6 +88,12 @@ pub enum SuiError {
         child_id: ObjectID,
         parent_id: ObjectID,
     },
+    #[error("Input {object_id} already has {queue_len} transactions pending, above threshold of {threshold}")]
+    TooManyTransactionsPendingOnObject {
+        object_id: ObjectID,
+        queue_len: usize,
+        threshold: usize,
+    },
 
     // Signature verification
     #[error("Signature is not valid: {}", error)]


### PR DESCRIPTION
It is possible for users to create many transactions with the same shared input object, in a rate that is faster than the rate Sui can execute them serially. This PR adds a basic rate limiting mechanism: reject signing or submitting new transactions, if one of its input object ID has > 1000 pending transactions. This scheme is not bulletproof, but should help the case when users are unintentionally generating too much load.

If the overall approach looks ok, I will add tests.