### PR TITLE
[explorer] fix validator `getName` error when name is not a b64 encoded string

### DIFF
--- a/apps/explorer/src/utils/getName.ts
+++ b/apps/explorer/src/utils/getName.ts
@@ -6,14 +6,15 @@ import { VALDIATOR_NAME } from '~/pages/validator/ValidatorDataTypes';
 
 export function getName(rawName: string | number[]) {
     let name: string;
+    if (Array.isArray(rawName)) return String.fromCharCode(...rawName);
 
-    if (Array.isArray(rawName)) {
-        name = String.fromCharCode(...rawName);
-    } else {
+    try {
         name = decodeURIComponent(atob(rawName));
         if (!VALDIATOR_NAME.test(name)) {
             name = rawName;
         }
+    } catch (e) {
+        name = rawName;
     }
     return name;
 }


### PR DESCRIPTION
noticed an error when developing locally: 

![image](https://user-images.githubusercontent.com/122397493/212816182-9fbff5e5-9a37-40d0-b6ae-8e52d6706c95.png)
