### PR TITLE
wallet-ext: wallet standard interface emit chain changes

### DIFF
--- a/apps/wallet/src/background/NetworkEnv.ts
+++ b/apps/wallet/src/background/NetworkEnv.ts
@@ -5,7 +5,8 @@ import mitt from 'mitt';
 import Browser from 'webextension-polyfill';
 
 import FeatureGating from './FeatureGating';
-import { API_ENV, API_ENV_TO_INFO, DEFAULT_API_ENV } from '_app/ApiProvider';
+import { API_ENV_TO_INFO, DEFAULT_API_ENV } from '_app/ApiProvider';
+import { API_ENV } from '_src/shared/api-env';
 import { FEATURES } from '_src/shared/experimentation/features';
 import { isValidUrl } from '_src/shared/utils';
 

--- a/apps/wallet/src/background/connections/index.ts
+++ b/apps/wallet/src/background/connections/index.ts
@@ -59,6 +59,10 @@ export class Connections {
             | { event: 'permissionReply'; permission: Permission }
             | {
                   event: 'walletStatusChange';
+                  change: Omit<WalletStatusChange, 'accounts'>;
+              }
+            | {
+                  event: 'walletStatusChange';
                   origin: string;
                   change: WalletStatusChange;
               }
@@ -70,7 +74,10 @@ export class Connections {
                         aConnection.permissionReply(notification.permission);
                         break;
                     case 'walletStatusChange':
-                        if (aConnection.origin === notification.origin) {
+                        if (
+                            !('origin' in notification) ||
+                            aConnection.origin === notification.origin
+                        ) {
                             aConnection.send(
                                 createMessage<WalletStatusChangePayload>({
                                     type: 'wallet-status-changed',

--- a/apps/wallet/src/background/index.ts
+++ b/apps/wallet/src/background/index.ts
@@ -103,4 +103,8 @@ NetworkEnv.on('changed', async (network) => {
         customRPC: network.customRpcUrl,
     });
     connections.notifyUI({ event: 'networkChanged', network });
+    connections.notifyContentScript({
+        event: 'walletStatusChange',
+        change: { network },
+    });
 });

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -29,8 +29,8 @@ import {
     type HasPermissionsResponse,
     ALL_PERMISSION_TYPES,
 } from '_payloads/permissions';
+import { API_ENV } from '_src/shared/api-env';
 import { isWalletStatusChangePayload } from '_src/shared/messaging/messages/payloads/wallet-status-change';
-import { API_ENV } from '_src/ui/app/ApiProvider';
 
 import type { SuiAddress } from '@mysten/sui.js/src';
 import type { BasePayload, Payload } from '_payloads';

--- a/apps/wallet/src/shared/api-env.ts
+++ b/apps/wallet/src/shared/api-env.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export enum API_ENV {
+    local = 'local',
+    devNet = 'devNet',
+    testNet = 'testNet',
+    customRPC = 'customRPC',
+}

--- a/apps/wallet/src/shared/experimentation/features.ts
+++ b/apps/wallet/src/shared/experimentation/features.ts
@@ -3,7 +3,7 @@
 
 import Browser from 'webextension-polyfill';
 
-import { API_ENV } from '_src/ui/app/ApiProvider';
+import { API_ENV } from '_src/shared/api-env';
 
 import type { GrowthBook } from '@growthbook/growthbook';
 

--- a/apps/wallet/src/shared/messaging/messages/payloads/wallet-status-change/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/wallet-status-change/index.ts
@@ -5,8 +5,10 @@ import { isBasePayload } from '_payloads';
 
 import type { SuiAddress } from '@mysten/sui.js/src';
 import type { BasePayload, Payload } from '_payloads';
+import type { NetworkEnvType } from '_src/background/NetworkEnv';
 
 export type WalletStatusChange = {
+    network?: NetworkEnvType;
     accounts?: SuiAddress[];
 };
 

--- a/apps/wallet/src/ui/app/ApiProvider.ts
+++ b/apps/wallet/src/ui/app/ApiProvider.ts
@@ -6,17 +6,11 @@ import { JsonRpcProvider, LocalTxnDataSerializer } from '@mysten/sui.js';
 import { BackgroundServiceSigner } from './background-client/BackgroundServiceSigner';
 import { queryClient } from './helpers/queryClient';
 import { growthbook } from '_app/experimentation/feature-gating';
+import { API_ENV } from '_src/shared/api-env';
 import { FEATURES } from '_src/shared/experimentation/features';
 
 import type { BackgroundClient } from './background-client';
 import type { SuiAddress, SignerWithProvider } from '@mysten/sui.js';
-
-export enum API_ENV {
-    local = 'local',
-    devNet = 'devNet',
-    testNet = 'testNet',
-    customRPC = 'customRPC',
-}
 
 type EnvInfo = {
     name: string;

--- a/apps/wallet/src/ui/app/components/account-address/index.tsx
+++ b/apps/wallet/src/ui/app/components/account-address/index.tsx
@@ -3,11 +3,11 @@
 
 import cl from 'classnames';
 
-import { API_ENV } from '_app/ApiProvider';
 import CopyToClipboard from '_components/copy-to-clipboard';
 import ExplorerLink from '_components/explorer-link';
 import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
 import { useAppSelector, useMiddleEllipsis } from '_hooks';
+import { API_ENV } from '_src/shared/api-env';
 
 import st from './AccountAddress.module.scss';
 

--- a/apps/wallet/src/ui/app/components/explorer-link/Explorer.ts
+++ b/apps/wallet/src/ui/app/components/explorer-link/Explorer.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { API_ENV, DEFAULT_API_ENV } from '_app/ApiProvider';
+import { DEFAULT_API_ENV } from '_app/ApiProvider';
+import { API_ENV } from '_src/shared/api-env';
 
 import type { ObjectId, SuiAddress, TransactionDigest } from '@mysten/sui.js';
 

--- a/apps/wallet/src/ui/app/components/logo/index.tsx
+++ b/apps/wallet/src/ui/app/components/logo/index.tsx
@@ -3,9 +3,9 @@
 
 import cl from 'classnames';
 
-import { API_ENV } from '../../ApiProvider';
 import { Text } from '../../shared/text';
 import Icon, { SuiIcons } from '_components/icon';
+import { API_ENV } from '_src/shared/api-env';
 
 const networkNames: Record<API_ENV, string> = {
     [API_ENV.local]: 'Local',

--- a/apps/wallet/src/ui/app/components/network-selector/custom-rpc-input/index.tsx
+++ b/apps/wallet/src/ui/app/components/network-selector/custom-rpc-input/index.tsx
@@ -12,8 +12,8 @@ import InputWithAction from '_app/shared/input-with-action';
 import Alert from '_components/alert';
 import { useAppSelector, useAppDispatch } from '_hooks';
 import { changeActiveNetwork } from '_redux/slices/app';
+import { API_ENV } from '_src/shared/api-env';
 import { isValidUrl } from '_src/shared/utils';
-import { API_ENV } from '_src/ui/app/ApiProvider';
 
 import st from '../NetworkSelector.module.scss';
 

--- a/apps/wallet/src/ui/app/components/network-selector/index.tsx
+++ b/apps/wallet/src/ui/app/components/network-selector/index.tsx
@@ -7,14 +7,11 @@ import { useMemo, useState, useEffect } from 'react';
 import { toast } from 'react-hot-toast';
 
 import { CustomRPCInput } from './custom-rpc-input';
-import {
-    API_ENV_TO_INFO,
-    API_ENV,
-    generateActiveNetworkList,
-} from '_app/ApiProvider';
+import { API_ENV_TO_INFO, generateActiveNetworkList } from '_app/ApiProvider';
 import Icon, { SuiIcons } from '_components/icon';
 import { useAppSelector, useAppDispatch } from '_hooks';
 import { changeActiveNetwork } from '_redux/slices/app';
+import { API_ENV } from '_src/shared/api-env';
 
 import st from './NetworkSelector.module.scss';
 

--- a/apps/wallet/src/ui/app/redux/slices/app/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/app/index.ts
@@ -4,7 +4,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
 import { AppType } from './AppType';
-import { DEFAULT_API_ENV, type API_ENV } from '_app/ApiProvider';
+import { DEFAULT_API_ENV } from '_app/ApiProvider';
 import {
     clearForNetworkSwitch,
     fetchAllOwnedAndRequiredObjects,
@@ -13,6 +13,7 @@ import {
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '_redux/RootReducer';
 import type { NetworkEnvType } from '_src/background/NetworkEnv';
+import type { API_ENV } from '_src/shared/api-env';
 import type { AppThunkConfig } from '_store/thunk-extras';
 
 type AppState = {


### PR DESCRIPTION
* add get active network call that returns the active network of the wallet
* notify dapp interface for network changes
* wallet standard interface use chains field of account to notify dapps for network/chain changes

closes: APPS-308, https://github.com/MystenLabs/sui/issues/7013