### PR TITLE
[refactor] narwhal not crash when components shutdown

### DIFF
--- a/narwhal/consensus/src/lib.rs
+++ b/narwhal/consensus/src/lib.rs
@@ -18,6 +18,8 @@ pub mod tusk;
 mod utils;
 
 pub use crate::consensus::Consensus;
+use store::StoreError;
+use thiserror::Error;
 
 use types::SequenceNumber;
 
@@ -26,3 +28,12 @@ pub const DEFAULT_CHANNEL_SIZE: usize = 1_000;
 
 /// The number of shutdown receivers to create on startup. We need one per component loop.
 pub const NUM_SHUTDOWN_RECEIVERS: u64 = 25;
+
+#[derive(Clone, Debug, Error)]
+enum ConsensusError {
+    #[error("Storage failure: {0}")]
+    StoreError(#[from] StoreError),
+
+    #[error("System shutting down")]
+    ShuttingDown,
+}

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -277,7 +277,7 @@ impl Synchronizer {
                 self.tx_certificate_fetcher
                     .send(certificate.clone())
                     .await
-                    .expect("Failed to send sync certificate request");
+                    .map_err(|_| DagError::ShuttingDown)?;
                 return Ok(false);
             }
         }

--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -27,12 +27,6 @@ macro_rules! ensure {
     };
 }
 
-/*
-#[macro_export(local_inner_macros)]
-macro_rules! ensure_unless_shutdown {
-
-}*/
-
 pub type DagResult<T> = Result<T, DagError>;
 
 #[derive(Clone, Debug, Error)]

--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -27,6 +27,12 @@ macro_rules! ensure {
     };
 }
 
+/*
+#[macro_export(local_inner_macros)]
+macro_rules! ensure_unless_shutdown {
+
+}*/
+
 pub type DagResult<T> = Result<T, DagError>;
 
 #[derive(Clone, Debug, Error)]


### PR DESCRIPTION
This PR is refactoring the `core`, `consensus` and `synchronizer` components  to treat the channel closures as part of the shutdown process and avoid panicking the component. Instead a `Shutdown` error will be returned and will be treated gracefully