### PR TITLE
categorize tx failures

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -270,6 +270,7 @@ impl EffectsStakeMap {
     errors
 )]
 pub struct QuorumExecuteCertificateError {
+    pub total_stake: StakeUnit,
     pub errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
 }
 
@@ -1707,6 +1708,7 @@ where
 
         // If none has, fail.
         Err(QuorumExecuteCertificateError {
+            total_stake: self.committee.total_votes,
             errors: state.errors,
         })
     }

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -180,8 +180,8 @@ async fn test_quorum_driver_update_validators_and_max_retry_times() {
         let ticket = quorum_driver.submit_transaction(tx).await.unwrap();
         // We have a timeout here to make the test fail fast if fails
         match tokio::time::timeout(Duration::from_secs(20), ticket).await {
-            Ok(Err(QuorumDriverError::FailedAfterMaximumAttempts { total_attempts })) => assert_eq!(total_attempts, 4),
-            _ => panic!("The transaction should err on SafeClient epoch check mismatch, be retried 3 times and raise QuorumDriverError::FailedAfterMaximumAttempts error"),
+            Ok(Err(QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { total_attempts })) => assert_eq!(total_attempts, 4),
+            _ => panic!("The transaction should err on SafeClient epoch check mismatch, be retried 3 times and raise QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts error"),
         };
     });
 

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1194,11 +1194,11 @@ async fn test_handle_transaction_response() {
         .unwrap();
 
     assert_resp_err(
-            &agg,
-            tx.clone(),
-            |e| matches!(e, SuiError::WrongEpoch { expected_epoch, actual_epoch } if *expected_epoch == 0 && *actual_epoch == 1)
-        )
-        .await;
+        &agg,
+        tx.clone(),
+        |e| matches!(e, SuiError::WrongEpoch { expected_epoch, actual_epoch } if *expected_epoch == 0 && *actual_epoch == 1)
+    )
+    .await;
 }
 
 async fn assert_resp_err<F>(

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -220,7 +220,7 @@ impl Committee {
     pub fn validity_threshold(&self) -> StakeUnit {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (N + 2) / 3 = f + 1 + k/3 = f + 1
-        (self.total_votes + 2) / 3
+        validity_threshold(self.total_votes)
     }
 
     #[inline]
@@ -351,6 +351,12 @@ impl Display for Committee {
             self.epoch, voting_rights
         )
     }
+}
+
+pub fn validity_threshold(total_stake: StakeUnit) -> StakeUnit {
+    // If N = 3f + 1 + k (0 <= k < 3)
+    // then (N + 2) / 3 = f + 1 + k/3 = f + 1
+    (total_stake + 2) / 3
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -18,8 +18,12 @@ pub type QuorumDriverResult = Result<QuorumDriverResponse, QuorumDriverError>;
 /// Every invariant needs detailed documents to instruct client handling.
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash, AsRefStr)]
 pub enum QuorumDriverError {
+    #[error("QuorumDriver internal error: {0:?}.")]
+    QuorumDriverInternalError(SuiError),
+    #[error("Invalid user signature: {0:?}.")]
+    InvalidUserSignature(SuiError),
     #[error(
-        "Failed to process transaction on a quorum of validators to form a transaction certificate because of locked objects: {:?}, retried a conflicting transaction {:?}, success: {:?}",
+        "Failed to sign transaction by a quorum of validators because of locked objects: {:?}, retried a conflicting transaction {:?}, success: {:?}",
         conflicting_txes,
         retried_tx,
         retried_tx_success
@@ -30,17 +34,11 @@ pub enum QuorumDriverError {
         retried_tx_success: Option<bool>,
     },
     #[error("Transaction timed out before reaching finality")]
-    TimeoutBeforeReachFinality,
-    #[error("Transaction failed to reach finality after {total_attempts} attempts.")]
-    FailedAfterMaximumAttempts { total_attempts: u8 },
-    // We expect this occrus very rarely. For any common error types,
-    // we should represent as a QuorumDriverError variant instead.
-    #[error("Transaction encountered uncategorized SuiError: {:?}", error)]
-    UncategorizedSuiError { error: SuiError },
-}
-
-impl From<SuiError> for QuorumDriverError {
-    fn from(error: SuiError) -> Self {
-        QuorumDriverError::UncategorizedSuiError { error }
-    }
+    TimeoutBeforeFinality,
+    #[error("Transaction failed to reach finality with transient error after {total_attempts} attempts.")]
+    FailedWithTransientErrorAfterMaximumAttempts { total_attempts: u8 },
+    #[error("Transaction has non recoverable errors from at least 1/3 of validators: {errors:?}.")]
+    NonRecoverableTransactionError {
+        errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
+    },
 }

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -247,7 +247,7 @@ async fn test_tx_across_epoch_boundaries() {
                         result_tx.send(tx_cert).await.unwrap();
                         break;
                     }
-                    Err(QuorumDriverError::TimeoutBeforeReachFinality) => {
+                    Err(QuorumDriverError::TimeoutBeforeFinality) => {
                         info!(?tx_digest, "tx result: timeout and will retry")
                     }
                     Err(other) => panic!("unexpected error: {:?}", other),


### PR DESCRIPTION
In this PR we categorize transaction failure errors and decide if a transaction is retryable. If more than 1/3 of failures are non-recoverable then the transaction is not retryable.