### PR TITLE
[epoch] Fix a few data races on epoch store

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1847,6 +1847,7 @@ impl AuthorityState {
             .compute_object_reference())
     }
 
+    // TODO: Audit every call to this function to make sure there are no data races during reconfig.
     pub fn get_sui_system_state_object(&self) -> SuiResult<SuiSystemState> {
         self.database.get_sui_system_state_object()
     }

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -84,7 +84,8 @@ impl AuthorityServer {
         ));
         let consensus_adapter = ConsensusAdapter::new(
             consensus_client,
-            state.clone(),
+            state.name,
+            &state.epoch_store_for_testing(),
             ConsensusAdapterMetrics::new_test(),
         );
 

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -32,7 +32,6 @@ use tap::prelude::*;
 use tokio::task::JoinHandle;
 use tokio::time;
 
-use crate::authority::AuthorityState;
 use mysten_metrics::spawn_monitored_task;
 use sui_types::base_types::AuthorityName;
 use sui_types::messages::ConsensusTransactionKind;
@@ -153,18 +152,19 @@ impl ConsensusAdapter {
     /// Make a new Consensus adapter instance.
     pub fn new(
         consensus_client: Box<dyn SubmitToConsensus>,
-        authority: Arc<AuthorityState>,
+        authority: AuthorityName,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
         opt_metrics: OptArcConsensusAdapterMetrics,
     ) -> Arc<Self> {
         let num_inflight_transactions = Default::default();
         let this = Arc::new(Self {
             consensus_client,
-            authority: authority.name,
+            authority,
             num_inflight_transactions,
             opt_metrics,
         });
         let recover = this.clone();
-        recover.submit_recovered(&authority.epoch_store());
+        recover.submit_recovered(epoch_store);
         this
     }
 

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -121,7 +121,8 @@ async fn submit_transaction_to_consensus_adapter() {
     // Make a new consensus adapter instance.
     let adapter = ConsensusAdapter::new(
         Box::new(SubmitDirectly(state.clone())),
-        state.clone(),
+        state.name,
+        &state.epoch_store_for_testing(),
         metrics,
     );
 


### PR DESCRIPTION
We should pass epoch store down to the creation of various validator components.
This PR fixes some of the left-over calls to epoch_store of the state.
There is one more bug that's not yet fixed in this PR, which is the narwhal committee. Let's fix it in a separate PR.