### PR TITLE
indexer: event handlers for new objects and new modules

### DIFF
--- a/crates/sui-indexer/migrations/2023-01-17-213935_publish_event/down.sql
+++ b/crates/sui-indexer/migrations/2023-01-17-213935_publish_event/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE publish_events;
+DROP TABLE publish_event_logs;

--- a/crates/sui-indexer/migrations/2023-01-17-213935_publish_event/up.sql
+++ b/crates/sui-indexer/migrations/2023-01-17-213935_publish_event/up.sql
@@ -1,0 +1,21 @@
+-- TODO: this is a temp workaround for wave 2
+-- remove when events throughput is high enough
+CREATE TABLE publish_events (
+    id BIGSERIAL PRIMARY KEY,
+    -- below 2 are from Event ID, tx_digest and event_seq
+    transaction_digest VARCHAR(255),
+    event_sequence BIGINT NOT NULL,
+    event_time TIMESTAMP,
+    event_type VARCHAR NOT NULL,
+    event_content VARCHAR NOT NULL,
+    UNIQUE (transaction_digest, event_sequence)
+);
+
+CREATE TABLE publish_event_logs (
+    id SERIAL PRIMARY KEY,
+    next_cursor_tx_dig TEXT,
+    next_cursor_event_seq BIGINT
+);
+
+INSERT INTO publish_event_logs (id, next_cursor_tx_dig, next_cursor_event_seq) VALUES
+(1, NULL, NULL);

--- a/crates/sui-indexer/migrations/2023-01-17-213941_object_event/down.sql
+++ b/crates/sui-indexer/migrations/2023-01-17-213941_object_event/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE object_events;
+DROP TABLE object_event_logs;

--- a/crates/sui-indexer/migrations/2023-01-17-213941_object_event/up.sql
+++ b/crates/sui-indexer/migrations/2023-01-17-213941_object_event/up.sql
@@ -1,0 +1,21 @@
+-- TODO: this is a temp workaround for wave 2
+-- remove when events throughput is high enough
+CREATE TABLE object_events (
+    id BIGSERIAL PRIMARY KEY,
+    -- below 2 are from Event ID, tx_digest and event_seq
+    transaction_digest VARCHAR(255),
+    event_sequence BIGINT NOT NULL,
+    event_time TIMESTAMP,
+    event_type VARCHAR NOT NULL,
+    event_content VARCHAR NOT NULL,
+    UNIQUE (transaction_digest, event_sequence)
+);
+
+CREATE TABLE object_event_logs (
+    id SERIAL PRIMARY KEY,
+    next_cursor_tx_dig TEXT,
+    next_cursor_event_seq BIGINT
+);
+
+INSERT INTO object_event_logs (id, next_cursor_tx_dig, next_cursor_event_seq) VALUES
+(1, NULL, NULL);

--- a/crates/sui-indexer/src/handlers/handler_orchestrator.rs
+++ b/crates/sui-indexer/src/handlers/handler_orchestrator.rs
@@ -15,6 +15,8 @@ use crate::handlers::checkpoint_handler::CheckpointHandler;
 use crate::handlers::event_handler::EventHandler;
 use crate::handlers::transaction_handler::TransactionHandler;
 
+use crate::handlers::object_event_handler::ObjectEventHandler;
+use crate::handlers::publish_event_handler::PublishEventHandler;
 const BACKOFF_MAX_INTERVAL_IN_SECS: u64 = 600;
 
 #[derive(Clone)]
@@ -45,6 +47,16 @@ impl HandlerOrchestrator {
             &self.prometheus_registry,
         );
         let event_handler = EventHandler::new(
+            self.rpc_client.clone(),
+            self.pg_connection_pool.clone(),
+            &self.prometheus_registry,
+        );
+        let obj_event_handler = ObjectEventHandler::new(
+            self.rpc_client.clone(),
+            self.pg_connection_pool.clone(),
+            &self.prometheus_registry,
+        );
+        let publish_event_handler = PublishEventHandler::new(
             self.rpc_client.clone(),
             self.pg_connection_pool.clone(),
             &self.prometheus_registry,
@@ -133,8 +145,66 @@ impl HandlerOrchestrator {
                 );
             }
         });
-        try_join_all(vec![checkpoint_handle, txn_handle, event_handle])
-            .await
-            .expect("Handler orchestrator shoult not run into errors.");
+        let object_event_handle = tokio::task::spawn(async move {
+            let backoff_config = ExponentialBackoffBuilder::new()
+                .with_max_interval(std::time::Duration::from_secs(BACKOFF_MAX_INTERVAL_IN_SECS))
+                .build();
+            let object_event_res = retry(backoff_config, || async {
+                let object_event_handler_exec_res = obj_event_handler.start().await;
+                if let Err(e) = object_event_handler_exec_res.clone() {
+                    obj_event_handler
+                        .event_handler_metrics
+                        .total_object_event_handler_error
+                        .inc();
+                    warn!(
+                        "Indexer object event handler failed with error: {:?}, retrying...",
+                        e
+                    );
+                }
+                Ok(object_event_handler_exec_res?)
+            })
+            .await;
+            if let Err(e) = object_event_res {
+                error!(
+                    "Indexer object event handler failed after retrials with error: {:?}",
+                    e
+                );
+            }
+        });
+        let publish_event_handle = tokio::task::spawn(async move {
+            let backoff_config = ExponentialBackoffBuilder::new()
+                .with_max_interval(std::time::Duration::from_secs(BACKOFF_MAX_INTERVAL_IN_SECS))
+                .build();
+            let publish_event_res = retry(backoff_config, || async {
+                let publish_event_handler_exec_res = publish_event_handler.start().await;
+                if let Err(e) = publish_event_handler_exec_res.clone() {
+                    publish_event_handler
+                        .event_handler_metrics
+                        .total_publish_event_handler_error
+                        .inc();
+                    warn!(
+                        "Indexer publish event handler failed with error: {:?}, retrying...",
+                        e
+                    );
+                }
+                Ok(publish_event_handler_exec_res?)
+            })
+            .await;
+            if let Err(e) = publish_event_res {
+                error!(
+                    "Indexer publish event handler failed after retrials with error: {:?}",
+                    e
+                );
+            }
+        });
+        try_join_all(vec![
+            txn_handle,
+            event_handle,
+            checkpoint_handle,
+            object_event_handle,
+            publish_event_handle,
+        ])
+        .await
+        .expect("Handler orchestrator shoult not run into errors.");
     }
 }

--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -5,3 +5,6 @@ pub mod checkpoint_handler;
 pub mod event_handler;
 pub mod handler_orchestrator;
 pub mod transaction_handler;
+// TODO: remove below after wave 2
+pub mod object_event_handler;
+pub mod publish_event_handler;

--- a/crates/sui-indexer/src/handlers/object_event_handler.rs
+++ b/crates/sui-indexer/src/handlers/object_event_handler.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::Registry;
+use std::sync::Arc;
+use sui_json_rpc_types::EventPage;
+use sui_sdk::SuiClient;
+use sui_types::event::{EventID, EventType};
+use sui_types::query::EventQuery;
+use tracing::info;
+
+use sui_indexer::errors::IndexerError;
+use sui_indexer::metrics::IndexerObjectEventHandlerMetrics;
+use sui_indexer::models::object_event_logs::{commit_event_log, read_event_log};
+use sui_indexer::models::object_events::commit_events;
+use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
+
+const EVENT_PAGE_SIZE: usize = 10;
+
+pub struct ObjectEventHandler {
+    rpc_client: SuiClient,
+    pg_connection_pool: Arc<PgConnectionPool>,
+    pub event_handler_metrics: IndexerObjectEventHandlerMetrics,
+}
+
+impl ObjectEventHandler {
+    pub fn new(
+        rpc_client: SuiClient,
+        pg_connection_pool: Arc<PgConnectionPool>,
+        prometheus_registry: &Registry,
+    ) -> Self {
+        let event_handler_metrics = IndexerObjectEventHandlerMetrics::new(prometheus_registry);
+        Self {
+            rpc_client,
+            pg_connection_pool,
+            event_handler_metrics,
+        }
+    }
+
+    pub async fn start(&self) -> Result<(), IndexerError> {
+        info!("Indexer object event handler started...");
+        let mut pg_pool_conn = get_pg_pool_connection(self.pg_connection_pool.clone())?;
+
+        let mut next_cursor = None;
+        let event_log = read_event_log(&mut pg_pool_conn)?;
+        let (tx_dig_opt, event_seq_opt) = (
+            event_log.next_cursor_tx_dig,
+            event_log.next_cursor_event_seq,
+        );
+        if let (Some(tx_dig), Some(event_seq)) = (tx_dig_opt, event_seq_opt) {
+            let tx_digest = tx_dig.parse().map_err(|e| {
+                IndexerError::TransactionDigestParsingError(format!(
+                    "Failed parsing transaction digest {:?} with error: {:?}",
+                    tx_dig, e
+                ))
+            })?;
+            next_cursor = Some(EventID {
+                tx_digest,
+                event_seq,
+            });
+        }
+
+        loop {
+            let event_page =
+                fetch_object_event_page(self.rpc_client.clone(), next_cursor.clone()).await?;
+            let event_count = event_page.data.len();
+            self.event_handler_metrics
+                .total_object_events_received
+                .inc_by(event_count as u64);
+            info!(
+                "Received object event page with {} events, next cursor: {:?}",
+                event_count, event_page.next_cursor
+            );
+
+            commit_events(&mut pg_pool_conn, event_page.clone())?;
+            if let Some(next_cursor_val) = event_page.next_cursor.clone() {
+                commit_event_log(
+                    &mut pg_pool_conn,
+                    Some(next_cursor_val.tx_digest.base58_encode()),
+                    Some(next_cursor_val.event_seq),
+                )?;
+                self.event_handler_metrics
+                    .total_object_events_processed
+                    .inc_by(event_count as u64);
+                next_cursor = Some(next_cursor_val);
+            }
+        }
+    }
+}
+
+async fn fetch_object_event_page(
+    rpc_client: SuiClient,
+    next_cursor: Option<EventID>,
+) -> Result<EventPage, IndexerError> {
+    rpc_client
+        .event_api()
+        .get_events(
+            EventQuery::EventType(EventType::NewObject),
+            next_cursor.clone(),
+            Some(EVENT_PAGE_SIZE),
+            false,
+        )
+        .await
+        .map_err(|e| {
+            IndexerError::FullNodeReadingError(format!(
+                "Failed reading event page with cursor {:?} and error: {:?}",
+                next_cursor, e
+            ))
+        })
+}

--- a/crates/sui-indexer/src/handlers/publish_event_handler.rs
+++ b/crates/sui-indexer/src/handlers/publish_event_handler.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::Registry;
+use std::sync::Arc;
+use sui_json_rpc_types::EventPage;
+use sui_sdk::SuiClient;
+use sui_types::event::{EventID, EventType};
+use sui_types::query::EventQuery;
+use tracing::info;
+
+use sui_indexer::errors::IndexerError;
+use sui_indexer::metrics::IndexerPublishEventHandlerMetrics;
+use sui_indexer::models::publish_event_logs::{commit_event_log, read_event_log};
+use sui_indexer::models::publish_events::commit_events;
+use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
+
+const EVENT_PAGE_SIZE: usize = 10;
+
+pub struct PublishEventHandler {
+    rpc_client: SuiClient,
+    pg_connection_pool: Arc<PgConnectionPool>,
+    pub event_handler_metrics: IndexerPublishEventHandlerMetrics,
+}
+
+impl PublishEventHandler {
+    pub fn new(
+        rpc_client: SuiClient,
+        pg_connection_pool: Arc<PgConnectionPool>,
+        prometheus_registry: &Registry,
+    ) -> Self {
+        let event_handler_metrics = IndexerPublishEventHandlerMetrics::new(prometheus_registry);
+        Self {
+            rpc_client,
+            pg_connection_pool,
+            event_handler_metrics,
+        }
+    }
+
+    pub async fn start(&self) -> Result<(), IndexerError> {
+        info!("Indexer publish event handler started...");
+        let mut pg_pool_conn = get_pg_pool_connection(self.pg_connection_pool.clone())?;
+
+        let mut next_cursor = None;
+        let event_log = read_event_log(&mut pg_pool_conn)?;
+        let (tx_dig_opt, event_seq_opt) = (
+            event_log.next_cursor_tx_dig,
+            event_log.next_cursor_event_seq,
+        );
+        if let (Some(tx_dig), Some(event_seq)) = (tx_dig_opt, event_seq_opt) {
+            let tx_digest = tx_dig.parse().map_err(|e| {
+                IndexerError::TransactionDigestParsingError(format!(
+                    "Failed parsing transaction digest {:?} with error: {:?}",
+                    tx_dig, e
+                ))
+            })?;
+            next_cursor = Some(EventID {
+                tx_digest,
+                event_seq,
+            });
+        }
+
+        loop {
+            let event_page =
+                fetch_publish_event_page(self.rpc_client.clone(), next_cursor.clone()).await?;
+            let event_count = event_page.data.len();
+            self.event_handler_metrics
+                .total_publish_events_received
+                .inc_by(event_count as u64);
+            info!(
+                "Received publish event page with {} events, next cursor: {:?}",
+                event_count, event_page.next_cursor
+            );
+
+            commit_events(&mut pg_pool_conn, event_page.clone())?;
+            if let Some(next_cursor_val) = event_page.next_cursor.clone() {
+                commit_event_log(
+                    &mut pg_pool_conn,
+                    Some(next_cursor_val.tx_digest.base58_encode()),
+                    Some(next_cursor_val.event_seq),
+                )?;
+                self.event_handler_metrics
+                    .total_publish_events_processed
+                    .inc_by(event_count as u64);
+                next_cursor = Some(next_cursor_val);
+            }
+        }
+    }
+}
+
+async fn fetch_publish_event_page(
+    rpc_client: SuiClient,
+    next_cursor: Option<EventID>,
+) -> Result<EventPage, IndexerError> {
+    rpc_client
+        .event_api()
+        .get_events(
+            EventQuery::EventType(EventType::Publish),
+            next_cursor.clone(),
+            Some(EVENT_PAGE_SIZE),
+            false,
+        )
+        .await
+        .map_err(|e| {
+            IndexerError::FullNodeReadingError(format!(
+                "Failed reading event page with cursor {:?} and error: {:?}",
+                next_cursor, e
+            ))
+        })
+}

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -116,6 +116,71 @@ impl IndexerEventHandlerMetrics {
 }
 
 #[derive(Clone, Debug)]
+
+// TODO: remove object and publish event related metrics after wave 2
+pub struct IndexerObjectEventHandlerMetrics {
+    pub total_object_events_received: IntCounter,
+    pub total_object_events_processed: IntCounter,
+    pub total_object_event_handler_error: IntCounter,
+}
+
+impl IndexerObjectEventHandlerMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            total_object_events_received: register_int_counter_with_registry!(
+                "total_object_events_received",
+                "Total number of object events received",
+                registry,
+            )
+            .unwrap(),
+            total_object_events_processed: register_int_counter_with_registry!(
+                "total_object_events_processed",
+                "Total number of object events processed",
+                registry,
+            )
+            .unwrap(),
+            total_object_event_handler_error: register_int_counter_with_registry!(
+                "total_object_event_handler_error",
+                "Total number of object event handler error",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexerPublishEventHandlerMetrics {
+    pub total_publish_events_received: IntCounter,
+    pub total_publish_events_processed: IntCounter,
+    pub total_publish_event_handler_error: IntCounter,
+}
+
+impl IndexerPublishEventHandlerMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            total_publish_events_received: register_int_counter_with_registry!(
+                "total_publish_events_received",
+                "Total number of publish events received",
+                registry,
+            )
+            .unwrap(),
+            total_publish_events_processed: register_int_counter_with_registry!(
+                "total_publish_events_processed",
+                "Total number of publish events processed",
+                registry,
+            )
+            .unwrap(),
+            total_publish_event_handler_error: register_int_counter_with_registry!(
+                "total_publish_event_handler_error",
+                "Total number of publish event handler error",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
 pub struct IndexerCheckpointHandlerMetrics {
     pub total_checkpoint_requested: IntCounter,
     pub total_checkpoint_received: IntCounter,

--- a/crates/sui-indexer/src/models/mod.rs
+++ b/crates/sui-indexer/src/models/mod.rs
@@ -14,3 +14,8 @@ pub mod package_logs;
 pub mod packages;
 pub mod transaction_logs;
 pub mod transactions;
+// TODO: remove below after wave 2
+pub mod object_event_logs;
+pub mod object_events;
+pub mod publish_event_logs;
+pub mod publish_events;

--- a/crates/sui-indexer/src/models/object_event_logs.rs
+++ b/crates/sui-indexer/src/models/object_event_logs.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::object_event_logs;
+use crate::schema::object_event_logs::dsl::*;
+use crate::PgPoolConnection;
+
+use diesel::prelude::*;
+use diesel::result::Error;
+
+#[derive(Queryable, Debug, Identifiable)]
+#[diesel(primary_key(id))]
+pub struct ObjectEventLog {
+    pub id: i32,
+    pub next_cursor_tx_dig: Option<String>,
+    pub next_cursor_event_seq: Option<i64>,
+}
+
+pub fn read_event_log(pg_pool_conn: &mut PgPoolConnection) -> Result<ObjectEventLog, IndexerError> {
+    let event_log_read_result: Result<ObjectEventLog, Error> = pg_pool_conn
+        .build_transaction()
+        .read_only()
+        .run::<_, Error, _>(|conn| object_event_logs.limit(1).first::<ObjectEventLog>(conn));
+
+    event_log_read_result.map_err(|e| {
+        IndexerError::PostgresReadError(format!(
+            "Failed reading object event log in PostgresDB with error {:?}",
+            e
+        ))
+    })
+}
+
+pub fn commit_event_log(
+    pg_pool_conn: &mut PgPoolConnection,
+    tx_digest: Option<String>,
+    event_seq: Option<i64>,
+) -> Result<usize, IndexerError> {
+    let event_log_commit_result: Result<usize, Error> = pg_pool_conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|conn| {
+            diesel::update(object_event_logs::table)
+                .set((
+                    next_cursor_tx_dig.eq(tx_digest.clone()),
+                    next_cursor_event_seq.eq(event_seq),
+                ))
+                .execute(conn)
+        });
+
+    event_log_commit_result.map_err(|e|
+        IndexerError::PostgresWriteError(format!(
+            "Failed updating object event log in PostgresDB with tx seq {:?}, event seq {:?} and error {:?}",
+            tx_digest.clone(), event_seq, e
+        ))
+    )
+}

--- a/crates/sui-indexer/src/models/object_events.rs
+++ b/crates/sui-indexer/src/models/object_events.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::object_events;
+use crate::schema::object_events::{event_sequence, transaction_digest};
+use crate::utils::log_errors_to_pg;
+use crate::PgPoolConnection;
+
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+use diesel::result::Error;
+use sui_json_rpc_types::{EventPage, SuiEventEnvelope};
+
+#[derive(Queryable, Debug)]
+pub struct ObjectEvent {
+    pub id: i64,
+    pub transaction_digest: Option<String>,
+    pub event_sequence: i64,
+    pub event_time: Option<NaiveDateTime>,
+    pub event_type: String,
+    pub event_content: String,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = object_events)]
+pub struct NewObjectEvent {
+    pub transaction_digest: String,
+    pub event_sequence: i64,
+    pub event_time: Option<NaiveDateTime>,
+    pub event_type: String,
+    pub event_content: String,
+}
+
+fn event_to_new_object_event(e: SuiEventEnvelope) -> Result<NewObjectEvent, IndexerError> {
+    let event_json = serde_json::to_string(&e.event).map_err(|err| {
+        IndexerError::InsertableParsingError(format!(
+            "Failed converting event to JSON with error: {:?}",
+            err
+        ))
+    })?;
+    let timestamp = NaiveDateTime::from_timestamp_millis(e.timestamp as i64).ok_or_else(|| {
+        IndexerError::DateTimeParsingError(format!(
+            "Cannot convert timestamp {:?} to NaiveDateTime",
+            e.timestamp
+        ))
+    })?;
+
+    Ok(NewObjectEvent {
+        transaction_digest: format!("{:?}", e.tx_digest),
+        event_sequence: e.id.event_seq,
+        event_time: Some(timestamp),
+        event_type: e.event.get_event_type(),
+        event_content: event_json,
+    })
+}
+
+pub fn commit_events(
+    pg_pool_conn: &mut PgPoolConnection,
+    event_page: EventPage,
+) -> Result<usize, IndexerError> {
+    let events = event_page.data;
+    let mut errors = vec![];
+    let new_events: Vec<NewObjectEvent> = events
+        .into_iter()
+        .map(event_to_new_object_event)
+        .filter_map(|r| r.map_err(|e| errors.push(e)).ok())
+        .collect();
+    log_errors_to_pg(pg_pool_conn, errors);
+
+    let event_commit_result: Result<usize, Error> = pg_pool_conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|conn| {
+        diesel::insert_into(object_events::table)
+            .values(&new_events)
+            .on_conflict((transaction_digest, event_sequence))
+            .do_nothing()
+            .execute(conn)
+    });
+
+    event_commit_result.map_err(|e| {
+        IndexerError::PostgresWriteError(format!(
+            "Failed writing object events to PostgresDB with object events {:?} and error: {:?}",
+            new_events, e
+        ))
+    })
+}

--- a/crates/sui-indexer/src/models/publish_event_logs.rs
+++ b/crates/sui-indexer/src/models/publish_event_logs.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::publish_event_logs;
+use crate::schema::publish_event_logs::dsl::*;
+use crate::PgPoolConnection;
+
+use diesel::prelude::*;
+use diesel::result::Error;
+
+#[derive(Queryable, Debug, Identifiable)]
+#[diesel(primary_key(id))]
+pub struct PublishEventLog {
+    pub id: i32,
+    pub next_cursor_tx_dig: Option<String>,
+    pub next_cursor_event_seq: Option<i64>,
+}
+
+pub fn read_event_log(
+    pg_pool_conn: &mut PgPoolConnection,
+) -> Result<PublishEventLog, IndexerError> {
+    let event_log_read_result: Result<PublishEventLog, Error> = pg_pool_conn
+        .build_transaction()
+        .read_only()
+        .run::<_, Error, _>(|conn| publish_event_logs.limit(1).first::<PublishEventLog>(conn));
+
+    event_log_read_result.map_err(|e| {
+        IndexerError::PostgresReadError(format!(
+            "Failed reading publish event log in PostgresDB with error {:?}",
+            e
+        ))
+    })
+}
+
+pub fn commit_event_log(
+    pg_pool_conn: &mut PgPoolConnection,
+    tx_digest: Option<String>,
+    event_seq: Option<i64>,
+) -> Result<usize, IndexerError> {
+    let event_log_commit_result: Result<usize, Error> = pg_pool_conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|conn| {
+            diesel::update(publish_event_logs::table)
+                .set((
+                    next_cursor_tx_dig.eq(tx_digest.clone()),
+                    next_cursor_event_seq.eq(event_seq),
+                ))
+                .execute(conn)
+        });
+
+    event_log_commit_result.map_err(|e|
+        IndexerError::PostgresWriteError(format!(
+            "Failed updating publish event log in PostgresDB with tx seq {:?}, event seq {:?} and error {:?}",
+            tx_digest.clone(), event_seq, e
+        ))
+    )
+}

--- a/crates/sui-indexer/src/models/publish_events.rs
+++ b/crates/sui-indexer/src/models/publish_events.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::publish_events;
+use crate::schema::publish_events::{event_sequence, transaction_digest};
+use crate::utils::log_errors_to_pg;
+use crate::PgPoolConnection;
+
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+use diesel::result::Error;
+use sui_json_rpc_types::{EventPage, SuiEventEnvelope};
+
+#[derive(Queryable, Debug)]
+pub struct PublishEvent {
+    pub id: i64,
+    pub transaction_digest: Option<String>,
+    pub event_sequence: i64,
+    pub event_time: Option<NaiveDateTime>,
+    pub event_type: String,
+    pub event_content: String,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = publish_events)]
+pub struct NewPublishEvent {
+    pub transaction_digest: String,
+    pub event_sequence: i64,
+    pub event_time: Option<NaiveDateTime>,
+    pub event_type: String,
+    pub event_content: String,
+}
+
+fn event_to_new_publish_event(e: SuiEventEnvelope) -> Result<NewPublishEvent, IndexerError> {
+    let event_json = serde_json::to_string(&e.event).map_err(|err| {
+        IndexerError::InsertableParsingError(format!(
+            "Failed converting event to JSON with error: {:?}",
+            err
+        ))
+    })?;
+    let timestamp = NaiveDateTime::from_timestamp_millis(e.timestamp as i64).ok_or_else(|| {
+        IndexerError::DateTimeParsingError(format!(
+            "Cannot convert timestamp {:?} to NaiveDateTime",
+            e.timestamp
+        ))
+    })?;
+
+    Ok(NewPublishEvent {
+        transaction_digest: format!("{:?}", e.tx_digest),
+        event_sequence: e.id.event_seq,
+        event_time: Some(timestamp),
+        event_type: e.event.get_event_type(),
+        event_content: event_json,
+    })
+}
+
+pub fn commit_events(
+    pg_pool_conn: &mut PgPoolConnection,
+    event_page: EventPage,
+) -> Result<usize, IndexerError> {
+    let events = event_page.data;
+    let mut errors = vec![];
+    let new_events: Vec<NewPublishEvent> = events
+        .into_iter()
+        .map(event_to_new_publish_event)
+        .filter_map(|r| r.map_err(|e| errors.push(e)).ok())
+        .collect();
+    log_errors_to_pg(pg_pool_conn, errors);
+
+    let event_commit_result: Result<usize, Error> = pg_pool_conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|conn| {
+        diesel::insert_into(publish_events::table)
+            .values(&new_events)
+            .on_conflict((transaction_digest, event_sequence))
+            .do_nothing()
+            .execute(conn)
+    });
+
+    event_commit_result.map_err(|e| {
+        IndexerError::PostgresWriteError(format!(
+            "Failed writing publish events to PostgresDB with publish events {:?} and error: {:?}",
+            new_events, e
+        ))
+    })
+}

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -66,6 +66,25 @@ diesel::table! {
 }
 
 diesel::table! {
+    object_event_logs (id) {
+        id -> Int4,
+        next_cursor_tx_dig -> Nullable<Text>,
+        next_cursor_event_seq -> Nullable<Int8>,
+    }
+}
+
+diesel::table! {
+    object_events (id) {
+        id -> Int8,
+        transaction_digest -> Nullable<Varchar>,
+        event_sequence -> Int8,
+        event_time -> Nullable<Timestamp>,
+        event_type -> Varchar,
+        event_content -> Varchar,
+    }
+}
+
+diesel::table! {
     object_logs (last_processed_id) {
         last_processed_id -> Int8,
     }
@@ -97,6 +116,25 @@ diesel::table! {
         author -> Text,
         module_names -> Array<Nullable<Text>>,
         package_content -> Text,
+    }
+}
+
+diesel::table! {
+    publish_event_logs (id) {
+        id -> Int4,
+        next_cursor_tx_dig -> Nullable<Text>,
+        next_cursor_event_seq -> Nullable<Int8>,
+    }
+}
+
+diesel::table! {
+    publish_events (id) {
+        id -> Int8,
+        transaction_digest -> Nullable<Varchar>,
+        event_sequence -> Int8,
+        event_time -> Nullable<Timestamp>,
+        event_type -> Varchar,
+        event_content -> Varchar,
     }
 }
 
@@ -139,10 +177,14 @@ diesel::allow_tables_to_appear_in_same_query!(
     error_logs,
     event_logs,
     events,
+    object_event_logs,
+    object_events,
     object_logs,
     objects,
     package_logs,
     packages,
+    publish_event_logs,
+    publish_events,
     transaction_logs,
     transactions,
 );


### PR DESCRIPTION
b/c of throughput regression along with table size, indexer was not able to stay updated on private testnet.
This PR adds separate event handlers that only reads new modules / new objects.