### PR TITLE
Disable collecting rocksdb perf metrics and fix db_name cardinality spike

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -27,7 +27,7 @@ use sui_types::messages::{
     VerifiedCertificate, VerifiedSignedTransaction,
 };
 use tracing::{debug, info, trace, warn};
-use typed_store::rocks::{DBBatch, DBMap, DBOptions, TypedStoreError};
+use typed_store::rocks::{DBBatch, DBMap, DBOptions, MetricConf, TypedStoreError};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 
 use crate::authority::authority_notify_read::NotifyRead;
@@ -227,11 +227,21 @@ pub struct AuthorityEpochTables {
 
 impl AuthorityEpochTables {
     pub fn open(epoch: EpochId, parent_path: &Path, db_options: Option<Options>) -> Self {
-        Self::open_tables_transactional(Self::path(epoch, parent_path), db_options, None)
+        Self::open_tables_transactional(
+            Self::path(epoch, parent_path),
+            MetricConf::with_db_name("epoch"),
+            db_options,
+            None,
+        )
     }
 
     pub fn open_readonly(epoch: EpochId, parent_path: &Path) -> AuthorityEpochTablesReadOnly {
-        Self::get_read_only_handle(Self::path(epoch, parent_path), None, None)
+        Self::get_read_only_handle(
+            Self::path(epoch, parent_path),
+            None,
+            None,
+            MetricConf::with_db_name("epoch"),
+        )
     }
 
     pub fn path(epoch: EpochId, parent_path: &Path) -> PathBuf {

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -8,7 +8,8 @@ use std::path::Path;
 use sui_storage::default_db_options;
 use sui_types::base_types::SequenceNumber;
 use sui_types::messages::TrustedCertificate;
-use typed_store::rocks::{DBMap, DBOptions};
+use typed_store::metrics::SamplingInterval;
+use typed_store::rocks::{DBMap, DBOptions, MetricConf};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 
 use typed_store_derive::DBMapUtils;
@@ -88,11 +89,16 @@ impl AuthorityPerpetualTables {
     }
 
     pub fn open(parent_path: &Path, db_options: Option<Options>) -> Self {
-        Self::open_tables_read_write(Self::path(parent_path), db_options, None)
+        Self::open_tables_read_write(
+            Self::path(parent_path),
+            MetricConf::with_sampling(SamplingInterval::new(Duration::from_secs(60), 0)),
+            db_options,
+            None,
+        )
     }
 
     pub fn open_readonly(parent_path: &Path) -> AuthorityPerpetualTablesReadOnly {
-        Self::get_read_only_handle(Self::path(parent_path), None, None)
+        Self::get_read_only_handle(Self::path(parent_path), None, None, MetricConf::default())
     }
 
     /// Read an object and return it, or Ok(None) if the object was not found.

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -41,7 +41,7 @@ use sui_types::messages_checkpoint::{
 use tokio::sync::{mpsc, watch, Notify};
 use tokio::time::Instant;
 use tracing::{debug, error, error_span, info, warn, Instrument};
-use typed_store::rocks::{DBMap, TypedStoreError};
+use typed_store::rocks::{DBMap, MetricConf, TypedStoreError};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store::Map;
 use typed_store_derive::DBMapUtils;
@@ -87,7 +87,12 @@ pub struct CheckpointStore {
 
 impl CheckpointStore {
     pub fn new(path: &Path) -> Arc<Self> {
-        Arc::new(Self::open_tables_read_write(path.to_path_buf(), None, None))
+        Arc::new(Self::open_tables_read_write(
+            path.to_path_buf(),
+            MetricConf::default(),
+            None,
+            None,
+        ))
     }
 
     pub fn insert_genesis_checkpoint(

--- a/crates/sui-core/src/epoch/committee_store.rs
+++ b/crates/sui-core/src/epoch/committee_store.rs
@@ -7,7 +7,7 @@ use sui_storage::default_db_options;
 use sui_types::base_types::ObjectID;
 use sui_types::committee::{Committee, EpochId};
 use sui_types::error::SuiResult;
-use typed_store::rocks::{DBMap, DBOptions};
+use typed_store::rocks::{DBMap, DBOptions, MetricConf};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 
 use typed_store::Map;
@@ -29,7 +29,8 @@ fn committee_table_default_config() -> DBOptions {
 
 impl CommitteeStore {
     pub fn new(path: PathBuf, genesis_committee: &Committee, db_options: Option<Options>) -> Self {
-        let committee_store = Self::open_tables_read_write(path, db_options, None);
+        let committee_store =
+            Self::open_tables_read_write(path, MetricConf::default(), db_options, None);
         if committee_store.database_is_empty() {
             committee_store
                 .init_genesis_committee(genesis_committee.clone())

--- a/crates/sui-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/sui-faucet/src/faucet/write_ahead_log.rs
@@ -34,7 +34,12 @@ pub struct Entry {
 
 impl WriteAheadLog {
     pub(crate) fn open(path: &Path) -> Self {
-        Self::open_tables_read_write(path.to_path_buf(), None, None)
+        Self::open_tables_read_write(
+            path.to_path_buf(),
+            typed_store::rocks::MetricConf::default(),
+            None,
+            None,
+        )
     }
 
     /// Mark `coin` as reserved for transaction `tx` sending coin to `recipient`. Fails if `coin` is

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -24,7 +24,7 @@ use sui_storage::default_db_options;
 use sui_types::base_types::{EpochId, SuiAddress};
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tracing::{debug, error, info};
-use typed_store::rocks::{DBMap, DBOptions};
+use typed_store::rocks::{DBMap, DBOptions, MetricConf};
 use typed_store::traits::TableSummary;
 use typed_store::traits::TypedStoreDebug;
 use typed_store::Map;
@@ -336,7 +336,12 @@ pub struct CheckpointIndexStore {
 
 impl CheckpointIndexStore {
     pub fn open(db_dir: &Path, db_options: Option<Options>) -> Self {
-        Self::open_tables_read_write(db_dir.to_path_buf(), db_options, None)
+        Self::open_tables_read_write(
+            db_dir.to_path_buf(),
+            MetricConf::default(),
+            db_options,
+            None,
+        )
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -10,8 +10,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::debug;
-use typed_store::rocks::DBMap;
 use typed_store::rocks::DBOptions;
+use typed_store::rocks::{DBMap, MetricConf};
 use typed_store::traits::Map;
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store_derive::DBMapUtils;
@@ -130,7 +130,8 @@ fn dynamic_field_index_table_default_config() -> DBOptions {
 
 impl IndexStore {
     pub fn new(path: PathBuf) -> Self {
-        let tables = IndexStoreTables::open_tables_read_write(path, None, None);
+        let tables =
+            IndexStoreTables::open_tables_read_write(path, MetricConf::default(), None, None);
         let next_sequence_number = tables
             .transaction_order
             .iter()

--- a/crates/sui-storage/src/write_ahead_log.rs
+++ b/crates/sui-storage/src/write_ahead_log.rs
@@ -23,6 +23,7 @@ use typed_store::{rocks::DBMap, traits::Map};
 use tracing::{debug, error, instrument, trace, warn};
 
 use tap::TapFallible;
+use typed_store::rocks::MetricConf;
 
 /// TxGuard is a handle on an in-progress transaction.
 ///
@@ -221,7 +222,8 @@ where
     ExecutionOutput: Serialize + DeserializeOwned + Debug,
 {
     pub fn new(path: PathBuf) -> Self {
-        let tables = DBWriteAheadLogTables::open_tables_read_write(path, None, None);
+        let tables =
+            DBWriteAheadLogTables::open_tables_read_write(path, MetricConf::default(), None, None);
 
         // Read in any digests that were left in the log, e.g. due to a crash.
         //

--- a/crates/sui-storage/src/write_path_pending_tx_log.rs
+++ b/crates/sui-storage/src/write_path_pending_tx_log.rs
@@ -12,6 +12,7 @@ use sui_types::crypto::EmptySignInfo;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::message_envelope::TrustedEnvelope;
 use sui_types::messages::{SenderSignedData, VerifiedTransaction};
+use typed_store::rocks::MetricConf;
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store::{rocks::DBMap, traits::Map};
 use typed_store_derive::DBMapUtils;
@@ -29,8 +30,12 @@ pub struct WritePathPendingTransactionLog {
 
 impl WritePathPendingTransactionLog {
     pub fn new(path: PathBuf) -> Self {
-        let pending_transactions =
-            WritePathPendingTransactionTable::open_tables_transactional(path, None, None);
+        let pending_transactions = WritePathPendingTransactionTable::open_tables_transactional(
+            path,
+            MetricConf::default(),
+            None,
+            None,
+        );
         Self {
             pending_transactions,
         }

--- a/crates/sui-tool/src/db_tool/db_dump.rs
+++ b/crates/sui-tool/src/db_tool/db_dump.rs
@@ -18,6 +18,7 @@ use sui_types::base_types::{EpochId, ObjectID};
 use sui_types::messages::{SignedTransactionEffects, TrustedCertificate};
 use sui_types::object::Data;
 use sui_types::temporary_store::InnerTemporaryStore;
+use typed_store::rocks::MetricConf;
 use typed_store::traits::{Map, TableSummary};
 
 #[derive(EnumString, Parser, Debug)]
@@ -71,15 +72,19 @@ pub fn table_summary(
             }
         }
         StoreName::Index => {
-            IndexStoreTables::get_read_only_handle(db_path, None, None).table_summary(table_name)
+            IndexStoreTables::get_read_only_handle(db_path, None, None, MetricConf::default())
+                .table_summary(table_name)
         }
-        StoreName::Wal => DBWriteAheadLogTables::<
-            TrustedCertificate,
-            (InnerTemporaryStore, SignedTransactionEffects),
-        >::get_read_only_handle(db_path, None, None)
-        .table_summary(table_name),
+        StoreName::Wal => {
+            DBWriteAheadLogTables::<
+                TrustedCertificate,
+                (InnerTemporaryStore, SignedTransactionEffects),
+            >::get_read_only_handle(db_path, None, None, MetricConf::default())
+            .table_summary(table_name)
+        }
         StoreName::Epoch => {
-            CommitteeStore::get_read_only_handle(db_path, None, None).table_summary(table_name)
+            CommitteeStore::get_read_only_handle(db_path, None, None, MetricConf::default())
+                .table_summary(table_name)
         }
     }
     .map_err(|err| anyhow!(err.to_string()))
@@ -141,19 +146,23 @@ pub fn dump_table(
                 )
             }
         }
-        StoreName::Index => IndexStoreTables::get_read_only_handle(db_path, None, None).dump(
-            table_name,
-            page_size,
-            page_number,
-        ),
+        StoreName::Index => {
+            IndexStoreTables::get_read_only_handle(db_path, None, None, MetricConf::default()).dump(
+                table_name,
+                page_size,
+                page_number,
+            )
+        }
         StoreName::Wal => Err(eyre!(
             "Dumping WAL not yet supported. It requires kmowing the value type"
         )),
-        StoreName::Epoch => CommitteeStore::get_read_only_handle(db_path, None, None).dump(
-            table_name,
-            page_size,
-            page_number,
-        ),
+        StoreName::Epoch => {
+            CommitteeStore::get_read_only_handle(db_path, None, None, MetricConf::default()).dump(
+                table_name,
+                page_size,
+                page_number,
+            )
+        }
     }
     .map_err(|err| anyhow!(err.to_string()))
 }

--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -33,7 +33,8 @@ pub struct SamplingInterval {
 
 impl Default for SamplingInterval {
     fn default() -> Self {
-        SamplingInterval::new(Duration::from_secs(60), 0)
+        // Disabled by default
+        SamplingInterval::new(Duration::ZERO, u64::MAX - 1)
     }
 }
 

--- a/crates/typed-store/src/sally/mod.rs
+++ b/crates/typed-store/src/sally/mod.rs
@@ -43,7 +43,7 @@
 //!     insert_key_vals(&table).await;
 //!     // switch to rocksdb backend
 //!     let primary_path = tempfile::tempdir().expect("Failed to open db path").into_path();
-//!     table = ExampleTable::init(SallyDBOptions::RocksDB((primary_path, RocksDBAccessType::Primary, None, None)));
+//!     table = ExampleTable::init(SallyDBOptions::RocksDB((primary_path, MetricConf::default(), RocksDBAccessType::Primary, None, None)));
 //!     insert_key_vals(&table).await;
 //!     Ok(())
 //! }
@@ -58,7 +58,7 @@ use crate::{
 };
 
 use crate::rocks::iter::Iter as RocksDBIter;
-use crate::rocks::DBMapTableConfigMap;
+use crate::rocks::{DBMapTableConfigMap, MetricConf};
 use async_trait::async_trait;
 use collectable::TryExtend;
 use rocksdb::Options;
@@ -457,6 +457,7 @@ pub enum SallyDBOptions {
     RocksDB(
         (
             PathBuf,
+            MetricConf,
             RocksDBAccessType,
             Option<Options>,
             Option<DBMapTableConfigMap>,
@@ -468,7 +469,7 @@ pub enum SallyDBOptions {
 /// Options to configure a sally db instance for performing read only operations at the global level
 pub enum SallyReadOnlyDBOptions {
     // Options when sally db instance is backed by a single rocksdb instance
-    RocksDB((PathBuf, Option<PathBuf>, Option<Options>)),
+    RocksDB(Box<(PathBuf, MetricConf, Option<PathBuf>, Option<Options>)>),
     TestDB,
 }
 

--- a/crates/typed-store/src/tests/store_tests.rs
+++ b/crates/typed-store/src/tests/store_tests.rs
@@ -12,14 +12,22 @@ fn temp_dir() -> std::path::PathBuf {
 #[tokio::test]
 async fn create_store() {
     // Create new store.
-    let db = rocks::DBMap::<usize, String>::open(temp_dir(), None, None).unwrap();
+    let db =
+        rocks::DBMap::<usize, String>::open(temp_dir(), rocks::MetricConf::default(), None, None)
+            .unwrap();
     let _ = Store::<usize, String>::new(db);
 }
 
 #[tokio::test]
 async fn read_async_write_value() {
     // Create new store.
-    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(temp_dir(), None, None).unwrap();
+    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(
+        temp_dir(),
+        rocks::MetricConf::default(),
+        None,
+        None,
+    )
+    .unwrap();
     let store = Store::new(db);
 
     // Write value to the store.
@@ -38,7 +46,13 @@ async fn read_async_write_value() {
 #[tokio::test]
 async fn read_sync_write_value() {
     // Create new store.
-    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(temp_dir(), None, None).unwrap();
+    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(
+        temp_dir(),
+        rocks::MetricConf::default(),
+        None,
+        None,
+    )
+    .unwrap();
     let store = Store::new(db);
 
     // Write value to the store.
@@ -57,7 +71,9 @@ async fn read_sync_write_value() {
 #[tokio::test]
 async fn read_raw_write_value() {
     // Create new store.
-    let db = rocks::DBMap::<Vec<u8>, String>::open(temp_dir(), None, None).unwrap();
+    let db =
+        rocks::DBMap::<Vec<u8>, String>::open(temp_dir(), rocks::MetricConf::default(), None, None)
+            .unwrap();
     let store = Store::new(db);
 
     // Write value to the store.
@@ -76,7 +92,13 @@ async fn read_raw_write_value() {
 #[tokio::test]
 async fn read_unknown_key() {
     // Create new store.
-    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(temp_dir(), None, None).unwrap();
+    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(
+        temp_dir(),
+        rocks::MetricConf::default(),
+        None,
+        None,
+    )
+    .unwrap();
     let store = Store::new(db);
 
     // Try to read unknown key.
@@ -89,7 +111,13 @@ async fn read_unknown_key() {
 #[tokio::test]
 async fn read_notify() {
     // Create new store.
-    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(temp_dir(), None, None).unwrap();
+    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(
+        temp_dir(),
+        rocks::MetricConf::default(),
+        None,
+        None,
+    )
+    .unwrap();
     let store = Store::new(db);
 
     // Try to read a kew that does not yet exist. Then write a value
@@ -116,7 +144,13 @@ async fn read_notify() {
 #[tokio::test]
 async fn remove_all_successfully() {
     // GIVEN Create new store.
-    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(temp_dir(), None, None).unwrap();
+    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(
+        temp_dir(),
+        rocks::MetricConf::default(),
+        None,
+        None,
+    )
+    .unwrap();
     let store = Store::new(db);
 
     // AND Write values to the store.
@@ -148,7 +182,13 @@ async fn remove_all_successfully() {
 #[tokio::test]
 async fn write_and_read_all_successfully() {
     // GIVEN Create new store.
-    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(temp_dir(), None, None).unwrap();
+    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(
+        temp_dir(),
+        rocks::MetricConf::default(),
+        None,
+        None,
+    )
+    .unwrap();
     let store = Store::new(db);
 
     // AND key-values to store.
@@ -180,7 +220,13 @@ async fn write_and_read_all_successfully() {
 #[tokio::test]
 async fn iter_successfully() {
     // GIVEN Create new store.
-    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(temp_dir(), None, None).unwrap();
+    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(
+        temp_dir(),
+        rocks::MetricConf::default(),
+        None,
+        None,
+    )
+    .unwrap();
     let store = Store::new(db);
 
     // AND key-values to store.
@@ -206,7 +252,13 @@ async fn iter_successfully() {
 #[tokio::test]
 async fn iter_and_filter_successfully() {
     // GIVEN Create new store.
-    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(temp_dir(), None, None).unwrap();
+    let db = rocks::DBMap::<Vec<u8>, Vec<u8>>::open(
+        temp_dir(),
+        rocks::MetricConf::default(),
+        None,
+        None,
+    )
+    .unwrap();
     let store = Store::new(db);
 
     // AND key-values to store.

--- a/narwhal/consensus/src/tests/consensus_utils.rs
+++ b/narwhal/consensus/src/tests/consensus_utils.rs
@@ -3,6 +3,7 @@
 use crypto::PublicKey;
 use std::sync::Arc;
 use storage::CertificateStore;
+use store::rocks::MetricConf;
 use store::{reopen, rocks, rocks::DBMap};
 use types::{
     Certificate, CertificateDigest, CommittedSubDagShell, ConsensusStore, Round, SequenceNumber,
@@ -12,8 +13,13 @@ pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore>
     const LAST_COMMITTED_CF: &str = "last_committed";
     const SEQUENCE_CF: &str = "sequence";
 
-    let rocksdb = rocks::open_cf(store_path, None, &[LAST_COMMITTED_CF, SEQUENCE_CF])
-        .expect("Failed to create database");
+    let rocksdb = rocks::open_cf(
+        store_path,
+        None,
+        MetricConf::default(),
+        &[LAST_COMMITTED_CF, SEQUENCE_CF],
+    )
+    .expect("Failed to create database");
 
     let (last_committed_map, sequence_map) = reopen!(&rocksdb,
         LAST_COMMITTED_CF;<PublicKey, Round>,
@@ -31,6 +37,7 @@ pub fn make_certificate_store(store_path: &std::path::Path) -> CertificateStore 
     let rocksdb = rocks::open_cf(
         store_path,
         None,
+        MetricConf::default(),
         &[
             CERTIFICATES_CF,
             CERTIFICATE_DIGEST_BY_ROUND_CF,

--- a/narwhal/primary/src/tests/common.rs
+++ b/narwhal/primary/src/tests/common.rs
@@ -16,6 +16,7 @@ use types::{
 
 use crypto::PublicKey;
 use storage::PayloadToken;
+use store::rocks::MetricConf;
 use tokio::{task::JoinHandle, time::Instant};
 
 pub fn create_db_stores() -> (
@@ -27,6 +28,7 @@ pub fn create_db_stores() -> (
     let rocksdb = rocks::open_cf(
         temp_dir(),
         None,
+        MetricConf::default(),
         &[
             HEADERS_CF,
             CERTIFICATES_CF,
@@ -63,7 +65,8 @@ pub fn create_db_stores() -> (
 
 pub fn create_test_vote_store() -> Store<PublicKey, VoteInfo> {
     // Create a new test store.
-    let rocksdb = rocks::open_cf(temp_dir(), None, &[VOTES_CF]).expect("Failed creating database");
+    let rocksdb = rocks::open_cf(temp_dir(), None, MetricConf::default(), &[VOTES_CF])
+        .expect("Failed creating database");
     let votes_map = reopen!(&rocksdb, VOTES_CF;<PublicKey, VoteInfo>);
     Store::new(votes_map)
 }

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -30,7 +30,7 @@ use std::{
 use storage::CertificateStore;
 use storage::NodeStorage;
 use storage::PayloadToken;
-use store::rocks::DBMap;
+use store::rocks::{DBMap, MetricConf};
 use store::Store;
 use test_utils::{temp_dir, CommitteeFixture};
 use tokio::sync::watch;
@@ -989,6 +989,7 @@ async fn test_process_payload_availability_when_failures() {
     let rocksdb = store::rocks::open_cf(
         temp_dir(),
         None,
+        MetricConf::default(),
         &[
             test_utils::CERTIFICATES_CF,
             test_utils::CERTIFICATE_DIGEST_BY_ROUND_CF,

--- a/narwhal/storage/src/certificate_store.rs
+++ b/narwhal/storage/src/certificate_store.rs
@@ -435,6 +435,7 @@ mod test {
         collections::{BTreeSet, HashSet},
         time::Instant,
     };
+    use store::rocks::MetricConf;
     use store::{
         reopen,
         rocks::{open_cf, DBMap},
@@ -450,6 +451,7 @@ mod test {
         let rocksdb = open_cf(
             path,
             None,
+            MetricConf::default(),
             &[
                 CERTIFICATES_CF,
                 CERTIFICATE_ID_BY_ROUND_CF,

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -5,8 +5,8 @@ use crate::{CertificateStore, ProposerStore};
 use config::WorkerId;
 use crypto::PublicKey;
 use std::sync::Arc;
-use store::rocks::open_cf;
 use store::rocks::DBMap;
+use store::rocks::{open_cf, MetricConf};
 use store::{reopen, Store};
 use types::{
     Batch, BatchDigest, Certificate, CertificateDigest, CommittedSubDagShell, ConsensusStore,
@@ -46,6 +46,7 @@ impl NodeStorage {
         let rocksdb = open_cf(
             store_path,
             None,
+            MetricConf::with_db_name("consensus_epoch"),
             &[
                 Self::LAST_PROPOSED_CF,
                 Self::VOTES_CF,

--- a/narwhal/storage/src/proposer_store.rs
+++ b/narwhal/storage/src/proposer_store.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use store::rocks::open_cf;
+use store::rocks::{open_cf, MetricConf};
 use store::{reopen, rocks::DBMap, Map};
 use types::{Header, StoreResult};
 
@@ -23,8 +23,13 @@ impl ProposerStore {
 
     pub fn new_for_tests() -> ProposerStore {
         const LAST_PROPOSED_CF: &str = "last_proposed";
-        let rocksdb = open_cf(tempfile::tempdir().unwrap(), None, &[LAST_PROPOSED_CF])
-            .expect("Cannot open database");
+        let rocksdb = open_cf(
+            tempfile::tempdir().unwrap(),
+            None,
+            MetricConf::default(),
+            &[LAST_PROPOSED_CF],
+        )
+        .expect("Cannot open database");
         let last_proposed_map = reopen!(&rocksdb, LAST_PROPOSED_CF;<ProposerKey, Header>);
         ProposerStore::new(last_proposed_map)
     }

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -24,6 +24,7 @@ use std::{
     ops::RangeInclusive,
     sync::Arc,
 };
+use store::rocks::MetricConf;
 use store::{reopen, rocks, rocks::DBMap, Store};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tracing::info;
@@ -125,8 +126,13 @@ pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore>
     const LAST_COMMITTED_CF: &str = "last_committed";
     const SEQUENCE_CF: &str = "sequence";
 
-    let rocksdb = rocks::open_cf(store_path, None, &[LAST_COMMITTED_CF, SEQUENCE_CF])
-        .expect("Failed creating database");
+    let rocksdb = rocks::open_cf(
+        store_path,
+        None,
+        MetricConf::default(),
+        &[LAST_COMMITTED_CF, SEQUENCE_CF],
+    )
+    .expect("Failed creating database");
 
     let (last_committed_map, sequence_map) = reopen!(&rocksdb,
         LAST_COMMITTED_CF;<PublicKey, Round>,
@@ -370,7 +376,13 @@ pub fn batch_with_transactions(num_of_transactions: usize) -> Batch {
 const BATCHES_CF: &str = "batches";
 
 pub fn open_batch_store() -> Store<BatchDigest, Batch> {
-    let db = DBMap::<BatchDigest, Batch>::open(temp_dir(), None, Some(BATCHES_CF)).unwrap();
+    let db = DBMap::<BatchDigest, Batch>::open(
+        temp_dir(),
+        MetricConf::default(),
+        None,
+        Some(BATCHES_CF),
+    )
+    .unwrap();
     Store::new(db)
 }
 

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -6,11 +6,18 @@ use super::*;
 use crate::NUM_SHUTDOWN_RECEIVERS;
 use prometheus::Registry;
 use store::rocks;
+use store::rocks::MetricConf;
 use test_utils::{temp_dir, transaction};
 use types::PreSubscribedBroadcastSender;
 
 fn create_batches_store() -> Store<BatchDigest, Batch> {
-    let db = rocks::DBMap::<BatchDigest, Batch>::open(temp_dir(), None, Some("batches")).unwrap();
+    let db = rocks::DBMap::<BatchDigest, Batch>::open(
+        temp_dir(),
+        MetricConf::default(),
+        None,
+        Some("batches"),
+    )
+    .unwrap();
     Store::new(db)
 }
 

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -17,6 +17,7 @@ use prometheus::Registry;
 use std::time::Duration;
 use storage::NodeStorage;
 use store::rocks;
+use store::rocks::MetricConf;
 use test_utils::{batch, temp_dir, test_network, transaction, CommitteeFixture};
 use tokio::sync::watch;
 use types::{
@@ -55,7 +56,13 @@ async fn reject_invalid_clients_transactions() {
     };
 
     // Create a new test store.
-    let db = rocks::DBMap::<BatchDigest, Batch>::open(temp_dir(), None, Some("batches")).unwrap();
+    let db = rocks::DBMap::<BatchDigest, Batch>::open(
+        temp_dir(),
+        MetricConf::default(),
+        None,
+        Some("batches"),
+    )
+    .unwrap();
     let store = Store::new(db);
 
     let registry = Registry::new();
@@ -142,7 +149,13 @@ async fn handle_clients_transactions() {
     };
 
     // Create a new test store.
-    let db = rocks::DBMap::<BatchDigest, Batch>::open(temp_dir(), None, Some("batches")).unwrap();
+    let db = rocks::DBMap::<BatchDigest, Batch>::open(
+        temp_dir(),
+        MetricConf::default(),
+        None,
+        Some("batches"),
+    )
+    .unwrap();
     let store = Store::new(db);
 
     let registry = Registry::new();


### PR DESCRIPTION
A lot of RocksDB metrics are collected per db which started causing cardinality spike because of ephemeral epoch databases (more pronounced in private testnet where we are creating new epoch every 5 mins or so).  Specifically, the value for the label `db_name` now has multiple possible values as epoch grows `epoch0`, `epoch1`, `epoch2`,.. To fix this, we added a `MetricConf` struct which a user can pass while opening the db and provide a label value to use for `db_name` label. After this change, the value for label `db_name` will stay constant to `epoch` (authorities epoch db) or `consensus_epoch` (consensus epoch db) even with new epochs and stop the blowout.

The other problem is a lot of read/write/iter perf context metrics are expensive because they are captured per column family. Given these are not actively used, we are going to disable their collection for almost all the databases (minus read perf context in authority store db). We will turn them on if we are doing any perf related debugging. 
NOTE: We are still going to collect db and cf metrics needed for db operational insight (e.g disk and memory usage, etc) but with perf metrics gone, these should be much fewer in number going forward.