### PR TITLE
[TypeScript SDK] Disable DevNet e2e until it's stable

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,29 +64,3 @@ jobs:
           name: playwright-report-wallet
           path: apps/wallet/playwright-report/
           retention-days: 30
-
-  devnet:
-    name: Devnet
-    needs: diff
-    if: needs.diff.outputs.isTypescriptSDK == 'true'
-    runs-on: [self-hosted, self-hosted-arc]
-    steps:
-      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
-        with:
-          version: 7
-      - run: cargo build --bin sui --profile dev
-      - name: Install Nodejs
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
-          cache: "pnpm"
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Run e2e tests
-        env:
-          VITE_FAUCET_URL: "https://faucet.devnet.sui.io:443/gas"
-          VITE_FULLNODE_URL: "https://fullnode.devnet.sui.io"
-        run: pnpm sdk test:e2e:nowait


### PR DESCRIPTION
The e2e has become unstable recently due to:
- The DevNet Faucet/Fullnode was unstable for a few weeks that caused the tests to be flaky
- There was at least one [breaking change ](https://github.com/MystenLabs/sui/pull/6944)accidentally committed
- Some other failures hidden by the first two

I'll disable the test for now and debug them until the test becomes stable


Context: https://mysten-labs.slack.com/archives/C04FG4Q7YJ3/p1673998807710829?thread_ts=1673992931.859329&cid=C04FG4Q7YJ3