### PR TITLE
Mark poison-pill txns as such, refuse to execute them or include them in checkpoints

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1460,6 +1460,11 @@ impl AuthorityPerEpochStore {
         Ok(self.tables.poison_pill_transactions.insert(tx, &true)?)
     }
 
+    pub fn erase_poison_pill_tx(&self, tx: &TransactionDigest) -> SuiResult {
+        info!(tx_digest = ?tx, "erase_poison_pill_tx");
+        Ok(self.tables.poison_pill_transactions.remove(tx)?)
+    }
+
     pub(crate) fn record_epoch_pending_certs_process_time_metric(&self) {
         if let Some(epoch_close_time) = *self.epoch_close_time.read() {
             self.metrics

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -344,7 +344,7 @@ impl ValidatorService {
             // For shared objects this will wait until either timeout or we have heard back from consensus.
             // For owned objects this will return without waiting for certificate to be sequenced
             // First do quick dirty non-async check
-            if !epoch_store.is_tx_cert_consensus_message_processed(&certificate)? {
+            if !epoch_store.is_tx_cert_consensus_message_processed(&tx_digest)? {
                 if consensus_adapter.num_inflight_transactions()
                     > MAX_PENDING_CONSENSUS_TRANSACTIONS
                 {


### PR DESCRIPTION
I'm only 90% confident this is the right approach, so please poke holes in this.

The idea is to interfere as little as possible with the consensus machinery in order to (hopefully) make it impossible for this to cause a fork (except in the case of a tx that only crashes some validators, in which case a fork is unavoidable). Therefore we only check if a tx is poisoned in two places:

a) before enqueue it for execution (necessary to prevent repeated crashes)
b) before inclusion in a checkpoint (necessary to avoid putting an unexecutable TX into a checkpoint and blocking reconfiguration.

Fixes #7408 