### PR TITLE
Logging improvements

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -745,7 +745,7 @@ impl AuthorityStore {
         write_batch = write_batch.insert_batch(
             &self.perpetual_tables.objects,
             written.iter().map(|(_, (obj_ref, new_object, _kind))| {
-                trace!(tx_digest=?transaction_digest, ?obj_ref, "writing object");
+                debug!(?obj_ref, "writing object");
                 (ObjectKey::from(obj_ref), new_object)
             }),
         )?;
@@ -796,7 +796,7 @@ impl AuthorityStore {
         // TODO: replace with optimistic transactions (i.e. set lock to tx if none)
         let _mutexes = self.acquire_locks(owned_input_objects).await;
 
-        debug!(?tx_digest, ?owned_input_objects, "acquire_locks");
+        debug!(?owned_input_objects, "acquire_locks");
         let mut locks_to_write = Vec::new();
 
         let locks = self
@@ -847,7 +847,7 @@ impl AuthorityStore {
                     // Exactly the same epoch and same transaction, nothing to lock here.
                     continue;
                 } else {
-                    debug!(prev_epoch =? previous_epoch, cur_epoch =? epoch, ?tx_digest, "Overriding an old lock from previous epoch");
+                    debug!(prev_epoch =? previous_epoch, cur_epoch =? epoch, "Overriding an old lock from previous epoch");
                     // Fall through and override the old lock.
                 }
             }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -37,7 +37,7 @@ use tokio::{
     time::timeout,
 };
 use tokio_stream::StreamExt;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, instrument, warn};
 use typed_store::{rocks::TypedStoreError, Map};
 
 use crate::authority::AuthorityStore;
@@ -516,6 +516,7 @@ impl CheckpointExecutorEventLoop {
     }
 }
 
+#[instrument(level = "error", skip_all, fields(seq = ?checkpoint.sequence_number(), epoch = ?epoch_store.epoch()))]
 pub async fn execute_checkpoint(
     checkpoint: VerifiedCheckpoint,
     authority_store: Arc<AuthorityStore>,

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -83,44 +83,39 @@ pub async fn execution_process(
 
         // Certificate execution can take significant time, so run it in a separate task.
         spawn_monitored_task!(async move {
-            let execution_future = async move {
-                let _guard = permit;
-                if let Ok(true) = authority.is_tx_already_executed(&digest) {
-                    return;
-                }
-                let mut attempts = 0;
-                loop {
-                    attempts += 1;
-                    let res = authority
-                        .try_execute_immediately(&certificate, &epoch_store)
-                        .await;
-                    if let Err(e) = res {
-                        if attempts == EXECUTION_MAX_ATTEMPTS {
-                            error!("Failed to execute certified transaction after {attempts} attempts! error={e} certificate={:?}", certificate);
-                            authority.metrics.execution_driver_execution_failures.inc();
-                            return;
-                        }
-                        // Assume only transient failure can happen. Permanent failure is probably
-                        // a bug. There is nothing that can be done to recover from permanent failures.
-                        error!(tx_digest=?digest, "Failed to execute certified transaction! attempt {attempts}, {e}");
-                        sleep(EXECUTION_FAILURE_RETRY_INTERVAL).await;
-                    } else {
-                        break;
+            let _guard = permit;
+            if let Ok(true) = authority.is_tx_already_executed(&digest) {
+                return;
+            }
+            let mut attempts = 0;
+            loop {
+                attempts += 1;
+                let res = authority
+                    .try_execute_immediately(&certificate, &epoch_store)
+                    .await;
+                if let Err(e) = res {
+                    if attempts == EXECUTION_MAX_ATTEMPTS {
+                        error!("Failed to execute certified transaction after {attempts} attempts! error={e} certificate={:?}", certificate);
+                        authority.metrics.execution_driver_execution_failures.inc();
+                        return;
                     }
+                    // Assume only transient failure can happen. Permanent failure is probably
+                    // a bug. There is nothing that can be done to recover from permanent failures.
+                    error!(tx_digest=?digest, "Failed to execute certified transaction! attempt {attempts}, {e}");
+                    sleep(EXECUTION_FAILURE_RETRY_INTERVAL).await;
+                } else {
+                    break;
                 }
+            }
 
-                // Remove the certificate that finished execution from the pending_certificates table.
-                authority.certificate_executed(&digest, &epoch_store);
+            // Remove the certificate that finished execution from the pending_certificates table.
+            authority.certificate_executed(&digest, &epoch_store);
 
-                authority
-                    .metrics
-                    .execution_driver_executed_transactions
-                    .inc();
-            };
+            authority
+                .metrics
+                .execution_driver_executed_transactions
+                .inc();
 
-            execution_future
-                .instrument(error_span!("execution_driver", tx_digest = ?digest))
-                .await;
-        });
+        }.instrument(error_span!("execution_driver", tx_digest = ?digest)));
     }
 }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -128,7 +128,7 @@ impl TransactionManager {
                 .expect("Are shared object locks set prior to enqueueing certificates?");
 
             if missing.is_empty() {
-                debug!(tx_digest = ?digest, "certificate ready");
+                debug!("certificate ready");
                 assert!(inner.executing_certificates.insert(digest));
                 self.certificate_ready(cert);
                 self.metrics

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -36,7 +36,7 @@ use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::broadcast::{self, Receiver};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, error_span, info, instrument, warn, Instrument};
 
 use sui_types::messages::VerifiedTransaction;
 
@@ -268,6 +268,7 @@ where
                 &validator_state.epoch_store(),
             ),
         )
+        .instrument(error_span!("transaction_orchestrator", ?tx_digest))
         .await
         {
             Err(_elapsed) => {

--- a/crates/sui-storage/src/write_ahead_log.rs
+++ b/crates/sui-storage/src/write_ahead_log.rs
@@ -282,7 +282,7 @@ where
 
     fn commit_tx(&self, tx: &TransactionDigest, is_commit: bool) -> SuiResult {
         if is_commit {
-            debug!(digest = ?tx, "committing tx");
+            debug!("committing tx");
         }
         let write_batch = self.tables.log.batch();
         let write_batch = write_batch.delete_batch(&self.tables.log, std::iter::once(tx))?;


### PR DESCRIPTION
Instead of littering the code with logs that include (or don't include) the current digest, we just create spans before beginning any tx execution, so that all logs are annotated with the tx digest by default. This also allows us to provide context about what call site initiated the execution.

Note that while the spans in question are all at `error` level, they don't create any logs on their own. This simply ensures that we still get the context information even if we are only logging at ERROR level. Span creation (without recording) should be plenty cheap enough to do once-per-tx-execution, but we can always lower the level if they prove to be too costly later.

Below are what the logs look like when you grep for a tx digest.

Before: https://gist.githubusercontent.com/mystenmark/0e94c9e22ec722ad0952fa4dea2e5b6d/raw/f08eba653bd98d6462c39785aba0880522342ffb/gistfile0.txt

After: https://gist.githubusercontent.com/mystenmark/715354ee76b83591f5f4cfa081350da7/raw/56ecca6ec70eb88e5943dd082e3fd7426d8f3e9b/gistfile0.txt