### PR TITLE
[wallet-ext] Don't display non-string names

### DIFF
--- a/apps/wallet/src/ui/app/components/nft-display/index.tsx
+++ b/apps/wallet/src/ui/app/components/nft-display/index.tsx
@@ -52,7 +52,7 @@ function NFTDisplayCard({
         OBJ_TYPE_MAX_LENGTH,
         OBJ_TYPE_MAX_PREFIX_LENGTH
     );
-    const displayTitle = name || objIDShort;
+    const displayTitle = typeof name === 'string' ? name : objIDShort;
     return (
         <div className={nftDisplayCardStyles({ animateHover, wideView })}>
             <NftImage


### PR DESCRIPTION
We were previously just assuming the `name` property was always a string, but this updates it to instead check that it is a string before rendering it.