### PR TITLE
update to averageAPY add make validator name clickable

### DIFF
--- a/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -50,7 +50,12 @@ const validatorsTable = (
     const validators = processValidators(
         validatorsData.validators.fields.active_validators,
         totalStake
-    ).sort((a, b) => (a.name > b.name ? 1 : -1));
+    ).sort((a, b) =>
+        a.name.localeCompare(b.name, 'en', {
+            sensitivity: 'base',
+            numeric: true,
+        })
+    );
 
     const validatorsItems = limit ? validators.splice(0, limit) : validators;
 

--- a/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -68,9 +68,10 @@ const validatorsTable = (
                                 circle
                             />
                         )}
-                        <Text variant="bodySmall/medium" color="steel-darker">
+
+                        <Link to={`/validator/${encodeURIComponent(address)}`}>
                             {name}
-                        </Text>
+                        </Link>
                     </div>
                 ),
                 stake: <StakeColumn stake={stake} />,

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -30,6 +30,7 @@ const APY_DECIMALS = 4;
 
 const ValidatorMap = lazy(() => import('../../components/node-map'));
 
+
 function validatorsTableData(validators: ActiveValidator[], epoch: number) {
     return {
         data: validators.map((validator, index) => {

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -30,7 +30,6 @@ const APY_DECIMALS = 4;
 
 const ValidatorMap = lazy(() => import('../../components/node-map'));
 
-
 function validatorsTableData(validators: ActiveValidator[], epoch: number) {
     return {
         data: validators.map((validator, index) => {


### PR DESCRIPTION
Make the validator name clickable and round the average APY. Maybe we have to update `InternalLink` component to include text and an option to disable mono?