### PR TITLE
make SuiExecuteTransactionResponse struct but not enum

### DIFF
--- a/.changeset/nice-beers-hammer.md
+++ b/.changeset/nice-beers-hammer.md
@@ -1,0 +1,12 @@
+---
+"@mysten/sui.js": minor
+"@mysten/wallet-adapter-wallet-standard": patch
+"@mysten/wallet-adapter-unsafe-burner": patch
+"@mysten/wallet-adapter-base": patch
+"@mysten/wallet-adapter-all-wallets": patch
+"@mysten/wallet-kit-core": patch
+"@mysten/wallet-standard": patch
+"@mysten/wallet-kit": patch
+---
+
+update SuiExecuteTransactionResponse

--- a/apps/explorer/tests/objects.spec.ts
+++ b/apps/explorer/tests/objects.spec.ts
@@ -9,7 +9,7 @@ test('can be reached through URL', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
 
-    const { objectId } = tx.EffectsCert.effects.effects.created![0].reference;
+    const { objectId } = tx.effects.effects.created![0].reference;
     await page.goto(`/object/${objectId}`);
     await expect(page.getByRole('heading', { name: objectId })).toBeVisible();
 });
@@ -19,7 +19,7 @@ test.describe('Owned Objects', () => {
         const address = await faucet();
         const tx = await mint(address);
 
-        const [nft] = tx.EffectsCert.effects.effects.created!;
+        const [nft] = tx.effects.effects.created!;
         await page.goto(`/address/0x${address}`);
 
         // Find a reference to the NFT:

--- a/apps/explorer/tests/search.spec.ts
+++ b/apps/explorer/tests/search.spec.ts
@@ -22,7 +22,7 @@ test('can search for objects', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
 
-    const { objectId } = tx.EffectsCert.effects.effects.created![0].reference;
+    const { objectId } = tx.effects.effects.created![0].reference;
     await page.goto('/');
     await search(page, objectId);
     await expect(page).toHaveURL(`/object/${objectId}`);
@@ -32,7 +32,7 @@ test('can search for transaction', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
 
-    const txid = tx.EffectsCert.certificate.transactionDigest;
+    const txid = tx.certificate.transactionDigest;
     await page.goto('/');
     await search(page, txid);
     await expect(page).toHaveURL(`/transaction/${txid}`);

--- a/apps/explorer/tests/transaction.spec.ts
+++ b/apps/explorer/tests/transaction.spec.ts
@@ -7,7 +7,7 @@ import { faucet, mint } from './utils/localnet';
 test('displays the transaction timestamp', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
-    const txid = tx.EffectsCert.certificate.transactionDigest;
+    const txid = tx.certificate.transactionDigest;
     await page.goto(`/transaction/${txid}`);
     await expect(
         page.getByTestId('transaction-timestamp').locator('div').nth(1)
@@ -17,7 +17,7 @@ test('displays the transaction timestamp', async ({ page }) => {
 test('displays gas breakdown', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
-    const txid = tx.EffectsCert.certificate.transactionDigest;
+    const txid = tx.certificate.transactionDigest;
     await page.goto(`/transaction/${txid}`);
     await expect(page.getByTestId('gas-breakdown')).toBeVisible();
 });

--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -45,8 +45,11 @@ export async function mint(address: string) {
         gasBudget: 30000,
     });
 
-    if (!('EffectsCert' in tx)) {
-        throw new Error('Missing effects cert');
+    if (!('certificate' in tx)) {
+        throw new Error('Missing certificate');
+    }
+    if (!('effects' in tx)) {
+        throw new Error('Missing effects');
     }
 
     return tx;

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -412,15 +412,12 @@ pub struct SuiTBlsSignRandomnessObjectResponse {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
-pub enum SuiExecuteTransactionResponse {
-    // TODO: Change to CertifiedTransactionEffects eventually.
-    EffectsCert {
-        certificate: SuiCertifiedTransaction,
-        effects: SuiCertifiedTransactionEffects,
-        // If the transaction is confirmed to be executed locally
-        // before this response.
-        confirmed_local_execution: bool,
-    },
+pub struct SuiExecuteTransactionResponse {
+    pub certificate: SuiCertifiedTransaction,
+    pub effects: SuiCertifiedTransactionEffects,
+    // If the transaction is confirmed to be executed locally
+    // before this response.
+    pub confirmed_local_execution: bool,
 }
 
 impl SuiExecuteTransactionResponse {
@@ -434,7 +431,7 @@ impl SuiExecuteTransactionResponse {
                 let certificate: SuiCertifiedTransaction = certificate.try_into()?;
                 let effects: SuiCertifiedTransactionEffects =
                     SuiCertifiedTransactionEffects::try_from(effects, resolver)?;
-                SuiExecuteTransactionResponse::EffectsCert {
+                SuiExecuteTransactionResponse {
                     certificate,
                     effects,
                     confirmed_local_execution: is_executed_locally,

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -81,7 +81,7 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
+    let SuiExecuteTransactionResponse { effects, .. } = tx_response;
     assert_eq!(
         dryrun_response.transaction_digest,
         effects.effects.transaction_digest
@@ -269,7 +269,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
-    matches!(tx_response, SuiExecuteTransactionResponse::EffectsCert {effects, ..} if effects.effects.created.len() == 6);
+    matches!(tx_response, SuiExecuteTransactionResponse {effects, ..} if effects.effects.created.len() == 6);
     Ok(())
 }
 
@@ -320,7 +320,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
-    matches!(tx_response, SuiExecuteTransactionResponse::EffectsCert {effects, ..} if effects.effects.created.len() == 1);
+    matches!(tx_response, SuiExecuteTransactionResponse {effects, ..} if effects.effects.created.len() == 1);
     Ok(())
 }
 
@@ -428,7 +428,7 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
+    let SuiExecuteTransactionResponse { effects, .. } = tx_response;
 
     let package_id = effects
         .effects
@@ -487,7 +487,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
+    let SuiExecuteTransactionResponse { effects, .. } = tx_response;
 
     let package_id = effects
         .effects
@@ -565,7 +565,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
+    let SuiExecuteTransactionResponse { effects, .. } = tx_response;
 
     assert_eq!(SuiExecutionStatus::Success, effects.effects.status);
 
@@ -619,7 +619,7 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
     for tx_digest in tx {
         let response: SuiTransactionResponse = http_client.get_transaction(tx_digest).await?;
         assert!(tx_responses.iter().any(
-            |resp| matches!(resp, SuiExecuteTransactionResponse::EffectsCert {effects, ..} if effects.effects.transaction_digest == response.effects.transaction_digest)
+            |resp| matches!(resp, SuiExecuteTransactionResponse {effects, ..} if effects.effects.transaction_digest == response.effects.transaction_digest)
         ))
     }
 

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -132,7 +132,7 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
+    let SuiExecuteTransactionResponse { effects, .. } = tx_response;
     assert_eq!(SuiExecutionStatus::Success, effects.effects.status);
 
     let package_id = effects
@@ -176,7 +176,7 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
+    let SuiExecuteTransactionResponse { effects, .. } = tx_response;
     assert_eq!(SuiExecutionStatus::Success, effects.effects.status);
 
     let randomness_object_id = effects
@@ -234,7 +234,7 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
             ExecuteTransactionRequestType::WaitForEffectsCert,
         )
         .await?;
-    let SuiExecuteTransactionResponse::EffectsCert { effects, .. } = tx_response;
+    let SuiExecuteTransactionResponse { effects, .. } = tx_response;
     assert_eq!(SuiExecutionStatus::Success, effects.effects.status);
 
     Ok(())

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5296,36 +5296,23 @@
         }
       },
       "SuiExecuteTransactionResponse": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "EffectsCert"
-            ],
-            "properties": {
-              "EffectsCert": {
-                "type": "object",
-                "required": [
-                  "certificate",
-                  "confirmed_local_execution",
-                  "effects"
-                ],
-                "properties": {
-                  "certificate": {
-                    "$ref": "#/components/schemas/CertifiedTransaction"
-                  },
-                  "confirmed_local_execution": {
-                    "type": "boolean"
-                  },
-                  "effects": {
-                    "$ref": "#/components/schemas/CertifiedTransactionEffects"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
+        "type": "object",
+        "required": [
+          "certificate",
+          "confirmed_local_execution",
+          "effects"
+        ],
+        "properties": {
+          "certificate": {
+            "$ref": "#/components/schemas/CertifiedTransaction"
+          },
+          "confirmed_local_execution": {
+            "type": "boolean"
+          },
+          "effects": {
+            "$ref": "#/components/schemas/CertifiedTransactionEffects"
           }
-        ]
+        }
       },
       "SuiExecutionResult": {
         "type": "object",

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -1035,7 +1035,7 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
             .await
             .unwrap();
 
-        let SuiExecuteTransactionResponse::EffectsCert {
+        let SuiExecuteTransactionResponse {
             certificate,
             effects: _,
             confirmed_local_execution,
@@ -1075,7 +1075,7 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
         .await
         .unwrap();
 
-    let SuiExecuteTransactionResponse::EffectsCert {
+    let SuiExecuteTransactionResponse {
         certificate,
         effects: _,
         confirmed_local_execution,
@@ -1100,7 +1100,7 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
         .await
         .unwrap();
 
-    let SuiExecuteTransactionResponse::EffectsCert {
+    let SuiExecuteTransactionResponse {
         certificate,
         effects: _,
         confirmed_local_execution,


### PR DESCRIPTION
as title, this is to clean up the leftover  from the Quorum Driver refactor