### PR TITLE
[epoch] Change Epoch transaction cannot fail to execute

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -99,13 +99,14 @@ impl CheckpointOutput for LogCheckpointOutput {
             summary.sequence_number, contents
         );
         info!(
-            "Creating checkpoint {:?} at epoch {}, sequence {}, previous digest {:?}, transactions count {}, content digest {:?}",
+            "Creating checkpoint {:?} at epoch {}, sequence {}, previous digest {:?}, transactions count {}, content digest {:?}, next_epoch_committee {:?}",
             Hex::encode(summary.digest()),
             summary.epoch,
             summary.sequence_number,
             summary.previous_digest.map(Hex::encode),
             contents.size(),
             Hex::encode(summary.content_digest),
+            summary.next_epoch_committee,
         );
 
         Ok(())

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -656,6 +656,13 @@ impl CheckpointBuilder {
             .state
             .try_execute_immediately(&cert, &self.epoch_store)
             .await?;
+        debug!(
+            "Effects of the change epoch transaction: {:?}",
+            signed_effect
+        );
+        // The change epoch transaction cannot fail to execute.
+        // TODO: Audit the advance_epoch move call to make sure there is no way for it to fail.
+        assert!(signed_effect.status.is_ok());
         effects.push(signed_effect.into_message());
         Ok(())
     }


### PR DESCRIPTION
It's unclear whether this holds today, but we must make sure it always execute successfully (i.e. Move cannot throw an exception). Add assertion and more debug info.