### PR TITLE
Record wrapped objects in the index store and use `object_to_owner_index` instead of `modified_at_version`

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4573,7 +4573,7 @@ async fn test_owner_index() {
 
     // create a inner object
     let create_inner_effects = create_move_object(
-        &object_basics,
+        &object_basics.0,
         &authority_state,
         &gas_object_id,
         &sender,
@@ -4598,7 +4598,7 @@ async fn test_owner_index() {
         &gas_object_id,
         &sender,
         &sender_key,
-        &object_basics,
+        &object_basics.0,
         "object_basics",
         "wrap_object",
         vec![],
@@ -4623,7 +4623,7 @@ async fn test_owner_index() {
         &gas_object_id,
         &sender,
         &sender_key,
-        &object_basics,
+        &object_basics.0,
         "object_basics",
         "unwrap_object",
         vec![],

--- a/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
+++ b/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
@@ -24,6 +24,11 @@ module examples::object_basics {
         new_value: u64
     }
 
+    struct ObjectWrapper has key, store {
+        id: UID,
+        object: Object,
+    }
+
     public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
         transfer::transfer(
             Object { id: object::new(ctx), value },
@@ -138,4 +143,20 @@ module examples::object_basics {
     public entry fun generic_test<T>() {}
 
     public entry fun use_clock(_clock: &Clock) {}
+
+    public entry fun wrap_object(object: Object, ctx: &mut TxContext) {
+        transfer::transfer(
+            ObjectWrapper { id: object::new(ctx), object },
+            tx_context::sender(ctx)
+        )
+    }
+
+    public entry fun unwrap_object(wrapper: ObjectWrapper, ctx: &mut TxContext) {
+        let ObjectWrapper{id, object } = wrapper;
+        object::delete(id);
+        transfer::transfer(
+            object,
+            tx_context::sender(ctx)
+        )
+    }
 }

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1070,7 +1070,7 @@ impl<T: SuiData> TryFrom<ObjectRead> for SuiObjectRead<T> {
 pub type GetPastObjectDataResponse = SuiPastObjectRead<SuiParsedData>;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
-#[serde(tag = "status", content = "details", rename = "ObjectRead")]
+#[serde(tag = "status", content = "details", rename = "PastObjectRead")]
 pub enum SuiPastObjectRead<T: SuiData> {
     /// The object exists and is found with this version
     VersionFound(SuiObject<T>),

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1086,6 +1086,10 @@ pub enum SuiPastObjectRead<T: SuiData> {
         asked_version: SequenceNumber,
         latest_version: SequenceNumber,
     },
+    Wrapped {
+        object_id: ObjectID,
+        wrapped_version: SequenceNumber,
+    },
 }
 
 impl<T: SuiData> SuiPastObjectRead<T> {
@@ -1112,6 +1116,13 @@ impl<T: SuiData> SuiPastObjectRead<T> {
                 object_id: *object_id,
                 asked_version: *asked_version,
                 latest_version: *latest_version,
+            }),
+            SuiPastObjectRead::Wrapped {
+                object_id,
+                wrapped_version,
+            } => Err(SuiError::ObjectWrapped {
+                object_id: *object_id,
+                version: *wrapped_version,
             }),
         }
     }
@@ -1140,6 +1151,13 @@ impl<T: SuiData> SuiPastObjectRead<T> {
                 asked_version,
                 latest_version,
             }),
+            SuiPastObjectRead::Wrapped {
+                object_id,
+                wrapped_version,
+            } => Err(SuiError::ObjectWrapped {
+                object_id,
+                version: wrapped_version,
+            }),
         }
     }
 }
@@ -1167,6 +1185,13 @@ impl<T: SuiData> TryFrom<PastObjectRead> for SuiPastObjectRead<T> {
                 object_id,
                 asked_version,
                 latest_version,
+            }),
+            PastObjectRead::Wrapped {
+                object_id,
+                wrapped_version,
+            } => Ok(SuiPastObjectRead::Wrapped {
+                object_id,
+                wrapped_version,
             }),
         }
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2833,7 +2833,7 @@
         "name": "GetPastObjectDataResponse",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/ObjectRead"
+          "$ref": "#/components/schemas/PastObjectRead"
         }
       },
       "examples": [
@@ -5192,6 +5192,161 @@
             ]
           }
         }
+      },
+      "PastObjectRead": {
+        "oneOf": [
+          {
+            "description": "The object exists and is found with this version",
+            "type": "object",
+            "required": [
+              "details",
+              "status"
+            ],
+            "properties": {
+              "details": {
+                "$ref": "#/components/schemas/Object"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "VersionFound"
+                ]
+              }
+            }
+          },
+          {
+            "description": "The object does not exist",
+            "type": "object",
+            "required": [
+              "details",
+              "status"
+            ],
+            "properties": {
+              "details": {
+                "$ref": "#/components/schemas/ObjectID"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "ObjectNotExists"
+                ]
+              }
+            }
+          },
+          {
+            "description": "The object is found to be deleted with this version",
+            "type": "object",
+            "required": [
+              "details",
+              "status"
+            ],
+            "properties": {
+              "details": {
+                "$ref": "#/components/schemas/ObjectRef"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "ObjectDeleted"
+                ]
+              }
+            }
+          },
+          {
+            "description": "The object exists but not found with this version",
+            "type": "object",
+            "required": [
+              "details",
+              "status"
+            ],
+            "properties": {
+              "details": {
+                "type": "array",
+                "items": [
+                  {
+                    "$ref": "#/components/schemas/ObjectID"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "VersionNotFound"
+                ]
+              }
+            }
+          },
+          {
+            "description": "The asked object version is higher than the latest",
+            "type": "object",
+            "required": [
+              "details",
+              "status"
+            ],
+            "properties": {
+              "details": {
+                "type": "object",
+                "required": [
+                  "asked_version",
+                  "latest_version",
+                  "object_id"
+                ],
+                "properties": {
+                  "asked_version": {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  },
+                  "latest_version": {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  },
+                  "object_id": {
+                    "$ref": "#/components/schemas/ObjectID"
+                  }
+                }
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "VersionTooHigh"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "details",
+              "status"
+            ],
+            "properties": {
+              "details": {
+                "type": "object",
+                "required": [
+                  "object_id",
+                  "wrapped_version"
+                ],
+                "properties": {
+                  "object_id": {
+                    "$ref": "#/components/schemas/ObjectID"
+                  },
+                  "wrapped_version": {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  }
+                }
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "Wrapped"
+                ]
+              }
+            }
+          }
+        ]
       },
       "Pay": {
         "type": "object",

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -387,6 +387,11 @@ pub enum SuiError {
     },
     #[error("Object deleted at reference {:?}.", object_ref)]
     ObjectDeleted { object_ref: ObjectRef },
+    #[error("Object [{}] wrapped at version {}.", object_id, version)]
+    ObjectWrapped {
+        object_id: ObjectID,
+        version: SequenceNumber,
+    },
     #[error("Object ID did not have the expected type")]
     BadObjectType { error: String },
     #[error("Move Execution failed")]

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -821,6 +821,10 @@ pub enum PastObjectRead {
         asked_version: SequenceNumber,
         latest_version: SequenceNumber,
     },
+    Wrapped {
+        object_id: ObjectID,
+        wrapped_version: SequenceNumber,
+    },
 }
 
 impl PastObjectRead {
@@ -845,6 +849,13 @@ impl PastObjectRead {
                 object_id,
                 asked_version,
                 latest_version,
+            }),
+            PastObjectRead::Wrapped {
+                object_id,
+                wrapped_version,
+            } => Err(SuiError::ObjectWrapped {
+                object_id,
+                version: wrapped_version,
             }),
         }
     }
@@ -875,6 +886,15 @@ impl Display for PastObjectRead {
                 latest_version,
             } => {
                 write!(f, "PastObjectRead::VersionTooHigh ({:?}, asked sequence number {:?}, latest sequence number {:?})", object_id, asked_version, latest_version)
+            }
+            PastObjectRead::Wrapped {
+                object_id,
+                wrapped_version,
+            } => {
+                write!(
+                    f,
+                    "PastObjectRead::Wrapped ({object_id}, {wrapped_version})"
+                )
             }
         }
     }


### PR DESCRIPTION
Notable changes: 
* Added wrapped object to the index store
* get_past_object query the indexstore for wrapped object info, instead of returning object not found.
* index_tx uses the new object to owner index instead of last modified at to work out the last owner information.