### PR TITLE
Run sim_tests under `cargo test/nextest` unless disabled

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,11 @@ env:
   # RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
 
+  # Tests written with #[sim_test] are often flaky if run as #[tokio::test] - this var
+  # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
+  # non-deterministic `test` job.
+  SUI_SKIP_SIMTESTS: 1
+
 jobs:
   diff:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,11 +30,6 @@ env:
   # RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
 
-  # Tests written with #[sim_test] are often flaky if run as #[tokio::test] - this var
-  # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
-  # non-deterministic `test` job.
-  SUI_SKIP_SIMTESTS: 1
-
 jobs:
   diff:
     runs-on: [ubuntu-latest]
@@ -67,6 +62,11 @@ jobs:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
+    env:
+      # Tests written with #[sim_test] are often flaky if run as #[tokio::test] - this var
+      # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
+      # non-deterministic `test` job.
+      SUI_SKIP_SIMTESTS: 1
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -170,14 +170,13 @@ pub fn sim_test(args: TokenStream, item: TokenStream) -> TokenStream {
 
                     struct Ret;
 
-                    impl Into<()> for Ret {
-                        fn into(self) -> () {
-                            ()
+                    impl From<Ret> for () {
+                        fn from(_ret: Ret) -> Self {
                         }
                     }
 
-                    impl<E> Into<Result<(), E>> for Ret {
-                        fn into(self) -> Result<(), E> {
+                    impl<E> From<Ret> for Result<(), E> {
+                        fn from(_ret: Ret) -> Self {
                             Ok(())
                         }
                     }

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -332,7 +332,6 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[allow(clippy::assertions_on_constants)]
 #[sim_test]
 async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await?;
@@ -418,10 +417,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     {
         new_objs.first().unwrap().reference.object_id
     } else {
-        // User assert since panic causes test issues
-        assert!(false);
-        // Use this to satisfy type checker
-        ObjectID::random()
+        panic!();
     };
 
     // Try a bad argument: decimal
@@ -499,7 +495,6 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[allow(clippy::assertions_on_constants)]
 #[sim_test]
 async fn test_package_publish_command() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await?;
@@ -551,7 +546,6 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[allow(clippy::assertions_on_constants)]
 #[sim_test]
 async fn test_native_transfer() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await?;
@@ -590,7 +584,6 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
                 mutated.get(1).unwrap().reference.object_id,
             )
         } else {
-            assert!(false);
             panic!()
         };
 
@@ -608,8 +601,6 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     {
         object
     } else {
-        // Fail this way because Panic! causes test issues
-        assert!(false);
         panic!()
     };
 
@@ -626,8 +617,6 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     {
         object
     } else {
-        // Fail this way because Panic! causes test issues
-        assert!(false);
         panic!()
     };
 
@@ -669,7 +658,6 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
                 mutated.get(1).unwrap().reference.object_id,
             )
         } else {
-            assert!(false);
             panic!()
         };
 
@@ -687,7 +675,6 @@ fn test_bug_1078() {
     write!(writer, "{:?}", read).unwrap();
 }
 
-#[allow(clippy::assertions_on_constants)]
 #[sim_test]
 async fn test_switch_command() -> Result<(), anyhow::Error> {
     let mut cluster = TestClusterBuilder::new().build().await?;
@@ -816,7 +803,6 @@ async fn test_new_address_command_by_flag() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[allow(clippy::assertions_on_constants)]
 #[sim_test]
 async fn test_active_address_command() -> Result<(), anyhow::Error> {
     let mut cluster = TestClusterBuilder::new().build().await?;
@@ -878,7 +864,6 @@ async fn get_parsed_object_assert_existence(
         .expect("Object {object_id} does not exist.")
 }
 
-#[allow(clippy::assertions_on_constants)]
 #[sim_test]
 async fn test_merge_coin() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await?;
@@ -969,7 +954,6 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[allow(clippy::assertions_on_constants)]
 #[sim_test]
 async fn test_split_coin() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await?;


### PR DESCRIPTION
When running locally, `cargo nextest` (or `cargo test`) will run `#[sim_test]` tests via `#[tokio::test]`, unless disabled by setting the environment variable `SUI_SKIP_SIMTESTS`.

`SUI_SKIP_SIMTESTS` is set in the Rust workflow, so this PR has no effect on CI runs.