### PR TITLE
[checkpoints] Introduce checkpoint timestamps

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -706,6 +706,7 @@ fn create_genesis_checkpoint(
         previous_digest: None,
         epoch_rolling_gas_cost_summary: Default::default(),
         next_epoch_committee: None,
+        timestamp_ms: 0, /*todo - put a proper timestamp*/
     };
 
     (checkpoint, contents)

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -63,7 +63,10 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         let checkpoint_seq = summary.sequence_number;
-        debug!("Sending checkpoint signature at sequence {checkpoint_seq} to consensus");
+        debug!(
+            "Sending checkpoint signature at sequence {checkpoint_seq} to consensus, timestamp {}",
+            summary.timestamp_ms
+        );
         LogCheckpointOutput
             .checkpoint_created(summary, contents, epoch_store)
             .await?;

--- a/crates/sui-network/src/state_sync/test_utils.rs
+++ b/crates/sui-network/src/state_sync/test_utils.rs
@@ -62,6 +62,7 @@ impl CommitteeFixture {
             previous_digest: None,
             epoch_rolling_gas_cost_summary: Default::default(),
             next_epoch_committee: None,
+            timestamp_ms: 0,
         };
 
         self.create_certified_checkpoint(checkpoint)
@@ -117,6 +118,7 @@ impl CommitteeFixture {
                 previous_digest: Some(prev.summary.digest()),
                 epoch_rolling_gas_cost_summary: Default::default(),
                 next_epoch_committee: None,
+                timestamp_ms: 0,
             };
 
             let checkpoint = self.create_certified_checkpoint(summary);
@@ -159,6 +161,7 @@ impl CommitteeFixture {
             previous_digest: Some(previous_checkpoint.summary.digest()),
             epoch_rolling_gas_cost_summary: Default::default(),
             next_epoch_committee: Some(next_epoch_committee),
+            timestamp_ms: 0,
         };
 
         let checkpoint = self.create_certified_checkpoint(summary);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -3019,7 +3019,8 @@
           "epoch",
           "epoch_rolling_gas_cost_summary",
           "network_total_transactions",
-          "sequence_number"
+          "sequence_number",
+          "timestamp_ms"
         ],
         "properties": {
           "content_digest": {
@@ -3077,6 +3078,12 @@
             ]
           },
           "sequence_number": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "timestamp_ms": {
+            "description": "Timestamp of the checkpoint - number of milliseconds from the Unix epoch Checkpoint timestamps are monotonic, but not strongly monotonic - subsequent checkpoints can have same timestamp if they originate from the same underlining consensus commit",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -100,6 +100,7 @@ pub fn mock_certified_checkpoint<'a>(
                 None,
                 GasCostSummary::default(),
                 None,
+                0,
             )
         })
         .collect();


### PR DESCRIPTION
This PR adds `CheckpointSummary::timestamp_ms` field and populates it from the time of narwhal commit