### PR TITLE
fix underterminism in simt test_tx_across_epoch_boundaries

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -79,7 +79,7 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
             .await?;
         if let Some(checkpoints_per_epoch) = self.checkpoints_per_epoch {
             if checkpoint_seq != 0 && checkpoint_seq % checkpoints_per_epoch == 0 {
-                self.sender.close_epoch(epoch_store)?;
+                self.sender.close_epoch(epoch_store);
             }
         }
         Ok(())

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -418,8 +418,8 @@ pub fn position_submit_certificate(
 impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
     /// This method is called externally to begin reconfiguration
     /// It transition reconfig state to reject new certificates from user
-    /// ConsensusAdapter will send EndOfPublish message once pending certificate queue is drained
-    fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) -> SuiResult {
+    /// ConsensusAdapter will send EndOfPublish message once pending certificate queue is drained.
+    fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
         let send_end_of_publish = {
             let reconfig_guard = epoch_store.get_reconfig_state_write_lock_guard();
             let send_end_of_publish = epoch_store.pending_consensus_certificates_empty();
@@ -435,7 +435,6 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
                 warn!("Error when sending end of publish message: {:?}", err);
             }
         }
-        Ok(())
     }
 }
 

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -4,7 +4,6 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use sui_types::error::SuiResult;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ReconfigCertStatus {
@@ -51,5 +50,5 @@ impl ReconfigState {
 }
 
 pub trait ReconfigurationInitiator {
-    fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) -> SuiResult;
+    fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>);
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -306,6 +306,7 @@ impl SuiNode {
         self.state.epoch()
     }
 
+    // Init reconfig process by starting to reject user certs
     pub async fn close_epoch(&self) -> SuiResult {
         info!("close_epoch (current epoch = {})", self.state.epoch());
         self.validator_components
@@ -316,7 +317,8 @@ impl SuiNode {
             .consensus_adapter
             // TODO: If this function is ever called in non-testing code, we need to make sure this
             // function has no race with the passive reconfiguration.
-            .close_epoch(&self.state.epoch_store())
+            .close_epoch(&self.state.epoch_store());
+        Ok(())
     }
 
     pub fn is_transaction_executed_in_checkpoint(

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -4,6 +4,7 @@
 use prometheus::Registry;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
+use sui_macros::sim_test;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::messages::{
     CertifiedTransaction, ExecuteTransactionRequest, ExecuteTransactionRequestType,
@@ -21,8 +22,6 @@ use test_utils::network::wait_for_nodes_transition_to_epoch;
 use test_utils::network::TestClusterBuilder;
 use test_utils::transaction::wait_for_tx;
 use tracing::info;
-
-use sui_macros::sim_test;
 
 #[sim_test]
 async fn test_blocking_execution() -> Result<(), anyhow::Error> {
@@ -203,39 +202,42 @@ async fn test_transaction_orchestrator_reconfig() {
 #[sim_test]
 async fn test_tx_across_epoch_boundaries() {
     telemetry_subscribers::init_for_testing();
-    let total_tx_cnt = 1800;
+    let total_tx_cnt = 1;
     let (sender, keypair) = get_key_pair::<AccountKeyPair>();
-    let gas_objects = generate_test_gas_objects_with_owner(total_tx_cnt, sender);
+    let gas_objects = generate_test_gas_objects_with_owner(1, sender);
     let (result_tx, mut result_rx) =
         tokio::sync::mpsc::channel::<CertifiedTransaction>(total_tx_cnt);
 
-    let (config, gas_objects) = test_authority_configs_with_objects(gas_objects);
+    let (config, mut gas_objects) = test_authority_configs_with_objects(gas_objects);
     let authorities = spawn_test_authorities([], &config).await;
     let fullnode = spawn_fullnode(&config, None).await;
+    let gas_object = gas_objects.swap_remove(0);
+    let data = TransactionData::new_transfer_sui_with_dummy_gas_price(
+        get_key_pair::<AccountKeyPair>().0,
+        sender,
+        None,
+        gas_object.compute_object_reference(),
+        5000,
+    );
+    let tx = to_sender_signed_transaction(data, &keypair);
 
-    let txes = gas_objects
-        .iter()
-        .map(|o| {
-            let data = TransactionData::new_transfer_sui_with_dummy_gas_price(
-                get_key_pair::<AccountKeyPair>().0,
-                sender,
-                None,
-                o.compute_object_reference(),
-                5000,
-            );
-            to_sender_signed_transaction(data, &keypair)
-        })
-        .collect::<Vec<_>>();
-    let to = fullnode.with(|node| node.transaction_orchestrator().unwrap());
+    // We first let 2 validators stop accepting user cert
+    // to make sure QD does not get quorum until reconfig
+    for handle in authorities.iter().take(2) {
+        handle
+            .with_async(|node| async { node.close_epoch().await.unwrap() })
+            .await;
+    }
 
-    // Spawn a task that fires transactions through TransactionOrchestrator
+    // Spawn a task that fire the transaction through TransactionOrchestrator
     // across the epoch boundary.
-    tokio::task::spawn(async move {
-        for tx in txes {
+    fullnode
+        .with_async(|node| async {
+            let to = node.transaction_orchestrator().unwrap();
             let tx_digest = *tx.digest();
             info!(?tx_digest, "Submitting tx");
             let tx = tx.into_inner();
-            loop {
+            tokio::task::spawn(async move {
                 match to
                     .execute_transaction(ExecuteTransactionRequest {
                         transaction: tx.clone(),
@@ -247,25 +249,19 @@ async fn test_tx_across_epoch_boundaries() {
                         info!(?tx_digest, "tx result: ok");
                         let (tx_cert, _, _) = *res;
                         result_tx.send(tx_cert).await.unwrap();
-                        break;
                     }
                     Err(QuorumDriverError::TimeoutBeforeFinality) => {
                         info!(?tx_digest, "tx result: timeout and will retry")
                     }
                     Err(other) => panic!("unexpected error: {:?}", other),
                 }
-                // Retry a transaction if it times out (e.g. in epoch boundary) after 500 ms.
-                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-            }
-        }
-    });
+            });
+        })
+        .await;
 
-    // uncomment this will cause fullnode not be able to advance epoch
-    // Wait for the task to start firing txes
-    // let tx_cert = result_rx.recv().await.unwrap();
-    // assert_eq!(tx_cert.auth_sig().epoch, 0);
-
-    for handle in &authorities {
+    info!("Asking remaining validators to change epoch");
+    // Ask the remaining 2 validators to close epoch
+    for handle in authorities.iter().skip(2) {
         handle
             .with_async(|node| async { node.close_epoch().await.unwrap() })
             .await;
@@ -278,18 +274,10 @@ async fn test_tx_across_epoch_boundaries() {
     wait_for_nodes_transition_to_epoch(std::iter::once(&fullnode), 1).await;
     info!("All nodes including fullnode finished");
 
-    // Newer transactions's cert must be in epoch 1
-    // Will all transactions finish in epoch 0?  Local testing results say
-    // unlikely with total_tx_size = 180.
-    loop {
-        match tokio::time::timeout(tokio::time::Duration::from_secs(60), result_rx.recv()).await {
-            Ok(Some(tx_cert)) => {
-                if tx_cert.auth_sig().epoch == 1 {
-                    return;
-                }
-            }
-            other => panic!("unexpected error: {:?}", other),
-        }
+    // The transaction must finalize in epoch 1
+    match tokio::time::timeout(tokio::time::Duration::from_secs(10), result_rx.recv()).await {
+        Ok(Some(tx_cert)) if tx_cert.auth_sig().epoch == 1 => (),
+        other => panic!("unexpected error: {:?}", other),
     }
 }
 


### PR DESCRIPTION
1. update `close_epoch` to return `()` since it doesn't return any error today
2. convert `test_tx_across_epoch_boundaries` to a `sim_test`, and fix the undeterminism because of race conditions. Now in the test case, we first ask two validators to close epoch, and then submit the transaction. The transaction will be retried because now 2 validators sign it but the rest 2 reject it. Then we ask the remaining 2 validators to change epoch as well. Eventually the transaction will go through in the new epoch.