### PR TITLE
indexer: add gas_price field to transaction table

### DIFF
--- a/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
@@ -20,6 +20,9 @@ CREATE TABLE transactions (
     computation_cost BIGINT NOT NULL,
     storage_cost BIGINT NOT NULL,
     storage_rebate BIGINT NOT NULL,
+    -- gas price from transaction data,
+    -- not the reference gas price
+    gas_price BIGINT NOT NULL,
     -- serialized transaction
     transaction_content TEXT NOT NULL,
     UNIQUE(transaction_digest) 

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -14,7 +14,7 @@ use crate::errors::IndexerError;
 use crate::schema::transactions::transaction_digest;
 use crate::PgPoolConnection;
 
-#[derive(Debug, Queryable)]
+#[derive(Clone, Debug, Queryable)]
 pub struct Transaction {
     pub id: i64,
     pub transaction_digest: String,
@@ -34,10 +34,11 @@ pub struct Transaction {
     pub computation_cost: i64,
     pub storage_cost: i64,
     pub storage_rebate: i64,
+    pub gas_price: i64,
     pub transaction_content: String,
 }
 
-#[derive(Debug, Insertable)]
+#[derive(Clone, Debug, Insertable)]
 #[diesel(table_name = transactions)]
 pub struct NewTransaction {
     pub transaction_digest: String,
@@ -57,6 +58,7 @@ pub struct NewTransaction {
     pub computation_cost: i64,
     pub storage_cost: i64,
     pub storage_rebate: i64,
+    pub gas_price: i64,
     pub transaction_content: String,
 }
 
@@ -130,6 +132,7 @@ pub fn transaction_response_to_new_transaction(
     // canonical txn digest string is Base58 encoded
     let tx_digest = cer.transaction_digest.base58_encode();
     let gas_budget = cer.data.gas_budget;
+    let gas_price = cer.data.gas_price;
     let sender = cer.data.sender.to_string();
     let txn_kind_iter = cer.data.transactions.iter().map(|k| k.to_string());
 
@@ -202,6 +205,7 @@ pub fn transaction_response_to_new_transaction(
         // NOTE: cast u64 to i64 here is safe because
         // max value of i64 is 9223372036854775807 MISTs, which is 9223372036.85 SUI, which is way bigger than budget or cost constant already.
         gas_budget: gas_budget as i64,
+        gas_price: gas_price as i64,
         total_gas_cost: (computation_cost + storage_cost) as i64 - (storage_rebate as i64),
         computation_cost: computation_cost as i64,
         storage_cost: storage_cost as i64,

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -165,6 +165,7 @@ diesel::table! {
         computation_cost -> Int8,
         storage_cost -> Int8,
         storage_rebate -> Int8,
+        gas_price -> Int8,
         transaction_content -> Text,
     }
 }


### PR DESCRIPTION
add `gas_price` field to transactions table.

tested with local validator to make sure txns table can be populated with gas_price
<img width="1526" alt="Screen Shot 2023-01-18 at 12 57 25 PM" src="https://user-images.githubusercontent.com/106119108/213281786-cffb35e5-4008-436d-915f-37525a3cde1c.png">
