### PR TITLE
[wallet-ext] Remove faucet for testnet

### DIFF
--- a/apps/wallet/src/ui/app/ApiProvider.ts
+++ b/apps/wallet/src/ui/app/ApiProvider.ts
@@ -24,7 +24,7 @@ type EnvInfo = {
 
 type ApiEndpoints = {
     fullNode: string;
-    faucet: string;
+    faucet?: string;
 } | null;
 export const API_ENV_TO_INFO: Record<API_ENV, EnvInfo> = {
     [API_ENV.local]: { name: 'Local' },
@@ -45,7 +45,8 @@ export const ENV_TO_API: Record<API_ENV, ApiEndpoints> = {
     [API_ENV.customRPC]: null,
     [API_ENV.testNet]: {
         fullNode: process.env.API_ENDPOINT_TEST_NET_FULLNODE || '',
-        faucet: process.env.API_ENDPOINT_TEST_NET_FAUCET || '',
+        // NOTE: Faucet is currently disabled for testnet:
+        // faucet: process.env.API_ENDPOINT_TEST_NET_FAUCET || '',
     },
 };
 

--- a/apps/wallet/src/ui/app/shared/faucet/request-button/index.tsx
+++ b/apps/wallet/src/ui/app/shared/faucet/request-button/index.tsx
@@ -6,7 +6,7 @@ import { toast } from 'react-hot-toast';
 
 import FaucetMessageInfo from '../message-info';
 import { useFaucetMutation } from '../useFaucetMutation';
-import { API_ENV_TO_INFO, API_ENV } from '_app/ApiProvider';
+import { API_ENV_TO_INFO } from '_app/ApiProvider';
 import Button from '_app/shared/button';
 import Icon, { SuiIcons } from '_components/icon';
 import { useAppSelector } from '_hooks';
@@ -27,9 +27,8 @@ function FaucetRequestButton({
 }: FaucetRequestButtonProps) {
     const network = useAppSelector(({ app }) => app.apiEnv);
     const networkName = API_ENV_TO_INFO[network].name.replace(/sui\s*/gi, '');
-    const showFaucetRequestButton = API_ENV.customRPC !== network;
     const mutation = useFaucetMutation();
-    return showFaucetRequestButton ? (
+    return mutation.enabled ? (
         <Button
             mode={mode}
             onClick={() => {

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
@@ -29,6 +29,8 @@ export function useFaucetMutation() {
     });
     return {
         ...mutation,
+        /** If the currently-configured endpoint supports faucet: */
+        enabled: !!api.endpoints.faucet,
         /**
          * is any faucet request in progress across different instances of the mutation
          */


### PR DESCRIPTION
This removes the faucet button for testnet. I removed the display check with a new one that checks to see if we have a faucet URL to begin with, which seems far more robust.