### PR TITLE
Ignore range tombstones during object table read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8688,6 +8688,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
+ "pprof",
  "pretty_assertions",
  "prometheus",
  "rand 0.8.5",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -33,6 +33,7 @@ tokio-retry = "0.3"
 scopeguard = "1.1"
 once_cell = "1.16"
 tap = "1.0"
+pprof = { version = "0.11.0", features = ["cpp", "frame-pointer"] }
 either = "1.8.0"
 rand = "0.8.5"
 sui-adapter = { path = "../sui-adapter" }

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -3,8 +3,9 @@
 
 use std::{sync::Arc, time::Duration};
 use sui_config::node::AuthorityStorePruningConfig;
+use sui_types::object::Object;
 use sui_types::{
-    base_types::{ObjectID, SequenceNumber, VersionNumber},
+    base_types::{ObjectID, VersionNumber},
     storage::ObjectKey,
 };
 use tokio::{
@@ -12,6 +13,7 @@ use tokio::{
     time::{self, Instant},
 };
 use tracing::log::{error, info};
+use typed_store::rocks::DBMap;
 use typed_store::Map;
 
 use super::authority_store_tables::AuthorityPerpetualTables;
@@ -23,11 +25,8 @@ pub struct AuthorityStorePruner {
 }
 
 impl AuthorityStorePruner {
-    fn prune_objects(
-        num_versions_to_retain: u64,
-        perpetual_db: Arc<AuthorityPerpetualTables>,
-    ) -> u64 {
-        let iter = perpetual_db.objects.iter().skip_to_last().reverse();
+    fn prune_objects(num_versions_to_retain: u64, objects: &DBMap<ObjectKey, Object>) -> u64 {
+        let iter = objects.iter().skip_to_last().reverse();
         let mut total_keys_scanned = 0;
         let mut total_objects_scanned = 0;
         let mut num_versions_for_key = 0;
@@ -36,7 +35,7 @@ impl AuthorityStorePruner {
         let mut delete_range_end: Option<VersionNumber> = None;
         let mut num_pending_wb_ops = 0;
         let mut total_pruned: u64 = 0;
-        let mut wb = perpetual_db.objects.batch();
+        let mut wb = objects.batch();
         for (key, _value) in iter {
             total_keys_scanned += 1;
             if let Some(obj_id) = object_id {
@@ -47,25 +46,25 @@ impl AuthorityStorePruner {
                     {
                         let start = ObjectKey(obj_id, start_seq_num);
                         let end = ObjectKey(obj_id, end_seq_num);
-                        if let Ok(new_wb) = wb.delete_range(&perpetual_db.objects, &start, &end) {
+                        if let Ok(new_wb) = wb.delete_range(objects, &start, &end) {
                             wb = new_wb;
                             num_pending_wb_ops += 1;
                         } else {
                             error!("Failed to invoke delete_range on write batch while compacting objects");
-                            wb = perpetual_db.objects.batch();
+                            wb = objects.batch();
                             num_pending_wb_ops = 0;
                             break;
                         }
                         if num_pending_wb_ops >= MAX_OPS_IN_ONE_WRITE_BATCH {
                             if wb.write().is_err() {
                                 error!("Failed to commit write batch while compacting objects");
-                                wb = perpetual_db.objects.batch();
+                                wb = objects.batch();
                                 num_pending_wb_ops = 0;
                                 break;
                             } else {
                                 info!("Committed write batch while compacting objects, keys scanned = {:?}, objects scanned = {:?}", total_keys_scanned, total_objects_scanned);
                             }
-                            wb = perpetual_db.objects.batch();
+                            wb = objects.batch();
                             num_pending_wb_ops = 0;
                         }
                     }
@@ -99,12 +98,12 @@ impl AuthorityStorePruner {
             {
                 let start = ObjectKey(obj_id, start_seq_num);
                 let end = ObjectKey(obj_id, end_seq_num);
-                if let Ok(new_wb) = wb.delete_range(&perpetual_db.objects, &start, &end) {
+                if let Ok(new_wb) = wb.delete_range(objects, &start, &end) {
                     wb = new_wb;
                     num_pending_wb_ops += 1;
                 } else {
                     error!("Failed to invoke delete_range on write batch while compacting objects");
-                    wb = perpetual_db.objects.batch();
+                    wb = objects.batch();
                     num_pending_wb_ops = 0;
                 }
             }
@@ -145,32 +144,13 @@ impl AuthorityStorePruner {
                 tokio::select! {
                     _ = prune_interval.tick() => {
                         info!("Starting pruning of objects table");
-                        let num_pruned = Self::prune_objects(num_versions_to_retain, perpetual_db.clone());
+                        let num_pruned = Self::prune_objects(num_versions_to_retain, &perpetual_db.objects);
                         info!("Finished pruning with total object versions pruned = {}", num_pruned);
                         if let Ok(()) = perpetual_db.objects.flush() {
                             info!("Completed flushing objects table");
                         } else {
                             error!("Failed to flush objects table");
                         }
-                        let start = Instant::now();
-                        let min_key = ObjectKey(ObjectID::ZERO, SequenceNumber::MIN);
-                        let max_key = ObjectKey(ObjectID::MAX, SequenceNumber::MAX);
-                        if let Ok(()) = perpetual_db.objects.set_options(&[("disable_auto_compactions", "true")]) {
-                            info!("Disabled auto compaction for objects table");
-                            if let Ok(()) = perpetual_db.objects.compact_range(&min_key, &max_key) {
-                                info!("Completed compaction of objects table in {:?}", start.elapsed());
-                            } else {
-                                error!("Failed to compact objects table in  {:?}", start.elapsed());
-                            }
-                            if let Ok(()) = perpetual_db.objects.set_options(&[("disable_auto_compactions", "false")]) {
-                                info!("Enabled auto compaction for objects table");
-                            } else {
-                                error!("Failed to enable auto compaction on objects table");
-                            }
-                        } else {
-                            error!("Failed to disable auto compaction on object table");
-                        }
-
                     }
                     _ = &mut recv => break,
                 }
@@ -195,69 +175,133 @@ impl AuthorityStorePruner {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, sync::Arc};
-
-    use crate::authority::authority_store_tables::AuthorityPerpetualTables;
     use fs_extra::dir::get_size;
     use more_asserts as ma;
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+    use std::{collections::HashSet, sync::Arc};
+    use tracing::log::{error, info};
+
+    use crate::authority::authority_store_tables::AuthorityPerpetualTables;
+    use pprof::Symbol;
+    use sui_types::base_types::VersionNumber;
     use sui_types::{
         base_types::{ObjectID, SequenceNumber},
         object::Object,
         storage::ObjectKey,
     };
-    use tracing::log::info;
+    use typed_store::rocks::{DBMap, MetricConf, ReadWriteOptions};
     use typed_store::Map;
 
     use super::AuthorityStorePruner;
 
-    async fn test_pruning(
-        perpetual_db: Arc<AuthorityPerpetualTables>,
-        num_versions_per_object: u64,
-        num_object_versions_to_retain: u64,
-        total_unique_object_ids: u32,
-    ) -> Result<u64, anyhow::Error> {
-        // this contains the set of keys that should not have been pruned
-        let mut expected = HashSet::new();
-        let ids = ObjectID::in_range(ObjectID::ZERO, total_unique_object_ids.into())?;
+    fn get_keys_after_pruning(db_path: PathBuf) -> anyhow::Result<HashSet<ObjectKey>> {
+        let perpetual_db_path = db_path.join(Path::new("perpetual"));
+        let cf_names = AuthorityPerpetualTables::describe_tables();
+        let cfs: Vec<&str> = cf_names.keys().map(|x| x.as_str()).collect();
+        let perpetual_db =
+            typed_store::rocks::open_cf(perpetual_db_path, None, MetricConf::default(), &cfs);
+
+        let mut after_pruning = HashSet::new();
+        let objects = DBMap::<ObjectKey, Object>::reopen(
+            &perpetual_db?,
+            Some("objects"),
+            // open the db to bypass default db options which ignores range tombstones
+            // so we can read the accurate number of retained versions
+            &ReadWriteOptions::default(),
+        )?;
+        let iter = objects.iter();
+        for (k, _v) in iter {
+            after_pruning.insert(k);
+        }
+        Ok(after_pruning)
+    }
+
+    fn is_rocksdb_range_tombstone_frame(vs: &[Symbol]) -> bool {
+        for symbol in vs.iter() {
+            if symbol
+                .name()
+                .contains("rocksdb::FragmentedRangeTombstoneList")
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn insert_keys(objects: &DBMap<ObjectKey, Object>) -> Result<(), anyhow::Error> {
+        let total_unique_object_ids = 100_000;
+        let num_versions_per_object = 10;
+        let ids = ObjectID::in_range(ObjectID::ZERO, total_unique_object_ids)?;
         for id in ids {
-            for (counter, i) in (0..num_versions_per_object).rev().enumerate() {
-                let object_key = ObjectKey(id, SequenceNumber::from_u64(i));
-                if counter < num_object_versions_to_retain.try_into().unwrap() {
-                    // latest `num_object_versions_to_retain` should not have been pruned
-                    expected.insert(object_key);
-                }
-                perpetual_db.objects.insert(
+            for i in (0..num_versions_per_object).rev() {
+                objects.insert(
                     &ObjectKey(id, SequenceNumber::from(i)),
                     &Object::immutable_with_id_for_testing(id),
                 )?;
             }
         }
-        assert_eq!(
-            expected.len() as u64,
-            std::cmp::min(num_object_versions_to_retain, num_versions_per_object)
-                * total_unique_object_ids as u64
-        );
-        let total_pruned = AuthorityStorePruner::prune_objects(
-            num_object_versions_to_retain,
-            perpetual_db.clone(),
-        );
-        let mut after_pruning = HashSet::new();
-        let iter = perpetual_db.objects.iter();
-        for (k, _v) in iter {
-            after_pruning.insert(k);
+        Ok(())
+    }
+
+    fn read_keys(objects: &DBMap<ObjectKey, Object>) -> Result<(), anyhow::Error> {
+        let mut i = 0;
+        while i < 1000 {
+            let _res = objects.get(&ObjectKey(ObjectID::random(), VersionNumber::MAX))?;
+            i += 1;
         }
+        Ok(())
+    }
+
+    async fn test_pruning(
+        primary_path: PathBuf,
+        num_versions_per_object: u64,
+        num_object_versions_to_retain: u64,
+        total_unique_object_ids: u32,
+    ) -> Result<u64, anyhow::Error> {
+        let mut expected = HashSet::new();
+        let total_pruned = {
+            // create db
+            // let primary_path = tempfile::tempdir()?.into_path();
+            let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
+            // this contains the set of keys that should not have been pruned
+
+            let ids = ObjectID::in_range(ObjectID::ZERO, total_unique_object_ids.into())?;
+            for id in ids {
+                for (counter, i) in (0..num_versions_per_object).rev().enumerate() {
+                    let object_key = ObjectKey(id, SequenceNumber::from_u64(i));
+                    if counter < num_object_versions_to_retain.try_into().unwrap() {
+                        // latest `num_object_versions_to_retain` should not have been pruned
+                        expected.insert(object_key);
+                    }
+                    perpetual_db.objects.insert(
+                        &ObjectKey(id, SequenceNumber::from(i)),
+                        &Object::immutable_with_id_for_testing(id),
+                    )?;
+                }
+            }
+            assert_eq!(
+                expected.len() as u64,
+                std::cmp::min(num_object_versions_to_retain, num_versions_per_object)
+                    * total_unique_object_ids as u64
+            );
+            AuthorityStorePruner::prune_objects(
+                num_object_versions_to_retain,
+                &perpetual_db.objects,
+            )
+        };
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let after_pruning = get_keys_after_pruning(primary_path)?;
         assert_eq!(expected, after_pruning);
         Ok(total_pruned)
     }
 
     #[tokio::test]
-    async fn test_rights_versions_are_pruned() -> Result<(), anyhow::Error> {
+    async fn test_correct_object_versions_are_pruned() -> Result<(), anyhow::Error> {
         {
-            let primary_path = tempfile::tempdir()?.into_path();
-            let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
             // add 3 versions for every object id and 1000 unique object ids
             let total_pruned = test_pruning(
-                perpetual_db,
+                tempfile::tempdir()?.into_path(),
                 /* num_versions_per_object */ 3,
                 /* num_object_versions_to_retain */ 2,
                 /* total_unique_object_ids */ 1000,
@@ -267,11 +311,9 @@ mod tests {
             assert_eq!(1000, total_pruned.unwrap());
         }
         {
-            let primary_path = tempfile::tempdir()?.into_path();
-            let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
             // add 3 versions for every object id and 1000 unique object ids
             let total_pruned = test_pruning(
-                perpetual_db,
+                tempfile::tempdir()?.into_path(),
                 /* num_versions_per_object */ 2,
                 /* num_object_versions_to_retain */ 2,
                 /* total_unique_object_ids */ 1000,
@@ -281,11 +323,9 @@ mod tests {
             assert_eq!(0, total_pruned.unwrap());
         }
         {
-            let primary_path = tempfile::tempdir()?.into_path();
-            let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
             // add 3 versions for every object id and 1000 unique object ids
             let total_pruned = test_pruning(
-                perpetual_db,
+                tempfile::tempdir()?.into_path(),
                 /* num_versions_per_object */ 1,
                 /* num_object_versions_to_retain */ 2,
                 /* total_unique_object_ids */ 1000,
@@ -313,10 +353,9 @@ mod tests {
             }
         }
         perpetual_db.objects.rocksdb.flush()?;
-
         let before_compaction_size = get_size(primary_path.clone()).unwrap();
 
-        let total_pruned = AuthorityStorePruner::prune_objects(2, perpetual_db.clone());
+        let total_pruned = AuthorityStorePruner::prune_objects(2, &perpetual_db.objects);
         info!("Total pruned keys = {:?}", total_pruned);
         let start = ObjectKey(ObjectID::ZERO, SequenceNumber::MIN);
         let end = ObjectKey(ObjectID::MAX, SequenceNumber::MAX);
@@ -329,6 +368,99 @@ mod tests {
             before_compaction_size, after_compaction_size
         );
         ma::assert_le!(after_compaction_size, before_compaction_size);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ensure_tombstone_fragmentation_in_stack_frame_without_ignore_range_delete(
+    ) -> Result<(), anyhow::Error> {
+        // This test writes a bunch of objects to objects table, invokes pruning on it and
+        // then does a bunch of get(). We open the db with `ignore_range_delete` set to false.
+        // We then record a cpu profile of the `get()` calls and find a range fragmentation stack frame
+        // in it.
+        let primary_path = tempfile::tempdir()?.into_path();
+        let perpetual_db_path = primary_path.join(Path::new("perpetual"));
+        let cf_names = AuthorityPerpetualTables::describe_tables();
+        let cfs: Vec<&str> = cf_names.keys().map(|x| x.as_str()).collect();
+        let perpetual_db =
+            typed_store::rocks::open_cf(perpetual_db_path, None, MetricConf::default(), &cfs);
+        let objects = DBMap::<ObjectKey, Object>::reopen(
+            &perpetual_db?,
+            Some("objects"),
+            &ReadWriteOptions {
+                // Disable `ignore_range_delete` so we can see rocksdb trying to
+                // fragment range tombstones during `get()` calls
+                ignore_range_deletions: false,
+            },
+        )?;
+        insert_keys(&objects)?;
+        let _total_pruned = AuthorityStorePruner::prune_objects(2, &objects);
+        let guard = pprof::ProfilerGuardBuilder::default()
+            .frequency(1000)
+            .build()
+            .unwrap();
+        read_keys(&objects)?;
+        if let Ok(report) = guard.report().build() {
+            assert!(report.data.keys().any(|f| f
+                .frames
+                .iter()
+                .any(|vs| is_rocksdb_range_tombstone_frame(vs))));
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ensure_no_tombstone_fragmentation_in_stack_frame_with_ignore_tombstones(
+    ) -> Result<(), anyhow::Error> {
+        // This test writes a bunch of objects to objects table, invokes pruning on it and
+        // then does a bunch of get(). We open the db with `ignore_range_delete` set to true (default mode).
+        // We then record a cpu profile of the `get()` calls and do not find any range fragmentation stack frame
+        // in it.
+        let primary_path = tempfile::tempdir()?.into_path();
+        let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
+        insert_keys(&perpetual_db.objects)?;
+        let _total_pruned = AuthorityStorePruner::prune_objects(2, &perpetual_db.objects);
+        let guard = pprof::ProfilerGuardBuilder::default()
+            .frequency(1000)
+            .build()
+            .unwrap();
+        read_keys(&perpetual_db.objects)?;
+        if let Ok(report) = guard.report().build() {
+            assert!(!report.data.keys().any(|f| f
+                .frames
+                .iter()
+                .any(|vs| is_rocksdb_range_tombstone_frame(vs))));
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ensure_no_tombstone_fragmentation_in_stack_frame_after_flush(
+    ) -> Result<(), anyhow::Error> {
+        // This test writes a bunch of objects to objects table, invokes pruning on it and
+        // then does a bunch of get(). We open the db with `ignore_range_delete` set to true (default mode).
+        // We then record a cpu profile of the `get()` calls and do not find any range fragmentation stack frame
+        // in it.
+        let primary_path = tempfile::tempdir()?.into_path();
+        let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
+        insert_keys(&perpetual_db.objects)?;
+        let _total_pruned = AuthorityStorePruner::prune_objects(2, &perpetual_db.objects);
+        if let Ok(()) = perpetual_db.objects.flush() {
+            info!("Completed flushing objects table");
+        } else {
+            error!("Failed to flush objects table");
+        }
+        let guard = pprof::ProfilerGuardBuilder::default()
+            .frequency(1000)
+            .build()
+            .unwrap();
+        read_keys(&perpetual_db.objects)?;
+        if let Ok(report) = guard.report().build() {
+            assert!(!report.data.keys().any(|f| f
+                .frames
+                .iter()
+                .any(|vs| is_rocksdb_range_tombstone_frame(vs))));
+        }
         Ok(())
     }
 }

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -9,7 +9,7 @@ use sui_storage::default_db_options;
 use sui_types::base_types::SequenceNumber;
 use sui_types::messages::TrustedCertificate;
 use typed_store::metrics::SamplingInterval;
-use typed_store::rocks::{DBMap, DBOptions, MetricConf};
+use typed_store::rocks::{DBMap, DBOptions, MetricConf, ReadWriteOptions};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 
 use typed_store_derive::DBMapUtils;
@@ -214,7 +214,13 @@ fn owned_object_transaction_locks_table_default_config() -> DBOptions {
     default_db_options(None, None).1
 }
 fn objects_table_default_config() -> DBOptions {
-    default_db_options(None, None).1
+    let db_options = default_db_options(None, None).1;
+    DBOptions {
+        options: db_options.options,
+        rw_options: ReadWriteOptions {
+            ignore_range_deletions: true,
+        },
+    }
 }
 fn certificates_table_default_config() -> DBOptions {
     default_db_options(None, None).1

--- a/crates/sui-storage/src/lib.rs
+++ b/crates/sui-storage/src/lib.rs
@@ -10,7 +10,9 @@ pub mod write_ahead_log;
 pub mod write_path_pending_tx_log;
 
 use rocksdb::Options;
-use typed_store::rocks::{default_db_options as default_rocksdb_options, DBOptions};
+use typed_store::rocks::{
+    default_db_options as default_rocksdb_options, DBOptions, ReadWriteOptions,
+};
 
 /// Given a provided `db_options`, add a few default options.
 /// Returns the default option and the point lookup option.
@@ -19,7 +21,10 @@ pub fn default_db_options(
     cache_capacity: Option<usize>,
 ) -> (DBOptions, DBOptions) {
     let mut db_options = db_options
-        .map(|o| DBOptions { options: o })
+        .map(|o| DBOptions {
+            options: o,
+            rw_options: ReadWriteOptions::default(),
+        })
         .unwrap_or_else(default_rocksdb_options);
 
     // One common issue when running tests on Mac is that the default ulimit is too low,

--- a/crates/typed-store/src/tests/store_tests.rs
+++ b/crates/typed-store/src/tests/store_tests.rs
@@ -12,9 +12,14 @@ fn temp_dir() -> std::path::PathBuf {
 #[tokio::test]
 async fn create_store() {
     // Create new store.
-    let db =
-        rocks::DBMap::<usize, String>::open(temp_dir(), rocks::MetricConf::default(), None, None)
-            .unwrap();
+    let db = rocks::DBMap::<usize, String>::open(
+        temp_dir(),
+        rocks::MetricConf::default(),
+        None,
+        None,
+        &rocks::ReadWriteOptions::default(),
+    )
+    .unwrap();
     let _ = Store::<usize, String>::new(db);
 }
 
@@ -26,6 +31,7 @@ async fn read_async_write_value() {
         rocks::MetricConf::default(),
         None,
         None,
+        &rocks::ReadWriteOptions::default(),
     )
     .unwrap();
     let store = Store::new(db);
@@ -51,6 +57,7 @@ async fn read_sync_write_value() {
         rocks::MetricConf::default(),
         None,
         None,
+        &rocks::ReadWriteOptions::default(),
     )
     .unwrap();
     let store = Store::new(db);
@@ -71,9 +78,14 @@ async fn read_sync_write_value() {
 #[tokio::test]
 async fn read_raw_write_value() {
     // Create new store.
-    let db =
-        rocks::DBMap::<Vec<u8>, String>::open(temp_dir(), rocks::MetricConf::default(), None, None)
-            .unwrap();
+    let db = rocks::DBMap::<Vec<u8>, String>::open(
+        temp_dir(),
+        rocks::MetricConf::default(),
+        None,
+        None,
+        &rocks::ReadWriteOptions::default(),
+    )
+    .unwrap();
     let store = Store::new(db);
 
     // Write value to the store.
@@ -97,6 +109,7 @@ async fn read_unknown_key() {
         rocks::MetricConf::default(),
         None,
         None,
+        &rocks::ReadWriteOptions::default(),
     )
     .unwrap();
     let store = Store::new(db);
@@ -116,6 +129,7 @@ async fn read_notify() {
         rocks::MetricConf::default(),
         None,
         None,
+        &rocks::ReadWriteOptions::default(),
     )
     .unwrap();
     let store = Store::new(db);
@@ -149,6 +163,7 @@ async fn remove_all_successfully() {
         rocks::MetricConf::default(),
         None,
         None,
+        &rocks::ReadWriteOptions::default(),
     )
     .unwrap();
     let store = Store::new(db);
@@ -187,6 +202,7 @@ async fn write_and_read_all_successfully() {
         rocks::MetricConf::default(),
         None,
         None,
+        &rocks::ReadWriteOptions::default(),
     )
     .unwrap();
     let store = Store::new(db);
@@ -225,6 +241,7 @@ async fn iter_successfully() {
         rocks::MetricConf::default(),
         None,
         None,
+        &rocks::ReadWriteOptions::default(),
     )
     .unwrap();
     let store = Store::new(db);
@@ -257,6 +274,7 @@ async fn iter_and_filter_successfully() {
         rocks::MetricConf::default(),
         None,
         None,
+        &rocks::ReadWriteOptions::default(),
     )
     .unwrap();
     let store = Store::new(db);

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -36,7 +36,6 @@ struct Tables {
     table1: DBMap<String, String>,
     table2: DBMap<i32, String>,
 }
-
 // Check that generics work
 #[derive(DBMapUtils)]
 struct TablesGenerics<Q, W> {

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -132,6 +132,7 @@ console-subscriber = { version = "0.1" }
 const-oid = { version = "0.9", default-features = false }
 constant_time_eq = { version = "0.2", default-features = false }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
+cpp_demangle = { version = "0.4" }
 crc = { version = "3", default-features = false }
 crc-catalog = { version = "2", default-features = false }
 crc32fast = { version = "1" }
@@ -161,6 +162,7 @@ data-encoding = { version = "2" }
 data-encoding-macro = { version = "0.1", default-features = false }
 datatest-stable = { version = "0.1", default-features = false }
 debug-ignore = { version = "1", default-features = false }
+debugid = { version = "0.8", default-features = false }
 der = { version = "0.6", default-features = false, features = ["oid", "std", "zeroize"] }
 der-parser = { version = "8", features = ["bigint"] }
 derive_builder = { version = "0.12" }
@@ -206,6 +208,7 @@ fd-lock = { version = "3", default-features = false }
 fdlimit = { version = "0.2", default-features = false }
 ff = { version = "0.12", default-features = false }
 fiat-crypto = { version = "0.1" }
+findshlibs = { version = "0.10", default-features = false }
 fixed-hash = { version = "0.7", default-features = false, features = ["std"] }
 fixedbitset-6f8ce4dd05d13bba = { package = "fixedbitset", version = "0.2", default-features = false }
 fixedbitset-9fbad63c4bcf4a8f = { package = "fixedbitset", version = "0.4", default-features = false }
@@ -305,7 +308,7 @@ lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", defau
 lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false }
 leb128 = { version = "0.2", default-features = false }
 lexical-core = { version = "0.7" }
-libc = { version = "0.2" }
+libc = { version = "0.2", features = ["extra_traits"] }
 libm = { version = "0.2" }
 librocksdb-sys = { version = "0.8", features = ["bzip2", "lz4", "snappy", "zlib", "zstd"] }
 libsqlite3-sys = { version = "0.25", default-features = false, features = ["bundled", "pkg-config", "unlock_notify", "vcpkg"] }
@@ -319,6 +322,7 @@ matchers = { version = "0.1", default-features = false }
 matchit-d8f496e17d97b5cb = { package = "matchit", version = "0.5" }
 matchit-ca01ad9e24f5d932 = { package = "matchit", version = "0.7" }
 memchr = { version = "2", features = ["use_std"] }
+memmap2 = { version = "0.5", default-features = false }
 memoffset-ca01ad9e24f5d932 = { package = "memoffset", version = "0.7" }
 merlin = { version = "3" }
 mime = { version = "0.3", default-features = false }
@@ -371,6 +375,7 @@ nested = { version = "0.1", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "78f131b6e56b7d2dc7419997bc757f015f6d58df", default-features = false }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "78f131b6e56b7d2dc7419997bc757f015f6d58df", default-features = false }
 nibble_vec = { version = "0.1", default-features = false }
+nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "signal"] }
 no-std-compat = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 nom-cdf1610d3e1514e9 = { package = "nom", version = "5" }
 nom-a490c3000a992113 = { package = "nom", version = "6" }
@@ -432,6 +437,7 @@ plotters-backend = { version = "0.3", default-features = false }
 plotters-svg = { version = "0.3", default-features = false }
 polyval = { version = "0.6", default-features = false }
 portable-atomic = { version = "0.3" }
+pprof = { version = "0.11", features = ["frame-pointer"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 pq-sys = { version = "0.4", default-features = false }
 predicates = { version = "2" }
@@ -557,6 +563,8 @@ structopt = { version = "0.3" }
 strum = { version = "0.24", features = ["derive"] }
 subtle = { version = "2", default-features = false, features = ["i128", "std"] }
 subtle-ng = { version = "2", default-features = false, features = ["std"] }
+symbolic-common = { version = "10", default-features = false }
+symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
 tabular = { version = "0.2", features = ["ansi-cell"] }
@@ -799,6 +807,7 @@ constant_time_eq = { version = "0.2", default-features = false }
 convert_case-9fbad63c4bcf4a8f = { package = "convert_case", version = "0.4", default-features = false }
 convert_case-3b31131e45eafb45 = { package = "convert_case", version = "0.6", default-features = false }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
+cpp_demangle = { version = "0.4" }
 crc = { version = "3", default-features = false }
 crc-catalog = { version = "2", default-features = false }
 crc32fast = { version = "1" }
@@ -832,6 +841,7 @@ data-encoding-macro = { version = "0.1", default-features = false }
 data-encoding-macro-internal = { version = "0.1", default-features = false }
 datatest-stable = { version = "0.1", default-features = false }
 debug-ignore = { version = "1", default-features = false }
+debugid = { version = "0.8", default-features = false }
 der = { version = "0.6", default-features = false, features = ["oid", "std", "zeroize"] }
 der-parser = { version = "8", features = ["bigint"] }
 derivative = { version = "2", default-features = false, features = ["use_core"] }
@@ -886,6 +896,7 @@ fd-lock = { version = "3", default-features = false }
 fdlimit = { version = "0.2", default-features = false }
 ff = { version = "0.12", default-features = false }
 fiat-crypto = { version = "0.1" }
+findshlibs = { version = "0.10", default-features = false }
 fixed-hash = { version = "0.7", default-features = false, features = ["std"] }
 fixedbitset-6f8ce4dd05d13bba = { package = "fixedbitset", version = "0.2", default-features = false }
 fixedbitset-9fbad63c4bcf4a8f = { package = "fixedbitset", version = "0.4", default-features = false }
@@ -996,7 +1007,7 @@ lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default
 lazycell = { version = "1", default-features = false }
 leb128 = { version = "0.2", default-features = false }
 lexical-core = { version = "0.7" }
-libc = { version = "0.2" }
+libc = { version = "0.2", features = ["extra_traits"] }
 libloading = { version = "0.7", default-features = false }
 libm = { version = "0.2" }
 librocksdb-sys = { version = "0.8", features = ["bzip2", "lz4", "snappy", "zlib", "zstd"] }
@@ -1011,6 +1022,7 @@ matchers = { version = "0.1", default-features = false }
 matchit-d8f496e17d97b5cb = { package = "matchit", version = "0.5" }
 matchit-ca01ad9e24f5d932 = { package = "matchit", version = "0.7" }
 memchr = { version = "2", features = ["use_std"] }
+memmap2 = { version = "0.5", default-features = false }
 memoffset-ca01ad9e24f5d932 = { package = "memoffset", version = "0.7" }
 merlin = { version = "3" }
 mime = { version = "0.3", default-features = false }
@@ -1066,6 +1078,7 @@ nested = { version = "0.1", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "78f131b6e56b7d2dc7419997bc757f015f6d58df", default-features = false }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "78f131b6e56b7d2dc7419997bc757f015f6d58df", default-features = false }
 nibble_vec = { version = "0.1", default-features = false }
+nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "signal"] }
 no-std-compat = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 nom-cdf1610d3e1514e9 = { package = "nom", version = "5" }
 nom-a490c3000a992113 = { package = "nom", version = "6" }
@@ -1141,6 +1154,7 @@ plotters-backend = { version = "0.3", default-features = false }
 plotters-svg = { version = "0.3", default-features = false }
 polyval = { version = "0.6", default-features = false }
 portable-atomic = { version = "0.3" }
+pprof = { version = "0.11", features = ["frame-pointer"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 pq-sys = { version = "0.4", default-features = false }
 predicates = { version = "2" }
@@ -1294,6 +1308,8 @@ strum_macros = { version = "0.24", default-features = false }
 subprocess = { version = "0.2", default-features = false }
 subtle = { version = "2", default-features = false, features = ["i128", "std"] }
 subtle-ng = { version = "2", default-features = false, features = ["std"] }
+symbolic-common = { version = "10", default-features = false }
+symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "full", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
@@ -1423,28 +1439,22 @@ zstd-sys = { version = "2" }
 [target.aarch64-apple-darwin.dependencies]
 core-foundation = { version = "0.9", default-features = false }
 core-foundation-sys = { version = "0.8", default-features = false }
-cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
-debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8" }
 errno = { version = "0.2", default-features = false }
-findshlibs = { version = "0.10", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 inferno = { version = "0.11", default-features = false, features = ["nameattr"] }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
-libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 mach = { version = "0.3" }
-memmap2 = { version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 native-tls = { version = "0.2", default-features = false }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "signal"] }
 num-format = { version = "0.4", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
-pprof = { version = "0.11", features = ["criterion", "flamegraph"] }
+pprof = { version = "0.11", default-features = false, features = ["criterion", "flamegraph"] }
 quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rgb = { version = "0.8" }
@@ -1455,8 +1465,6 @@ signal-hook = { version = "0.3" }
 signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
 str_stack = { version = "0.1", default-features = false }
-symbolic-common = { version = "10", default-features = false }
-symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
@@ -1464,28 +1472,22 @@ web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 autotools = { version = "0.2", default-features = false }
 core-foundation = { version = "0.9", default-features = false }
 core-foundation-sys = { version = "0.8", default-features = false }
-cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
-debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8" }
 errno = { version = "0.2", default-features = false }
-findshlibs = { version = "0.10", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 inferno = { version = "0.11", default-features = false, features = ["nameattr"] }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
-libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 mach = { version = "0.3" }
-memmap2 = { version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 native-tls = { version = "0.2", default-features = false }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "signal"] }
 num-format = { version = "0.4", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
-pprof = { version = "0.11", features = ["criterion", "flamegraph"] }
+pprof = { version = "0.11", default-features = false, features = ["criterion", "flamegraph"] }
 protobuf-src = { version = "1", default-features = false }
 quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
@@ -1497,17 +1499,12 @@ signal-hook = { version = "0.3" }
 signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
 str_stack = { version = "0.1", default-features = false }
-symbolic-common = { version = "10", default-features = false }
-symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
-debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8" }
-findshlibs = { version = "0.10", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
@@ -1515,20 +1512,17 @@ inferno = { version = "0.11", default-features = false, features = ["nameattr"] 
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
-libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 linux-raw-sys = { version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
-memmap2 = { version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 native-tls = { version = "0.2", default-features = false }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "signal"] }
 num-format = { version = "0.4", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
 openssl = { version = "0.10" }
 openssl-probe = { version = "0.1", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
-pprof = { version = "0.11", features = ["criterion", "flamegraph"] }
+pprof = { version = "0.11", default-features = false, features = ["criterion", "flamegraph"] }
 quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 raw-cpuid = { version = "10", default-features = false }
@@ -1539,18 +1533,13 @@ signal-hook-mio = { version = "0.2", default-features = false, features = ["supp
 signal-hook-registry = { version = "1", default-features = false }
 spin-d8f496e17d97b5cb = { package = "spin", version = "0.5", default-features = false }
 str_stack = { version = "0.1", default-features = false }
-symbolic-common = { version = "10", default-features = false }
-symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 autotools = { version = "0.2", default-features = false }
-cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
-debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8" }
-findshlibs = { version = "0.10", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
@@ -1558,21 +1547,18 @@ inferno = { version = "0.11", default-features = false, features = ["nameattr"] 
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
-libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 linux-raw-sys = { version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
-memmap2 = { version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 native-tls = { version = "0.2", default-features = false }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "signal"] }
 num-format = { version = "0.4", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
 openssl = { version = "0.10" }
 openssl-macros = { version = "0.1", default-features = false }
 openssl-probe = { version = "0.1", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
-pprof = { version = "0.11", features = ["criterion", "flamegraph"] }
+pprof = { version = "0.11", default-features = false, features = ["criterion", "flamegraph"] }
 protobuf-src = { version = "1", default-features = false }
 quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
@@ -1584,8 +1570,6 @@ signal-hook-mio = { version = "0.2", default-features = false, features = ["supp
 signal-hook-registry = { version = "1", default-features = false }
 spin-d8f496e17d97b5cb = { package = "spin", version = "0.5", default-features = false }
 str_stack = { version = "0.1", default-features = false }
-symbolic-common = { version = "10", default-features = false }
-symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
@@ -1610,7 +1594,7 @@ str-buf = { version = "1", default-features = false }
 tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }
-winapi = { version = "0.3", default-features = false, features = ["activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "libloaderapi", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+winapi = { version = "0.3", default-features = false, features = ["activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "libloaderapi", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "psapi", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
 windows-sys = { version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
 windows_x86_64_msvc = { version = "0.42", default-features = false }
@@ -1638,7 +1622,7 @@ str-buf = { version = "1", default-features = false }
 tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }
-winapi = { version = "0.3", default-features = false, features = ["activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "libloaderapi", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+winapi = { version = "0.3", default-features = false, features = ["activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "libloaderapi", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "psapi", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
 windows-sys = { version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
 windows_x86_64_msvc = { version = "0.42", default-features = false }

--- a/narwhal/consensus/src/tests/consensus_utils.rs
+++ b/narwhal/consensus/src/tests/consensus_utils.rs
@@ -4,7 +4,7 @@ use crypto::PublicKey;
 use std::sync::Arc;
 use storage::CertificateStore;
 use store::rocks::MetricConf;
-use store::{reopen, rocks, rocks::DBMap};
+use store::{reopen, rocks, rocks::DBMap, rocks::ReadWriteOptions};
 use types::{
     Certificate, CertificateDigest, CommittedSubDagShell, ConsensusStore, Round, SequenceNumber,
 };

--- a/narwhal/primary/src/tests/common.rs
+++ b/narwhal/primary/src/tests/common.rs
@@ -4,7 +4,7 @@ use config::WorkerId;
 use crypto::NetworkKeyPair;
 use std::time::Duration;
 use storage::CertificateStore;
-use store::{reopen, rocks, rocks::DBMap, Store};
+use store::{reopen, rocks, rocks::DBMap, rocks::ReadWriteOptions, Store};
 use test_utils::{
     temp_dir, PrimaryToWorkerMockServer, CERTIFICATES_CF, CERTIFICATE_DIGEST_BY_ORIGIN_CF,
     CERTIFICATE_DIGEST_BY_ROUND_CF, HEADERS_CF, PAYLOAD_CF, VOTES_CF,

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -30,7 +30,7 @@ use std::{
 use storage::CertificateStore;
 use storage::NodeStorage;
 use storage::PayloadToken;
-use store::rocks::{DBMap, MetricConf};
+use store::rocks::{DBMap, MetricConf, ReadWriteOptions};
 use store::Store;
 use test_utils::{temp_dir, CommitteeFixture};
 use tokio::sync::watch;
@@ -1091,6 +1091,7 @@ async fn test_process_payload_availability_when_failures() {
                     .expect("Couldn't find column family"),
                 serialised_key,
                 dummy_value,
+                &ReadWriteOptions::default().writeopts(),
             )
             .expect("Couldn't insert value");
 

--- a/narwhal/storage/src/certificate_store.rs
+++ b/narwhal/storage/src/certificate_store.rs
@@ -438,7 +438,7 @@ mod test {
     use store::rocks::MetricConf;
     use store::{
         reopen,
-        rocks::{open_cf, DBMap},
+        rocks::{open_cf, DBMap, ReadWriteOptions},
     };
     use test_utils::{temp_dir, CommitteeFixture};
     use types::{Certificate, CertificateDigest, Round};

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -6,7 +6,7 @@ use config::WorkerId;
 use crypto::PublicKey;
 use std::sync::Arc;
 use store::rocks::DBMap;
-use store::rocks::{open_cf, MetricConf};
+use store::rocks::{open_cf, MetricConf, ReadWriteOptions};
 use store::{reopen, Store};
 use types::{
     Batch, BatchDigest, Certificate, CertificateDigest, CommittedSubDagShell, ConsensusStore,

--- a/narwhal/storage/src/proposer_store.rs
+++ b/narwhal/storage/src/proposer_store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use store::rocks::{open_cf, MetricConf};
-use store::{reopen, rocks::DBMap, Map};
+use store::{reopen, rocks::DBMap, rocks::ReadWriteOptions, Map};
 use types::{Header, StoreResult};
 
 pub type ProposerKey = u32;

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -25,6 +25,7 @@ use std::{
     sync::Arc,
 };
 use store::rocks::MetricConf;
+use store::rocks::ReadWriteOptions;
 use store::{reopen, rocks, rocks::DBMap, Store};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tracing::info;
@@ -381,6 +382,7 @@ pub fn open_batch_store() -> Store<BatchDigest, Batch> {
         MetricConf::default(),
         None,
         Some(BATCHES_CF),
+        &ReadWriteOptions::default(),
     )
     .unwrap();
     Store::new(db)

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -7,6 +7,7 @@ use crate::NUM_SHUTDOWN_RECEIVERS;
 use prometheus::Registry;
 use store::rocks;
 use store::rocks::MetricConf;
+use store::rocks::ReadWriteOptions;
 use test_utils::{temp_dir, transaction};
 use types::PreSubscribedBroadcastSender;
 
@@ -16,6 +17,7 @@ fn create_batches_store() -> Store<BatchDigest, Batch> {
         MetricConf::default(),
         None,
         Some("batches"),
+        &ReadWriteOptions::default(),
     )
     .unwrap();
     Store::new(db)

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use storage::NodeStorage;
 use store::rocks;
 use store::rocks::MetricConf;
+use store::rocks::ReadWriteOptions;
 use test_utils::{batch, temp_dir, test_network, transaction, CommitteeFixture};
 use tokio::sync::watch;
 use types::{
@@ -61,6 +62,7 @@ async fn reject_invalid_clients_transactions() {
         MetricConf::default(),
         None,
         Some("batches"),
+        &ReadWriteOptions::default(),
     )
     .unwrap();
     let store = Store::new(db);
@@ -154,6 +156,7 @@ async fn handle_clients_transactions() {
         MetricConf::default(),
         None,
         Some("batches"),
+        &ReadWriteOptions::default(),
     )
     .unwrap();
     let store = Store::new(db);


### PR DESCRIPTION
When reading from objects table after invoking pruning, we run into rocksdb range tombstone fragmentation which ends up using significant cpu resources. RocksDB allows for an option (`ignore_range_deletion`) to disable the use of range tombstone iterator (which does fragmentation) during reads. So, we now setup `objects` table default read option to use `ignore_range_deletion` set as true going forward. The flip side is after pruning the object table of older object versions, those are still going to be visible to db read until compaction. But that is fine since we only ever read the latest object version (which is never pruned).