### PR TITLE
Disable auto compaction on object table during manual compaction run

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -334,6 +334,14 @@ impl RocksDB {
     pub fn flush(&self) -> Result<(), rocksdb::Error> {
         delegate_call!(self.flush())
     }
+
+    pub fn set_options_cf(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        opts: &[(&str, &str)],
+    ) -> Result<(), rocksdb::Error> {
+        delegate_call!(self.set_options_cf(cf, opts))
+    }
 }
 
 pub enum RocksDBBatch {
@@ -524,6 +532,10 @@ impl<K, V> DBMap<K, V> {
 
     pub fn iterator_cf(&self) -> RocksDBIter<'_> {
         self.rocksdb.iterator_cf(&self.cf(), IteratorMode::Start)
+    }
+
+    pub fn set_options(&self, opts: &[(&str, &str)]) -> Result<(), rocksdb::Error> {
+        self.rocksdb.set_options_cf(&self.cf(), opts)
     }
 
     fn get_int_property(


### PR DESCRIPTION
This is to avoid any write stalls that may happen because of manual compaction triggered during object pruning. The default soft and hard compaction limits are [here](https://github.com/facebook/rocksdb/blob/5602b1d3d9021c0e57490db4237841eaef01445d/include/rocksdb/advanced_options.h#L620). The default soft limit is 64GB and hard limit is 256GB which means during manual full compaction run, if the size of objects table that is being compacted hits these limits, RocksDB will trigger write slowdown and stall (i.e. writes to object table will fail) respectively for the foreground requests.  The setting `disable_auto_compactions` would prevent RocksDB from triggering these during the course of manual run which we re enable  after the manual compaction run completes.