### PR TITLE
wallet-ext, explorer: terms of service & privacy policy links

### DIFF
--- a/apps/explorer/src/components/footer/Footer.module.css
+++ b/apps/explorer/src/components/footer/Footer.module.css
@@ -3,7 +3,7 @@ footer {
 }
 
 nav.links {
-    @apply mx-auto grid grid-cols-3 text-center sm:grid-cols-4 sm:text-left;
+    @apply mx-auto grid grid-cols-4 text-center sm:grid-cols-5 sm:text-left;
 }
 
 nav.links > div > h6 {

--- a/apps/explorer/src/components/footer/Footer.tsx
+++ b/apps/explorer/src/components/footer/Footer.tsx
@@ -70,6 +70,21 @@ function Footer() {
                         </li>
                     </ul>
                 </div>
+                <div>
+                    <h6>Legal</h6>
+                    <ul>
+                        <li>
+                            <Link href="https://mystenlabs.com/legal?content=terms">
+                                Terms & Conditions
+                            </Link>
+                        </li>
+                        <li>
+                            <Link href="https://mystenlabs.com/legal?content=privacy">
+                                Privacy Policy
+                            </Link>
+                        </li>
+                    </ul>
+                </div>
             </nav>
             <div className={styles.logomobile}>
                 <SuiLogoIcon />

--- a/apps/wallet/src/shared/constants.ts
+++ b/apps/wallet/src/shared/constants.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export const ToS_LINK = 'https://sui.io/terms';
-export const PRIVACY_POLICY_LINK = 'https://sui.io/policy/';
+export const ToS_LINK = 'https://mystenlabs.com/legal?content=terms';
+export const PRIVACY_POLICY_LINK =
+    'https://mystenlabs.com/legal?content=privacy';
 
 export const AUTO_LOCK_TIMER_STORAGE_KEY = 'auto-lock-timer-interval';
 export const AUTO_LOCK_TIMER_DEFAULT_INTERVAL_MINUTES = 5;


### PR DESCRIPTION
* wallet-ext: links now point to mystenlabs instead of sui.io
* explorer: adds legal section with ToS and Privacy Policy links

| before | after |
| -- | -- |
| <img width="930" alt="Screenshot 2023-01-19 at 13 53 41" src="https://user-images.githubusercontent.com/10210143/213460558-b3a8a2ad-e7e3-414f-a310-12729330f2c1.png"> | <img width="930" alt="Screenshot 2023-01-19 at 13 54 37" src="https://user-images.githubusercontent.com/10210143/213460625-0fb37f17-d572-434e-90d2-bb2eed220383.png"> |

closes APPS-346