### PR TITLE
[narwhal] refactor transactions server

### DIFF
--- a/narwhal/worker/src/lib.rs
+++ b/narwhal/worker/src/lib.rs
@@ -13,6 +13,7 @@ mod handlers;
 pub mod metrics;
 mod primary_connector;
 mod quorum_waiter;
+mod transactions_server;
 mod tx_validator;
 mod worker;
 

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -11,6 +11,7 @@ use fastcrypto::{
     hash::Hash,
 };
 use futures::stream::FuturesOrdered;
+use futures::StreamExt;
 use primary::{NetworkModel, Primary, CHANNEL_CAPACITY, NUM_SHUTDOWN_RECEIVERS};
 use prometheus::Registry;
 use std::time::Duration;
@@ -19,8 +20,8 @@ use store::rocks;
 use test_utils::{batch, temp_dir, test_network, transaction, CommitteeFixture};
 use tokio::sync::watch;
 use types::{
-    MockWorkerToPrimary, MockWorkerToWorker, PreSubscribedBroadcastSender, TransactionsClient,
-    WorkerBatchMessage, WorkerToPrimaryServer, WorkerToWorkerClient,
+    MockWorkerToPrimary, MockWorkerToWorker, PreSubscribedBroadcastSender, TransactionProto,
+    TransactionsClient, WorkerBatchMessage, WorkerToPrimaryServer, WorkerToWorkerClient,
 };
 
 // A test validator that rejects every transaction / batch

--- a/narwhal/worker/src/transactions_server.rs
+++ b/narwhal/worker/src/transactions_server.rs
@@ -1,0 +1,202 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::metrics::WorkerEndpointMetrics;
+use crate::TransactionValidator;
+use async_trait::async_trait;
+use futures::StreamExt;
+use multiaddr::Multiaddr;
+use mysten_metrics::spawn_logged_monitored_task;
+use mysten_network::server::Server;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout};
+use tonic::{Request, Response, Status};
+use tracing::{error, info, warn};
+use types::error::DagError;
+use types::metered_channel::Sender;
+use types::{
+    ConditionalBroadcastReceiver, Empty, Transaction, TransactionProto, Transactions,
+    TransactionsServer, TxResponse,
+};
+
+/// The maximum allowed size of transactions into Narwhal.
+pub const MAX_ALLOWED_TRANSACTION_SIZE: usize = 6 * 1024 * 1024;
+
+pub struct TxServer<V: TransactionValidator> {
+    address: Multiaddr,
+    rx_shutdown: ConditionalBroadcastReceiver,
+    endpoint_metrics: WorkerEndpointMetrics,
+    tx_batch_maker: Sender<(Transaction, TxResponse)>,
+    validator: V,
+}
+
+impl<V: TransactionValidator> TxServer<V> {
+    #[must_use]
+    pub fn spawn(
+        address: Multiaddr,
+        rx_shutdown: ConditionalBroadcastReceiver,
+        endpoint_metrics: WorkerEndpointMetrics,
+        tx_batch_maker: Sender<(Transaction, TxResponse)>,
+        validator: V,
+    ) -> JoinHandle<()> {
+        spawn_logged_monitored_task!(
+            Self {
+                address,
+                tx_batch_maker,
+                endpoint_metrics,
+                validator,
+                rx_shutdown
+            }
+            .run(),
+            "TxServer"
+        )
+    }
+
+    async fn run(mut self) {
+        const MAX_RETRIES: usize = 10;
+        const RETRY_BACKOFF: Duration = Duration::from_millis(1_000);
+        const GRACEFUL_SHUTDOWN_DURATION: Duration = Duration::from_millis(2_000);
+
+        // create the handler
+        let tx_handler = TxReceiverHandler {
+            tx_batch_maker: self.tx_batch_maker,
+            validator: self.validator,
+        };
+
+        //now create the server
+        let mut retries = MAX_RETRIES;
+        let mut server: Server;
+
+        loop {
+            match mysten_network::config::Config::new()
+                .server_builder_with_metrics(self.endpoint_metrics.clone())
+                .add_service(TransactionsServer::new(tx_handler.clone()))
+                .bind(&self.address)
+                .await
+            {
+                Ok(s) => {
+                    server = s;
+                    break;
+                }
+                Err(err) => {
+                    retries -= 1;
+                    if retries == 0 {
+                        panic!(
+                            "Couldn't boot transactions server, permanently failed: {}",
+                            err
+                        );
+                    }
+
+                    error!(
+                        "Couldn't boot transactions server at try {}, will wait {}s and retry: {}",
+                        retries,
+                        RETRY_BACKOFF.as_secs_f64(),
+                        err
+                    );
+
+                    sleep(RETRY_BACKOFF).await;
+                }
+            }
+        }
+
+        let shutdown_handle = server.take_cancel_handle().unwrap();
+
+        let server_handle = spawn_logged_monitored_task!(server.serve());
+
+        // wait to receive a shutdown signal
+        let _ = self.rx_shutdown.receiver.recv().await;
+
+        // once do just gracefully shutdown the node
+        shutdown_handle.send(()).unwrap();
+
+        // now wait until the handle completes or timeout if it takes long time
+        match timeout(GRACEFUL_SHUTDOWN_DURATION, server_handle).await {
+            Ok(_) => {
+                info!("Successfully shutting down gracefully transactions server");
+            }
+            Err(err) => {
+                warn!(
+                    "Time out while waiting to gracefully shutdown transactions server: {}",
+                    err
+                )
+            }
+        }
+    }
+}
+
+/// Defines how the network receiver handles incoming transactions.
+#[derive(Clone)]
+pub(crate) struct TxReceiverHandler<V> {
+    pub(crate) tx_batch_maker: Sender<(Transaction, TxResponse)>,
+    pub(crate) validator: V,
+}
+
+#[async_trait]
+impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
+    async fn submit_transaction(
+        &self,
+        request: Request<TransactionProto>,
+    ) -> Result<Response<Empty>, Status> {
+        let message = request.into_inner().transaction;
+        if message.len() > MAX_ALLOWED_TRANSACTION_SIZE {
+            return Err(Status::resource_exhausted(format!(
+                "Transaction size is too large: {} > {}",
+                message.len(),
+                MAX_ALLOWED_TRANSACTION_SIZE
+            )));
+        }
+        if self.validator.validate(message.as_ref()).is_err() {
+            return Err(Status::invalid_argument("Invalid transaction"));
+        }
+        // Send the transaction to the batch maker.
+        let (notifier, when_done) = tokio::sync::oneshot::channel();
+        self.tx_batch_maker
+            .send((message.to_vec(), notifier))
+            .await
+            .map_err(|_| DagError::ShuttingDown)
+            .map_err(|e| Status::not_found(e.to_string()))?;
+
+        // TODO: distingush between a digest being returned vs the channel closing
+        // suggesting an error.
+        let _digest = when_done.await;
+
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn submit_transaction_stream(
+        &self,
+        request: Request<tonic::Streaming<types::TransactionProto>>,
+    ) -> Result<Response<types::Empty>, Status> {
+        let mut transactions = request.into_inner();
+        let mut responses = Vec::new();
+
+        while let Some(Ok(txn)) = transactions.next().await {
+            if let Err(err) = self.validator.validate(txn.transaction.as_ref()) {
+                // If the transaction is invalid (often cryptographically), better to drop the client
+                return Err(Status::invalid_argument(format!(
+                    "Stream contains an invalid transaction {err}"
+                )));
+            }
+            // Send the transaction to the batch maker.
+            let (notifier, when_done) = tokio::sync::oneshot::channel();
+            self.tx_batch_maker
+                .send((txn.transaction.to_vec(), notifier))
+                .await
+                .expect("Failed to send transaction");
+
+            // Note that here we do not wait for a response because this would
+            // mean that we process only a single message from this stream at a
+            // time. Instead we gather them and resolve them once the stream is over.
+            responses.push(when_done);
+        }
+
+        // TODO: activate when we provide a meaningful guarantee, and
+        // distingush between a digest being returned vs the channel closing
+        // suggesting an error.
+        // for response in responses {
+        //     let _digest = response.await;
+        // }
+
+        Ok(Response::new(Empty {}))
+    }
+}

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -18,10 +18,8 @@ use anemo_tower::{
     trace::{DefaultMakeSpan, DefaultOnFailure, TraceLayer},
 };
 use anemo_tower::{rate_limit, set_header::SetResponseHeaderLayer};
-use async_trait::async_trait;
 use config::{Parameters, SharedCommittee, SharedWorkerCache, WorkerId};
 use crypto::{traits::KeyPair as _, NetworkKeyPair, NetworkPublicKey, PublicKey};
-use futures::StreamExt;
 use multiaddr::{Multiaddr, Protocol};
 use mysten_metrics::spawn_logged_monitored_task;
 use network::epoch_filter::{AllowedEpoch, EPOCH_HEADER_KEY};
@@ -33,15 +31,12 @@ use std::{net::Ipv4Addr, sync::Arc, thread::sleep};
 use store::Store;
 use tap::TapFallible;
 use tokio::task::JoinHandle;
-use tonic::{Request, Response, Status};
 use tower::ServiceBuilder;
 use tracing::{error, info};
 use types::{
-    error::DagError,
     metered_channel::{channel_with_total, Sender},
-    Batch, BatchDigest, ConditionalBroadcastReceiver, Empty, PreSubscribedBroadcastSender,
-    PrimaryToWorkerServer, Transaction, TransactionProto, Transactions, TransactionsServer,
-    TxResponse, WorkerOurBatchMessage, WorkerToWorkerServer,
+    Batch, BatchDigest, ConditionalBroadcastReceiver, PreSubscribedBroadcastSender,
+    PrimaryToWorkerServer, WorkerOurBatchMessage, WorkerToWorkerServer,
 };
 
 #[cfg(test)]
@@ -51,10 +46,8 @@ pub mod worker_tests;
 /// The default channel capacity for each channel of the worker.
 pub const CHANNEL_CAPACITY: usize = 1_000;
 
-/// The maximum allowed size of transactions into Narwhal.
-pub const MAX_ALLOWED_TRANSACTION_SIZE: usize = 6 * 1024 * 1024;
-
 use crate::metrics::{Metrics, WorkerEndpointMetrics, WorkerMetrics};
+use crate::transactions_server::TxServer;
 
 pub struct Worker {
     /// The public key of this authority.
@@ -469,14 +462,13 @@ impl Worker {
         let address = address
             .replace(0, |_protocol| Some(Protocol::Ip4(Ipv4Addr::UNSPECIFIED)))
             .unwrap();
-        let tx_receiver_handle = TxReceiverHandler {
-            tx_batch_maker,
-            validator,
-        }
-        .spawn(
+
+        let tx_server_handle = TxServer::spawn(
             address.clone(),
             shutdown_receivers.pop().unwrap(),
             endpoint_metrics,
+            tx_batch_maker,
+            validator,
         );
 
         // The transactions are sent to the `BatchMaker` that assembles them into batches. It then broadcasts
@@ -511,114 +503,6 @@ impl Worker {
             self.id, address
         );
 
-        vec![batch_maker_handle, quorum_waiter_handle, tx_receiver_handle]
-    }
-}
-
-/// Defines how the network receiver handles incoming transactions.
-#[derive(Clone)]
-struct TxReceiverHandler<V> {
-    tx_batch_maker: Sender<(Transaction, TxResponse)>,
-    validator: V,
-}
-
-impl<V: TransactionValidator> TxReceiverHandler<V> {
-    async fn wait_for_shutdown(mut tx_shutdown: ConditionalBroadcastReceiver) {
-        _ = tx_shutdown.receiver.recv().await;
-    }
-
-    #[must_use]
-    fn spawn(
-        self,
-        address: Multiaddr,
-        rx_shutdown: ConditionalBroadcastReceiver,
-        endpoint_metrics: WorkerEndpointMetrics,
-    ) -> JoinHandle<()> {
-        spawn_logged_monitored_task!(
-            async move {
-                tokio::select! {
-                    _result =  mysten_network::config::Config::new()
-                        .server_builder_with_metrics(endpoint_metrics)
-                        .add_service(TransactionsServer::new(self))
-                        .bind(&address)
-                        .await
-                        .unwrap()
-                        .serve() => (),
-
-                    () = Self::wait_for_shutdown(rx_shutdown) => ()
-                }
-            },
-            "TxReceiverHandlerTask"
-        )
-    }
-}
-
-#[async_trait]
-impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
-    async fn submit_transaction(
-        &self,
-        request: Request<TransactionProto>,
-    ) -> Result<Response<Empty>, Status> {
-        let message = request.into_inner().transaction;
-        if message.len() > MAX_ALLOWED_TRANSACTION_SIZE {
-            return Err(Status::resource_exhausted(format!(
-                "Transaction size is too large: {} > {}",
-                message.len(),
-                MAX_ALLOWED_TRANSACTION_SIZE
-            )));
-        }
-        if self.validator.validate(message.as_ref()).is_err() {
-            return Err(Status::invalid_argument("Invalid transaction"));
-        }
-        // Send the transaction to the batch maker.
-        let (notifier, when_done) = tokio::sync::oneshot::channel();
-        self.tx_batch_maker
-            .send((message.to_vec(), notifier))
-            .await
-            .map_err(|_| DagError::ShuttingDown)
-            .map_err(|e| Status::not_found(e.to_string()))?;
-
-        // TODO: distingush between a digest being returned vs the channel closing
-        // suggesting an error.
-        let _digest = when_done.await;
-
-        Ok(Response::new(Empty {}))
-    }
-
-    async fn submit_transaction_stream(
-        &self,
-        request: Request<tonic::Streaming<types::TransactionProto>>,
-    ) -> Result<Response<types::Empty>, Status> {
-        let mut transactions = request.into_inner();
-        let mut responses = Vec::new();
-
-        while let Some(Ok(txn)) = transactions.next().await {
-            if let Err(err) = self.validator.validate(txn.transaction.as_ref()) {
-                // If the transaction is invalid (often cryptographically), better to drop the client
-                return Err(Status::invalid_argument(format!(
-                    "Stream contains an invalid transaction {err}"
-                )));
-            }
-            // Send the transaction to the batch maker.
-            let (notifier, when_done) = tokio::sync::oneshot::channel();
-            self.tx_batch_maker
-                .send((txn.transaction.to_vec(), notifier))
-                .await
-                .expect("Failed to send transaction");
-
-            // Note that here we do not wait for a response because this would
-            // mean that we process only a single message from this stream at a
-            // time. Instead we gather them and resolve them once the stream is over.
-            responses.push(when_done);
-        }
-
-        // TODO: activate when we provide a meaningful guarantee, and
-        // distingush between a digest being returned vs the channel closing
-        // suggesting an error.
-        // for response in responses {
-        //     let _digest = response.await;
-        // }
-
-        Ok(Response::new(Empty {}))
+        vec![batch_maker_handle, quorum_waiter_handle, tx_server_handle]
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/sui/issues/7499

Refactors the code and instead of having a struct `TxReceiverHandler` that acts as both a server and a request handler, it is now split into two distinct components:
* the `TxServer` which is only responsible for bootstrapping the grpc server to accept transactions
* the `TxReceiverHandler` which is basically acting as a controller which handles the transaction requests

that makes the code cleaner and easier to handle all the server-related operations. For the server two major changes have happened:
1. A retry logic has been introduced to try a few times until it succeeds to bind to a port - that will help us avoid errors that can happen where the port unbind has been delayed
2. The server is tried to be shutdown gracefully with a timeout (before we were just exiting the task that was awaiting on the server). Now we'll give the opportunity to do this in a more graceful way and potentially improve the cases where port is not getting successfully immediately unbinded.