### PR TITLE
[move] Use new voting power module

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -8,8 +8,6 @@ epoch: 0
 validators:
   validator_stake: 1
   delegation_stake: 0
-  total_voting_power: 1
-  quorum_threshold: 1
   active_validators:
     - metadata:
         sui_address: "0x21b60aa9a8cb189ccbe20461dbfad2202fdef55b"
@@ -237,7 +235,7 @@ validators:
         next_epoch_delegation: 0
         next_epoch_gas_price: 1
         next_epoch_commission_rate: 0
-      voting_power: 1
+      voting_power: 10000
       stake_amount: 1
       pending_stake: 0
       pending_withdraw: 0
@@ -497,7 +495,7 @@ parameters:
   min_validator_stake: 100000000000000
   max_validator_candidate_count: 100
   storage_gas_price: 1
-reference_gas_price: 0
+reference_gas_price: 1
 validator_report_records:
   contents: []
 stake_subsidy:

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,13 +4,13 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
-    "computation_cost": 7514,
-    "storage_cost": 10804,
+    "computation_cost": 7462,
+    "storage_cost": 10728,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 8373,
-    "storage_cost": 12007,
+    "computation_cost": 8322,
+    "storage_cost": 11931,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
@@ -29,8 +29,8 @@ expression: common_costs_estimate
     "storage_rebate": 0
   },
   "SplitCoin": {
-    "computation_cost": 7492,
-    "storage_cost": 10772,
+    "computation_cost": 7440,
+    "storage_cost": 10696,
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -21,9 +21,7 @@
 -  [Function `request_set_gas_price`](#0x2_validator_set_request_set_gas_price)
 -  [Function `request_set_commission_rate`](#0x2_validator_set_request_set_commission_rate)
 -  [Function `advance_epoch`](#0x2_validator_set_advance_epoch)
--  [Function `update_validator_voting_power`](#0x2_validator_set_update_validator_voting_power)
 -  [Function `derive_reference_gas_price`](#0x2_validator_set_derive_reference_gas_price)
--  [Function `total_voting_power`](#0x2_validator_set_total_voting_power)
 -  [Function `total_validator_stake`](#0x2_validator_set_total_validator_stake)
 -  [Function `total_delegation_stake`](#0x2_validator_set_total_delegation_stake)
 -  [Function `validator_total_stake_amount`](#0x2_validator_set_validator_total_stake_amount)
@@ -42,7 +40,6 @@
 -  [Function `process_pending_delegation_switches`](#0x2_validator_set_process_pending_delegation_switches)
 -  [Function `process_pending_delegations_and_withdraws`](#0x2_validator_set_process_pending_delegations_and_withdraws)
 -  [Function `calculate_total_stakes`](#0x2_validator_set_calculate_total_stakes)
--  [Function `calculate_total_voting_power_and_quorum_threshold`](#0x2_validator_set_calculate_total_voting_power_and_quorum_threshold)
 -  [Function `adjust_stake_and_gas_price`](#0x2_validator_set_adjust_stake_and_gas_price)
 -  [Function `compute_reward_adjustments`](#0x2_validator_set_compute_reward_adjustments)
 -  [Function `compute_slashed_validators_and_total_stake`](#0x2_validator_set_compute_slashed_validators_and_total_stake)
@@ -69,6 +66,7 @@
 <b>use</b> <a href="validator.md#0x2_validator">0x2::validator</a>;
 <b>use</b> <a href="vec_map.md#0x2_vec_map">0x2::vec_map</a>;
 <b>use</b> <a href="vec_set.md#0x2_vec_set">0x2::vec_set</a>;
+<b>use</b> <a href="voting_power.md#0x2_voting_power">0x2::voting_power</a>;
 </code></pre>
 
 
@@ -101,20 +99,6 @@
 </dt>
 <dd>
  Total amount of stake from delegation, at the beginning of the epoch.
-</dd>
-<dt>
-<code>total_voting_power: u64</code>
-</dt>
-<dd>
- Sum of voting power of validators.
-</dd>
-<dt>
-<code>quorum_threshold: u64</code>
-</dt>
-<dd>
- The amount of accumulated voting power to reach a quorum among all active validators.
- This is always 2/3 of total voting power. Keep it here to reduce potential inconsistencies
- among validators.
 </dd>
 <dt>
 <code>active_validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;</code>
@@ -368,13 +352,9 @@ each validator, emitted during epoch advancement.
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_new">new</a>(init_active_validators: <a href="">vector</a>&lt;Validator&gt;): <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a> {
     <b>let</b> (total_validator_stake, total_delegation_stake) =
         <a href="validator_set.md#0x2_validator_set_calculate_total_stakes">calculate_total_stakes</a>(&init_active_validators);
-    <b>let</b> (total_voting_power, quorum_threshold) =
-        <a href="validator_set.md#0x2_validator_set_calculate_total_voting_power_and_quorum_threshold">calculate_total_voting_power_and_quorum_threshold</a>(&init_active_validators);
     <b>let</b> validators = <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a> {
         total_validator_stake,
         total_delegation_stake,
-        total_voting_power,
-        quorum_threshold,
         active_validators: init_active_validators,
         pending_validators: <a href="_empty">vector::empty</a>(),
         pending_removals: <a href="_empty">vector::empty</a>(),
@@ -382,7 +362,7 @@ each validator, emitted during epoch advancement.
         pending_delegation_switches: <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>(),
     };
     validators.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(&validators);
-    <a href="validator_set.md#0x2_validator_set_update_validator_voting_power">update_validator_voting_power</a>(&<b>mut</b> validators);
+    <a href="voting_power.md#0x2_voting_power_set_voting_power">voting_power::set_voting_power</a>(&<b>mut</b> validators.active_validators);
     validators
 }
 </code></pre>
@@ -856,51 +836,13 @@ It does the following things:
 
     <a href="validator_set.md#0x2_validator_set_process_pending_removals">process_pending_removals</a>(self, ctx);
 
-    // Update the voting power of each <a href="validator.md#0x2_validator">validator</a>, now that the pending <a href="validator.md#0x2_validator">validator</a> additions
-    // and the removals have been processed.
-    <a href="validator_set.md#0x2_validator_set_update_validator_voting_power">update_validator_voting_power</a>(self);
-
     self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
 
     <b>let</b> (validator_stake, delegation_stake) = <a href="validator_set.md#0x2_validator_set_calculate_total_stakes">calculate_total_stakes</a>(&self.active_validators);
     self.total_validator_stake = validator_stake;
     self.total_delegation_stake = delegation_stake;
 
-    <b>let</b> (total_voting_power, quorum_threshold) =
-        <a href="validator_set.md#0x2_validator_set_calculate_total_voting_power_and_quorum_threshold">calculate_total_voting_power_and_quorum_threshold</a>(&self.active_validators);
-    self.total_voting_power = total_voting_power;
-    self.quorum_threshold = quorum_threshold;
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_validator_set_update_validator_voting_power"></a>
-
-## Function `update_validator_voting_power`
-
-
-
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_update_validator_voting_power">update_validator_voting_power</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_update_validator_voting_power">update_validator_voting_power</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>) {
-    <b>let</b> num_validators = <a href="_length">vector::length</a>(&self.active_validators);
-    <b>let</b> i = 0;
-    <b>while</b> (i &lt; num_validators) {
-        <b>let</b> validator_mut = <a href="_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.active_validators, i);
-        <b>let</b> updated_voting_power = <a href="validator.md#0x2_validator_total_stake">validator::total_stake</a>(validator_mut);
-        <a href="validator.md#0x2_validator_set_voting_power">validator::set_voting_power</a>(validator_mut, updated_voting_power);
-        i = i + 1;
-    };
+    <a href="voting_power.md#0x2_voting_power_set_voting_power">voting_power::set_voting_power</a>(&<b>mut</b> self.active_validators);
 }
 </code></pre>
 
@@ -936,15 +878,14 @@ gas price, weighted by stake.
         <b>let</b> v = <a href="_borrow">vector::borrow</a>(vs, i);
         <a href="_push_back">vector::push_back</a>(
             &<b>mut</b> entries,
-            // Count both self and delegated <a href="stake.md#0x2_stake">stake</a>
-            pq::new_entry(<a href="validator.md#0x2_validator_gas_price">validator::gas_price</a>(v), <a href="validator.md#0x2_validator_stake_amount">validator::stake_amount</a>(v) + <a href="validator.md#0x2_validator_delegate_amount">validator::delegate_amount</a>(v))
+            pq::new_entry(<a href="validator.md#0x2_validator_gas_price">validator::gas_price</a>(v), <a href="validator.md#0x2_validator_voting_power">validator::voting_power</a>(v))
         );
         i = i + 1;
     };
     // Build a priority queue that will pop entries <b>with</b> gas price from the highest <b>to</b> the lowest.
     <b>let</b> pq = pq::new(entries);
     <b>let</b> sum = 0;
-    <b>let</b> threshold = self.total_voting_power - self.quorum_threshold;
+    <b>let</b> threshold = <a href="voting_power.md#0x2_voting_power_total_voting_power">voting_power::total_voting_power</a>() - <a href="voting_power.md#0x2_voting_power_quorum_threshold">voting_power::quorum_threshold</a>();
     <b>let</b> result = 0;
     <b>while</b> (sum &lt; threshold) {
         <b>let</b> (gas_price, <a href="stake.md#0x2_stake">stake</a>) = pq::pop_max(&<b>mut</b> pq);
@@ -952,30 +893,6 @@ gas price, weighted by stake.
         sum = sum + <a href="stake.md#0x2_stake">stake</a>;
     };
     result
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_validator_set_total_voting_power"></a>
-
-## Function `total_voting_power`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_total_voting_power">total_voting_power</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>): u64
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_total_voting_power">total_voting_power</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>): u64 {
-    self.total_voting_power
 }
 </code></pre>
 
@@ -1541,39 +1458,6 @@ Calculate the total active validator and delegated stake.
         i = i + 1;
     };
     (validator_state, delegate_stake)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_validator_set_calculate_total_voting_power_and_quorum_threshold"></a>
-
-## Function `calculate_total_voting_power_and_quorum_threshold`
-
-Calculate the total voting power, and the amount of voting power to reach quorum.
-
-
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_calculate_total_voting_power_and_quorum_threshold">calculate_total_voting_power_and_quorum_threshold</a>(validators: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;): (u64, u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_calculate_total_voting_power_and_quorum_threshold">calculate_total_voting_power_and_quorum_threshold</a>(validators: &<a href="">vector</a>&lt;Validator&gt;): (u64, u64) {
-    <b>let</b> total_voting_power = 0;
-    <b>let</b> length = <a href="_length">vector::length</a>(validators);
-    <b>let</b> i = 0;
-    <b>while</b> (i &lt; length) {
-        <b>let</b> v = <a href="_borrow">vector::borrow</a>(validators, i);
-        total_voting_power = total_voting_power + <a href="validator.md#0x2_validator_voting_power">validator::voting_power</a>(v);
-        i = i + 1;
-    };
-    (total_voting_power, (total_voting_power + 1) * 2 / 3)
 }
 </code></pre>
 

--- a/crates/sui-framework/tests/validator_set_tests.move
+++ b/crates/sui-framework/tests/validator_set_tests.move
@@ -13,6 +13,7 @@ module sui::validator_set_tests {
     use sui::vec_map;
     use std::ascii;
     use std::option;
+    use sui::test_utils::assert_eq;
 
     #[test]
     fun test_validator_set_flow() {
@@ -116,7 +117,7 @@ module sui::validator_set_tests {
         // Create a validator set with only the first validator in it.
         let validator_set = validator_set::new(vector[v1]);
 
-        assert!(validator_set::derive_reference_gas_price(&validator_set) == 45, 0);
+        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 45);
 
         validator_set::request_add_validator(
             &mut validator_set,
@@ -124,7 +125,7 @@ module sui::validator_set_tests {
         );
         advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
 
-        assert!(validator_set::derive_reference_gas_price(&validator_set) == 45, 1);
+        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 45);
 
         validator_set::request_add_validator(
             &mut validator_set,
@@ -132,7 +133,7 @@ module sui::validator_set_tests {
         );
         advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
 
-        assert!(validator_set::derive_reference_gas_price(&validator_set) == 42, 2);
+        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 42);
 
         validator_set::request_add_validator(
             &mut validator_set,
@@ -140,7 +141,7 @@ module sui::validator_set_tests {
         );
         advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
 
-        assert!(validator_set::derive_reference_gas_price(&validator_set) == 41, 3);
+        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 42);
 
         validator_set::request_add_validator(
             &mut validator_set,
@@ -148,7 +149,7 @@ module sui::validator_set_tests {
         );
         advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
 
-        assert!(validator_set::derive_reference_gas_price(&validator_set) == 43, 4);
+        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 43);
 
         validator_set::destroy_for_testing(validator_set);
         test_scenario::end(scenario);
@@ -217,9 +218,9 @@ module sui::validator_set_tests {
 
         validator_set::advance_epoch(
             1, // dummy new epoch number
-            validator_set, 
-            &mut dummy_computation_reward, 
-            &mut dummy_storage_fund_reward, 
+            validator_set,
+            &mut dummy_computation_reward,
+            &mut dummy_storage_fund_reward,
             vec_map::empty(),
             0,
             0,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6585,8 +6585,6 @@
           "pending_delegation_switches",
           "pending_removals",
           "pending_validators",
-          "quorum_threshold",
-          "total_voting_power",
           "validator_stake"
         ],
         "properties": {
@@ -6623,16 +6621,6 @@
             "items": {
               "$ref": "#/components/schemas/Validator"
             }
-          },
-          "quorum_threshold": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "total_voting_power": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
           },
           "validator_stake": {
             "type": "integer",

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -161,8 +161,6 @@ pub struct ValidatorPair {
 pub struct ValidatorSet {
     pub validator_stake: u64,
     pub delegation_stake: u64,
-    pub total_voting_power: u64,
-    pub quorum_threshold: u64,
     pub active_validators: Vec<Validator>,
     pub pending_validators: Vec<Validator>,
     pub pending_removals: Vec<u64>,

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -77,8 +77,6 @@ pub fn test_sui_system_state(epoch: EpochId, validators: Vec<Validator>) -> SuiS
     let validator_set = ValidatorSet {
         validator_stake: 1,
         delegation_stake: 1,
-        total_voting_power: 1,
-        quorum_threshold: 1,
         active_validators: validators,
         pending_validators: vec![],
         pending_removals: vec![],


### PR DESCRIPTION
This PR uses the new voting power module:
1. Sets the voting power at end of epoch
2. Remove total power and quorum threshold as they are now constant
3. Use the voting power for reference price setting

Will update tally rule in a different PR because that requires a few other changes in different places