### PR TITLE
[core] Call monitor_reconfig only once

### DIFF
--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -73,8 +73,9 @@ async fn main() -> Result<()> {
 
     sui_node::admin::start_admin_server(config.admin_interface_port, filter_handle);
 
-    let node = sui_node::SuiNode::start(&config, registry_service).await?;
-    node.monitor_reconfiguration().await?;
-
-    Ok(())
+    let _node = sui_node::SuiNode::start(&config, registry_service).await?;
+    // TODO: Do we want to provide a way for the node to gracefully shutdown?
+    loop {
+        tokio::time::sleep(Duration::from_secs(1000)).await;
+    }
 }


### PR DESCRIPTION
monitor_reconfig is already called inside SuiNode::start
Not the best fix, but should work for now