### PR TITLE
[move] Fix tally using voting power

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -11,9 +11,7 @@ use sui_types::crypto::sha3_hash;
 use tracing::{debug, instrument};
 
 use crate::adapter;
-use sui_protocol_constants::{
-    MAX_TX_GAS, REWARD_SLASHING_RATE, REWARD_SLASHING_THRESHOLD_BPS, STORAGE_FUND_REINVEST_RATE,
-};
+use sui_protocol_constants::{MAX_TX_GAS, REWARD_SLASHING_RATE, STORAGE_FUND_REINVEST_RATE};
 use sui_types::coin::{transfer_coin, update_input_coins, Coin};
 use sui_types::committee::EpochId;
 use sui_types::error::{ExecutionError, ExecutionErrorKind};
@@ -322,7 +320,6 @@ fn execution_loop<
                         CallArg::Pure(bcs::to_bytes(&computation_charge).unwrap()),
                         CallArg::Pure(bcs::to_bytes(&storage_rebate).unwrap()),
                         CallArg::Pure(bcs::to_bytes(&STORAGE_FUND_REINVEST_RATE).unwrap()),
-                        CallArg::Pure(bcs::to_bytes(&REWARD_SLASHING_THRESHOLD_BPS).unwrap()),
                         CallArg::Pure(bcs::to_bytes(&REWARD_SLASHING_RATE).unwrap()),
                     ],
                     gas_status.create_move_gas_status(),

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,13 +4,13 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
-    "computation_cost": 7462,
-    "storage_cost": 10728,
+    "computation_cost": 7457,
+    "storage_cost": 10720,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 8322,
-    "storage_cost": 11931,
+    "computation_cost": 8316,
+    "storage_cost": 11923,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
@@ -29,8 +29,8 @@ expression: common_costs_estimate
     "storage_rebate": 0
   },
   "SplitCoin": {
-    "computation_cost": 7440,
-    "storage_cost": 10696,
+    "computation_cost": 7435,
+    "storage_cost": 10688,
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -958,7 +958,7 @@ gas coins.
 4. Update all validators.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_epoch: u64, storage_charge: u64, computation_charge: u64, storage_rebate: u64, storage_fund_reinvest_rate: u64, reward_slashing_threshold_bps: u64, reward_slashing_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_epoch: u64, storage_charge: u64, computation_charge: u64, storage_rebate: u64, storage_fund_reinvest_rate: u64, reward_slashing_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -975,8 +975,6 @@ gas coins.
     storage_rebate: u64,
     storage_fund_reinvest_rate: u64, // share of storage fund's rewards that's reinvested
                                      // into storage fund, in basis point.
-    reward_slashing_threshold_bps: u64, // threshold of <a href="validator.md#0x2_validator">validator</a> reports filed this epoch
-                                         // before a <a href="validator.md#0x2_validator">validator</a>'s rewards are slashed, in bps.
     reward_slashing_rate: u64, // how much rewards are slashed <b>to</b> punish a <a href="validator.md#0x2_validator">validator</a>, in bps.
     ctx: &<b>mut</b> TxContext,
 ) {
@@ -987,7 +985,6 @@ gas coins.
     // Rates can't be higher than 100%.
     <b>assert</b>!(
         storage_fund_reinvest_rate &lt;= bps_denominator_u64
-        && reward_slashing_threshold_bps &lt;= bps_denominator_u64
         && reward_slashing_rate &lt;= bps_denominator_u64,
         <a href="sui_system.md#0x2_sui_system_EBPS_TOO_LARGE">EBPS_TOO_LARGE</a>,
     );
@@ -1032,7 +1029,6 @@ gas coins.
         &<b>mut</b> computation_reward,
         &<b>mut</b> storage_fund_reward,
         self.validator_report_records,
-        reward_slashing_threshold_bps,
         reward_slashing_rate,
         ctx,
     );

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -48,7 +48,7 @@
 -  [Function `distribute_reward`](#0x2_validator_set_distribute_reward)
 -  [Function `derive_next_epoch_validators`](#0x2_validator_set_derive_next_epoch_validators)
 -  [Function `emit_validator_epoch_events`](#0x2_validator_set_emit_validator_epoch_events)
--  [Function `sum_up_total_stake`](#0x2_validator_set_sum_up_total_stake)
+-  [Function `sum_voting_power_by_addresses`](#0x2_validator_set_sum_voting_power_by_addresses)
 -  [Function `active_validators`](#0x2_validator_set_active_validators)
 
 
@@ -741,7 +741,7 @@ It does the following things:
 5. At the end, we calculate the total stake for the new epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_advance_epoch">advance_epoch</a>(new_epoch: u64, self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, computation_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, validator_report_records: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;, reward_slashing_threshold_bps: u64, reward_slashing_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_advance_epoch">advance_epoch</a>(new_epoch: u64, self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, computation_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, validator_report_records: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;, reward_slashing_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -756,7 +756,6 @@ It does the following things:
     computation_reward: &<b>mut</b> Balance&lt;SUI&gt;,
     storage_fund_reward: &<b>mut</b> Balance&lt;SUI&gt;,
     validator_report_records: VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
-    reward_slashing_threshold_bps: u64,
     reward_slashing_rate: u64,
     ctx: &<b>mut</b> TxContext,
 ) {
@@ -776,8 +775,6 @@ It does the following things:
         <a href="validator_set.md#0x2_validator_set_compute_slashed_validators_and_total_stake">compute_slashed_validators_and_total_stake</a>(
             self,
             <b>copy</b> validator_report_records,
-            total_stake,
-            reward_slashing_threshold_bps,
         );
 
     // Compute the reward adjustments of slashed validators, <b>to</b> be taken into
@@ -1570,7 +1567,7 @@ Process the validator report records of the epoch and return the addresses of th
 non-performant validators according to the input threshold.
 
 
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_slashed_validators_and_total_stake">compute_slashed_validators_and_total_stake</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_report_records: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;, total_stake: u64, reward_slashing_threshold_bps: u64): (<a href="">vector</a>&lt;<b>address</b>&gt;, u64)
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_slashed_validators_and_total_stake">compute_slashed_validators_and_total_stake</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_report_records: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;): (<a href="">vector</a>&lt;<b>address</b>&gt;, u64)
 </code></pre>
 
 
@@ -1582,10 +1579,7 @@ non-performant validators according to the input threshold.
 <pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_slashed_validators_and_total_stake">compute_slashed_validators_and_total_stake</a>(
     self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
     validator_report_records: VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
-    total_stake: u64,
-    reward_slashing_threshold_bps: u64,
 ): (<a href="">vector</a>&lt;<b>address</b>&gt;, u64) {
-    <b>let</b> reward_slashing_threshold = (total_stake <b>as</b> u128) * (reward_slashing_threshold_bps <b>as</b> u128) / <a href="validator_set.md#0x2_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
     <b>let</b> slashed_validators = <a href="">vector</a>[];
     <b>let</b> sum_of_stake = 0;
     <b>while</b> (!<a href="vec_map.md#0x2_vec_map_is_empty">vec_map::is_empty</a>(&validator_report_records)) {
@@ -1594,10 +1588,10 @@ non-performant validators according to the input threshold.
             <a href="validator_set.md#0x2_validator_set_is_active_validator">is_active_validator</a>(self, validator_address),
             <a href="validator_set.md#0x2_validator_set_ENON_VALIDATOR_IN_REPORT_RECORDS">ENON_VALIDATOR_IN_REPORT_RECORDS</a>
         );
-        // Sum up the stakes of validators that have reported this <a href="validator.md#0x2_validator">validator</a> and check <b>if</b> it <b>has</b>
+        // Sum up the voting power of validators that have reported this <a href="validator.md#0x2_validator">validator</a> and check <b>if</b> it <b>has</b>
         // passed the slashing threshold.
-        <b>let</b> reporter_stake = <a href="validator_set.md#0x2_validator_set_sum_up_total_stake">sum_up_total_stake</a>(&self.active_validators, &<a href="vec_set.md#0x2_vec_set_into_keys">vec_set::into_keys</a>(reporters));
-        <b>if</b> (reporter_stake &gt;= (reward_slashing_threshold <b>as</b> u64)) {
+        <b>let</b> reporter_votes = <a href="validator_set.md#0x2_validator_set_sum_voting_power_by_addresses">sum_voting_power_by_addresses</a>(&self.active_validators, &<a href="vec_set.md#0x2_vec_set_into_keys">vec_set::into_keys</a>(reporters));
+        <b>if</b> (reporter_votes &gt;= <a href="voting_power.md#0x2_voting_power_quorum_threshold">voting_power::quorum_threshold</a>()) {
             sum_of_stake = sum_of_stake + <a href="validator_set.md#0x2_validator_set_validator_total_stake_amount">validator_total_stake_amount</a>(self, validator_address);
             <a href="_push_back">vector::push_back</a>(&<b>mut</b> slashed_validators, validator_address);
         }
@@ -1917,14 +1911,14 @@ including stakes, rewards, performance, etc.
 
 </details>
 
-<a name="0x2_validator_set_sum_up_total_stake"></a>
+<a name="0x2_validator_set_sum_voting_power_by_addresses"></a>
 
-## Function `sum_up_total_stake`
+## Function `sum_voting_power_by_addresses`
 
 Sum up the total stake of a given list of validator addresses.
 
 
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_sum_up_total_stake">sum_up_total_stake</a>(vs: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, addresses: &<a href="">vector</a>&lt;<b>address</b>&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_sum_voting_power_by_addresses">sum_voting_power_by_addresses</a>(vs: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, addresses: &<a href="">vector</a>&lt;<b>address</b>&gt;): u64
 </code></pre>
 
 
@@ -1933,13 +1927,13 @@ Sum up the total stake of a given list of validator addresses.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_sum_up_total_stake">sum_up_total_stake</a>(vs: &<a href="">vector</a>&lt;Validator&gt;, addresses: &<a href="">vector</a>&lt;<b>address</b>&gt;): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_sum_voting_power_by_addresses">sum_voting_power_by_addresses</a>(vs: &<a href="">vector</a>&lt;Validator&gt;, addresses: &<a href="">vector</a>&lt;<b>address</b>&gt;): u64 {
     <b>let</b> sum = 0;
     <b>let</b> i = 0;
     <b>let</b> length = <a href="_length">vector::length</a>(addresses);
     <b>while</b> (i &lt; length) {
         <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_ref">get_validator_ref</a>(vs, *<a href="_borrow">vector::borrow</a>(addresses, i));
-        sum = sum + <a href="validator.md#0x2_validator_total_stake_amount">validator::total_stake_amount</a>(<a href="validator.md#0x2_validator">validator</a>);
+        sum = sum + <a href="validator.md#0x2_validator_voting_power">validator::voting_power</a>(<a href="validator.md#0x2_validator">validator</a>);
         i = i + 1;
     };
     sum

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -417,8 +417,6 @@ module sui::sui_system {
         storage_rebate: u64,
         storage_fund_reinvest_rate: u64, // share of storage fund's rewards that's reinvested
                                          // into storage fund, in basis point.
-        reward_slashing_threshold_bps: u64, // threshold of validator reports filed this epoch
-                                             // before a validator's rewards are slashed, in bps.
         reward_slashing_rate: u64, // how much rewards are slashed to punish a validator, in bps.
         ctx: &mut TxContext,
     ) {
@@ -428,8 +426,7 @@ module sui::sui_system {
         let bps_denominator_u64 = (BASIS_POINT_DENOMINATOR as u64);
         // Rates can't be higher than 100%.
         assert!(
-            storage_fund_reinvest_rate <= bps_denominator_u64 
-            && reward_slashing_threshold_bps <= bps_denominator_u64
+            storage_fund_reinvest_rate <= bps_denominator_u64
             && reward_slashing_rate <= bps_denominator_u64,
             EBPS_TOO_LARGE,
         );
@@ -474,14 +471,13 @@ module sui::sui_system {
             &mut computation_reward,
             &mut storage_fund_reward,
             self.validator_report_records,
-            reward_slashing_threshold_bps,
             reward_slashing_rate,
             ctx,
         );
         // Derive the reference gas price for the new epoch
         self.reference_gas_price = validator_set::derive_reference_gas_price(&self.validators);
         // Because of precision issues with integer divisions, we expect that there will be some
-        // remaining balance in `storage_fund_reward` and `computation_reward`. 
+        // remaining balance in `storage_fund_reward` and `computation_reward`.
         // All of these go to the storage fund.
         balance::join(&mut self.storage_fund, storage_fund_reward);
         balance::join(&mut self.storage_fund, computation_reward);

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -307,7 +307,6 @@ module sui::validator_set {
         computation_reward: &mut Balance<SUI>,
         storage_fund_reward: &mut Balance<SUI>,
         validator_report_records: VecMap<address, VecSet<address>>,
-        reward_slashing_threshold_bps: u64,
         reward_slashing_rate: u64,
         ctx: &mut TxContext,
     ) {
@@ -327,8 +326,6 @@ module sui::validator_set {
             compute_slashed_validators_and_total_stake(
                 self,
                 copy validator_report_records,
-                total_stake,
-                reward_slashing_threshold_bps,
             );
 
         // Compute the reward adjustments of slashed validators, to be taken into
@@ -698,10 +695,7 @@ module sui::validator_set {
     fun compute_slashed_validators_and_total_stake(
         self: &ValidatorSet,
         validator_report_records: VecMap<address, VecSet<address>>,
-        total_stake: u64,
-        reward_slashing_threshold_bps: u64,
     ): (vector<address>, u64) {
-        let reward_slashing_threshold = (total_stake as u128) * (reward_slashing_threshold_bps as u128) / BASIS_POINT_DENOMINATOR;
         let slashed_validators = vector[];
         let sum_of_stake = 0;
         while (!vec_map::is_empty(&validator_report_records)) {
@@ -710,10 +704,10 @@ module sui::validator_set {
                 is_active_validator(self, validator_address),
                 ENON_VALIDATOR_IN_REPORT_RECORDS
             );
-            // Sum up the stakes of validators that have reported this validator and check if it has
+            // Sum up the voting power of validators that have reported this validator and check if it has
             // passed the slashing threshold.
-            let reporter_stake = sum_up_total_stake(&self.active_validators, &vec_set::into_keys(reporters));
-            if (reporter_stake >= (reward_slashing_threshold as u64)) {
+            let reporter_votes = sum_voting_power_by_addresses(&self.active_validators, &vec_set::into_keys(reporters));
+            if (reporter_votes >= voting_power::quorum_threshold()) {
                 sum_of_stake = sum_of_stake + validator_total_stake_amount(self, validator_address);
                 vector::push_back(&mut slashed_validators, validator_address);
             }
@@ -929,13 +923,13 @@ module sui::validator_set {
     }
 
     /// Sum up the total stake of a given list of validator addresses.
-    fun sum_up_total_stake(vs: &vector<Validator>, addresses: &vector<address>): u64 {
+    public fun sum_voting_power_by_addresses(vs: &vector<Validator>, addresses: &vector<address>): u64 {
         let sum = 0;
         let i = 0;
         let length = vector::length(addresses);
         while (i < length) {
             let validator = get_validator_ref(vs, *vector::borrow(addresses, i));
-            sum = sum + validator::total_stake_amount(validator);
+            sum = sum + validator::voting_power(validator);
             i = i + 1;
         };
         sum

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -93,14 +93,13 @@ module sui::governance_test_utils {
 
         let ctx = test_scenario::ctx(scenario);
 
-        sui_system::advance_epoch(&mut system_state, new_epoch, storage_charge, computation_charge, 0, 0, 0, 0, ctx);
+        sui_system::advance_epoch(&mut system_state, new_epoch, storage_charge, computation_charge, 0, 0, 0, ctx);
         test_scenario::return_shared(system_state);
     }
 
     public fun advance_epoch_with_reward_amounts_and_slashing_rates(
         storage_charge: u64,
         computation_charge: u64,
-        reward_slashing_threshold_bps: u64,
         reward_slashing_rate: u64,
         scenario: &mut Scenario
     ) {
@@ -111,8 +110,7 @@ module sui::governance_test_utils {
         let ctx = test_scenario::ctx(scenario);
 
         sui_system::advance_epoch(
-            &mut system_state, new_epoch, storage_charge, computation_charge, 0, 0,
-            reward_slashing_threshold_bps, reward_slashing_rate, ctx
+            &mut system_state, new_epoch, storage_charge, computation_charge, 0, 0, reward_slashing_rate, ctx
         );
         test_scenario::return_shared(system_state);
     }

--- a/crates/sui-framework/tests/rewards_distribution_tests.move
+++ b/crates/sui-framework/tests/rewards_distribution_tests.move
@@ -8,13 +8,13 @@ module sui::rewards_distribution_tests {
     use sui::sui_system::{Self, SuiSystemState};
 
     use sui::governance_test_utils::{
-        Self, 
+        Self,
         advance_epoch,
         advance_epoch_with_reward_amounts,
         advance_epoch_with_reward_amounts_and_slashing_rates,
         assert_validator_delegate_amounts,
         assert_validator_stake_amounts,
-        create_validator_for_testing, 
+        create_validator_for_testing,
         create_sui_system_state_for_testing,
         delegate_to,
         total_sui_balance, undelegate
@@ -40,7 +40,7 @@ module sui::rewards_distribution_tests {
         advance_epoch_with_reward_amounts(0, 100, scenario);
         assert_validator_stake_amounts(validator_addrs(), vector[110, 220, 330, 440], scenario);
 
-        test_scenario::next_tx(scenario, VALIDATOR_ADDR_2); 
+        test_scenario::next_tx(scenario, VALIDATOR_ADDR_2);
         {
             let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
             let ctx = test_scenario::ctx(scenario);
@@ -76,7 +76,7 @@ module sui::rewards_distribution_tests {
         undelegate(DELEGATOR_ADDR_1, 0, 0, scenario);
         delegate_to(DELEGATOR_ADDR_2, VALIDATOR_ADDR_1, 600, scenario);
         // 10 SUI rewards for each 110 SUI of stake
-        advance_epoch_with_reward_amounts(0, 130, scenario); 
+        advance_epoch_with_reward_amounts(0, 130, scenario);
         assert!(total_sui_balance(DELEGATOR_ADDR_1, scenario) == 240, 0); // 40 SUI of rewards received
         assert_validator_stake_amounts(validator_addrs(), vector[120, 240, 360, 480], scenario);
         undelegate(DELEGATOR_ADDR_2, 0, 0, scenario);
@@ -86,9 +86,9 @@ module sui::rewards_distribution_tests {
         // 10 SUI rewards for each 120 SUI of stake
         advance_epoch_with_reward_amounts(0, 150, scenario);
         undelegate(DELEGATOR_ADDR_2, 0, 0, scenario); // unstake 600 principal SUI
-        governance_test_utils::advance_epoch(scenario); 
+        governance_test_utils::advance_epoch(scenario);
         // additional 600 SUI of principal and 50 SUI of rewards withdrawn to Coin<SUI>
-        assert!(total_sui_balance(DELEGATOR_ADDR_2, scenario) == 770, 0); 
+        assert!(total_sui_balance(DELEGATOR_ADDR_2, scenario) == 770, 0);
         test_scenario::end(scenario_val);
     }
 
@@ -136,11 +136,11 @@ module sui::rewards_distribution_tests {
         assert_validator_stake_amounts(validator_addrs(), vector[110, 225, 330, 440], scenario);
 
         set_commission_rate_and_advance_epoch(VALIDATOR_ADDR_1, 1000, scenario); // 10% commission
-        
+
         // 20 SUI for each 110 SUI staked
         advance_epoch_with_reward_amounts(0, 240, scenario);
 
-        // 2 SUI, or 10 % of delegator_1's rewards (20 SUI), goes to validator_1 
+        // 2 SUI, or 10 % of delegator_1's rewards (20 SUI), goes to validator_1
         // so delegator_1 now has 110 + 20 - 2 = 128 SUI.
         // And 10 SUI, or 50% of delegator_2's rewards (20 SUI) goes to validator_2
         // so delegator_2 now has 105 +20 - 10 = 115 SUI.
@@ -180,7 +180,7 @@ module sui::rewards_distribution_tests {
         // 1200 SUI of total rewards, 50% threshold and 10% reward slashing.
         // So validator_2 is the only one whose rewards should get slashed.
         advance_epoch_with_reward_amounts_and_slashing_rates(
-            0, 1200, 5000, 1000, scenario
+            0, 1200, 1000, scenario
         );
 
         // Without reward slashing, the validator's stakes should be [200, 400, 600, 800]
@@ -225,7 +225,7 @@ module sui::rewards_distribution_tests {
         // 1000 SUI of storage rewards, 1500 SUI of computation rewards, 50% slashing threshold
         // and 20% slashing rate
         advance_epoch_with_reward_amounts_and_slashing_rates(
-            1000, 1500, 5000, 2000, scenario
+            1000, 1500, 2000, scenario
         );
 
         // Validator 1 gets 100 SUI of computation rewards + 75 SUI of storage fund rewards +
@@ -252,7 +252,7 @@ module sui::rewards_distribution_tests {
         let ctx = test_scenario::ctx(scenario);
 
         let validators = vector[
-            create_validator_for_testing(VALIDATOR_ADDR_1, 100, ctx), 
+            create_validator_for_testing(VALIDATOR_ADDR_1, 100, ctx),
             create_validator_for_testing(VALIDATOR_ADDR_2, 200, ctx),
             create_validator_for_testing(VALIDATOR_ADDR_3, 300, ctx),
             create_validator_for_testing(VALIDATOR_ADDR_4, 400, ctx),

--- a/crates/sui-framework/tests/validator_set_tests.move
+++ b/crates/sui-framework/tests/validator_set_tests.move
@@ -223,7 +223,6 @@ module sui::validator_set_tests {
             &mut dummy_storage_fund_reward,
             vec_map::empty(),
             0,
-            0,
             ctx
         );
 

--- a/crates/sui-protocol-constants/src/lib.rs
+++ b/crates/sui-protocol-constants/src/lib.rs
@@ -112,10 +112,5 @@ pub const STORAGE_REBATE_RATE: f64 = 1.0;
 pub const STORAGE_FUND_REINVEST_RATE: u64 = 0;
 
 // TODO: placeholder value here
-// 66.67% of the active validators will have to report one validator as non-performant
-// during an epoch before this validator's rewards for this epoch are slashed.
-pub const REWARD_SLASHING_THRESHOLD_BPS: u64 = 6667;
-
-// TODO: placeholder value here
 // The share of rewards that will be slashed and redistributed is 10%.
 pub const REWARD_SLASHING_RATE: u64 = 1000;


### PR DESCRIPTION
This PR changes how we decide whether a validator should be slashed:
1. We use voting power instead of stake
2. We use constant quorum threshold instead of passing the threshold from Rust.