### PR TITLE
add stake request cancellation

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -249,9 +249,12 @@ validators:
         delegation_token_supply:
           value: 0
         pending_delegations:
-          contents:
-            id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f"
-            size: 0
+          id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f"
+          size: 0
+          head:
+            vec: []
+          tail:
+            vec: []
         pending_withdraws:
           contents:
             id: "0xab8235dace3d68c7fb48110d63cbf4d6fd81ce10"

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,13 +4,13 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
-    "computation_cost": 7700,
-    "storage_cost": 11081,
+    "computation_cost": 7801,
+    "storage_cost": 11230,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 8560,
-    "storage_cost": 12284,
+    "computation_cost": 8660,
+    "storage_cost": 12433,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
@@ -29,8 +29,8 @@ expression: common_costs_estimate
     "storage_rebate": 0
   },
   "SplitCoin": {
-    "computation_cost": 7679,
-    "storage_cost": 11049,
+    "computation_cost": 7779,
+    "storage_cost": 11198,
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -23,6 +23,7 @@
 -  [Function `request_add_delegation_mul_locked_coin`](#0x2_sui_system_request_add_delegation_mul_locked_coin)
 -  [Function `request_withdraw_delegation`](#0x2_sui_system_request_withdraw_delegation)
 -  [Function `request_switch_delegation`](#0x2_sui_system_request_switch_delegation)
+-  [Function `cancel_delegation_request`](#0x2_sui_system_cancel_delegation_request)
 -  [Function `report_validator`](#0x2_sui_system_report_validator)
 -  [Function `undo_report_validator`](#0x2_sui_system_undo_report_validator)
 -  [Function `advance_epoch`](#0x2_sui_system_advance_epoch)
@@ -313,6 +314,15 @@ the epoch advancement transaction.
 
 
 <pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EREPORT_RECORD_NOT_FOUND">EREPORT_RECORD_NOT_FOUND</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_ESTAKED_SUI_FROM_WRONG_EPOCH"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ESTAKED_SUI_FROM_WRONG_EPOCH">ESTAKED_SUI_FROM_WRONG_EPOCH</a>: u64 = 6;
 </code></pre>
 
 
@@ -850,6 +860,39 @@ Withdraw some portion of a delegation from a validator's staking pool.
 ) {
     <a href="validator_set.md#0x2_validator_set_request_switch_delegation">validator_set::request_switch_delegation</a>(
         &<b>mut</b> self.validators, delegation, staked_sui, new_validator_address, ctx
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_cancel_delegation_request"></a>
+
+## Function `cancel_delegation_request`
+
+Cancel a delegation requests sent during the current epoch.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_cancel_delegation_request">cancel_delegation_request</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_cancel_delegation_request">cancel_delegation_request</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    staked_sui: StakedSui,
+    ctx: &<b>mut</b> TxContext,
+) {
+    // The delegation request <b>has</b> <b>to</b> have happened within the current epoch.
+    <b>assert</b>!(<a href="staking_pool.md#0x2_staking_pool_delegation_request_epoch">staking_pool::delegation_request_epoch</a>(&staked_sui) == self.epoch, <a href="sui_system.md#0x2_sui_system_ESTAKED_SUI_FROM_WRONG_EPOCH">ESTAKED_SUI_FROM_WRONG_EPOCH</a>);
+    <a href="validator_set.md#0x2_validator_set_cancel_delegation_request">validator_set::cancel_delegation_request</a>(
+        &<b>mut</b> self.validators, staked_sui, ctx
     );
 }
 </code></pre>

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -16,6 +16,7 @@
 -  [Function `adjust_stake_and_gas_price`](#0x2_validator_adjust_stake_and_gas_price)
 -  [Function `request_add_delegation`](#0x2_validator_request_add_delegation)
 -  [Function `request_withdraw_delegation`](#0x2_validator_request_withdraw_delegation)
+-  [Function `cancel_delegation_request`](#0x2_validator_cancel_delegation_request)
 -  [Function `decrease_next_epoch_delegation`](#0x2_validator_decrease_next_epoch_delegation)
 -  [Function `request_set_gas_price`](#0x2_validator_request_set_gas_price)
 -  [Function `request_set_commission_rate`](#0x2_validator_request_set_commission_rate)
@@ -577,6 +578,36 @@ Request to withdraw delegation from the validator's staking pool, processed at t
     <b>let</b> principal_withdraw_amount = <a href="staking_pool.md#0x2_staking_pool_request_withdraw_delegation">staking_pool::request_withdraw_delegation</a>(
             &<b>mut</b> self.delegation_staking_pool, delegation, staked_sui, ctx);
     <a href="validator.md#0x2_validator_decrease_next_epoch_delegation">decrease_next_epoch_delegation</a>(self, principal_withdraw_amount);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_cancel_delegation_request"></a>
+
+## Function `cancel_delegation_request`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_cancel_delegation_request">cancel_delegation_request</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_cancel_delegation_request">cancel_delegation_request</a>(
+    self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>,
+    staked_sui: StakedSui,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> delegate_amount = <a href="staking_pool.md#0x2_staking_pool_staked_sui_amount">staking_pool::staked_sui_amount</a>(&staked_sui);
+    <a href="staking_pool.md#0x2_staking_pool_cancel_delegation_request">staking_pool::cancel_delegation_request</a>(&<b>mut</b> self.delegation_staking_pool, staked_sui, ctx);
+    self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation - delegate_amount;
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -16,6 +16,7 @@
 -  [Function `request_add_stake`](#0x2_validator_set_request_add_stake)
 -  [Function `request_withdraw_stake`](#0x2_validator_set_request_withdraw_stake)
 -  [Function `request_add_delegation`](#0x2_validator_set_request_add_delegation)
+-  [Function `cancel_delegation_request`](#0x2_validator_set_cancel_delegation_request)
 -  [Function `request_withdraw_delegation`](#0x2_validator_set_request_withdraw_delegation)
 -  [Function `request_switch_delegation`](#0x2_validator_set_request_switch_delegation)
 -  [Function `request_set_gas_price`](#0x2_validator_set_request_set_gas_price)
@@ -522,7 +523,6 @@ The remaining stake of the validator cannot be lower than <code>min_validator_st
 Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>, to add a new delegation to the validator.
 This request is added to the validator's staking pool's pending delegation entries, processed at the end
 of the epoch.
-TODO: impl max stake requirement.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_delegation">request_add_delegation</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>, delegated_stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, locking_period: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -554,6 +554,36 @@ TODO: impl max stake requirement.
             amount,
         }
     );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_cancel_delegation_request"></a>
+
+## Function `cancel_delegation_request`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_cancel_delegation_request">cancel_delegation_request</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_cancel_delegation_request">cancel_delegation_request</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    staked_sui: StakedSui,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> validator_address = <a href="staking_pool.md#0x2_staking_pool_validator_address">staking_pool::validator_address</a>(&staked_sui);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
+    <a href="validator.md#0x2_validator_cancel_delegation_request">validator::cancel_delegation_request</a>(<a href="validator.md#0x2_validator">validator</a>, staked_sui, ctx);
 }
 </code></pre>
 

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -22,6 +22,7 @@ module sui::sui_system {
     use sui::epoch_time_lock;
     use sui::pay;
     use sui::event;
+    use sui::staking_pool;
 
     friend sui::genesis;
 
@@ -88,6 +89,7 @@ module sui::sui_system {
     const ECANNOT_REPORT_ONESELF: u64 = 3;
     const EREPORT_RECORD_NOT_FOUND: u64 = 4;
     const EBPS_TOO_LARGE: u64 = 5;
+    const ESTAKED_SUI_FROM_WRONG_EPOCH: u64 = 6;
 
     const BASIS_POINT_DENOMINATOR: u128 = 10000;
 
@@ -358,6 +360,20 @@ module sui::sui_system {
             &mut self.validators, delegation, staked_sui, new_validator_address, ctx
         );
     }
+
+    /// Cancel a delegation requests sent during the current epoch.
+    public entry fun cancel_delegation_request(
+        self: &mut SuiSystemState,
+        staked_sui: StakedSui,
+        ctx: &mut TxContext,
+    ) {
+        // The delegation request has to have happened within the current epoch.
+        assert!(staking_pool::delegation_request_epoch(&staked_sui) == self.epoch, ESTAKED_SUI_FROM_WRONG_EPOCH);
+        validator_set::cancel_delegation_request(
+            &mut self.validators, staked_sui, ctx
+        );
+    }
+
 
     /// Report a validator as a bad or non-performant actor in the system.
     /// Succeeds iff both the sender and the input `validator_addr` are active validators

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -252,6 +252,16 @@ module sui::validator {
         decrease_next_epoch_delegation(self, principal_withdraw_amount);
     }
 
+    public (friend) fun cancel_delegation_request(
+        self: &mut Validator,
+        staked_sui: StakedSui,
+        ctx: &mut TxContext,
+    ) {
+        let delegate_amount = staking_pool::staked_sui_amount(&staked_sui);
+        staking_pool::cancel_delegation_request(&mut self.delegation_staking_pool, staked_sui, ctx);
+        self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation - delegate_amount;
+    }
+
     /// Decrement the delegation amount for next epoch. Also called by `validator_set` when handling delegation switches.
     public(friend) fun decrease_next_epoch_delegation(self: &mut Validator, amount: u64) {
         self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation - amount;

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -179,7 +179,6 @@ module sui::validator_set {
     /// Called by `sui_system`, to add a new delegation to the validator.
     /// This request is added to the validator's staking pool's pending delegation entries, processed at the end
     /// of the epoch.
-    /// TODO: impl max stake requirement.
     public(friend) fun request_add_delegation(
         self: &mut ValidatorSet,
         validator_address: address,
@@ -200,6 +199,16 @@ module sui::validator_set {
                 amount,
             }
         );
+    }
+
+    public (friend) fun cancel_delegation_request(
+        self: &mut ValidatorSet,
+        staked_sui: StakedSui,
+        ctx: &mut TxContext,
+    ) {
+        let validator_address = staking_pool::validator_address(&staked_sui);
+        let validator = get_validator_mut(&mut self.active_validators, validator_address);
+        validator::cancel_delegation_request(validator, staked_sui, ctx);
     }
 
     /// Called by `sui_system`, to withdraw some share of a delegation from the validator. The share to withdraw

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4305,6 +4305,32 @@
           }
         ]
       },
+      "LinkedTable_for_ObjectID": {
+        "description": "Rust version of the Move sui::linked_table::LinkedTable type. Putting it here since we only use it in sui_system in the framework.",
+        "type": "object",
+        "required": [
+          "head",
+          "id",
+          "size",
+          "tail"
+        ],
+        "properties": {
+          "head": {
+            "$ref": "#/components/schemas/MoveOption_for_ObjectID"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ObjectID"
+          },
+          "size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "tail": {
+            "$ref": "#/components/schemas/MoveOption_for_ObjectID"
+          }
+        }
+      },
       "MoveCall": {
         "type": "object",
         "required": [
@@ -4390,6 +4416,21 @@
             "additionalProperties": false
           }
         ]
+      },
+      "MoveOption_for_ObjectID": {
+        "description": "Rust version of the Move std::option::Option type. Putting it in this file because it's only used here.",
+        "type": "object",
+        "required": [
+          "vec"
+        ],
+        "properties": {
+          "vec": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectID"
+            }
+          }
+        }
       },
       "MovePackage": {
         "type": "object",
@@ -5132,7 +5173,7 @@
             "$ref": "#/components/schemas/Supply"
           },
           "pending_delegations": {
-            "$ref": "#/components/schemas/TableVec"
+            "$ref": "#/components/schemas/LinkedTable_for_ObjectID"
           },
           "pending_withdraws": {
             "$ref": "#/components/schemas/TableVec"

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -31,7 +31,7 @@ pub struct SystemParameters {
 
 /// Rust version of the Move std::option::Option type.
 /// Putting it in this file because it's only used here.
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct MoveOption<T> {
     pub vec: Vec<T>,
 }
@@ -136,6 +136,27 @@ pub struct Table {
     pub size: u64,
 }
 
+/// Rust version of the Move sui::linked_table::LinkedTable type. Putting it here since
+/// we only use it in sui_system in the framework.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+pub struct LinkedTable<K> {
+    pub id: ObjectID,
+    pub size: u64,
+    pub head: MoveOption<K>,
+    pub tail: MoveOption<K>,
+}
+
+impl<K> Default for LinkedTable<K> {
+    fn default() -> Self {
+        LinkedTable {
+            id: ObjectID::from(SuiAddress::ZERO),
+            size: 0,
+            head: MoveOption { vec: vec![] },
+            tail: MoveOption { vec: vec![] },
+        }
+    }
+}
+
 /// Rust version of the Move sui::staking_pool::StakingPool type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct StakingPool {
@@ -144,7 +165,7 @@ pub struct StakingPool {
     pub sui_balance: u64,
     pub rewards_pool: Balance,
     pub delegation_token_supply: Supply,
-    pub pending_delegations: TableVec,
+    pub pending_delegations: LinkedTable<ObjectID>,
     pub pending_withdraws: TableVec,
 }
 

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -12,7 +12,8 @@ use sui_types::crypto::{
 use sui_types::id::UID;
 use sui_types::sui_system_state::SystemParameters;
 use sui_types::sui_system_state::{
-    StakeSubsidy, StakingPool, SuiSystemState, TableVec, Validator, ValidatorMetadata, ValidatorSet,
+    LinkedTable, StakeSubsidy, StakingPool, SuiSystemState, TableVec, Validator, ValidatorMetadata,
+    ValidatorSet,
 };
 use sui_types::SUI_SYSTEM_STATE_OBJECT_ID;
 
@@ -49,7 +50,7 @@ pub fn test_staking_pool(sui_address: SuiAddress, sui_balance: u64) -> StakingPo
         sui_balance,
         rewards_pool: Balance::new(0),
         delegation_token_supply: Supply { value: 0 },
-        pending_delegations: TableVec::default(),
+        pending_delegations: LinkedTable::default(),
         pending_withdraws: TableVec::default(),
     }
 }


### PR DESCRIPTION
This PR adds another entry fun `cancel_delegation_request` that allows a user to cancel a delegation request sent during the same epoch.