### PR TITLE
[Sui Rosetta] - use checkpoint api instead of creating fake blocks from transactions

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2161,7 +2161,7 @@ impl AuthorityState {
             .ok_or_else(|| anyhow!("Latest checkpoint sequence number not found"))
     }
 
-    pub fn get_checkpoint_summary(
+    pub fn get_checkpoint_summary_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<CheckpointSummary, anyhow::Error> {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5,6 +5,8 @@
 use anyhow::anyhow;
 use arc_swap::{ArcSwap, Guard};
 use chrono::prelude::*;
+use fastcrypto::encoding::Base58;
+use fastcrypto::encoding::Encoding;
 use fastcrypto::traits::KeyPair;
 use move_bytecode_utils::module_cache::SyncModuleCache;
 use move_core_types::account_address::AccountAddress;
@@ -60,7 +62,8 @@ use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldType};
 use sui_types::event::{Event, EventID};
 use sui_types::gas::{GasCostSummary, SuiGasStatus};
 use sui_types::messages_checkpoint::{
-    CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, CheckpointSummary,
+    CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
+    CheckpointSummary,
 };
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::{Owner, PastObjectRead};
@@ -2174,6 +2177,22 @@ impl AuthorityState {
         }
     }
 
+    pub fn get_checkpoint_summary_by_digest(
+        &self,
+        digest: CheckpointDigest,
+    ) -> Result<CheckpointSummary, anyhow::Error> {
+        let verified_checkpoint = self
+            .get_checkpoint_store()
+            .get_checkpoint_by_digest(&digest)?;
+        match verified_checkpoint {
+            Some(verified_checkpoint) => Ok(verified_checkpoint.into_inner().summary),
+            None => Err(anyhow!(
+                "Verified checkpoint not found for digest: {}",
+                Base58::encode(digest)
+            )),
+        }
+    }
+
     pub fn get_checkpoint_contents(
         &self,
         digest: CheckpointContentsDigest,
@@ -2193,14 +2212,7 @@ impl AuthorityState {
         match verified_checkpoint {
             Some(verified_checkpoint) => {
                 let content_digest = verified_checkpoint.into_inner().content_digest();
-                self.get_checkpoint_store()
-                    .get_checkpoint_contents(&content_digest)?
-                    .ok_or_else(|| {
-                        anyhow!(
-                            "Checkpoint contents not found for sequence number: {}",
-                            sequence_number
-                        )
-                    })
+                self.get_checkpoint_contents(content_digest)
             }
             None => Err(anyhow!(
                 "Verified checkpoint not found for sequence number {}",

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -52,7 +52,9 @@ use sui_types::messages::{
     PaySui, SingleTransactionKind, TransactionData, TransactionEffects, TransactionKind,
     VerifiedCertificate,
 };
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::messages_checkpoint::{
+    CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
+};
 use sui_types::move_package::{disassemble_modules, MovePackage};
 use sui_types::object::{
     Data, MoveObject, Object, ObjectFormatOptions, ObjectRead, Owner, PastObjectRead,
@@ -2959,4 +2961,12 @@ impl TransactionBytes {
 pub struct Page<T, C> {
     pub data: Vec<T>,
     pub next_cursor: Option<C>,
+}
+
+#[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
+pub struct Checkpoint {
+    #[serde(flatten)]
+    pub summary: CheckpointSummary,
+    #[serde(flatten)]
+    pub content: CheckpointContents,
 }

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -52,9 +52,7 @@ use sui_types::messages::{
     PaySui, SingleTransactionKind, TransactionData, TransactionEffects, TransactionKind,
     VerifiedCertificate,
 };
-use sui_types::messages_checkpoint::{
-    CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
-};
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::move_package::{disassemble_modules, MovePackage};
 use sui_types::object::{
     Data, MoveObject, Object, ObjectFormatOptions, ObjectRead, Owner, PastObjectRead,
@@ -2961,12 +2959,4 @@ impl TransactionBytes {
 pub struct Page<T, C> {
     pub data: Vec<T>,
     pub next_cursor: Option<C>,
-}
-
-#[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
-pub struct Checkpoint {
-    #[serde(flatten)]
-    pub summary: CheckpointSummary,
-    #[serde(flatten)]
-    pub content: CheckpointContents,
 }

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -9,13 +9,13 @@ use jsonrpsee_proc_macros::rpc;
 
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
-    Balance, CoinPage, DevInspectResults, DynamicFieldPage, EventPage, GetObjectDataResponse,
-    GetPastObjectDataResponse, GetRawObjectDataResponse, MoveFunctionArgType,
-    RPCTransactionRequestParams, SuiCoinMetadata, SuiEventEnvelope, SuiEventFilter,
-    SuiExecuteTransactionResponse, SuiMoveNormalizedFunction, SuiMoveNormalizedModule,
-    SuiMoveNormalizedStruct, SuiObjectInfo, SuiTransactionAuthSignersResponse,
-    SuiTransactionBuilderMode, SuiTransactionEffects, SuiTransactionFilter, SuiTransactionResponse,
-    SuiTypeTag, TransactionBytes, TransactionsPage,
+    Balance, Checkpoint, CoinPage, DevInspectResults, DynamicFieldPage, EventPage,
+    GetObjectDataResponse, GetPastObjectDataResponse, GetRawObjectDataResponse,
+    MoveFunctionArgType, RPCTransactionRequestParams, SuiCoinMetadata, SuiEventEnvelope,
+    SuiEventFilter, SuiExecuteTransactionResponse, SuiMoveNormalizedFunction,
+    SuiMoveNormalizedModule, SuiMoveNormalizedStruct, SuiObjectInfo,
+    SuiTransactionAuthSignersResponse, SuiTransactionBuilderMode, SuiTransactionEffects,
+    SuiTransactionFilter, SuiTransactionResponse, SuiTypeTag, TransactionBytes, TransactionsPage,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::balance::Supply;
@@ -28,7 +28,8 @@ use sui_types::governance::DelegatedStake;
 use sui_types::messages::CommitteeInfoResponse;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::messages_checkpoint::{
-    CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, CheckpointSummary,
+    CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
+    CheckpointSummary,
 };
 use sui_types::query::{EventQuery, TransactionQuery};
 use sui_types::sui_system_state::{SuiSystemState, ValidatorMetadata};
@@ -308,6 +309,14 @@ pub trait RpcFullNodeReadApi {
         &self,
         digest: CheckpointContentsDigest,
     ) -> RpcResult<CheckpointContents>;
+
+    /// Return contents of a checkpoint, namely a list of execution digests
+    #[method(name = "getCheckpoint")]
+    fn get_checkpoint(&self, sequence_number: CheckpointSequenceNumber) -> RpcResult<Checkpoint>;
+
+    /// Return contents of a checkpoint, namely a list of execution digests
+    #[method(name = "getCheckpointByDigest")]
+    fn get_checkpoint_by_digest(&self, digest: CheckpointDigest) -> RpcResult<Checkpoint>;
 
     /// Return contents of a checkpoint based on its sequence number
     #[method(name = "getCheckpointContentsBySequenceNumber")]

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -9,13 +9,13 @@ use jsonrpsee_proc_macros::rpc;
 
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
-    Balance, Checkpoint, CoinPage, DevInspectResults, DynamicFieldPage, EventPage,
-    GetObjectDataResponse, GetPastObjectDataResponse, GetRawObjectDataResponse,
-    MoveFunctionArgType, RPCTransactionRequestParams, SuiCoinMetadata, SuiEventEnvelope,
-    SuiEventFilter, SuiExecuteTransactionResponse, SuiMoveNormalizedFunction,
-    SuiMoveNormalizedModule, SuiMoveNormalizedStruct, SuiObjectInfo,
-    SuiTransactionAuthSignersResponse, SuiTransactionBuilderMode, SuiTransactionEffects,
-    SuiTransactionFilter, SuiTransactionResponse, SuiTypeTag, TransactionBytes, TransactionsPage,
+    Balance, CoinPage, DevInspectResults, DynamicFieldPage, EventPage, GetObjectDataResponse,
+    GetPastObjectDataResponse, GetRawObjectDataResponse, MoveFunctionArgType,
+    RPCTransactionRequestParams, SuiCoinMetadata, SuiEventEnvelope, SuiEventFilter,
+    SuiExecuteTransactionResponse, SuiMoveNormalizedFunction, SuiMoveNormalizedModule,
+    SuiMoveNormalizedStruct, SuiObjectInfo, SuiTransactionAuthSignersResponse,
+    SuiTransactionBuilderMode, SuiTransactionEffects, SuiTransactionFilter, SuiTransactionResponse,
+    SuiTypeTag, TransactionBytes, TransactionsPage,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::balance::Supply;
@@ -303,26 +303,25 @@ pub trait RpcFullNodeReadApi {
         sequence_number: CheckpointSequenceNumber,
     ) -> RpcResult<CheckpointSummary>;
 
+    /// Return a checkpoint summary based on checkpoint digest
+    #[method(name = "getCheckpointSummaryByDigest")]
+    fn get_checkpoint_summary_by_digest(
+        &self,
+        digest: CheckpointDigest,
+    ) -> RpcResult<CheckpointSummary>;
+
     /// Return contents of a checkpoint, namely a list of execution digests
     #[method(name = "getCheckpointContents")]
     fn get_checkpoint_contents(
         &self,
-        digest: CheckpointContentsDigest,
+        sequence_number: CheckpointSequenceNumber,
     ) -> RpcResult<CheckpointContents>;
 
-    /// Return contents of a checkpoint, namely a list of execution digests
-    #[method(name = "getCheckpoint")]
-    fn get_checkpoint(&self, sequence_number: CheckpointSequenceNumber) -> RpcResult<Checkpoint>;
-
-    /// Return contents of a checkpoint, namely a list of execution digests
-    #[method(name = "getCheckpointByDigest")]
-    fn get_checkpoint_by_digest(&self, digest: CheckpointDigest) -> RpcResult<Checkpoint>;
-
-    /// Return contents of a checkpoint based on its sequence number
-    #[method(name = "getCheckpointContentsBySequenceNumber")]
-    fn get_checkpoint_contents_by_sequence_number(
+    /// Return contents of a checkpoint based on checkpoint content digest
+    #[method(name = "getCheckpointContentsByDigest")]
+    fn get_checkpoint_contents_by_digest(
         &self,
-        sequence_number: CheckpointSequenceNumber,
+        digest: CheckpointContentsDigest,
     ) -> RpcResult<CheckpointContents>;
 }
 

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -18,11 +18,10 @@ use fastcrypto::encoding::Base64;
 use jsonrpsee::RpcModule;
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::{
-    Checkpoint, DevInspectResults, DynamicFieldPage, GetObjectDataResponse,
-    GetPastObjectDataResponse, MoveFunctionArgType, ObjectValueKind, Page,
-    SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct, SuiObjectInfo,
-    SuiTransactionAuthSignersResponse, SuiTransactionEffects, SuiTransactionResponse, SuiTypeTag,
-    TransactionsPage,
+    DevInspectResults, DynamicFieldPage, GetObjectDataResponse, GetPastObjectDataResponse,
+    MoveFunctionArgType, ObjectValueKind, Page, SuiMoveNormalizedFunction, SuiMoveNormalizedModule,
+    SuiMoveNormalizedStruct, SuiObjectInfo, SuiTransactionAuthSignersResponse,
+    SuiTransactionEffects, SuiTransactionResponse, SuiTypeTag, TransactionsPage,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::SequenceNumber;
@@ -444,40 +443,40 @@ impl RpcFullNodeReadApiServer for FullNodeApi {
             })?)
     }
 
+    fn get_checkpoint_summary_by_digest(
+        &self,
+        digest: CheckpointDigest,
+    ) -> RpcResult<CheckpointSummary> {
+        Ok(self
+            .state
+            .get_checkpoint_summary_by_digest(digest)
+            .map_err(|e| {
+                anyhow!(
+                    "Checkpoint summary based on digest: {digest:?} were not found with error: {e}"
+                )
+            })?)
+    }
+
     fn get_checkpoint_summary(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> RpcResult<CheckpointSummary> {
-        Ok(self.state.get_checkpoint_summary(sequence_number)
+        Ok(self.state.get_checkpoint_summary_by_sequence_number(sequence_number)
         .map_err(|e| anyhow!("Checkpoint summary based on sequence number: {sequence_number} was not found with error :{e}"))?)
     }
 
-    fn get_checkpoint(&self, sequence_number: CheckpointSequenceNumber) -> RpcResult<Checkpoint> {
-        let summary = self.get_checkpoint_summary(sequence_number)?;
-        let content = self.get_checkpoint_contents_by_sequence_number(sequence_number)?;
-        Ok(Checkpoint { summary, content })
-    }
-
-    fn get_checkpoint_contents(
+    fn get_checkpoint_contents_by_digest(
         &self,
         digest: CheckpointContentsDigest,
     ) -> RpcResult<CheckpointContents> {
         Ok(self.state.get_checkpoint_contents(digest).map_err(|e| {
             anyhow!(
-                "Checkpoint contents based on digest: {:?} were not found with error: {}",
-                digest,
-                e
+                "Checkpoint contents based on digest: {digest:?} were not found with error: {e}"
             )
         })?)
     }
 
-    fn get_checkpoint_by_digest(&self, digest: CheckpointDigest) -> RpcResult<Checkpoint> {
-        let summary = self.state.get_checkpoint_summary_by_digest(digest)?;
-        let content = self.get_checkpoint_contents(summary.content_digest)?;
-        Ok(Checkpoint { summary, content })
-    }
-
-    fn get_checkpoint_contents_by_sequence_number(
+    fn get_checkpoint_contents(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> RpcResult<CheckpointContents> {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -614,10 +614,12 @@
       "description": "Return contents of a checkpoint, namely a list of execution digests",
       "params": [
         {
-          "name": "digest",
+          "name": "sequence_number",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/CheckpointContentsDigest"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         }
       ],
@@ -630,21 +632,19 @@
       }
     },
     {
-      "name": "sui_getCheckpointContentsBySequenceNumber",
+      "name": "sui_getCheckpointContentsByDigest",
       "tags": [
         {
           "name": "Full Node API"
         }
       ],
-      "description": "Return contents of a checkpoint based on its sequence number",
+      "description": "Return contents of a checkpoint based on checkpoint content digest",
       "params": [
         {
-          "name": "sequence_number",
+          "name": "digest",
           "required": true,
           "schema": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/CheckpointContentsDigest"
           }
         }
       ],
@@ -672,6 +672,31 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "CheckpointSummary",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/CheckpointSummary"
+        }
+      }
+    },
+    {
+      "name": "sui_getCheckpointSummaryByDigest",
+      "tags": [
+        {
+          "name": "Full Node API"
+        }
+      ],
+      "description": "Return a checkpoint summary based on checkpoint digest",
+      "params": [
+        {
+          "name": "digest",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/CheckpointDigest"
           }
         }
       ],

--- a/crates/sui-rosetta/src/account.rs
+++ b/crates/sui-rosetta/src/account.rs
@@ -32,7 +32,7 @@ pub async fn balance(
     if let Some(SubAccount { account_type }) = request.account_identifier.sub_account {
         let balances = get_sub_account_balances(account_type, &ctx.client, address).await?;
         Ok(AccountBalanceResponse {
-            block_identifier: ctx.blocks().current_block_identifier()?,
+            block_identifier: ctx.blocks().current_block_identifier().await?,
             balances,
         })
     } else {
@@ -43,7 +43,7 @@ pub async fn balance(
             let response = ctx.blocks().get_block_by_hash(hash).await?;
             response.block.block_identifier
         } else {
-            ctx.blocks().current_block_identifier()?
+            ctx.blocks().current_block_identifier().await?
         };
 
         ctx.blocks()
@@ -137,7 +137,7 @@ pub async fn coins(
         .await;
 
     Ok(AccountCoinsResponse {
-        block_identifier: context.blocks().current_block_identifier()?,
+        block_identifier: context.blocks().current_block_identifier().await?,
         coins,
     })
 }

--- a/crates/sui-rosetta/src/lib.rs
+++ b/crates/sui-rosetta/src/lib.rs
@@ -15,7 +15,7 @@ use mysten_metrics::spawn_monitored_task;
 use sui_sdk::SuiClient;
 
 use crate::errors::Error;
-use crate::state::{OnlineServerContext, PseudoBlockProvider};
+use crate::state::{CheckpointBlockProvider, OnlineServerContext};
 use crate::types::{Currency, SuiEnv};
 
 /// This lib implements the Rosetta online and offline server defined by the [Rosetta API Spec](https://www.rosetta-api.org/docs/Reference.html)
@@ -40,7 +40,7 @@ pub struct RosettaOnlineServer {
 
 impl RosettaOnlineServer {
     pub fn new(env: SuiEnv, client: SuiClient, data_path: &Path) -> Self {
-        let blocks = Arc::new(PseudoBlockProvider::spawn(client.clone(), data_path));
+        let blocks = Arc::new(CheckpointBlockProvider::spawn(client.clone(), data_path));
         Self {
             env,
             context: OnlineServerContext::new(client, blocks),

--- a/crates/sui-rosetta/src/network.rs
+++ b/crates/sui-rosetta/src/network.rs
@@ -67,8 +67,8 @@ pub async fn status(
     Ok(NetworkStatusResponse {
         current_block_identifier: current_block.block.block_identifier,
         current_block_timestamp: current_block.block.timestamp,
-        genesis_block_identifier: blocks.genesis_block_identifier(),
-        oldest_block_identifier: Some(blocks.oldest_block_identifier()?),
+        genesis_block_identifier: blocks.genesis_block_identifier().await?,
+        oldest_block_identifier: Some(blocks.oldest_block_identifier().await?),
         sync_status: Some(SyncStatus {
             current_index: Some(index),
             target_index: Some(target),

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -267,7 +267,7 @@ impl CheckpointBlockProvider {
             block: Block {
                 block_identifier: BlockIdentifier { index, hash },
                 parent_block_identifier,
-                timestamp: 0,
+                timestamp: checkpoint.summary.timestamp_ms,
                 transactions,
                 metadata: None,
             },

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -3,7 +3,7 @@
 
 use crate::operations::Operations;
 use crate::types::{
-    Block, BlockHash, BlockHeight, BlockIdentifier, BlockResponse, OperationType, Transaction,
+    Block, BlockHash, BlockIdentifier, BlockResponse, OperationType, Transaction,
     TransactionIdentifier,
 };
 use crate::Error;
@@ -17,12 +17,12 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use sui_sdk::rpc_types::SuiTransactionKind;
+use std::time::Duration;
+use sui_sdk::rpc_types::Checkpoint;
 use sui_sdk::SuiClient;
 use sui_storage::default_db_options;
-use sui_types::base_types::SuiAddress;
-use sui_types::query::TransactionQuery;
+use sui_types::base_types::{EpochId, SuiAddress};
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tracing::{debug, error, info};
 use typed_store::rocks::{DBMap, DBOptions};
 use typed_store::traits::TableSummary;
@@ -58,9 +58,9 @@ pub trait BlockProvider {
     async fn get_block_by_index(&self, index: u64) -> Result<BlockResponse, Error>;
     async fn get_block_by_hash(&self, hash: BlockHash) -> Result<BlockResponse, Error>;
     async fn current_block(&self) -> Result<BlockResponse, Error>;
-    fn genesis_block_identifier(&self) -> BlockIdentifier;
-    fn oldest_block_identifier(&self) -> Result<BlockIdentifier, Error>;
-    fn current_block_identifier(&self) -> Result<BlockIdentifier, Error>;
+    async fn genesis_block_identifier(&self) -> Result<BlockIdentifier, Error>;
+    async fn oldest_block_identifier(&self) -> Result<BlockIdentifier, Error>;
+    async fn current_block_identifier(&self) -> Result<BlockIdentifier, Error>;
     async fn get_balance_at_block(
         &self,
         addr: SuiAddress,
@@ -69,84 +69,43 @@ pub trait BlockProvider {
 }
 
 #[derive(Clone)]
-pub struct PseudoBlockProvider {
-    database: Arc<BlockProviderTables>,
+pub struct CheckpointBlockProvider {
+    index_store: Arc<CheckpointIndexStore>,
     client: SuiClient,
 }
 
 #[async_trait]
-impl BlockProvider for PseudoBlockProvider {
+impl BlockProvider for CheckpointBlockProvider {
     async fn get_block_by_index(&self, index: u64) -> Result<BlockResponse, Error> {
-        let (block_id, parent, timestamp) =
-            &self
-                .database
-                .blocks
-                .get(&index)?
-                .ok_or(Error::BlockNotFound {
-                    index: Some(index),
-                    hash: None,
-                })?;
-
-        Ok(self
-            .create_block_response(*block_id, *parent, *timestamp)
-            .await?)
+        let checkpoint = self.client.read_api().get_checkpoint(index).await?;
+        self.create_block_response(checkpoint).await
     }
 
     async fn get_block_by_hash(&self, hash: BlockHash) -> Result<BlockResponse, Error> {
-        let height = self
-            .database
-            .block_heights
-            .get(&hash)?
-            .ok_or(Error::BlockNotFound {
-                index: None,
-                hash: Some(hash),
-            })?;
-        self.get_block_by_index(height).await
+        let checkpoint = self
+            .client
+            .read_api()
+            .get_checkpoint_by_digest(hash)
+            .await?;
+        self.create_block_response(checkpoint).await
     }
 
     async fn current_block(&self) -> Result<BlockResponse, Error> {
-        let (_, (block_id, parent, timestamp)) = self
-            .database
-            .blocks
-            .iter()
-            .skip_prior_to(&BlockHeight::MAX)?
-            .next()
-            .ok_or(Error::BlockNotFound {
-                index: None,
-                hash: None,
-            })?;
-        Ok(self
-            .create_block_response(block_id, parent, timestamp)
-            .await?)
+        self.get_block_by_index(self.last_indexed_checkpoint()?)
+            .await
     }
 
-    fn genesis_block_identifier(&self) -> BlockIdentifier {
-        self.oldest_block_identifier().unwrap()
+    async fn genesis_block_identifier(&self) -> Result<BlockIdentifier, Error> {
+        self.create_block_identifier(0).await
     }
 
-    fn oldest_block_identifier(&self) -> Result<BlockIdentifier, Error> {
-        self.database
-            .blocks
-            .iter()
-            .next()
-            .map(|(_, (id, _, _))| id)
-            .ok_or(Error::BlockNotFound {
-                index: None,
-                hash: None,
-            })
+    async fn oldest_block_identifier(&self) -> Result<BlockIdentifier, Error> {
+        self.create_block_identifier(0).await
     }
 
-    fn current_block_identifier(&self) -> Result<BlockIdentifier, Error> {
-        let (_, (block_id, ..)) =
-            self.database
-                .blocks
-                .iter()
-                .last()
-                .ok_or(Error::BlockNotFound {
-                    index: None,
-                    hash: None,
-                })?;
-        Ok(block_id)
+    async fn current_block_identifier(&self) -> Result<BlockIdentifier, Error> {
+        self.create_block_identifier(self.last_indexed_checkpoint()?)
+            .await
     }
 
     async fn get_balance_at_block(
@@ -155,7 +114,7 @@ impl BlockProvider for PseudoBlockProvider {
         block_height: u64,
     ) -> Result<u128, Error> {
         Ok(self
-            .database
+            .index_store
             .balances
             .iter()
             .skip_prior_to(&(addr, block_height))?
@@ -171,111 +130,76 @@ impl BlockProvider for PseudoBlockProvider {
     }
 }
 
-impl PseudoBlockProvider {
+impl CheckpointBlockProvider {
     pub fn spawn(client: SuiClient, db_path: &Path) -> Self {
         let blocks = Self {
-            database: Arc::new(BlockProviderTables::open(db_path, None)),
-            client: client.clone(),
+            index_store: Arc::new(CheckpointIndexStore::open(db_path, None)),
+            client,
         };
 
-        let block_interval = option_env!("SUI_BLOCK_INTERVAL")
+        let update_interval = option_env!("CHECKPOINT_UPDATE_INTERVAL")
             .map(|i| u64::from_str(i).ok())
             .flatten()
             .unwrap_or(2000);
-        let block_interval = Duration::from_millis(block_interval);
+        let update_interval = Duration::from_millis(update_interval);
 
         let f = blocks.clone();
         spawn_monitored_task!(async move {
-            if f.database.is_empty() {
-                // We expect creating genesis block to success.
-                info!("Datastore is empty, processing genesis block.");
-                process_genesis_block(&client, &f).await.unwrap()
+            if f.index_store.is_empty() {
+                info!("Index Store is empty, indexing genesis block.");
+                let checkpoint = f.client.read_api().get_checkpoint(0).await.unwrap();
+                let resp = f.create_block_response(checkpoint).await.unwrap();
+                f.update_balance(0, resp.block.transactions).await.unwrap();
             } else {
-                let current_block = f.current_block_identifier().unwrap();
+                let current_block = f.current_block_identifier().await.unwrap();
                 info!("Resuming from block {}", current_block.index);
             };
             loop {
-                if let Err(e) = f.create_next_block(&client).await {
-                    error!("Error creating block, cause: {e:?}")
+                if let Err(e) = f.index_checkpoints().await {
+                    error!("Error indexing checkpoint, cause: {e:?}")
                 }
-                tokio::time::sleep(block_interval).await;
+                tokio::time::sleep(update_interval).await;
             }
         });
 
         blocks
     }
 
-    async fn create_next_block(&self, client: &SuiClient) -> Result<(), Error> {
-        let current_block = self.current_block_identifier()?;
-        // Sui get_total_transaction_number starts from 1.
-        let total_tx = client.read_api().get_total_transaction_number().await? - 1;
-        if total_tx == 0 {
-            return Ok(());
-        }
-        if current_block.index < total_tx {
-            let cursor = current_block.hash;
-            let mut tx_digests = client
-                .read_api()
-                .get_transactions(TransactionQuery::All, Some(cursor), None, false)
-                .await?
-                .data;
-            if tx_digests.remove(0) != cursor {
-                return Err(Error::DataError(
-                    "Incorrect transaction data returned from Sui.".to_string(),
-                ));
-            }
-
-            let mut index = current_block.index;
-            let mut parent_block_identifier = current_block;
-
-            for digest in tx_digests {
-                index += 1;
-                let block_identifier = BlockIdentifier {
-                    index,
-                    hash: digest,
-                };
-
-                // update balance
-                let response = client.read_api().get_transaction(digest).await?;
-
-                let operations = response.try_into()?;
-
-                self.add_block_index(&block_identifier, &parent_block_identifier)?;
-                self.update_balance(index, operations)
-                    .await
-                    .map_err(|e| anyhow!("Failed to update balance, cause : {e}",))?;
-                parent_block_identifier = block_identifier
+    async fn index_checkpoints(&self) -> Result<(), Error> {
+        let last_checkpoint = self.last_indexed_checkpoint()?;
+        let head = self
+            .client
+            .read_api()
+            .get_latest_checkpoint_sequence_number()
+            .await?;
+        if last_checkpoint < head {
+            for seq in last_checkpoint + 1..=head {
+                let checkpoint = self.client.read_api().get_checkpoint(seq).await?;
+                let resp = self.create_block_response(checkpoint).await?;
+                self.update_balance(seq, resp.block.transactions).await?;
             }
         } else {
-            debug!("No new transactions.")
+            debug!("No new checkpoints.")
         };
-
-        Ok(())
-    }
-
-    fn add_block_index(
-        &self,
-        block_id: &BlockIdentifier,
-        parent: &BlockIdentifier,
-    ) -> Result<(), Error> {
-        let index = &block_id.index;
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
-        self.database.block_heights.insert(&block_id.hash, index)?;
-        self.database
-            .blocks
-            .insert(index, &(*block_id, *parent, timestamp))?;
         Ok(())
     }
 
     async fn update_balance(
         &self,
         block_height: u64,
-        ops: Operations,
+        transactions: Vec<Transaction>,
     ) -> Result<(), anyhow::Error> {
-        for (addr, value) in extract_balance_changes_from_ops(ops)? {
+        let balances: HashMap<SuiAddress, i128> =
+            transactions
+                .into_iter()
+                .try_fold(HashMap::new(), |mut changes, tx| {
+                    for (address, balance) in extract_balance_changes_from_ops(tx.operations)? {
+                        *changes.entry(address).or_default() += balance;
+                    }
+                    Ok::<HashMap<SuiAddress, i128>, anyhow::Error>(changes)
+                })?;
+
+        for (addr, value) in balances {
             let current_balance = self.get_balance_at_block(addr, block_height).await? as i128;
             let new_balance = if value.is_negative() {
                 if current_balance < value.abs() {
@@ -292,7 +216,7 @@ impl PseudoBlockProvider {
                 current_balance + value.abs()
             };
 
-            self.database.balances.insert(
+            self.index_store.balances.insert(
                 &(addr, block_height),
                 &HistoricBalance {
                     block_height,
@@ -303,38 +227,71 @@ impl PseudoBlockProvider {
         Ok(())
     }
 
-    async fn create_block_response(
-        &self,
-        block_identifier: BlockIdentifier,
-        parent_block_identifier: BlockIdentifier,
-        timestamp: u64,
-    ) -> Result<BlockResponse, Error> {
-        let tx = self
-            .client
-            .read_api()
-            .get_transaction(block_identifier.hash)
-            .await?;
+    async fn create_block_response(&self, checkpoint: Checkpoint) -> Result<BlockResponse, Error> {
+        let index = checkpoint.summary.sequence_number;
+        let hash = checkpoint.summary.digest();
+        let mut transactions = vec![];
+        for digest in checkpoint.content.iter() {
+            let tx = self
+                .client
+                .read_api()
+                .get_transaction(digest.transaction)
+                .await?;
+            transactions.push(Transaction {
+                transaction_identifier: TransactionIdentifier {
+                    hash: tx.certificate.transaction_digest,
+                },
+                operations: Operations::try_from(tx)?,
+                related_transactions: vec![],
+                metadata: None,
+            })
+        }
 
-        let digest = tx.certificate.transaction_digest;
-        let operations = tx.try_into()?;
+        // previous digest should only be None for genesis block.
+        if checkpoint.summary.previous_digest.is_none() && index != 0 {
+            return Err(Error::DataError(format!(
+                "Previous digest is None for checkpoint [{index}], digest: [{hash:?}]"
+            )));
+        }
 
-        let transaction = Transaction {
-            transaction_identifier: TransactionIdentifier { hash: digest },
-            operations,
-            related_transactions: vec![],
-            metadata: None,
-        };
+        let parent_block_identifier = checkpoint
+            .summary
+            .previous_digest
+            .map(|hash| BlockIdentifier {
+                index: index - 1,
+                hash,
+            })
+            .unwrap_or_else(|| BlockIdentifier { index, hash });
 
         Ok(BlockResponse {
             block: Block {
-                block_identifier,
+                block_identifier: BlockIdentifier { index, hash },
                 parent_block_identifier,
-                timestamp,
-                transactions: vec![transaction],
+                timestamp: 0,
+                transactions,
                 metadata: None,
             },
             other_transactions: vec![],
         })
+    }
+
+    async fn create_block_identifier(
+        &self,
+        seq_number: CheckpointSequenceNumber,
+    ) -> Result<BlockIdentifier, Error> {
+        let checkpoint = self.client.read_api().get_checkpoint(seq_number).await?;
+        Ok(BlockIdentifier {
+            index: checkpoint.summary.sequence_number,
+            hash: checkpoint.summary.digest(),
+        })
+    }
+
+    fn last_indexed_checkpoint(&self) -> Result<CheckpointSequenceNumber, Error> {
+        Ok(self
+            .index_store
+            .last_checkpoint
+            .get(&true)?
+            .unwrap_or_default())
     }
 }
 
@@ -368,58 +325,21 @@ fn extract_balance_changes_from_ops(
         })
 }
 
-async fn process_genesis_block(client: &SuiClient, f: &PseudoBlockProvider) -> Result<(), Error> {
-    let digest = *client
-        .read_api()
-        .get_transactions(TransactionQuery::All, None, Some(1), false)
-        .await?
-        .data
-        .first()
-        .ok_or_else(|| Error::InternalError(anyhow!("Cannot find genesis transaction.")))?;
-
-    let response = client.read_api().get_transaction(digest).await?;
-    if !response
-        .certificate
-        .data
-        .transactions
-        .iter()
-        .any(|tx| matches!(tx, SuiTransactionKind::Genesis(_)))
-    {
-        return Err(Error::InternalError(anyhow!(
-            "Transaction [{digest:?}] is not a Genesis transaction."
-        )));
-    }
-    let operations = response.try_into()?;
-    let block_identifier = BlockIdentifier {
-        index: 0,
-        hash: digest,
-    };
-
-    f.add_block_index(&block_identifier, &block_identifier)?;
-    f.update_balance(0, operations)
-        .await
-        .map_err(|e| anyhow!("Failed to update balance, cause : {e}",))?;
-
-    Ok(())
-}
-
 #[derive(DBMapUtils)]
-pub struct BlockProviderTables {
+pub struct CheckpointIndexStore {
     #[default_options_override_fn = "default_config"]
-    blocks: DBMap<BlockHeight, (BlockIdentifier, BlockIdentifier, u64)>,
+    balances: DBMap<(SuiAddress, EpochId), HistoricBalance>,
     #[default_options_override_fn = "default_config"]
-    block_heights: DBMap<BlockHash, BlockHeight>,
-    #[default_options_override_fn = "default_config"]
-    balances: DBMap<(SuiAddress, u64), HistoricBalance>,
+    last_checkpoint: DBMap<bool, CheckpointSequenceNumber>,
 }
 
-impl BlockProviderTables {
+impl CheckpointIndexStore {
     pub fn open(db_dir: &Path, db_options: Option<Options>) -> Self {
         Self::open_tables_read_write(db_dir.to_path_buf(), db_options, None)
     }
 
     pub fn is_empty(&self) -> bool {
-        self.blocks.is_empty()
+        self.last_checkpoint.is_empty()
     }
 }
 

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -178,6 +178,7 @@ impl CheckpointBlockProvider {
                 let resp = self.create_block_response(checkpoint).await?;
                 self.update_balance(seq, resp.block.transactions).await?;
             }
+            self.index_store.last_checkpoint.insert(&true, &head)?;
         } else {
             debug!("No new checkpoints.")
         };

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-use sui_sdk::rpc_types::Checkpoint;
+use sui_sdk::apis::Checkpoint;
 use sui_sdk::SuiClient;
 use sui_storage::default_db_options;
 use sui_types::base_types::{EpochId, SuiAddress};

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -28,6 +28,7 @@ use sui_types::governance::{
 use sui_types::messages::{
     CallArg, MoveCall, ObjectArg, PaySui, SingleTransactionKind, TransactionData, TransactionKind,
 };
+use sui_types::messages_checkpoint::CheckpointDigest;
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
 use sui_types::{SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
 
@@ -129,7 +130,7 @@ pub struct BlockIdentifier {
     pub hash: BlockHash,
 }
 
-pub type BlockHash = TransactionDigest;
+pub type BlockHash = CheckpointDigest;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Amount {

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sui_json_rpc::api::GovernanceReadApiClient;
 use sui_json_rpc_types::{
-    Balance, Coin, CoinPage, DynamicFieldPage, EventPage, GetObjectDataResponse,
+    Balance, Checkpoint, Coin, CoinPage, DynamicFieldPage, EventPage, GetObjectDataResponse,
     GetPastObjectDataResponse, GetRawObjectDataResponse, SuiCoinMetadata, SuiEventEnvelope,
     SuiEventFilter, SuiExecuteTransactionResponse, SuiMoveNormalizedModule, SuiObjectInfo,
     SuiTransactionEffects, SuiTransactionResponse, TransactionsPage,
@@ -28,7 +28,10 @@ use sui_types::event::EventID;
 use sui_types::messages::{
     CommitteeInfoResponse, ExecuteTransactionRequestType, TransactionData, VerifiedTransaction,
 };
-use sui_types::messages_checkpoint::{CheckpointSequenceNumber, CheckpointSummary};
+use sui_types::messages_checkpoint::{
+    CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
+    CheckpointSummary,
+};
 use sui_types::query::{EventQuery, TransactionQuery};
 use sui_types::sui_system_state::{SuiSystemState, ValidatorMetadata};
 
@@ -139,11 +142,59 @@ impl ReadApi {
             .await?)
     }
 
+    /// Return a checkpoint summary based on a checkpoint sequence number
+    pub async fn get_checkpoint(
+        &self,
+        seq_number: CheckpointSequenceNumber,
+    ) -> SuiRpcResult<Checkpoint> {
+        Ok(self.api.http.get_checkpoint(seq_number).await?)
+    }
+
+    /// Return a checkpoint summary based on a checkpoint sequence number
+    pub async fn get_checkpoint_by_digest(
+        &self,
+        digest: CheckpointDigest,
+    ) -> SuiRpcResult<Checkpoint> {
+        Ok(self.api.http.get_checkpoint_by_digest(digest).await?)
+    }
+
+    /// Return a checkpoint summary based on a checkpoint sequence number
     pub async fn get_checkpoint_summary(
         &self,
         seq_number: CheckpointSequenceNumber,
     ) -> SuiRpcResult<CheckpointSummary> {
         Ok(self.api.http.get_checkpoint_summary(seq_number).await?)
+    }
+
+    /// Return the sequence number of the latest checkpoint that has been executed
+    pub async fn get_latest_checkpoint_sequence_number(
+        &self,
+    ) -> SuiRpcResult<CheckpointSequenceNumber> {
+        Ok(self
+            .api
+            .http
+            .get_latest_checkpoint_sequence_number()
+            .await?)
+    }
+
+    /// Return contents of a checkpoint, namely a list of execution digests
+    pub async fn get_checkpoint_contents(
+        &self,
+        digest: CheckpointContentsDigest,
+    ) -> SuiRpcResult<CheckpointContents> {
+        Ok(self.api.http.get_checkpoint_contents(digest).await?)
+    }
+
+    /// Return contents of a checkpoint based on its sequence number
+    pub async fn get_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> SuiRpcResult<CheckpointContents> {
+        Ok(self
+            .api
+            .http
+            .get_checkpoint_contents_by_sequence_number(sequence_number)
+            .await?)
     }
 
     pub fn get_transactions_stream(


### PR DESCRIPTION
Use checkpoint apis to create blocks, we still need to index transactions on rosetta side to record all balance changes at each checkpoint. We could remove this if we decide to index balances in indexer later on.

Also:
* added get_checkpoint_summary_by_digest and minor renaming to make checkpoint api more consistent 
* added missing checkpoint api methods to Rust SDK