### PR TITLE
[reconfig] Add advance epoch safe mode

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -505,4 +505,5 @@ stake_subsidy:
   balance:
     value: 0
   current_epoch_amount: 1000000
+safe_mode: false
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1594,6 +1594,10 @@ impl AuthorityPerEpochStore {
             .set(elapsed_ms);
     }
 
+    pub(crate) fn record_is_safe_mode_metric(&self, safe_mode: bool) {
+        self.metrics.is_safe_mode.set(safe_mode as i64);
+    }
+
     fn record_epoch_total_duration_metric(&self) {
         self.metrics.current_epoch.set(self.epoch() as i64);
         self.metrics

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -675,7 +675,10 @@ impl CheckpointBuilder {
             .await?;
         debug!(
             "Effects of the change epoch transaction: {:?}",
-            signed_effect
+            signed_effect.data()
+        );
+        self.epoch_store.record_is_safe_mode_metric(
+            self.state.get_sui_system_state_object().unwrap().safe_mode,
         );
         // The change epoch transaction cannot fail to execute.
         // TODO: Audit the advance_epoch move call to make sure there is no way for it to fail.

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -80,6 +80,9 @@ pub struct EpochMetrics {
 
     /// Tallying rule scores for all validators this epoch.
     pub tallying_rule_scores: IntGaugeVec,
+
+    /// Whether we are running in safe mode where reward distribution and tokenomics are disabled.
+    pub is_safe_mode: IntGauge,
 }
 
 impl EpochMetrics {
@@ -162,6 +165,11 @@ impl EpochMetrics {
                 "Tallying rule scores for validators each epoch",
                 &["validator", "epoch"],
                 registry
+            ).unwrap(),
+            is_safe_mode: register_int_gauge_with_registry!(
+                "is_safe_mode",
+                "Whether we are running in safe mode",
+                registry,
             ).unwrap(),
         };
         Arc::new(this)

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,13 +4,13 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
-    "computation_cost": 7802,
-    "storage_cost": 11231,
+    "computation_cost": 7814,
+    "storage_cost": 11250,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 8661,
-    "storage_cost": 12434,
+    "computation_cost": 8674,
+    "storage_cost": 12453,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
@@ -29,8 +29,8 @@ expression: common_costs_estimate
     "storage_rebate": 0
   },
   "SplitCoin": {
-    "computation_cost": 7780,
-    "storage_cost": 11198,
+    "computation_cost": 7793,
+    "storage_cost": 11217,
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -27,6 +27,7 @@
 -  [Function `report_validator`](#0x2_sui_system_report_validator)
 -  [Function `undo_report_validator`](#0x2_sui_system_undo_report_validator)
 -  [Function `advance_epoch`](#0x2_sui_system_advance_epoch)
+-  [Function `advance_epoch_safe_mode`](#0x2_sui_system_advance_epoch_safe_mode)
 -  [Function `epoch`](#0x2_sui_system_epoch)
 -  [Function `validator_delegate_amount`](#0x2_sui_system_validator_delegate_amount)
 -  [Function `validator_stake_amount`](#0x2_sui_system_validator_stake_amount)
@@ -167,6 +168,16 @@ The top-level object containing all information of the Sui system.
 </dt>
 <dd>
  Schedule of stake subsidies given out each epoch.
+</dd>
+<dt>
+<code>safe_mode: bool</code>
+</dt>
+<dd>
+ Whether the system is running in a downgraded safe mode due to a non-recoverable bug.
+ This is set whenever we failed to execute advance_epoch, and ended up executing advance_epoch_safe_mode.
+ It can be reset once we are able to successfully execute advance_epoch.
+ TODO: Down the road we may want to save a few states such as pending gas rewards, so that we could
+ redistribute them.
 </dd>
 </dl>
 
@@ -368,6 +379,7 @@ This function will be called only once in genesis.
         reference_gas_price,
         validator_report_records: <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>(),
         <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>: <a href="stake_subsidy.md#0x2_stake_subsidy_create">stake_subsidy::create</a>(initial_stake_subsidy_amount),
+        safe_mode: <b>false</b>,
     };
     <a href="transfer.md#0x2_transfer_share_object">transfer::share_object</a>(state);
 }
@@ -1103,6 +1115,8 @@ gas coins.
             total_stake_rewards: total_rewards_amount,
         }
     );
+
+    self.safe_mode = <b>false</b>;
 }
 </code></pre>
 
@@ -1119,6 +1133,41 @@ Total supply of SUI increases by the amount of stake subsidy we minted.
 
 <pre><code><b>ensures</b> <a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(self.sui_supply)
     == <b>old</b>(<a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(self.sui_supply)) + <b>old</b>(<a href="stake_subsidy.md#0x2_stake_subsidy_current_epoch_subsidy_amount">stake_subsidy::current_epoch_subsidy_amount</a>(self.<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>));
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_advance_epoch_safe_mode"></a>
+
+## Function `advance_epoch_safe_mode`
+
+An extremely simple version of advance_epoch.
+This is only called when the call to advance_epoch failed due to a bug, and we want to be able to keep the system
+running and continue making epoch changes.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch_safe_mode">advance_epoch_safe_mode</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch_safe_mode">advance_epoch_safe_mode</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    new_epoch: u64,
+    ctx: &<b>mut</b> TxContext,
+) {
+    // Validator will make a special system call <b>with</b> sender set <b>as</b> 0x0.
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, 0);
+
+    self.epoch = new_epoch;
+    self.safe_mode = <b>true</b>;
+}
 </code></pre>
 
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5843,6 +5843,7 @@
           "info",
           "parameters",
           "reference_gas_price",
+          "safe_mode",
           "stake_subsidy",
           "storage_fund",
           "treasury_cap",
@@ -5865,6 +5866,9 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
+          },
+          "safe_mode": {
+            "type": "boolean"
           },
           "stake_subsidy": {
             "$ref": "#/components/schemas/StakeSubsidy"

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -21,6 +21,7 @@ use std::collections::BTreeMap;
 const SUI_SYSTEM_STATE_STRUCT_NAME: &IdentStr = ident_str!("SuiSystemState");
 pub const SUI_SYSTEM_MODULE_NAME: &IdentStr = ident_str!("sui_system");
 pub const ADVANCE_EPOCH_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch");
+pub const ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch_safe_mode");
 
 /// Rust version of the Move sui::sui_system::SystemParameters type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
@@ -200,6 +201,7 @@ pub struct SuiSystemState {
     pub reference_gas_price: u64,
     pub validator_report_records: VecMap<SuiAddress, VecSet<SuiAddress>>,
     pub stake_subsidy: StakeSubsidy,
+    pub safe_mode: bool,
     // TODO: Use getters instead of all pub.
 }
 

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -101,5 +101,6 @@ pub fn test_sui_system_state(epoch: EpochId, validators: Vec<Validator>) -> SuiS
             balance: Balance::new(0),
             current_epoch_amount: 0,
         },
+        safe_mode: false,
     }
 }


### PR DESCRIPTION
This PR adds a simplified version of `advance_epoch` that only updates the epoch ID.
In the execution_engine, if we failed to execute the normal advance_epoch, we fall back to execute the simple one.
And if this ever happened, we memorized it through a bool safe_mode for signaling. If we are able to successfully execute advance_epoch again, we will be out of this mode.
Also added logging and metric so that we could monitor it.