### PR TITLE
[Narwhal] remove unused code and noisy logs related to reconfig

### DIFF
--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -63,7 +63,8 @@ impl ConsensusProtocol for Bullshark {
         self.log_error_if_missing_parents(&certificate, state);
 
         // Add the new certificate to the local storage.
-        if state.try_insert(&certificate).is_err() {
+        if !state.try_insert(&certificate) {
+            // Certificate is not inserted. This operation is a no-op.
             return Ok(Vec::new());
         }
 
@@ -87,7 +88,8 @@ impl ConsensusProtocol for Bullshark {
         self.max_inserted_certificate_round = self.max_inserted_certificate_round.max(round);
 
         // Try to order the dag to commit. Start from the highest round for which we have at least
-        // f+1 certificates. This is because we need them to reveal the common coin.
+        // f+1 certificates. This is because we need them to reveal the common coin, or provide
+        // enough support to the leader.
         let r = round - 1;
 
         // We only elect leaders for even round numbers.
@@ -114,7 +116,7 @@ impl ConsensusProtocol for Bullshark {
             }
         };
 
-        // Check if the leader has f+1 support from its children (ie. round r-1).
+        // Check if the leader has f+1 support from its children (ie. round r+1).
         let stake: Stake = state
             .dag
             .get(&round)
@@ -210,11 +212,6 @@ impl ConsensusProtocol for Bullshark {
             .observe(total_commits as f64);
 
         Ok(committed_sub_dags)
-    }
-
-    fn update_committee(&mut self, new_committee: Committee) -> StoreResult<()> {
-        self.committee = new_committee;
-        self.store.clear()
     }
 }
 

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -88,7 +88,7 @@ impl ConsensusProtocol for Bullshark {
         self.max_inserted_certificate_round = self.max_inserted_certificate_round.max(round);
 
         // Try to order the dag to commit. Start from the highest round for which we have at least
-        // f+1 certificates. This is because we need them to reveal the common coin, or provide
+        // f+1 certificates. This is because we need them to provide
         // enough support to the leader.
         let r = round - 1;
 

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -122,7 +122,7 @@ impl ConsensusState {
 
         let mut num_certs = 0;
         for cert in &certificates {
-            if Self::try_insert_in_dag(&mut dag, last_committed, cert).is_ok() {
+            if Self::try_insert_in_dag(&mut dag, last_committed, cert) {
                 info!("Inserted certificate: {:?}", cert);
                 num_certs += 1;
             }
@@ -136,27 +136,27 @@ impl ConsensusState {
         dag
     }
 
-    #[allow(clippy::result_unit_err)]
-    pub fn try_insert(&mut self, certificate: &Certificate) -> Result<(), ()> {
+    /// Returns true if certificate is inserted in the dag.
+    pub fn try_insert(&mut self, certificate: &Certificate) -> bool {
         Self::try_insert_in_dag(&mut self.dag, &self.last_committed, certificate)
     }
 
-    #[allow(clippy::result_unit_err)]
+    /// Returns true if certificate is inserted in the dag.
     fn try_insert_in_dag(
         dag: &mut Dag,
         last_committed: &HashMap<PublicKey, Round>,
         certificate: &Certificate,
-    ) -> Result<(), ()> {
+    ) -> bool {
         let last_committed_round = last_committed
             .get(&certificate.origin())
             .cloned()
             .unwrap_or_default();
         if certificate.round() < last_committed_round {
             debug!(
-                "Ignoring certificate {:?} as it is past last committed round for this origin {}",
+                "Ignoring certificate {:?} as it is before last committed round for this origin {}",
                 certificate, last_committed_round
             );
-            return Err(());
+            return false;
         }
 
         dag.entry(certificate.round())
@@ -165,7 +165,7 @@ impl ConsensusState {
                 certificate.origin(),
                 (certificate.digest(), certificate.clone()),
             );
-        Ok(())
+        true
     }
 
     /// Update and clean up internal state base on committed certificates.
@@ -218,8 +218,6 @@ pub trait ConsensusProtocol {
         // The new certificate.
         certificate: Certificate,
     ) -> StoreResult<Vec<CommittedSubDag>>;
-
-    fn update_committee(&mut self, new_committee: Committee) -> StoreResult<()>;
 }
 
 pub struct Consensus<ConsensusProtocol> {
@@ -317,10 +315,7 @@ where
                 }
 
                 Some(certificate) = self.rx_new_certificates.recv() => {
-                    // If the core already moved to the next epoch we should pull the next
-                    // committee as well.
                     match certificate.epoch().cmp(&self.committee.epoch()) {
-
                         Ordering::Equal => {
                             // we can proceed.
                         }

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -124,11 +124,6 @@ impl ConsensusProtocol for Tusk {
 
         Ok(committed_sub_dags)
     }
-
-    fn update_committee(&mut self, new_committee: Committee) -> StoreResult<()> {
-        self.committee = new_committee;
-        self.store.clear()
-    }
 }
 
 impl Tusk {

--- a/narwhal/consensus/src/utils.rs
+++ b/narwhal/consensus/src/utils.rs
@@ -44,7 +44,7 @@ fn linked(leader: &Certificate, prev_leader: &Certificate, dag: &Dag) -> bool {
     let mut parents = vec![leader];
     for r in (prev_leader.round()..leader.round()).rev() {
         parents = dag
-            .get(&(r))
+            .get(&r)
             .expect("We should have the whole history by now")
             .values()
             .filter(|(digest, _)| parents.iter().any(|x| x.header.parents.contains(digest)))

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -319,7 +319,7 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
                 return Some(batch);
             }
             Ok(None) => debug!("Payload {} not found locally", digest),
-            Err(err) => error!("Error communicating with own worker: {}", err),
+            Err(err) => warn!("Error communicating with own worker: {}", err),
         }
         None
     }


### PR DESCRIPTION
Remove unused functions. Decrease severity for failures expected during reconfigs.

No functional change is expected.