### PR TITLE
[explorer] Improvements for forms

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -20,7 +20,7 @@
         "preview-storybook": "pnpm dlx serve ./storybook-static"
     },
     "dependencies": {
-        "@floating-ui/react-dom-interactions": "^0.13.3",
+        "@floating-ui/react": "^0.18.0",
         "@fontsource/inter": "^4.5.14",
         "@fontsource/red-hat-mono": "^4.5.11",
         "@growthbook/growthbook": "^0.20.1",
@@ -50,7 +50,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^3.1.4",
-        "react-hook-form": "^7.41.5",
+        "react-hook-form": "^7.42.1",
         "react-hot-toast": "^2.4.0",
         "react-router-dom": "^6.5.0",
         "topojson-client": "^3.1.0",

--- a/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
+++ b/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
@@ -49,6 +49,8 @@ export function ModuleFunction({
     const { handleSubmit, formState, register, control } = useZodForm({
         schema: argsSchema,
     });
+    const { isValidating, isValid, isSubmitting } = formState;
+
     const typeArguments = useFunctionTypeArguments(
         functionDetails.type_parameters
     );
@@ -86,10 +88,8 @@ export function ModuleFunction({
         },
     });
     const isExecuteDisabled =
-        formState.isValidating ||
-        !formState.isValid ||
-        formState.isSubmitting ||
-        !isConnected;
+        isValidating || !isValid || isSubmitting || !isConnected;
+
     return (
         <DisclosureBox defaultOpen={defaultOpen} title={functionName}>
             <form
@@ -115,7 +115,7 @@ export function ModuleFunction({
                         label={`Arg${index}`}
                         {...register(`params.${index}` as const)}
                         placeholder={paramTypeText}
-                        disabled={formState.isSubmitting}
+                        disabled={isSubmitting}
                     />
                 ))}
                 <div className="flex items-stretch justify-end gap-1.5">

--- a/apps/explorer/src/ui/Tooltip.tsx
+++ b/apps/explorer/src/ui/Tooltip.tsx
@@ -14,13 +14,13 @@ import {
     useInteractions,
     FloatingPortal,
     arrow,
-} from '@floating-ui/react-dom-interactions';
+} from '@floating-ui/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRef, useState } from 'react';
 
 import { ReactComponent as InfoSvg } from './icons/info.svg';
 
-import type { Placement } from '@floating-ui/react-dom-interactions';
+import type { Placement } from '@floating-ui/react';
 import type { ReactNode, CSSProperties } from 'react';
 
 const TOOLTIP_DELAY = 150;

--- a/apps/explorer/src/ui/header/NetworkSelect.tsx
+++ b/apps/explorer/src/ui/header/NetworkSelect.tsx
@@ -15,7 +15,7 @@ import {
     offset,
     shift,
     useFloating,
-} from '@floating-ui/react-dom-interactions';
+} from '@floating-ui/react';
 import { Popover } from '@headlessui/react';
 import clsx from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -105,6 +105,8 @@ function CustomRPCInput({
         },
     });
 
+    const { errors, isDirty, isValid } = formState;
+
     return (
         <form
             onSubmit={handleSubmit((values) => {
@@ -117,7 +119,7 @@ function CustomRPCInput({
                 type="text"
                 className={clsx(
                     'block w-full rounded-md border border-solid p-3 pr-16 shadow-sm outline-none',
-                    formState.errors.url
+                    errors.url
                         ? 'border-issue-dark text-issue-dark'
                         : 'border-gray-65 text-gray-90'
                 )}
@@ -125,7 +127,7 @@ function CustomRPCInput({
 
             <div className="absolute inset-y-0 right-0 flex flex-col justify-center px-3">
                 <button
-                    disabled={!formState.isDirty || !formState.isValid}
+                    disabled={!isDirty || !isValid}
                     type="submit"
                     className="flex items-center justify-center rounded-full border-0 bg-gray-90 px-2 py-1 text-captionSmall font-semibold uppercase text-white transition disabled:bg-gray-45 disabled:text-gray-65"
                 >

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -110,7 +110,7 @@
         "webpack-merge": "^5.8.0"
     },
     "dependencies": {
-        "@floating-ui/react-dom-interactions": "^0.13.3",
+        "@floating-ui/react": "^0.18.0",
         "@fontsource/inter": "^4.5.14",
         "@fontsource/red-hat-mono": "^4.5.11",
         "@growthbook/growthbook": "^0.20.1",

--- a/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
+++ b/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
@@ -8,7 +8,7 @@ import {
     useDismiss,
     offset,
     arrow,
-} from '@floating-ui/react-dom-interactions';
+} from '@floating-ui/react';
 import cn from 'classnames';
 import { motion, AnimatePresence } from 'framer-motion';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';

--- a/apps/wallet/src/ui/app/shared/tooltip/index.tsx
+++ b/apps/wallet/src/ui/app/shared/tooltip/index.tsx
@@ -14,13 +14,13 @@ import {
     useInteractions,
     FloatingPortal,
     arrow,
-} from '@floating-ui/react-dom-interactions';
+} from '@floating-ui/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRef, useState } from 'react';
 
 import Icon, { SuiIcons } from '_components/icon';
 
-import type { Placement } from '@floating-ui/react-dom-interactions';
+import type { Placement } from '@floating-ui/react';
 import type { ReactNode, CSSProperties } from 'react';
 
 const TOOLTIP_DELAY = 150;

--- a/dapps/frenemies/package.json
+++ b/dapps/frenemies/package.json
@@ -12,8 +12,8 @@
     "@fontsource/inter": "^4.5.14",
     "@headlessui/react": "^1.7.7",
     "@hookform/resolvers": "^2.9.10",
-    "@mysten/icons": "workspace:*",
     "@mysten/core": "workspace:*",
+    "@mysten/icons": "workspace:*",
     "@mysten/sui.js": "workspace:*",
     "@mysten/wallet-kit": "workspace:*",
     "@tanstack/react-query": "^4.22.0",
@@ -24,7 +24,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^3.1.4",
-    "react-hook-form": "^7.41.5",
+    "react-hook-form": "^7.42.1",
     "react-hot-toast": "^2.4.0",
     "react-router-dom": "^6.6.2",
     "zod": "^3.20.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
   apps/explorer:
     specifiers:
       '@babel/core': ^7.20.12
-      '@floating-ui/react-dom-interactions': ^0.13.3
+      '@floating-ui/react': ^0.18.0
       '@fontsource/inter': ^4.5.14
       '@fontsource/red-hat-mono': ^4.5.11
       '@growthbook/growthbook': ^0.20.1
@@ -87,7 +87,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-error-boundary: ^3.1.4
-      react-hook-form: ^7.41.5
+      react-hook-form: ^7.42.1
       react-hot-toast: ^2.4.0
       react-router-dom: ^6.5.0
       start-server-and-test: ^1.15.2
@@ -102,13 +102,13 @@ importers:
       web-vitals: ^3.1.0
       zod: ^3.20.2
     dependencies:
-      '@floating-ui/react-dom-interactions': 0.13.3_ib3m5ricvtkl2cll7qpr2f6lvq
+      '@floating-ui/react': 0.18.0_ib3m5ricvtkl2cll7qpr2f6lvq
       '@fontsource/inter': 4.5.14
       '@fontsource/red-hat-mono': 4.5.11
       '@growthbook/growthbook': 0.20.1
       '@growthbook/growthbook-react': 0.10.1_react@18.2.0
       '@headlessui/react': 1.7.7_biqbaboplfbrettd7655fr4n2y
-      '@hookform/resolvers': 2.9.10_react-hook-form@7.41.5
+      '@hookform/resolvers': 2.9.10_react-hook-form@7.42.1
       '@mysten/core': link:../core
       '@mysten/icons': link:../icons
       '@mysten/sui.js': link:../../sdk/typescript
@@ -132,7 +132,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-error-boundary: 3.1.4_react@18.2.0
-      react-hook-form: 7.41.5_react@18.2.0
+      react-hook-form: 7.42.1_react@18.2.0
       react-hot-toast: 2.4.0_biqbaboplfbrettd7655fr4n2y
       react-router-dom: 6.6.2_biqbaboplfbrettd7655fr4n2y
       topojson-client: 3.1.0
@@ -169,7 +169,7 @@ importers:
       prettier-plugin-tailwindcss: 0.2.1_prettier@2.8.1
       start-server-and-test: 1.15.2
       storybook: 7.0.0-beta.3_o4scbtliisanygemawej7x2d6i
-      tailwindcss: 3.2.4
+      tailwindcss: 3.2.4_postcss@8.4.21
       tsconfig-paths: 4.1.2
       typescript: 4.9.4
       vite: 4.0.4_@types+node@18.11.18
@@ -196,7 +196,7 @@ importers:
     specifiers:
       '@babel/preset-env': ^7.20.2
       '@babel/preset-typescript': ^7.18.6
-      '@floating-ui/react-dom-interactions': ^0.13.3
+      '@floating-ui/react': ^0.18.0
       '@fontsource/inter': ^4.5.14
       '@fontsource/red-hat-mono': ^4.5.11
       '@growthbook/growthbook': ^0.20.1
@@ -304,7 +304,7 @@ importers:
       yup: ^0.32.11
       zxcvbn: ^4.4.2
     dependencies:
-      '@floating-ui/react-dom-interactions': 0.13.3_ib3m5ricvtkl2cll7qpr2f6lvq
+      '@floating-ui/react': 0.18.0_ib3m5ricvtkl2cll7qpr2f6lvq
       '@fontsource/inter': 4.5.14
       '@fontsource/red-hat-mono': 4.5.11
       '@growthbook/growthbook': 0.20.1
@@ -339,7 +339,7 @@ importers:
       rxjs: 7.8.0
       semver: 7.3.8
       stream-browserify: 3.0.0
-      tailwindcss: 3.2.4_ts-node@10.9.1
+      tailwindcss: 3.2.4_aesdjsunmf4wiehhujt67my7tu
       throttle-debounce: 5.0.0
       tweetnacl: 1.0.3
       uuid: 8.3.2
@@ -437,7 +437,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-error-boundary: ^3.1.4
-      react-hook-form: ^7.41.5
+      react-hook-form: ^7.42.1
       react-hot-toast: ^2.4.0
       react-router-dom: ^6.6.2
       tailwindcss: ^3.2.4
@@ -447,7 +447,7 @@ importers:
     dependencies:
       '@fontsource/inter': 4.5.14
       '@headlessui/react': 1.7.7_biqbaboplfbrettd7655fr4n2y
-      '@hookform/resolvers': 2.9.10_react-hook-form@7.41.5
+      '@hookform/resolvers': 2.9.10_react-hook-form@7.42.1
       '@mysten/core': link:../../apps/core
       '@mysten/icons': link:../../apps/icons
       '@mysten/sui.js': link:../../sdk/typescript
@@ -460,7 +460,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-error-boundary: 3.1.4_react@18.2.0
-      react-hook-form: 7.41.5_react@18.2.0
+      react-hook-form: 7.42.1_react@18.2.0
       react-hot-toast: 2.4.0_biqbaboplfbrettd7655fr4n2y
       react-router-dom: 6.6.2_biqbaboplfbrettd7655fr4n2y
       zod: 3.20.2
@@ -470,7 +470,7 @@ importers:
       '@vitejs/plugin-react': 3.0.1_vite@4.0.4
       autoprefixer: 10.4.13_postcss@8.4.21
       postcss: 8.4.21
-      tailwindcss: 3.2.4
+      tailwindcss: 3.2.4_postcss@8.4.21
       typescript: 4.9.4
       vite: 4.0.4
 
@@ -3714,24 +3714,8 @@ packages:
       '@floating-ui/core': 1.1.0
     dev: false
 
-  /@floating-ui/react-dom-interactions/0.13.3_ib3m5ricvtkl2cll7qpr2f6lvq:
-    resolution: {integrity: sha512-AnCW06eIZxzD/Hl1Qbi2JkQRU5KpY7Dn81k3xRfbvs+HylhB+t3x88/GNKLK39mMTlJ/ylxm5prUpiLrTWvifQ==}
-    deprecated: Package renamed to @floating-ui/react
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-    dependencies:
-      '@floating-ui/react-dom': 1.1.1_biqbaboplfbrettd7655fr4n2y
-      aria-hidden: 1.2.2_kzbn2opkn2327fwg5yzwzya5o4
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      tabbable: 6.0.1
-    transitivePeerDependencies:
-      - '@types/react'
-    dev: false
-
-  /@floating-ui/react-dom/1.1.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-F27E+7SLB5NZvwF9Egqx/PlvxOhMnA6k/yNMQUqaQ9BPZdr4fQgSW6J6AKNIrBQElBT8IRDtv9j6h7FDkgp3dA==}
+  /@floating-ui/react-dom/1.2.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-YCLlqibZtgUhxUpxkSp1oekvYgH/jI4KdZEJv85E62twlZHN43xdlQNe6JcF4ROD3/Zu6juNHN+aOygN+6yZjg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -3739,6 +3723,21 @@ packages:
       '@floating-ui/dom': 1.1.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@floating-ui/react/0.18.0_ib3m5ricvtkl2cll7qpr2f6lvq:
+    resolution: {integrity: sha512-zxgwWigxaph1TIBdezCDdc3eo+4FUDKY2MiBR3gywZtx5Eeb0KBRRZ9PyzznTXuYO5Y9BFHAC0Yikqp7rr+oKQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/react-dom': 1.2.1_biqbaboplfbrettd7655fr4n2y
+      aria-hidden: 1.2.2_kzbn2opkn2327fwg5yzwzya5o4
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      tabbable: 6.0.1
+    transitivePeerDependencies:
+      - '@types/react'
     dev: false
 
   /@fontsource/inter/4.5.14:
@@ -3889,12 +3888,12 @@ packages:
       tailwindcss: 3.2.4
     dev: true
 
-  /@hookform/resolvers/2.9.10_react-hook-form@7.41.5:
+  /@hookform/resolvers/2.9.10_react-hook-form@7.42.1:
     resolution: {integrity: sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A==}
     peerDependencies:
       react-hook-form: ^7.0.0
     dependencies:
-      react-hook-form: 7.41.5_react@18.2.0
+      react-hook-form: 7.42.1_react@18.2.0
     dev: false
 
   /@httptoolkit/httpolyglot/2.0.1:
@@ -4705,7 +4704,7 @@ packages:
       '@storybook/components': 7.0.0-beta.3_biqbaboplfbrettd7655fr4n2y
       '@storybook/csf-plugin': 7.0.0-beta.3
       '@storybook/csf-tools': 7.0.0-beta.3
-      '@storybook/mdx2-csf': 1.0.0-next.4
+      '@storybook/mdx2-csf': 1.0.0-next.5
       '@storybook/node-logger': 7.0.0-beta.3
       '@storybook/postinstall': 7.0.0-beta.3
       '@storybook/preview-api': 7.0.0-beta.3
@@ -5013,7 +5012,7 @@ packages:
       '@storybook/client-logger': 7.0.0-beta.3
       '@storybook/core-common': 7.0.0-beta.3_typescript@4.9.4
       '@storybook/csf-plugin': 7.0.0-beta.3
-      '@storybook/mdx2-csf': 1.0.0-next.4
+      '@storybook/mdx2-csf': 1.0.0-next.5
       '@storybook/node-logger': 7.0.0-beta.3
       '@storybook/preview': 7.0.0-beta.3
       '@storybook/preview-api': 7.0.0-beta.3
@@ -5449,8 +5448,8 @@ packages:
     resolution: {integrity: sha512-qRIMeBfkMFbmUXKsuJMsKJxkpfCNJv1PLuj0MIf5C1/QEymilakVohIi8LalREy716JgkhuOq2HPnMnsK8s3VA==}
     dev: true
 
-  /@storybook/mdx2-csf/1.0.0-next.4:
-    resolution: {integrity: sha512-nvRgYdpYvXsvSgCzKc4LQA1JxtJzmv47IsFAsh1rTz5FoHyK8watLU2WqX9T4w52fpFXBHx7RwGEsCRt0XgZlQ==}
+  /@storybook/mdx2-csf/1.0.0-next.5:
+    resolution: {integrity: sha512-02w0sgGZaK1agT050yCVhJ+o4rLHANWvLKWjQjeAsYbjneLC5ITt+3GDB4jRiWwJboZ8dHW1fGSK1Vg5fA34aQ==}
     dev: true
 
   /@storybook/node-logger/7.0.0-beta.3:
@@ -14758,6 +14757,17 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
+  /postcss-import/14.1.0:
+    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+    dev: true
+
   /postcss-import/14.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
     engines: {node: '>=10.0.0'}
@@ -14775,6 +14785,15 @@ packages:
       postcss: ^8.0.0
     dependencies:
       postcss: 8.4.21
+    dev: true
+
+  /postcss-js/4.0.0:
+    resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      camelcase-css: 2.0.1
     dev: true
 
   /postcss-js/4.0.0_postcss@8.4.21:
@@ -14941,6 +14960,15 @@ packages:
     dependencies:
       icss-utils: 5.1.0_postcss@8.4.21
       postcss: 8.4.21
+    dev: true
+
+  /postcss-nested/6.0.0:
+    resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss-selector-parser: 6.0.11
     dev: true
 
   /postcss-nested/6.0.0_postcss@8.4.21:
@@ -15522,8 +15550,8 @@ packages:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
     dev: false
 
-  /react-hook-form/7.41.5_react@18.2.0:
-    resolution: {integrity: sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q==}
+  /react-hook-form/7.42.1_react@18.2.0:
+    resolution: {integrity: sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18
@@ -17346,6 +17374,8 @@ packages:
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -17362,10 +17392,10 @@ packages:
       object-hash: 3.0.0
       picocolors: 1.0.0
       postcss: 8.4.21
-      postcss-import: 14.1.0_postcss@8.4.21
-      postcss-js: 4.0.0_postcss@8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21
-      postcss-nested: 6.0.0_postcss@8.4.21
+      postcss-import: 14.1.0
+      postcss-js: 4.0.0
+      postcss-load-config: 3.1.4
+      postcss-nested: 6.0.0
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
@@ -17374,10 +17404,12 @@ packages:
       - ts-node
     dev: true
 
-  /tailwindcss/3.2.4_ts-node@10.9.1:
+  /tailwindcss/3.2.4_aesdjsunmf4wiehhujt67my7tu:
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -17405,6 +17437,40 @@ packages:
     transitivePeerDependencies:
       - ts-node
     dev: false
+
+  /tailwindcss/3.2.4_postcss@8.4.21:
+    resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.12
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.0.6
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.21
+      postcss-import: 14.1.0_postcss@8.4.21
+      postcss-js: 4.0.0_postcss@8.4.21
+      postcss-load-config: 3.1.4_postcss@8.4.21
+      postcss-nested: 6.0.0_postcss@8.4.21
+      postcss-selector-parser: 6.0.11
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: true
 
   /tapable/2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}


### PR DESCRIPTION
This fixes some usage of `react-hook-form` so that the UI for custom RPC renders consistently. The package uses a proxy to detect properties that are accessed and re-render when they are. Because of this, we really need to destructure out of the `formState` object to ensure that we touch all of the properties we need and that we don't short-circuit any of them. This will fix an issue where pasting into the custom RPC URL works inconsistently.

I also moved us to the new floating UI package since it was complaining about being deprecated.