### PR TITLE
Disable benchmark for now

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,8 +85,8 @@ jobs:
           cargo nextest run --profile ci
       - name: benchmark (smoke)
         run: |
-          cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s
-          pushd narwhal/benchmark && fab smoke && popd
+          # cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s
+          # pushd narwhal/benchmark && fab smoke && popd
       - name: doctests
         run: |
           cargo test --doc


### PR DESCRIPTION
It's blocking PRs from merging in main.
Re-enable it after we fixed the issue