### PR TITLE
[epoch] Emergency Framework Upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8644,6 +8644,7 @@ dependencies = [
  "serde_yaml",
  "sui-adapter",
  "sui-framework",
+ "sui-framework-override",
  "sui-keys",
  "sui-simulator",
  "sui-types",
@@ -8852,6 +8853,38 @@ dependencies = [
  "serde-reflection",
  "sui-types",
  "sui-verifier",
+ "workspace-hack",
+]
+
+[[package]]
+name = "sui-framework-override"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "better_any",
+ "curve25519-dalek-ng",
+ "digest 0.10.6",
+ "fastcrypto",
+ "fastcrypto-zkp",
+ "linked-hash-map",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-cli",
+ "move-compiler",
+ "move-core-types",
+ "move-package",
+ "move-stdlib",
+ "move-unit-test",
+ "move-vm-runtime",
+ "move-vm-test-utils",
+ "move-vm-types",
+ "num_enum",
+ "once_cell",
+ "serde 1.0.152",
+ "smallvec",
+ "sui-framework-build",
+ "sui-types",
  "workspace-hack",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9929,9 +9929,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -30,6 +30,7 @@ narwhal-config = { path = "../../narwhal/config" }
 narwhal-crypto = { path = "../../narwhal/crypto" }
 
 sui-framework = { path = "../sui-framework" }
+sui-framework-override = { path = "../sui-framework-override" }
 sui-adapter = { path = "../sui-adapter" }
 sui-types = { path = "../sui-types" }
 sui-keys = { path = "../sui-keys" }

--- a/crates/sui-config/src/framework.rs
+++ b/crates/sui-config/src/framework.rs
@@ -5,6 +5,9 @@ use move_binary_format::CompiledModule;
 
 /// TEMPORARY: Detect if we should update to a new framework before epoch `epoch` starts.  Returns
 /// the modules to replace the Sui Framework with, if an upgrade is detected, or None otherwise.
-pub fn override_sui_framework(_epoch: u64) -> Option<Vec<CompiledModule>> {
-    None
+pub fn override_sui_framework(epoch: u64) -> Option<Vec<CompiledModule>> {
+    match epoch {
+        5 => Some(sui_framework_override::get_sui_framework()),
+        _ => None,
+    }
 }

--- a/crates/sui-config/src/framework.rs
+++ b/crates/sui-config/src/framework.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::CompiledModule;
+
+/// TEMPORARY: Detect if we should update to a new framework before epoch `epoch` starts.  Returns
+/// the modules to replace the Sui Framework with, if an upgrade is detected, or None otherwise.
+pub fn override_sui_framework(_epoch: u64) -> Option<Vec<CompiledModule>> {
+    None
+}

--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -11,6 +11,7 @@ use sui_types::committee::StakeUnit;
 use tracing::trace;
 
 pub mod builder;
+pub mod framework;
 pub mod genesis;
 pub mod genesis_config;
 pub mod node;

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -518,7 +518,8 @@ impl AuthorityStore {
     /// Insert an object directly into the store, and also update relevant tables
     /// NOTE: does not handle transaction lock.
     /// This is used to insert genesis objects
-    async fn insert_object_direct(&self, object_ref: ObjectRef, object: &Object) -> SuiResult {
+    /// TEMPORARY: `pub` to expose to SuiNode, for emergency framework upgrades
+    pub async fn insert_object_direct(&self, object_ref: ObjectRef, object: &Object) -> SuiResult {
         let mut write_batch = self.perpetual_tables.objects.batch();
 
         // Insert object

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,13 +4,13 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
-    "computation_cost": 7802,
-    "storage_cost": 11231,
+    "computation_cost": 7812,
+    "storage_cost": 11247,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 8661,
-    "storage_cost": 12434,
+    "computation_cost": 8672,
+    "storage_cost": 12450,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
@@ -29,8 +29,8 @@ expression: common_costs_estimate
     "storage_rebate": 0
   },
   "SplitCoin": {
-    "computation_cost": 7780,
-    "storage_cost": 11198,
+    "computation_cost": 7791,
+    "storage_cost": 11215,
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-framework-override/Cargo.toml
+++ b/crates/sui-framework-override/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "sui-framework-override"
+version = "0.1.0"
+edition = "2021"
+authors = ["Mysten Labs <eng@mystenlabs.com>"]
+description = "Move framework for sui platform"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+anyhow = { version = "1.0.64", features = ["backtrace"] }
+better_any = "0.1.1"
+bcs = "0.1.4"
+linked-hash-map = "0.5.6"
+smallvec = "1.9.0"
+num_enum = "0.5.7"
+once_cell = "1.16"
+curve25519-dalek-ng = "4.1.1"
+
+fastcrypto.workspace = true
+fastcrypto-zkp.workspace = true
+
+digest = "0.10.3"
+serde = { version = "1.0.144", features = ["derive"] }
+
+sui-framework-build = { path = "../sui-framework-build" }
+sui-types = { path = "../sui-types" }
+
+move-binary-format.workspace = true
+move-bytecode-verifier.workspace = true
+move-cli.workspace = true
+move-compiler.workspace = true
+move-core-types.workspace = true
+move-package.workspace = true
+move-stdlib.workspace = true
+move-unit-test.workspace = true
+move-vm-runtime.workspace = true
+move-vm-test-utils.workspace = true
+move-vm-types.workspace = true
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[build-dependencies]
+anyhow = { version = "1.0.64", features = ["backtrace"] }
+bcs = "0.1.4"
+
+sui-framework-build = { path = "../sui-framework-build" }
+
+move-binary-format.workspace = true
+move-package.workspace = true
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["move-cli", "move-unit-test"]

--- a/crates/sui-framework-override/Move.toml
+++ b/crates/sui-framework-override/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "Sui"
+version = "0.0.1"
+
+[dependencies]
+# Using a local dep for the Move stdlib instead of a git dep to avoid the overhead of fetching the git dep in
+# CI. The local dep is an unmodified version of the upstream stdlib
+MoveStdlib = { local = "deps/move-stdlib" }
+#MoveStdlib = { git = "https://github.com/diem/diem.git", subdir="language/move-stdlib", rev = "346301f33b3489bb4e486ae6c0aa5e030223b492" }
+
+[addresses]
+sui = "0x2"

--- a/crates/sui-framework-override/README.md
+++ b/crates/sui-framework-override/README.md
@@ -1,0 +1,17 @@
+# Sui Programmability with Move
+
+This is a proof-of-concept Move standard library for Sui (`sources/`), along with several examples of programs that Sui users might want to write (`examples`). `custom_object_template.move` is a good starting point for understanding the proposed model.
+
+To set up and build the [Sui CLI client](https://docs.sui.io/build/cli-client) needed for Move development, follow the instructions to [install Sui](https://docs.sui.io/build/install).
+
+## To add a new native Move function
+
+1. Add a new `./sui-framework/{name}.move` file or find an appropriate `.move`.
+2. Add the signature of the function you are adding in `{name}.move`. 
+3. Add the rust implementation of the function under `./sui-framework/src/natives` with name `{name}.rs`.
+4. Link the move interface with the native function in [all_natives](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/src/natives/mod.rs#L23)
+5. Write some tests in `{name}_tests.move` and pass `run_framework_move_unit_tests`.
+6. Optionally, update the mock move VM value in [gas_tests.rs](https://github.com/MystenLabs/sui/blob/276356e168047cdfce71814cb14403f4653a3656/crates/sui-core/src/unit_tests/gas_tests.rs) since the sui-framework package will increase the gas metering.
+7. Optionally, run `cargo insta test` and `cargo insta review` since the sui-framework build will change the empty genesis config.
+
+Note: The gas metering for native functions is currently a WIP; use a dummy value for now and please open an issue with `move` label.

--- a/crates/sui-framework-override/build.rs
+++ b/crates/sui-framework-override/build.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use move_binary_format::CompiledModule;
+use move_package::BuildConfig as MoveBuildConfig;
+use std::thread::Builder;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use sui_framework_build::compiled_package::BuildConfig;
+
+const FRAMEWORK_DOCS_DIR: &str = "docs";
+
+/// Save revision info to environment variable
+fn main() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let sui_framework_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let move_stdlib_path = sui_framework_path.join("deps").join("move-stdlib");
+
+    Builder::new()
+        .stack_size(16 * 1024 * 1024) // build_move_package require bigger stack size on windows.
+        .spawn(move || build_framework_and_stdlib(sui_framework_path, out_dir))
+        .unwrap()
+        .join()
+        .unwrap();
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!(
+        "cargo:rerun-if-changed={}",
+        sui_framework_path.join("Move.toml").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        sui_framework_path.join("sources").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        move_stdlib_path.join("Move.toml").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        move_stdlib_path.join("sources").display()
+    );
+}
+
+fn build_framework_and_stdlib(sui_framework_path: &Path, out_dir: PathBuf) {
+    let config = MoveBuildConfig {
+        generate_docs: true,
+        ..Default::default()
+    };
+    debug_assert!(!config.test_mode);
+    build_framework_and_stdlib_with_move_config(
+        sui_framework_path,
+        out_dir.clone(),
+        "sui-framework",
+        "move-stdlib",
+        config,
+    );
+    let config = MoveBuildConfig {
+        generate_docs: true,
+        test_mode: true,
+        ..Default::default()
+    };
+    build_framework_and_stdlib_with_move_config(
+        sui_framework_path,
+        out_dir,
+        "sui-framework-test",
+        "move-stdlib-test",
+        config,
+    );
+}
+
+fn build_framework_and_stdlib_with_move_config(
+    sui_framework_path: &Path,
+    out_dir: PathBuf,
+    framework_dir: &str,
+    stdlib_dir: &str,
+    config: MoveBuildConfig,
+) {
+    let pkg = BuildConfig {
+        config,
+        run_bytecode_verifier: true,
+        print_diags_to_stderr: false,
+    }
+    .build(sui_framework_path.to_path_buf())
+    .unwrap();
+    let sui_framework = pkg.get_framework_modules();
+    let move_stdlib = pkg.get_stdlib_modules();
+
+    serialize_modules_to_file(sui_framework, &out_dir.join(framework_dir)).unwrap();
+    serialize_modules_to_file(move_stdlib, &out_dir.join(stdlib_dir)).unwrap();
+    // write out generated docs
+    // TODO: remove docs of deleted files
+    for (fname, doc) in pkg.package.compiled_docs.unwrap() {
+        let mut dst_path = PathBuf::from(FRAMEWORK_DOCS_DIR);
+        dst_path.push(fname);
+        fs::write(dst_path, doc).unwrap();
+    }
+}
+
+fn serialize_modules_to_file<'a>(
+    modules: impl Iterator<Item = &'a CompiledModule>,
+    file: &Path,
+) -> Result<()> {
+    let mut serialized_modules = Vec::new();
+    for module in modules {
+        let mut buf = Vec::new();
+        module.serialize(&mut buf)?;
+        serialized_modules.push(buf);
+    }
+    assert!(
+        !serialized_modules.is_empty(),
+        "Failed to find framework or stdlib modules"
+    );
+
+    let binary = bcs::to_bytes(&serialized_modules)?;
+
+    fs::write(file, &binary)?;
+
+    Ok(())
+}

--- a/crates/sui-framework-override/deps/move-stdlib/Move.toml
+++ b/crates/sui-framework-override/deps/move-stdlib/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "MoveStdlib"
+version = "1.5.0"
+
+[addresses]
+std = "0x1"

--- a/crates/sui-framework-override/deps/move-stdlib/sources/address.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/address.move
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Provides a way to get address length since it's a
+/// platform-specific parameter.
+module std::address {
+    /// Should be converted to a native function.
+    /// Current implementation only works for Sui.
+    public fun length(): u64 {
+        20
+    }
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/ascii.move
@@ -1,0 +1,151 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// The `ASCII` module defines basic string and char newtypes in Move that verify
+/// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
+module std::ascii {
+    use std::vector;
+    use std::option::{Self, Option};
+
+    /// An invalid ASCII character was encountered when creating an ASCII string.
+    const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
+
+   /// The `String` struct holds a vector of bytes that all represent
+   /// valid ASCII characters. Note that these ASCII characters may not all
+   /// be printable. To determine if a `String` contains only "printable"
+   /// characters you should use the `all_characters_printable` predicate
+   /// defined in this module.
+   struct String has copy, drop, store {
+       bytes: vector<u8>,
+   }
+   spec String {
+       invariant forall i in 0..len(bytes): is_valid_char(bytes[i]);
+   }
+
+   /// An ASCII character.
+   struct Char has copy, drop, store {
+       byte: u8,
+   }
+   spec Char {
+       invariant is_valid_char(byte);
+   }
+
+    /// Convert a `byte` into a `Char` that is checked to make sure it is valid ASCII.
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
+        Char { byte }
+    }
+    spec char {
+        aborts_if !is_valid_char(byte) with EINVALID_ASCII_CHARACTER;
+    }
+
+    /// Convert a vector of bytes `bytes` into an `String`. Aborts if
+    /// `bytes` contains non-ASCII characters.
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            option::is_some(&x),
+            EINVALID_ASCII_CHARACTER
+       );
+       option::destroy_some(x)
+    }
+    spec string {
+        aborts_if exists i in 0..len(bytes): !is_valid_char(bytes[i]) with EINVALID_ASCII_CHARACTER;
+    }
+
+    /// Convert a vector of bytes `bytes` into an `String`. Returns
+    /// `Some(<ascii_string>)` if the `bytes` contains all valid ASCII
+    /// characters. Otherwise returns `None`.
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       let len = vector::length(&bytes);
+       let i = 0;
+       while ({
+           spec {
+               invariant i <= len;
+               invariant forall j in 0..i: is_valid_char(bytes[j]);
+           };
+           i < len
+       }) {
+           let possible_byte = *vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return option::none();
+           i = i + 1;
+       };
+       spec {
+           assert i == len;
+           assert forall j in 0..len: is_valid_char(bytes[j]);
+       };
+       option::some(String { bytes })
+    }
+
+    /// Returns `true` if all characters in `string` are printable characters
+    /// Returns `false` otherwise. Not all `String`s are printable strings.
+    public fun all_characters_printable(string: &String): bool {
+       let len = vector::length(&string.bytes);
+       let i = 0;
+       while ({
+           spec {
+               invariant i <= len;
+               invariant forall j in 0..i: is_printable_char(string.bytes[j]);
+           };
+           i < len
+       }) {
+           let byte = *vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       spec {
+           assert i == len;
+           assert forall j in 0..len: is_printable_char(string.bytes[j]);
+       };
+       true
+    }
+    spec all_characters_printable {
+        ensures result ==> (forall j in 0..len(string.bytes): is_printable_char(string.bytes[j]));
+    }
+
+    public fun push_char(string: &mut String, char: Char) {
+        vector::push_back(&mut string.bytes, char.byte);
+    }
+    spec push_char {
+        ensures len(string.bytes) == len(old(string.bytes)) + 1;
+    }
+
+    public fun pop_char(string: &mut String): Char {
+        Char { byte: vector::pop_back(&mut string.bytes) }
+    }
+    spec pop_char {
+        ensures len(string.bytes) == len(old(string.bytes)) - 1;
+    }
+
+    public fun length(string: &String): u64 {
+        vector::length(as_bytes(string))
+    }
+
+    /// Get the inner bytes of the `string` as a reference
+    public fun as_bytes(string: &String): &vector<u8> {
+       &string.bytes
+    }
+
+    /// Unpack the `string` to get its backing bytes
+    public fun into_bytes(string: String): vector<u8> {
+       let String { bytes } = string;
+       bytes
+    }
+
+    /// Unpack the `char` into its underlying byte.
+    public fun byte(char: Char): u8 {
+       let Char { byte } = char;
+       byte
+    }
+
+    /// Returns `true` if `b` is a valid ASCII character. Returns `false` otherwise.
+    public fun is_valid_char(b: u8): bool {
+       b <= 0x7F
+    }
+
+    /// Returns `true` if `byte` is an printable ASCII character. Returns `false` otherwise.
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/bcs.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/bcs.move
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Utility for converting a Move value to its binary representation in BCS (Binary Canonical
+/// Serialization). BCS is the binary encoding for Move resources and other non-module values
+/// published on-chain. See https://github.com/diem/bcs#binary-canonical-serialization-bcs for more
+/// details on BCS.
+module std::bcs {
+    /// Return the binary representation of `v` in BCS (Binary Canonical Serialization) format
+    native public fun to_bytes<MoveValue>(v: &MoveValue): vector<u8>;
+
+    // ==============================
+    // Module Specification
+    spec module {} // switch to module documentation context
+
+    spec module {
+        /// Native function which is defined in the prover's prelude.
+        native fun serialize<MoveValue>(v: &MoveValue): vector<u8>;
+    }
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/bit_vector.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/bit_vector.move
@@ -1,0 +1,164 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module std::bit_vector {
+    use std::vector;
+
+    /// The provided index is out of bounds
+    const EINDEX: u64 = 0x20000;
+    /// An invalid length of bitvector was given
+    const ELENGTH: u64 = 0x20001;
+
+    const WORD_SIZE: u64 = 1;
+    /// The maximum allowed bitvector size
+    const MAX_SIZE: u64 = 1024;
+
+    struct BitVector has copy, drop, store {
+        length: u64,
+        bit_field: vector<bool>,
+    }
+
+    public fun new(length: u64): BitVector {
+        assert!(length > 0, ELENGTH);
+        assert!(length < MAX_SIZE, ELENGTH);
+        let counter = 0;
+        let bit_field = vector::empty();
+        while ({spec {
+            invariant counter <= length;
+            invariant len(bit_field) == counter;
+        };
+            (counter < length)}) {
+            vector::push_back(&mut bit_field, false);
+            counter = counter + 1;
+        };
+        spec {
+            assert counter == length;
+            assert len(bit_field) == length;
+        };
+
+        BitVector {
+            length,
+            bit_field,
+        }
+    }
+    spec new {
+        include NewAbortsIf;
+        ensures result.length == length;
+        ensures len(result.bit_field) == length;
+    }
+    spec schema NewAbortsIf {
+        length: u64;
+        aborts_if length <= 0 with ELENGTH;
+        aborts_if length >= MAX_SIZE with ELENGTH;
+    }
+
+    /// Set the bit at `bit_index` in the `bitvector` regardless of its previous state.
+    public fun set(bitvector: &mut BitVector, bit_index: u64) {
+        assert!(bit_index < vector::length(&bitvector.bit_field), EINDEX);
+        let x = vector::borrow_mut(&mut bitvector.bit_field, bit_index);
+        *x = true;
+    }
+    spec set {
+        include SetAbortsIf;
+        ensures bitvector.bit_field[bit_index];
+    }
+    spec schema SetAbortsIf {
+        bitvector: BitVector;
+        bit_index: u64;
+        aborts_if bit_index >= length(bitvector) with EINDEX;
+    }
+
+    /// Unset the bit at `bit_index` in the `bitvector` regardless of its previous state.
+    public fun unset(bitvector: &mut BitVector, bit_index: u64) {
+        assert!(bit_index < vector::length(&bitvector.bit_field), EINDEX);
+        let x = vector::borrow_mut(&mut bitvector.bit_field, bit_index);
+        *x = false;
+    }
+    spec set {
+        include UnsetAbortsIf;
+        ensures bitvector.bit_field[bit_index];
+    }
+    spec schema UnsetAbortsIf {
+        bitvector: BitVector;
+        bit_index: u64;
+        aborts_if bit_index >= length(bitvector) with EINDEX;
+    }
+
+    /// Shift the `bitvector` left by `amount`. If `amount` is greater than the
+    /// bitvector's length the bitvector will be zeroed out.
+    public fun shift_left(bitvector: &mut BitVector, amount: u64) {
+        if (amount >= bitvector.length) {
+           let len = vector::length(&bitvector.bit_field);
+           let i = 0;
+           while (i < len) {
+               let elem = vector::borrow_mut(&mut bitvector.bit_field, i);
+               *elem = false;
+               i = i + 1;
+           };
+        } else {
+            let i = amount;
+
+            while (i < bitvector.length) {
+                if (is_index_set(bitvector, i)) set(bitvector, i - amount)
+                else unset(bitvector, i - amount);
+                i = i + 1;
+            };
+
+            i = bitvector.length - amount;
+
+            while (i < bitvector.length) {
+                unset(bitvector, i);
+                i = i + 1;
+            };
+        }
+    }
+
+    /// Return the value of the bit at `bit_index` in the `bitvector`. `true`
+    /// represents "1" and `false` represents a 0
+    public fun is_index_set(bitvector: &BitVector, bit_index: u64): bool {
+        assert!(bit_index < vector::length(&bitvector.bit_field), EINDEX);
+        *vector::borrow(&bitvector.bit_field, bit_index)
+    }
+    spec is_index_set {
+        include IsIndexSetAbortsIf;
+        ensures result == bitvector.bit_field[bit_index];
+    }
+    spec schema IsIndexSetAbortsIf {
+        bitvector: BitVector;
+        bit_index: u64;
+        aborts_if bit_index >= length(bitvector) with EINDEX;
+    }
+    spec fun spec_is_index_set(bitvector: BitVector, bit_index: u64): bool {
+        if (bit_index >= length(bitvector)) {
+            false
+        } else {
+            bitvector.bit_field[bit_index]
+        }
+    }
+
+    /// Return the length (number of usable bits) of this bitvector
+    public fun length(bitvector: &BitVector): u64 {
+        vector::length(&bitvector.bit_field)
+    }
+
+    /// Returns the length of the longest sequence of set bits starting at (and
+    /// including) `start_index` in the `bitvector`. If there is no such
+    /// sequence, then `0` is returned.
+    public fun longest_set_sequence_starting_at(bitvector: &BitVector, start_index: u64): u64 {
+        assert!(start_index < bitvector.length, EINDEX);
+        let index = start_index;
+
+        // Find the greatest index in the vector such that all indices less than it are set.
+        while (index < bitvector.length) {
+            if (!is_index_set(bitvector, index)) break;
+            index = index + 1;
+        };
+
+        index - start_index
+    }
+
+    #[test_only]
+    public fun word_size(): u64 {
+        WORD_SIZE
+    }
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/debug.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/debug.move
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module providing debug functionality.
+module std::debug {
+    native public fun print<T>(x: &T);
+
+    native public fun print_stack_trace();
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/fixed_point32.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/fixed_point32.move
@@ -1,0 +1,167 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Defines a fixed-point numeric type with a 32-bit integer part and
+/// a 32-bit fractional part.
+
+module std::fixed_point32 {
+
+    /// Define a fixed-point numeric type with 32 fractional bits.
+    /// This is just a u64 integer but it is wrapped in a struct to
+    /// make a unique type. This is a binary representation, so decimal
+    /// values may not be exactly representable, but it provides more
+    /// than 9 decimal digits of precision both before and after the
+    /// decimal point (18 digits total). For comparison, double precision
+    /// floating-point has less than 16 decimal digits of precision, so
+    /// be careful about using floating-point to convert these values to
+    /// decimal.
+    struct FixedPoint32 has copy, drop, store { value: u64 }
+
+    ///> TODO: This is a basic constant and should be provided somewhere centrally in the framework.
+    const MAX_U64: u128 = 18446744073709551615;
+
+    /// The denominator provided was zero
+    const EDENOMINATOR: u64 = 0x10001;
+    /// The quotient value would be too large to be held in a `u64`
+    const EDIVISION: u64 = 0x20002;
+    /// The multiplied value would be too large to be held in a `u64`
+    const EMULTIPLICATION: u64 = 0x20003;
+    /// A division by zero was encountered
+    const EDIVISION_BY_ZERO: u64 = 0x10004;
+    /// The computed ratio when converting to a `FixedPoint32` would be unrepresentable
+    const ERATIO_OUT_OF_RANGE: u64 = 0x20005;
+
+    /// Multiply a u64 integer by a fixed-point number, truncating any
+    /// fractional part of the product. This will abort if the product
+    /// overflows.
+    public fun multiply_u64(val: u64, multiplier: FixedPoint32): u64 {
+        // The product of two 64 bit values has 128 bits, so perform the
+        // multiplication with u128 types and keep the full 128 bit product
+        // to avoid losing accuracy.
+        let unscaled_product = (val as u128) * (multiplier.value as u128);
+        // The unscaled product has 32 fractional bits (from the multiplier)
+        // so rescale it by shifting away the low bits.
+        let product = unscaled_product >> 32;
+        // Check whether the value is too large.
+        assert!(product <= MAX_U64, EMULTIPLICATION);
+        (product as u64)
+    }
+    spec multiply_u64 {
+        pragma opaque;
+        include MultiplyAbortsIf;
+        ensures result == spec_multiply_u64(val, multiplier);
+    }
+    spec schema MultiplyAbortsIf {
+        val: num;
+        multiplier: FixedPoint32;
+        aborts_if spec_multiply_u64(val, multiplier) > MAX_U64 with EMULTIPLICATION;
+    }
+    spec fun spec_multiply_u64(val: num, multiplier: FixedPoint32): num {
+        (val * multiplier.value) >> 32
+    }
+
+    /// Divide a u64 integer by a fixed-point number, truncating any
+    /// fractional part of the quotient. This will abort if the divisor
+    /// is zero or if the quotient overflows.
+    public fun divide_u64(val: u64, divisor: FixedPoint32): u64 {
+        // Check for division by zero.
+        assert!(divisor.value != 0, EDIVISION_BY_ZERO);
+        // First convert to 128 bits and then shift left to
+        // add 32 fractional zero bits to the dividend.
+        let scaled_value = (val as u128) << 32;
+        let quotient = scaled_value / (divisor.value as u128);
+        // Check whether the value is too large.
+        assert!(quotient <= MAX_U64, EDIVISION);
+        // the value may be too large, which will cause the cast to fail
+        // with an arithmetic error.
+        (quotient as u64)
+    }
+    spec divide_u64 {
+        pragma opaque;
+        include DivideAbortsIf;
+        ensures result == spec_divide_u64(val, divisor);
+    }
+    spec schema DivideAbortsIf {
+        val: num;
+        divisor: FixedPoint32;
+        aborts_if divisor.value == 0 with EDIVISION_BY_ZERO;
+        aborts_if spec_divide_u64(val, divisor) > MAX_U64 with EDIVISION;
+    }
+    spec fun spec_divide_u64(val: num, divisor: FixedPoint32): num {
+        (val << 32) / divisor.value
+    }
+
+    /// Create a fixed-point value from a rational number specified by its
+    /// numerator and denominator. Calling this function should be preferred
+    /// for using `Self::create_from_raw_value` which is also available.
+    /// This will abort if the denominator is zero. It will also
+    /// abort if the numerator is nonzero and the ratio is not in the range
+    /// 2^-32 .. 2^32-1. When specifying decimal fractions, be careful about
+    /// rounding errors: if you round to display N digits after the decimal
+    /// point, you can use a denominator of 10^N to avoid numbers where the
+    /// very small imprecision in the binary representation could change the
+    /// rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
+    public fun create_from_rational(numerator: u64, denominator: u64): FixedPoint32 {
+        // If the denominator is zero, this will abort.
+        // Scale the numerator to have 64 fractional bits and the denominator
+        // to have 32 fractional bits, so that the quotient will have 32
+        // fractional bits.
+        let scaled_numerator = (numerator as u128) << 64;
+        let scaled_denominator = (denominator as u128) << 32;
+        assert!(scaled_denominator != 0, EDENOMINATOR);
+        let quotient = scaled_numerator / scaled_denominator;
+        assert!(quotient != 0 || numerator == 0, ERATIO_OUT_OF_RANGE);
+        // Return the quotient as a fixed-point number. We first need to check whether the cast
+        // can succeed.
+        assert!(quotient <= MAX_U64, ERATIO_OUT_OF_RANGE);
+        FixedPoint32 { value: (quotient as u64) }
+    }
+    spec create_from_rational {
+        pragma opaque;
+        include CreateFromRationalAbortsIf;
+        ensures result == spec_create_from_rational(numerator, denominator);
+    }
+    spec schema CreateFromRationalAbortsIf {
+        numerator: u64;
+        denominator: u64;
+        let scaled_numerator = numerator << 64;
+        let scaled_denominator = denominator << 32;
+        let quotient = scaled_numerator / scaled_denominator;
+        aborts_if scaled_denominator == 0 with EDENOMINATOR;
+        aborts_if quotient == 0 && scaled_numerator != 0 with ERATIO_OUT_OF_RANGE;
+        aborts_if quotient > MAX_U64 with ERATIO_OUT_OF_RANGE;
+    }
+    spec fun spec_create_from_rational(numerator: num, denominator: num): FixedPoint32 {
+        FixedPoint32{value: (numerator << 64) / (denominator << 32)}
+    }
+
+    /// Create a fixedpoint value from a raw value.
+    public fun create_from_raw_value(value: u64): FixedPoint32 {
+        FixedPoint32 { value }
+    }
+    spec create_from_raw_value {
+        pragma opaque;
+        aborts_if false;
+        ensures result.value == value;
+    }
+
+    /// Accessor for the raw u64 value. Other less common operations, such as
+    /// adding or subtracting FixedPoint32 values, can be done using the raw
+    /// values directly.
+    public fun get_raw_value(num: FixedPoint32): u64 {
+        num.value
+    }
+
+    /// Returns true if the ratio is zero.
+    public fun is_zero(num: FixedPoint32): bool {
+        num.value == 0
+    }
+
+    // **************** SPECIFICATIONS ****************
+
+    spec module {} // switch documentation context to module level
+
+    spec module {
+        pragma aborts_if_is_strict;
+    }
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/hash.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/hash.move
@@ -1,0 +1,11 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module which defines SHA hashes for byte vectors.
+///
+/// The functions in this module are natively declared both in the Move runtime
+/// as in the Move prover's prelude.
+module std::hash {
+    native public fun sha2_256(data: vector<u8>): vector<u8>;
+    native public fun sha3_256(data: vector<u8>): vector<u8>;
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/option.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/option.move
@@ -1,0 +1,262 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This module defines the Option type and its methods to represent and handle an optional value.
+module std::option {
+    use std::vector;
+
+    /// Abstraction of a value that may or may not be present. Implemented with a vector of size
+    /// zero or one because Move bytecode does not have ADTs.
+    struct Option<Element> has copy, drop, store {
+        vec: vector<Element>
+    }
+    spec Option {
+        /// The size of vector is always less than equal to 1
+        /// because it's 0 for "none" or 1 for "some".
+        invariant len(vec) <= 1;
+    }
+
+    /// The `Option` is in an invalid state for the operation attempted.
+    /// The `Option` is `Some` while it should be `None`.
+    const EOPTION_IS_SET: u64 = 0x40000;
+    /// The `Option` is in an invalid state for the operation attempted.
+    /// The `Option` is `None` while it should be `Some`.
+    const EOPTION_NOT_SET: u64 = 0x40001;
+
+    /// Return an empty `Option`
+    public fun none<Element>(): Option<Element> {
+        Option { vec: vector::empty() }
+    }
+    spec none {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_none<Element>();
+    }
+    spec fun spec_none<Element>(): Option<Element> {
+        Option{ vec: vec() }
+    }
+
+    /// Return an `Option` containing `e`
+    public fun some<Element>(e: Element): Option<Element> {
+        Option { vec: vector::singleton(e) }
+    }
+    spec some {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_some(e);
+    }
+    spec fun spec_some<Element>(e: Element): Option<Element> {
+        Option{ vec: vec(e) }
+    }
+
+    /// Return true if `t` does not hold a value
+    public fun is_none<Element>(t: &Option<Element>): bool {
+        vector::is_empty(&t.vec)
+    }
+    spec is_none {
+        pragma opaque;
+        aborts_if false;
+        ensures result == is_none(t);
+    }
+
+    /// Return true if `t` holds a value
+    public fun is_some<Element>(t: &Option<Element>): bool {
+        !vector::is_empty(&t.vec)
+    }
+    spec is_some {
+        pragma opaque;
+        aborts_if false;
+        ensures result == is_some(t);
+    }
+
+    /// Return true if the value in `t` is equal to `e_ref`
+    /// Always returns `false` if `t` does not hold a value
+    public fun contains<Element>(t: &Option<Element>, e_ref: &Element): bool {
+        vector::contains(&t.vec, e_ref)
+    }
+    spec contains {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_contains(t, e_ref);
+    }
+    spec fun spec_contains<Element>(t: Option<Element>, e: Element): bool {
+        is_some(t) && borrow(t) == e
+    }
+
+    /// Return an immutable reference to the value inside `t`
+    /// Aborts if `t` does not hold a value
+    public fun borrow<Element>(t: &Option<Element>): &Element {
+        assert!(is_some(t), EOPTION_NOT_SET);
+        vector::borrow(&t.vec, 0)
+    }
+    spec borrow {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(t);
+    }
+
+    /// Return a reference to the value inside `t` if it holds one
+    /// Return `default_ref` if `t` does not hold a value
+    public fun borrow_with_default<Element>(t: &Option<Element>, default_ref: &Element): &Element {
+        let vec_ref = &t.vec;
+        if (vector::is_empty(vec_ref)) default_ref
+        else vector::borrow(vec_ref, 0)
+    }
+    spec borrow_with_default {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (if (is_some(t)) borrow(t) else default_ref);
+    }
+
+    /// Return the value inside `t` if it holds one
+    /// Return `default` if `t` does not hold a value
+    public fun get_with_default<Element: copy + drop>(
+        t: &Option<Element>,
+        default: Element,
+    ): Element {
+        let vec_ref = &t.vec;
+        if (vector::is_empty(vec_ref)) default
+        else *vector::borrow(vec_ref, 0)
+    }
+    spec get_with_default {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (if (is_some(t)) borrow(t) else default);
+    }
+
+    /// Convert the none option `t` to a some option by adding `e`.
+    /// Aborts if `t` already holds a value
+    public fun fill<Element>(t: &mut Option<Element>, e: Element) {
+        let vec_ref = &mut t.vec;
+        if (vector::is_empty(vec_ref)) vector::push_back(vec_ref, e)
+        else abort EOPTION_IS_SET
+    }
+    spec fill {
+        pragma opaque;
+        aborts_if is_some(t) with EOPTION_IS_SET;
+        ensures is_some(t);
+        ensures borrow(t) == e;
+    }
+
+    /// Convert a `some` option to a `none` by removing and returning the value stored inside `t`
+    /// Aborts if `t` does not hold a value
+    public fun extract<Element>(t: &mut Option<Element>): Element {
+        assert!(is_some(t), EOPTION_NOT_SET);
+        vector::pop_back(&mut t.vec)
+    }
+    spec extract {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(old(t));
+        ensures is_none(t);
+    }
+
+    /// Return a mutable reference to the value inside `t`
+    /// Aborts if `t` does not hold a value
+    public fun borrow_mut<Element>(t: &mut Option<Element>): &mut Element {
+        assert!(is_some(t), EOPTION_NOT_SET);
+        vector::borrow_mut(&mut t.vec, 0)
+    }
+    spec borrow_mut {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(t);
+    }
+
+    /// Swap the old value inside `t` with `e` and return the old value
+    /// Aborts if `t` does not hold a value
+    public fun swap<Element>(t: &mut Option<Element>, e: Element): Element {
+        assert!(is_some(t), EOPTION_NOT_SET);
+        let vec_ref = &mut t.vec;
+        let old_value = vector::pop_back(vec_ref);
+        vector::push_back(vec_ref, e);
+        old_value
+    }
+    spec swap {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(old(t));
+        ensures is_some(t);
+        ensures borrow(t) == e;
+    }
+
+    /// Swap the old value inside `t` with `e` and return the old value;
+    /// or if there is no old value, fill it with `e`.
+    /// Different from swap(), swap_or_fill() allows for `t` not holding a value.
+    public fun swap_or_fill<Element>(t: &mut Option<Element>, e: Element): Option<Element> {
+        let vec_ref = &mut t.vec;
+        let old_value = if (vector::is_empty(vec_ref)) none()
+            else some(vector::pop_back(vec_ref));
+        vector::push_back(vec_ref, e);
+        old_value
+    }
+    spec swap_or_fill {
+        pragma opaque;
+        ensures result == old(t);
+        ensures borrow(t) == e;
+    }
+
+    /// Destroys `t.` If `t` holds a value, return it. Returns `default` otherwise
+    public fun destroy_with_default<Element: drop>(t: Option<Element>, default: Element): Element {
+        let Option { vec } = t;
+        if (vector::is_empty(&mut vec)) default
+        else vector::pop_back(&mut vec)
+    }
+    spec destroy_with_default {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (if (is_some(t)) borrow(t) else default);
+    }
+
+    /// Unpack `t` and return its contents
+    /// Aborts if `t` does not hold a value
+    public fun destroy_some<Element>(t: Option<Element>): Element {
+        assert!(is_some(&t), EOPTION_NOT_SET);
+        let Option { vec } = t;
+        let elem = vector::pop_back(&mut vec);
+        vector::destroy_empty(vec);
+        elem
+    }
+    spec destroy_some {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(t);
+    }
+
+    /// Unpack `t`
+    /// Aborts if `t` holds a value
+    public fun destroy_none<Element>(t: Option<Element>) {
+        assert!(is_none(&t), EOPTION_IS_SET);
+        let Option { vec } = t;
+        vector::destroy_empty(vec)
+    }
+    spec destroy_none {
+        pragma opaque;
+        aborts_if is_some(t) with EOPTION_IS_SET;
+    }
+
+    /// Convert `t` into a vector of length 1 if it is `Some`,
+    /// and an empty vector otherwise
+    public fun to_vec<Element>(t: Option<Element>): vector<Element> {
+        let Option { vec } = t;
+        vec
+    }
+    spec to_vec {
+        pragma opaque;
+        aborts_if false;
+        ensures result == t.vec;
+    }
+
+    spec module {} // switch documentation context back to module level
+
+    spec module {
+        pragma aborts_if_is_strict;
+    }
+
+    /// # Helper Schema
+
+    spec schema AbortsIfNone<Element> {
+        t: Option<Element>;
+        aborts_if is_none(t) with EOPTION_NOT_SET;
+    }
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/string.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/string.move
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// The `string` module defines the `String` type which represents UTF8 encoded strings.
+module std::string {
+    use std::ascii;
+    use std::vector;
+    use std::option::{Self, Option};
+
+    /// An invalid UTF8 encoding.
+    const EINVALID_UTF8: u64 = 1;
+
+    /// Index out of range.
+    const EINVALID_INDEX: u64 = 2;
+
+    /// A `String` holds a sequence of bytes which is guaranteed to be in utf8 format.
+    struct String has copy, drop, store {
+        bytes: vector<u8>,
+    }
+
+    /// Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
+    public fun utf8(bytes: vector<u8>): String {
+        assert!(internal_check_utf8(&bytes), EINVALID_UTF8);
+        String{bytes}
+    }
+
+    /// Convert an ASCII string to a UTF8 string
+    public fun from_ascii(s: ascii::String): String {
+        String { bytes: ascii::into_bytes(s) }
+    }
+
+    /// Convert an UTF8 string to an ASCII string.
+    /// Aborts if `s` is not valid ASCII
+    public fun to_ascii(s: String): ascii::String {
+        let String { bytes } = s;
+        ascii::string(bytes)
+    }
+
+    /// Tries to create a new string from a sequence of bytes.
+    public fun try_utf8(bytes: vector<u8>): Option<String> {
+        if (internal_check_utf8(&bytes)) {
+            option::some(String{bytes})
+        } else {
+            option::none()
+        }
+    }
+
+    /// Returns a reference to the underlying byte vector.
+    public fun bytes(s: &String): &vector<u8> {
+        &s.bytes
+    }
+
+    /// Checks whether this string is empty.
+    public fun is_empty(s: &String): bool {
+        vector::is_empty(&s.bytes)
+    }
+
+    /// Returns the length of this string, in bytes.
+    public fun length(s: &String): u64 {
+        vector::length(&s.bytes)
+    }
+
+    /// Appends a string.
+    public fun append(s: &mut String, r: String) {
+        vector::append(&mut s.bytes, r.bytes)
+    }
+
+    /// Appends bytes which must be in valid utf8 format.
+    public fun append_utf8(s: &mut String, bytes: vector<u8>) {
+        append(s, utf8(bytes))
+    }
+
+    /// Insert the other string at the byte index in given string. The index must be at a valid utf8 char
+    /// boundary.
+    public fun insert(s: &mut String, at: u64, o: String) {
+        let bytes = &s.bytes;
+        assert!(at <= vector::length(bytes) && internal_is_char_boundary(bytes, at), EINVALID_INDEX);
+        let l = length(s);
+        let front = sub_string(s, 0, at);
+        let end = sub_string(s, at, l);
+        append(&mut front, o);
+        append(&mut front, end);
+        *s = front;
+    }
+
+    /// Returns a sub-string using the given byte indices, where `i` is the first byte position and `j` is the start
+    /// of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
+    /// guaranteeing that the result is valid utf8.
+    public fun sub_string(s: &String, i: u64, j: u64): String {
+        let bytes = &s.bytes;
+        let l = vector::length(bytes);
+        assert!(
+            j <= l && i <= j && internal_is_char_boundary(bytes, i) && internal_is_char_boundary(bytes, j),
+            EINVALID_INDEX
+        );
+        String{bytes: internal_sub_string(bytes, i, j)}
+    }
+
+    /// Computes the index of the first occurrence of a string. Returns `length(s)` if no occurrence found.
+    public fun index_of(s: &String, r: &String): u64 {
+        internal_index_of(&s.bytes, &r.bytes)
+    }
+
+
+    // Native API
+    native fun internal_check_utf8(v: &vector<u8>): bool;
+    native fun internal_is_char_boundary(v: &vector<u8>, i: u64): bool;
+    native fun internal_sub_string(v: &vector<u8>, i: u64, j: u64): vector<u8>;
+    native fun internal_index_of(v: &vector<u8>, r: &vector<u8>): u64;
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/type_name.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/type_name.move
@@ -1,0 +1,79 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Functionality for converting Move types into values. Use with care!
+module std::type_name {
+    use std::ascii::{Self, String};
+    use std::address;
+    use std::vector;
+
+    /// ASCII Character code for the `:` (colon) symbol.
+    const ASCII_COLON: u8 = 58;
+
+    struct TypeName has copy, drop, store {
+        /// String representation of the type. All types are represented
+        /// using their source syntax:
+        /// "u8", "u64", "u128", "bool", "address", "vector", "signer" for ground types.
+        /// Struct types are represented as fully qualified type names; e.g.
+        /// `00000000000000000000000000000001::string::String` or
+        /// `0000000000000000000000000000000a::module_name1::type_name1<0000000000000000000000000000000a::module_name2::type_name2<u64>>`
+        /// Addresses are hex-encoded lowercase values of length ADDRESS_LENGTH (16, 20, or 32 depending on the Move platform)
+        name: String
+    }
+
+    /// Return a value representation of the type `T`.
+    public native fun get<T>(): TypeName;
+    spec get {
+        pragma opaque;
+    }
+
+    /// Get the String representation of `self`
+    public fun borrow_string(self: &TypeName): &String {
+        &self.name
+    }
+
+    /// Get Address string (Base16 encoded), first part of the TypeName.
+    public fun get_address(self: &TypeName): String {
+        // Base16 (string) representation of an address has 2 symbols per byte.
+        let len = address::length() * 2;
+        let str_bytes = ascii::as_bytes(&self.name);
+        let addr_bytes = vector[];
+        let i = 0;
+
+        // Read `len` bytes from the type name and push them to addr_bytes.
+        while (i < len) {
+            vector::push_back(
+                &mut addr_bytes,
+                *vector::borrow(str_bytes, i)
+            );
+            i = i + 1;
+        };
+
+        ascii::string(addr_bytes)
+    }
+
+    /// Get name of the module.
+    public fun get_module(self: &TypeName): String {
+        // Starts after address and a double colon: `<addr as HEX>::`
+        let i = address::length() * 2 + 2;
+        let str_bytes = ascii::as_bytes(&self.name);
+        let module_name = vector[];
+
+        loop {
+            let char = vector::borrow(str_bytes, i);
+            if (char != &ASCII_COLON) {
+                vector::push_back(&mut module_name, *char);
+                i = i + 1;
+            } else {
+                break
+            }
+        };
+
+        ascii::string(module_name)
+    }
+
+    /// Convert `self` into its inner String
+    public fun into_string(self: TypeName): String {
+        self.name
+    }
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/unit_test.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/unit_test.move
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+/// Module providing testing functionality. Only included for tests.
+module std::unit_test {
+    /// Return a `num_signers` number of unique signer values. No ordering or
+    /// starting value guarantees are made, only that the order and values of
+    /// the signers in the returned vector is deterministic.
+    ///
+    /// This function is also used to poison modules compiled in `test` mode.
+    /// This will cause a linking failure if an attempt is made to publish a
+    /// test module in a VM that isn't in unit test mode.
+    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
+}

--- a/crates/sui-framework-override/deps/move-stdlib/sources/vector.move
+++ b/crates/sui-framework-override/deps/move-stdlib/sources/vector.move
@@ -1,0 +1,220 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A variable-sized container that can hold any type. Indexing is 0-based, and
+/// vectors are growable. This module has many native functions.
+/// Verification of modules that use this one uses model functions that are implemented
+/// directly in Boogie. The specification language has built-in functions operations such
+/// as `singleton_vector`. There are some helper functions defined here for specifications in other
+/// modules as well.
+///
+/// >Note: We did not verify most of the
+/// Move functions here because many have loops, requiring loop invariants to prove, and
+/// the return on investment didn't seem worth it for these simple functions.
+module std::vector {
+
+    /// The index into the vector is out of bounds
+    const EINDEX_OUT_OF_BOUNDS: u64 = 0x20000;
+
+    #[bytecode_instruction]
+    /// Create an empty vector.
+    native public fun empty<Element>(): vector<Element>;
+
+    #[bytecode_instruction]
+    /// Return the length of the vector.
+    native public fun length<Element>(v: &vector<Element>): u64;
+
+    #[bytecode_instruction]
+    /// Acquire an immutable reference to the `i`th element of the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+
+    #[bytecode_instruction]
+    /// Add element `e` to the end of the vector `v`.
+    native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+
+    #[bytecode_instruction]
+    /// Return a mutable reference to the `i`th element in the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+
+    #[bytecode_instruction]
+    /// Pop an element from the end of vector `v`.
+    /// Aborts if `v` is empty.
+    native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+
+    #[bytecode_instruction]
+    /// Destroy the vector `v`.
+    /// Aborts if `v` is not empty.
+    native public fun destroy_empty<Element>(v: vector<Element>);
+
+    #[bytecode_instruction]
+    /// Swaps the elements at the `i`th and `j`th indices in the vector `v`.
+    /// Aborts if `i` or `j` is out of bounds.
+    native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+
+    /// Return an vector of size one containing element `e`.
+    public fun singleton<Element>(e: Element): vector<Element> {
+        let v = empty();
+        push_back(&mut v, e);
+        v
+    }
+    spec singleton {
+        // TODO: when using opaque here, we get verification errors.
+        // pragma opaque;
+        aborts_if false;
+        ensures result == vec(e);
+    }
+
+    /// Reverses the order of the elements in the vector `v` in place.
+    public fun reverse<Element>(v: &mut vector<Element>) {
+        let len = length(v);
+        if (len == 0) return ();
+
+        let front_index = 0;
+        let back_index = len -1;
+        while (front_index < back_index) {
+            swap(v, front_index, back_index);
+            front_index = front_index + 1;
+            back_index = back_index - 1;
+        }
+    }
+    spec reverse {
+        pragma intrinsic = true;
+    }
+
+
+    /// Pushes all of the elements of the `other` vector into the `lhs` vector.
+    public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>) {
+        reverse(&mut other);
+        while (!is_empty(&other)) push_back(lhs, pop_back(&mut other));
+        destroy_empty(other);
+    }
+    spec append {
+        pragma intrinsic = true;
+    }
+    spec is_empty {
+        pragma intrinsic = true;
+    }
+
+
+    /// Return `true` if the vector `v` has no elements and `false` otherwise.
+    public fun is_empty<Element>(v: &vector<Element>): bool {
+        length(v) == 0
+    }
+
+    /// Return true if `e` is in the vector `v`.
+    /// Otherwise, returns false.
+    public fun contains<Element>(v: &vector<Element>, e: &Element): bool {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return true;
+            i = i + 1;
+        };
+        false
+    }
+    spec contains {
+        pragma intrinsic = true;
+    }
+
+    /// Return `(true, i)` if `e` is in the vector `v` at index `i`.
+    /// Otherwise, returns `(false, 0)`.
+    public fun index_of<Element>(v: &vector<Element>, e: &Element): (bool, u64) {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return (true, i);
+            i = i + 1;
+        };
+        (false, 0)
+    }
+    spec index_of {
+        pragma intrinsic = true;
+    }
+
+    /// Remove the `i`th element of the vector `v`, shifting all subsequent elements.
+    /// This is O(n) and preserves ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
+    public fun remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        let len = length(v);
+        // i out of bounds; abort
+        if (i >= len) abort EINDEX_OUT_OF_BOUNDS;
+
+        len = len - 1;
+        while (i < len) swap(v, i, { i = i + 1; i });
+        pop_back(v)
+    }
+    spec remove {
+        pragma intrinsic = true;
+    }
+
+    /// Insert `e` at position `i` in the vector `v`.
+    /// If `i` is in bounds, this shifts the old `v[i]` and all subsequent elements to the right.
+    /// If `i == length(v)`, this adds `e` to the end of the vector.
+    /// This is O(n) and preserves ordering of elements in the vector.
+    /// Aborts if `i > length(v)`
+    public fun insert<Element>(v: &mut vector<Element>, e: Element, i: u64) {
+        let len = length(v);
+        // i too big abort
+        if (i > len) abort EINDEX_OUT_OF_BOUNDS;
+
+        push_back(v, e);
+        while (i < len) {
+            swap(v, i, len);
+            i = i + 1
+        }
+    }
+    spec insert {
+        pragma intrinsic = true;
+    }
+
+    /// Swap the `i`th element of the vector `v` with the last element and then pop the vector.
+    /// This is O(1), but does not preserve ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
+    public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        assert!(!is_empty(v), EINDEX_OUT_OF_BOUNDS);
+        let last_idx = length(v) - 1;
+        swap(v, i, last_idx);
+        pop_back(v)
+    }
+    spec swap_remove {
+        pragma intrinsic = true;
+    }
+
+    // =================================================================
+    // Module Specification
+
+    spec module {} // Switch to module documentation context
+
+    /// # Helper Functions
+
+    spec module {
+        /// Check if `v1` is equal to the result of adding `e` at the end of `v2`
+        fun eq_push_back<Element>(v1: vector<Element>, v2: vector<Element>, e: Element): bool {
+            len(v1) == len(v2) + 1 &&
+            v1[len(v1)-1] == e &&
+            v1[0..len(v1)-1] == v2[0..len(v2)]
+        }
+
+        /// Check if `v` is equal to the result of concatenating `v1` and `v2`
+        fun eq_append<Element>(v: vector<Element>, v1: vector<Element>, v2: vector<Element>): bool {
+            len(v) == len(v1) + len(v2) &&
+            v[0..len(v1)] == v1 &&
+            v[len(v1)..len(v)] == v2
+        }
+
+        /// Check `v1` is equal to the result of removing the first element of `v2`
+        fun eq_pop_front<Element>(v1: vector<Element>, v2: vector<Element>): bool {
+            len(v1) + 1 == len(v2) &&
+            v1 == v2[1..len(v2)]
+        }
+
+        /// Check that `v1` is equal to the result of removing the element at index `i` from `v2`.
+        fun eq_remove_elem_at_index<Element>(i: u64, v1: vector<Element>, v2: vector<Element>): bool {
+            len(v1) + 1 == len(v2) &&
+            v1[0..i] == v2[0..i] &&
+            v1[i..len(v1)] == v2[i + 1..len(v2)]
+        }
+    }
+}

--- a/crates/sui-framework-override/docs/address.md
+++ b/crates/sui-framework-override/docs/address.md
@@ -1,0 +1,276 @@
+
+<a name="0x2_address"></a>
+
+# Module `0x2::address`
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `to_u256`](#0x2_address_to_u256)
+-  [Function `from_u256`](#0x2_address_from_u256)
+-  [Function `from_bytes`](#0x2_address_from_bytes)
+-  [Function `to_bytes`](#0x2_address_to_bytes)
+-  [Function `to_ascii_string`](#0x2_address_to_ascii_string)
+-  [Function `to_string`](#0x2_address_to_string)
+-  [Function `length`](#0x2_address_length)
+-  [Function `max`](#0x2_address_max)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="">0x1::ascii</a>;
+<b>use</b> <a href="">0x1::bcs</a>;
+<b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="hex.md#0x2_hex">0x2::hex</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_address_EAddressParseError"></a>
+
+Error from <code>from_bytes</code> when it is supplied too many or too few bytes.
+
+
+<pre><code><b>const</b> <a href="address.md#0x2_address_EAddressParseError">EAddressParseError</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_address_EU256TooBigToConvertToAddress"></a>
+
+Error from <code>from_u256</code> when
+
+
+<pre><code><b>const</b> <a href="address.md#0x2_address_EU256TooBigToConvertToAddress">EU256TooBigToConvertToAddress</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_address_LENGTH"></a>
+
+The length of an address, in bytes
+
+
+<pre><code><b>const</b> <a href="address.md#0x2_address_LENGTH">LENGTH</a>: u64 = 20;
+</code></pre>
+
+
+
+<a name="0x2_address_MAX"></a>
+
+
+
+<pre><code><b>const</b> <a href="address.md#0x2_address_MAX">MAX</a>: u256 = 1461501637330902918203684832716283019655932542975;
+</code></pre>
+
+
+
+<a name="0x2_address_to_u256"></a>
+
+## Function `to_u256`
+
+Convert <code>a</code> into a u256 by interpreting <code>a</code> as the bytes of a big-endian integer
+(e.g., <code><a href="address.md#0x2_address_to_u256">to_u256</a>(0x1) == 1</code>)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_to_u256">to_u256</a>(a: <b>address</b>): u256
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="address.md#0x2_address_to_u256">to_u256</a>(a: <b>address</b>): u256;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_address_from_u256"></a>
+
+## Function `from_u256`
+
+Convert <code>n</code> into an address by encoding it as a big-endian integer (e.g., <code><a href="address.md#0x2_address_from_u256">from_u256</a>(1) = @0x1</code>)
+Aborts if <code>n</code> > <code>MAX_ADDRESS</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_from_u256">from_u256</a>(n: u256): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="address.md#0x2_address_from_u256">from_u256</a>(n: u256): <b>address</b>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_address_from_bytes"></a>
+
+## Function `from_bytes`
+
+Convert <code>bytes</code> into an address.
+Aborts with <code><a href="address.md#0x2_address_EAddressParseError">EAddressParseError</a></code> if the length of <code>bytes</code> is not 20
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_from_bytes">from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="address.md#0x2_address_from_bytes">from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <b>address</b>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_address_to_bytes"></a>
+
+## Function `to_bytes`
+
+Convert <code>a</code> into BCS-encoded bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_to_bytes">to_bytes</a>(a: <b>address</b>): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_to_bytes">to_bytes</a>(a: <b>address</b>): <a href="">vector</a>&lt;u8&gt; {
+    <a href="_to_bytes">bcs::to_bytes</a>(&a)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_address_to_ascii_string"></a>
+
+## Function `to_ascii_string`
+
+Convert <code>a</code> to a hex-encoded ASCII string
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_to_ascii_string">to_ascii_string</a>(a: <b>address</b>): <a href="_String">ascii::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_to_ascii_string">to_ascii_string</a>(a: <b>address</b>): <a href="_String">ascii::String</a> {
+    <a href="_string">ascii::string</a>(<a href="hex.md#0x2_hex_encode">hex::encode</a>(<a href="address.md#0x2_address_to_bytes">to_bytes</a>(a)))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_address_to_string"></a>
+
+## Function `to_string`
+
+Convert <code>a</code> to a hex-encoded ASCII string
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_to_string">to_string</a>(a: <b>address</b>): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_to_string">to_string</a>(a: <b>address</b>): <a href="_String">string::String</a> {
+    <a href="_from_ascii">string::from_ascii</a>(<a href="address.md#0x2_address_to_ascii_string">to_ascii_string</a>(a))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_address_length"></a>
+
+## Function `length`
+
+Length of a Sui address in bytes
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_length">length</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_length">length</a>(): u64 {
+    <a href="address.md#0x2_address_LENGTH">LENGTH</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_address_max"></a>
+
+## Function `max`
+
+Largest possible address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_max">max</a>(): u256
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_max">max</a>(): u256 {
+    <a href="address.md#0x2_address_MAX">MAX</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="@Module_Specification_1"></a>
+
+## Module Specification
+
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>

--- a/crates/sui-framework-override/docs/bag.md
+++ b/crates/sui-framework-override/docs/bag.md
@@ -1,0 +1,368 @@
+
+<a name="0x2_bag"></a>
+
+# Module `0x2::bag`
+
+A bag is a heterogeneous map-like collection. The collection is similar to <code>sui::table</code> in that
+its keys and values are not stored within the <code><a href="bag.md#0x2_bag_Bag">Bag</a></code> value, but instead are stored using Sui's
+object system. The <code><a href="bag.md#0x2_bag_Bag">Bag</a></code> struct acts only as a handle into the object system to retrieve those
+keys and values.
+Note that this means that <code><a href="bag.md#0x2_bag_Bag">Bag</a></code> values with exactly the same key-value mapping will not be
+equal, with <code>==</code>, at runtime. For example
+```
+let bag1 = bag::new();
+let bag2 = bag::new();
+bag::add(&mut bag1, 0, false);
+bag::add(&mut bag1, 1, true);
+bag::add(&mut bag2, 0, false);
+bag::add(&mut bag2, 1, true);
+// bag1 does not equal bag2, despite having the same entries
+assert!(&bag1 != &bag2, 0);
+```
+At it's core, <code>sui::bag</code> is a wrapper around <code>UID</code> that allows for access to
+<code>sui::dynamic_field</code> while preventing accidentally stranding field values. A <code>UID</code> can be
+deleted, even if it has dynamic fields associated with it, but a bag, on the other hand, must be
+empty to be destroyed.
+
+
+-  [Resource `Bag`](#0x2_bag_Bag)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x2_bag_new)
+-  [Function `add`](#0x2_bag_add)
+-  [Function `borrow`](#0x2_bag_borrow)
+-  [Function `borrow_mut`](#0x2_bag_borrow_mut)
+-  [Function `remove`](#0x2_bag_remove)
+-  [Function `contains`](#0x2_bag_contains)
+-  [Function `contains_with_type`](#0x2_bag_contains_with_type)
+-  [Function `length`](#0x2_bag_length)
+-  [Function `is_empty`](#0x2_bag_is_empty)
+-  [Function `destroy_empty`](#0x2_bag_destroy_empty)
+
+
+<pre><code><b>use</b> <a href="dynamic_field.md#0x2_dynamic_field">0x2::dynamic_field</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_bag_Bag"></a>
+
+## Resource `Bag`
+
+
+
+<pre><code><b>struct</b> <a href="bag.md#0x2_bag_Bag">Bag</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+ the ID of this bag
+</dd>
+<dt>
+<code>size: u64</code>
+</dt>
+<dd>
+ the number of key-value pairs in the bag
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_bag_EBagNotEmpty"></a>
+
+
+
+<pre><code><b>const</b> <a href="bag.md#0x2_bag_EBagNotEmpty">EBagNotEmpty</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_bag_new"></a>
+
+## Function `new`
+
+Creates a new, empty bag
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="bag.md#0x2_bag_Bag">bag::Bag</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_new">new</a>(ctx: &<b>mut</b> TxContext): <a href="bag.md#0x2_bag_Bag">Bag</a> {
+    <a href="bag.md#0x2_bag_Bag">Bag</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        size: 0,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bag_add"></a>
+
+## Function `add`
+
+Adds a key-value pair to the bag <code><a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="bag.md#0x2_bag_Bag">Bag</a></code>
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the bag already has an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_add">add</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="bag.md#0x2_bag_Bag">bag::Bag</a>, k: K, v: V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_add">add</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="bag.md#0x2_bag_Bag">Bag</a>, k: K, v: V) {
+    field::add(&<b>mut</b> <a href="bag.md#0x2_bag">bag</a>.id, k, v);
+    <a href="bag.md#0x2_bag">bag</a>.size = <a href="bag.md#0x2_bag">bag</a>.size + 1;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bag_borrow"></a>
+
+## Function `borrow`
+
+Immutable borrows the value associated with the key in the bag <code><a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">Bag</a></code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): &V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">Bag</a>, k: K): &V {
+    field::borrow(&<a href="bag.md#0x2_bag">bag</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bag_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Mutably borrows the value associated with the key in the bag <code><a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="bag.md#0x2_bag_Bag">Bag</a></code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): &<b>mut</b> V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="bag.md#0x2_bag_Bag">Bag</a>, k: K): &<b>mut</b> V {
+    field::borrow_mut(&<b>mut</b> <a href="bag.md#0x2_bag">bag</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bag_remove"></a>
+
+## Function `remove`
+
+Mutably borrows the key-value pair in the bag <code><a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="bag.md#0x2_bag_Bag">Bag</a></code> and returns the value.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="bag.md#0x2_bag_Bag">Bag</a>, k: K): V {
+    <b>let</b> v = field::remove(&<b>mut</b> <a href="bag.md#0x2_bag">bag</a>.id, k);
+    <a href="bag.md#0x2_bag">bag</a>.size = <a href="bag.md#0x2_bag">bag</a>.size - 1;
+    v
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bag_contains"></a>
+
+## Function `contains`
+
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">Bag</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_contains">contains</a>&lt;K: <b>copy</b>, drop, store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_contains">contains</a>&lt;K: <b>copy</b> + drop + store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">Bag</a>, k: K): bool {
+    field::exists_&lt;K&gt;(&<a href="bag.md#0x2_bag">bag</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bag_contains_with_type"></a>
+
+## Function `contains_with_type`
+
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">Bag</a></code>
+with an assigned value of type <code>V</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">Bag</a>, k: K): bool {
+    field::exists_with_type&lt;K, V&gt;(&<a href="bag.md#0x2_bag">bag</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bag_length"></a>
+
+## Function `length`
+
+Returns the size of the bag, the number of key-value pairs
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_length">length</a>(<a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">bag::Bag</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_length">length</a>(<a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">Bag</a>): u64 {
+    <a href="bag.md#0x2_bag">bag</a>.size
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bag_is_empty"></a>
+
+## Function `is_empty`
+
+Returns true iff the bag is empty (if <code>length</code> returns <code>0</code>)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_is_empty">is_empty</a>(<a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">bag::Bag</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_is_empty">is_empty</a>(<a href="bag.md#0x2_bag">bag</a>: &<a href="bag.md#0x2_bag_Bag">Bag</a>): bool {
+    <a href="bag.md#0x2_bag">bag</a>.size == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bag_destroy_empty"></a>
+
+## Function `destroy_empty`
+
+Destroys an empty bag
+Aborts with <code><a href="bag.md#0x2_bag_EBagNotEmpty">EBagNotEmpty</a></code> if the bag still contains values
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_destroy_empty">destroy_empty</a>(<a href="bag.md#0x2_bag">bag</a>: <a href="bag.md#0x2_bag_Bag">bag::Bag</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bag.md#0x2_bag_destroy_empty">destroy_empty</a>(<a href="bag.md#0x2_bag">bag</a>: <a href="bag.md#0x2_bag_Bag">Bag</a>) {
+    <b>let</b> <a href="bag.md#0x2_bag_Bag">Bag</a> { id, size } = <a href="bag.md#0x2_bag">bag</a>;
+    <b>assert</b>!(size == 0, <a href="bag.md#0x2_bag_EBagNotEmpty">EBagNotEmpty</a>);
+    <a href="object.md#0x2_object_delete">object::delete</a>(id)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/balance.md
+++ b/crates/sui-framework-override/docs/balance.md
@@ -1,0 +1,463 @@
+
+<a name="0x2_balance"></a>
+
+# Module `0x2::balance`
+
+A storable handler for Balances in general. Is used in the <code>Coin</code>
+module to allow balance operations and can be used to implement
+custom coins with <code><a href="balance.md#0x2_balance_Supply">Supply</a></code> and <code><a href="balance.md#0x2_balance_Balance">Balance</a></code>s.
+
+
+-  [Struct `Supply`](#0x2_balance_Supply)
+-  [Struct `Balance`](#0x2_balance_Balance)
+-  [Constants](#@Constants_0)
+-  [Function `value`](#0x2_balance_value)
+-  [Function `supply_value`](#0x2_balance_supply_value)
+-  [Function `create_supply`](#0x2_balance_create_supply)
+-  [Function `increase_supply`](#0x2_balance_increase_supply)
+-  [Function `decrease_supply`](#0x2_balance_decrease_supply)
+-  [Function `zero`](#0x2_balance_zero)
+-  [Function `join`](#0x2_balance_join)
+-  [Function `split`](#0x2_balance_split)
+-  [Function `destroy_zero`](#0x2_balance_destroy_zero)
+-  [Function `create_staking_rewards`](#0x2_balance_create_staking_rewards)
+-  [Function `destroy_storage_rebates`](#0x2_balance_destroy_storage_rebates)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_balance_Supply"></a>
+
+## Struct `Supply`
+
+A Supply of T. Used for minting and burning.
+Wrapped into a <code>TreasuryCap</code> in the <code>Coin</code> module.
+
+
+<pre><code><b>struct</b> <a href="balance.md#0x2_balance_Supply">Supply</a>&lt;T&gt; <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>value: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_balance_Balance"></a>
+
+## Struct `Balance`
+
+Storable balance - an inner struct of a Coin type.
+Can be used to store coins which don't need the key ability.
+
+
+<pre><code><b>struct</b> <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt; <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>value: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_balance_ENonZero"></a>
+
+For when trying to destroy a non-zero balance.
+
+
+<pre><code><b>const</b> <a href="balance.md#0x2_balance_ENonZero">ENonZero</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_balance_ENotEnough"></a>
+
+For when trying to withdraw more than there is.
+
+
+<pre><code><b>const</b> <a href="balance.md#0x2_balance_ENotEnough">ENotEnough</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_balance_EOverflow"></a>
+
+For when an overflow is happening on Supply operations.
+
+
+<pre><code><b>const</b> <a href="balance.md#0x2_balance_EOverflow">EOverflow</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_balance_value"></a>
+
+## Function `value`
+
+Get the amount stored in a <code><a href="balance.md#0x2_balance_Balance">Balance</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_value">value</a>&lt;T&gt;(self: &<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_value">value</a>&lt;T&gt;(self: &<a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;): u64 {
+    self.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_supply_value"></a>
+
+## Function `supply_value`
+
+Get the <code><a href="balance.md#0x2_balance_Supply">Supply</a></code> value.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_supply_value">supply_value</a>&lt;T&gt;(supply: &<a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_supply_value">supply_value</a>&lt;T&gt;(supply: &<a href="balance.md#0x2_balance_Supply">Supply</a>&lt;T&gt;): u64 {
+    supply.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_create_supply"></a>
+
+## Function `create_supply`
+
+Create a new supply for type T.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_create_supply">create_supply</a>&lt;T: drop&gt;(_: T): <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_create_supply">create_supply</a>&lt;T: drop&gt;(_: T): <a href="balance.md#0x2_balance_Supply">Supply</a>&lt;T&gt; {
+    <a href="balance.md#0x2_balance_Supply">Supply</a> { value: 0 }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_increase_supply"></a>
+
+## Function `increase_supply`
+
+Increase supply by <code>value</code> and create a new <code><a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;</code> with this value.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_increase_supply">increase_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;, value: u64): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_increase_supply">increase_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="balance.md#0x2_balance_Supply">Supply</a>&lt;T&gt;, value: u64): <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt; {
+    <b>assert</b>!(<a href="balance.md#0x2_balance_value">value</a> &lt; (18446744073709551615u64 - self.value), <a href="balance.md#0x2_balance_EOverflow">EOverflow</a>);
+    self.value = self.value + value;
+    <a href="balance.md#0x2_balance_Balance">Balance</a> { value }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_decrease_supply"></a>
+
+## Function `decrease_supply`
+
+Burn a Balance<T> and decrease Supply<T>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_decrease_supply">decrease_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;, <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_decrease_supply">decrease_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="balance.md#0x2_balance_Supply">Supply</a>&lt;T&gt;, <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;): u64 {
+    <b>let</b> <a href="balance.md#0x2_balance_Balance">Balance</a> { value } = <a href="balance.md#0x2_balance">balance</a>;
+    <b>assert</b>!(self.value &gt;= value, <a href="balance.md#0x2_balance_EOverflow">EOverflow</a>);
+    self.value = self.value - value;
+    value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_zero"></a>
+
+## Function `zero`
+
+Create a zero <code><a href="balance.md#0x2_balance_Balance">Balance</a></code> for type <code>T</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_zero">zero</a>&lt;T&gt;(): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_zero">zero</a>&lt;T&gt;(): <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt; {
+    <a href="balance.md#0x2_balance_Balance">Balance</a> { value: 0 }
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result.value == 0;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_join"></a>
+
+## Function `join`
+
+Join two balances together.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;, <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;): u64 {
+    <b>let</b> <a href="balance.md#0x2_balance_Balance">Balance</a> { value } = <a href="balance.md#0x2_balance">balance</a>;
+    self.value = self.value + value;
+    self.value
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>ensures</b> self.value == <b>old</b>(self.value) + <a href="balance.md#0x2_balance">balance</a>.value;
+<b>ensures</b> result == self.value;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_split"></a>
+
+## Function `split`
+
+Split a <code><a href="balance.md#0x2_balance_Balance">Balance</a></code> and take a sub balance from it.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, value: u64): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;, value: u64): <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt; {
+    <b>assert</b>!(self.value &gt;= value, <a href="balance.md#0x2_balance_ENotEnough">ENotEnough</a>);
+    self.value = self.value - value;
+    <a href="balance.md#0x2_balance_Balance">Balance</a> { value }
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> self.<a href="balance.md#0x2_balance_value">value</a> &lt; value <b>with</b> <a href="balance.md#0x2_balance_ENotEnough">ENotEnough</a>;
+<b>ensures</b> self.value == <b>old</b>(self.value) - value;
+<b>ensures</b> result.value == value;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_destroy_zero"></a>
+
+## Function `destroy_zero`
+
+Destroy a zero <code><a href="balance.md#0x2_balance_Balance">Balance</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_destroy_zero">destroy_zero</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance_destroy_zero">destroy_zero</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;) {
+    <b>assert</b>!(<a href="balance.md#0x2_balance">balance</a>.value == 0, <a href="balance.md#0x2_balance_ENonZero">ENonZero</a>);
+    <b>let</b> <a href="balance.md#0x2_balance_Balance">Balance</a> { value: _ } = <a href="balance.md#0x2_balance">balance</a>;
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> <a href="balance.md#0x2_balance">balance</a>.value != 0 <b>with</b> <a href="balance.md#0x2_balance_ENonZero">ENonZero</a>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_create_staking_rewards"></a>
+
+## Function `create_staking_rewards`
+
+CAUTION: this function creates a <code><a href="balance.md#0x2_balance_Balance">Balance</a></code> without increasing the supply.
+It should only be called by <code><a href="sui_system.md#0x2_sui_system_advance_epoch">sui_system::advance_epoch</a></code> to create staking rewards,
+and nowhere else.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_create_staking_rewards">create_staking_rewards</a>&lt;T&gt;(value: u64): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_create_staking_rewards">create_staking_rewards</a>&lt;T&gt;(value: u64): <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt; {
+    <a href="balance.md#0x2_balance_Balance">Balance</a> { value }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_destroy_storage_rebates"></a>
+
+## Function `destroy_storage_rebates`
+
+CAUTION: this function destroys a <code><a href="balance.md#0x2_balance_Balance">Balance</a></code> without decreasing the supply.
+It should only be called by <code><a href="sui_system.md#0x2_sui_system_advance_epoch">sui_system::advance_epoch</a></code> to destroy storage rebates,
+and nowhere else.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_destroy_storage_rebates">destroy_storage_rebates</a>&lt;T&gt;(self: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_destroy_storage_rebates">destroy_storage_rebates</a>&lt;T&gt;(self: <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;) {
+    <b>let</b> <a href="balance.md#0x2_balance_Balance">Balance</a> { value: _ } = self;
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/bcs.md
+++ b/crates/sui-framework-override/docs/bcs.md
@@ -1,0 +1,747 @@
+
+<a name="0x2_bcs"></a>
+
+# Module `0x2::bcs`
+
+This module implements BCS (de)serialization in Move.
+Full specification can be found here: https://github.com/diem/bcs
+
+Short summary (for Move-supported types):
+
+- address - sequence of X bytes
+- bool - byte with 0 or 1
+- u8 - a single u8 byte
+- u64 / u128 - LE bytes
+- vector - ULEB128 length + LEN elements
+- option - first byte bool: None (0) or Some (1), then value
+
+Usage example:
+```
+/// This function reads u8 and u64 value from the input
+/// and returns the rest of the bytes.
+fun deserialize(bytes: vector<u8>): (u8, u64, vector<u8>) {
+use sui::bcs::{Self, BCS};
+
+let prepared: BCS = bcs::new(bytes);
+let (u8_value, u64_value) = (
+bcs::peel_u8(&mut prepared),
+bcs::peel_u64(&mut prepared)
+);
+
+// unpack bcs struct
+let leftovers = bcs::into_remainder_bytes(prepared);
+
+(u8_value, u64_value, leftovers)
+}
+```
+
+
+-  [Struct `BCS`](#0x2_bcs_BCS)
+-  [Constants](#@Constants_0)
+-  [Function `to_bytes`](#0x2_bcs_to_bytes)
+-  [Function `new`](#0x2_bcs_new)
+-  [Function `into_remainder_bytes`](#0x2_bcs_into_remainder_bytes)
+-  [Function `peel_address`](#0x2_bcs_peel_address)
+-  [Function `peel_bool`](#0x2_bcs_peel_bool)
+-  [Function `peel_u8`](#0x2_bcs_peel_u8)
+-  [Function `peel_u64`](#0x2_bcs_peel_u64)
+-  [Function `peel_u128`](#0x2_bcs_peel_u128)
+-  [Function `peel_vec_length`](#0x2_bcs_peel_vec_length)
+-  [Function `peel_vec_address`](#0x2_bcs_peel_vec_address)
+-  [Function `peel_vec_bool`](#0x2_bcs_peel_vec_bool)
+-  [Function `peel_vec_u8`](#0x2_bcs_peel_vec_u8)
+-  [Function `peel_vec_vec_u8`](#0x2_bcs_peel_vec_vec_u8)
+-  [Function `peel_vec_u64`](#0x2_bcs_peel_vec_u64)
+-  [Function `peel_vec_u128`](#0x2_bcs_peel_vec_u128)
+-  [Function `peel_option_address`](#0x2_bcs_peel_option_address)
+-  [Function `peel_option_bool`](#0x2_bcs_peel_option_bool)
+-  [Function `peel_option_u8`](#0x2_bcs_peel_option_u8)
+-  [Function `peel_option_u64`](#0x2_bcs_peel_option_u64)
+-  [Function `peel_option_u128`](#0x2_bcs_peel_option_u128)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="">0x1::bcs</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="address.md#0x2_address">0x2::address</a>;
+</code></pre>
+
+
+
+<a name="0x2_bcs_BCS"></a>
+
+## Struct `BCS`
+
+A helper struct that saves resources on operations. For better
+vector performance, it stores reversed bytes of the BCS and
+enables use of <code><a href="_pop_back">vector::pop_back</a></code>.
+
+
+<pre><code><b>struct</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_bcs_ELenOutOfRange"></a>
+
+For when ULEB byte is out of range (or not found).
+
+
+<pre><code><b>const</b> <a href="bcs.md#0x2_bcs_ELenOutOfRange">ELenOutOfRange</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_bcs_ENotBool"></a>
+
+For when the boolean value different than <code>0</code> or <code>1</code>.
+
+
+<pre><code><b>const</b> <a href="bcs.md#0x2_bcs_ENotBool">ENotBool</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_bcs_EOutOfRange"></a>
+
+For when bytes length is less than required for deserialization.
+
+
+<pre><code><b>const</b> <a href="bcs.md#0x2_bcs_EOutOfRange">EOutOfRange</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_bcs_to_bytes"></a>
+
+## Function `to_bytes`
+
+Get BCS serialized bytes for any value.
+Re-exports stdlib <code><a href="_to_bytes">bcs::to_bytes</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_to_bytes">to_bytes</a>&lt;T&gt;(value: &T): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_to_bytes">to_bytes</a>&lt;T&gt;(value: &T): <a href="">vector</a>&lt;u8&gt; {
+    <a href="_to_bytes">bcs::to_bytes</a>(value)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_new"></a>
+
+## Function `new`
+
+Creates a new instance of BCS wrapper that holds inversed
+bytes for better performance.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_new">new</a>(bytes: <a href="">vector</a>&lt;u8&gt;): bcs::BCS
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_new">new</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="bcs.md#0x2_bcs_BCS">BCS</a> {
+    v::reverse(&<b>mut</b> bytes);
+    <a href="bcs.md#0x2_bcs_BCS">BCS</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_into_remainder_bytes"></a>
+
+## Function `into_remainder_bytes`
+
+Unpack the <code><a href="bcs.md#0x2_bcs_BCS">BCS</a></code> struct returning the leftover bytes.
+Useful for passing the data further after partial deserialization.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_into_remainder_bytes">into_remainder_bytes</a>(<a href="">bcs</a>: bcs::BCS): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_into_remainder_bytes">into_remainder_bytes</a>(<a href="">bcs</a>: <a href="bcs.md#0x2_bcs_BCS">BCS</a>): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a> { bytes } = <a href="">bcs</a>;
+    v::reverse(&<b>mut</b> bytes);
+    bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_address"></a>
+
+## Function `peel_address`
+
+Read address from the bcs-serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_address">peel_address</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_address">peel_address</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): <b>address</b> {
+    <b>assert</b>!(v::length(&<a href="">bcs</a>.bytes) &gt;= <a href="_length">address::length</a>(), <a href="bcs.md#0x2_bcs_EOutOfRange">EOutOfRange</a>);
+    <b>let</b> (addr_bytes, i) = (v::empty(), 0);
+    <b>while</b> (i &lt; 20) {
+        v::push_back(&<b>mut</b> addr_bytes, v::pop_back(&<b>mut</b> <a href="">bcs</a>.bytes));
+        i = i + 1;
+    };
+    address::from_bytes(addr_bytes)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_bool"></a>
+
+## Function `peel_bool`
+
+Read a <code>bool</code> value from bcs-serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_bool">peel_bool</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_bool">peel_bool</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): bool {
+    <b>let</b> value = <a href="bcs.md#0x2_bcs_peel_u8">peel_u8</a>(<a href="">bcs</a>);
+    <b>if</b> (value == 0) {
+        <b>false</b>
+    } <b>else</b> <b>if</b> (value == 1) {
+        <b>true</b>
+    } <b>else</b> {
+        <b>abort</b> <a href="bcs.md#0x2_bcs_ENotBool">ENotBool</a>
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_u8"></a>
+
+## Function `peel_u8`
+
+Read <code>u8</code> value from bcs-serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_u8">peel_u8</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_u8">peel_u8</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): u8 {
+    <b>assert</b>!(v::length(&<a href="">bcs</a>.bytes) &gt;= 1, <a href="bcs.md#0x2_bcs_EOutOfRange">EOutOfRange</a>);
+    v::pop_back(&<b>mut</b> <a href="">bcs</a>.bytes)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_u64"></a>
+
+## Function `peel_u64`
+
+Read <code>u64</code> value from bcs-serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_u64">peel_u64</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_u64">peel_u64</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): u64 {
+    <b>assert</b>!(v::length(&<a href="">bcs</a>.bytes) &gt;= 8, <a href="bcs.md#0x2_bcs_EOutOfRange">EOutOfRange</a>);
+
+    <b>let</b> (value, i) = (0u64, 0u8);
+    <b>while</b> (i &lt; 64) {
+        <b>let</b> byte = (v::pop_back(&<b>mut</b> <a href="">bcs</a>.bytes) <b>as</b> u64);
+        value = value + (byte &lt;&lt; i);
+        i = i + 8;
+    };
+
+    value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_u128"></a>
+
+## Function `peel_u128`
+
+Read <code>u128</code> value from bcs-serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_u128">peel_u128</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_u128">peel_u128</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): u128 {
+    <b>assert</b>!(v::length(&<a href="">bcs</a>.bytes) &gt;= 16, <a href="bcs.md#0x2_bcs_EOutOfRange">EOutOfRange</a>);
+
+    <b>let</b> (value, i) = (0u128, 0u8);
+    <b>while</b> (i &lt; 128) {
+        <b>let</b> byte = (v::pop_back(&<b>mut</b> <a href="">bcs</a>.bytes) <b>as</b> u128);
+        value = value + (byte &lt;&lt; i);
+        i = i + 8;
+    };
+
+    value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_vec_length"></a>
+
+## Function `peel_vec_length`
+
+Read ULEB bytes expecting a vector length. Result should
+then be used to perform <code>peel_*</code> operation LEN times.
+
+In BCS <code><a href="">vector</a></code> length is implemented with ULEB128;
+See more here: https://en.wikipedia.org/wiki/LEB128
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_length">peel_vec_length</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_length">peel_vec_length</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): u64 {
+    <b>let</b> (total, shift, len) = (0u64, 0, 0);
+    <b>while</b> (<b>true</b>) {
+        <b>assert</b>!(len &lt;= 4, <a href="bcs.md#0x2_bcs_ELenOutOfRange">ELenOutOfRange</a>);
+        <b>let</b> byte = (v::pop_back(&<b>mut</b> <a href="">bcs</a>.bytes) <b>as</b> u64);
+        len = len + 1;
+        total = total | ((byte & 0x7f) &lt;&lt; shift);
+        <b>if</b> ((byte & 0x80) == 0) {
+            <b>break</b>
+        };
+        shift = shift + 7;
+    };
+    total
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_vec_address"></a>
+
+## Function `peel_vec_address`
+
+Peel a vector of <code><b>address</b></code> from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_address">peel_vec_address</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="">vector</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_address">peel_vec_address</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): <a href="">vector</a>&lt;<b>address</b>&gt; {
+    <b>let</b> (len, i, res) = (<a href="bcs.md#0x2_bcs_peel_vec_length">peel_vec_length</a>(<a href="">bcs</a>), 0, <a href="">vector</a>[]);
+    <b>while</b> (i &lt; len) {
+        v::push_back(&<b>mut</b> res, <a href="bcs.md#0x2_bcs_peel_address">peel_address</a>(<a href="">bcs</a>));
+        i = i + 1;
+    };
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_vec_bool"></a>
+
+## Function `peel_vec_bool`
+
+Peel a vector of <code><b>address</b></code> from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_bool">peel_vec_bool</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="">vector</a>&lt;bool&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_bool">peel_vec_bool</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): <a href="">vector</a>&lt;bool&gt; {
+    <b>let</b> (len, i, res) = (<a href="bcs.md#0x2_bcs_peel_vec_length">peel_vec_length</a>(<a href="">bcs</a>), 0, <a href="">vector</a>[]);
+    <b>while</b> (i &lt; len) {
+        v::push_back(&<b>mut</b> res, <a href="bcs.md#0x2_bcs_peel_bool">peel_bool</a>(<a href="">bcs</a>));
+        i = i + 1;
+    };
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_vec_u8"></a>
+
+## Function `peel_vec_u8`
+
+Peel a vector of <code>u8</code> (eg string) from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_u8">peel_vec_u8</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_u8">peel_vec_u8</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> (len, i, res) = (<a href="bcs.md#0x2_bcs_peel_vec_length">peel_vec_length</a>(<a href="">bcs</a>), 0, <a href="">vector</a>[]);
+    <b>while</b> (i &lt; len) {
+        v::push_back(&<b>mut</b> res, <a href="bcs.md#0x2_bcs_peel_u8">peel_u8</a>(<a href="">bcs</a>));
+        i = i + 1;
+    };
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_vec_vec_u8"></a>
+
+## Function `peel_vec_vec_u8`
+
+Peel a <code><a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code> (eg vec of string) from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_vec_u8">peel_vec_vec_u8</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_vec_u8">peel_vec_vec_u8</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    <b>let</b> (len, i, res) = (<a href="bcs.md#0x2_bcs_peel_vec_length">peel_vec_length</a>(<a href="">bcs</a>), 0, <a href="">vector</a>[]);
+    <b>while</b> (i &lt; len) {
+        v::push_back(&<b>mut</b> res, <a href="bcs.md#0x2_bcs_peel_vec_u8">peel_vec_u8</a>(<a href="">bcs</a>));
+        i = i + 1;
+    };
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_vec_u64"></a>
+
+## Function `peel_vec_u64`
+
+Peel a vector of <code>u64</code> from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_u64">peel_vec_u64</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="">vector</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_u64">peel_vec_u64</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): <a href="">vector</a>&lt;u64&gt; {
+    <b>let</b> (len, i, res) = (<a href="bcs.md#0x2_bcs_peel_vec_length">peel_vec_length</a>(<a href="">bcs</a>), 0, <a href="">vector</a>[]);
+    <b>while</b> (i &lt; len) {
+        v::push_back(&<b>mut</b> res, <a href="bcs.md#0x2_bcs_peel_u64">peel_u64</a>(<a href="">bcs</a>));
+        i = i + 1;
+    };
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_vec_u128"></a>
+
+## Function `peel_vec_u128`
+
+Peel a vector of <code>u128</code> from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_u128">peel_vec_u128</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="">vector</a>&lt;u128&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_vec_u128">peel_vec_u128</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): <a href="">vector</a>&lt;u128&gt; {
+    <b>let</b> (len, i, res) = (<a href="bcs.md#0x2_bcs_peel_vec_length">peel_vec_length</a>(<a href="">bcs</a>), 0, <a href="">vector</a>[]);
+    <b>while</b> (i &lt; len) {
+        v::push_back(&<b>mut</b> res, <a href="bcs.md#0x2_bcs_peel_u128">peel_u128</a>(<a href="">bcs</a>));
+        i = i + 1;
+    };
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_option_address"></a>
+
+## Function `peel_option_address`
+
+Peel <code>Option&lt;<b>address</b>&gt;</code> from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_option_address">peel_option_address</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="_Option">option::Option</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_option_address">peel_option_address</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): Option&lt;<b>address</b>&gt; {
+    <b>if</b> (<a href="bcs.md#0x2_bcs_peel_bool">peel_bool</a>(<a href="">bcs</a>)) {
+        <a href="_some">option::some</a>(<a href="bcs.md#0x2_bcs_peel_address">peel_address</a>(<a href="">bcs</a>))
+    } <b>else</b> {
+        <a href="_none">option::none</a>()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_option_bool"></a>
+
+## Function `peel_option_bool`
+
+Peel <code>Option&lt;bool&gt;</code> from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_option_bool">peel_option_bool</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="_Option">option::Option</a>&lt;bool&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_option_bool">peel_option_bool</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): Option&lt;bool&gt; {
+    <b>if</b> (<a href="bcs.md#0x2_bcs_peel_bool">peel_bool</a>(<a href="">bcs</a>)) {
+        <a href="_some">option::some</a>(<a href="bcs.md#0x2_bcs_peel_bool">peel_bool</a>(<a href="">bcs</a>))
+    } <b>else</b> {
+        <a href="_none">option::none</a>()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_option_u8"></a>
+
+## Function `peel_option_u8`
+
+Peel <code>Option&lt;u8&gt;</code> from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_option_u8">peel_option_u8</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="_Option">option::Option</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_option_u8">peel_option_u8</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): Option&lt;u8&gt; {
+    <b>if</b> (<a href="bcs.md#0x2_bcs_peel_bool">peel_bool</a>(<a href="">bcs</a>)) {
+        <a href="_some">option::some</a>(<a href="bcs.md#0x2_bcs_peel_u8">peel_u8</a>(<a href="">bcs</a>))
+    } <b>else</b> {
+        <a href="_none">option::none</a>()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_option_u64"></a>
+
+## Function `peel_option_u64`
+
+Peel <code>Option&lt;u64&gt;</code> from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_option_u64">peel_option_u64</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_option_u64">peel_option_u64</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): Option&lt;u64&gt; {
+    <b>if</b> (<a href="bcs.md#0x2_bcs_peel_bool">peel_bool</a>(<a href="">bcs</a>)) {
+        <a href="_some">option::some</a>(<a href="bcs.md#0x2_bcs_peel_u64">peel_u64</a>(<a href="">bcs</a>))
+    } <b>else</b> {
+        <a href="_none">option::none</a>()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bcs_peel_option_u128"></a>
+
+## Function `peel_option_u128`
+
+Peel <code>Option&lt;u128&gt;</code> from serialized bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_option_u128">peel_option_u128</a>(<a href="">bcs</a>: &<b>mut</b> bcs::BCS): <a href="_Option">option::Option</a>&lt;u128&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x2_bcs_peel_option_u128">peel_option_u128</a>(<a href="">bcs</a>: &<b>mut</b> <a href="bcs.md#0x2_bcs_BCS">BCS</a>): Option&lt;u128&gt; {
+    <b>if</b> (<a href="bcs.md#0x2_bcs_peel_bool">peel_bool</a>(<a href="">bcs</a>)) {
+        <a href="_some">option::some</a>(<a href="bcs.md#0x2_bcs_peel_u128">peel_u128</a>(<a href="">bcs</a>))
+    } <b>else</b> {
+        <a href="_none">option::none</a>()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="@Module_Specification_1"></a>
+
+## Module Specification
+
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>

--- a/crates/sui-framework-override/docs/bls12381.md
+++ b/crates/sui-framework-override/docs/bls12381.md
@@ -1,0 +1,133 @@
+
+<a name="0x2_bls12381"></a>
+
+# Module `0x2::bls12381`
+
+
+
+-  [Function `bls12381_min_sig_verify`](#0x2_bls12381_bls12381_min_sig_verify)
+-  [Function `bls12381_min_sig_verify_with_domain`](#0x2_bls12381_bls12381_min_sig_verify_with_domain)
+-  [Function `bls12381_min_pk_verify`](#0x2_bls12381_bls12381_min_pk_verify)
+
+
+<pre><code><b>use</b> <a href="">0x1::vector</a>;
+</code></pre>
+
+
+
+<a name="0x2_bls12381_bls12381_min_sig_verify"></a>
+
+## Function `bls12381_min_sig_verify`
+
+@param signature: A 48-bytes signature that is a point on the G1 subgroup.
+@param public_key: A 96-bytes public key that is a point on the G2 subgroup.
+@param msg: The message that we test the signature against.
+
+If the signature is a valid signature of the message and public key according to
+BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return false.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bls12381.md#0x2_bls12381_bls12381_min_sig_verify">bls12381_min_sig_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="bls12381.md#0x2_bls12381_bls12381_min_sig_verify">bls12381_min_sig_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bls12381_bls12381_min_sig_verify_with_domain"></a>
+
+## Function `bls12381_min_sig_verify_with_domain`
+
+@param signature: A 48-bytes signature that is a point on the G1 subgroup.
+@param public_key: A 96-bytes public key that is a point on the G2 subgroup.
+@param msg: The message that we test the signature against.
+@param domain: The domain that the signature is tested again. We essentially prepend this to the message.
+
+If the signature is a valid signature of the message and public key according to
+BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return false.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bls12381.md#0x2_bls12381_bls12381_min_sig_verify_with_domain">bls12381_min_sig_verify_with_domain</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: <a href="">vector</a>&lt;u8&gt;, domain: <a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bls12381.md#0x2_bls12381_bls12381_min_sig_verify_with_domain">bls12381_min_sig_verify_with_domain</a>(
+    signature: &<a href="">vector</a>&lt;u8&gt;,
+    public_key: &<a href="">vector</a>&lt;u8&gt;,
+    msg: <a href="">vector</a>&lt;u8&gt;,
+    domain: <a href="">vector</a>&lt;u8&gt;
+): bool {
+    std::vector::append(&<b>mut</b> domain, msg);
+    <a href="bls12381.md#0x2_bls12381_bls12381_min_sig_verify">bls12381_min_sig_verify</a>(signature, public_key, &domain)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bls12381_bls12381_min_pk_verify"></a>
+
+## Function `bls12381_min_pk_verify`
+
+@param signature: A 96-bytes signature that is a point on the G2 subgroup.
+@param public_key: A 48-bytes public key that is a point on the G1 subgroup.
+@param msg: The message that we test the signature against.
+
+If the signature is a valid signature of the message and public key according to
+BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return false.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bls12381.md#0x2_bls12381_bls12381_min_pk_verify">bls12381_min_pk_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="bls12381.md#0x2_bls12381_bls12381_min_pk_verify">bls12381_min_pk_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/bulletproofs.md
+++ b/crates/sui-framework-override/docs/bulletproofs.md
@@ -1,0 +1,79 @@
+
+<a name="0x2_bulletproofs"></a>
+
+# Module `0x2::bulletproofs`
+
+
+
+-  [Function `native_verify_full_range_proof`](#0x2_bulletproofs_native_verify_full_range_proof)
+-  [Function `verify_full_range_proof`](#0x2_bulletproofs_verify_full_range_proof)
+
+
+<pre><code><b>use</b> <a href="elliptic_curve.md#0x2_elliptic_curve">0x2::elliptic_curve</a>;
+</code></pre>
+
+
+
+<a name="0x2_bulletproofs_native_verify_full_range_proof"></a>
+
+## Function `native_verify_full_range_proof`
+
+Only bit_length = 64, 32, 16, 8 will work.
+
+
+<pre><code><b>fun</b> <a href="bulletproofs.md#0x2_bulletproofs_native_verify_full_range_proof">native_verify_full_range_proof</a>(proof: &<a href="">vector</a>&lt;u8&gt;, commitment: &<a href="">vector</a>&lt;u8&gt;, bit_length: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="bulletproofs.md#0x2_bulletproofs_native_verify_full_range_proof">native_verify_full_range_proof</a>(proof: &<a href="">vector</a>&lt;u8&gt;, commitment: &<a href="">vector</a>&lt;u8&gt;, bit_length: u64): bool;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_bulletproofs_verify_full_range_proof"></a>
+
+## Function `verify_full_range_proof`
+
+@param proof: The bulletproof
+@param commitment: The commitment which we are trying to verify the range proof for
+@param bit_length: The bit length that we prove the committed value is whithin. Note that bit_length must be either 64, 32, 16, or 8.
+
+If the range proof is valid, execution succeeds, else panics.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bulletproofs.md#0x2_bulletproofs_verify_full_range_proof">verify_full_range_proof</a>(proof: &<a href="">vector</a>&lt;u8&gt;, commitment: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">elliptic_curve::RistrettoPoint</a>, bit_length: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bulletproofs.md#0x2_bulletproofs_verify_full_range_proof">verify_full_range_proof</a>(proof: &<a href="">vector</a>&lt;u8&gt;, commitment: &RistrettoPoint, bit_length: u64): bool {
+    <a href="bulletproofs.md#0x2_bulletproofs_native_verify_full_range_proof">native_verify_full_range_proof</a>(proof, &ec::bytes(commitment), bit_length)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/coin.md
+++ b/crates/sui-framework-override/docs/coin.md
@@ -1,0 +1,1265 @@
+
+<a name="0x2_coin"></a>
+
+# Module `0x2::coin`
+
+Defines the <code><a href="coin.md#0x2_coin_Coin">Coin</a></code> type - platform wide representation of fungible
+tokens and coins. <code><a href="coin.md#0x2_coin_Coin">Coin</a></code> can be described as a secure wrapper around
+<code>Balance</code> type.
+
+
+-  [Resource `Coin`](#0x2_coin_Coin)
+-  [Resource `CoinMetadata`](#0x2_coin_CoinMetadata)
+-  [Resource `TreasuryCap`](#0x2_coin_TreasuryCap)
+-  [Struct `CurrencyCreated`](#0x2_coin_CurrencyCreated)
+-  [Constants](#@Constants_0)
+-  [Function `total_supply`](#0x2_coin_total_supply)
+-  [Function `treasury_into_supply`](#0x2_coin_treasury_into_supply)
+-  [Function `supply`](#0x2_coin_supply)
+-  [Function `supply_mut`](#0x2_coin_supply_mut)
+-  [Function `value`](#0x2_coin_value)
+-  [Function `balance`](#0x2_coin_balance)
+-  [Function `balance_mut`](#0x2_coin_balance_mut)
+-  [Function `from_balance`](#0x2_coin_from_balance)
+-  [Function `into_balance`](#0x2_coin_into_balance)
+-  [Function `take`](#0x2_coin_take)
+-  [Function `put`](#0x2_coin_put)
+-  [Function `join`](#0x2_coin_join)
+-  [Function `split`](#0x2_coin_split)
+-  [Function `divide_into_n`](#0x2_coin_divide_into_n)
+-  [Function `zero`](#0x2_coin_zero)
+-  [Function `destroy_zero`](#0x2_coin_destroy_zero)
+-  [Function `create_currency`](#0x2_coin_create_currency)
+-  [Function `mint`](#0x2_coin_mint)
+-  [Function `mint_balance`](#0x2_coin_mint_balance)
+-  [Function `burn`](#0x2_coin_burn)
+-  [Function `mint_and_transfer`](#0x2_coin_mint_and_transfer)
+-  [Function `burn_`](#0x2_coin_burn_)
+-  [Function `update_name`](#0x2_coin_update_name)
+-  [Function `update_symbol`](#0x2_coin_update_symbol)
+-  [Function `update_description`](#0x2_coin_update_description)
+-  [Function `update_icon_url`](#0x2_coin_update_icon_url)
+-  [Function `get_decimals`](#0x2_coin_get_decimals)
+-  [Function `get_name`](#0x2_coin_get_name)
+-  [Function `get_symbol`](#0x2_coin_get_symbol)
+-  [Function `get_description`](#0x2_coin_get_description)
+-  [Function `get_icon_url`](#0x2_coin_get_icon_url)
+
+
+<pre><code><b>use</b> <a href="">0x1::ascii</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+<b>use</b> <a href="types.md#0x2_types">0x2::types</a>;
+<b>use</b> <a href="url.md#0x2_url">0x2::url</a>;
+</code></pre>
+
+
+
+<a name="0x2_coin_Coin"></a>
+
+## Resource `Coin`
+
+A coin of type <code>T</code> worth <code>value</code>. Transferable and storable
+
+
+<pre><code><b>struct</b> <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt; <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_coin_CoinMetadata"></a>
+
+## Resource `CoinMetadata`
+
+Each Coin type T created through <code>create_currency</code> function will have a
+unique instance of CoinMetadata<T> that stores the metadata for this coin type.
+
+
+<pre><code><b>struct</b> <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt; <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>decimals: u8</code>
+</dt>
+<dd>
+ Number of decimal places the coin uses.
+ A coin with <code>value </code> N and <code>decimals</code> D should be shown as N / 10^D
+ E.g., a coin with <code>value</code> 7002 and decimals 3 should be displayed as 7.002
+ This is metadata for display usage only.
+</dd>
+<dt>
+<code>name: <a href="_String">string::String</a></code>
+</dt>
+<dd>
+ Name for the token
+</dd>
+<dt>
+<code>symbol: <a href="_String">ascii::String</a></code>
+</dt>
+<dd>
+ Symbol for the token
+</dd>
+<dt>
+<code>description: <a href="_String">string::String</a></code>
+</dt>
+<dd>
+ Description of the token
+</dd>
+<dt>
+<code>icon_url: <a href="_Option">option::Option</a>&lt;<a href="url.md#0x2_url_Url">url::Url</a>&gt;</code>
+</dt>
+<dd>
+ URL for the token logo
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_coin_TreasuryCap"></a>
+
+## Resource `TreasuryCap`
+
+Capability allowing the bearer to mint and burn
+coins of type <code>T</code>. Transferable
+
+
+<pre><code><b>struct</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt; <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>total_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_coin_CurrencyCreated"></a>
+
+## Struct `CurrencyCreated`
+
+Emitted when new currency is created through the <code>create_currency</code> call.
+Contains currency metadata for off-chain discovery. Type parameter <code>T</code>
+matches the one in <code><a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;</code>
+
+
+<pre><code><b>struct</b> <a href="coin.md#0x2_coin_CurrencyCreated">CurrencyCreated</a>&lt;T&gt; <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>decimals: u8</code>
+</dt>
+<dd>
+ Number of decimal places the coin uses.
+ A coin with <code>value </code> N and <code>decimals</code> D should be shown as N / 10^D
+ E.g., a coin with <code>value</code> 7002 and decimals 3 should be displayed as 7.002
+ This is metadata for display usage only.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_coin_ENotEnough"></a>
+
+For when trying to split a coin more times than its balance allows.
+
+
+<pre><code><b>const</b> <a href="coin.md#0x2_coin_ENotEnough">ENotEnough</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_coin_EBadWitness"></a>
+
+For when a type passed to create_supply is not a one-time witness.
+
+
+<pre><code><b>const</b> <a href="coin.md#0x2_coin_EBadWitness">EBadWitness</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_coin_EInvalidArg"></a>
+
+For when invalid arguments are passed to a function.
+
+
+<pre><code><b>const</b> <a href="coin.md#0x2_coin_EInvalidArg">EInvalidArg</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_coin_total_supply"></a>
+
+## Function `total_supply`
+
+Return the total number of <code>T</code>'s in circulation.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_total_supply">total_supply</a>&lt;T&gt;(cap: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_total_supply">total_supply</a>&lt;T&gt;(cap: &<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;): u64 {
+    <a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(&cap.total_supply)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_treasury_into_supply"></a>
+
+## Function `treasury_into_supply`
+
+Unwrap <code><a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> getting the <code>Supply</code>.
+
+Operation is irreversible. Supply cannot be converted into a <code><a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> due
+to different security guarantees (TreasuryCap can be created only once for a type)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_treasury_into_supply">treasury_into_supply</a>&lt;T&gt;(treasury: <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_treasury_into_supply">treasury_into_supply</a>&lt;T&gt;(treasury: <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;): Supply&lt;T&gt; {
+    <b>let</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a> { id, total_supply } = treasury;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    total_supply
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_supply"></a>
+
+## Function `supply`
+
+Get immutable reference to the treasury's <code>Supply</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_supply">supply</a>&lt;T&gt;(treasury: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): &<a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_supply">supply</a>&lt;T&gt;(treasury: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;): &Supply&lt;T&gt; {
+    &treasury.total_supply
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_supply_mut"></a>
+
+## Function `supply_mut`
+
+Get mutable reference to the treasury's <code>Supply</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_supply_mut">supply_mut</a>&lt;T&gt;(treasury: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): &<b>mut</b> <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_supply_mut">supply_mut</a>&lt;T&gt;(treasury: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;): &<b>mut</b> Supply&lt;T&gt; {
+    &<b>mut</b> treasury.total_supply
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_value"></a>
+
+## Function `value`
+
+Public getter for the coin's value
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_value">value</a>&lt;T&gt;(self: &<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_value">value</a>&lt;T&gt;(self: &<a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;): u64 {
+    <a href="balance.md#0x2_balance_value">balance::value</a>(&self.<a href="balance.md#0x2_balance">balance</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_balance"></a>
+
+## Function `balance`
+
+Get immutable reference to the balance of a coin.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance">balance</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: &<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): &<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance">balance</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: &<a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;): &Balance&lt;T&gt; {
+    &<a href="coin.md#0x2_coin">coin</a>.<a href="balance.md#0x2_balance">balance</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_balance_mut"></a>
+
+## Function `balance_mut`
+
+Get a mutable reference to the balance of a coin.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_balance_mut">balance_mut</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_balance_mut">balance_mut</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;): &<b>mut</b> Balance&lt;T&gt; {
+    &<b>mut</b> <a href="coin.md#0x2_coin">coin</a>.<a href="balance.md#0x2_balance">balance</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_from_balance"></a>
+
+## Function `from_balance`
+
+Wrap a balance into a Coin to make it transferable.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_from_balance">from_balance</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_from_balance">from_balance</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: Balance&lt;T&gt;, ctx: &<b>mut</b> TxContext): <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt; {
+    <a href="coin.md#0x2_coin_Coin">Coin</a> { id: <a href="object.md#0x2_object_new">object::new</a>(ctx), <a href="balance.md#0x2_balance">balance</a> }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_into_balance"></a>
+
+## Function `into_balance`
+
+Destruct a Coin wrapper and keep the balance.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_into_balance">into_balance</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_into_balance">into_balance</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;): Balance&lt;T&gt; {
+    <b>let</b> <a href="coin.md#0x2_coin_Coin">Coin</a> { id, <a href="balance.md#0x2_balance">balance</a> } = <a href="coin.md#0x2_coin">coin</a>;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    <a href="balance.md#0x2_balance">balance</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_take"></a>
+
+## Function `take`
+
+Take a <code><a href="coin.md#0x2_coin_Coin">Coin</a></code> worth of <code>value</code> from <code>Balance</code>.
+Aborts if <code>value &gt; <a href="balance.md#0x2_balance">balance</a>.value</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_take">take</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, value: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_take">take</a>&lt;T&gt;(
+    <a href="balance.md#0x2_balance">balance</a>: &<b>mut</b> Balance&lt;T&gt;, value: u64, ctx: &<b>mut</b> TxContext,
+): <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt; {
+    <a href="coin.md#0x2_coin_Coin">Coin</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_split">balance::split</a>(<a href="balance.md#0x2_balance">balance</a>, value)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>let</b> before_val = <a href="balance.md#0x2_balance">balance</a>.value;
+<b>let</b> <b>post</b> after_val = <a href="balance.md#0x2_balance">balance</a>.value;
+<b>ensures</b> after_val == before_val - value;
+<b>aborts_if</b> value &gt; before_val;
+<b>aborts_if</b> ctx.ids_created + 1 &gt; MAX_U64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_put"></a>
+
+## Function `put`
+
+Put a <code><a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;</code> to the <code>Balance&lt;T&gt;</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_put">put</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_put">put</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: &<b>mut</b> Balance&lt;T&gt;, <a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;) {
+    <a href="balance.md#0x2_balance_join">balance::join</a>(<a href="balance.md#0x2_balance">balance</a>, <a href="coin.md#0x2_coin_into_balance">into_balance</a>(<a href="coin.md#0x2_coin">coin</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>let</b> before_val = <a href="balance.md#0x2_balance">balance</a>.value;
+<b>let</b> <b>post</b> after_val = <a href="balance.md#0x2_balance">balance</a>.value;
+<b>ensures</b> after_val == before_val + <a href="coin.md#0x2_coin">coin</a>.<a href="balance.md#0x2_balance">balance</a>.value;
+<b>aborts_if</b> before_val + <a href="coin.md#0x2_coin">coin</a>.<a href="balance.md#0x2_balance">balance</a>.value &gt; MAX_U64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_join"></a>
+
+## Function `join`
+
+Consume the coin <code>c</code> and add its value to <code>self</code>.
+Aborts if <code>c.value + self.value &gt; U64_MAX</code>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;) {
+    <b>let</b> <a href="coin.md#0x2_coin_Coin">Coin</a> { id, <a href="balance.md#0x2_balance">balance</a> } = c;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.<a href="balance.md#0x2_balance">balance</a>, <a href="balance.md#0x2_balance">balance</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>let</b> before_val = self.<a href="balance.md#0x2_balance">balance</a>.value;
+<b>let</b> <b>post</b> after_val = self.<a href="balance.md#0x2_balance">balance</a>.value;
+<b>ensures</b> after_val == before_val + c.<a href="balance.md#0x2_balance">balance</a>.value;
+<b>aborts_if</b> before_val + c.<a href="balance.md#0x2_balance">balance</a>.value &gt; MAX_U64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_split"></a>
+
+## Function `split`
+
+Split coin <code>self</code> to two coins, one with balance <code>split_amount</code>,
+and the remaining balance is left is <code>self</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_split">split</a>&lt;T&gt;(
+    self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> TxContext
+): <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt; {
+    <a href="coin.md#0x2_coin_take">take</a>(&<b>mut</b> self.<a href="balance.md#0x2_balance">balance</a>, split_amount, ctx)
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>let</b> before_val = self.<a href="balance.md#0x2_balance">balance</a>.value;
+<b>let</b> <b>post</b> after_val = self.<a href="balance.md#0x2_balance">balance</a>.value;
+<b>ensures</b> after_val == before_val - split_amount;
+<b>aborts_if</b> split_amount &gt; before_val;
+<b>aborts_if</b> ctx.ids_created + 1 &gt; MAX_U64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_divide_into_n"></a>
+
+## Function `divide_into_n`
+
+Split coin <code>self</code> into <code>n - 1</code> coins with equal balances. The remainder is left in
+<code>self</code>. Return newly created coins.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_divide_into_n">divide_into_n</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, n: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_divide_into_n">divide_into_n</a>&lt;T&gt;(
+    self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;, n: u64, ctx: &<b>mut</b> TxContext
+): <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;&gt; {
+    <b>assert</b>!(n &gt; 0, <a href="coin.md#0x2_coin_EInvalidArg">EInvalidArg</a>);
+    <b>assert</b>!(n &lt;= <a href="coin.md#0x2_coin_value">value</a>(self), <a href="coin.md#0x2_coin_ENotEnough">ENotEnough</a>);
+
+    <b>let</b> vec = <a href="_empty">vector::empty</a>&lt;<a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;&gt;();
+    <b>let</b> i = 0;
+    <b>let</b> split_amount = <a href="coin.md#0x2_coin_value">value</a>(self) / n;
+    <b>while</b> ({
+        <b>spec</b> {
+            <b>invariant</b> i &lt;= n-1;
+            <b>invariant</b> self.<a href="balance.md#0x2_balance">balance</a>.value == <b>old</b>(self).<a href="balance.md#0x2_balance">balance</a>.value - (i * split_amount);
+            <b>invariant</b> ctx.ids_created == <b>old</b>(ctx).ids_created + i;
+        };
+        i &lt; n - 1
+    }) {
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> vec, <a href="coin.md#0x2_coin_split">split</a>(self, split_amount, ctx));
+        i = i + 1;
+    };
+    vec
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>let</b> before_val = self.<a href="balance.md#0x2_balance">balance</a>.value;
+<b>let</b> <b>post</b> after_val = self.<a href="balance.md#0x2_balance">balance</a>.value;
+<b>let</b> split_amount = before_val / n;
+<b>ensures</b> after_val == before_val - ((n - 1) * split_amount);
+<b>aborts_if</b> n == 0;
+<b>aborts_if</b> self.<a href="balance.md#0x2_balance">balance</a>.<a href="coin.md#0x2_coin_value">value</a> &lt; n;
+<b>aborts_if</b> ctx.ids_created + n - 1 &gt; MAX_U64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_zero"></a>
+
+## Function `zero`
+
+Make any Coin with a zero value. Useful for placeholding
+bids/payments or preemptively making empty balances.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_zero">zero</a>&lt;T&gt;(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_zero">zero</a>&lt;T&gt;(ctx: &<b>mut</b> TxContext): <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt; {
+    <a href="coin.md#0x2_coin_Coin">Coin</a> { id: <a href="object.md#0x2_object_new">object::new</a>(ctx), <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_zero">balance::zero</a>() }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_destroy_zero"></a>
+
+## Function `destroy_zero`
+
+Destroy a coin with value zero
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_destroy_zero">destroy_zero</a>&lt;T&gt;(c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_destroy_zero">destroy_zero</a>&lt;T&gt;(c: <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;) {
+    <b>let</b> <a href="coin.md#0x2_coin_Coin">Coin</a> { id, <a href="balance.md#0x2_balance">balance</a> } = c;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(<a href="balance.md#0x2_balance">balance</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_create_currency"></a>
+
+## Function `create_currency`
+
+Create a new currency type <code>T</code> as and return the <code><a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> for
+<code>T</code> to the caller. Can only be called with a <code>one-time-witness</code>
+type, ensuring that there's only one <code><a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> per <code>T</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_create_currency">create_currency</a>&lt;T: drop&gt;(witness: T, decimals: u8, symbol: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, icon_url: <a href="_Option">option::Option</a>&lt;<a href="url.md#0x2_url_Url">url::Url</a>&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_create_currency">create_currency</a>&lt;T: drop&gt;(
+    witness: T,
+    decimals: u8,
+    symbol: <a href="">vector</a>&lt;u8&gt;,
+    name: <a href="">vector</a>&lt;u8&gt;,
+    description: <a href="">vector</a>&lt;u8&gt;,
+    icon_url: Option&lt;Url&gt;,
+    ctx: &<b>mut</b> TxContext
+): (<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;) {
+    // Make sure there's only one instance of the type T
+    <b>assert</b>!(sui::types::is_one_time_witness(&witness), <a href="coin.md#0x2_coin_EBadWitness">EBadWitness</a>);
+
+    // Emit Currency metadata <b>as</b> an <a href="event.md#0x2_event">event</a>.
+    <a href="event.md#0x2_event_emit">event::emit</a>(<a href="coin.md#0x2_coin_CurrencyCreated">CurrencyCreated</a>&lt;T&gt; {
+        decimals
+    });
+
+    (
+        <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a> {
+            id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+            total_supply: <a href="balance.md#0x2_balance_create_supply">balance::create_supply</a>(witness)
+        },
+        <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a> {
+            id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+            decimals,
+            name: <a href="_utf8">string::utf8</a>(name),
+            symbol: <a href="_string">ascii::string</a>(symbol),
+            description: <a href="_utf8">string::utf8</a>(description),
+            icon_url
+        }
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_mint"></a>
+
+## Function `mint`
+
+Create a coin worth <code>value</code>. and increase the total supply
+in <code>cap</code> accordingly.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_mint">mint</a>&lt;T&gt;(cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, value: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_mint">mint</a>&lt;T&gt;(
+    cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, value: u64, ctx: &<b>mut</b> TxContext,
+): <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt; {
+    <a href="coin.md#0x2_coin_Coin">Coin</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(&<b>mut</b> cap.total_supply, value)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> <a href="coin.md#0x2_coin_MintBalance">MintBalance</a>&lt;T&gt;;
+<b>aborts_if</b> ctx.ids_created + 1 &gt; MAX_U64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_mint_balance"></a>
+
+## Function `mint_balance`
+
+Mint some amount of T as a <code>Balance</code> and increase the total
+supply in <code>cap</code> accordingly.
+Aborts if <code>value</code> + <code>cap.total_supply</code> >= U64_MAX
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_mint_balance">mint_balance</a>&lt;T&gt;(cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, value: u64): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_mint_balance">mint_balance</a>&lt;T&gt;(
+    cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, value: u64
+): Balance&lt;T&gt; {
+    <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(&<b>mut</b> cap.total_supply, value)
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> <a href="coin.md#0x2_coin_MintBalance">MintBalance</a>&lt;T&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_burn"></a>
+
+## Function `burn`
+
+Destroy the coin <code>c</code> and decrease the total supply in <code>cap</code>
+accordingly.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;): u64 {
+    <b>let</b> <a href="coin.md#0x2_coin_Coin">Coin</a> { id, <a href="balance.md#0x2_balance">balance</a> } = c;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    <a href="balance.md#0x2_balance_decrease_supply">balance::decrease_supply</a>(&<b>mut</b> cap.total_supply, <a href="balance.md#0x2_balance">balance</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> <a href="coin.md#0x2_coin_Burn">Burn</a>&lt;T&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_mint_and_transfer"></a>
+
+## Function `mint_and_transfer`
+
+Mint <code>amount</code> of <code><a href="coin.md#0x2_coin_Coin">Coin</a></code> and send it to <code>recipient</code>. Invokes <code><a href="coin.md#0x2_coin_mint">mint</a>()</code>.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(
+    c: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> TxContext
+) {
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_mint">mint</a>(c, amount, ctx), recipient)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_burn_"></a>
+
+## Function `burn_`
+
+Burn a Coin and reduce the total_supply. Invokes <code><a href="coin.md#0x2_coin_burn">burn</a>()</code>.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_burn_">burn_</a>&lt;T&gt;(cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_burn_">burn_</a>&lt;T&gt;(cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;) {
+    <a href="coin.md#0x2_coin_burn">burn</a>(cap, c);
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> <a href="coin.md#0x2_coin_Burn">Burn</a>&lt;T&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_update_name"></a>
+
+## Function `update_name`
+
+Update name of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_name">update_name</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, name: <a href="_String">string::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_name">update_name</a>&lt;T&gt;(
+    _treasury: &<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;, name: <a href="_String">string::String</a>
+) {
+    metadata.name = name;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_update_symbol"></a>
+
+## Function `update_symbol`
+
+Update the symbol of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_symbol">update_symbol</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, symbol: <a href="_String">ascii::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_symbol">update_symbol</a>&lt;T&gt;(
+    _treasury: &<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;, symbol: <a href="_String">ascii::String</a>
+) {
+    metadata.symbol = symbol;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_update_description"></a>
+
+## Function `update_description`
+
+Update the description of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_description">update_description</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, description: <a href="_String">string::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_description">update_description</a>&lt;T&gt;(
+    _treasury: &<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;, description: <a href="_String">string::String</a>
+) {
+    metadata.description = description;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_update_icon_url"></a>
+
+## Function `update_icon_url`
+
+Update the url of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, <a href="url.md#0x2_url">url</a>: <a href="_String">ascii::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(
+    _treasury: &<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;, <a href="url.md#0x2_url">url</a>: <a href="_String">ascii::String</a>
+) {
+    metadata.icon_url = <a href="_some">option::some</a>(<a href="url.md#0x2_url_new_unsafe">url::new_unsafe</a>(<a href="url.md#0x2_url">url</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_get_decimals"></a>
+
+## Function `get_decimals`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_get_decimals">get_decimals</a>&lt;T&gt;(metadata: &<a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_get_decimals">get_decimals</a>&lt;T&gt;(
+    metadata: &<a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;
+): u8 {
+    metadata.decimals
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_get_name"></a>
+
+## Function `get_name`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_get_name">get_name</a>&lt;T&gt;(metadata: &<a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_get_name">get_name</a>&lt;T&gt;(
+    metadata: &<a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;
+): <a href="_String">string::String</a> {
+    metadata.name
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_get_symbol"></a>
+
+## Function `get_symbol`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_get_symbol">get_symbol</a>&lt;T&gt;(metadata: &<a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;): <a href="_String">ascii::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_get_symbol">get_symbol</a>&lt;T&gt;(
+    metadata: &<a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;
+): <a href="_String">ascii::String</a> {
+    metadata.symbol
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_get_description"></a>
+
+## Function `get_description`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_get_description">get_description</a>&lt;T&gt;(metadata: &<a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_get_description">get_description</a>&lt;T&gt;(
+    metadata: &<a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;
+): <a href="_String">string::String</a> {
+    metadata.description
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_get_icon_url"></a>
+
+## Function `get_icon_url`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_get_icon_url">get_icon_url</a>&lt;T&gt;(metadata: &<a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;): <a href="_Option">option::Option</a>&lt;<a href="url.md#0x2_url_Url">url::Url</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_get_icon_url">get_icon_url</a>&lt;T&gt;(
+    metadata: &<a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;
+): Option&lt;Url&gt; {
+    metadata.icon_url
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/devnet_nft.md
+++ b/crates/sui-framework-override/docs/devnet_nft.md
@@ -1,0 +1,286 @@
+
+<a name="0x2_devnet_nft"></a>
+
+# Module `0x2::devnet_nft`
+
+A minimalist example to demonstrate how to create an NFT like object
+on Sui. The user should be able to use the wallet command line tool
+(https://docs.sui.io/build/wallet) to mint an NFT. For example,
+<code>wallet example-nft --<a href="devnet_nft.md#0x2_devnet_nft_name">name</a> &lt;Name&gt; --<a href="devnet_nft.md#0x2_devnet_nft_description">description</a> &lt;Description&gt; --<a href="url.md#0x2_url">url</a> &lt;URL&gt;</code>
+
+
+-  [Resource `DevNetNFT`](#0x2_devnet_nft_DevNetNFT)
+-  [Struct `MintNFTEvent`](#0x2_devnet_nft_MintNFTEvent)
+-  [Function `mint`](#0x2_devnet_nft_mint)
+-  [Function `update_description`](#0x2_devnet_nft_update_description)
+-  [Function `burn`](#0x2_devnet_nft_burn)
+-  [Function `name`](#0x2_devnet_nft_name)
+-  [Function `description`](#0x2_devnet_nft_description)
+-  [Function `url`](#0x2_devnet_nft_url)
+
+
+<pre><code><b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+<b>use</b> <a href="url.md#0x2_url">0x2::url</a>;
+</code></pre>
+
+
+
+<a name="0x2_devnet_nft_DevNetNFT"></a>
+
+## Resource `DevNetNFT`
+
+An example NFT that can be minted by anybody
+
+
+<pre><code><b>struct</b> <a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">DevNetNFT</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>name: <a href="_String">string::String</a></code>
+</dt>
+<dd>
+ Name for the token
+</dd>
+<dt>
+<code>description: <a href="_String">string::String</a></code>
+</dt>
+<dd>
+ Description of the token
+</dd>
+<dt>
+<code><a href="url.md#0x2_url">url</a>: <a href="url.md#0x2_url_Url">url::Url</a></code>
+</dt>
+<dd>
+ URL for the token
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_devnet_nft_MintNFTEvent"></a>
+
+## Struct `MintNFTEvent`
+
+
+
+<pre><code><b>struct</b> <a href="devnet_nft.md#0x2_devnet_nft_MintNFTEvent">MintNFTEvent</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>object_id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>creator: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>name: <a href="_String">string::String</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_devnet_nft_mint"></a>
+
+## Function `mint`
+
+Create a new devnet_nft
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="devnet_nft.md#0x2_devnet_nft_mint">mint</a>(name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, <a href="url.md#0x2_url">url</a>: <a href="">vector</a>&lt;u8&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="devnet_nft.md#0x2_devnet_nft_mint">mint</a>(
+    name: <a href="">vector</a>&lt;u8&gt;,
+    description: <a href="">vector</a>&lt;u8&gt;,
+    <a href="url.md#0x2_url">url</a>: <a href="">vector</a>&lt;u8&gt;,
+    ctx: &<b>mut</b> TxContext
+) {
+    <b>let</b> nft = <a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">DevNetNFT</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        name: <a href="_utf8">string::utf8</a>(name),
+        description: <a href="_utf8">string::utf8</a>(description),
+        <a href="url.md#0x2_url">url</a>: <a href="url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(<a href="url.md#0x2_url">url</a>)
+    };
+    <b>let</b> sender = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <a href="event.md#0x2_event_emit">event::emit</a>(<a href="devnet_nft.md#0x2_devnet_nft_MintNFTEvent">MintNFTEvent</a> {
+        object_id: <a href="object.md#0x2_object_uid_to_inner">object::uid_to_inner</a>(&nft.id),
+        creator: sender,
+        name: nft.name,
+    });
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(nft, sender);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_devnet_nft_update_description"></a>
+
+## Function `update_description`
+
+Update the <code>description</code> of <code>nft</code> to <code>new_description</code>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="devnet_nft.md#0x2_devnet_nft_update_description">update_description</a>(nft: &<b>mut</b> <a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">devnet_nft::DevNetNFT</a>, new_description: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="devnet_nft.md#0x2_devnet_nft_update_description">update_description</a>(
+    nft: &<b>mut</b> <a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">DevNetNFT</a>,
+    new_description: <a href="">vector</a>&lt;u8&gt;,
+) {
+    nft.description = <a href="_utf8">string::utf8</a>(new_description)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_devnet_nft_burn"></a>
+
+## Function `burn`
+
+Permanently delete <code>nft</code>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="devnet_nft.md#0x2_devnet_nft_burn">burn</a>(nft: <a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">devnet_nft::DevNetNFT</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="devnet_nft.md#0x2_devnet_nft_burn">burn</a>(nft: <a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">DevNetNFT</a>) {
+    <b>let</b> <a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">DevNetNFT</a> { id, name: _, description: _, <a href="url.md#0x2_url">url</a>: _ } = nft;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_devnet_nft_name"></a>
+
+## Function `name`
+
+Get the NFT's <code>name</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="devnet_nft.md#0x2_devnet_nft_name">name</a>(nft: &<a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">devnet_nft::DevNetNFT</a>): &<a href="_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="devnet_nft.md#0x2_devnet_nft_name">name</a>(nft: &<a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">DevNetNFT</a>): &<a href="_String">string::String</a> {
+    &nft.name
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_devnet_nft_description"></a>
+
+## Function `description`
+
+Get the NFT's <code>description</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="devnet_nft.md#0x2_devnet_nft_description">description</a>(nft: &<a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">devnet_nft::DevNetNFT</a>): &<a href="_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="devnet_nft.md#0x2_devnet_nft_description">description</a>(nft: &<a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">DevNetNFT</a>): &<a href="_String">string::String</a> {
+    &nft.description
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_devnet_nft_url"></a>
+
+## Function `url`
+
+Get the NFT's <code><a href="url.md#0x2_url">url</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="url.md#0x2_url">url</a>(nft: &<a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">devnet_nft::DevNetNFT</a>): &<a href="url.md#0x2_url_Url">url::Url</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="url.md#0x2_url">url</a>(nft: &<a href="devnet_nft.md#0x2_devnet_nft_DevNetNFT">DevNetNFT</a>): &Url {
+    &nft.<a href="url.md#0x2_url">url</a>
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/digest.md
+++ b/crates/sui-framework-override/docs/digest.md
@@ -1,0 +1,121 @@
+
+<a name="0x2_digest"></a>
+
+# Module `0x2::digest`
+
+Sui types for message digests.
+
+
+-  [Struct `Sha3256Digest`](#0x2_digest_Sha3256Digest)
+-  [Constants](#@Constants_0)
+-  [Function `sha3_256_digest_from_bytes`](#0x2_digest_sha3_256_digest_from_bytes)
+-  [Function `sha3_256_digest_to_bytes`](#0x2_digest_sha3_256_digest_to_bytes)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_digest_Sha3256Digest"></a>
+
+## Struct `Sha3256Digest`
+
+Sha3256Digest: An immutable wrapper of SHA3_256_DIGEST_VECTOR_LENGTH bytes.
+
+
+<pre><code><b>struct</b> <a href="digest.md#0x2_digest_Sha3256Digest">Sha3256Digest</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="digest.md#0x2_digest">digest</a>: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_digest_EHashLengthMismatch"></a>
+
+Error code when the length of the digest vector is invalid.
+
+
+<pre><code><b>const</b> <a href="digest.md#0x2_digest_EHashLengthMismatch">EHashLengthMismatch</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_digest_SHA3_256_DIGEST_VECTOR_LENGTH"></a>
+
+Length of the vector<u8> representing a SHA3-256 digest.
+
+
+<pre><code><b>const</b> <a href="digest.md#0x2_digest_SHA3_256_DIGEST_VECTOR_LENGTH">SHA3_256_DIGEST_VECTOR_LENGTH</a>: u64 = 32;
+</code></pre>
+
+
+
+<a name="0x2_digest_sha3_256_digest_from_bytes"></a>
+
+## Function `sha3_256_digest_from_bytes`
+
+Create a <code><a href="digest.md#0x2_digest_Sha3256Digest">Sha3256Digest</a></code> from bytes. Aborts if <code>bytes</code> is not of length 32.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="digest.md#0x2_digest_sha3_256_digest_from_bytes">sha3_256_digest_from_bytes</a>(<a href="digest.md#0x2_digest">digest</a>: <a href="">vector</a>&lt;u8&gt;): <a href="digest.md#0x2_digest_Sha3256Digest">digest::Sha3256Digest</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="digest.md#0x2_digest_sha3_256_digest_from_bytes">sha3_256_digest_from_bytes</a>(<a href="digest.md#0x2_digest">digest</a>: <a href="">vector</a>&lt;u8&gt;): <a href="digest.md#0x2_digest_Sha3256Digest">Sha3256Digest</a> {
+    <b>assert</b>!(<a href="_length">vector::length</a>(&<a href="digest.md#0x2_digest">digest</a>) == <a href="digest.md#0x2_digest_SHA3_256_DIGEST_VECTOR_LENGTH">SHA3_256_DIGEST_VECTOR_LENGTH</a>, <a href="digest.md#0x2_digest_EHashLengthMismatch">EHashLengthMismatch</a>);
+    <a href="digest.md#0x2_digest_Sha3256Digest">Sha3256Digest</a> { <a href="digest.md#0x2_digest">digest</a> }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_digest_sha3_256_digest_to_bytes"></a>
+
+## Function `sha3_256_digest_to_bytes`
+
+Get the digest.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="digest.md#0x2_digest_sha3_256_digest_to_bytes">sha3_256_digest_to_bytes</a>(self: &<a href="digest.md#0x2_digest_Sha3256Digest">digest::Sha3256Digest</a>): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="digest.md#0x2_digest_sha3_256_digest_to_bytes">sha3_256_digest_to_bytes</a>(self: &<a href="digest.md#0x2_digest_Sha3256Digest">Sha3256Digest</a>): <a href="">vector</a>&lt;u8&gt; {
+    self.<a href="digest.md#0x2_digest">digest</a>
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/dynamic_field.md
+++ b/crates/sui-framework-override/docs/dynamic_field.md
@@ -1,0 +1,547 @@
+
+<a name="0x2_dynamic_field"></a>
+
+# Module `0x2::dynamic_field`
+
+In addition to the fields declared in its type definition, a Sui object can have dynamic fields
+that can be added after the object has been constructed. Unlike ordinary field names
+(which are always statically declared identifiers) a dynamic field name can be any value with
+the <code><b>copy</b></code>, <code>drop</code>, and <code>store</code> abilities, e.g. an integer, a boolean, or a string.
+This gives Sui programmers the flexibility to extend objects on-the-fly, and it also serves as a
+building block for core collection types
+
+
+-  [Resource `Field`](#0x2_dynamic_field_Field)
+-  [Constants](#@Constants_0)
+-  [Function `add`](#0x2_dynamic_field_add)
+-  [Function `borrow`](#0x2_dynamic_field_borrow)
+-  [Function `borrow_mut`](#0x2_dynamic_field_borrow_mut)
+-  [Function `remove`](#0x2_dynamic_field_remove)
+-  [Function `exists_`](#0x2_dynamic_field_exists_)
+-  [Function `exists_with_type`](#0x2_dynamic_field_exists_with_type)
+-  [Function `field_info`](#0x2_dynamic_field_field_info)
+-  [Function `field_info_mut`](#0x2_dynamic_field_field_info_mut)
+-  [Function `hash_type_and_key`](#0x2_dynamic_field_hash_type_and_key)
+-  [Function `add_child_object`](#0x2_dynamic_field_add_child_object)
+-  [Function `borrow_child_object`](#0x2_dynamic_field_borrow_child_object)
+-  [Function `borrow_child_object_mut`](#0x2_dynamic_field_borrow_child_object_mut)
+-  [Function `remove_child_object`](#0x2_dynamic_field_remove_child_object)
+-  [Function `has_child_object`](#0x2_dynamic_field_has_child_object)
+-  [Function `has_child_object_with_ty`](#0x2_dynamic_field_has_child_object_with_ty)
+
+
+<pre><code><b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+</code></pre>
+
+
+
+<a name="0x2_dynamic_field_Field"></a>
+
+## Resource `Field`
+
+Internal object used for storing the field and value
+
+
+<pre><code><b>struct</b> <a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt; <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+ Determined by the hash of the object ID, the field name value and it's type,
+ i.e. hash(parent.id || name || Name)
+</dd>
+<dt>
+<code>name: Name</code>
+</dt>
+<dd>
+ The value for the name of this field
+</dd>
+<dt>
+<code>value: Value</code>
+</dt>
+<dd>
+ The value bound to this field
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_dynamic_field_EBCSSerializationFailure"></a>
+
+Failed to serialize the field's name
+
+
+<pre><code><b>const</b> <a href="dynamic_field.md#0x2_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_dynamic_field_EFieldAlreadyExists"></a>
+
+The object already has a dynamic field with this name (with the value and type specified)
+
+
+<pre><code><b>const</b> <a href="dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExists">EFieldAlreadyExists</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_dynamic_field_EFieldDoesNotExist"></a>
+
+Cannot load dynamic field.
+The object does not have a dynamic field with this name (with the value and type specified)
+
+
+<pre><code><b>const</b> <a href="dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_dynamic_field_EFieldTypeMismatch"></a>
+
+The object has a field with that name, but the value type does not match
+
+
+<pre><code><b>const</b> <a href="dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_dynamic_field_add"></a>
+
+## Function `add`
+
+Adds a dynamic field to the object <code><a href="object.md#0x2_object">object</a>: &<b>mut</b> UID</code> at field specified by <code>name: Name</code>.
+Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExists">EFieldAlreadyExists</a></code> if the object already has that field with that name.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_add">add</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> <a href="object.md#0x2_object_UID">object::UID</a>, name: Name, value: Value)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_add">add</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
+    // we <b>use</b> &<b>mut</b> UID in several spots for access control
+    <a href="object.md#0x2_object">object</a>: &<b>mut</b> UID,
+    name: Name,
+    value: Value,
+) {
+    <b>let</b> object_addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>);
+    <b>let</b> hash = <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>assert</b>!(!<a href="dynamic_field.md#0x2_dynamic_field_has_child_object">has_child_object</a>(object_addr, hash), <a href="dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExists">EFieldAlreadyExists</a>);
+    <b>let</b> field = <a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a> {
+        id: <a href="object.md#0x2_object_new_uid_from_hash">object::new_uid_from_hash</a>(hash),
+        name,
+        value,
+    };
+    <a href="dynamic_field.md#0x2_dynamic_field_add_child_object">add_child_object</a>(object_addr, field)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_borrow"></a>
+
+## Function `borrow`
+
+Immutably borrows the <code><a href="object.md#0x2_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code>.
+Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
+Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow">borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="object.md#0x2_object">object</a>: &<a href="object.md#0x2_object_UID">object::UID</a>, name: Name): &Value
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow">borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
+    <a href="object.md#0x2_object">object</a>: &UID,
+    name: Name,
+): &Value {
+    <b>let</b> object_addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>);
+    <b>let</b> hash = <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>let</b> field = <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;<a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(<a href="object.md#0x2_object">object</a>, hash);
+    &field.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Mutably borrows the <code><a href="object.md#0x2_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code>.
+Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
+Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> <a href="object.md#0x2_object_UID">object::UID</a>, name: Name): &<b>mut</b> Value
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
+    <a href="object.md#0x2_object">object</a>: &<b>mut</b> UID,
+    name: Name,
+): &<b>mut</b> Value {
+    <b>let</b> object_addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>);
+    <b>let</b> hash = <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>let</b> field = <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;<a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(<a href="object.md#0x2_object">object</a>, hash);
+    &<b>mut</b> field.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_remove"></a>
+
+## Function `remove`
+
+Removes the <code><a href="object.md#0x2_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code> and returns the
+bound value.
+Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
+Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_remove">remove</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> <a href="object.md#0x2_object_UID">object::UID</a>, name: Name): Value
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_remove">remove</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
+    <a href="object.md#0x2_object">object</a>: &<b>mut</b> UID,
+    name: Name,
+): Value {
+    <b>let</b> object_addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>);
+    <b>let</b> hash = <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>let</b> <a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a> { id, name: _, value } = <a href="dynamic_field.md#0x2_dynamic_field_remove_child_object">remove_child_object</a>&lt;<a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(object_addr, hash);
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_exists_"></a>
+
+## Function `exists_`
+
+Returns true if and only if the <code><a href="object.md#0x2_object">object</a></code> has a dynamic field with the name specified by
+<code>name: Name</code> but without specifying the <code>Value</code> type
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_exists_">exists_</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="object.md#0x2_object">object</a>: &<a href="object.md#0x2_object_UID">object::UID</a>, name: Name): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_exists_">exists_</a>&lt;Name: <b>copy</b> + drop + store&gt;(
+    <a href="object.md#0x2_object">object</a>: &UID,
+    name: Name,
+): bool {
+    <b>let</b> object_addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>);
+    <b>let</b> hash = <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <a href="dynamic_field.md#0x2_dynamic_field_has_child_object">has_child_object</a>(object_addr, hash)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_exists_with_type"></a>
+
+## Function `exists_with_type`
+
+Returns true if and only if the <code><a href="object.md#0x2_object">object</a></code> has a dynamic field with the name specified by
+<code>name: Name</code> with an assigned value of type <code>Value</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="object.md#0x2_object">object</a>: &<a href="object.md#0x2_object_UID">object::UID</a>, name: Name): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
+    <a href="object.md#0x2_object">object</a>: &UID,
+    name: Name,
+): bool {
+    <b>let</b> object_addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>);
+    <b>let</b> hash = <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <a href="dynamic_field.md#0x2_dynamic_field_has_child_object_with_ty">has_child_object_with_ty</a>&lt;<a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(object_addr, hash)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_field_info"></a>
+
+## Function `field_info`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_field_info">field_info</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="object.md#0x2_object">object</a>: &<a href="object.md#0x2_object_UID">object::UID</a>, name: Name): (&<a href="object.md#0x2_object_UID">object::UID</a>, <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_field_info">field_info</a>&lt;Name: <b>copy</b> + drop + store&gt;(
+    <a href="object.md#0x2_object">object</a>: &UID,
+    name: Name,
+): (&UID, <b>address</b>) {
+    <b>let</b> object_addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>);
+    <b>let</b> hash = <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>let</b> <a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a> { id, name: _, value } = <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;<a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name, ID&gt;&gt;(<a href="object.md#0x2_object">object</a>, hash);
+    (id, <a href="object.md#0x2_object_id_to_address">object::id_to_address</a>(value))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_field_info_mut"></a>
+
+## Function `field_info_mut`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_field_info_mut">field_info_mut</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> <a href="object.md#0x2_object_UID">object::UID</a>, name: Name): (&<b>mut</b> <a href="object.md#0x2_object_UID">object::UID</a>, <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_field_info_mut">field_info_mut</a>&lt;Name: <b>copy</b> + drop + store&gt;(
+    <a href="object.md#0x2_object">object</a>: &<b>mut</b> UID,
+    name: Name,
+): (&<b>mut</b> UID, <b>address</b>) {
+    <b>let</b> object_addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>);
+    <b>let</b> hash = <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>let</b> <a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a> { id, name: _, value } = <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;<a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name, ID&gt;&gt;(<a href="object.md#0x2_object">object</a>, hash);
+    (id, <a href="object.md#0x2_object_id_to_address">object::id_to_address</a>(value))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_hash_type_and_key"></a>
+
+## Function `hash_type_and_key`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>&lt;K: <b>copy</b>, drop, store&gt;(parent: <b>address</b>, k: K): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>&lt;K: <b>copy</b> + drop + store&gt;(parent: <b>address</b>, k: K): <b>address</b>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_add_child_object"></a>
+
+## Function `add_child_object`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_add_child_object">add_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, child: Child)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_add_child_object">add_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, child: Child);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_borrow_child_object"></a>
+
+## Function `borrow_child_object`
+
+throws <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if a child does not exist with that ID
+or throws <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the type does not match
+we need two versions to return a reference or a mutable reference
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;Child: key&gt;(<a href="object.md#0x2_object">object</a>: &<a href="object.md#0x2_object_UID">object::UID</a>, id: <b>address</b>): &Child
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;Child: key&gt;(<a href="object.md#0x2_object">object</a>: &UID, id: <b>address</b>): &Child;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_borrow_child_object_mut"></a>
+
+## Function `borrow_child_object_mut`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;Child: key&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> <a href="object.md#0x2_object_UID">object::UID</a>, id: <b>address</b>): &<b>mut</b> Child
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;Child: key&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> UID, id: <b>address</b>): &<b>mut</b> Child;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_remove_child_object"></a>
+
+## Function `remove_child_object`
+
+throws <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if a child does not exist with that ID
+or throws <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the type does not match
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_remove_child_object">remove_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): Child
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_remove_child_object">remove_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): Child;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_has_child_object"></a>
+
+## Function `has_child_object`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_has_child_object">has_child_object</a>(parent: <b>address</b>, id: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_has_child_object">has_child_object</a>(parent: <b>address</b>, id: <b>address</b>): bool;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_has_child_object_with_ty"></a>
+
+## Function `has_child_object_with_ty`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_has_child_object_with_ty">has_child_object_with_ty</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_has_child_object_with_ty">has_child_object_with_ty</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): bool;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/dynamic_object_field.md
+++ b/crates/sui-framework-override/docs/dynamic_object_field.md
@@ -1,0 +1,285 @@
+
+<a name="0x2_dynamic_object_field"></a>
+
+# Module `0x2::dynamic_object_field`
+
+Similar to <code>sui::dynamic_field</code>, this module allows for the access of dynamic fields. But
+unlike, <code>sui::dynamic_field</code> the values bound to these dynamic fields _must_ be objects
+themselves. This allows for the objects to still exist within in storage, which may be important
+for external tools. The difference is otherwise not observable from within Move.
+
+
+-  [Struct `Wrapper`](#0x2_dynamic_object_field_Wrapper)
+-  [Function `add`](#0x2_dynamic_object_field_add)
+-  [Function `borrow`](#0x2_dynamic_object_field_borrow)
+-  [Function `borrow_mut`](#0x2_dynamic_object_field_borrow_mut)
+-  [Function `remove`](#0x2_dynamic_object_field_remove)
+-  [Function `exists_`](#0x2_dynamic_object_field_exists_)
+-  [Function `exists_with_type`](#0x2_dynamic_object_field_exists_with_type)
+-  [Function `id`](#0x2_dynamic_object_field_id)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="dynamic_field.md#0x2_dynamic_field">0x2::dynamic_field</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+</code></pre>
+
+
+
+<a name="0x2_dynamic_object_field_Wrapper"></a>
+
+## Struct `Wrapper`
+
+
+
+<pre><code><b>struct</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt; <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>name: Name</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_dynamic_object_field_add"></a>
+
+## Function `add`
+
+Adds a dynamic object field to the object <code><a href="object.md#0x2_object">object</a>: &<b>mut</b> UID</code> at field specified by <code>name: Name</code>.
+Aborts with <code>EFieldAlreadyExists</code> if the object already has that field with that name.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_add">add</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> <a href="object.md#0x2_object_UID">object::UID</a>, name: Name, value: Value)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_add">add</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(
+    // we <b>use</b> &<b>mut</b> UID in several spots for access control
+    <a href="object.md#0x2_object">object</a>: &<b>mut</b> UID,
+    name: Name,
+    value: Value,
+) {
+    <b>let</b> key = <a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a> { name };
+    <b>let</b> id = <a href="object.md#0x2_object_id">object::id</a>(&value);
+    field::add(<a href="object.md#0x2_object">object</a>, key, id);
+    <b>let</b> (field, _) = field::field_info&lt;<a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>, key);
+    add_child_object(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(field), value);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_object_field_borrow"></a>
+
+## Function `borrow`
+
+Immutably borrows the <code><a href="object.md#0x2_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code>.
+Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_borrow">borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="object.md#0x2_object">object</a>: &<a href="object.md#0x2_object_UID">object::UID</a>, name: Name): &Value
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_borrow">borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(
+    <a href="object.md#0x2_object">object</a>: &UID,
+    name: Name,
+): &Value {
+    <b>let</b> key = <a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a> { name };
+    <b>let</b> (field, value_id) = field::field_info&lt;<a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>, key);
+    borrow_child_object&lt;Value&gt;(field, value_id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_object_field_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Mutably borrows the <code><a href="object.md#0x2_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code>.
+Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> <a href="object.md#0x2_object_UID">object::UID</a>, name: Name): &<b>mut</b> Value
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(
+    <a href="object.md#0x2_object">object</a>: &<b>mut</b> UID,
+    name: Name,
+): &<b>mut</b> Value {
+    <b>let</b> key = <a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a> { name };
+    <b>let</b> (field, value_id) = field::field_info_mut&lt;<a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>, key);
+    borrow_child_object_mut&lt;Value&gt;(field, value_id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_object_field_remove"></a>
+
+## Function `remove`
+
+Removes the <code><a href="object.md#0x2_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code> and returns
+the bound object.
+Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_remove">remove</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> <a href="object.md#0x2_object_UID">object::UID</a>, name: Name): Value
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_remove">remove</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(
+    <a href="object.md#0x2_object">object</a>: &<b>mut</b> UID,
+    name: Name,
+): Value {
+    <b>let</b> key = <a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a> { name };
+    <b>let</b> (field, value_id) = field::field_info&lt;<a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>, key);
+    <b>let</b> value = remove_child_object&lt;Value&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(field), value_id);
+    field::remove&lt;<a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;, ID&gt;(<a href="object.md#0x2_object">object</a>, key);
+    value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_object_field_exists_"></a>
+
+## Function `exists_`
+
+Returns true if and only if the <code><a href="object.md#0x2_object">object</a></code> has a dynamic object field with the name specified by
+<code>name: Name</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_exists_">exists_</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="object.md#0x2_object">object</a>: &<a href="object.md#0x2_object_UID">object::UID</a>, name: Name): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_exists_">exists_</a>&lt;Name: <b>copy</b> + drop + store&gt;(
+    <a href="object.md#0x2_object">object</a>: &UID,
+    name: Name,
+): bool {
+    <b>let</b> key = <a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a> { name };
+    field::exists_with_type&lt;<a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;, ID&gt;(<a href="object.md#0x2_object">object</a>, key)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_object_field_exists_with_type"></a>
+
+## Function `exists_with_type`
+
+Returns true if and only if the <code><a href="object.md#0x2_object">object</a></code> has a dynamic field with the name specified by
+<code>name: Name</code> with an assigned value of type <code>Value</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="object.md#0x2_object">object</a>: &<a href="object.md#0x2_object_UID">object::UID</a>, name: Name): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(
+    <a href="object.md#0x2_object">object</a>: &UID,
+    name: Name,
+): bool {
+    <b>let</b> key = <a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a> { name };
+    <b>if</b> (!field::exists_with_type&lt;<a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;, ID&gt;(<a href="object.md#0x2_object">object</a>, key)) <b>return</b> <b>false</b>;
+    <b>let</b> (field, value_id) = field::field_info&lt;<a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>, key);
+    field::has_child_object_with_ty&lt;Value&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(field), value_id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_object_field_id"></a>
+
+## Function `id`
+
+Returns the ID of the object associated with the dynamic object field
+Returns none otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_id">id</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="object.md#0x2_object">object</a>: &<a href="object.md#0x2_object_UID">object::UID</a>, name: Name): <a href="_Option">option::Option</a>&lt;<a href="object.md#0x2_object_ID">object::ID</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field_id">id</a>&lt;Name: <b>copy</b> + drop + store&gt;(
+    <a href="object.md#0x2_object">object</a>: &UID,
+    name: Name,
+): Option&lt;ID&gt; {
+    <b>let</b> key = <a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a> { name };
+    <b>if</b> (!field::exists_with_type&lt;<a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;, ID&gt;(<a href="object.md#0x2_object">object</a>, key)) <b>return</b> <a href="_none">option::none</a>();
+    <b>let</b> (_field, value_id) = field::field_info&lt;<a href="dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>, key);
+    <a href="_some">option::some</a>(<a href="object.md#0x2_object_id_from_address">object::id_from_address</a>(value_id))
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/ecdsa.md
+++ b/crates/sui-framework-override/docs/ecdsa.md
@@ -1,0 +1,153 @@
+
+<a name="0x2_ecdsa"></a>
+
+# Module `0x2::ecdsa`
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `ecrecover`](#0x2_ecdsa_ecrecover)
+-  [Function `decompress_pubkey`](#0x2_ecdsa_decompress_pubkey)
+-  [Function `keccak256`](#0x2_ecdsa_keccak256)
+-  [Function `secp256k1_verify`](#0x2_ecdsa_secp256k1_verify)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_ecdsa_EFailToRecoverPubKey"></a>
+
+
+
+<pre><code><b>const</b> <a href="ecdsa.md#0x2_ecdsa_EFailToRecoverPubKey">EFailToRecoverPubKey</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_ecdsa_EInvalidSignature"></a>
+
+
+
+<pre><code><b>const</b> <a href="ecdsa.md#0x2_ecdsa_EInvalidSignature">EInvalidSignature</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_ecdsa_ecrecover"></a>
+
+## Function `ecrecover`
+
+@param signature: A 65-bytes signature in form (r, s, v) that is signed using
+Secp256k1. Reference implementation on signature generation using RFC6979:
+https://github.com/MystenLabs/narwhal/blob/5d6f6df8ccee94446ff88786c0dbbc98be7cfc09/crypto/src/secp256k1.rs
+The accepted v values are {0, 1, 2, 3}.
+
+@param hashed_msg: the hashed 32-bytes message. The message must be hashed instead
+of plain text to be secure.
+
+If the signature is valid, return the corresponding recovered Secpk256k1 public
+key, otherwise throw error. This is similar to ecrecover in Ethereum, can only be
+applied to Secp256k1 signatures.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa.md#0x2_ecdsa_ecrecover">ecrecover</a>(signature: &<a href="">vector</a>&lt;u8&gt;, hashed_msg: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ecdsa.md#0x2_ecdsa_ecrecover">ecrecover</a>(signature: &<a href="">vector</a>&lt;u8&gt;, hashed_msg: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_ecdsa_decompress_pubkey"></a>
+
+## Function `decompress_pubkey`
+
+@param pubkey: A 33-bytes compressed public key, a prefix either 0x02 or 0x03 and a 256-bit integer.
+
+If the compressed public key is valid, return the 65-bytes uncompressed public key,
+otherwise throw error.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa.md#0x2_ecdsa_decompress_pubkey">decompress_pubkey</a>(pubkey: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ecdsa.md#0x2_ecdsa_decompress_pubkey">decompress_pubkey</a>(pubkey: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_ecdsa_keccak256"></a>
+
+## Function `keccak256`
+
+@param data: arbitrary bytes data to hash
+Hash the input bytes using keccak256 and returns 32 bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa.md#0x2_ecdsa_keccak256">keccak256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ecdsa.md#0x2_ecdsa_keccak256">keccak256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_ecdsa_secp256k1_verify"></a>
+
+## Function `secp256k1_verify`
+
+@param signature: A 65-bytes signature in form (r, s, v) that is signed using
+Secp256k1. Reference implementation on signature generation using RFC6979:
+https://github.com/MystenLabs/narwhal/blob/5d6f6df8ccee94446ff88786c0dbbc98be7cfc09/crypto/src/secp256k1.rs
+
+@param public_key: The public key to verify the signature against
+@param hashed_msg: The hashed 32-bytes message, same as what the signature is signed against.
+
+If the signature is valid to the pubkey and hashed message, return true. Else false.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa.md#0x2_ecdsa_secp256k1_verify">secp256k1_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, hashed_msg: &<a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ecdsa.md#0x2_ecdsa_secp256k1_verify">secp256k1_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, hashed_msg: &<a href="">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/ecdsa_k1.md
+++ b/crates/sui-framework-override/docs/ecdsa_k1.md
@@ -1,0 +1,153 @@
+
+<a name="0x2_ecdsa_k1"></a>
+
+# Module `0x2::ecdsa_k1`
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `ecrecover`](#0x2_ecdsa_k1_ecrecover)
+-  [Function `decompress_pubkey`](#0x2_ecdsa_k1_decompress_pubkey)
+-  [Function `keccak256`](#0x2_ecdsa_k1_keccak256)
+-  [Function `secp256k1_verify`](#0x2_ecdsa_k1_secp256k1_verify)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_ecdsa_k1_EFailToRecoverPubKey"></a>
+
+
+
+<pre><code><b>const</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_EFailToRecoverPubKey">EFailToRecoverPubKey</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_ecdsa_k1_EInvalidSignature"></a>
+
+
+
+<pre><code><b>const</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_EInvalidSignature">EInvalidSignature</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_ecdsa_k1_ecrecover"></a>
+
+## Function `ecrecover`
+
+@param signature: A 65-bytes signature in form (r, s, v) that is signed using
+Secp256k1. Reference implementation on signature generation using RFC6979:
+https://github.com/MystenLabs/narwhal/blob/5d6f6df8ccee94446ff88786c0dbbc98be7cfc09/crypto/src/secp256k1.rs
+The accepted v values are {0, 1, 2, 3}.
+
+@param hashed_msg: the hashed 32-bytes message. The message must be hashed instead
+of plain text to be secure.
+
+If the signature is valid, return the corresponding recovered Secpk256k1 public
+key, otherwise throw error. This is similar to ecrecover in Ethereum, can only be
+applied to Secp256k1 signatures.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_ecrecover">ecrecover</a>(signature: &<a href="">vector</a>&lt;u8&gt;, hashed_msg: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_ecrecover">ecrecover</a>(signature: &<a href="">vector</a>&lt;u8&gt;, hashed_msg: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_ecdsa_k1_decompress_pubkey"></a>
+
+## Function `decompress_pubkey`
+
+@param pubkey: A 33-bytes compressed public key, a prefix either 0x02 or 0x03 and a 256-bit integer.
+
+If the compressed public key is valid, return the 65-bytes uncompressed public key,
+otherwise throw error.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_decompress_pubkey">decompress_pubkey</a>(pubkey: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_decompress_pubkey">decompress_pubkey</a>(pubkey: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_ecdsa_k1_keccak256"></a>
+
+## Function `keccak256`
+
+@param data: arbitrary bytes data to hash
+Hash the input bytes using keccak256 and returns 32 bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_keccak256">keccak256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_keccak256">keccak256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_ecdsa_k1_secp256k1_verify"></a>
+
+## Function `secp256k1_verify`
+
+@param signature: A 65-bytes signature in form (r, s, v) that is signed using
+Secp256k1. Reference implementation on signature generation using RFC6979:
+https://github.com/MystenLabs/narwhal/blob/5d6f6df8ccee94446ff88786c0dbbc98be7cfc09/crypto/src/secp256k1.rs
+
+@param public_key: The public key to verify the signature against
+@param hashed_msg: The hashed 32-bytes message, same as what the signature is signed against.
+
+If the signature is valid to the pubkey and hashed message, return true. Else false.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_secp256k1_verify">secp256k1_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, hashed_msg: &<a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_secp256k1_verify">secp256k1_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, hashed_msg: &<a href="">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/ed25519.md
+++ b/crates/sui-framework-override/docs/ed25519.md
@@ -1,0 +1,87 @@
+
+<a name="0x2_ed25519"></a>
+
+# Module `0x2::ed25519`
+
+
+
+-  [Function `ed25519_verify`](#0x2_ed25519_ed25519_verify)
+-  [Function `ed25519_verify_with_domain`](#0x2_ed25519_ed25519_verify_with_domain)
+
+
+<pre><code><b>use</b> <a href="">0x1::vector</a>;
+</code></pre>
+
+
+
+<a name="0x2_ed25519_ed25519_verify"></a>
+
+## Function `ed25519_verify`
+
+@param signature: 32-byte signature that is a point on the Ed25519 elliptic curve.
+@param public_key: 32-byte signature that is a point on the Ed25519 elliptic curve.
+@param msg: The message that we test the signature against.
+
+If the signature is a valid Ed25519 signature of the message and public key, return true.
+Otherwise, return false.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x2_ed25519_ed25519_verify">ed25519_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ed25519.md#0x2_ed25519_ed25519_verify">ed25519_verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_ed25519_ed25519_verify_with_domain"></a>
+
+## Function `ed25519_verify_with_domain`
+
+@param signature: 32-byte signature that is a point on the Ed25519 elliptic curve.
+@param public_key: 32-byte signature that is a point on the Ed25519 elliptic curve.
+@param msg: The message that we test the signature against.
+@param domain: The domain that the signature is tested again. We essentially prepend this to the message.
+
+If the signature is a valid Ed25519 signature of the message and public key, return true.
+Otherwise, return false.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="ed25519.md#0x2_ed25519_ed25519_verify_with_domain">ed25519_verify_with_domain</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: <a href="">vector</a>&lt;u8&gt;, domain: <a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="ed25519.md#0x2_ed25519_ed25519_verify_with_domain">ed25519_verify_with_domain</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: <a href="">vector</a>&lt;u8&gt;, domain: <a href="">vector</a>&lt;u8&gt;): bool {
+    std::vector::append(&<b>mut</b> domain, msg);
+    <a href="ed25519.md#0x2_ed25519_ed25519_verify">ed25519_verify</a>(signature, public_key, &domain)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/elliptic_curve.md
+++ b/crates/sui-framework-override/docs/elliptic_curve.md
@@ -1,0 +1,486 @@
+
+<a name="0x2_elliptic_curve"></a>
+
+# Module `0x2::elliptic_curve`
+
+Library for Elliptic Curve operations for Pedersen Commitment on a prime order group.
+We specifically support the Ristretto-255 sub-group.
+
+
+-  [Struct `RistrettoPoint`](#0x2_elliptic_curve_RistrettoPoint)
+-  [Struct `Scalar`](#0x2_elliptic_curve_Scalar)
+-  [Function `native_create_pedersen_commitment`](#0x2_elliptic_curve_native_create_pedersen_commitment)
+-  [Function `native_add_ristretto_point`](#0x2_elliptic_curve_native_add_ristretto_point)
+-  [Function `native_subtract_ristretto_point`](#0x2_elliptic_curve_native_subtract_ristretto_point)
+-  [Function `native_scalar_from_u64`](#0x2_elliptic_curve_native_scalar_from_u64)
+-  [Function `native_scalar_from_bytes`](#0x2_elliptic_curve_native_scalar_from_bytes)
+-  [Function `new_scalar_from_u64`](#0x2_elliptic_curve_new_scalar_from_u64)
+-  [Function `create_pedersen_commitment`](#0x2_elliptic_curve_create_pedersen_commitment)
+-  [Function `new_scalar_from_bytes`](#0x2_elliptic_curve_new_scalar_from_bytes)
+-  [Function `scalar_bytes`](#0x2_elliptic_curve_scalar_bytes)
+-  [Function `bytes`](#0x2_elliptic_curve_bytes)
+-  [Function `add`](#0x2_elliptic_curve_add)
+-  [Function `subtract`](#0x2_elliptic_curve_subtract)
+-  [Function `new_from_bytes`](#0x2_elliptic_curve_new_from_bytes)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_elliptic_curve_RistrettoPoint"></a>
+
+## Struct `RistrettoPoint`
+
+Elliptic Curve structs
+Represents a point on the Ristretto-255 subgroup.
+
+
+<pre><code><b>struct</b> <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>value: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_elliptic_curve_Scalar"></a>
+
+## Struct `Scalar`
+
+Represents a scalar within the Curve25519 prime-order group.
+
+
+<pre><code><b>struct</b> <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">Scalar</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>value: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_elliptic_curve_native_create_pedersen_commitment"></a>
+
+## Function `native_create_pedersen_commitment`
+
+Private
+@param value: The value to commit to
+@param blinding_factor: A random number used to ensure that the commitment is hiding.
+
+
+<pre><code><b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_create_pedersen_commitment">native_create_pedersen_commitment</a>(value: <a href="">vector</a>&lt;u8&gt;, blinding_factor: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_create_pedersen_commitment">native_create_pedersen_commitment</a>(value: <a href="">vector</a>&lt;u8&gt;, blinding_factor: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_native_add_ristretto_point"></a>
+
+## Function `native_add_ristretto_point`
+
+@param self: bytes representation of an EC point on the Ristretto-255 subgroup
+@param other: bytes representation of an EC point on the Ristretto-255 subgroup
+A native move wrapper around the addition of Ristretto points. Returns self + other.
+
+
+<pre><code><b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_add_ristretto_point">native_add_ristretto_point</a>(point1: <a href="">vector</a>&lt;u8&gt;, point2: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_add_ristretto_point">native_add_ristretto_point</a>(point1: <a href="">vector</a>&lt;u8&gt;, point2: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_native_subtract_ristretto_point"></a>
+
+## Function `native_subtract_ristretto_point`
+
+@param self: bytes representation of an EC point on the Ristretto-255 subgroup
+@param other: bytes representation of an EC point on the Ristretto-255 subgroup
+A native move wrapper around the subtraction of Ristretto points. Returns self - other.
+
+
+<pre><code><b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_subtract_ristretto_point">native_subtract_ristretto_point</a>(point1: <a href="">vector</a>&lt;u8&gt;, point2: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_subtract_ristretto_point">native_subtract_ristretto_point</a>(point1: <a href="">vector</a>&lt;u8&gt;, point2: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_native_scalar_from_u64"></a>
+
+## Function `native_scalar_from_u64`
+
+@param value: the value of the to-be-created scalar
+TODO: Transfer this into a Move function some time in the future.
+A native move wrapper for the creation of Scalars on Curve25519.
+
+
+<pre><code><b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_scalar_from_u64">native_scalar_from_u64</a>(value: u64): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_scalar_from_u64">native_scalar_from_u64</a>(value: u64): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_native_scalar_from_bytes"></a>
+
+## Function `native_scalar_from_bytes`
+
+@param value: the bytes representation of the scalar.
+TODO: Transfer this into a Move function some time in the future.
+A native move wrapper for the creation of Scalars on Curve25519.
+
+
+<pre><code><b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_scalar_from_bytes">native_scalar_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_native_scalar_from_bytes">native_scalar_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_new_scalar_from_u64"></a>
+
+## Function `new_scalar_from_u64`
+
+Public
+Create a field element from u64
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_new_scalar_from_u64">new_scalar_from_u64</a>(value: u64): <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">elliptic_curve::Scalar</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_new_scalar_from_u64">new_scalar_from_u64</a>(value: u64): <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">Scalar</a> {
+    <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">Scalar</a> {
+        value: <a href="elliptic_curve.md#0x2_elliptic_curve_native_scalar_from_u64">native_scalar_from_u64</a>(value)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_create_pedersen_commitment"></a>
+
+## Function `create_pedersen_commitment`
+
+Create a pedersen commitment from two field elements
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_create_pedersen_commitment">create_pedersen_commitment</a>(value: <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">elliptic_curve::Scalar</a>, blinding_factor: <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">elliptic_curve::Scalar</a>): <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">elliptic_curve::RistrettoPoint</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_create_pedersen_commitment">create_pedersen_commitment</a>(value: <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">Scalar</a>, blinding_factor: <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">Scalar</a>): <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a> {
+    <b>return</b> <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a> {
+        value: <a href="elliptic_curve.md#0x2_elliptic_curve_native_create_pedersen_commitment">native_create_pedersen_commitment</a>(value.value, blinding_factor.value)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_new_scalar_from_bytes"></a>
+
+## Function `new_scalar_from_bytes`
+
+Creates a new field element from byte representation. Note that
+<code>value</code> must be 32-bytes
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_new_scalar_from_bytes">new_scalar_from_bytes</a>(value: <a href="">vector</a>&lt;u8&gt;): <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">elliptic_curve::Scalar</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_new_scalar_from_bytes">new_scalar_from_bytes</a>(value: <a href="">vector</a>&lt;u8&gt;): <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">Scalar</a> {
+    <a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">Scalar</a> {
+        value: <a href="elliptic_curve.md#0x2_elliptic_curve_native_scalar_from_bytes">native_scalar_from_bytes</a>(value)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_scalar_bytes"></a>
+
+## Function `scalar_bytes`
+
+Get the byte representation of the field element
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_scalar_bytes">scalar_bytes</a>(self: &<a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">elliptic_curve::Scalar</a>): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_scalar_bytes">scalar_bytes</a>(self: &<a href="elliptic_curve.md#0x2_elliptic_curve_Scalar">Scalar</a>): <a href="">vector</a>&lt;u8&gt; {
+    self.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_bytes"></a>
+
+## Function `bytes`
+
+Get the underlying compressed byte representation of the group element
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_bytes">bytes</a>(self: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">elliptic_curve::RistrettoPoint</a>): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_bytes">bytes</a>(self: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a>): <a href="">vector</a>&lt;u8&gt; {
+    self.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_add"></a>
+
+## Function `add`
+
+Perform addition on two group elements
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_add">add</a>(self: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">elliptic_curve::RistrettoPoint</a>, other: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">elliptic_curve::RistrettoPoint</a>): <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">elliptic_curve::RistrettoPoint</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_add">add</a>(self: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a>, other: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a>): <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a> {
+    <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a> {
+        value: <a href="elliptic_curve.md#0x2_elliptic_curve_native_add_ristretto_point">native_add_ristretto_point</a>(self.value, other.value)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_subtract"></a>
+
+## Function `subtract`
+
+Perform subtraction on two group elements
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_subtract">subtract</a>(self: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">elliptic_curve::RistrettoPoint</a>, other: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">elliptic_curve::RistrettoPoint</a>): <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">elliptic_curve::RistrettoPoint</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_subtract">subtract</a>(self: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a>, other: &<a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a>): <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a> {
+    <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a> {
+        value: <a href="elliptic_curve.md#0x2_elliptic_curve_native_subtract_ristretto_point">native_subtract_ristretto_point</a>(self.value, other.value)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_elliptic_curve_new_from_bytes"></a>
+
+## Function `new_from_bytes`
+
+Attempt to create a new group element from compressed bytes representation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_new_from_bytes">new_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">elliptic_curve::RistrettoPoint</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="elliptic_curve.md#0x2_elliptic_curve_new_from_bytes">new_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a> {
+    <b>assert</b>!(<a href="_length">vector::length</a>(&bytes) == 32, 1);
+    <a href="elliptic_curve.md#0x2_elliptic_curve_RistrettoPoint">RistrettoPoint</a> {
+        value: bytes
+    }
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/epoch_time_lock.md
+++ b/crates/sui-framework-override/docs/epoch_time_lock.md
@@ -1,0 +1,175 @@
+
+<a name="0x2_epoch_time_lock"></a>
+
+# Module `0x2::epoch_time_lock`
+
+
+
+-  [Struct `EpochTimeLock`](#0x2_epoch_time_lock_EpochTimeLock)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x2_epoch_time_lock_new)
+-  [Function `destroy`](#0x2_epoch_time_lock_destroy)
+-  [Function `destroy_unchecked`](#0x2_epoch_time_lock_destroy_unchecked)
+-  [Function `epoch`](#0x2_epoch_time_lock_epoch)
+
+
+<pre><code><b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_epoch_time_lock_EpochTimeLock"></a>
+
+## Struct `EpochTimeLock`
+
+Holder of an epoch number that can only be discarded in the epoch or
+after the epoch has passed.
+
+
+<pre><code><b>struct</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">EpochTimeLock</a> <b>has</b> <b>copy</b>, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_epoch_time_lock_EEpochAlreadyPassed"></a>
+
+The epoch passed into the creation of a lock has already passed.
+
+
+<pre><code><b>const</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_EEpochAlreadyPassed">EEpochAlreadyPassed</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_epoch_time_lock_EEpochNotYetEnded"></a>
+
+Attempt is made to unlock a lock that cannot be unlocked yet.
+
+
+<pre><code><b>const</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_EEpochNotYetEnded">EEpochNotYetEnded</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_epoch_time_lock_new"></a>
+
+## Function `new`
+
+Create a new epoch time lock with <code>epoch</code>. Aborts if the current epoch is less than the input epoch.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_new">new</a>(epoch: u64, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_new">new</a>(epoch: u64, ctx: &TxContext) : <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">EpochTimeLock</a> {
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) &lt; epoch, <a href="epoch_time_lock.md#0x2_epoch_time_lock_EEpochAlreadyPassed">EEpochAlreadyPassed</a>);
+    <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">EpochTimeLock</a> { epoch }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_epoch_time_lock_destroy"></a>
+
+## Function `destroy`
+
+Destroys an epoch time lock. Aborts if the current epoch is less than the locked epoch.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_destroy">destroy</a>(lock: <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_destroy">destroy</a>(lock: <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">EpochTimeLock</a>, ctx: &TxContext) {
+    <b>let</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">EpochTimeLock</a> { epoch } = lock;
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) &gt;= epoch, <a href="epoch_time_lock.md#0x2_epoch_time_lock_EEpochNotYetEnded">EEpochNotYetEnded</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_epoch_time_lock_destroy_unchecked"></a>
+
+## Function `destroy_unchecked`
+
+Destroys an epoch time lock.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_destroy_unchecked">destroy_unchecked</a>(lock: <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_destroy_unchecked">destroy_unchecked</a>(lock: <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">EpochTimeLock</a>) {
+    <b>let</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">EpochTimeLock</a> { epoch: _ } = lock;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_epoch_time_lock_epoch"></a>
+
+## Function `epoch`
+
+Getter for the epoch number.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_epoch">epoch</a>(lock: &<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock_epoch">epoch</a>(lock: &<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">EpochTimeLock</a>): u64 {
+    lock.epoch
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/erc721_metadata.md
+++ b/crates/sui-framework-override/docs/erc721_metadata.md
@@ -1,0 +1,222 @@
+
+<a name="0x2_erc721_metadata"></a>
+
+# Module `0x2::erc721_metadata`
+
+
+
+-  [Struct `ERC721Metadata`](#0x2_erc721_metadata_ERC721Metadata)
+-  [Struct `TokenID`](#0x2_erc721_metadata_TokenID)
+-  [Function `new`](#0x2_erc721_metadata_new)
+-  [Function `new_token_id`](#0x2_erc721_metadata_new_token_id)
+-  [Function `token_id`](#0x2_erc721_metadata_token_id)
+-  [Function `token_uri`](#0x2_erc721_metadata_token_uri)
+-  [Function `name`](#0x2_erc721_metadata_name)
+
+
+<pre><code><b>use</b> <a href="">0x1::ascii</a>;
+<b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="url.md#0x2_url">0x2::url</a>;
+</code></pre>
+
+
+
+<a name="0x2_erc721_metadata_ERC721Metadata"></a>
+
+## Struct `ERC721Metadata`
+
+A wrapper type for the ERC721 metadata standard https://eips.ethereum.org/EIPS/eip-721
+
+
+<pre><code><b>struct</b> <a href="erc721_metadata.md#0x2_erc721_metadata_ERC721Metadata">ERC721Metadata</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>token_id: <a href="erc721_metadata.md#0x2_erc721_metadata_TokenID">erc721_metadata::TokenID</a></code>
+</dt>
+<dd>
+ The token id associated with the source contract on Ethereum
+</dd>
+<dt>
+<code>name: <a href="_String">string::String</a></code>
+</dt>
+<dd>
+ A descriptive name for a collection of NFTs in this contract.
+ This corresponds to the <code><a href="erc721_metadata.md#0x2_erc721_metadata_name">name</a>()</code> method in the
+ ERC721Metadata interface in EIP-721.
+</dd>
+<dt>
+<code>token_uri: <a href="url.md#0x2_url_Url">url::Url</a></code>
+</dt>
+<dd>
+ A distinct Uniform Resource Identifier (URI) for a given asset.
+ This corresponds to the <code>tokenURI()</code> method in the ERC721Metadata
+ interface in EIP-721.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_erc721_metadata_TokenID"></a>
+
+## Struct `TokenID`
+
+An ERC721 token ID
+
+
+<pre><code><b>struct</b> <a href="erc721_metadata.md#0x2_erc721_metadata_TokenID">TokenID</a> <b>has</b> <b>copy</b>, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_erc721_metadata_new"></a>
+
+## Function `new`
+
+Construct a new ERC721Metadata from the given inputs. Does not perform any validation
+on <code>token_uri</code> or <code>name</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="erc721_metadata.md#0x2_erc721_metadata_new">new</a>(token_id: <a href="erc721_metadata.md#0x2_erc721_metadata_TokenID">erc721_metadata::TokenID</a>, name: <a href="">vector</a>&lt;u8&gt;, token_uri: <a href="">vector</a>&lt;u8&gt;): <a href="erc721_metadata.md#0x2_erc721_metadata_ERC721Metadata">erc721_metadata::ERC721Metadata</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="erc721_metadata.md#0x2_erc721_metadata_new">new</a>(token_id: <a href="erc721_metadata.md#0x2_erc721_metadata_TokenID">TokenID</a>, name: <a href="">vector</a>&lt;u8&gt;, token_uri: <a href="">vector</a>&lt;u8&gt;): <a href="erc721_metadata.md#0x2_erc721_metadata_ERC721Metadata">ERC721Metadata</a> {
+    // Note: this will <b>abort</b> <b>if</b> `token_uri` is not valid ASCII
+    <b>let</b> uri_str = <a href="_string">ascii::string</a>(token_uri);
+    <a href="erc721_metadata.md#0x2_erc721_metadata_ERC721Metadata">ERC721Metadata</a> {
+        token_id,
+        name: <a href="_utf8">string::utf8</a>(name),
+        token_uri: <a href="url.md#0x2_url_new_unsafe">url::new_unsafe</a>(uri_str),
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_erc721_metadata_new_token_id"></a>
+
+## Function `new_token_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="erc721_metadata.md#0x2_erc721_metadata_new_token_id">new_token_id</a>(id: u64): <a href="erc721_metadata.md#0x2_erc721_metadata_TokenID">erc721_metadata::TokenID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="erc721_metadata.md#0x2_erc721_metadata_new_token_id">new_token_id</a>(id: u64): <a href="erc721_metadata.md#0x2_erc721_metadata_TokenID">TokenID</a> {
+    <a href="erc721_metadata.md#0x2_erc721_metadata_TokenID">TokenID</a> { id }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_erc721_metadata_token_id"></a>
+
+## Function `token_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="erc721_metadata.md#0x2_erc721_metadata_token_id">token_id</a>(self: &<a href="erc721_metadata.md#0x2_erc721_metadata_ERC721Metadata">erc721_metadata::ERC721Metadata</a>): &<a href="erc721_metadata.md#0x2_erc721_metadata_TokenID">erc721_metadata::TokenID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="erc721_metadata.md#0x2_erc721_metadata_token_id">token_id</a>(self: &<a href="erc721_metadata.md#0x2_erc721_metadata_ERC721Metadata">ERC721Metadata</a>): &<a href="erc721_metadata.md#0x2_erc721_metadata_TokenID">TokenID</a> {
+    &self.token_id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_erc721_metadata_token_uri"></a>
+
+## Function `token_uri`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="erc721_metadata.md#0x2_erc721_metadata_token_uri">token_uri</a>(self: &<a href="erc721_metadata.md#0x2_erc721_metadata_ERC721Metadata">erc721_metadata::ERC721Metadata</a>): &<a href="url.md#0x2_url_Url">url::Url</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="erc721_metadata.md#0x2_erc721_metadata_token_uri">token_uri</a>(self: &<a href="erc721_metadata.md#0x2_erc721_metadata_ERC721Metadata">ERC721Metadata</a>): &Url {
+    &self.token_uri
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_erc721_metadata_name"></a>
+
+## Function `name`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="erc721_metadata.md#0x2_erc721_metadata_name">name</a>(self: &<a href="erc721_metadata.md#0x2_erc721_metadata_ERC721Metadata">erc721_metadata::ERC721Metadata</a>): &<a href="_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="erc721_metadata.md#0x2_erc721_metadata_name">name</a>(self: &<a href="erc721_metadata.md#0x2_erc721_metadata_ERC721Metadata">ERC721Metadata</a>): &<a href="_String">string::String</a> {
+    &self.name
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/event.md
+++ b/crates/sui-framework-override/docs/event.md
@@ -1,0 +1,36 @@
+
+<a name="0x2_event"></a>
+
+# Module `0x2::event`
+
+
+
+-  [Function `emit`](#0x2_event_emit)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_event_emit"></a>
+
+## Function `emit`
+
+Add <code>t</code> to the event log of this transaction
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_emit">emit</a>&lt;T: <b>copy</b>, drop&gt;(<a href="event.md#0x2_event">event</a>: T)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="event.md#0x2_event_emit">emit</a>&lt;T: <b>copy</b> + drop&gt;(<a href="event.md#0x2_event">event</a>: T);
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/genesis.md
+++ b/crates/sui-framework-override/docs/genesis.md
@@ -1,0 +1,174 @@
+
+<a name="0x2_genesis"></a>
+
+# Module `0x2::genesis`
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `create`](#0x2_genesis_create)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
+<b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="sui_system.md#0x2_sui_system">0x2::sui_system</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+<b>use</b> <a href="validator.md#0x2_validator">0x2::validator</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_genesis_INIT_MAX_VALIDATOR_COUNT"></a>
+
+Initial value of the upper-bound on the number of validators.
+
+
+<pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_MAX_VALIDATOR_COUNT">INIT_MAX_VALIDATOR_COUNT</a>: u64 = 100;
+</code></pre>
+
+
+
+<a name="0x2_genesis_INIT_MIN_VALIDATOR_STAKE"></a>
+
+Initial value of the lower-bound on the amount of stake required to become a validator.
+TODO: testnet only. Needs to be changed.
+
+
+<pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_MIN_VALIDATOR_STAKE">INIT_MIN_VALIDATOR_STAKE</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_genesis_INIT_STAKE_SUBSIDY_AMOUNT"></a>
+
+Stake subisidy to be given out in the very first epoch. Placeholder value.
+
+
+<pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_STAKE_SUBSIDY_AMOUNT">INIT_STAKE_SUBSIDY_AMOUNT</a>: u64 = 1000000;
+</code></pre>
+
+
+
+<a name="0x2_genesis_INIT_STORAGE_FUND"></a>
+
+The initial amount of SUI locked in the storage fund.
+
+
+<pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_STORAGE_FUND">INIT_STORAGE_FUND</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_genesis_create"></a>
+
+## Function `create`
+
+This function will be explicitly called once at genesis.
+It will create a singleton SuiSystemState object, which contains
+all the information we need in the system.
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_consensus_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_stakes: <a href="">vector</a>&lt;u64&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(
+    validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;,
+    validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_consensus_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_stakes: <a href="">vector</a>&lt;u64&gt;,
+    validator_gas_prices: <a href="">vector</a>&lt;u64&gt;,
+    validator_commission_rates: <a href="">vector</a>&lt;u64&gt;,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> sui_supply = <a href="sui.md#0x2_sui_new">sui::new</a>(ctx);
+    <b>let</b> storage_fund = <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(&<b>mut</b> sui_supply, <a href="genesis.md#0x2_genesis_INIT_STORAGE_FUND">INIT_STORAGE_FUND</a>);
+    <b>let</b> validators = <a href="_empty">vector::empty</a>();
+    <b>let</b> count = <a href="_length">vector::length</a>(&validator_pubkeys);
+    <b>assert</b>!(
+        <a href="_length">vector::length</a>(&validator_sui_addresses) == count
+            && <a href="_length">vector::length</a>(&validator_stakes) == count
+            && <a href="_length">vector::length</a>(&validator_names) == count
+            && <a href="_length">vector::length</a>(&validator_descriptions) == count
+            && <a href="_length">vector::length</a>(&validator_image_urls) == count
+            && <a href="_length">vector::length</a>(&validator_project_urls) == count
+            && <a href="_length">vector::length</a>(&validator_net_addresses) == count
+            && <a href="_length">vector::length</a>(&validator_consensus_addresses) == count
+            && <a href="_length">vector::length</a>(&validator_worker_addresses) == count
+            && <a href="_length">vector::length</a>(&validator_gas_prices) == count
+            && <a href="_length">vector::length</a>(&validator_commission_rates) == count,
+        1
+    );
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; count) {
+        <b>let</b> sui_address = *<a href="_borrow">vector::borrow</a>(&validator_sui_addresses, i);
+        <b>let</b> pubkey = *<a href="_borrow">vector::borrow</a>(&validator_pubkeys, i);
+        <b>let</b> network_pubkey = *<a href="_borrow">vector::borrow</a>(&validator_network_pubkeys, i);
+        <b>let</b> worker_pubkey = *<a href="_borrow">vector::borrow</a>(&validator_worker_pubkeys, i);
+        <b>let</b> proof_of_possession = *<a href="_borrow">vector::borrow</a>(&validator_proof_of_possessions, i);
+        <b>let</b> name = *<a href="_borrow">vector::borrow</a>(&validator_names, i);
+        <b>let</b> description = *<a href="_borrow">vector::borrow</a>(&validator_descriptions, i);
+        <b>let</b> image_url = *<a href="_borrow">vector::borrow</a>(&validator_image_urls, i);
+        <b>let</b> project_url = *<a href="_borrow">vector::borrow</a>(&validator_project_urls, i);
+        <b>let</b> net_address = *<a href="_borrow">vector::borrow</a>(&validator_net_addresses, i);
+        <b>let</b> consensus_address = *<a href="_borrow">vector::borrow</a>(&validator_consensus_addresses, i);
+        <b>let</b> worker_address = *<a href="_borrow">vector::borrow</a>(&validator_worker_addresses, i);
+        <b>let</b> <a href="stake.md#0x2_stake">stake</a> = *<a href="_borrow">vector::borrow</a>(&validator_stakes, i);
+        <b>let</b> gas_price = *<a href="_borrow">vector::borrow</a>(&validator_gas_prices, i);
+        <b>let</b> commission_rate = *<a href="_borrow">vector::borrow</a>(&validator_commission_rates, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> validators, <a href="validator.md#0x2_validator_new">validator::new</a>(
+            sui_address,
+            pubkey,
+            network_pubkey,
+            worker_pubkey,
+            proof_of_possession,
+            name,
+            description,
+            image_url,
+            project_url,
+            net_address,
+            consensus_address,
+            worker_address,
+            <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(&<b>mut</b> sui_supply, <a href="stake.md#0x2_stake">stake</a>),
+            <a href="_none">option::none</a>(),
+            gas_price,
+            commission_rate,
+            ctx
+        ));
+        i = i + 1;
+    };
+    <a href="sui_system.md#0x2_sui_system_create">sui_system::create</a>(
+        validators,
+        sui_supply,
+        storage_fund,
+        <a href="genesis.md#0x2_genesis_INIT_MAX_VALIDATOR_COUNT">INIT_MAX_VALIDATOR_COUNT</a>,
+        <a href="genesis.md#0x2_genesis_INIT_MIN_VALIDATOR_STAKE">INIT_MIN_VALIDATOR_STAKE</a>,
+        <a href="genesis.md#0x2_genesis_INIT_STAKE_SUBSIDY_AMOUNT">INIT_STAKE_SUBSIDY_AMOUNT</a>,
+    );
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/groth16.md
+++ b/crates/sui-framework-override/docs/groth16.md
@@ -1,0 +1,359 @@
+
+<a name="0x2_groth16"></a>
+
+# Module `0x2::groth16`
+
+
+
+-  [Struct `PreparedVerifyingKey`](#0x2_groth16_PreparedVerifyingKey)
+-  [Struct `PublicProofInputs`](#0x2_groth16_PublicProofInputs)
+-  [Struct `ProofPoints`](#0x2_groth16_ProofPoints)
+-  [Constants](#@Constants_0)
+-  [Function `pvk_from_bytes`](#0x2_groth16_pvk_from_bytes)
+-  [Function `pvk_to_bytes`](#0x2_groth16_pvk_to_bytes)
+-  [Function `public_proof_inputs_from_bytes`](#0x2_groth16_public_proof_inputs_from_bytes)
+-  [Function `proof_points_from_bytes`](#0x2_groth16_proof_points_from_bytes)
+-  [Function `prepare_verifying_key`](#0x2_groth16_prepare_verifying_key)
+-  [Function `verify_groth16_proof`](#0x2_groth16_verify_groth16_proof)
+-  [Function `verify_groth16_proof_internal`](#0x2_groth16_verify_groth16_proof_internal)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_groth16_PreparedVerifyingKey"></a>
+
+## Struct `PreparedVerifyingKey`
+
+A <code><a href="groth16.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a></code> consisting of four components in serialized form.
+
+
+<pre><code><b>struct</b> <a href="groth16.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>vk_gamma_abc_g1_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>alpha_g1_beta_g2_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>gamma_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delta_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_groth16_PublicProofInputs"></a>
+
+## Struct `PublicProofInputs`
+
+A <code><a href="groth16.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a></code> wrapper around its serialized bytes.
+
+
+<pre><code><b>struct</b> <a href="groth16.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_groth16_ProofPoints"></a>
+
+## Struct `ProofPoints`
+
+A <code><a href="groth16.md#0x2_groth16_ProofPoints">ProofPoints</a></code> wrapper around the serialized form of three proof points.
+
+
+<pre><code><b>struct</b> <a href="groth16.md#0x2_groth16_ProofPoints">ProofPoints</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_groth16_EInvalidVerifyingKey"></a>
+
+
+
+<pre><code><b>const</b> <a href="groth16.md#0x2_groth16_EInvalidVerifyingKey">EInvalidVerifyingKey</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_groth16_pvk_from_bytes"></a>
+
+## Function `pvk_from_bytes`
+
+Creates a <code><a href="groth16.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a></code> from bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_pvk_from_bytes">pvk_from_bytes</a>(vk_gamma_abc_g1_bytes: <a href="">vector</a>&lt;u8&gt;, alpha_g1_beta_g2_bytes: <a href="">vector</a>&lt;u8&gt;, gamma_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;, delta_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;): <a href="groth16.md#0x2_groth16_PreparedVerifyingKey">groth16::PreparedVerifyingKey</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_pvk_from_bytes">pvk_from_bytes</a>(vk_gamma_abc_g1_bytes: <a href="">vector</a>&lt;u8&gt;, alpha_g1_beta_g2_bytes: <a href="">vector</a>&lt;u8&gt;, gamma_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;, delta_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;): <a href="groth16.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a> {
+    <a href="groth16.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a> {
+        vk_gamma_abc_g1_bytes,
+        alpha_g1_beta_g2_bytes,
+        gamma_g2_neg_pc_bytes,
+        delta_g2_neg_pc_bytes
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_pvk_to_bytes"></a>
+
+## Function `pvk_to_bytes`
+
+Returns bytes of the four components of the <code><a href="groth16.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_pvk_to_bytes">pvk_to_bytes</a>(pvk: <a href="groth16.md#0x2_groth16_PreparedVerifyingKey">groth16::PreparedVerifyingKey</a>): <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_pvk_to_bytes">pvk_to_bytes</a>(pvk: <a href="groth16.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a>): <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    <b>let</b> res = <a href="_empty">vector::empty</a>();
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, pvk.vk_gamma_abc_g1_bytes);
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, pvk.alpha_g1_beta_g2_bytes);
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, pvk.gamma_g2_neg_pc_bytes);
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, pvk.delta_g2_neg_pc_bytes);
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_public_proof_inputs_from_bytes"></a>
+
+## Function `public_proof_inputs_from_bytes`
+
+Creates a <code><a href="groth16.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a></code> wrapper from bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_public_proof_inputs_from_bytes">public_proof_inputs_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="groth16.md#0x2_groth16_PublicProofInputs">groth16::PublicProofInputs</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_public_proof_inputs_from_bytes">public_proof_inputs_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="groth16.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a> {
+    <a href="groth16.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_proof_points_from_bytes"></a>
+
+## Function `proof_points_from_bytes`
+
+Creates a Groth16 <code><a href="groth16.md#0x2_groth16_ProofPoints">ProofPoints</a></code> from bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_proof_points_from_bytes">proof_points_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="groth16.md#0x2_groth16_ProofPoints">groth16::ProofPoints</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_proof_points_from_bytes">proof_points_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="groth16.md#0x2_groth16_ProofPoints">ProofPoints</a> {
+    <a href="groth16.md#0x2_groth16_ProofPoints">ProofPoints</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_prepare_verifying_key"></a>
+
+## Function `prepare_verifying_key`
+
+@param veriyfing_key: An Arkworks canonical serialization of a verifying key.
+
+Returns four vectors of bytes representing the four components of a prepared verifying key.
+This step computes one pairing e(P, Q), and binds the verification to one particular proof statement.
+This can be used as inputs for the <code>verify_groth16_proof</code> function.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_prepare_verifying_key">prepare_verifying_key</a>(verifying_key: &<a href="">vector</a>&lt;u8&gt;): <a href="groth16.md#0x2_groth16_PreparedVerifyingKey">groth16::PreparedVerifyingKey</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="groth16.md#0x2_groth16_prepare_verifying_key">prepare_verifying_key</a>(verifying_key: &<a href="">vector</a>&lt;u8&gt;): <a href="groth16.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a>;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_verify_groth16_proof"></a>
+
+## Function `verify_groth16_proof`
+
+@param prepared_verifying_key: Consists of four vectors of bytes representing the four components of a prepared verifying key.
+@param public_proof_inputs: Represent inputs that are public.
+@param proof_points: Represent three proof points.
+
+Returns a boolean indicating whether the proof is valid.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_verify_groth16_proof">verify_groth16_proof</a>(prepared_verifying_key: &<a href="groth16.md#0x2_groth16_PreparedVerifyingKey">groth16::PreparedVerifyingKey</a>, public_proof_inputs: &<a href="groth16.md#0x2_groth16_PublicProofInputs">groth16::PublicProofInputs</a>, proof_points: &<a href="groth16.md#0x2_groth16_ProofPoints">groth16::ProofPoints</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_verify_groth16_proof">verify_groth16_proof</a>(prepared_verifying_key: &<a href="groth16.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a>, public_proof_inputs: &<a href="groth16.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a>, proof_points: &<a href="groth16.md#0x2_groth16_ProofPoints">ProofPoints</a>): bool {
+    <a href="groth16.md#0x2_groth16_verify_groth16_proof_internal">verify_groth16_proof_internal</a>(
+        &prepared_verifying_key.vk_gamma_abc_g1_bytes,
+        &prepared_verifying_key.alpha_g1_beta_g2_bytes,
+        &prepared_verifying_key.gamma_g2_neg_pc_bytes,
+        &prepared_verifying_key.delta_g2_neg_pc_bytes,
+        &public_proof_inputs.bytes,
+        &proof_points.bytes
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_verify_groth16_proof_internal"></a>
+
+## Function `verify_groth16_proof_internal`
+
+Native functions that flattens the inputs into arrays of vectors and passed to the Rust native function.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="groth16.md#0x2_groth16_verify_groth16_proof_internal">verify_groth16_proof_internal</a>(vk_gamma_abc_g1_bytes: &<a href="">vector</a>&lt;u8&gt;, alpha_g1_beta_g2_bytes: &<a href="">vector</a>&lt;u8&gt;, gamma_g2_neg_pc_bytes: &<a href="">vector</a>&lt;u8&gt;, delta_g2_neg_pc_bytes: &<a href="">vector</a>&lt;u8&gt;, public_proof_inputs: &<a href="">vector</a>&lt;u8&gt;, proof_points: &<a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="groth16.md#0x2_groth16_verify_groth16_proof_internal">verify_groth16_proof_internal</a>(vk_gamma_abc_g1_bytes: &<a href="">vector</a>&lt;u8&gt;, alpha_g1_beta_g2_bytes: &<a href="">vector</a>&lt;u8&gt;, gamma_g2_neg_pc_bytes: &<a href="">vector</a>&lt;u8&gt;, delta_g2_neg_pc_bytes: &<a href="">vector</a>&lt;u8&gt;, public_proof_inputs: &<a href="">vector</a>&lt;u8&gt;, proof_points: &<a href="">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/hex.md
+++ b/crates/sui-framework-override/docs/hex.md
@@ -1,0 +1,164 @@
+
+<a name="0x2_hex"></a>
+
+# Module `0x2::hex`
+
+HEX (Base16) encoding utility.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `encode`](#0x2_hex_encode)
+-  [Function `decode`](#0x2_hex_decode)
+-  [Function `decode_byte`](#0x2_hex_decode_byte)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="">0x1::vector</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_hex_EInvalidHexLength"></a>
+
+
+
+<pre><code><b>const</b> <a href="hex.md#0x2_hex_EInvalidHexLength">EInvalidHexLength</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_hex_ENotValidHexCharacter"></a>
+
+
+
+<pre><code><b>const</b> <a href="hex.md#0x2_hex_ENotValidHexCharacter">ENotValidHexCharacter</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_hex_HEX"></a>
+
+Vector of Base16 values from <code>00</code> to <code>FF</code>
+
+
+<pre><code><b>const</b> <a href="hex.md#0x2_hex_HEX">HEX</a>: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt; = [ByteArray([48, 48]), ByteArray([48, 49]), ByteArray([48, 50]), ByteArray([48, 51]), ByteArray([48, 52]), ByteArray([48, 53]), ByteArray([48, 54]), ByteArray([48, 55]), ByteArray([48, 56]), ByteArray([48, 57]), ByteArray([48, 97]), ByteArray([48, 98]), ByteArray([48, 99]), ByteArray([48, 100]), ByteArray([48, 101]), ByteArray([48, 102]), ByteArray([49, 48]), ByteArray([49, 49]), ByteArray([49, 50]), ByteArray([49, 51]), ByteArray([49, 52]), ByteArray([49, 53]), ByteArray([49, 54]), ByteArray([49, 55]), ByteArray([49, 56]), ByteArray([49, 57]), ByteArray([49, 97]), ByteArray([49, 98]), ByteArray([49, 99]), ByteArray([49, 100]), ByteArray([49, 101]), ByteArray([49, 102]), ByteArray([50, 48]), ByteArray([50, 49]), ByteArray([50, 50]), ByteArray([50, 51]), ByteArray([50, 52]), ByteArray([50, 53]), ByteArray([50, 54]), ByteArray([50, 55]), ByteArray([50, 56]), ByteArray([50, 57]), ByteArray([50, 97]), ByteArray([50, 98]), ByteArray([50, 99]), ByteArray([50, 100]), ByteArray([50, 101]), ByteArray([50, 102]), ByteArray([51, 48]), ByteArray([51, 49]), ByteArray([51, 50]), ByteArray([51, 51]), ByteArray([51, 52]), ByteArray([51, 53]), ByteArray([51, 54]), ByteArray([51, 55]), ByteArray([51, 56]), ByteArray([51, 57]), ByteArray([51, 97]), ByteArray([51, 98]), ByteArray([51, 99]), ByteArray([51, 100]), ByteArray([51, 101]), ByteArray([51, 102]), ByteArray([52, 48]), ByteArray([52, 49]), ByteArray([52, 50]), ByteArray([52, 51]), ByteArray([52, 52]), ByteArray([52, 53]), ByteArray([52, 54]), ByteArray([52, 55]), ByteArray([52, 56]), ByteArray([52, 57]), ByteArray([52, 97]), ByteArray([52, 98]), ByteArray([52, 99]), ByteArray([52, 100]), ByteArray([52, 101]), ByteArray([52, 102]), ByteArray([53, 48]), ByteArray([53, 49]), ByteArray([53, 50]), ByteArray([53, 51]), ByteArray([53, 52]), ByteArray([53, 53]), ByteArray([53, 54]), ByteArray([53, 55]), ByteArray([53, 56]), ByteArray([53, 57]), ByteArray([53, 97]), ByteArray([53, 98]), ByteArray([53, 99]), ByteArray([53, 100]), ByteArray([53, 101]), ByteArray([53, 102]), ByteArray([54, 48]), ByteArray([54, 49]), ByteArray([54, 50]), ByteArray([54, 51]), ByteArray([54, 52]), ByteArray([54, 53]), ByteArray([54, 54]), ByteArray([54, 55]), ByteArray([54, 56]), ByteArray([54, 57]), ByteArray([54, 97]), ByteArray([54, 98]), ByteArray([54, 99]), ByteArray([54, 100]), ByteArray([54, 101]), ByteArray([54, 102]), ByteArray([55, 48]), ByteArray([55, 49]), ByteArray([55, 50]), ByteArray([55, 51]), ByteArray([55, 52]), ByteArray([55, 53]), ByteArray([55, 54]), ByteArray([55, 55]), ByteArray([55, 56]), ByteArray([55, 57]), ByteArray([55, 97]), ByteArray([55, 98]), ByteArray([55, 99]), ByteArray([55, 100]), ByteArray([55, 101]), ByteArray([55, 102]), ByteArray([56, 48]), ByteArray([56, 49]), ByteArray([56, 50]), ByteArray([56, 51]), ByteArray([56, 52]), ByteArray([56, 53]), ByteArray([56, 54]), ByteArray([56, 55]), ByteArray([56, 56]), ByteArray([56, 57]), ByteArray([56, 97]), ByteArray([56, 98]), ByteArray([56, 99]), ByteArray([56, 100]), ByteArray([56, 101]), ByteArray([56, 102]), ByteArray([57, 48]), ByteArray([57, 49]), ByteArray([57, 50]), ByteArray([57, 51]), ByteArray([57, 52]), ByteArray([57, 53]), ByteArray([57, 54]), ByteArray([57, 55]), ByteArray([57, 56]), ByteArray([57, 57]), ByteArray([57, 97]), ByteArray([57, 98]), ByteArray([57, 99]), ByteArray([57, 100]), ByteArray([57, 101]), ByteArray([57, 102]), ByteArray([97, 48]), ByteArray([97, 49]), ByteArray([97, 50]), ByteArray([97, 51]), ByteArray([97, 52]), ByteArray([97, 53]), ByteArray([97, 54]), ByteArray([97, 55]), ByteArray([97, 56]), ByteArray([97, 57]), ByteArray([97, 97]), ByteArray([97, 98]), ByteArray([97, 99]), ByteArray([97, 100]), ByteArray([97, 101]), ByteArray([97, 102]), ByteArray([98, 48]), ByteArray([98, 49]), ByteArray([98, 50]), ByteArray([98, 51]), ByteArray([98, 52]), ByteArray([98, 53]), ByteArray([98, 54]), ByteArray([98, 55]), ByteArray([98, 56]), ByteArray([98, 57]), ByteArray([98, 97]), ByteArray([98, 98]), ByteArray([98, 99]), ByteArray([98, 100]), ByteArray([98, 101]), ByteArray([98, 102]), ByteArray([99, 48]), ByteArray([99, 49]), ByteArray([99, 50]), ByteArray([99, 51]), ByteArray([99, 52]), ByteArray([99, 53]), ByteArray([99, 54]), ByteArray([99, 55]), ByteArray([99, 56]), ByteArray([99, 57]), ByteArray([99, 97]), ByteArray([99, 98]), ByteArray([99, 99]), ByteArray([99, 100]), ByteArray([99, 101]), ByteArray([99, 102]), ByteArray([100, 48]), ByteArray([100, 49]), ByteArray([100, 50]), ByteArray([100, 51]), ByteArray([100, 52]), ByteArray([100, 53]), ByteArray([100, 54]), ByteArray([100, 55]), ByteArray([100, 56]), ByteArray([100, 57]), ByteArray([100, 97]), ByteArray([100, 98]), ByteArray([100, 99]), ByteArray([100, 100]), ByteArray([100, 101]), ByteArray([100, 102]), ByteArray([101, 48]), ByteArray([101, 49]), ByteArray([101, 50]), ByteArray([101, 51]), ByteArray([101, 52]), ByteArray([101, 53]), ByteArray([101, 54]), ByteArray([101, 55]), ByteArray([101, 56]), ByteArray([101, 57]), ByteArray([101, 97]), ByteArray([101, 98]), ByteArray([101, 99]), ByteArray([101, 100]), ByteArray([101, 101]), ByteArray([101, 102]), ByteArray([102, 48]), ByteArray([102, 49]), ByteArray([102, 50]), ByteArray([102, 51]), ByteArray([102, 52]), ByteArray([102, 53]), ByteArray([102, 54]), ByteArray([102, 55]), ByteArray([102, 56]), ByteArray([102, 57]), ByteArray([102, 97]), ByteArray([102, 98]), ByteArray([102, 99]), ByteArray([102, 100]), ByteArray([102, 101]), ByteArray([102, 102])];
+</code></pre>
+
+
+
+<a name="0x2_hex_encode"></a>
+
+## Function `encode`
+
+Encode <code>bytes</code> in lowercase hex
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hex.md#0x2_hex_encode">encode</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hex.md#0x2_hex_encode">encode</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> (i, r, l) = (0, <a href="">vector</a>[], <a href="_length">vector::length</a>(&bytes));
+    <b>while</b> (i &lt; l) {
+        <a href="_append">vector::append</a>(
+            &<b>mut</b> r,
+            *<a href="_borrow">vector::borrow</a>(&<a href="hex.md#0x2_hex_HEX">HEX</a>, (*<a href="_borrow">vector::borrow</a>(&bytes, i) <b>as</b> u64))
+        );
+        i = i + 1;
+    };
+    r
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_hex_decode"></a>
+
+## Function `decode`
+
+Decode hex into <code>bytes</code>
+Takes a hex string (no 0x prefix) (e.g. b"0f3a")
+Returns vector of <code>bytes</code> that represents the hex string (e.g. x"0f3a")
+Hex string can be case insensitive (e.g. b"0F3A" and b"0f3a" both return x"0f3a")
+Aborts if the hex string does not have an even number of characters (as each hex charater is 2 characters long)
+Aborts if the hex string contains non-valid hex characters (valid charaters are 0 - 9, a - f, A - F)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hex.md#0x2_hex_decode">decode</a>(<a href="hex.md#0x2_hex">hex</a>: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hex.md#0x2_hex_decode">decode</a>(<a href="hex.md#0x2_hex">hex</a>: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> (i, r, l) = (0, <a href="">vector</a>[], <a href="_length">vector::length</a>(&<a href="hex.md#0x2_hex">hex</a>));
+    <b>assert</b>!(l % 2 == 0, <a href="hex.md#0x2_hex_EInvalidHexLength">EInvalidHexLength</a>);
+    <b>while</b> (i &lt; l) {
+        <b>let</b> decimal = (<a href="hex.md#0x2_hex_decode_byte">decode_byte</a>(*<a href="_borrow">vector::borrow</a>(&<a href="hex.md#0x2_hex">hex</a>, i)) * 16) +
+                      <a href="hex.md#0x2_hex_decode_byte">decode_byte</a>(*<a href="_borrow">vector::borrow</a>(&<a href="hex.md#0x2_hex">hex</a>, i + 1));
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> r, decimal);
+        i = i + 2;
+    };
+    r
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_hex_decode_byte"></a>
+
+## Function `decode_byte`
+
+
+
+<pre><code><b>fun</b> <a href="hex.md#0x2_hex_decode_byte">decode_byte</a>(<a href="hex.md#0x2_hex">hex</a>: u8): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="hex.md#0x2_hex_decode_byte">decode_byte</a>(<a href="hex.md#0x2_hex">hex</a>: u8): u8 {
+    <b>if</b> (/* 0 .. 9 */ 48 &lt;= <a href="hex.md#0x2_hex">hex</a> && <a href="hex.md#0x2_hex">hex</a> &lt; 58) {
+        <a href="hex.md#0x2_hex">hex</a> - 48
+    } <b>else</b> <b>if</b> (/* A .. F */ 65 &lt;= <a href="hex.md#0x2_hex">hex</a> && <a href="hex.md#0x2_hex">hex</a> &lt; 71) {
+        10 + <a href="hex.md#0x2_hex">hex</a> - 65
+    } <b>else</b> <b>if</b> (/* a .. f */ 97 &lt;= <a href="hex.md#0x2_hex">hex</a> && <a href="hex.md#0x2_hex">hex</a> &lt; 103) {
+        10 + <a href="hex.md#0x2_hex">hex</a> - 97
+    } <b>else</b> {
+        <b>abort</b> <a href="hex.md#0x2_hex_ENotValidHexCharacter">ENotValidHexCharacter</a>
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="@Module_Specification_1"></a>
+
+## Module Specification
+
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>

--- a/crates/sui-framework-override/docs/hmac.md
+++ b/crates/sui-framework-override/docs/hmac.md
@@ -1,0 +1,79 @@
+
+<a name="0x2_hmac"></a>
+
+# Module `0x2::hmac`
+
+
+
+-  [Function `native_hmac_sha3_256`](#0x2_hmac_native_hmac_sha3_256)
+-  [Function `hmac_sha3_256`](#0x2_hmac_hmac_sha3_256)
+
+
+<pre><code><b>use</b> <a href="digest.md#0x2_digest">0x2::digest</a>;
+</code></pre>
+
+
+
+<a name="0x2_hmac_native_hmac_sha3_256"></a>
+
+## Function `native_hmac_sha3_256`
+
+@param key: HMAC key, arbitrary bytes.
+@param msg: message to sign, arbitrary bytes.
+A native move wrapper around the HMAC-SHA3-256. Returns the digest.
+
+
+<pre><code><b>fun</b> <a href="hmac.md#0x2_hmac_native_hmac_sha3_256">native_hmac_sha3_256</a>(key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="hmac.md#0x2_hmac_native_hmac_sha3_256">native_hmac_sha3_256</a>(key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_hmac_hmac_sha3_256"></a>
+
+## Function `hmac_sha3_256`
+
+@param key: HMAC key, arbitrary bytes.
+@param msg: message to sign, arbitrary bytes.
+Returns the 32 bytes digest of HMAC-SHA3-256(key, msg).
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hmac.md#0x2_hmac_hmac_sha3_256">hmac_sha3_256</a>(key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): <a href="digest.md#0x2_digest_Sha3256Digest">digest::Sha3256Digest</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hmac.md#0x2_hmac_hmac_sha3_256">hmac_sha3_256</a>(key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): <a href="digest.md#0x2_digest_Sha3256Digest">digest::Sha3256Digest</a> {
+    <a href="digest.md#0x2_digest_sha3_256_digest_from_bytes">digest::sha3_256_digest_from_bytes</a>(<a href="hmac.md#0x2_hmac_native_hmac_sha3_256">native_hmac_sha3_256</a>(key, msg))
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/immutable_external_resource.md
+++ b/crates/sui-framework-override/docs/immutable_external_resource.md
@@ -1,0 +1,168 @@
+
+<a name="0x2_immutable_external_resource"></a>
+
+# Module `0x2::immutable_external_resource`
+
+Sui types for specifying off-chain/external resources.
+
+The keywords "MUST", "MUST NOT", "SHOULD", "SHOULD NOT" and "MAY" below should be interpreted as described in
+RFC 2119.
+
+
+-  [Struct `ImmutableExternalResource`](#0x2_immutable_external_resource_ImmutableExternalResource)
+-  [Function `new`](#0x2_immutable_external_resource_new)
+-  [Function `digest`](#0x2_immutable_external_resource_digest)
+-  [Function `url`](#0x2_immutable_external_resource_url)
+-  [Function `update`](#0x2_immutable_external_resource_update)
+
+
+<pre><code><b>use</b> <a href="">0x1::ascii</a>;
+<b>use</b> <a href="digest.md#0x2_digest">0x2::digest</a>;
+<b>use</b> <a href="url.md#0x2_url">0x2::url</a>;
+</code></pre>
+
+
+
+<a name="0x2_immutable_external_resource_ImmutableExternalResource"></a>
+
+## Struct `ImmutableExternalResource`
+
+ImmutableExternalResource: An arbitrary, mutable URL plus an immutable digest of the resource.
+
+Represents a resource that can move but must never change. Example use cases:
+- NFT images.
+- NFT metadata.
+
+<code><a href="url.md#0x2_url">url</a></code> MUST follow RFC-3986. Clients MUST support (at least) the following schemes: ipfs, https.
+<code><a href="digest.md#0x2_digest">digest</a></code> MUST be set to SHA3-256(content of resource at <code><a href="url.md#0x2_url">url</a></code>).
+
+Clients of this type MUST fetch the resource at <code><a href="url.md#0x2_url">url</a></code>, compute its digest and compare it against <code><a href="digest.md#0x2_digest">digest</a></code>. If
+the result is false, clients SHOULD indicate that to users or ignore the resource.
+
+
+<pre><code><b>struct</b> <a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">ImmutableExternalResource</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="url.md#0x2_url">url</a>: <a href="url.md#0x2_url_Url">url::Url</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="digest.md#0x2_digest">digest</a>: <a href="digest.md#0x2_digest_Sha3256Digest">digest::Sha3256Digest</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_immutable_external_resource_new"></a>
+
+## Function `new`
+
+Create a <code><a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">ImmutableExternalResource</a></code>, and set the immutable hash.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="immutable_external_resource.md#0x2_immutable_external_resource_new">new</a>(<a href="url.md#0x2_url">url</a>: <a href="url.md#0x2_url_Url">url::Url</a>, <a href="digest.md#0x2_digest">digest</a>: <a href="digest.md#0x2_digest_Sha3256Digest">digest::Sha3256Digest</a>): <a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">immutable_external_resource::ImmutableExternalResource</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="immutable_external_resource.md#0x2_immutable_external_resource_new">new</a>(<a href="url.md#0x2_url">url</a>: Url, <a href="digest.md#0x2_digest">digest</a>: Sha3256Digest): <a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">ImmutableExternalResource</a> {
+    <a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">ImmutableExternalResource</a> { <a href="url.md#0x2_url">url</a>, <a href="digest.md#0x2_digest">digest</a> }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_immutable_external_resource_digest"></a>
+
+## Function `digest`
+
+Get the hash of the resource.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="digest.md#0x2_digest">digest</a>(self: &<a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">immutable_external_resource::ImmutableExternalResource</a>): <a href="digest.md#0x2_digest_Sha3256Digest">digest::Sha3256Digest</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="digest.md#0x2_digest">digest</a>(self: &<a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">ImmutableExternalResource</a>): Sha3256Digest {
+    self.<a href="digest.md#0x2_digest">digest</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_immutable_external_resource_url"></a>
+
+## Function `url`
+
+Get the URL of the resource.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="url.md#0x2_url">url</a>(self: &<a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">immutable_external_resource::ImmutableExternalResource</a>): <a href="url.md#0x2_url_Url">url::Url</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="url.md#0x2_url">url</a>(self: &<a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">ImmutableExternalResource</a>): Url {
+    self.<a href="url.md#0x2_url">url</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_immutable_external_resource_update"></a>
+
+## Function `update`
+
+Update the URL, but the digest of the resource must never change.
+
+
+<pre><code><b>public</b> <b>fun</b> <b>update</b>(self: &<b>mut</b> <a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">immutable_external_resource::ImmutableExternalResource</a>, <a href="url.md#0x2_url">url</a>: <a href="url.md#0x2_url_Url">url::Url</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <b>update</b>(self: &<b>mut</b> <a href="immutable_external_resource.md#0x2_immutable_external_resource_ImmutableExternalResource">ImmutableExternalResource</a>, <a href="url.md#0x2_url">url</a>: Url) {
+    sui::url::update(&<b>mut</b> self.<a href="url.md#0x2_url">url</a>, inner_url(&<a href="url.md#0x2_url">url</a>))
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/linked_table.md
+++ b/crates/sui-framework-override/docs/linked_table.md
@@ -1,0 +1,649 @@
+
+<a name="0x2_linked_table"></a>
+
+# Module `0x2::linked_table`
+
+Similar to <code>sui::table</code> but the values are linked together, allowing for ordered insertion and
+removal
+
+
+-  [Resource `LinkedTable`](#0x2_linked_table_LinkedTable)
+-  [Struct `Node`](#0x2_linked_table_Node)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x2_linked_table_new)
+-  [Function `front`](#0x2_linked_table_front)
+-  [Function `back`](#0x2_linked_table_back)
+-  [Function `push_front`](#0x2_linked_table_push_front)
+-  [Function `push_back`](#0x2_linked_table_push_back)
+-  [Function `borrow`](#0x2_linked_table_borrow)
+-  [Function `borrow_mut`](#0x2_linked_table_borrow_mut)
+-  [Function `prev`](#0x2_linked_table_prev)
+-  [Function `next`](#0x2_linked_table_next)
+-  [Function `remove`](#0x2_linked_table_remove)
+-  [Function `pop_front`](#0x2_linked_table_pop_front)
+-  [Function `pop_back`](#0x2_linked_table_pop_back)
+-  [Function `contains`](#0x2_linked_table_contains)
+-  [Function `length`](#0x2_linked_table_length)
+-  [Function `is_empty`](#0x2_linked_table_is_empty)
+-  [Function `destroy_empty`](#0x2_linked_table_destroy_empty)
+-  [Function `drop`](#0x2_linked_table_drop)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="dynamic_field.md#0x2_dynamic_field">0x2::dynamic_field</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_linked_table_LinkedTable"></a>
+
+## Resource `LinkedTable`
+
+
+
+<pre><code><b>struct</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K: <b>copy</b>, drop, store, V: store&gt; <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+ the ID of this table
+</dd>
+<dt>
+<code>size: u64</code>
+</dt>
+<dd>
+ the number of key-value pairs in the table
+</dd>
+<dt>
+<code>head: <a href="_Option">option::Option</a>&lt;K&gt;</code>
+</dt>
+<dd>
+ the front of the table, i.e. the key of the first entry
+</dd>
+<dt>
+<code>tail: <a href="_Option">option::Option</a>&lt;K&gt;</code>
+</dt>
+<dd>
+ the back of the table, i.e. the key of the last entry
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_linked_table_Node"></a>
+
+## Struct `Node`
+
+
+
+<pre><code><b>struct</b> <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K: <b>copy</b>, drop, store, V: store&gt; <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>prev: <a href="_Option">option::Option</a>&lt;K&gt;</code>
+</dt>
+<dd>
+ the previous key
+</dd>
+<dt>
+<code>next: <a href="_Option">option::Option</a>&lt;K&gt;</code>
+</dt>
+<dd>
+ the next key
+</dd>
+<dt>
+<code>value: V</code>
+</dt>
+<dd>
+ the value being stored
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_linked_table_ETableNotEmpty"></a>
+
+
+
+<pre><code><b>const</b> <a href="linked_table.md#0x2_linked_table_ETableNotEmpty">ETableNotEmpty</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_linked_table_ETableIsEmpty"></a>
+
+
+
+<pre><code><b>const</b> <a href="linked_table.md#0x2_linked_table_ETableIsEmpty">ETableIsEmpty</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_linked_table_new"></a>
+
+## Function `new`
+
+Creates a new, empty table
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_new">new</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_new">new</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(ctx: &<b>mut</b> TxContext): <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt; {
+    <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        size: 0,
+        head: <a href="_none">option::none</a>(),
+        tail: <a href="_none">option::none</a>(),
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_front"></a>
+
+## Function `front`
+
+Returns the key for the first element in the table, or None if the table is empty
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_front">front</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): &<a href="_Option">option::Option</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_front">front</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): &Option&lt;K&gt; {
+    &<a href="table.md#0x2_table">table</a>.head
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_back"></a>
+
+## Function `back`
+
+Returns the key for the last element in the table, or None if the table is empty
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_back">back</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): &<a href="_Option">option::Option</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_back">back</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): &Option&lt;K&gt; {
+    &<a href="table.md#0x2_table">table</a>.tail
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_push_front"></a>
+
+## Function `push_front`
+
+Inserts a key-value pair at the front of the table, i.e. the newly inserted pair will be
+the first element in the table
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the table already has an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_push_front">push_front</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K, value: V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_push_front">push_front</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(
+    <a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;,
+    k: K,
+    value: V,
+) {
+    <b>let</b> old_head = <a href="_swap_or_fill">option::swap_or_fill</a>(&<b>mut</b> <a href="table.md#0x2_table">table</a>.head, k);
+    <b>if</b> (<a href="_is_none">option::is_none</a>(&<a href="table.md#0x2_table">table</a>.tail)) <a href="_fill">option::fill</a>(&<b>mut</b> <a href="table.md#0x2_table">table</a>.tail, k);
+    <b>let</b> prev = <a href="_none">option::none</a>();
+    <b>let</b> next = <b>if</b> (<a href="_is_some">option::is_some</a>(&old_head)) {
+        <b>let</b> old_head_k = <a href="_destroy_some">option::destroy_some</a>(old_head);
+        field::borrow_mut&lt;K, <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, old_head_k).prev = <a href="_some">option::some</a>(k);
+        <a href="_some">option::some</a>(old_head_k)
+    } <b>else</b> {
+        <a href="_none">option::none</a>()
+    };
+    field::add(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, k, <a href="linked_table.md#0x2_linked_table_Node">Node</a> { prev, next, value });
+    <a href="table.md#0x2_table">table</a>.size = <a href="table.md#0x2_table">table</a>.size + 1;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_push_back"></a>
+
+## Function `push_back`
+
+Inserts a key-value pair at the back of the table, i.e. the newly inserted pair will be
+the last element in the table
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the table already has an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_push_back">push_back</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K, value: V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_push_back">push_back</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(
+    <a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;,
+    k: K,
+    value: V,
+) {
+    <b>if</b> (<a href="_is_none">option::is_none</a>(&<a href="table.md#0x2_table">table</a>.head)) <a href="_fill">option::fill</a>(&<b>mut</b> <a href="table.md#0x2_table">table</a>.head, k);
+    <b>let</b> old_tail = <a href="_swap_or_fill">option::swap_or_fill</a>(&<b>mut</b> <a href="table.md#0x2_table">table</a>.tail, k);
+    <b>let</b> prev = <b>if</b> (<a href="_is_some">option::is_some</a>(&old_tail)) {
+        <b>let</b> old_tail_k = <a href="_destroy_some">option::destroy_some</a>(old_tail);
+        field::borrow_mut&lt;K, <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, old_tail_k).next = <a href="_some">option::some</a>(k);
+        <a href="_some">option::some</a>(old_tail_k)
+    } <b>else</b> {
+        <a href="_none">option::none</a>()
+    };
+    <b>let</b> next = <a href="_none">option::none</a>();
+    field::add(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, k, <a href="linked_table.md#0x2_linked_table_Node">Node</a> { prev, next, value });
+    <a href="table.md#0x2_table">table</a>.size = <a href="table.md#0x2_table">table</a>.size + 1;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_borrow"></a>
+
+## Function `borrow`
+
+Immutable borrows the value associated with the key in the table <code><a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): &V {
+    &field::borrow&lt;K, <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<a href="table.md#0x2_table">table</a>.id, k).value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Mutably borrows the value associated with the key in the table <code><a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(
+    <a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;,
+    k: K,
+): &<b>mut</b> V {
+    &<b>mut</b> field::borrow_mut&lt;K, <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, k).value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_prev"></a>
+
+## Function `prev`
+
+Borrows the key for the previous entry of the specified key <code>k: K</code> in the table
+<code><a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>. Returns None if the entry does not have a predecessor.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_prev">prev</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<a href="_Option">option::Option</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_prev">prev</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): &Option&lt;K&gt; {
+    &field::borrow&lt;K, <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<a href="table.md#0x2_table">table</a>.id, k).prev
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_next"></a>
+
+## Function `next`
+
+Borrows the key for the next entry of the specified key <code>k: K</code> in the table
+<code><a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>. Returns None if the entry does not have a predecessor.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_next">next</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<a href="_Option">option::Option</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_next">next</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): &Option&lt;K&gt; {
+    &field::borrow&lt;K, <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<a href="table.md#0x2_table">table</a>.id, k).next
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_remove"></a>
+
+## Function `remove`
+
+Removes the key-value pair in the table <code><a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code> and returns the value.
+This splices the element out of the ordering.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>. Note: this is also what happens when the table is empty.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): V {
+    <b>let</b> <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K, V&gt; { prev, next, value } = field::remove(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, k);
+    <a href="table.md#0x2_table">table</a>.size = <a href="table.md#0x2_table">table</a>.size - 1;
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&prev)) {
+        field::borrow_mut&lt;K, <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, *<a href="_borrow">option::borrow</a>(&prev)).next = next
+    };
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&next)) {
+        field::borrow_mut&lt;K, <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, *<a href="_borrow">option::borrow</a>(&next)).prev = prev
+    };
+    <b>if</b> (<a href="_borrow">option::borrow</a>(&<a href="table.md#0x2_table">table</a>.head) == &k) <a href="table.md#0x2_table">table</a>.head = next;
+    <b>if</b> (<a href="_borrow">option::borrow</a>(&<a href="table.md#0x2_table">table</a>.tail) == &k) <a href="table.md#0x2_table">table</a>.tail = prev;
+    value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_pop_front"></a>
+
+## Function `pop_front`
+
+Removes the front of the table <code><a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code> and returns the value.
+Aborts with <code><a href="linked_table.md#0x2_linked_table_ETableIsEmpty">ETableIsEmpty</a></code> if the table is empty
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_pop_front">pop_front</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): (K, V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_pop_front">pop_front</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): (K, V) {
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&<a href="table.md#0x2_table">table</a>.head), <a href="linked_table.md#0x2_linked_table_ETableIsEmpty">ETableIsEmpty</a>);
+    <b>let</b> head = *<a href="_borrow">option::borrow</a>(&<a href="table.md#0x2_table">table</a>.head);
+    (head, <a href="linked_table.md#0x2_linked_table_remove">remove</a>(<a href="table.md#0x2_table">table</a>, head))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_pop_back"></a>
+
+## Function `pop_back`
+
+Removes the back of the table <code><a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code> and returns the value.
+Aborts with <code><a href="linked_table.md#0x2_linked_table_ETableIsEmpty">ETableIsEmpty</a></code> if the table is empty
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_pop_back">pop_back</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): (K, V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_pop_back">pop_back</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): (K, V) {
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&<a href="table.md#0x2_table">table</a>.tail), <a href="linked_table.md#0x2_linked_table_ETableIsEmpty">ETableIsEmpty</a>);
+    <b>let</b> tail = *<a href="_borrow">option::borrow</a>(&<a href="table.md#0x2_table">table</a>.tail);
+    (tail, <a href="linked_table.md#0x2_linked_table_remove">remove</a>(<a href="table.md#0x2_table">table</a>, tail))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_contains"></a>
+
+## Function `contains`
+
+Returns true iff there is a value associated with the key <code>k: K</code> in table
+<code><a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_contains">contains</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_contains">contains</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): bool {
+    field::exists_with_type&lt;K, <a href="linked_table.md#0x2_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<a href="table.md#0x2_table">table</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_length"></a>
+
+## Function `length`
+
+Returns the size of the table, the number of key-value pairs
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_length">length</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_length">length</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): u64 {
+    <a href="table.md#0x2_table">table</a>.size
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_is_empty"></a>
+
+## Function `is_empty`
+
+Returns true iff the table is empty (if <code>length</code> returns <code>0</code>)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_is_empty">is_empty</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): bool {
+    <a href="table.md#0x2_table">table</a>.size == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_destroy_empty"></a>
+
+## Function `destroy_empty`
+
+Destroys an empty table
+Aborts with <code><a href="linked_table.md#0x2_linked_table_ETableNotEmpty">ETableNotEmpty</a></code> if the table still contains values
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a> { id, size, head: _, tail: _ } = <a href="table.md#0x2_table">table</a>;
+    <b>assert</b>!(size == 0, <a href="linked_table.md#0x2_linked_table_ETableNotEmpty">ETableNotEmpty</a>);
+    <a href="object.md#0x2_object_delete">object::delete</a>(id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_linked_table_drop"></a>
+
+## Function `drop`
+
+Drop a possibly non-empty table.
+Usable only if the value type <code>V</code> has the <code>drop</code> ability
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_drop">drop</a>&lt;K: <b>copy</b>, drop, store, V: drop, store&gt;(<a href="table.md#0x2_table">table</a>: <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="linked_table.md#0x2_linked_table_drop">drop</a>&lt;K: <b>copy</b> + drop + store, V: drop + store&gt;(<a href="table.md#0x2_table">table</a>: <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a> { id, size: _, head: _, tail: _ } = <a href="table.md#0x2_table">table</a>;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/locked_coin.md
+++ b/crates/sui-framework-override/docs/locked_coin.md
@@ -1,0 +1,207 @@
+
+<a name="0x2_locked_coin"></a>
+
+# Module `0x2::locked_coin`
+
+
+
+-  [Resource `LockedCoin`](#0x2_locked_coin_LockedCoin)
+-  [Function `new_from_balance`](#0x2_locked_coin_new_from_balance)
+-  [Function `into_balance`](#0x2_locked_coin_into_balance)
+-  [Function `value`](#0x2_locked_coin_value)
+-  [Function `lock_coin`](#0x2_locked_coin_lock_coin)
+-  [Function `unlock_coin`](#0x2_locked_coin_unlock_coin)
+
+
+<pre><code><b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_locked_coin_LockedCoin"></a>
+
+## Resource `LockedCoin`
+
+A coin of type <code>T</code> locked until <code>locked_until_epoch</code>.
+
+
+<pre><code><b>struct</b> <a href="locked_coin.md#0x2_locked_coin_LockedCoin">LockedCoin</a>&lt;T&gt; <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>locked_until_epoch: <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_locked_coin_new_from_balance"></a>
+
+## Function `new_from_balance`
+
+Create a LockedCoin from <code><a href="balance.md#0x2_balance">balance</a></code> and transfer it to <code>owner</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_new_from_balance">new_from_balance</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, locked_until_epoch: <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>, owner: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_new_from_balance">new_from_balance</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: Balance&lt;T&gt;, locked_until_epoch: EpochTimeLock, owner: <b>address</b>, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> <a href="locked_coin.md#0x2_locked_coin">locked_coin</a> = <a href="locked_coin.md#0x2_locked_coin_LockedCoin">LockedCoin</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        <a href="balance.md#0x2_balance">balance</a>,
+        locked_until_epoch
+    };
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="locked_coin.md#0x2_locked_coin">locked_coin</a>, owner);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_locked_coin_into_balance"></a>
+
+## Function `into_balance`
+
+Destruct a LockedCoin wrapper and keep the balance.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_into_balance">into_balance</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: <a href="locked_coin.md#0x2_locked_coin_LockedCoin">locked_coin::LockedCoin</a>&lt;T&gt;): (<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_into_balance">into_balance</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: <a href="locked_coin.md#0x2_locked_coin_LockedCoin">LockedCoin</a>&lt;T&gt;): (Balance&lt;T&gt;, EpochTimeLock) {
+    <b>let</b> <a href="locked_coin.md#0x2_locked_coin_LockedCoin">LockedCoin</a> { id, locked_until_epoch, <a href="balance.md#0x2_balance">balance</a> } = <a href="coin.md#0x2_coin">coin</a>;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    (<a href="balance.md#0x2_balance">balance</a>, locked_until_epoch)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_locked_coin_value"></a>
+
+## Function `value`
+
+Public getter for the locked coin's value
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_value">value</a>&lt;T&gt;(self: &<a href="locked_coin.md#0x2_locked_coin_LockedCoin">locked_coin::LockedCoin</a>&lt;T&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_value">value</a>&lt;T&gt;(self: &<a href="locked_coin.md#0x2_locked_coin_LockedCoin">LockedCoin</a>&lt;T&gt;): u64 {
+    <a href="balance.md#0x2_balance_value">balance::value</a>(&self.<a href="balance.md#0x2_balance">balance</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_locked_coin_lock_coin"></a>
+
+## Function `lock_coin`
+
+Lock a coin up until <code>locked_until_epoch</code>. The input Coin<T> is deleted and a LockedCoin<T>
+is transferred to the <code>recipient</code>. This function aborts if the <code>locked_until_epoch</code> is less than
+or equal to the current epoch.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_lock_coin">lock_coin</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, recipient: <b>address</b>, locked_until_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_lock_coin">lock_coin</a>&lt;T&gt;(
+    <a href="coin.md#0x2_coin">coin</a>: Coin&lt;T&gt;, recipient: <b>address</b>, locked_until_epoch: u64, ctx: &<b>mut</b> TxContext
+) {
+    <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(<a href="coin.md#0x2_coin">coin</a>);
+    <a href="locked_coin.md#0x2_locked_coin_new_from_balance">new_from_balance</a>(<a href="balance.md#0x2_balance">balance</a>, <a href="epoch_time_lock.md#0x2_epoch_time_lock_new">epoch_time_lock::new</a>(locked_until_epoch, ctx), recipient, ctx);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_locked_coin_unlock_coin"></a>
+
+## Function `unlock_coin`
+
+Unlock a locked coin. The function aborts if the current epoch is less than the <code>locked_until_epoch</code>
+of the coin. If the check is successful, the locked coin is deleted and a Coin<T> is transferred back
+to the sender.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_unlock_coin">unlock_coin</a>&lt;T&gt;(<a href="locked_coin.md#0x2_locked_coin">locked_coin</a>: <a href="locked_coin.md#0x2_locked_coin_LockedCoin">locked_coin::LockedCoin</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_unlock_coin">unlock_coin</a>&lt;T&gt;(<a href="locked_coin.md#0x2_locked_coin">locked_coin</a>: <a href="locked_coin.md#0x2_locked_coin_LockedCoin">LockedCoin</a>&lt;T&gt;, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> <a href="locked_coin.md#0x2_locked_coin_LockedCoin">LockedCoin</a> { id, <a href="balance.md#0x2_balance">balance</a>, locked_until_epoch } = <a href="locked_coin.md#0x2_locked_coin">locked_coin</a>;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    <a href="epoch_time_lock.md#0x2_epoch_time_lock_destroy">epoch_time_lock::destroy</a>(locked_until_epoch, ctx);
+    <b>let</b> <a href="coin.md#0x2_coin">coin</a> = <a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(<a href="balance.md#0x2_balance">balance</a>, ctx);
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin">coin</a>, <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/math.md
+++ b/crates/sui-framework-override/docs/math.md
@@ -1,0 +1,298 @@
+
+<a name="0x2_math"></a>
+
+# Module `0x2::math`
+
+Basic math for nicer programmability
+
+
+-  [Function `max`](#0x2_math_max)
+-  [Function `min`](#0x2_math_min)
+-  [Function `diff`](#0x2_math_diff)
+-  [Function `pow`](#0x2_math_pow)
+-  [Function `sqrt`](#0x2_math_sqrt)
+-  [Function `sqrt_u128`](#0x2_math_sqrt_u128)
+-  [Function `divide_and_round_up`](#0x2_math_divide_and_round_up)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_math_max"></a>
+
+## Function `max`
+
+Return the larger of <code>x</code> and <code>y</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_max">max</a>(x: u64, y: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_max">max</a>(x: u64, y: u64): u64 {
+    <b>if</b> (x &gt; y) {
+        x
+    } <b>else</b> {
+        y
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_math_min"></a>
+
+## Function `min`
+
+Return the smaller of <code>x</code> and <code>y</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(x: u64, y: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(x: u64, y: u64): u64 {
+    <b>if</b> (x &lt; y) {
+        x
+    } <b>else</b> {
+        y
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_math_diff"></a>
+
+## Function `diff`
+
+Return the absolute value of x - y
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_diff">diff</a>(x: u64, y: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_diff">diff</a>(x: u64, y: u64): u64 {
+    <b>if</b> (x &gt; y) {
+        x - y
+    } <b>else</b> {
+        y - x
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_math_pow"></a>
+
+## Function `pow`
+
+Return the value of a base raised to a power
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_pow">pow</a>(base: u64, exponent: u8): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_pow">pow</a>(base: u64, exponent: u8): u64 {
+    <b>let</b> res = 1;
+    <b>while</b> (exponent &gt;= 1) {
+        <b>if</b> (exponent % 2 == 0) {
+            base = base * base;
+            exponent = exponent / 2;
+        } <b>else</b> {
+            res = res * base;
+            exponent = exponent - 1;
+        }
+    };
+
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_math_sqrt"></a>
+
+## Function `sqrt`
+
+Get a nearest lower integer Square Root for <code>x</code>. Given that this
+function can only operate with integers, it is impossible
+to get perfect (or precise) integer square root for some numbers.
+
+Example:
+```
+math::sqrt(9) => 3
+math::sqrt(8) => 2 // the nearest lower square root is 4;
+```
+
+In integer math, one of the possible ways to get results with more
+precision is to use higher values or temporarily multiply the
+value by some bigger number. Ideally if this is a square of 10 or 100.
+
+Example:
+```
+math::sqrt(8) => 2;
+math::sqrt(8 * 10000) => 282;
+// now we can use this value as if it was 2.82;
+// but to get the actual result, this value needs
+// to be divided by 100 (because sqrt(10000)).
+
+
+math::sqrt(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
+```
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_sqrt">sqrt</a>(x: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_sqrt">sqrt</a>(x: u64): u64 {
+    <b>let</b> bit = 1u128 &lt;&lt; 64;
+    <b>let</b> res = 0u128;
+    <b>let</b> x = (x <b>as</b> u128);
+
+    <b>while</b> (bit != 0) {
+        <b>if</b> (x &gt;= res + bit) {
+            x = x - (res + bit);
+            res = (res &gt;&gt; 1) + bit;
+        } <b>else</b> {
+            res = res &gt;&gt; 1;
+        };
+        bit = bit &gt;&gt; 2;
+    };
+
+    (res <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_math_sqrt_u128"></a>
+
+## Function `sqrt_u128`
+
+Similar to math::sqrt, but for u128 numbers. Get a nearest lower integer Square Root for <code>x</code>. Given that this
+function can only operate with integers, it is impossible
+to get perfect (or precise) integer square root for some numbers.
+
+Example:
+```
+math::sqrt_u128(9) => 3
+math::sqrt_u128(8) => 2 // the nearest lower square root is 4;
+```
+
+In integer math, one of the possible ways to get results with more
+precision is to use higher values or temporarily multiply the
+value by some bigger number. Ideally if this is a square of 10 or 100.
+
+Example:
+```
+math::sqrt_u128(8) => 2;
+math::sqrt_u128(8 * 10000) => 282;
+// now we can use this value as if it was 2.82;
+// but to get the actual result, this value needs
+// to be divided by 100 (because sqrt_u128(10000)).
+
+
+math::sqrt_u128(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
+```
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_sqrt_u128">sqrt_u128</a>(x: u128): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_sqrt_u128">sqrt_u128</a>(x: u128): u128 {
+    <b>let</b> bit = 1u256 &lt;&lt; 128;
+    <b>let</b> res = 0u256;
+    <b>let</b> x = (x <b>as</b> u256);
+
+    <b>while</b> (bit != 0) {
+        <b>if</b> (x &gt;= res + bit) {
+            x = x - (res + bit);
+            res = (res &gt;&gt; 1) + bit;
+        } <b>else</b> {
+            res = res &gt;&gt; 1;
+        };
+        bit = bit &gt;&gt; 2;
+    };
+
+    (res <b>as</b> u128)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_math_divide_and_round_up"></a>
+
+## Function `divide_and_round_up`
+
+Calculate x / y, but round up the result.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_divide_and_round_up">divide_and_round_up</a>(x: u64, y: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math.md#0x2_math_divide_and_round_up">divide_and_round_up</a>(x: u64, y: u64): u64 {
+    <b>if</b> (x % y == 0) {
+        x / y
+    } <b>else</b> {
+        x / y + 1
+    }
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/object.md
+++ b/crates/sui-framework-override/docs/object.md
@@ -1,0 +1,598 @@
+
+<a name="0x2_object"></a>
+
+# Module `0x2::object`
+
+Sui object identifiers
+
+
+-  [Struct `ID`](#0x2_object_ID)
+-  [Struct `UID`](#0x2_object_UID)
+-  [Constants](#@Constants_0)
+-  [Function `id_to_bytes`](#0x2_object_id_to_bytes)
+-  [Function `id_to_address`](#0x2_object_id_to_address)
+-  [Function `id_from_bytes`](#0x2_object_id_from_bytes)
+-  [Function `id_from_address`](#0x2_object_id_from_address)
+-  [Function `sui_system_state`](#0x2_object_sui_system_state)
+-  [Function `uid_as_inner`](#0x2_object_uid_as_inner)
+-  [Function `uid_to_inner`](#0x2_object_uid_to_inner)
+-  [Function `uid_to_bytes`](#0x2_object_uid_to_bytes)
+-  [Function `uid_to_address`](#0x2_object_uid_to_address)
+-  [Function `new`](#0x2_object_new)
+-  [Function `delete`](#0x2_object_delete)
+-  [Function `id`](#0x2_object_id)
+-  [Function `borrow_id`](#0x2_object_borrow_id)
+-  [Function `id_bytes`](#0x2_object_id_bytes)
+-  [Function `id_address`](#0x2_object_id_address)
+-  [Function `borrow_uid`](#0x2_object_borrow_uid)
+-  [Function `new_uid_from_hash`](#0x2_object_new_uid_from_hash)
+-  [Function `delete_impl`](#0x2_object_delete_impl)
+-  [Function `record_new_uid`](#0x2_object_record_new_uid)
+
+
+<pre><code><b>use</b> <a href="">0x1::bcs</a>;
+<b>use</b> <a href="address.md#0x2_address">0x2::address</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_object_ID"></a>
+
+## Struct `ID`
+
+An object ID. This is used to reference Sui Objects.
+This is *not* guaranteed to be globally unique--anyone can create an <code><a href="object.md#0x2_object_ID">ID</a></code> from a <code><a href="object.md#0x2_object_UID">UID</a></code> or
+from an object, and ID's can be freely copied and dropped.
+Here, the values are not globally unique because there can be multiple values of type <code><a href="object.md#0x2_object_ID">ID</a></code>
+with the same underlying bytes. For example, <code><a href="object.md#0x2_object_id">object::id</a>(&obj)</code> can be called as many times
+as you want for a given <code>obj</code>, and each <code><a href="object.md#0x2_object_ID">ID</a></code> value will be identical.
+
+
+<pre><code><b>struct</b> <a href="object.md#0x2_object_ID">ID</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>bytes: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_object_UID"></a>
+
+## Struct `UID`
+
+Globally unique IDs that define an object's ID in storage. Any Sui Object, that is a struct
+with the <code>key</code> ability, must have <code>id: <a href="object.md#0x2_object_UID">UID</a></code> as its first field.
+These are globaly unique in the sense that no two values of type <code><a href="object.md#0x2_object_UID">UID</a></code> are ever equal, in
+other words for any two values <code>id1: <a href="object.md#0x2_object_UID">UID</a></code> and <code>id2: <a href="object.md#0x2_object_UID">UID</a></code>, <code>id1</code> != <code>id2</code>.
+This is a privileged type that can only be derived from a <code>TxContext</code>.
+<code><a href="object.md#0x2_object_UID">UID</a></code> doesn't have the <code>drop</code> ability, so deleting a <code><a href="object.md#0x2_object_UID">UID</a></code> requires a call to <code>delete</code>.
+
+
+<pre><code><b>struct</b> <a href="object.md#0x2_object_UID">UID</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_object_SUI_SYSTEM_STATE_OBJECT_ID"></a>
+
+The hardcoded ID for the singleton Sui System State Object.
+
+
+<pre><code><b>const</b> <a href="object.md#0x2_object_SUI_SYSTEM_STATE_OBJECT_ID">SUI_SYSTEM_STATE_OBJECT_ID</a>: <b>address</b> = 5;
+</code></pre>
+
+
+
+<a name="0x2_object_id_to_bytes"></a>
+
+## Function `id_to_bytes`
+
+Get the raw bytes of a <code><a href="object.md#0x2_object_ID">ID</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_to_bytes">id_to_bytes</a>(id: &<a href="object.md#0x2_object_ID">object::ID</a>): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_to_bytes">id_to_bytes</a>(id: &<a href="object.md#0x2_object_ID">ID</a>): <a href="">vector</a>&lt;u8&gt; {
+    <a href="_to_bytes">bcs::to_bytes</a>(&id.bytes)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_id_to_address"></a>
+
+## Function `id_to_address`
+
+Get the inner bytes of <code>id</code> as an address.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_to_address">id_to_address</a>(id: &<a href="object.md#0x2_object_ID">object::ID</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_to_address">id_to_address</a>(id: &<a href="object.md#0x2_object_ID">ID</a>): <b>address</b> {
+    id.bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_id_from_bytes"></a>
+
+## Function `id_from_bytes`
+
+Make an <code><a href="object.md#0x2_object_ID">ID</a></code> from raw bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_from_bytes">id_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_from_bytes">id_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="object.md#0x2_object_ID">ID</a> {
+    <a href="object.md#0x2_object_id_from_address">id_from_address</a>(address::from_bytes(bytes))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_id_from_address"></a>
+
+## Function `id_from_address`
+
+Make an <code><a href="object.md#0x2_object_ID">ID</a></code> from an address.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_from_address">id_from_address</a>(bytes: <b>address</b>): <a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_from_address">id_from_address</a>(bytes: <b>address</b>): <a href="object.md#0x2_object_ID">ID</a> {
+    <a href="object.md#0x2_object_ID">ID</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_sui_system_state"></a>
+
+## Function `sui_system_state`
+
+Create the <code><a href="object.md#0x2_object_UID">UID</a></code> for the singleton <code>SuiSystemState</code> object.
+This should only be called once from <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_sui_system_state">sui_system_state</a>(): <a href="object.md#0x2_object_UID">object::UID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_sui_system_state">sui_system_state</a>(): <a href="object.md#0x2_object_UID">UID</a> {
+    <a href="object.md#0x2_object_UID">UID</a> {
+        id: <a href="object.md#0x2_object_ID">ID</a> { bytes: <a href="object.md#0x2_object_SUI_SYSTEM_STATE_OBJECT_ID">SUI_SYSTEM_STATE_OBJECT_ID</a> },
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_uid_as_inner"></a>
+
+## Function `uid_as_inner`
+
+Get the inner <code><a href="object.md#0x2_object_ID">ID</a></code> of <code>uid</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_uid_as_inner">uid_as_inner</a>(uid: &<a href="object.md#0x2_object_UID">object::UID</a>): &<a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_uid_as_inner">uid_as_inner</a>(uid: &<a href="object.md#0x2_object_UID">UID</a>): &<a href="object.md#0x2_object_ID">ID</a> {
+    &uid.id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_uid_to_inner"></a>
+
+## Function `uid_to_inner`
+
+Get the raw bytes of a <code>uid</code>'s inner <code><a href="object.md#0x2_object_ID">ID</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_uid_to_inner">uid_to_inner</a>(uid: &<a href="object.md#0x2_object_UID">object::UID</a>): <a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_uid_to_inner">uid_to_inner</a>(uid: &<a href="object.md#0x2_object_UID">UID</a>): <a href="object.md#0x2_object_ID">ID</a> {
+    uid.id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_uid_to_bytes"></a>
+
+## Function `uid_to_bytes`
+
+Get the raw bytes of a <code><a href="object.md#0x2_object_UID">UID</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_uid_to_bytes">uid_to_bytes</a>(uid: &<a href="object.md#0x2_object_UID">object::UID</a>): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_uid_to_bytes">uid_to_bytes</a>(uid: &<a href="object.md#0x2_object_UID">UID</a>): <a href="">vector</a>&lt;u8&gt; {
+    <a href="_to_bytes">bcs::to_bytes</a>(&uid.id.bytes)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_uid_to_address"></a>
+
+## Function `uid_to_address`
+
+Get the inner bytes of <code>id</code> as an address.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_uid_to_address">uid_to_address</a>(uid: &<a href="object.md#0x2_object_UID">object::UID</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_uid_to_address">uid_to_address</a>(uid: &<a href="object.md#0x2_object_UID">UID</a>): <b>address</b> {
+    uid.id.bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_new"></a>
+
+## Function `new`
+
+Create a new object. Returns the <code><a href="object.md#0x2_object_UID">UID</a></code> that must be stored in a Sui object.
+This is the only way to create <code><a href="object.md#0x2_object_UID">UID</a></code>s.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object.md#0x2_object_UID">object::UID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_new">new</a>(ctx: &<b>mut</b> TxContext): <a href="object.md#0x2_object_UID">UID</a> {
+    <a href="object.md#0x2_object_UID">UID</a> {
+        id: <a href="object.md#0x2_object_ID">ID</a> { bytes: <a href="tx_context.md#0x2_tx_context_new_object">tx_context::new_object</a>(ctx) },
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_delete"></a>
+
+## Function `delete`
+
+Delete the object and it's <code><a href="object.md#0x2_object_UID">UID</a></code>. This is the only way to eliminate a <code><a href="object.md#0x2_object_UID">UID</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_delete">delete</a>(id: <a href="object.md#0x2_object_UID">object::UID</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_delete">delete</a>(id: <a href="object.md#0x2_object_UID">UID</a>) {
+    <b>let</b> <a href="object.md#0x2_object_UID">UID</a> { id: <a href="object.md#0x2_object_ID">ID</a> { bytes } } = id;
+    <a href="object.md#0x2_object_delete_impl">delete_impl</a>(bytes)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_id"></a>
+
+## Function `id`
+
+Get the underlying <code><a href="object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id">id</a>&lt;T: key&gt;(obj: &T): <a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id">id</a>&lt;T: key&gt;(obj: &T): <a href="object.md#0x2_object_ID">ID</a> {
+    <a href="object.md#0x2_object_borrow_uid">borrow_uid</a>(obj).id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_borrow_id"></a>
+
+## Function `borrow_id`
+
+Borrow the underlying <code><a href="object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow_id">borrow_id</a>&lt;T: key&gt;(obj: &T): &<a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow_id">borrow_id</a>&lt;T: key&gt;(obj: &T): &<a href="object.md#0x2_object_ID">ID</a> {
+    &<a href="object.md#0x2_object_borrow_uid">borrow_uid</a>(obj).id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_id_bytes"></a>
+
+## Function `id_bytes`
+
+Get the raw bytes for the underlying <code><a href="object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_bytes">id_bytes</a>&lt;T: key&gt;(obj: &T): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_bytes">id_bytes</a>&lt;T: key&gt;(obj: &T): <a href="">vector</a>&lt;u8&gt; {
+    <a href="_to_bytes">bcs::to_bytes</a>(&<a href="object.md#0x2_object_borrow_uid">borrow_uid</a>(obj).id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_id_address"></a>
+
+## Function `id_address`
+
+Get the inner bytes for the underlying <code><a href="object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_address">id_address</a>&lt;T: key&gt;(obj: &T): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_address">id_address</a>&lt;T: key&gt;(obj: &T): <b>address</b> {
+    <a href="object.md#0x2_object_borrow_uid">borrow_uid</a>(obj).id.bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_borrow_uid"></a>
+
+## Function `borrow_uid`
+
+Get the <code><a href="object.md#0x2_object_UID">UID</a></code> for <code>obj</code>.
+Safe because Sui has an extra bytecode verifier pass that forces every struct with
+the <code>key</code> ability to have a distinguished <code><a href="object.md#0x2_object_UID">UID</a></code> field.
+Cannot be made public as the access to <code><a href="object.md#0x2_object_UID">UID</a></code> for a given object must be privledged, and
+restrictable in the object's module.
+
+
+<pre><code><b>fun</b> <a href="object.md#0x2_object_borrow_uid">borrow_uid</a>&lt;T: key&gt;(obj: &T): &<a href="object.md#0x2_object_UID">object::UID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="object.md#0x2_object_borrow_uid">borrow_uid</a>&lt;T: key&gt;(obj: &T): &<a href="object.md#0x2_object_UID">UID</a>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_new_uid_from_hash"></a>
+
+## Function `new_uid_from_hash`
+
+Generate a new UID specifically used for creating a UID from a hash
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_new_uid_from_hash">new_uid_from_hash</a>(bytes: <b>address</b>): <a href="object.md#0x2_object_UID">object::UID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_new_uid_from_hash">new_uid_from_hash</a>(bytes: <b>address</b>): <a href="object.md#0x2_object_UID">UID</a> {
+    <a href="object.md#0x2_object_record_new_uid">record_new_uid</a>(bytes);
+    <a href="object.md#0x2_object_UID">UID</a> { id: <a href="object.md#0x2_object_ID">ID</a> { bytes } }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_delete_impl"></a>
+
+## Function `delete_impl`
+
+
+
+<pre><code><b>fun</b> <a href="object.md#0x2_object_delete_impl">delete_impl</a>(id: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="object.md#0x2_object_delete_impl">delete_impl</a>(id: <b>address</b>);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_record_new_uid"></a>
+
+## Function `record_new_uid`
+
+
+
+<pre><code><b>fun</b> <a href="object.md#0x2_object_record_new_uid">record_new_uid</a>(id: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="object.md#0x2_object_record_new_uid">record_new_uid</a>(id: <b>address</b>);
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/object_bag.md
+++ b/crates/sui-framework-override/docs/object_bag.md
@@ -1,0 +1,380 @@
+
+<a name="0x2_object_bag"></a>
+
+# Module `0x2::object_bag`
+
+Similar to <code>sui::bag</code>, an <code><a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a></code> is a heterogeneous map-like collection. But unlike
+<code>sui::bag</code>, the values bound to these dynamic fields _must_ be objects themselves. This allows
+for the objects to still exist in storage, which may be important for external tools.
+The difference is otherwise not observable from within Move.
+
+
+-  [Resource `ObjectBag`](#0x2_object_bag_ObjectBag)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x2_object_bag_new)
+-  [Function `add`](#0x2_object_bag_add)
+-  [Function `borrow`](#0x2_object_bag_borrow)
+-  [Function `borrow_mut`](#0x2_object_bag_borrow_mut)
+-  [Function `remove`](#0x2_object_bag_remove)
+-  [Function `contains`](#0x2_object_bag_contains)
+-  [Function `contains_with_type`](#0x2_object_bag_contains_with_type)
+-  [Function `length`](#0x2_object_bag_length)
+-  [Function `is_empty`](#0x2_object_bag_is_empty)
+-  [Function `destroy_empty`](#0x2_object_bag_destroy_empty)
+-  [Function `value_id`](#0x2_object_bag_value_id)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field">0x2::dynamic_object_field</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_object_bag_ObjectBag"></a>
+
+## Resource `ObjectBag`
+
+
+
+<pre><code><b>struct</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+ the ID of this bag
+</dd>
+<dt>
+<code>size: u64</code>
+</dt>
+<dd>
+ the number of key-value pairs in the bag
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_object_bag_EBagNotEmpty"></a>
+
+
+
+<pre><code><b>const</b> <a href="object_bag.md#0x2_object_bag_EBagNotEmpty">EBagNotEmpty</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_object_bag_new"></a>
+
+## Function `new`
+
+Creates a new, empty bag
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_new">new</a>(ctx: &<b>mut</b> TxContext): <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a> {
+    <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        size: 0,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_bag_add"></a>
+
+## Function `add`
+
+Adds a key-value pair to the bag <code><a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a></code>
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the bag already has an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_add">add</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>, k: K, v: V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_add">add</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a>, k: K, v: V) {
+    ofield::add(&<b>mut</b> <a href="bag.md#0x2_bag">bag</a>.id, k, v);
+    <a href="bag.md#0x2_bag">bag</a>.size = <a href="bag.md#0x2_bag">bag</a>.size + 1;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_bag_borrow"></a>
+
+## Function `borrow`
+
+Immutably borrows the value associated with the key in the bag <code><a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a></code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>, k: K): &V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a>, k: K): &V {
+    ofield::borrow(&<a href="bag.md#0x2_bag">bag</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_bag_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Mutably borrows the value associated with the key in the bag <code><a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a></code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>, k: K): &<b>mut</b> V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a>, k: K): &<b>mut</b> V {
+    ofield::borrow_mut(&<b>mut</b> <a href="bag.md#0x2_bag">bag</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_bag_remove"></a>
+
+## Function `remove`
+
+Mutably borrows the key-value pair in the bag <code><a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a></code> and returns the value.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>, k: K): V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a>, k: K): V {
+    <b>let</b> v = ofield::remove(&<b>mut</b> <a href="bag.md#0x2_bag">bag</a>.id, k);
+    <a href="bag.md#0x2_bag">bag</a>.size = <a href="bag.md#0x2_bag">bag</a>.size - 1;
+    v
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_bag_contains"></a>
+
+## Function `contains`
+
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_contains">contains</a>&lt;K: <b>copy</b>, drop, store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>, k: K): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_contains">contains</a>&lt;K: <b>copy</b> + drop + store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a>, k: K): bool {
+    ofield::exists_&lt;K&gt;(&<a href="bag.md#0x2_bag">bag</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_bag_contains_with_type"></a>
+
+## Function `contains_with_type`
+
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a></code>
+with an assigned value of type <code>V</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>, k: K): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a>, k: K): bool {
+    ofield::exists_with_type&lt;K, V&gt;(&<a href="bag.md#0x2_bag">bag</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_bag_length"></a>
+
+## Function `length`
+
+Returns the size of the bag, the number of key-value pairs
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_length">length</a>(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_length">length</a>(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a>): u64 {
+    <a href="bag.md#0x2_bag">bag</a>.size
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_bag_is_empty"></a>
+
+## Function `is_empty`
+
+Returns true iff the bag is empty (if <code>length</code> returns <code>0</code>)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_is_empty">is_empty</a>(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_is_empty">is_empty</a>(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a>): bool {
+    <a href="bag.md#0x2_bag">bag</a>.size == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_bag_destroy_empty"></a>
+
+## Function `destroy_empty`
+
+Destroys an empty bag
+Aborts with <code><a href="object_bag.md#0x2_object_bag_EBagNotEmpty">EBagNotEmpty</a></code> if the bag still contains values
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_destroy_empty">destroy_empty</a>(<a href="bag.md#0x2_bag">bag</a>: <a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_destroy_empty">destroy_empty</a>(<a href="bag.md#0x2_bag">bag</a>: <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a>) {
+    <b>let</b> <a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a> { id, size } = <a href="bag.md#0x2_bag">bag</a>;
+    <b>assert</b>!(size == 0, <a href="object_bag.md#0x2_object_bag_EBagNotEmpty">EBagNotEmpty</a>);
+    <a href="object.md#0x2_object_delete">object::delete</a>(id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_bag_value_id"></a>
+
+## Function `value_id`
+
+Returns the ID of the object associated with the key if the bag has an entry with key <code>k: K</code>
+Returns none otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_value_id">value_id</a>&lt;K: <b>copy</b>, drop, store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">object_bag::ObjectBag</a>, k: K): <a href="_Option">option::Option</a>&lt;<a href="object.md#0x2_object_ID">object::ID</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_bag.md#0x2_object_bag_value_id">value_id</a>&lt;K: <b>copy</b> + drop + store&gt;(<a href="bag.md#0x2_bag">bag</a>: &<a href="object_bag.md#0x2_object_bag_ObjectBag">ObjectBag</a>, k: K): Option&lt;ID&gt; {
+    ofield::id(&<a href="bag.md#0x2_bag">bag</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/object_table.md
+++ b/crates/sui-framework-override/docs/object_table.md
@@ -1,0 +1,354 @@
+
+<a name="0x2_object_table"></a>
+
+# Module `0x2::object_table`
+
+Similar to <code>sui::table</code>, an <code><a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code> is a map-like collection. But unlike
+<code>sui::table</code>, the values bound to these dynamic fields _must_ be objects themselves. This allows
+for the objects to still exist within in storage, which may be important for external tools.
+The difference is otherwise not observable from within Move.
+
+
+-  [Resource `ObjectTable`](#0x2_object_table_ObjectTable)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x2_object_table_new)
+-  [Function `add`](#0x2_object_table_add)
+-  [Function `borrow`](#0x2_object_table_borrow)
+-  [Function `borrow_mut`](#0x2_object_table_borrow_mut)
+-  [Function `remove`](#0x2_object_table_remove)
+-  [Function `contains`](#0x2_object_table_contains)
+-  [Function `length`](#0x2_object_table_length)
+-  [Function `is_empty`](#0x2_object_table_is_empty)
+-  [Function `destroy_empty`](#0x2_object_table_destroy_empty)
+-  [Function `value_id`](#0x2_object_table_value_id)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="dynamic_object_field.md#0x2_dynamic_object_field">0x2::dynamic_object_field</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_object_table_ObjectTable"></a>
+
+## Resource `ObjectTable`
+
+
+
+<pre><code><b>struct</b> <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt; <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+ the ID of this table
+</dd>
+<dt>
+<code>size: u64</code>
+</dt>
+<dd>
+ the number of key-value pairs in the table
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_object_table_ETableNotEmpty"></a>
+
+
+
+<pre><code><b>const</b> <a href="object_table.md#0x2_object_table_ETableNotEmpty">ETableNotEmpty</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_object_table_new"></a>
+
+## Function `new`
+
+Creates a new, empty table
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_new">new</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object_table.md#0x2_object_table_ObjectTable">object_table::ObjectTable</a>&lt;K, V&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_new">new</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(ctx: &<b>mut</b> TxContext): <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt; {
+    <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        size: 0,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_table_add"></a>
+
+## Function `add`
+
+Adds a key-value pair to the table <code><a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the table already has an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_add">add</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="object_table.md#0x2_object_table_ObjectTable">object_table::ObjectTable</a>&lt;K, V&gt;, k: K, v: V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_add">add</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K, v: V) {
+    ofield::add(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, k, v);
+    <a href="table.md#0x2_table">table</a>.size = <a href="table.md#0x2_table">table</a>.size + 1;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_table_borrow"></a>
+
+## Function `borrow`
+
+Immutable borrows the value associated with the key in the table <code><a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">object_table::ObjectTable</a>&lt;K, V&gt;, k: K): &V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K): &V {
+    ofield::borrow(&<a href="table.md#0x2_table">table</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_table_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Mutably borrows the value associated with the key in the table <code><a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="object_table.md#0x2_object_table_ObjectTable">object_table::ObjectTable</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(
+    <a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;,
+    k: K,
+): &<b>mut</b> V {
+    ofield::borrow_mut(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_table_remove"></a>
+
+## Function `remove`
+
+Removes the key-value pair in the table <code><a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code> and returns the value.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="object_table.md#0x2_object_table_ObjectTable">object_table::ObjectTable</a>&lt;K, V&gt;, k: K): V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K): V {
+    <b>let</b> v = ofield::remove(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, k);
+    <a href="table.md#0x2_table">table</a>.size = <a href="table.md#0x2_table">table</a>.size - 1;
+    v
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_table_contains"></a>
+
+## Function `contains`
+
+Returns true iff there is a value associated with the key <code>k: K</code> in table
+<code><a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_contains">contains</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">object_table::ObjectTable</a>&lt;K, V&gt;, k: K): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_contains">contains</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K): bool {
+    ofield::exists_&lt;K&gt;(&<a href="table.md#0x2_table">table</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_table_length"></a>
+
+## Function `length`
+
+Returns the size of the table, the number of key-value pairs
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_length">length</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">object_table::ObjectTable</a>&lt;K, V&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_length">length</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;): u64 {
+    <a href="table.md#0x2_table">table</a>.size
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_table_is_empty"></a>
+
+## Function `is_empty`
+
+Returns true iff the table is empty (if <code>length</code> returns <code>0</code>)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">object_table::ObjectTable</a>&lt;K, V&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_is_empty">is_empty</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;): bool {
+    <a href="table.md#0x2_table">table</a>.size == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_table_destroy_empty"></a>
+
+## Function `destroy_empty`
+
+Destroys an empty table
+Aborts with <code><a href="object_table.md#0x2_object_table_ETableNotEmpty">ETableNotEmpty</a></code> if the table still contains values
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="table.md#0x2_table">table</a>: <a href="object_table.md#0x2_object_table_ObjectTable">object_table::ObjectTable</a>&lt;K, V&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="table.md#0x2_table">table</a>: <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a> { id, size } = <a href="table.md#0x2_table">table</a>;
+    <b>assert</b>!(size == 0, <a href="object_table.md#0x2_object_table_ETableNotEmpty">ETableNotEmpty</a>);
+    <a href="object.md#0x2_object_delete">object::delete</a>(id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_table_value_id"></a>
+
+## Function `value_id`
+
+Returns the ID of the object associated with the key if the table has an entry with key <code>k: K</code>
+Returns none otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_value_id">value_id</a>&lt;K: <b>copy</b>, drop, store, V: store, key&gt;(<a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">object_table::ObjectTable</a>&lt;K, V&gt;, k: K): <a href="_Option">option::Option</a>&lt;<a href="object.md#0x2_object_ID">object::ID</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_table.md#0x2_object_table_value_id">value_id</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(
+    <a href="table.md#0x2_table">table</a>: &<a href="object_table.md#0x2_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;,
+    k: K,
+): Option&lt;ID&gt; {
+    ofield::id(&<a href="table.md#0x2_table">table</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/pay.md
+++ b/crates/sui-framework-override/docs/pay.md
@@ -1,0 +1,273 @@
+
+<a name="0x2_pay"></a>
+
+# Module `0x2::pay`
+
+This module provides handy functionality for wallets and <code>sui::Coin</code> management.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `keep`](#0x2_pay_keep)
+-  [Function `split`](#0x2_pay_split)
+-  [Function `split_vec`](#0x2_pay_split_vec)
+-  [Function `split_and_transfer`](#0x2_pay_split_and_transfer)
+-  [Function `divide_and_keep`](#0x2_pay_divide_and_keep)
+-  [Function `join`](#0x2_pay_join)
+-  [Function `join_vec`](#0x2_pay_join_vec)
+-  [Function `join_vec_and_transfer`](#0x2_pay_join_vec_and_transfer)
+
+
+<pre><code><b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_pay_ENoCoins"></a>
+
+For when empty vector is supplied into join function.
+
+
+<pre><code><b>const</b> <a href="pay.md#0x2_pay_ENoCoins">ENoCoins</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_pay_keep"></a>
+
+## Function `keep`
+
+Transfer <code>c</code> to the sender of the current transaction
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_keep">keep</a>&lt;T&gt;(c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_keep">keep</a>&lt;T&gt;(c: Coin&lt;T&gt;, ctx: &TxContext) {
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(c, <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_pay_split"></a>
+
+## Function `split`
+
+Split coin <code>self</code> to two coins, one with balance <code>split_amount</code>,
+and the remaining balance is left is <code>self</code>.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split">split</a>&lt;T&gt;(
+    self: &<b>mut</b> Coin&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> TxContext
+) {
+    <a href="pay.md#0x2_pay_keep">keep</a>(<a href="coin.md#0x2_coin_split">coin::split</a>(self, split_amount, ctx), ctx)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_pay_split_vec"></a>
+
+## Function `split_vec`
+
+Split coin <code>self</code> into multiple coins, each with balance specified
+in <code>split_amounts</code>. Remaining balance is left in <code>self</code>.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_vec">split_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amounts: <a href="">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_vec">split_vec</a>&lt;T&gt;(
+    self: &<b>mut</b> Coin&lt;T&gt;, split_amounts: <a href="">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> TxContext
+) {
+    <b>let</b> (i, len) = (0, <a href="_length">vector::length</a>(&split_amounts));
+    <b>while</b> (i &lt; len) {
+        <a href="pay.md#0x2_pay_split">split</a>(self, *<a href="_borrow">vector::borrow</a>(&split_amounts, i), ctx);
+        i = i + 1;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_pay_split_and_transfer"></a>
+
+## Function `split_and_transfer`
+
+Send <code>amount</code> units of <code>c</code> to <code>recipient</code>
+Aborts with <code>EVALUE</code> if <code>amount</code> is greater than or equal to <code>amount</code>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_and_transfer">split_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_and_transfer">split_and_transfer</a>&lt;T&gt;(
+    c: &<b>mut</b> Coin&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> TxContext
+) {
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_split">coin::split</a>(c, amount, ctx), recipient)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_pay_divide_and_keep"></a>
+
+## Function `divide_and_keep`
+
+Divide coin <code>self</code> into <code>n - 1</code> coins with equal balances. If the balance is
+not evenly divisible by <code>n</code>, the remainder is left in <code>self</code>.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_divide_and_keep">divide_and_keep</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, n: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_divide_and_keep">divide_and_keep</a>&lt;T&gt;(
+    self: &<b>mut</b> Coin&lt;T&gt;, n: u64, ctx: &<b>mut</b> TxContext
+) {
+    <b>let</b> vec: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt; = <a href="coin.md#0x2_coin_divide_into_n">coin::divide_into_n</a>(self, n, ctx);
+    <b>let</b> (i, len) = (0, <a href="_length">vector::length</a>(&vec));
+    <b>while</b> (i &lt; len) {
+        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="_pop_back">vector::pop_back</a>(&<b>mut</b> vec), <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+        i = i + 1;
+    };
+    <a href="_destroy_empty">vector::destroy_empty</a>(vec);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_pay_join"></a>
+
+## Function `join`
+
+Join <code><a href="coin.md#0x2_coin">coin</a></code> into <code>self</code>. Re-exports <code><a href="coin.md#0x2_coin_join">coin::join</a></code> function.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, <a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, <a href="coin.md#0x2_coin">coin</a>: Coin&lt;T&gt;) {
+    <a href="coin.md#0x2_coin_join">coin::join</a>(self, <a href="coin.md#0x2_coin">coin</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_pay_join_vec"></a>
+
+## Function `join_vec`
+
+Join everything in <code>coins</code> with <code>self</code>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join_vec">join_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, coins: <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join_vec">join_vec</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, coins: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt;) {
+    <b>let</b> (i, len) = (0, <a href="_length">vector::length</a>(&coins));
+    <b>while</b> (i &lt; len) {
+        <b>let</b> <a href="coin.md#0x2_coin">coin</a> = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> coins);
+        <a href="coin.md#0x2_coin_join">coin::join</a>(self, <a href="coin.md#0x2_coin">coin</a>);
+        i = i + 1
+    };
+    // <a href="safe.md#0x2_safe">safe</a> because we've drained the <a href="">vector</a>
+    <a href="_destroy_empty">vector::destroy_empty</a>(coins)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_pay_join_vec_and_transfer"></a>
+
+## Function `join_vec_and_transfer`
+
+Join a vector of <code>Coin</code> into a single object and transfer it to <code>receiver</code>.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join_vec_and_transfer">join_vec_and_transfer</a>&lt;T&gt;(coins: <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;, receiver: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join_vec_and_transfer">join_vec_and_transfer</a>&lt;T&gt;(coins: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt;, receiver: <b>address</b>) {
+    <b>assert</b>!(<a href="_length">vector::length</a>(&coins) &gt; 0, <a href="pay.md#0x2_pay_ENoCoins">ENoCoins</a>);
+
+    <b>let</b> self = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> coins);
+    <a href="pay.md#0x2_pay_join_vec">join_vec</a>(&<b>mut</b> self, coins);
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(self, receiver)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/priority_queue.md
+++ b/crates/sui-framework-override/docs/priority_queue.md
@@ -1,0 +1,342 @@
+
+<a name="0x2_priority_queue"></a>
+
+# Module `0x2::priority_queue`
+
+Priority queue implemented using a max heap.
+
+
+-  [Struct `PriorityQueue`](#0x2_priority_queue_PriorityQueue)
+-  [Struct `Entry`](#0x2_priority_queue_Entry)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x2_priority_queue_new)
+-  [Function `pop_max`](#0x2_priority_queue_pop_max)
+-  [Function `insert`](#0x2_priority_queue_insert)
+-  [Function `new_entry`](#0x2_priority_queue_new_entry)
+-  [Function `create_entries`](#0x2_priority_queue_create_entries)
+-  [Function `restore_heap_recursive`](#0x2_priority_queue_restore_heap_recursive)
+-  [Function `max_heapify_recursive`](#0x2_priority_queue_max_heapify_recursive)
+
+
+<pre><code><b>use</b> <a href="">0x1::vector</a>;
+</code></pre>
+
+
+
+<a name="0x2_priority_queue_PriorityQueue"></a>
+
+## Struct `PriorityQueue`
+
+
+
+<pre><code><b>struct</b> <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T: drop&gt; <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>entries: <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">priority_queue::Entry</a>&lt;T&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_priority_queue_Entry"></a>
+
+## Struct `Entry`
+
+
+
+<pre><code><b>struct</b> <a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a>&lt;T: drop&gt; <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>priority: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>value: T</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_priority_queue_EPopFromEmptyHeap"></a>
+
+For when heap is empty and there's no data to pop.
+
+
+<pre><code><b>const</b> <a href="priority_queue.md#0x2_priority_queue_EPopFromEmptyHeap">EPopFromEmptyHeap</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_priority_queue_new"></a>
+
+## Function `new`
+
+Create a new priority queue from the entries.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_new">new</a>&lt;T: drop&gt;(entries: <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">priority_queue::Entry</a>&lt;T&gt;&gt;): <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">priority_queue::PriorityQueue</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_new">new</a>&lt;T: drop&gt;(entries: <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a>&lt;T&gt;&gt;) : <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt; {
+    <b>let</b> len = <a href="_length">vector::length</a>(&entries);
+    <b>let</b> i = len / 2;
+    <b>while</b> (i &gt; 0) {
+        i = i - 1;
+        <a href="priority_queue.md#0x2_priority_queue_max_heapify_recursive">max_heapify_recursive</a>(&<b>mut</b> entries, len, i);
+    };
+    <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a> { entries }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_priority_queue_pop_max"></a>
+
+## Function `pop_max`
+
+Pop the entry with the highest priority value.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_pop_max">pop_max</a>&lt;T: drop&gt;(pq: &<b>mut</b> <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">priority_queue::PriorityQueue</a>&lt;T&gt;): (u64, T)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_pop_max">pop_max</a>&lt;T: drop&gt;(pq: &<b>mut</b> <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt;) : (u64, T) {
+    <b>let</b> len = <a href="_length">vector::length</a>(&pq.entries);
+    <b>assert</b>!(len &gt; 0, <a href="priority_queue.md#0x2_priority_queue_EPopFromEmptyHeap">EPopFromEmptyHeap</a>);
+    <b>let</b> <a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a> { priority, value } = <a href="_remove">vector::remove</a>(&<b>mut</b> pq.entries, 0);
+    <a href="priority_queue.md#0x2_priority_queue_max_heapify_recursive">max_heapify_recursive</a>(&<b>mut</b> pq.entries, len - 1, 0);
+    (priority, value)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_priority_queue_insert"></a>
+
+## Function `insert`
+
+Insert a new entry into the queue.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_insert">insert</a>&lt;T: drop&gt;(pq: &<b>mut</b> <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">priority_queue::PriorityQueue</a>&lt;T&gt;, priority: u64, value: T)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_insert">insert</a>&lt;T: drop&gt;(pq: &<b>mut</b> <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt;, priority: u64, value: T) {
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> pq.entries, <a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a> { priority, value});
+    <b>let</b> index = <a href="_length">vector::length</a>(&pq.entries) - 1;
+    <a href="priority_queue.md#0x2_priority_queue_restore_heap_recursive">restore_heap_recursive</a>(&<b>mut</b> pq.entries, index);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_priority_queue_new_entry"></a>
+
+## Function `new_entry`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_new_entry">new_entry</a>&lt;T: drop&gt;(priority: u64, value: T): <a href="priority_queue.md#0x2_priority_queue_Entry">priority_queue::Entry</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_new_entry">new_entry</a>&lt;T: drop&gt;(priority: u64, value: T): <a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a>&lt;T&gt; {
+    <a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a> { priority, value }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_priority_queue_create_entries"></a>
+
+## Function `create_entries`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_create_entries">create_entries</a>&lt;T: drop&gt;(p: <a href="">vector</a>&lt;u64&gt;, v: <a href="">vector</a>&lt;T&gt;): <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">priority_queue::Entry</a>&lt;T&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_create_entries">create_entries</a>&lt;T: drop&gt;(p: <a href="">vector</a>&lt;u64&gt;, v: <a href="">vector</a>&lt;T&gt;): <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a>&lt;T&gt;&gt; {
+    <b>let</b> len = <a href="_length">vector::length</a>(&p);
+    <b>assert</b>!(<a href="_length">vector::length</a>(&v) == len, 0);
+    <b>let</b> res = <a href="_empty">vector::empty</a>();
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; len) {
+        <b>let</b> priority = <a href="_remove">vector::remove</a>(&<b>mut</b> p, 0);
+        <b>let</b> value = <a href="_remove">vector::remove</a>(&<b>mut</b> v, 0);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, <a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a> { priority, value });
+        i = i + 1;
+    };
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_priority_queue_restore_heap_recursive"></a>
+
+## Function `restore_heap_recursive`
+
+
+
+<pre><code><b>fun</b> <a href="priority_queue.md#0x2_priority_queue_restore_heap_recursive">restore_heap_recursive</a>&lt;T: drop&gt;(v: &<b>mut</b> <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">priority_queue::Entry</a>&lt;T&gt;&gt;, i: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="priority_queue.md#0x2_priority_queue_restore_heap_recursive">restore_heap_recursive</a>&lt;T: drop&gt;(v: &<b>mut</b> <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a>&lt;T&gt;&gt;, i: u64) {
+    <b>if</b> (i == 0) {
+        <b>return</b>
+    };
+    <b>let</b> parent = (i - 1) / 2;
+
+    // If new elem is greater than its parent, swap them and recursively
+    // do the restoration upwards.
+    <b>if</b> (<a href="_borrow">vector::borrow</a>(v, i).priority &gt; <a href="_borrow">vector::borrow</a>(v, parent).priority) {
+        <a href="_swap">vector::swap</a>(v, i, parent);
+        <a href="priority_queue.md#0x2_priority_queue_restore_heap_recursive">restore_heap_recursive</a>(v, parent);
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_priority_queue_max_heapify_recursive"></a>
+
+## Function `max_heapify_recursive`
+
+
+
+<pre><code><b>fun</b> <a href="priority_queue.md#0x2_priority_queue_max_heapify_recursive">max_heapify_recursive</a>&lt;T: drop&gt;(v: &<b>mut</b> <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">priority_queue::Entry</a>&lt;T&gt;&gt;, len: u64, i: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="priority_queue.md#0x2_priority_queue_max_heapify_recursive">max_heapify_recursive</a>&lt;T: drop&gt;(v: &<b>mut</b> <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a>&lt;T&gt;&gt;, len: u64, i: u64) {
+    <b>if</b> (len == 0) {
+        <b>return</b>
+    };
+    <b>assert</b>!(i &lt; len, 1);
+    <b>let</b> left = i * 2 + 1;
+    <b>let</b> right = left + 1;
+    <b>let</b> max = i;
+    <b>if</b> (left &lt; len && <a href="_borrow">vector::borrow</a>(v, left).priority&gt; <a href="_borrow">vector::borrow</a>(v, max).priority) {
+        max = left;
+    };
+    <b>if</b> (right &lt; len && <a href="_borrow">vector::borrow</a>(v, right).priority &gt; <a href="_borrow">vector::borrow</a>(v, max).priority) {
+        max = right;
+    };
+    <b>if</b> (max != i) {
+        <a href="_swap">vector::swap</a>(v, max, i);
+        <a href="priority_queue.md#0x2_priority_queue_max_heapify_recursive">max_heapify_recursive</a>(v, len, max);
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/publisher.md
+++ b/crates/sui-framework-override/docs/publisher.md
@@ -1,0 +1,282 @@
+
+<a name="0x2_publisher"></a>
+
+# Module `0x2::publisher`
+
+Module that allows creation and proof of publishing.
+Based on the type name reflection; requires an OTW to claim
+in the module initializer.
+
+
+-  [Resource `Publisher`](#0x2_publisher_Publisher)
+-  [Constants](#@Constants_0)
+-  [Function `claim`](#0x2_publisher_claim)
+-  [Function `claim_and_keep`](#0x2_publisher_claim_and_keep)
+-  [Function `burn`](#0x2_publisher_burn)
+-  [Function `is_package`](#0x2_publisher_is_package)
+-  [Function `is_module`](#0x2_publisher_is_module)
+-  [Function `module_name`](#0x2_publisher_module_name)
+-  [Function `package`](#0x2_publisher_package)
+
+
+<pre><code><b>use</b> <a href="">0x1::ascii</a>;
+<b>use</b> <a href="">0x1::type_name</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+<b>use</b> <a href="types.md#0x2_types">0x2::types</a>;
+</code></pre>
+
+
+
+<a name="0x2_publisher_Publisher"></a>
+
+## Resource `Publisher`
+
+This type can only be created in the transaction that
+generates a module, by consuming its one-time witness, so it
+can be used to identify the address that published the package
+a type originated from.
+
+
+<pre><code><b>struct</b> <a href="publisher.md#0x2_publisher_Publisher">Publisher</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>package: <a href="_String">ascii::String</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>module_name: <a href="_String">ascii::String</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_publisher_ENotOneTimeWitness"></a>
+
+Tried to claim ownership using a type that isn't a one-time witness.
+
+
+<pre><code><b>const</b> <a href="publisher.md#0x2_publisher_ENotOneTimeWitness">ENotOneTimeWitness</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_publisher_claim"></a>
+
+## Function `claim`
+
+Claim a Publisher object.
+Requires a One-Time-Witness to prove ownership. Due to this constraint
+there can be only one Publisher object per module but multiple per package (!).
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_claim">claim</a>&lt;OTW: drop&gt;(otw: OTW, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="publisher.md#0x2_publisher_Publisher">publisher::Publisher</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_claim">claim</a>&lt;OTW: drop&gt;(otw: OTW, ctx: &<b>mut</b> TxContext): <a href="publisher.md#0x2_publisher_Publisher">Publisher</a> {
+    <b>assert</b>!(<a href="types.md#0x2_types_is_one_time_witness">types::is_one_time_witness</a>(&otw), <a href="publisher.md#0x2_publisher_ENotOneTimeWitness">ENotOneTimeWitness</a>);
+
+    <b>let</b> type = <a href="_get">type_name::get</a>&lt;OTW&gt;();
+
+    <a href="publisher.md#0x2_publisher_Publisher">Publisher</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        package: <a href="_get_address">type_name::get_address</a>(&type),
+        module_name: <a href="_get_module">type_name::get_module</a>(&type),
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_publisher_claim_and_keep"></a>
+
+## Function `claim_and_keep`
+
+Claim a Publisher object and send it to transaction sender.
+Since this function can only be called in the module initializer,
+the sender is the publisher.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_claim_and_keep">claim_and_keep</a>&lt;OTW: drop&gt;(otw: OTW, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_claim_and_keep">claim_and_keep</a>&lt;OTW: drop&gt;(otw: OTW, ctx: &<b>mut</b> TxContext) {
+    sui::transfer::transfer(<a href="publisher.md#0x2_publisher_claim">claim</a>(otw, ctx), sender(ctx))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_publisher_burn"></a>
+
+## Function `burn`
+
+Destroy a Publisher object effectively removing all privileges
+associated with it.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_burn">burn</a>(self: <a href="publisher.md#0x2_publisher_Publisher">publisher::Publisher</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_burn">burn</a>(self: <a href="publisher.md#0x2_publisher_Publisher">Publisher</a>) {
+    <b>let</b> <a href="publisher.md#0x2_publisher_Publisher">Publisher</a> { id, package: _, module_name: _ } = self;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_publisher_is_package"></a>
+
+## Function `is_package`
+
+Check whether type belongs to the same package as the publisher object.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_is_package">is_package</a>&lt;T&gt;(self: &<a href="publisher.md#0x2_publisher_Publisher">publisher::Publisher</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_is_package">is_package</a>&lt;T&gt;(self: &<a href="publisher.md#0x2_publisher_Publisher">Publisher</a>): bool {
+    <b>let</b> type = <a href="_get">type_name::get</a>&lt;T&gt;();
+
+    (<a href="_get_address">type_name::get_address</a>(&type) == self.package)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_publisher_is_module"></a>
+
+## Function `is_module`
+
+Check whether a type belogs to the same module as the publisher object.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_is_module">is_module</a>&lt;T&gt;(self: &<a href="publisher.md#0x2_publisher_Publisher">publisher::Publisher</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_is_module">is_module</a>&lt;T&gt;(self: &<a href="publisher.md#0x2_publisher_Publisher">Publisher</a>): bool {
+    <b>let</b> type = <a href="_get">type_name::get</a>&lt;T&gt;();
+
+    (<a href="_get_address">type_name::get_address</a>(&type) == self.package)
+        && (<a href="_get_module">type_name::get_module</a>(&type) == self.module_name)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_publisher_module_name"></a>
+
+## Function `module_name`
+
+Read the name of the module.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_module_name">module_name</a>(self: &<a href="publisher.md#0x2_publisher_Publisher">publisher::Publisher</a>): &<a href="_String">ascii::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_module_name">module_name</a>(self: &<a href="publisher.md#0x2_publisher_Publisher">Publisher</a>): &String {
+    &self.module_name
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_publisher_package"></a>
+
+## Function `package`
+
+Read the package address string.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_package">package</a>(self: &<a href="publisher.md#0x2_publisher_Publisher">publisher::Publisher</a>): &<a href="_String">ascii::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="publisher.md#0x2_publisher_package">package</a>(self: &<a href="publisher.md#0x2_publisher_Publisher">Publisher</a>): &String {
+    &self.package
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/safe.md
+++ b/crates/sui-framework-override/docs/safe.md
@@ -1,0 +1,625 @@
+
+<a name="0x2_safe"></a>
+
+# Module `0x2::safe`
+
+The Safe standard is a minimalistic shared wrapper around a coin. It provides a way for users to provide third-party dApps with
+the capability to transfer coins away from their wallets, if they are provided with the correct permission.
+
+
+-  [Resource `Safe`](#0x2_safe_Safe)
+-  [Resource `OwnerCapability`](#0x2_safe_OwnerCapability)
+-  [Resource `TransferCapability`](#0x2_safe_TransferCapability)
+-  [Constants](#@Constants_0)
+-  [Function `check_capability_validity`](#0x2_safe_check_capability_validity)
+-  [Function `check_owner_capability_validity`](#0x2_safe_check_owner_capability_validity)
+-  [Function `create_capability_`](#0x2_safe_create_capability_)
+-  [Function `balance`](#0x2_safe_balance)
+-  [Function `create_`](#0x2_safe_create_)
+-  [Function `create`](#0x2_safe_create)
+-  [Function `create_empty`](#0x2_safe_create_empty)
+-  [Function `deposit_`](#0x2_safe_deposit_)
+-  [Function `deposit`](#0x2_safe_deposit)
+-  [Function `withdraw_`](#0x2_safe_withdraw_)
+-  [Function `withdraw`](#0x2_safe_withdraw)
+-  [Function `debit`](#0x2_safe_debit)
+-  [Function `revoke_transfer_capability`](#0x2_safe_revoke_transfer_capability)
+-  [Function `self_revoke_transfer_capability`](#0x2_safe_self_revoke_transfer_capability)
+-  [Function `create_transfer_capability`](#0x2_safe_create_transfer_capability)
+
+
+<pre><code><b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+<b>use</b> <a href="vec_set.md#0x2_vec_set">0x2::vec_set</a>;
+</code></pre>
+
+
+
+<a name="0x2_safe_Safe"></a>
+
+## Resource `Safe`
+
+Allows any holder of a capability to transfer a fixed amount of assets from the safe.
+Useful in situations like an NFT marketplace where you wish to buy the NFTs at a specific price.
+
+@ownership: Shared
+
+
+
+<pre><code><b>struct</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt; <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>allowed_safes: <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<a href="object.md#0x2_object_ID">object::ID</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_safe_OwnerCapability"></a>
+
+## Resource `OwnerCapability`
+
+
+
+<pre><code><b>struct</b> <a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a>&lt;T&gt; <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>safe_id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_safe_TransferCapability"></a>
+
+## Resource `TransferCapability`
+
+
+Allows the owner of the capability to take <code>amount</code> of coins from the box.
+
+@ownership: Owned
+
+
+<pre><code><b>struct</b> <a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a>&lt;T&gt; <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>safe_id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_safe_INVALID_OWNER_CAPABILITY"></a>
+
+
+
+<pre><code><b>const</b> <a href="safe.md#0x2_safe_INVALID_OWNER_CAPABILITY">INVALID_OWNER_CAPABILITY</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_safe_INVALID_TRANSFER_CAPABILITY"></a>
+
+
+
+<pre><code><b>const</b> <a href="safe.md#0x2_safe_INVALID_TRANSFER_CAPABILITY">INVALID_TRANSFER_CAPABILITY</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_safe_MAX_CAPABILITY_ISSUABLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="safe.md#0x2_safe_MAX_CAPABILITY_ISSUABLE">MAX_CAPABILITY_ISSUABLE</a>: u64 = 1000;
+</code></pre>
+
+
+
+<a name="0x2_safe_OVERDRAWN"></a>
+
+
+
+<pre><code><b>const</b> <a href="safe.md#0x2_safe_OVERDRAWN">OVERDRAWN</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_safe_TRANSFER_CAPABILITY_REVOKED"></a>
+
+
+
+<pre><code><b>const</b> <a href="safe.md#0x2_safe_TRANSFER_CAPABILITY_REVOKED">TRANSFER_CAPABILITY_REVOKED</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_safe_check_capability_validity"></a>
+
+## Function `check_capability_validity`
+
+HELPER FUNCTIONS
+Check that the capability has not yet been revoked by the owner.
+
+
+<pre><code><b>fun</b> <a href="safe.md#0x2_safe_check_capability_validity">check_capability_validity</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_TransferCapability">safe::TransferCapability</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="safe.md#0x2_safe_check_capability_validity">check_capability_validity</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a>&lt;T&gt;) {
+    // Check that the ids match
+    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(<a href="safe.md#0x2_safe">safe</a>) == capability.safe_id, <a href="safe.md#0x2_safe_INVALID_TRANSFER_CAPABILITY">INVALID_TRANSFER_CAPABILITY</a>);
+    // Check that it <b>has</b> not been cancelled
+    <b>assert</b>!(<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(&<a href="safe.md#0x2_safe">safe</a>.allowed_safes, &<a href="object.md#0x2_object_id">object::id</a>(capability)), <a href="safe.md#0x2_safe_TRANSFER_CAPABILITY_REVOKED">TRANSFER_CAPABILITY_REVOKED</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_check_owner_capability_validity"></a>
+
+## Function `check_owner_capability_validity`
+
+
+
+<pre><code><b>fun</b> <a href="safe.md#0x2_safe_check_owner_capability_validity">check_owner_capability_validity</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">safe::OwnerCapability</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="safe.md#0x2_safe_check_owner_capability_validity">check_owner_capability_validity</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a>&lt;T&gt;) {
+    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(<a href="safe.md#0x2_safe">safe</a>) == capability.safe_id, <a href="safe.md#0x2_safe_INVALID_OWNER_CAPABILITY">INVALID_OWNER_CAPABILITY</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_create_capability_"></a>
+
+## Function `create_capability_`
+
+Helper function to create a capability.
+
+
+<pre><code><b>fun</b> <a href="safe.md#0x2_safe_create_capability_">create_capability_</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, withdraw_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="safe.md#0x2_safe_TransferCapability">safe::TransferCapability</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="safe.md#0x2_safe_create_capability_">create_capability_</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, withdraw_amount: u64, ctx: &<b>mut</b> TxContext): <a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a>&lt;T&gt; {
+    <b>let</b> cap_id = <a href="object.md#0x2_object_new">object::new</a>(ctx);
+    <a href="vec_set.md#0x2_vec_set_insert">vec_set::insert</a>(&<b>mut</b> <a href="safe.md#0x2_safe">safe</a>.allowed_safes, <a href="object.md#0x2_object_uid_to_inner">object::uid_to_inner</a>(&cap_id));
+
+    <b>let</b> capability = <a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a> {
+        id: cap_id,
+        safe_id: <a href="object.md#0x2_object_uid_to_inner">object::uid_to_inner</a>(&<a href="safe.md#0x2_safe">safe</a>.id),
+        amount: withdraw_amount,
+    };
+
+    capability
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_balance"></a>
+
+## Function `balance`
+
+PUBLIC FUNCTIONS
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance">balance</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;): &<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="balance.md#0x2_balance">balance</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;): &Balance&lt;T&gt; {
+    &<a href="safe.md#0x2_safe">safe</a>.<a href="balance.md#0x2_balance">balance</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_create_"></a>
+
+## Function `create_`
+
+Wrap a coin around a safe.
+a trusted party (or smart contract) to transfer the object out.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="safe.md#0x2_safe_create_">create_</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="safe.md#0x2_safe_OwnerCapability">safe::OwnerCapability</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="safe.md#0x2_safe_create_">create_</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: Balance&lt;T&gt;, ctx: &<b>mut</b> TxContext): <a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a>&lt;T&gt; {
+    <b>let</b> <a href="safe.md#0x2_safe">safe</a> = <a href="safe.md#0x2_safe_Safe">Safe</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        <a href="balance.md#0x2_balance">balance</a>,
+        allowed_safes: <a href="vec_set.md#0x2_vec_set_empty">vec_set::empty</a>(),
+    };
+    <b>let</b> cap = <a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        safe_id: <a href="object.md#0x2_object_id">object::id</a>(&<a href="safe.md#0x2_safe">safe</a>),
+    };
+    <a href="transfer.md#0x2_transfer_share_object">transfer::share_object</a>(<a href="safe.md#0x2_safe">safe</a>);
+    cap
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_create"></a>
+
+## Function `create`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_create">create</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_create">create</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: Coin&lt;T&gt;, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(<a href="coin.md#0x2_coin">coin</a>);
+    <b>let</b> cap = <a href="safe.md#0x2_safe_create_">create_</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>, ctx);
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(cap, sender(ctx));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_create_empty"></a>
+
+## Function `create_empty`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_create_empty">create_empty</a>&lt;T&gt;(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_create_empty">create_empty</a>&lt;T&gt;(ctx: &<b>mut</b> TxContext) {
+    <b>let</b> empty_balance = <a href="balance.md#0x2_balance_zero">balance::zero</a>&lt;T&gt;();
+    <b>let</b> cap = <a href="safe.md#0x2_safe_create_">create_</a>(empty_balance, ctx);
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(cap, sender(ctx));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_deposit_"></a>
+
+## Function `deposit_`
+
+Deposit funds to the safe
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="safe.md#0x2_safe_deposit_">deposit_</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="safe.md#0x2_safe_deposit_">deposit_</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, <a href="balance.md#0x2_balance">balance</a>: Balance&lt;T&gt;) {
+    <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> <a href="safe.md#0x2_safe">safe</a>.<a href="balance.md#0x2_balance">balance</a>, <a href="balance.md#0x2_balance">balance</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_deposit"></a>
+
+## Function `deposit`
+
+Deposit funds to the safe
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_deposit">deposit</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, <a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_deposit">deposit</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, <a href="coin.md#0x2_coin">coin</a>: Coin&lt;T&gt;) {
+    <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(<a href="coin.md#0x2_coin">coin</a>);
+    <a href="safe.md#0x2_safe_deposit_">deposit_</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>, <a href="balance.md#0x2_balance">balance</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_withdraw_"></a>
+
+## Function `withdraw_`
+
+Withdraw coins from the safe as a <code><a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a></code> holder
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="safe.md#0x2_safe_withdraw_">withdraw_</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">safe::OwnerCapability</a>&lt;T&gt;, withdraw_amount: u64): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="safe.md#0x2_safe_withdraw_">withdraw_</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a>&lt;T&gt;, withdraw_amount: u64): Balance&lt;T&gt; {
+    // Ensures that only the owner can withdraw from the <a href="safe.md#0x2_safe">safe</a>.
+    <a href="safe.md#0x2_safe_check_owner_capability_validity">check_owner_capability_validity</a>(<a href="safe.md#0x2_safe">safe</a>, capability);
+    <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> <a href="safe.md#0x2_safe">safe</a>.<a href="balance.md#0x2_balance">balance</a>, withdraw_amount)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_withdraw"></a>
+
+## Function `withdraw`
+
+Withdraw coins from the safe as a <code><a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a></code> holder
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_withdraw">withdraw</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">safe::OwnerCapability</a>&lt;T&gt;, withdraw_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_withdraw">withdraw</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a>&lt;T&gt;, withdraw_amount: u64, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="safe.md#0x2_safe_withdraw_">withdraw_</a>(<a href="safe.md#0x2_safe">safe</a>, capability, withdraw_amount);
+    <b>let</b> <a href="coin.md#0x2_coin">coin</a> = <a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(<a href="balance.md#0x2_balance">balance</a>, ctx);
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin">coin</a>, sender(ctx));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_debit"></a>
+
+## Function `debit`
+
+Withdraw coins from the safe as a <code><a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a></code> holder.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="safe.md#0x2_safe_debit">debit</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, capability: &<b>mut</b> <a href="safe.md#0x2_safe_TransferCapability">safe::TransferCapability</a>&lt;T&gt;, withdraw_amount: u64): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="safe.md#0x2_safe_debit">debit</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<b>mut</b> <a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a>&lt;T&gt;, withdraw_amount: u64): Balance&lt;T&gt; {
+    // Check the validity of the capability
+    <a href="safe.md#0x2_safe_check_capability_validity">check_capability_validity</a>(<a href="safe.md#0x2_safe">safe</a>, capability);
+
+    // Withdraw funds
+    <b>assert</b>!(capability.amount &gt;= withdraw_amount, <a href="safe.md#0x2_safe_OVERDRAWN">OVERDRAWN</a>);
+    capability.amount = capability.amount - withdraw_amount;
+    <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> <a href="safe.md#0x2_safe">safe</a>.<a href="balance.md#0x2_balance">balance</a>, withdraw_amount)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_revoke_transfer_capability"></a>
+
+## Function `revoke_transfer_capability`
+
+Revoke a <code><a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a></code> as an <code><a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a></code> holder
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_revoke_transfer_capability">revoke_transfer_capability</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">safe::OwnerCapability</a>&lt;T&gt;, capability_id: <a href="object.md#0x2_object_ID">object::ID</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_revoke_transfer_capability">revoke_transfer_capability</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a>&lt;T&gt;, capability_id: ID) {
+    // Ensures that only the owner can withdraw from the <a href="safe.md#0x2_safe">safe</a>.
+    <a href="safe.md#0x2_safe_check_owner_capability_validity">check_owner_capability_validity</a>(<a href="safe.md#0x2_safe">safe</a>, capability);
+    <a href="vec_set.md#0x2_vec_set_remove">vec_set::remove</a>(&<b>mut</b> <a href="safe.md#0x2_safe">safe</a>.allowed_safes, &capability_id);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_self_revoke_transfer_capability"></a>
+
+## Function `self_revoke_transfer_capability`
+
+Revoke a <code><a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a></code> as its owner
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_self_revoke_transfer_capability">self_revoke_transfer_capability</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_TransferCapability">safe::TransferCapability</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_self_revoke_transfer_capability">self_revoke_transfer_capability</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a>&lt;T&gt;) {
+    <a href="safe.md#0x2_safe_check_capability_validity">check_capability_validity</a>(<a href="safe.md#0x2_safe">safe</a>, capability);
+    <a href="vec_set.md#0x2_vec_set_remove">vec_set::remove</a>(&<b>mut</b> <a href="safe.md#0x2_safe">safe</a>.allowed_safes, &<a href="object.md#0x2_object_id">object::id</a>(capability));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_safe_create_transfer_capability"></a>
+
+## Function `create_transfer_capability`
+
+Create <code><a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a></code> as an <code><a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a></code> holder
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="safe.md#0x2_safe_create_transfer_capability">create_transfer_capability</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">safe::Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">safe::OwnerCapability</a>&lt;T&gt;, withdraw_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="safe.md#0x2_safe_TransferCapability">safe::TransferCapability</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="safe.md#0x2_safe_create_transfer_capability">create_transfer_capability</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a>&lt;T&gt;, withdraw_amount: u64, ctx: &<b>mut</b> TxContext): <a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a>&lt;T&gt; {
+    // Ensures that only the owner can withdraw from the <a href="safe.md#0x2_safe">safe</a>.
+    <a href="safe.md#0x2_safe_check_owner_capability_validity">check_owner_capability_validity</a>(<a href="safe.md#0x2_safe">safe</a>, capability);
+    <a href="safe.md#0x2_safe_create_capability_">create_capability_</a>(<a href="safe.md#0x2_safe">safe</a>, withdraw_amount, ctx)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/stake.md
+++ b/crates/sui-framework-override/docs/stake.md
@@ -1,0 +1,229 @@
+
+<a name="0x2_stake"></a>
+
+# Module `0x2::stake`
+
+
+
+-  [Resource `Stake`](#0x2_stake_Stake)
+-  [Constants](#@Constants_0)
+-  [Function `create`](#0x2_stake_create)
+-  [Function `withdraw_stake`](#0x2_stake_withdraw_stake)
+-  [Function `burn`](#0x2_stake_burn)
+-  [Function `value`](#0x2_stake_value)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
+<b>use</b> <a href="locked_coin.md#0x2_locked_coin">0x2::locked_coin</a>;
+<b>use</b> <a href="math.md#0x2_math">0x2::math</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_stake_Stake"></a>
+
+## Resource `Stake`
+
+A custodial stake object holding the staked SUI coin.
+
+
+<pre><code><b>struct</b> <a href="stake.md#0x2_stake_Stake">Stake</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+ The staked SUI tokens.
+</dd>
+<dt>
+<code>locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;</code>
+</dt>
+<dd>
+ The epoch until which the staked coin is locked. If the stake
+ comes from a Coin<SUI>, this field is None. If it comes from a LockedCoin<SUI>, this
+ field will record the original lock expiration epoch, to be used when unstaking.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_stake_BONDING_PERIOD"></a>
+
+The number of epochs the withdrawn stake is locked for.
+TODO: this is a placehodler number and may be changed.
+
+
+<pre><code><b>const</b> <a href="stake.md#0x2_stake_BONDING_PERIOD">BONDING_PERIOD</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_stake_ENONZERO_BALANCE"></a>
+
+Error number for when a Stake with nonzero balance is burnt.
+
+
+<pre><code><b>const</b> <a href="stake.md#0x2_stake_ENONZERO_BALANCE">ENONZERO_BALANCE</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_stake_create"></a>
+
+## Function `create`
+
+Create a stake object from a SUI balance. If the balance comes from a
+<code>LockedCoin</code>, an EpochTimeLock is passed in to keep track of locking period.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x2_stake_create">create</a>(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, recipient: <b>address</b>, locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x2_stake_create">create</a>(
+    <a href="balance.md#0x2_balance">balance</a>: Balance&lt;SUI&gt;,
+    recipient: <b>address</b>,
+    locked_until_epoch: Option&lt;EpochTimeLock&gt;,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> <a href="stake.md#0x2_stake">stake</a> = <a href="stake.md#0x2_stake_Stake">Stake</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        <a href="balance.md#0x2_balance">balance</a>,
+        locked_until_epoch,
+    };
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="stake.md#0x2_stake">stake</a>, recipient)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_stake_withdraw_stake"></a>
+
+## Function `withdraw_stake`
+
+Withdraw <code>amount</code> from the balance of <code><a href="stake.md#0x2_stake">stake</a></code>.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x2_stake_withdraw_stake">withdraw_stake</a>(self: &<b>mut</b> <a href="stake.md#0x2_stake_Stake">stake::Stake</a>, amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x2_stake_withdraw_stake">withdraw_stake</a>(
+    self: &<b>mut</b> <a href="stake.md#0x2_stake_Stake">Stake</a>,
+    amount: u64,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> sender = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> unlock_epoch = <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + <a href="stake.md#0x2_stake_BONDING_PERIOD">BONDING_PERIOD</a>;
+    <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> self.<a href="balance.md#0x2_balance">balance</a>, amount);
+
+    <b>if</b> (<a href="_is_none">option::is_none</a>(&self.locked_until_epoch)) {
+        // If the <a href="stake.md#0x2_stake">stake</a> didn't come from a locked <a href="coin.md#0x2_coin">coin</a>, we give back the <a href="stake.md#0x2_stake">stake</a> and
+        // lock the <a href="coin.md#0x2_coin">coin</a> for `<a href="stake.md#0x2_stake_BONDING_PERIOD">BONDING_PERIOD</a>`.
+        <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(<a href="balance.md#0x2_balance">balance</a>, <a href="epoch_time_lock.md#0x2_epoch_time_lock_new">epoch_time_lock::new</a>(unlock_epoch, ctx), sender, ctx);
+    } <b>else</b> {
+        // If the <a href="stake.md#0x2_stake">stake</a> did come from a locked <a href="coin.md#0x2_coin">coin</a>, we lock the <a href="coin.md#0x2_coin">coin</a> for
+        // max(<a href="stake.md#0x2_stake_BONDING_PERIOD">BONDING_PERIOD</a>, remaining_lock_time).
+        <b>let</b> original_unlock_epoch = <a href="epoch_time_lock.md#0x2_epoch_time_lock_epoch">epoch_time_lock::epoch</a>(<a href="_borrow">option::borrow</a>(&self.locked_until_epoch));
+        <b>let</b> unlock_epoch = <a href="math.md#0x2_math_max">math::max</a>(original_unlock_epoch, unlock_epoch);
+        <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(<a href="balance.md#0x2_balance">balance</a>, <a href="epoch_time_lock.md#0x2_epoch_time_lock_new">epoch_time_lock::new</a>(unlock_epoch, ctx), sender, ctx);
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_stake_burn"></a>
+
+## Function `burn`
+
+Burn the stake object. This can be done only when the stake has a zero balance.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="stake.md#0x2_stake_burn">burn</a>(self: <a href="stake.md#0x2_stake_Stake">stake::Stake</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="stake.md#0x2_stake_burn">burn</a>(self: <a href="stake.md#0x2_stake_Stake">Stake</a>, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> <a href="stake.md#0x2_stake_Stake">Stake</a> { id, <a href="balance.md#0x2_balance">balance</a>, locked_until_epoch } = self;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(<a href="balance.md#0x2_balance">balance</a>);
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&locked_until_epoch)) {
+        <a href="epoch_time_lock.md#0x2_epoch_time_lock_destroy">epoch_time_lock::destroy</a>(<a href="_extract">option::extract</a>(&<b>mut</b> locked_until_epoch), ctx);
+    };
+    <a href="_destroy_none">option::destroy_none</a>(locked_until_epoch);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_stake_value"></a>
+
+## Function `value`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="stake.md#0x2_stake_value">value</a>(self: &<a href="stake.md#0x2_stake_Stake">stake::Stake</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="stake.md#0x2_stake_value">value</a>(self: &<a href="stake.md#0x2_stake_Stake">Stake</a>): u64 {
+    <a href="balance.md#0x2_balance_value">balance::value</a>(&self.<a href="balance.md#0x2_balance">balance</a>)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/stake_subsidy.md
+++ b/crates/sui-framework-override/docs/stake_subsidy.md
@@ -1,0 +1,238 @@
+
+<a name="0x2_stake_subsidy"></a>
+
+# Module `0x2::stake_subsidy`
+
+
+
+-  [Struct `StakeSubsidy`](#0x2_stake_subsidy_StakeSubsidy)
+-  [Constants](#@Constants_0)
+-  [Function `create`](#0x2_stake_subsidy_create)
+-  [Function `mint_stake_subsidy_proportional_to_total_stake_testnet`](#0x2_stake_subsidy_mint_stake_subsidy_proportional_to_total_stake_testnet)
+-  [Function `advance_epoch`](#0x2_stake_subsidy_advance_epoch)
+-  [Function `withdraw_all`](#0x2_stake_subsidy_withdraw_all)
+-  [Function `current_epoch_subsidy_amount`](#0x2_stake_subsidy_current_epoch_subsidy_amount)
+
+
+<pre><code><b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+</code></pre>
+
+
+
+<a name="0x2_stake_subsidy_StakeSubsidy"></a>
+
+## Struct `StakeSubsidy`
+
+
+
+<pre><code><b>struct</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>epoch_counter: u64</code>
+</dt>
+<dd>
+ This counter may be different from the current epoch number if
+ in some epochs we decide to skip the subsidy.
+</dd>
+<dt>
+<code><a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+ Balance storing the accumulated stake subsidy.
+</dd>
+<dt>
+<code>current_epoch_amount: u64</code>
+</dt>
+<dd>
+ The amount of stake subsidy to be minted this epoch.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_stake_subsidy_BASIS_POINT_DENOMINATOR"></a>
+
+
+
+<pre><code><b>const</b> <a href="stake_subsidy.md#0x2_stake_subsidy_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>: u128 = 10000;
+</code></pre>
+
+
+
+<a name="0x2_stake_subsidy_STAKE_SUBSIDY_DECREASE_RATE"></a>
+
+
+
+<pre><code><b>const</b> <a href="stake_subsidy.md#0x2_stake_subsidy_STAKE_SUBSIDY_DECREASE_RATE">STAKE_SUBSIDY_DECREASE_RATE</a>: u128 = 1000;
+</code></pre>
+
+
+
+<a name="0x2_stake_subsidy_STAKE_SUBSIDY_PERIOD_LENGTH"></a>
+
+
+
+<pre><code><b>const</b> <a href="stake_subsidy.md#0x2_stake_subsidy_STAKE_SUBSIDY_PERIOD_LENGTH">STAKE_SUBSIDY_PERIOD_LENGTH</a>: u64 = 30;
+</code></pre>
+
+
+
+<a name="0x2_stake_subsidy_create"></a>
+
+## Function `create`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_create">create</a>(initial_stake_subsidy_amount: u64): <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_create">create</a>(initial_stake_subsidy_amount: u64): <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a> {
+    <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a> {
+        epoch_counter: 0,
+        <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_zero">balance::zero</a>(),
+        current_epoch_amount: initial_stake_subsidy_amount,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_stake_subsidy_mint_stake_subsidy_proportional_to_total_stake_testnet"></a>
+
+## Function `mint_stake_subsidy_proportional_to_total_stake_testnet`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_mint_stake_subsidy_proportional_to_total_stake_testnet">mint_stake_subsidy_proportional_to_total_stake_testnet</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>, supply: &<b>mut</b> <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, stake_subsidy_rate: u64, total_stake: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_mint_stake_subsidy_proportional_to_total_stake_testnet">mint_stake_subsidy_proportional_to_total_stake_testnet</a>(
+    subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a>, supply: &<b>mut</b> Supply&lt;SUI&gt;, stake_subsidy_rate: u64, total_stake: u64
+) {
+    <b>let</b> amount_to_mint = ((total_stake <b>as</b> u128) * (stake_subsidy_rate <b>as</b> u128)) / <a href="stake_subsidy.md#0x2_stake_subsidy_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
+    <a href="balance.md#0x2_balance_join">balance::join</a>(
+        &<b>mut</b> subsidy.<a href="balance.md#0x2_balance">balance</a>,
+        <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(supply, (amount_to_mint <b>as</b> u64))
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_stake_subsidy_advance_epoch"></a>
+
+## Function `advance_epoch`
+
+Advance the epoch counter and mint new subsidy for the epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_advance_epoch">advance_epoch</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>, supply: &<b>mut</b> <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_advance_epoch">advance_epoch</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a>, supply: &<b>mut</b> Supply&lt;SUI&gt;) {
+    // Mint new subsidy for this epoch.
+    <a href="balance.md#0x2_balance_join">balance::join</a>(
+        &<b>mut</b> subsidy.<a href="balance.md#0x2_balance">balance</a>,
+        <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(supply, subsidy.current_epoch_amount)
+    );
+    subsidy.epoch_counter = subsidy.epoch_counter + 1;
+    // Decrease the subsidy amount only when the current period ends.
+    <b>if</b> (subsidy.epoch_counter % <a href="stake_subsidy.md#0x2_stake_subsidy_STAKE_SUBSIDY_PERIOD_LENGTH">STAKE_SUBSIDY_PERIOD_LENGTH</a> == 0) {
+        <b>let</b> decrease_amount = (subsidy.current_epoch_amount <b>as</b> u128)
+            * <a href="stake_subsidy.md#0x2_stake_subsidy_STAKE_SUBSIDY_DECREASE_RATE">STAKE_SUBSIDY_DECREASE_RATE</a> / <a href="stake_subsidy.md#0x2_stake_subsidy_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
+        subsidy.current_epoch_amount = subsidy.current_epoch_amount - (decrease_amount <b>as</b> u64)
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_stake_subsidy_withdraw_all"></a>
+
+## Function `withdraw_all`
+
+Withdraw all the minted stake subsidy.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_withdraw_all">withdraw_all</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_withdraw_all">withdraw_all</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a>): Balance&lt;SUI&gt; {
+    <b>let</b> amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&subsidy.<a href="balance.md#0x2_balance">balance</a>);
+    <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> subsidy.<a href="balance.md#0x2_balance">balance</a>, amount)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_stake_subsidy_current_epoch_subsidy_amount"></a>
+
+## Function `current_epoch_subsidy_amount`
+
+Returns the amount of stake subsidy to be added at the end of the current epoch.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_current_epoch_subsidy_amount">current_epoch_subsidy_amount</a>(subsidy: &<a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_current_epoch_subsidy_amount">current_epoch_subsidy_amount</a>(subsidy: &<a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a>): u64 {
+    subsidy.current_epoch_amount
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/staking_pool.md
+++ b/crates/sui-framework-override/docs/staking_pool.md
@@ -1,0 +1,1395 @@
+
+<a name="0x2_staking_pool"></a>
+
+# Module `0x2::staking_pool`
+
+
+
+-  [Struct `StakingPool`](#0x2_staking_pool_StakingPool)
+-  [Struct `PoolTokenExchangeRate`](#0x2_staking_pool_PoolTokenExchangeRate)
+-  [Resource `InactiveStakingPool`](#0x2_staking_pool_InactiveStakingPool)
+-  [Struct `DelegationToken`](#0x2_staking_pool_DelegationToken)
+-  [Struct `PendingDelegationEntry`](#0x2_staking_pool_PendingDelegationEntry)
+-  [Struct `PendingWithdrawEntry`](#0x2_staking_pool_PendingWithdrawEntry)
+-  [Resource `Delegation`](#0x2_staking_pool_Delegation)
+-  [Resource `StakedSui`](#0x2_staking_pool_StakedSui)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x2_staking_pool_new)
+-  [Function `request_add_delegation`](#0x2_staking_pool_request_add_delegation)
+-  [Function `request_withdraw_delegation`](#0x2_staking_pool_request_withdraw_delegation)
+-  [Function `cancel_delegation_request`](#0x2_staking_pool_cancel_delegation_request)
+-  [Function `withdraw_from_principal`](#0x2_staking_pool_withdraw_from_principal)
+-  [Function `destroy_delegation_and_return_pool_tokens`](#0x2_staking_pool_destroy_delegation_and_return_pool_tokens)
+-  [Function `unwrap_staked_sui`](#0x2_staking_pool_unwrap_staked_sui)
+-  [Function `deposit_rewards`](#0x2_staking_pool_deposit_rewards)
+-  [Function `process_pending_delegation_withdraws`](#0x2_staking_pool_process_pending_delegation_withdraws)
+-  [Function `process_pending_delegations`](#0x2_staking_pool_process_pending_delegations)
+-  [Function `batch_withdraw_rewards_and_burn_pool_tokens`](#0x2_staking_pool_batch_withdraw_rewards_and_burn_pool_tokens)
+-  [Function `withdraw_rewards_and_burn_pool_tokens`](#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens)
+-  [Function `mint_delegation_tokens_to_delegator`](#0x2_staking_pool_mint_delegation_tokens_to_delegator)
+-  [Function `deactivate_staking_pool`](#0x2_staking_pool_deactivate_staking_pool)
+-  [Function `withdraw_from_inactive_pool`](#0x2_staking_pool_withdraw_from_inactive_pool)
+-  [Function `destroy_empty_delegation`](#0x2_staking_pool_destroy_empty_delegation)
+-  [Function `destroy_empty_staked_sui`](#0x2_staking_pool_destroy_empty_staked_sui)
+-  [Function `sui_balance`](#0x2_staking_pool_sui_balance)
+-  [Function `validator_address`](#0x2_staking_pool_validator_address)
+-  [Function `staked_sui_amount`](#0x2_staking_pool_staked_sui_amount)
+-  [Function `delegation_request_epoch`](#0x2_staking_pool_delegation_request_epoch)
+-  [Function `delegation_token_amount`](#0x2_staking_pool_delegation_token_amount)
+-  [Function `pool_token_exchange_rate`](#0x2_staking_pool_pool_token_exchange_rate)
+-  [Function `new_pending_withdraw_entry`](#0x2_staking_pool_new_pending_withdraw_entry)
+-  [Function `get_sui_amount`](#0x2_staking_pool_get_sui_amount)
+-  [Function `get_token_amount`](#0x2_staking_pool_get_token_amount)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
+<b>use</b> <a href="linked_table.md#0x2_linked_table">0x2::linked_table</a>;
+<b>use</b> <a href="locked_coin.md#0x2_locked_coin">0x2::locked_coin</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="table_vec.md#0x2_table_vec">0x2::table_vec</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_StakingPool"></a>
+
+## Struct `StakingPool`
+
+A staking pool embedded in each validator struct in the system state object.
+
+
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>validator_address: <b>address</b></code>
+</dt>
+<dd>
+ The sui address of the validator associated with this pool.
+</dd>
+<dt>
+<code>starting_epoch: u64</code>
+</dt>
+<dd>
+ The epoch at which this pool started operating. Should be the epoch at which the validator became active.
+</dd>
+<dt>
+<code>sui_balance: u64</code>
+</dt>
+<dd>
+ The total number of SUI tokens in this pool, including the SUI in the rewards_pool, as well as in all the principal
+ in the <code><a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a></code> object, updated at epoch boundaries.
+</dd>
+<dt>
+<code>rewards_pool: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+ The epoch delegation rewards will be added here at the end of each epoch.
+</dd>
+<dt>
+<code>delegation_token_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;</code>
+</dt>
+<dd>
+ The number of delegation pool tokens we have issued so far. This number should equal the sum of
+ pool token balance in all the <code><a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a></code> objects delegated to this pool. Updated at epoch boundaries.
+</dd>
+<dt>
+<code>pending_delegations: <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;<a href="object.md#0x2_object_ID">object::ID</a>, <a href="staking_pool.md#0x2_staking_pool_PendingDelegationEntry">staking_pool::PendingDelegationEntry</a>&gt;</code>
+</dt>
+<dd>
+ Delegations requested during the current epoch. We will activate these delegation at the end of current epoch
+ and distribute staking pool tokens at the end-of-epoch exchange rate after the rewards for the current epoch
+ have been deposited.
+</dd>
+<dt>
+<code>pending_withdraws: <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;<a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">staking_pool::PendingWithdrawEntry</a>&gt;</code>
+</dt>
+<dd>
+ Delegation withdraws requested during the current epoch. Similar to new delegation, the withdraws are processed
+ at epoch boundaries. Rewards are withdrawn and distributed after the rewards for the current epoch have come in.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_staking_pool_PoolTokenExchangeRate"></a>
+
+## Struct `PoolTokenExchangeRate`
+
+Struct representing the exchange rate of the delegation pool token to SUI.
+
+
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>sui_amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>pool_token_amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_staking_pool_InactiveStakingPool"></a>
+
+## Resource `InactiveStakingPool`
+
+An inactive staking pool associated with an inactive validator.
+Only withdraws can be made from this pool.
+
+
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_InactiveStakingPool">InactiveStakingPool</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>pool: <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_staking_pool_DelegationToken"></a>
+
+## Struct `DelegationToken`
+
+The staking pool token.
+
+
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a> <b>has</b> drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_staking_pool_PendingDelegationEntry"></a>
+
+## Struct `PendingDelegationEntry`
+
+Struct representing a pending delegation.
+
+
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_PendingDelegationEntry">PendingDelegationEntry</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>delegator: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>sui_amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_staking_pool_PendingWithdrawEntry"></a>
+
+## Struct `PendingWithdrawEntry`
+
+Struct representing a pending delegation withdraw.
+
+
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>delegator: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>principal_withdraw_amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>withdrawn_pool_tokens: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_staking_pool_Delegation"></a>
+
+## Resource `Delegation`
+
+A self-custodial delegation object, serving as evidence that the delegator
+has delegated to a staking pool.
+
+
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>staked_sui_id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+ The ID of the corresponding <code><a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a></code> object.
+</dd>
+<dt>
+<code>pool_tokens: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;</code>
+</dt>
+<dd>
+ The pool tokens representing the amount of rewards the delegator can get back when they withdraw
+ from the pool.
+</dd>
+<dt>
+<code>principal_sui_amount: u64</code>
+</dt>
+<dd>
+ Number of SUI token staked originally.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_staking_pool_StakedSui"></a>
+
+## Resource `StakedSui`
+
+A self-custodial object holding the staked SUI tokens.
+
+
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>validator_address: <b>address</b></code>
+</dt>
+<dd>
+ The validator we are staking with.
+</dd>
+<dt>
+<code>pool_starting_epoch: u64</code>
+</dt>
+<dd>
+ The epoch at which the staking pool started operating.
+</dd>
+<dt>
+<code>delegation_request_epoch: u64</code>
+</dt>
+<dd>
+ The epoch at which the delegation is requested.
+</dd>
+<dt>
+<code>principal: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+ The staked SUI tokens.
+</dd>
+<dt>
+<code>sui_token_lock: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;</code>
+</dt>
+<dd>
+ If the stake comes from a Coin<SUI>, this field is None. If it comes from a LockedCoin<SUI>, this
+ field will record the original lock expiration epoch, to be used when unstaking.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_staking_pool_EDESTROY_NON_ZERO_BALANCE"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EDESTROY_NON_ZERO_BALANCE">EDESTROY_NON_ZERO_BALANCE</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_EINSUFFICIENT_POOL_TOKEN_BALANCE"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EINSUFFICIENT_POOL_TOKEN_BALANCE">EINSUFFICIENT_POOL_TOKEN_BALANCE</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_EINSUFFICIENT_REWARDS_POOL_BALANCE"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EINSUFFICIENT_REWARDS_POOL_BALANCE">EINSUFFICIENT_REWARDS_POOL_BALANCE</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_EINSUFFICIENT_SUI_TOKEN_BALANCE"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EINSUFFICIENT_SUI_TOKEN_BALANCE">EINSUFFICIENT_SUI_TOKEN_BALANCE</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_EPENDING_DELEGATION_DOES_NOT_EXIST"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EPENDING_DELEGATION_DOES_NOT_EXIST">EPENDING_DELEGATION_DOES_NOT_EXIST</a>: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_ETOKEN_TIME_LOCK_IS_SOME"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_ETOKEN_TIME_LOCK_IS_SOME">ETOKEN_TIME_LOCK_IS_SOME</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_EWITHDRAW_AMOUNT_CANNOT_BE_ZERO"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWITHDRAW_AMOUNT_CANNOT_BE_ZERO">EWITHDRAW_AMOUNT_CANNOT_BE_ZERO</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_EWRONG_DELEGATION"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWRONG_DELEGATION">EWRONG_DELEGATION</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_EWRONG_POOL"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWRONG_POOL">EWRONG_POOL</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_new"></a>
+
+## Function `new`
+
+Create a new, empty staking pool.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(validator_address: <b>address</b>, starting_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(validator_address: <b>address</b>, starting_epoch: u64, ctx: &<b>mut</b> TxContext) : <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> {
+    <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> {
+        validator_address,
+        starting_epoch,
+        sui_balance: 0,
+        rewards_pool: <a href="balance.md#0x2_balance_zero">balance::zero</a>(),
+        delegation_token_supply: <a href="balance.md#0x2_balance_create_supply">balance::create_supply</a>(<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a> {}),
+        pending_delegations: <a href="linked_table.md#0x2_linked_table_new">linked_table::new</a>(ctx),
+        pending_withdraws: <a href="table_vec.md#0x2_table_vec_empty">table_vec::empty</a>(ctx),
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_request_add_delegation"></a>
+
+## Function `request_add_delegation`
+
+Request to delegate to a staking pool. The delegation gets counted at the beginning of the next epoch,
+when the delegation object containing the pool tokens is distributed to the delegator.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_add_delegation">request_add_delegation</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, <a href="stake.md#0x2_stake">stake</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, sui_token_lock: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, delegator: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_add_delegation">request_add_delegation</a>(
+    pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
+    <a href="stake.md#0x2_stake">stake</a>: Balance&lt;SUI&gt;,
+    sui_token_lock: Option&lt;EpochTimeLock&gt;,
+    delegator: <b>address</b>,
+    ctx: &<b>mut</b> TxContext
+) {
+    <b>let</b> sui_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&<a href="stake.md#0x2_stake">stake</a>);
+    <b>assert</b>!(sui_amount &gt; 0, 0);
+    <b>let</b> staked_sui = <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        validator_address: pool.validator_address,
+        pool_starting_epoch: pool.starting_epoch,
+        delegation_request_epoch: <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
+        principal: <a href="stake.md#0x2_stake">stake</a>,
+        sui_token_lock,
+    };
+    // insert delegation info into the pending_delegations <a href="table.md#0x2_table">table</a>.
+    <a href="linked_table.md#0x2_linked_table_push_back">linked_table::push_back</a>(
+        &<b>mut</b> pool.pending_delegations,
+        <a href="object.md#0x2_object_id">object::id</a>(&staked_sui),
+        <a href="staking_pool.md#0x2_staking_pool_PendingDelegationEntry">PendingDelegationEntry</a> { delegator, sui_amount }
+    );
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(staked_sui, delegator);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_request_withdraw_delegation"></a>
+
+## Function `request_withdraw_delegation`
+
+Request to withdraw <code>principal_withdraw_amount</code> of stake plus rewards from a staking pool.
+This amount of principal in SUI is withdrawn and transferred to the delegator. A proportional amount
+of pool tokens will be later burnt.
+The rewards portion will be withdrawn at the end of the epoch, after the rewards have come in so we
+can use the new exchange rate to calculate the rewards.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_withdraw_delegation">request_withdraw_delegation</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_withdraw_delegation">request_withdraw_delegation</a>(
+    pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
+    delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>,
+    staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>,
+    ctx: &<b>mut</b> TxContext
+) : u64 {
+    <b>let</b> (withdrawn_pool_tokens, principal_withdraw, time_lock) =
+        <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(pool, delegation, staked_sui);
+
+    <b>let</b> delegator = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> principal_withdraw_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&principal_withdraw);
+    <a href="table_vec.md#0x2_table_vec_push_back">table_vec::push_back</a>(&<b>mut</b> pool.pending_withdraws, <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> {
+        delegator, principal_withdraw_amount, withdrawn_pool_tokens });
+
+    // TODO: implement withdraw bonding period here.
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&time_lock)) {
+        <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(principal_withdraw, <a href="_destroy_some">option::destroy_some</a>(time_lock), delegator, ctx);
+    } <b>else</b> {
+        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(principal_withdraw, ctx), delegator);
+        <a href="_destroy_none">option::destroy_none</a>(time_lock);
+    };
+    principal_withdraw_amount
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_cancel_delegation_request"></a>
+
+## Function `cancel_delegation_request`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_cancel_delegation_request">cancel_delegation_request</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_cancel_delegation_request">cancel_delegation_request</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> delegator = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> staked_sui_id = <a href="object.md#0x2_object_id">object::id</a>(&staked_sui);
+    <b>assert</b>!(<a href="linked_table.md#0x2_linked_table_contains">linked_table::contains</a>(&<b>mut</b> pool.pending_delegations, staked_sui_id), <a href="staking_pool.md#0x2_staking_pool_EPENDING_DELEGATION_DOES_NOT_EXIST">EPENDING_DELEGATION_DOES_NOT_EXIST</a>);
+
+    <a href="linked_table.md#0x2_linked_table_remove">linked_table::remove</a>(&<b>mut</b> pool.pending_delegations, staked_sui_id);
+
+    <b>let</b> <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a> {
+        id,
+        validator_address,
+        pool_starting_epoch,
+        delegation_request_epoch: _,
+        principal,
+        sui_token_lock
+    } = staked_sui;
+
+    // sanity check that the <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a> is indeed from this pool. Should never fail.
+    <b>assert</b>!(
+        validator_address == pool.validator_address &&
+        pool_starting_epoch == pool.starting_epoch,
+        <a href="staking_pool.md#0x2_staking_pool_EWRONG_POOL">EWRONG_POOL</a>
+    );
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&sui_token_lock)) {
+        <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(principal, <a href="_destroy_some">option::destroy_some</a>(sui_token_lock), delegator, ctx);
+    } <b>else</b> {
+        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(principal, ctx), delegator);
+        <a href="_destroy_none">option::destroy_none</a>(sui_token_lock);
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_withdraw_from_principal"></a>
+
+## Function `withdraw_from_principal`
+
+Withdraw the requested amount of the principal SUI stored in the StakedSui object, as
+well as a proportional amount of pool tokens from the delegation object.
+For example, suppose the delegation object contains 15 pool tokens and the principal SUI
+amount is 21. Then if <code>principal_withdraw_amount</code> is 7, 5 pool tokens and 7 SUI tokens will
+be withdrawn.
+Returns values are withdrawn pool tokens, withdrawn principal portion of SUI, and its
+time lock if applicable.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): (<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;, <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(
+    pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
+    delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>,
+    staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>,
+) : (Balance&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a>&gt;, Balance&lt;SUI&gt;, Option&lt;EpochTimeLock&gt;) {
+    // Check that the delegation and staked <a href="sui.md#0x2_sui">sui</a> objects match.
+    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(&staked_sui) == delegation.staked_sui_id, <a href="staking_pool.md#0x2_staking_pool_EWRONG_DELEGATION">EWRONG_DELEGATION</a>);
+
+    // Check that the delegation information matches the pool.
+    <b>assert</b>!(
+        staked_sui.validator_address == pool.validator_address &&
+        staked_sui.pool_starting_epoch == pool.starting_epoch,
+        <a href="staking_pool.md#0x2_staking_pool_EWRONG_POOL">EWRONG_POOL</a>
+    );
+
+    <b>assert</b>!(delegation.principal_sui_amount == <a href="balance.md#0x2_balance_value">balance::value</a>(&staked_sui.principal), <a href="staking_pool.md#0x2_staking_pool_EINSUFFICIENT_SUI_TOKEN_BALANCE">EINSUFFICIENT_SUI_TOKEN_BALANCE</a>);
+
+    <b>let</b> pool_tokens = <a href="staking_pool.md#0x2_staking_pool_destroy_delegation_and_return_pool_tokens">destroy_delegation_and_return_pool_tokens</a>(delegation);
+    <b>let</b> (principal_withdraw, time_lock) = <a href="staking_pool.md#0x2_staking_pool_unwrap_staked_sui">unwrap_staked_sui</a>(staked_sui);
+
+    (
+        pool_tokens,
+        principal_withdraw,
+        time_lock
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_destroy_delegation_and_return_pool_tokens"></a>
+
+## Function `destroy_delegation_and_return_pool_tokens`
+
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_delegation_and_return_pool_tokens">destroy_delegation_and_return_pool_tokens</a>(delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_delegation_and_return_pool_tokens">destroy_delegation_and_return_pool_tokens</a>(delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>): Balance&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a>&gt; {
+    <b>let</b> <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a> { id, staked_sui_id: _, pool_tokens, principal_sui_amount: _ } = delegation;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    pool_tokens
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_unwrap_staked_sui"></a>
+
+## Function `unwrap_staked_sui`
+
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_unwrap_staked_sui">unwrap_staked_sui</a>(staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): (<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_unwrap_staked_sui">unwrap_staked_sui</a>(staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>): (Balance&lt;SUI&gt;, Option&lt;EpochTimeLock&gt;) {
+    <b>let</b> <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a> {
+        id,
+        validator_address: _,
+        pool_starting_epoch: _,
+        delegation_request_epoch: _,
+        principal,
+        sui_token_lock
+    } = staked_sui;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    (principal, sui_token_lock)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_deposit_rewards"></a>
+
+## Function `deposit_rewards`
+
+Called at epoch advancement times to add rewards (in SUI) to the staking pool.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deposit_rewards">deposit_rewards</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, rewards: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deposit_rewards">deposit_rewards</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, rewards: Balance&lt;SUI&gt;) {
+    pool.sui_balance = pool.sui_balance + <a href="balance.md#0x2_balance_value">balance::value</a>(&rewards);
+    <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> pool.rewards_pool, rewards);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_process_pending_delegation_withdraws"></a>
+
+## Function `process_pending_delegation_withdraws`
+
+Called at epoch boundaries to process pending delegation withdraws requested during the epoch.
+For each pending withdraw entry, we withdraw the rewards from the pool at the new exchange rate and burn the pool
+tokens.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation_withdraws">process_pending_delegation_withdraws</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation_withdraws">process_pending_delegation_withdraws</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, ctx: &<b>mut</b> TxContext) : u64 {
+    <b>let</b> total_reward_withdraw = 0;
+
+    <b>while</b> (!<a href="table_vec.md#0x2_table_vec_is_empty">table_vec::is_empty</a>(&pool.pending_withdraws)) {
+        <b>let</b> <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> {
+            delegator, principal_withdraw_amount, withdrawn_pool_tokens
+        } = <a href="table_vec.md#0x2_table_vec_pop_back">table_vec::pop_back</a>(&<b>mut</b> pool.pending_withdraws);
+        <b>let</b> reward_withdraw = <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(pool, principal_withdraw_amount, withdrawn_pool_tokens);
+        total_reward_withdraw = total_reward_withdraw + <a href="balance.md#0x2_balance_value">balance::value</a>(&reward_withdraw);
+        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(reward_withdraw, ctx), delegator);
+    };
+    total_reward_withdraw
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_process_pending_delegations"></a>
+
+## Function `process_pending_delegations`
+
+Called at epoch boundaries to mint new pool tokens to new delegators at the new exchange rate.
+New delegators include both entirely new delegations and delegations switched to this staking pool
+during the previous epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegations">process_pending_delegations</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegations">process_pending_delegations</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, ctx: &<b>mut</b> TxContext) {
+    <b>while</b> (!<a href="linked_table.md#0x2_linked_table_is_empty">linked_table::is_empty</a>(&pool.pending_delegations)) {
+        <b>let</b> (staked_sui_id, <a href="staking_pool.md#0x2_staking_pool_PendingDelegationEntry">PendingDelegationEntry</a> { delegator, sui_amount }) =
+            <a href="linked_table.md#0x2_linked_table_pop_back">linked_table::pop_back</a>(&<b>mut</b> pool.pending_delegations);
+        <a href="staking_pool.md#0x2_staking_pool_mint_delegation_tokens_to_delegator">mint_delegation_tokens_to_delegator</a>(pool, delegator, sui_amount, staked_sui_id, ctx);
+        pool.sui_balance = pool.sui_balance + sui_amount;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_batch_withdraw_rewards_and_burn_pool_tokens"></a>
+
+## Function `batch_withdraw_rewards_and_burn_pool_tokens`
+
+Called by validator_set at epoch boundaries for delegation switches.
+This function goes through the provided vector of pending withdraw entries,
+and for each entry, calls <code>withdraw_rewards_and_burn_pool_tokens</code> to withdraw
+the rewards portion of the delegation and burn the pool tokens. We then aggregate
+the delegator addresses and their rewards into vectors, as well as calculate
+the total amount of rewards SUI withdrawn. These three return values are then
+used in <code><a href="validator_set.md#0x2_validator_set">validator_set</a></code>'s delegation switching code to deposit the rewards part
+into the new validator's staking pool.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_batch_withdraw_rewards_and_burn_pool_tokens">batch_withdraw_rewards_and_burn_pool_tokens</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, entries: <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;<a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">staking_pool::PendingWithdrawEntry</a>&gt;): (<a href="">vector</a>&lt;<b>address</b>&gt;, <a href="">vector</a>&lt;<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;&gt;, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_batch_withdraw_rewards_and_burn_pool_tokens">batch_withdraw_rewards_and_burn_pool_tokens</a>(
+    pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
+    entries: TableVec&lt;<a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a>&gt;,
+) : (<a href="">vector</a>&lt;<b>address</b>&gt;, <a href="">vector</a>&lt;Balance&lt;SUI&gt;&gt;, u64) {
+    <b>let</b> (delegators, rewards, total_rewards_withdraw_amount) = (<a href="_empty">vector::empty</a>(), <a href="_empty">vector::empty</a>(), 0);
+    <b>while</b> (!<a href="table_vec.md#0x2_table_vec_is_empty">table_vec::is_empty</a>(&<b>mut</b> entries)) {
+        <b>let</b> <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> { delegator, principal_withdraw_amount, withdrawn_pool_tokens }
+            = <a href="table_vec.md#0x2_table_vec_pop_back">table_vec::pop_back</a>(&<b>mut</b> entries);
+        <b>let</b> reward = <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(pool, principal_withdraw_amount, withdrawn_pool_tokens);
+        total_rewards_withdraw_amount = total_rewards_withdraw_amount + <a href="balance.md#0x2_balance_value">balance::value</a>(&reward);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> delegators, delegator);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> rewards, reward);
+    };
+    <a href="table_vec.md#0x2_table_vec_destroy_empty">table_vec::destroy_empty</a>(entries);
+    (delegators, rewards, total_rewards_withdraw_amount)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens"></a>
+
+## Function `withdraw_rewards_and_burn_pool_tokens`
+
+This function does the following:
+1. Calculates the total amount of SUI (including principal and rewards) that the provided pool tokens represent
+at the current exchange rate.
+2. Using the above number and the given <code>principal_withdraw_amount</code>, calculates the rewards portion of the
+delegation we should withdraw.
+3. Withdraws the rewards portion from the rewards pool at the current exchange rate. We only withdraw the rewards
+portion because the principal portion was already taken out of the delegator's self custodied StakedSui at request
+time in <code>request_withdraw_stake</code>.
+4. Since SUI tokens are withdrawn, we need to burn the corresponding pool tokens to keep the exchange rate the same.
+5. Updates the SUI balance amount of the pool.
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, principal_withdraw_amount: u64, withdrawn_pool_tokens: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(
+    pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
+    principal_withdraw_amount: u64,
+    withdrawn_pool_tokens: Balance&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a>&gt;,
+) : Balance&lt;SUI&gt; {
+    <b>let</b> pool_token_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&withdrawn_pool_tokens);
+    <b>let</b> total_sui_withdraw_amount = <a href="staking_pool.md#0x2_staking_pool_get_sui_amount">get_sui_amount</a>(pool, pool_token_amount);
+    <b>let</b> reward_withdraw_amount =
+        <b>if</b> (total_sui_withdraw_amount &gt;= principal_withdraw_amount)
+            total_sui_withdraw_amount - principal_withdraw_amount
+        <b>else</b> 0;
+    <a href="balance.md#0x2_balance_decrease_supply">balance::decrease_supply</a>(
+        &<b>mut</b> pool.delegation_token_supply,
+        withdrawn_pool_tokens
+    );
+    pool.sui_balance = pool.sui_balance - (principal_withdraw_amount + reward_withdraw_amount);
+    <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> pool.rewards_pool, reward_withdraw_amount)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_mint_delegation_tokens_to_delegator"></a>
+
+## Function `mint_delegation_tokens_to_delegator`
+
+Given the <code>sui_amount</code>, mint the corresponding amount of pool tokens at the current exchange
+rate, puts the pool tokens in a delegation object, and gives the delegation object to the delegator.
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_mint_delegation_tokens_to_delegator">mint_delegation_tokens_to_delegator</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, delegator: <b>address</b>, sui_amount: u64, staked_sui_id: <a href="object.md#0x2_object_ID">object::ID</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_mint_delegation_tokens_to_delegator">mint_delegation_tokens_to_delegator</a>(
+    pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
+    delegator: <b>address</b>,
+    sui_amount: u64,
+    staked_sui_id: ID,
+    ctx: &<b>mut</b> TxContext
+) {
+    <b>let</b> new_pool_token_amount = <a href="staking_pool.md#0x2_staking_pool_get_token_amount">get_token_amount</a>(pool, sui_amount);
+
+    // Mint new pool tokens at the current exchange rate.
+    <b>let</b> pool_tokens = <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(&<b>mut</b> pool.delegation_token_supply, new_pool_token_amount);
+
+    <b>let</b> delegation = <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        staked_sui_id,
+        pool_tokens,
+        principal_sui_amount: sui_amount,
+    };
+
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(delegation, delegator);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_deactivate_staking_pool"></a>
+
+## Function `deactivate_staking_pool`
+
+Deactivate a staking pool by wrapping it in an <code><a href="staking_pool.md#0x2_staking_pool_InactiveStakingPool">InactiveStakingPool</a></code> and sharing this newly created object.
+After this pool deactivation, the pool stops earning rewards. Only delegation withdraws can be made to the pool.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">deactivate_staking_pool</a>(pool: <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">deactivate_staking_pool</a>(pool: <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> inactive_pool = <a href="staking_pool.md#0x2_staking_pool_InactiveStakingPool">InactiveStakingPool</a> { id: <a href="object.md#0x2_object_new">object::new</a>(ctx), pool};
+    <a href="transfer.md#0x2_transfer_share_object">transfer::share_object</a>(inactive_pool);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_withdraw_from_inactive_pool"></a>
+
+## Function `withdraw_from_inactive_pool`
+
+Withdraw delegation from an inactive pool. Since no epoch rewards will be added to an inactive pool,
+the exchange rate between pool tokens and SUI tokens stay the same. Therefore, unlike withdrawing
+from an active pool, we can handle both principal and rewards withdraws directly here.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_from_inactive_pool">withdraw_from_inactive_pool</a>(inactive_pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_InactiveStakingPool">staking_pool::InactiveStakingPool</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_from_inactive_pool">withdraw_from_inactive_pool</a>(
+    inactive_pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_InactiveStakingPool">InactiveStakingPool</a>,
+    staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>,
+    delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>,
+    ctx: &<b>mut</b> TxContext
+) {
+    <b>let</b> pool = &<b>mut</b> inactive_pool.pool;
+    <b>let</b> (withdrawn_pool_tokens, principal_withdraw, time_lock) =
+        <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(pool, delegation, staked_sui);
+    <b>let</b> principal_withdraw_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&principal_withdraw);
+    <b>let</b> rewards_withdraw = <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(pool, principal_withdraw_amount, withdrawn_pool_tokens);
+    <b>let</b> total_withdraw_amount = principal_withdraw_amount + <a href="balance.md#0x2_balance_value">balance::value</a>(&rewards_withdraw);
+    pool.sui_balance = pool.sui_balance - total_withdraw_amount;
+
+    <b>let</b> delegator = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    // TODO: implement withdraw bonding period here.
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&time_lock)) {
+        <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(principal_withdraw, <a href="_destroy_some">option::destroy_some</a>(time_lock), delegator, ctx);
+        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(rewards_withdraw, ctx), delegator);
+    } <b>else</b> {
+        <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> principal_withdraw, rewards_withdraw);
+        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(principal_withdraw, ctx), delegator);
+        <a href="_destroy_none">option::destroy_none</a>(time_lock);
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_destroy_empty_delegation"></a>
+
+## Function `destroy_empty_delegation`
+
+Destroy an empty delegation that no longer contains any SUI or pool tokens.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_empty_delegation">destroy_empty_delegation</a>(delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_empty_delegation">destroy_empty_delegation</a>(delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>) {
+    <b>let</b> <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a> {
+        id,
+        staked_sui_id: _,
+        pool_tokens,
+        principal_sui_amount,
+    } = delegation;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&pool_tokens) == 0, <a href="staking_pool.md#0x2_staking_pool_EDESTROY_NON_ZERO_BALANCE">EDESTROY_NON_ZERO_BALANCE</a>);
+    <b>assert</b>!(principal_sui_amount == 0, <a href="staking_pool.md#0x2_staking_pool_EDESTROY_NON_ZERO_BALANCE">EDESTROY_NON_ZERO_BALANCE</a>);
+    <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(pool_tokens);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_destroy_empty_staked_sui"></a>
+
+## Function `destroy_empty_staked_sui`
+
+Destroy an empty delegation that no longer contains any SUI or pool tokens.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_empty_staked_sui">destroy_empty_staked_sui</a>(staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_empty_staked_sui">destroy_empty_staked_sui</a>(staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>) {
+    <b>let</b> <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a> {
+        id,
+        validator_address: _,
+        pool_starting_epoch: _,
+        delegation_request_epoch: _,
+        principal,
+        sui_token_lock
+    } = staked_sui;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id);
+    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&principal) == 0, <a href="staking_pool.md#0x2_staking_pool_EDESTROY_NON_ZERO_BALANCE">EDESTROY_NON_ZERO_BALANCE</a>);
+    <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(principal);
+    <b>assert</b>!(<a href="_is_none">option::is_none</a>(&sui_token_lock), <a href="staking_pool.md#0x2_staking_pool_ETOKEN_TIME_LOCK_IS_SOME">ETOKEN_TIME_LOCK_IS_SOME</a>);
+    <a href="_destroy_none">option::destroy_none</a>(sui_token_lock);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_sui_balance"></a>
+
+## Function `sui_balance`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_sui_balance">sui_balance</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_sui_balance">sui_balance</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>) : u64 { pool.sui_balance }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_validator_address"></a>
+
+## Function `validator_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_validator_address">validator_address</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_validator_address">validator_address</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>) : <b>address</b> { staked_sui.validator_address }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_staked_sui_amount"></a>
+
+## Function `staked_sui_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_staked_sui_amount">staked_sui_amount</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_staked_sui_amount">staked_sui_amount</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>): u64 { <a href="balance.md#0x2_balance_value">balance::value</a>(&staked_sui.principal) }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_delegation_request_epoch"></a>
+
+## Function `delegation_request_epoch`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_request_epoch">delegation_request_epoch</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_request_epoch">delegation_request_epoch</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>): u64 {
+    staked_sui.delegation_request_epoch
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_delegation_token_amount"></a>
+
+## Function `delegation_token_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_token_amount">delegation_token_amount</a>(delegation: &<a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_token_amount">delegation_token_amount</a>(delegation: &<a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>): u64 { <a href="balance.md#0x2_balance_value">balance::value</a>(&delegation.pool_tokens) }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_pool_token_exchange_rate"></a>
+
+## Function `pool_token_exchange_rate`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate">pool_token_exchange_rate</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate">pool_token_exchange_rate</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> {
+    <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> {
+        sui_amount: pool.sui_balance,
+        pool_token_amount: <a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(&pool.delegation_token_supply),
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_new_pending_withdraw_entry"></a>
+
+## Function `new_pending_withdraw_entry`
+
+Create a new pending withdraw entry.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new_pending_withdraw_entry">new_pending_withdraw_entry</a>(delegator: <b>address</b>, principal_withdraw_amount: u64, withdrawn_pool_tokens: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;): <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">staking_pool::PendingWithdrawEntry</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new_pending_withdraw_entry">new_pending_withdraw_entry</a>(
+    delegator: <b>address</b>,
+    principal_withdraw_amount: u64,
+    withdrawn_pool_tokens: Balance&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a>&gt;,
+) : <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> {
+    <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> { delegator, principal_withdraw_amount, withdrawn_pool_tokens }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_get_sui_amount"></a>
+
+## Function `get_sui_amount`
+
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_sui_amount">get_sui_amount</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, token_amount: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_sui_amount">get_sui_amount</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, token_amount: u64): u64 {
+    <b>let</b> token_supply = <a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(&pool.delegation_token_supply);
+    <b>if</b> (token_supply == 0) {
+        <b>return</b> token_amount
+    };
+    <b>let</b> res = (pool.sui_balance <b>as</b> u128)
+            * (token_amount <b>as</b> u128)
+            / (token_supply <b>as</b> u128);
+    (res <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_get_token_amount"></a>
+
+## Function `get_token_amount`
+
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_token_amount">get_token_amount</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, sui_amount: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_token_amount">get_token_amount</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, sui_amount: u64): u64 {
+    <b>if</b> (pool.sui_balance == 0) {
+        <b>return</b> sui_amount
+    };
+    <b>let</b> token_supply = <a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(&pool.delegation_token_supply);
+    <b>let</b> res = (token_supply <b>as</b> u128)
+            * (sui_amount <b>as</b> u128)
+            / (pool.sui_balance <b>as</b> u128);
+    (res <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/sui.md
+++ b/crates/sui-framework-override/docs/sui.md
@@ -1,0 +1,166 @@
+
+<a name="0x2_sui"></a>
+
+# Module `0x2::sui`
+
+Coin<SUI> is the token used to pay for gas in Sui.
+It has 9 decimals, and the smallest unit (10^-9) is called "mist".
+
+
+-  [Struct `SUI`](#0x2_sui_SUI)
+-  [Struct `Canary`](#0x2_sui_Canary)
+-  [Function `coal_mine`](#0x2_sui_coal_mine)
+-  [Function `new`](#0x2_sui_new)
+-  [Function `transfer`](#0x2_sui_transfer)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+<b>use</b> <a href="url.md#0x2_url">0x2::url</a>;
+</code></pre>
+
+
+
+<a name="0x2_sui_SUI"></a>
+
+## Struct `SUI`
+
+Name of the coin
+
+
+<pre><code><b>struct</b> <a href="sui.md#0x2_sui_SUI">SUI</a> <b>has</b> drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_sui_Canary"></a>
+
+## Struct `Canary`
+
+
+
+<pre><code><b>struct</b> <a href="sui.md#0x2_sui_Canary">Canary</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>value: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_sui_coal_mine"></a>
+
+## Function `coal_mine`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui.md#0x2_sui_coal_mine">coal_mine</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui.md#0x2_sui_coal_mine">coal_mine</a>() {
+    <a href="event.md#0x2_event_emit">event::emit</a>(<a href="sui.md#0x2_sui_Canary">Canary</a> { value: 43 })
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_new"></a>
+
+## Function `new`
+
+Register the <code><a href="sui.md#0x2_sui_SUI">SUI</a></code> Coin to acquire its <code>Supply</code>.
+This should be called only once during genesis creation.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> TxContext): Supply&lt;<a href="sui.md#0x2_sui_SUI">SUI</a>&gt; {
+    <b>let</b> (treasury, metadata) = <a href="coin.md#0x2_coin_create_currency">coin::create_currency</a>(
+        <a href="sui.md#0x2_sui_SUI">SUI</a> {},
+        9,
+        b"<a href="sui.md#0x2_sui_SUI">SUI</a>",
+        b"Sui",
+        // TODO: add appropriate description and logo <a href="url.md#0x2_url">url</a>
+        b"",
+        <a href="_none">option::none</a>(),
+        ctx
+    );
+    <a href="transfer.md#0x2_transfer_freeze_object">transfer::freeze_object</a>(metadata);
+    <a href="coin.md#0x2_coin_treasury_into_supply">coin::treasury_into_supply</a>(treasury)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_transfer"></a>
+
+## Function `transfer`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>(c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, recipient: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>(c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">SUI</a>&gt;, recipient: <b>address</b>) {
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(c, recipient)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/sui_system.md
+++ b/crates/sui-framework-override/docs/sui_system.md
@@ -1,0 +1,1353 @@
+
+<a name="0x2_sui_system"></a>
+
+# Module `0x2::sui_system`
+
+
+
+-  [Struct `SystemParameters`](#0x2_sui_system_SystemParameters)
+-  [Resource `SuiSystemState`](#0x2_sui_system_SuiSystemState)
+-  [Struct `SystemEpochInfo`](#0x2_sui_system_SystemEpochInfo)
+-  [Constants](#@Constants_0)
+-  [Function `create`](#0x2_sui_system_create)
+-  [Function `request_add_validator`](#0x2_sui_system_request_add_validator)
+-  [Function `request_remove_validator`](#0x2_sui_system_request_remove_validator)
+-  [Function `request_set_gas_price`](#0x2_sui_system_request_set_gas_price)
+-  [Function `request_set_commission_rate`](#0x2_sui_system_request_set_commission_rate)
+-  [Function `request_add_stake`](#0x2_sui_system_request_add_stake)
+-  [Function `request_add_stake_with_locked_coin`](#0x2_sui_system_request_add_stake_with_locked_coin)
+-  [Function `request_withdraw_stake`](#0x2_sui_system_request_withdraw_stake)
+-  [Function `request_add_delegation`](#0x2_sui_system_request_add_delegation)
+-  [Function `request_add_delegation_mul_coin`](#0x2_sui_system_request_add_delegation_mul_coin)
+-  [Function `request_add_delegation_with_locked_coin`](#0x2_sui_system_request_add_delegation_with_locked_coin)
+-  [Function `request_add_delegation_mul_locked_coin`](#0x2_sui_system_request_add_delegation_mul_locked_coin)
+-  [Function `request_withdraw_delegation`](#0x2_sui_system_request_withdraw_delegation)
+-  [Function `request_switch_delegation`](#0x2_sui_system_request_switch_delegation)
+-  [Function `cancel_delegation_request`](#0x2_sui_system_cancel_delegation_request)
+-  [Function `report_validator`](#0x2_sui_system_report_validator)
+-  [Function `undo_report_validator`](#0x2_sui_system_undo_report_validator)
+-  [Function `advance_epoch`](#0x2_sui_system_advance_epoch)
+-  [Function `epoch`](#0x2_sui_system_epoch)
+-  [Function `validator_delegate_amount`](#0x2_sui_system_validator_delegate_amount)
+-  [Function `validator_stake_amount`](#0x2_sui_system_validator_stake_amount)
+-  [Function `get_reporters_of`](#0x2_sui_system_get_reporters_of)
+-  [Function `extract_coin_balance`](#0x2_sui_system_extract_coin_balance)
+-  [Function `extract_locked_coin_balance`](#0x2_sui_system_extract_locked_coin_balance)
+-  [Function `validators`](#0x2_sui_system_validators)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
+<b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
+<b>use</b> <a href="locked_coin.md#0x2_locked_coin">0x2::locked_coin</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="pay.md#0x2_pay">0x2::pay</a>;
+<b>use</b> <a href="stake.md#0x2_stake">0x2::stake</a>;
+<b>use</b> <a href="stake_subsidy.md#0x2_stake_subsidy">0x2::stake_subsidy</a>;
+<b>use</b> <a href="staking_pool.md#0x2_staking_pool">0x2::staking_pool</a>;
+<b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+<b>use</b> <a href="validator.md#0x2_validator">0x2::validator</a>;
+<b>use</b> <a href="validator_set.md#0x2_validator_set">0x2::validator_set</a>;
+<b>use</b> <a href="vec_map.md#0x2_vec_map">0x2::vec_map</a>;
+<b>use</b> <a href="vec_set.md#0x2_vec_set">0x2::vec_set</a>;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_SystemParameters"></a>
+
+## Struct `SystemParameters`
+
+A list of system config parameters.
+
+
+<pre><code><b>struct</b> <a href="sui_system.md#0x2_sui_system_SystemParameters">SystemParameters</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>min_validator_stake: u64</code>
+</dt>
+<dd>
+ Lower-bound on the amount of stake required to become a validator.
+</dd>
+<dt>
+<code>max_validator_candidate_count: u64</code>
+</dt>
+<dd>
+ Maximum number of validator candidates at any moment.
+ We do not allow the number of validators in any epoch to go above this.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_sui_system_SuiSystemState"></a>
+
+## Resource `SuiSystemState`
+
+The top-level object containing all information of the Sui system.
+
+
+<pre><code><b>struct</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+ The current epoch ID, starting from 0.
+</dd>
+<dt>
+<code>validators: <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a></code>
+</dt>
+<dd>
+ Contains all information about the validators.
+</dd>
+<dt>
+<code>sui_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+ The SUI treasury capability needed to mint SUI.
+</dd>
+<dt>
+<code>storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+ The storage fund.
+</dd>
+<dt>
+<code>parameters: <a href="sui_system.md#0x2_sui_system_SystemParameters">sui_system::SystemParameters</a></code>
+</dt>
+<dd>
+ A list of system config parameters.
+</dd>
+<dt>
+<code>reference_gas_price: u64</code>
+</dt>
+<dd>
+ The reference gas price for the current epoch.
+</dd>
+<dt>
+<code>validator_report_records: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;</code>
+</dt>
+<dd>
+ A map storing the records of validator reporting each other during the current epoch.
+ There is an entry in the map for each validator that has been reported
+ at least once. The entry VecSet contains all the validators that reported
+ them. If a validator has never been reported they don't have an entry in this map.
+ This map resets every epoch.
+</dd>
+<dt>
+<code><a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>: <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a></code>
+</dt>
+<dd>
+ Schedule of stake subsidies given out each epoch.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_sui_system_SystemEpochInfo"></a>
+
+## Struct `SystemEpochInfo`
+
+Event containing system-level epoch information, emitted during
+the epoch advancement transaction.
+
+
+<pre><code><b>struct</b> <a href="sui_system.md#0x2_sui_system_SystemEpochInfo">SystemEpochInfo</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>reference_gas_price: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>total_stake: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>storage_fund_inflows: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>storage_fund_outflows: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>storage_fund_balance: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>stake_subsidy_amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>total_gas_fees: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>total_stake_rewards: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_sui_system_BASIS_POINT_DENOMINATOR"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>: u128 = 10000;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_EBPS_TOO_LARGE"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EBPS_TOO_LARGE">EBPS_TOO_LARGE</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_ECANNOT_REPORT_ONESELF"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ECANNOT_REPORT_ONESELF">ECANNOT_REPORT_ONESELF</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_EEPOCH_NUMBER_MISMATCH"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EEPOCH_NUMBER_MISMATCH">EEPOCH_NUMBER_MISMATCH</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_ELIMIT_EXCEEDED"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ELIMIT_EXCEEDED">ELIMIT_EXCEEDED</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_ENOT_VALIDATOR"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ENOT_VALIDATOR">ENOT_VALIDATOR</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_EREPORT_RECORD_NOT_FOUND"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EREPORT_RECORD_NOT_FOUND">EREPORT_RECORD_NOT_FOUND</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_ESTAKED_SUI_FROM_WRONG_EPOCH"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ESTAKED_SUI_FROM_WRONG_EPOCH">ESTAKED_SUI_FROM_WRONG_EPOCH</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_create"></a>
+
+## Function `create`
+
+Create a new SuiSystemState object and make it shared.
+This function will be called only once in genesis.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, sui_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_candidate_count: u64, min_validator_stake: u64, initial_stake_subsidy_amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(
+    validators: <a href="">vector</a>&lt;Validator&gt;,
+    sui_supply: Supply&lt;SUI&gt;,
+    storage_fund: Balance&lt;SUI&gt;,
+    max_validator_candidate_count: u64,
+    min_validator_stake: u64,
+    initial_stake_subsidy_amount: u64,
+) {
+    <b>let</b> validators = <a href="validator_set.md#0x2_validator_set_new">validator_set::new</a>(validators);
+    <b>let</b> reference_gas_price = <a href="validator_set.md#0x2_validator_set_derive_reference_gas_price">validator_set::derive_reference_gas_price</a>(&validators);
+    <b>let</b> state = <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a> {
+        // Use a hardcoded ID.
+        id: <a href="object.md#0x2_object_sui_system_state">object::sui_system_state</a>(),
+        epoch: 0,
+        validators,
+        sui_supply,
+        storage_fund,
+        parameters: <a href="sui_system.md#0x2_sui_system_SystemParameters">SystemParameters</a> {
+            min_validator_stake,
+            max_validator_candidate_count,
+        },
+        reference_gas_price,
+        validator_report_records: <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>(),
+        <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>: <a href="stake_subsidy.md#0x2_stake_subsidy_create">stake_subsidy::create</a>(initial_stake_subsidy_amount),
+    };
+    <a href="transfer.md#0x2_transfer_share_object">transfer::share_object</a>(state);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_add_validator"></a>
+
+## Function `request_add_validator`
+
+Can be called by anyone who wishes to become a validator in the next epoch.
+The <code><a href="validator.md#0x2_validator">validator</a></code> object needs to be created before calling this.
+The amount of stake in the <code><a href="validator.md#0x2_validator">validator</a></code> object must meet the requirements.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, consensus_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, <a href="stake.md#0x2_stake">stake</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, gas_price: u64, commission_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_validator">request_add_validator</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
+    network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
+    worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
+    proof_of_possession: <a href="">vector</a>&lt;u8&gt;,
+    name: <a href="">vector</a>&lt;u8&gt;,
+    description: <a href="">vector</a>&lt;u8&gt;,
+    image_url: <a href="">vector</a>&lt;u8&gt;,
+    project_url: <a href="">vector</a>&lt;u8&gt;,
+    net_address: <a href="">vector</a>&lt;u8&gt;,
+    consensus_address: <a href="">vector</a>&lt;u8&gt;,
+    worker_address: <a href="">vector</a>&lt;u8&gt;,
+    <a href="stake.md#0x2_stake">stake</a>: Coin&lt;SUI&gt;,
+    gas_price: u64,
+    commission_rate: u64,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>assert</b>!(
+        <a href="validator_set.md#0x2_validator_set_next_epoch_validator_count">validator_set::next_epoch_validator_count</a>(&self.validators) &lt; self.parameters.max_validator_candidate_count,
+        <a href="sui_system.md#0x2_sui_system_ELIMIT_EXCEEDED">ELIMIT_EXCEEDED</a>,
+    );
+    <b>let</b> stake_amount = <a href="coin.md#0x2_coin_value">coin::value</a>(&<a href="stake.md#0x2_stake">stake</a>);
+    <b>assert</b>!(
+        stake_amount &gt;= self.parameters.min_validator_stake,
+        <a href="sui_system.md#0x2_sui_system_ELIMIT_EXCEEDED">ELIMIT_EXCEEDED</a>,
+    );
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator.md#0x2_validator_new">validator::new</a>(
+        <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx),
+        pubkey_bytes,
+        network_pubkey_bytes,
+        worker_pubkey_bytes,
+        proof_of_possession,
+        name,
+        description,
+        image_url,
+        project_url,
+        net_address,
+        consensus_address,
+        worker_address,
+        <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(<a href="stake.md#0x2_stake">stake</a>),
+        <a href="_none">option::none</a>(),
+        gas_price,
+        commission_rate,
+        ctx
+    );
+
+    // TODO: We need <b>to</b> verify the <a href="validator.md#0x2_validator">validator</a> metadata.
+    // https://github.com/MystenLabs/<a href="sui.md#0x2_sui">sui</a>/issues/7323
+
+    <a href="validator_set.md#0x2_validator_set_request_add_validator">validator_set::request_add_validator</a>(&<b>mut</b> self.validators, <a href="validator.md#0x2_validator">validator</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_remove_validator"></a>
+
+## Function `request_remove_validator`
+
+A validator can call this function to request a removal in the next epoch.
+We use the sender of <code>ctx</code> to look up the validator
+(i.e. sender must match the sui_address in the validator).
+At the end of the epoch, the <code><a href="validator.md#0x2_validator">validator</a></code> object will be returned to the sui_address
+of the validator.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_remove_validator">request_remove_validator</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_remove_validator">request_remove_validator</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <a href="validator_set.md#0x2_validator_set_request_remove_validator">validator_set::request_remove_validator</a>(
+        &<b>mut</b> self.validators,
+        ctx,
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_set_gas_price"></a>
+
+## Function `request_set_gas_price`
+
+A validator can call this entry function to submit a new gas price quote, to be
+used for the reference gas price calculation at the end of the epoch.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_set_gas_price">request_set_gas_price</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_gas_price: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_set_gas_price">request_set_gas_price</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    new_gas_price: u64,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <a href="validator_set.md#0x2_validator_set_request_set_gas_price">validator_set::request_set_gas_price</a>(
+        &<b>mut</b> self.validators,
+        new_gas_price,
+        ctx
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_set_commission_rate"></a>
+
+## Function `request_set_commission_rate`
+
+A validator can call this entry function to set a new commission rate, updated at the end of the epoch.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_set_commission_rate">request_set_commission_rate</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_commission_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_set_commission_rate">request_set_commission_rate</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    new_commission_rate: u64,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <a href="validator_set.md#0x2_validator_set_request_set_commission_rate">validator_set::request_set_commission_rate</a>(
+        &<b>mut</b> self.validators,
+        new_commission_rate,
+        ctx
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_add_stake"></a>
+
+## Function `request_add_stake`
+
+A validator can request adding more stake. This will be processed at the end of epoch.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_stake">request_add_stake</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_stake: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_stake">request_add_stake</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    new_stake: Coin&lt;SUI&gt;,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <a href="validator_set.md#0x2_validator_set_request_add_stake">validator_set::request_add_stake</a>(
+        &<b>mut</b> self.validators,
+        <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(new_stake),
+        <a href="_none">option::none</a>(),
+        ctx,
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_add_stake_with_locked_coin"></a>
+
+## Function `request_add_stake_with_locked_coin`
+
+A validator can request adding more stake using a locked coin. This will be processed at the end of epoch.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_stake_with_locked_coin">request_add_stake_with_locked_coin</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_stake: <a href="locked_coin.md#0x2_locked_coin_LockedCoin">locked_coin::LockedCoin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_stake_with_locked_coin">request_add_stake_with_locked_coin</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    new_stake: LockedCoin&lt;SUI&gt;,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> (<a href="balance.md#0x2_balance">balance</a>, <a href="epoch_time_lock.md#0x2_epoch_time_lock">epoch_time_lock</a>) = <a href="locked_coin.md#0x2_locked_coin_into_balance">locked_coin::into_balance</a>(new_stake);
+    <a href="validator_set.md#0x2_validator_set_request_add_stake">validator_set::request_add_stake</a>(
+        &<b>mut</b> self.validators,
+        <a href="balance.md#0x2_balance">balance</a>,
+        <a href="_some">option::some</a>(<a href="epoch_time_lock.md#0x2_epoch_time_lock">epoch_time_lock</a>),
+        ctx,
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_withdraw_stake"></a>
+
+## Function `request_withdraw_stake`
+
+A validator can request to withdraw stake.
+If the sender represents a pending validator (i.e. has just requested to become a validator
+in the current epoch and hence is not active yet), the stake will be withdrawn immediately
+and a coin with the withdraw amount will be sent to the validator's address.
+If the sender represents an active validator, the request will be processed at the end of epoch.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_withdraw_stake">request_withdraw_stake</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, <a href="stake.md#0x2_stake">stake</a>: &<b>mut</b> <a href="stake.md#0x2_stake_Stake">stake::Stake</a>, withdraw_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_withdraw_stake">request_withdraw_stake</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    <a href="stake.md#0x2_stake">stake</a>: &<b>mut</b> Stake,
+    withdraw_amount: u64,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <a href="validator_set.md#0x2_validator_set_request_withdraw_stake">validator_set::request_withdraw_stake</a>(
+        &<b>mut</b> self.validators,
+        <a href="stake.md#0x2_stake">stake</a>,
+        withdraw_amount,
+        self.parameters.min_validator_stake,
+        ctx,
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_add_delegation"></a>
+
+## Function `request_add_delegation`
+
+Add delegated stake to a validator's staking pool.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_delegation">request_add_delegation</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, delegate_stake: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_delegation">request_add_delegation</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    delegate_stake: Coin&lt;SUI&gt;,
+    validator_address: <b>address</b>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <a href="validator_set.md#0x2_validator_set_request_add_delegation">validator_set::request_add_delegation</a>(
+        &<b>mut</b> self.validators,
+        validator_address,
+        <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(delegate_stake),
+        <a href="_none">option::none</a>(),
+        ctx,
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_add_delegation_mul_coin"></a>
+
+## Function `request_add_delegation_mul_coin`
+
+Add delegated stake to a validator's staking pool using multiple coins.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_delegation_mul_coin">request_add_delegation_mul_coin</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, delegate_stakes: <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;&gt;, stake_amount: <a href="_Option">option::Option</a>&lt;u64&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_delegation_mul_coin">request_add_delegation_mul_coin</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    delegate_stakes: <a href="">vector</a>&lt;Coin&lt;SUI&gt;&gt;,
+    stake_amount: <a href="_Option">option::Option</a>&lt;u64&gt;,
+    validator_address: <b>address</b>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="sui_system.md#0x2_sui_system_extract_coin_balance">extract_coin_balance</a>(delegate_stakes, stake_amount, ctx);
+    <a href="validator_set.md#0x2_validator_set_request_add_delegation">validator_set::request_add_delegation</a>(&<b>mut</b> self.validators, validator_address, <a href="balance.md#0x2_balance">balance</a>, <a href="_none">option::none</a>(), ctx);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_add_delegation_with_locked_coin"></a>
+
+## Function `request_add_delegation_with_locked_coin`
+
+Add delegated stake to a validator's staking pool using a locked SUI coin.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_delegation_with_locked_coin">request_add_delegation_with_locked_coin</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, delegate_stake: <a href="locked_coin.md#0x2_locked_coin_LockedCoin">locked_coin::LockedCoin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_delegation_with_locked_coin">request_add_delegation_with_locked_coin</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    delegate_stake: LockedCoin&lt;SUI&gt;,
+    validator_address: <b>address</b>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> (<a href="balance.md#0x2_balance">balance</a>, lock) = <a href="locked_coin.md#0x2_locked_coin_into_balance">locked_coin::into_balance</a>(delegate_stake);
+    <a href="validator_set.md#0x2_validator_set_request_add_delegation">validator_set::request_add_delegation</a>(&<b>mut</b> self.validators, validator_address, <a href="balance.md#0x2_balance">balance</a>, <a href="_some">option::some</a>(lock), ctx);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_add_delegation_mul_locked_coin"></a>
+
+## Function `request_add_delegation_mul_locked_coin`
+
+Add delegated stake to a validator's staking pool using multiple locked SUI coins.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_delegation_mul_locked_coin">request_add_delegation_mul_locked_coin</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, delegate_stakes: <a href="">vector</a>&lt;<a href="locked_coin.md#0x2_locked_coin_LockedCoin">locked_coin::LockedCoin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;&gt;, stake_amount: <a href="_Option">option::Option</a>&lt;u64&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_delegation_mul_locked_coin">request_add_delegation_mul_locked_coin</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    delegate_stakes: <a href="">vector</a>&lt;LockedCoin&lt;SUI&gt;&gt;,
+    stake_amount: <a href="_Option">option::Option</a>&lt;u64&gt;,
+    validator_address: <b>address</b>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> (<a href="balance.md#0x2_balance">balance</a>, lock) = <a href="sui_system.md#0x2_sui_system_extract_locked_coin_balance">extract_locked_coin_balance</a>(delegate_stakes, stake_amount, ctx);
+    <a href="validator_set.md#0x2_validator_set_request_add_delegation">validator_set::request_add_delegation</a>(
+        &<b>mut</b> self.validators,
+        validator_address,
+        <a href="balance.md#0x2_balance">balance</a>,
+        <a href="_some">option::some</a>(lock),
+        ctx
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_withdraw_delegation"></a>
+
+## Function `request_withdraw_delegation`
+
+Withdraw some portion of a delegation from a validator's staking pool.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_withdraw_delegation">request_withdraw_delegation</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_withdraw_delegation">request_withdraw_delegation</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    delegation: Delegation,
+    staked_sui: StakedSui,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <a href="validator_set.md#0x2_validator_set_request_withdraw_delegation">validator_set::request_withdraw_delegation</a>(
+        &<b>mut</b> self.validators,
+        delegation,
+        staked_sui,
+        ctx,
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_switch_delegation"></a>
+
+## Function `request_switch_delegation`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_switch_delegation">request_switch_delegation</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, new_validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_switch_delegation">request_switch_delegation</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    delegation: Delegation,
+    staked_sui: StakedSui,
+    new_validator_address: <b>address</b>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <a href="validator_set.md#0x2_validator_set_request_switch_delegation">validator_set::request_switch_delegation</a>(
+        &<b>mut</b> self.validators, delegation, staked_sui, new_validator_address, ctx
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_cancel_delegation_request"></a>
+
+## Function `cancel_delegation_request`
+
+Cancel a delegation requests sent during the current epoch.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_cancel_delegation_request">cancel_delegation_request</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_cancel_delegation_request">cancel_delegation_request</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    staked_sui: StakedSui,
+    ctx: &<b>mut</b> TxContext,
+) {
+    // The delegation request <b>has</b> <b>to</b> have happened within the current epoch.
+    <b>assert</b>!(<a href="staking_pool.md#0x2_staking_pool_delegation_request_epoch">staking_pool::delegation_request_epoch</a>(&staked_sui) == self.epoch, <a href="sui_system.md#0x2_sui_system_ESTAKED_SUI_FROM_WRONG_EPOCH">ESTAKED_SUI_FROM_WRONG_EPOCH</a>);
+    <a href="validator_set.md#0x2_validator_set_cancel_delegation_request">validator_set::cancel_delegation_request</a>(
+        &<b>mut</b> self.validators, staked_sui, ctx
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_report_validator"></a>
+
+## Function `report_validator`
+
+Report a validator as a bad or non-performant actor in the system.
+Succeeds iff both the sender and the input <code>validator_addr</code> are active validators
+and they are not the same address. This function is idempotent within an epoch.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_report_validator">report_validator</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, validator_addr: <b>address</b>, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_report_validator">report_validator</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    validator_addr: <b>address</b>,
+    ctx: &TxContext,
+) {
+    <b>let</b> sender = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    // Both the reporter and the reported have <b>to</b> be validators.
+    <b>assert</b>!(<a href="validator_set.md#0x2_validator_set_is_active_validator">validator_set::is_active_validator</a>(&self.validators, sender), <a href="sui_system.md#0x2_sui_system_ENOT_VALIDATOR">ENOT_VALIDATOR</a>);
+    <b>assert</b>!(<a href="validator_set.md#0x2_validator_set_is_active_validator">validator_set::is_active_validator</a>(&self.validators, validator_addr), <a href="sui_system.md#0x2_sui_system_ENOT_VALIDATOR">ENOT_VALIDATOR</a>);
+    <b>assert</b>!(sender != validator_addr, <a href="sui_system.md#0x2_sui_system_ECANNOT_REPORT_ONESELF">ECANNOT_REPORT_ONESELF</a>);
+
+    <b>if</b> (!<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.validator_report_records, &validator_addr)) {
+        <a href="vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(&<b>mut</b> self.validator_report_records, validator_addr, <a href="vec_set.md#0x2_vec_set_singleton">vec_set::singleton</a>(sender));
+    } <b>else</b> {
+        <b>let</b> reporters = <a href="vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(&<b>mut</b> self.validator_report_records, &validator_addr);
+        <b>if</b> (!<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &sender)) {
+            <a href="vec_set.md#0x2_vec_set_insert">vec_set::insert</a>(reporters, sender);
+        }
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_undo_report_validator"></a>
+
+## Function `undo_report_validator`
+
+Undo a <code>report_validator</code> action. Aborts if the sender has not reported the
+<code>validator_addr</code> within this epoch.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_undo_report_validator">undo_report_validator</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, validator_addr: <b>address</b>, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_undo_report_validator">undo_report_validator</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    validator_addr: <b>address</b>,
+    ctx: &TxContext,
+) {
+    <b>let</b> sender = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+
+    <b>assert</b>!(<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.validator_report_records, &validator_addr), <a href="sui_system.md#0x2_sui_system_EREPORT_RECORD_NOT_FOUND">EREPORT_RECORD_NOT_FOUND</a>);
+    <b>let</b> reporters = <a href="vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(&<b>mut</b> self.validator_report_records, &validator_addr);
+    <b>assert</b>!(<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &sender), <a href="sui_system.md#0x2_sui_system_EREPORT_RECORD_NOT_FOUND">EREPORT_RECORD_NOT_FOUND</a>);
+    <a href="vec_set.md#0x2_vec_set_remove">vec_set::remove</a>(reporters, &sender);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_advance_epoch"></a>
+
+## Function `advance_epoch`
+
+This function should be called at the end of an epoch, and advances the system to the next epoch.
+It does the following things:
+1. Add storage charge to the storage fund.
+2. Burn the storage rebates from the storage fund. These are already refunded to transaction sender's
+gas coins.
+3. Distribute computation charge to validator stake and delegation stake.
+4. Update all validators.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_epoch: u64, storage_charge: u64, computation_charge: u64, storage_rebate: u64, storage_fund_reinvest_rate: u64, reward_slashing_rate: u64, stake_subsidy_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch">advance_epoch</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    new_epoch: u64,
+    storage_charge: u64,
+    computation_charge: u64,
+    storage_rebate: u64,
+    storage_fund_reinvest_rate: u64, // share of storage fund's rewards that's reinvested
+                                     // into storage fund, in basis point.
+    reward_slashing_rate: u64, // how much rewards are slashed <b>to</b> punish a <a href="validator.md#0x2_validator">validator</a>, in bps.
+    stake_subsidy_rate: u64, // what percentage of the total <a href="stake.md#0x2_stake">stake</a> do we mint <b>as</b> <a href="stake.md#0x2_stake">stake</a> subsidy.
+    ctx: &<b>mut</b> TxContext,
+) {
+    // Validator will make a special system call <b>with</b> sender set <b>as</b> 0x0.
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, 0);
+
+    <b>let</b> bps_denominator_u64 = (<a href="sui_system.md#0x2_sui_system_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a> <b>as</b> u64);
+    // Rates can't be higher than 100%.
+    <b>assert</b>!(
+        storage_fund_reinvest_rate &lt;= bps_denominator_u64
+        && reward_slashing_rate &lt;= bps_denominator_u64,
+        <a href="sui_system.md#0x2_sui_system_EBPS_TOO_LARGE">EBPS_TOO_LARGE</a>,
+    );
+
+    <b>let</b> delegation_stake = <a href="validator_set.md#0x2_validator_set_total_delegation_stake">validator_set::total_delegation_stake</a>(&self.validators);
+    <b>let</b> validator_stake = <a href="validator_set.md#0x2_validator_set_total_validator_stake">validator_set::total_validator_stake</a>(&self.validators);
+    <b>let</b> storage_fund_balance = <a href="balance.md#0x2_balance_value">balance::value</a>(&self.storage_fund);
+    <b>let</b> total_stake = delegation_stake + validator_stake + storage_fund_balance;
+
+    <b>let</b> storage_reward = <a href="balance.md#0x2_balance_create_staking_rewards">balance::create_staking_rewards</a>(storage_charge);
+    <b>let</b> computation_reward = <a href="balance.md#0x2_balance_create_staking_rewards">balance::create_staking_rewards</a>(computation_charge);
+
+    // Include <a href="stake.md#0x2_stake">stake</a> subsidy in the rewards given out <b>to</b> validators and delegators.
+    <a href="stake_subsidy.md#0x2_stake_subsidy_mint_stake_subsidy_proportional_to_total_stake_testnet">stake_subsidy::mint_stake_subsidy_proportional_to_total_stake_testnet</a>(
+        &<b>mut</b> self.<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>, &<b>mut</b> self.sui_supply, stake_subsidy_rate, delegation_stake + validator_stake);
+    <b>let</b> <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a> = <a href="stake_subsidy.md#0x2_stake_subsidy_withdraw_all">stake_subsidy::withdraw_all</a>(&<b>mut</b> self.<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>);
+    <b>let</b> stake_subsidy_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>);
+    <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> computation_reward, <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>);
+
+    <b>let</b> total_stake_u128 = (total_stake <b>as</b> u128);
+    <b>let</b> computation_charge_u128 = (computation_charge <b>as</b> u128);
+
+    <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.storage_fund, storage_reward);
+
+    <b>let</b> storage_fund_reward_amount = (storage_fund_balance <b>as</b> u128) * computation_charge_u128 / total_stake_u128;
+    <b>let</b> storage_fund_reward = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> computation_reward, (storage_fund_reward_amount <b>as</b> u64));
+    <b>let</b> storage_fund_reinvestment_amount =
+        storage_fund_reward_amount * (storage_fund_reinvest_rate <b>as</b> u128) / <a href="sui_system.md#0x2_sui_system_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
+    <b>let</b> storage_fund_reinvestment = <a href="balance.md#0x2_balance_split">balance::split</a>(
+        &<b>mut</b> storage_fund_reward,
+        (storage_fund_reinvestment_amount <b>as</b> u64),
+    );
+    <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.storage_fund, storage_fund_reinvestment);
+
+    self.epoch = self.epoch + 1;
+    // Sanity check <b>to</b> make sure we are advancing <b>to</b> the right epoch.
+    <b>assert</b>!(new_epoch == self.epoch, 0);
+    <b>let</b> total_rewards_amount =
+        <a href="balance.md#0x2_balance_value">balance::value</a>(&computation_reward)+ <a href="balance.md#0x2_balance_value">balance::value</a>(&storage_fund_reward);
+
+    <a href="validator_set.md#0x2_validator_set_advance_epoch">validator_set::advance_epoch</a>(
+        new_epoch,
+        &<b>mut</b> self.validators,
+        &<b>mut</b> computation_reward,
+        &<b>mut</b> storage_fund_reward,
+        self.validator_report_records,
+        reward_slashing_rate,
+        ctx,
+    );
+    // Derive the reference gas price for the new epoch
+    self.reference_gas_price = <a href="validator_set.md#0x2_validator_set_derive_reference_gas_price">validator_set::derive_reference_gas_price</a>(&self.validators);
+    // Because of precision issues <b>with</b> integer divisions, we expect that there will be some
+    // remaining <a href="balance.md#0x2_balance">balance</a> in `storage_fund_reward` and `computation_reward`.
+    // All of these go <b>to</b> the storage fund.
+    <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.storage_fund, storage_fund_reward);
+    <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.storage_fund, computation_reward);
+
+    // Destroy the storage rebate.
+    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&self.storage_fund) &gt;= storage_rebate, 0);
+    <a href="balance.md#0x2_balance_destroy_storage_rebates">balance::destroy_storage_rebates</a>(<a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> self.storage_fund, storage_rebate));
+
+    // Validator reports are only valid for the epoch.
+    // TODO: or do we want <b>to</b> make it persistent and validators have <b>to</b> explicitly change their scores?
+    self.validator_report_records = <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>();
+
+    <b>let</b> new_total_stake =
+        <a href="validator_set.md#0x2_validator_set_total_delegation_stake">validator_set::total_delegation_stake</a>(&self.validators)
+        + <a href="validator_set.md#0x2_validator_set_total_validator_stake">validator_set::total_validator_stake</a>(&self.validators);
+
+    <a href="event.md#0x2_event_emit">event::emit</a>(
+        <a href="sui_system.md#0x2_sui_system_SystemEpochInfo">SystemEpochInfo</a> {
+            epoch: self.epoch,
+            reference_gas_price: self.reference_gas_price,
+            total_stake: new_total_stake,
+            storage_fund_inflows: storage_charge + (storage_fund_reinvestment_amount <b>as</b> u64),
+            storage_fund_outflows: storage_rebate,
+            storage_fund_balance: <a href="balance.md#0x2_balance_value">balance::value</a>(&self.storage_fund),
+            stake_subsidy_amount,
+            total_gas_fees: computation_charge,
+            total_stake_rewards: total_rewards_amount,
+        }
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+Total supply of SUI increases by the amount of stake subsidy we minted.
+
+
+<pre><code><b>ensures</b> <a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(self.sui_supply)
+    == <b>old</b>(<a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(self.sui_supply)) + <b>old</b>(<a href="stake_subsidy.md#0x2_stake_subsidy_current_epoch_subsidy_amount">stake_subsidy::current_epoch_subsidy_amount</a>(self.<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>));
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_epoch"></a>
+
+## Function `epoch`
+
+Return the current epoch number. Useful for applications that need a coarse-grained concept of time,
+since epochs are ever-increasing and epoch changes are intended to happen every 24 hours.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_epoch">epoch</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_epoch">epoch</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>): u64 {
+    self.epoch
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_validator_delegate_amount"></a>
+
+## Function `validator_delegate_amount`
+
+Returns the amount of stake delegated to <code>validator_addr</code>.
+Aborts if <code>validator_addr</code> is not an active validator.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validator_delegate_amount">validator_delegate_amount</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, validator_addr: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validator_delegate_amount">validator_delegate_amount</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>, validator_addr: <b>address</b>): u64 {
+    <a href="validator_set.md#0x2_validator_set_validator_delegate_amount">validator_set::validator_delegate_amount</a>(&self.validators, validator_addr)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_validator_stake_amount"></a>
+
+## Function `validator_stake_amount`
+
+Returns the amount of stake <code>validator_addr</code> has.
+Aborts if <code>validator_addr</code> is not an active validator.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validator_stake_amount">validator_stake_amount</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, validator_addr: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validator_stake_amount">validator_stake_amount</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>, validator_addr: <b>address</b>): u64 {
+    <a href="validator_set.md#0x2_validator_set_validator_stake_amount">validator_set::validator_stake_amount</a>(&self.validators, validator_addr)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_get_reporters_of"></a>
+
+## Function `get_reporters_of`
+
+Returns all the validators who have reported <code>addr</code> this epoch.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_get_reporters_of">get_reporters_of</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, addr: <b>address</b>): <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_get_reporters_of">get_reporters_of</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>, addr: <b>address</b>): VecSet&lt;<b>address</b>&gt; {
+    <b>if</b> (<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.validator_report_records, &addr)) {
+        *<a href="vec_map.md#0x2_vec_map_get">vec_map::get</a>(&self.validator_report_records, &addr)
+    } <b>else</b> {
+        <a href="vec_set.md#0x2_vec_set_empty">vec_set::empty</a>()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_extract_coin_balance"></a>
+
+## Function `extract_coin_balance`
+
+Extract required Balance from vector of Coin<SUI>, transfer the remainder back to sender.
+
+
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_extract_coin_balance">extract_coin_balance</a>(coins: <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;&gt;, amount: <a href="_Option">option::Option</a>&lt;u64&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_extract_coin_balance">extract_coin_balance</a>(coins: <a href="">vector</a>&lt;Coin&lt;SUI&gt;&gt;, amount: <a href="_Option">option::Option</a>&lt;u64&gt;, ctx: &<b>mut</b> TxContext): Balance&lt;SUI&gt; {
+    <b>let</b> merged_coin = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> coins);
+    <a href="pay.md#0x2_pay_join_vec">pay::join_vec</a>(&<b>mut</b> merged_coin, coins);
+
+    <b>let</b> total_balance = <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(merged_coin);
+    // <b>return</b> the full amount <b>if</b> amount is not specified
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&amount)) {
+        <b>let</b> amount = <a href="_destroy_some">option::destroy_some</a>(amount);
+        <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> total_balance, amount);
+        // <a href="transfer.md#0x2_transfer">transfer</a> back the remainder <b>if</b> non zero.
+        <b>if</b> (<a href="balance.md#0x2_balance_value">balance::value</a>(&total_balance) &gt; 0) {
+            <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(total_balance, ctx), <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+        } <b>else</b> {
+            <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(total_balance);
+        };
+        <a href="balance.md#0x2_balance">balance</a>
+    } <b>else</b> {
+        total_balance
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_extract_locked_coin_balance"></a>
+
+## Function `extract_locked_coin_balance`
+
+Extract required Balance from vector of LockedCoin<SUI>, transfer the remainder back to sender.
+
+
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_extract_locked_coin_balance">extract_locked_coin_balance</a>(coins: <a href="">vector</a>&lt;<a href="locked_coin.md#0x2_locked_coin_LockedCoin">locked_coin::LockedCoin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;&gt;, amount: <a href="_Option">option::Option</a>&lt;u64&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_extract_locked_coin_balance">extract_locked_coin_balance</a>(
+    coins: <a href="">vector</a>&lt;LockedCoin&lt;SUI&gt;&gt;,
+    amount: <a href="_Option">option::Option</a>&lt;u64&gt;,
+    ctx: &<b>mut</b> TxContext
+): (Balance&lt;SUI&gt;, EpochTimeLock) {
+    <b>let</b> (total_balance, first_lock) = <a href="locked_coin.md#0x2_locked_coin_into_balance">locked_coin::into_balance</a>(<a href="_pop_back">vector::pop_back</a>(&<b>mut</b> coins));
+    <b>let</b> (i, len) = (0, <a href="_length">vector::length</a>(&coins));
+    <b>while</b> (i &lt; len) {
+        <b>let</b> (<a href="balance.md#0x2_balance">balance</a>, lock) = <a href="locked_coin.md#0x2_locked_coin_into_balance">locked_coin::into_balance</a>(<a href="_pop_back">vector::pop_back</a>(&<b>mut</b> coins));
+        // Make sure all time locks are the same
+        <b>assert</b>!(<a href="epoch_time_lock.md#0x2_epoch_time_lock_epoch">epoch_time_lock::epoch</a>(&lock) == <a href="epoch_time_lock.md#0x2_epoch_time_lock_epoch">epoch_time_lock::epoch</a>(&first_lock), 0);
+        <a href="epoch_time_lock.md#0x2_epoch_time_lock_destroy_unchecked">epoch_time_lock::destroy_unchecked</a>(lock);
+        <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> total_balance, <a href="balance.md#0x2_balance">balance</a>);
+        i = i + 1
+    };
+    <a href="_destroy_empty">vector::destroy_empty</a>(coins);
+
+    // <b>return</b> the full amount <b>if</b> amount is not specified
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&amount)){
+        <b>let</b> amount = <a href="_destroy_some">option::destroy_some</a>(amount);
+        <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> total_balance, amount);
+        <b>if</b> (<a href="balance.md#0x2_balance_value">balance::value</a>(&total_balance) &gt; 0) {
+            <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(total_balance, first_lock, <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx), ctx);
+        } <b>else</b> {
+            <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(total_balance);
+        };
+        (<a href="balance.md#0x2_balance">balance</a>, first_lock)
+    } <b>else</b>{
+        (total_balance, first_lock)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_validators"></a>
+
+## Function `validators`
+
+Return the current validator set
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validators">validators</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>): &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validators">validators</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>): &ValidatorSet {
+    &self.validators
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/table.md
+++ b/crates/sui-framework-override/docs/table.md
@@ -1,0 +1,358 @@
+
+<a name="0x2_table"></a>
+
+# Module `0x2::table`
+
+A table is a map-like collection. But unlike a traditional collection, it's keys and values are
+not stored within the <code><a href="table.md#0x2_table_Table">Table</a></code> value, but instead are stored using Sui's object system. The
+<code><a href="table.md#0x2_table_Table">Table</a></code> struct acts only as a handle into the object system to retrieve those keys and values.
+Note that this means that <code><a href="table.md#0x2_table_Table">Table</a></code> values with exactly the same key-value mapping will not be
+equal, with <code>==</code>, at runtime. For example
+```
+let table1 = table::new<u64, bool>();
+let table2 = table::new<u64, bool>();
+table::add(&mut table1, 0, false);
+table::add(&mut table1, 1, true);
+table::add(&mut table2, 0, false);
+table::add(&mut table2, 1, true);
+// table1 does not equal table2, despite having the same entries
+assert!(&table1 != &table2, 0);
+```
+
+
+-  [Resource `Table`](#0x2_table_Table)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x2_table_new)
+-  [Function `add`](#0x2_table_add)
+-  [Function `borrow`](#0x2_table_borrow)
+-  [Function `borrow_mut`](#0x2_table_borrow_mut)
+-  [Function `remove`](#0x2_table_remove)
+-  [Function `contains`](#0x2_table_contains)
+-  [Function `length`](#0x2_table_length)
+-  [Function `is_empty`](#0x2_table_is_empty)
+-  [Function `destroy_empty`](#0x2_table_destroy_empty)
+-  [Function `drop`](#0x2_table_drop)
+
+
+<pre><code><b>use</b> <a href="dynamic_field.md#0x2_dynamic_field">0x2::dynamic_field</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_table_Table"></a>
+
+## Resource `Table`
+
+
+
+<pre><code><b>struct</b> <a href="table.md#0x2_table_Table">Table</a>&lt;K: <b>copy</b>, drop, store, V: store&gt; <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+ the ID of this table
+</dd>
+<dt>
+<code>size: u64</code>
+</dt>
+<dd>
+ the number of key-value pairs in the table
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_table_ETableNotEmpty"></a>
+
+
+
+<pre><code><b>const</b> <a href="table.md#0x2_table_ETableNotEmpty">ETableNotEmpty</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_table_new"></a>
+
+## Function `new`
+
+Creates a new, empty table
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_new">new</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_new">new</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(ctx: &<b>mut</b> TxContext): <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt; {
+    <a href="table.md#0x2_table_Table">Table</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        size: 0,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_add"></a>
+
+## Function `add`
+
+Adds a key-value pair to the table <code><a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the table already has an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_add">add</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K, v: V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_add">add</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;, k: K, v: V) {
+    field::add(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, k, v);
+    <a href="table.md#0x2_table">table</a>.size = <a href="table.md#0x2_table">table</a>.size + 1;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_borrow"></a>
+
+## Function `borrow`
+
+Immutable borrows the value associated with the key in the table <code><a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): &V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;, k: K): &V {
+    field::borrow(&<a href="table.md#0x2_table">table</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Mutably borrows the value associated with the key in the table <code><a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;, k: K): &<b>mut</b> V {
+    field::borrow_mut(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_remove"></a>
+
+## Function `remove`
+
+Removes the key-value pair in the table <code><a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code> and returns the value.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<b>mut</b> <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;, k: K): V {
+    <b>let</b> v = field::remove(&<b>mut</b> <a href="table.md#0x2_table">table</a>.id, k);
+    <a href="table.md#0x2_table">table</a>.size = <a href="table.md#0x2_table">table</a>.size - 1;
+    v
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_contains"></a>
+
+## Function `contains`
+
+Returns true iff there is a value associated with the key <code>k: K</code> in table <code><a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_contains">contains</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_contains">contains</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;, k: K): bool {
+    field::exists_with_type&lt;K, V&gt;(&<a href="table.md#0x2_table">table</a>.id, k)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_length"></a>
+
+## Function `length`
+
+Returns the size of the table, the number of key-value pairs
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_length">length</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_length">length</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;): u64 {
+    <a href="table.md#0x2_table">table</a>.size
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_is_empty"></a>
+
+## Function `is_empty`
+
+Returns true iff the table is empty (if <code>length</code> returns <code>0</code>)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_is_empty">is_empty</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;): bool {
+    <a href="table.md#0x2_table">table</a>.size == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_destroy_empty"></a>
+
+## Function `destroy_empty`
+
+Destroys an empty table
+Aborts with <code><a href="table.md#0x2_table_ETableNotEmpty">ETableNotEmpty</a></code> if the table still contains values
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="table.md#0x2_table_Table">Table</a> { id, size } = <a href="table.md#0x2_table">table</a>;
+    <b>assert</b>!(size == 0, <a href="table.md#0x2_table_ETableNotEmpty">ETableNotEmpty</a>);
+    <a href="object.md#0x2_object_delete">object::delete</a>(id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_drop"></a>
+
+## Function `drop`
+
+Drop a possibly non-empty table.
+Usable only if the value type <code>V</code> has the <code>drop</code> ability
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_drop">drop</a>&lt;K: <b>copy</b>, drop, store, V: drop, store&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_drop">drop</a>&lt;K: <b>copy</b> + drop + store, V: drop + store&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="table.md#0x2_table_Table">Table</a> { id, size: _ } = <a href="table.md#0x2_table">table</a>;
+    <a href="object.md#0x2_object_delete">object::delete</a>(id)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/table_vec.md
+++ b/crates/sui-framework-override/docs/table_vec.md
@@ -1,0 +1,316 @@
+
+<a name="0x2_table_vec"></a>
+
+# Module `0x2::table_vec`
+
+A basic scalable vector library implemented using <code>Table</code>.
+
+
+-  [Struct `TableVec`](#0x2_table_vec_TableVec)
+-  [Constants](#@Constants_0)
+-  [Function `empty`](#0x2_table_vec_empty)
+-  [Function `singleton`](#0x2_table_vec_singleton)
+-  [Function `length`](#0x2_table_vec_length)
+-  [Function `is_empty`](#0x2_table_vec_is_empty)
+-  [Function `borrow`](#0x2_table_vec_borrow)
+-  [Function `push_back`](#0x2_table_vec_push_back)
+-  [Function `borrow_mut`](#0x2_table_vec_borrow_mut)
+-  [Function `pop_back`](#0x2_table_vec_pop_back)
+-  [Function `destroy_empty`](#0x2_table_vec_destroy_empty)
+
+
+<pre><code><b>use</b> <a href="table.md#0x2_table">0x2::table</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_table_vec_TableVec"></a>
+
+## Struct `TableVec`
+
+
+
+<pre><code><b>struct</b> <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element: store&gt; <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>contents: <a href="table.md#0x2_table_Table">table::Table</a>&lt;u64, Element&gt;</code>
+</dt>
+<dd>
+ The contents of the table vector.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_table_vec_EINDEX_OUT_OF_BOUND"></a>
+
+
+
+<pre><code><b>const</b> <a href="table_vec.md#0x2_table_vec_EINDEX_OUT_OF_BOUND">EINDEX_OUT_OF_BOUND</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_table_vec_ETABLE_NONEMPTY"></a>
+
+
+
+<pre><code><b>const</b> <a href="table_vec.md#0x2_table_vec_ETABLE_NONEMPTY">ETABLE_NONEMPTY</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_table_vec_empty"></a>
+
+## Function `empty`
+
+Create an empty TableVec.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_empty">empty</a>&lt;Element: store&gt;(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_empty">empty</a>&lt;Element: store&gt;(ctx: &<b>mut</b> TxContext): <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt; {
+    <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a> {
+        contents: <a href="table.md#0x2_table_new">table::new</a>(ctx)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_vec_singleton"></a>
+
+## Function `singleton`
+
+Return a TableVec of size one containing element <code>e</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_singleton">singleton</a>&lt;Element: store&gt;(e: Element, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_singleton">singleton</a>&lt;Element: store&gt;(e: Element, ctx: &<b>mut</b> TxContext): <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt; {
+    <b>let</b> t = <a href="table_vec.md#0x2_table_vec_empty">empty</a>(ctx);
+    <a href="table_vec.md#0x2_table_vec_push_back">push_back</a>(&<b>mut</b> t, e);
+    t
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_vec_length"></a>
+
+## Function `length`
+
+Return the length of the TableVec.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_length">length</a>&lt;Element: store&gt;(t: &<a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_length">length</a>&lt;Element: store&gt;(t: &<a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;): u64 {
+    <a href="table.md#0x2_table_length">table::length</a>(&t.contents)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_vec_is_empty"></a>
+
+## Function `is_empty`
+
+Return if the TableVec is empty or not.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_is_empty">is_empty</a>&lt;Element: store&gt;(t: &<a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_is_empty">is_empty</a>&lt;Element: store&gt;(t: &<a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;): bool {
+    <a href="table_vec.md#0x2_table_vec_length">length</a>(t) == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_vec_borrow"></a>
+
+## Function `borrow`
+
+Acquire an immutable reference to the <code>i</code>th element of the TableVec <code>t</code>.
+Aborts if <code>i</code> is out of bounds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_borrow">borrow</a>&lt;Element: store&gt;(t: &<a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;, i: u64): &Element
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_borrow">borrow</a>&lt;Element: store&gt;(t: &<a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;, i: u64): &Element {
+    <b>assert</b>!(<a href="table_vec.md#0x2_table_vec_length">length</a>(t) &gt; i, <a href="table_vec.md#0x2_table_vec_EINDEX_OUT_OF_BOUND">EINDEX_OUT_OF_BOUND</a>);
+    <a href="table.md#0x2_table_borrow">table::borrow</a>(&t.contents, i)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_vec_push_back"></a>
+
+## Function `push_back`
+
+Add element <code>e</code> to the end of the TableVec <code>t</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_push_back">push_back</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;, e: Element)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_push_back">push_back</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;, e: Element) {
+    <b>let</b> key = <a href="table_vec.md#0x2_table_vec_length">length</a>(t);
+    <a href="table.md#0x2_table_add">table::add</a>(&<b>mut</b> t.contents, key, e);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_vec_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Return a mutable reference to the <code>i</code>th element in the TableVec <code>t</code>.
+Aborts if <code>i</code> is out of bounds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_borrow_mut">borrow_mut</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_borrow_mut">borrow_mut</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element {
+    <b>assert</b>!(<a href="table_vec.md#0x2_table_vec_length">length</a>(t) &gt; i, <a href="table_vec.md#0x2_table_vec_EINDEX_OUT_OF_BOUND">EINDEX_OUT_OF_BOUND</a>);
+    <a href="table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> t.contents, i)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_vec_pop_back"></a>
+
+## Function `pop_back`
+
+Pop an element from the end of TableVec <code>t</code>.
+Aborts if <code>t</code> is empty.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_pop_back">pop_back</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;): Element
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_pop_back">pop_back</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;): Element {
+    <b>let</b> length = <a href="table_vec.md#0x2_table_vec_length">length</a>(t);
+    <b>assert</b>!(length &gt; 0, <a href="table_vec.md#0x2_table_vec_EINDEX_OUT_OF_BOUND">EINDEX_OUT_OF_BOUND</a>);
+    <a href="table.md#0x2_table_remove">table::remove</a>(&<b>mut</b> t.contents, length - 1)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_vec_destroy_empty"></a>
+
+## Function `destroy_empty`
+
+Destroy the TableVec <code>t</code>.
+Aborts if <code>t</code> is not empty.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_destroy_empty">destroy_empty</a>&lt;Element: store&gt;(t: <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_destroy_empty">destroy_empty</a>&lt;Element: store&gt;(t: <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;) {
+    <b>assert</b>!(<a href="table_vec.md#0x2_table_vec_length">length</a>(&t) == 0, <a href="table_vec.md#0x2_table_vec_ETABLE_NONEMPTY">ETABLE_NONEMPTY</a>);
+    <b>let</b> <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a> { contents } = t;
+    <a href="table.md#0x2_table_destroy_empty">table::destroy_empty</a>(contents);
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/transfer.md
+++ b/crates/sui-framework-override/docs/transfer.md
@@ -1,0 +1,134 @@
+
+<a name="0x2_transfer"></a>
+
+# Module `0x2::transfer`
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `transfer`](#0x2_transfer_transfer)
+-  [Function `freeze_object`](#0x2_transfer_freeze_object)
+-  [Function `share_object`](#0x2_transfer_share_object)
+-  [Function `transfer_internal`](#0x2_transfer_transfer_internal)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_transfer_ESharedNonNewObject"></a>
+
+Shared an object that was previously created. Shared objects must currently
+be constructed in the transaction they are created.
+
+
+<pre><code><b>const</b> <a href="transfer.md#0x2_transfer_ESharedNonNewObject">ESharedNonNewObject</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_transfer_transfer"></a>
+
+## Function `transfer`
+
+Transfer ownership of <code>obj</code> to <code>recipient</code>. <code>obj</code> must have the
+<code>key</code> attribute, which (in turn) ensures that <code>obj</code> has a globally
+unique ID.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>) {
+    // TODO: emit <a href="event.md#0x2_event">event</a>
+    <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>(obj, recipient)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_transfer_freeze_object"></a>
+
+## Function `freeze_object`
+
+Freeze <code>obj</code>. After freezing <code>obj</code> becomes immutable and can no
+longer be transferred or mutated.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer_freeze_object">freeze_object</a>&lt;T: key&gt;(obj: T)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="transfer.md#0x2_transfer_freeze_object">freeze_object</a>&lt;T: key&gt;(obj: T);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_transfer_share_object"></a>
+
+## Function `share_object`
+
+Turn the given object into a mutable shared object that everyone
+can access and mutate. This is irreversible, i.e. once an object
+is shared, it will stay shared forever.
+Aborts with <code><a href="transfer.md#0x2_transfer_ESharedNonNewObject">ESharedNonNewObject</a></code> of the object being shared was not created
+in this transaction. This restriction may be relaxed in the future.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer_share_object">share_object</a>&lt;T: key&gt;(obj: T)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="transfer.md#0x2_transfer_share_object">share_object</a>&lt;T: key&gt;(obj: T);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_transfer_transfer_internal"></a>
+
+## Function `transfer_internal`
+
+
+
+<pre><code><b>fun</b> <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>);
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/tx_context.md
+++ b/crates/sui-framework-override/docs/tx_context.md
@@ -1,0 +1,221 @@
+
+<a name="0x2_tx_context"></a>
+
+# Module `0x2::tx_context`
+
+
+
+-  [Struct `TxContext`](#0x2_tx_context_TxContext)
+-  [Constants](#@Constants_0)
+-  [Function `sender`](#0x2_tx_context_sender)
+-  [Function `epoch`](#0x2_tx_context_epoch)
+-  [Function `new_object`](#0x2_tx_context_new_object)
+-  [Function `ids_created`](#0x2_tx_context_ids_created)
+-  [Function `derive_id`](#0x2_tx_context_derive_id)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_tx_context_TxContext"></a>
+
+## Struct `TxContext`
+
+Information about the transaction currently being executed.
+This cannot be constructed by a transaction--it is a privileged object created by
+the VM and passed in to the entrypoint of the transaction as <code>&<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a></code>.
+
+
+<pre><code><b>struct</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a> <b>has</b> drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>sender: <b>address</b></code>
+</dt>
+<dd>
+ The address of the user that signed the current transaction
+</dd>
+<dt>
+<code>tx_hash: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ Hash of the current transaction
+</dd>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+ The current epoch number.
+</dd>
+<dt>
+<code>ids_created: u64</code>
+</dt>
+<dd>
+ Counter recording the number of fresh id's created while executing
+ this transaction. Always 0 at the start of a transaction
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_tx_context_EBadTxHashLength"></a>
+
+Expected an tx hash of length 32, but found a different length
+
+
+<pre><code><b>const</b> <a href="tx_context.md#0x2_tx_context_EBadTxHashLength">EBadTxHashLength</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_tx_context_TX_HASH_LENGTH"></a>
+
+Number of bytes in an tx hash (which will be the transaction digest)
+
+
+<pre><code><b>const</b> <a href="tx_context.md#0x2_tx_context_TX_HASH_LENGTH">TX_HASH_LENGTH</a>: u64 = 32;
+</code></pre>
+
+
+
+<a name="0x2_tx_context_sender"></a>
+
+## Function `sender`
+
+Return the address of the user that signed the current
+transaction
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_sender">sender</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_sender">sender</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <b>address</b> {
+    self.sender
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_tx_context_epoch"></a>
+
+## Function `epoch`
+
+Return the current epoch
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_epoch">epoch</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_epoch">epoch</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): u64 {
+    self.epoch
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_tx_context_new_object"></a>
+
+## Function `new_object`
+
+Generate a new, globally unique object ID with version 0
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_new_object">new_object</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_new_object">new_object</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <b>address</b> {
+    <b>let</b> ids_created = ctx.ids_created;
+    <b>let</b> id = <a href="tx_context.md#0x2_tx_context_derive_id">derive_id</a>(*&ctx.tx_hash, ids_created);
+    ctx.ids_created = ids_created + 1;
+    id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_tx_context_ids_created"></a>
+
+## Function `ids_created`
+
+Return the number of id's created by the current transaction.
+Hidden for now, but may expose later
+
+
+<pre><code><b>fun</b> <a href="tx_context.md#0x2_tx_context_ids_created">ids_created</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="tx_context.md#0x2_tx_context_ids_created">ids_created</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): u64 {
+    self.ids_created
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_tx_context_derive_id"></a>
+
+## Function `derive_id`
+
+Native function for deriving an ID via hash(tx_hash || ids_created)
+
+
+<pre><code><b>fun</b> <a href="tx_context.md#0x2_tx_context_derive_id">derive_id</a>(tx_hash: <a href="">vector</a>&lt;u8&gt;, ids_created: u64): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_derive_id">derive_id</a>(tx_hash: <a href="">vector</a>&lt;u8&gt;, ids_created: u64): <b>address</b>;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/typed_id.md
+++ b/crates/sui-framework-override/docs/typed_id.md
@@ -1,0 +1,162 @@
+
+<a name="0x2_typed_id"></a>
+
+# Module `0x2::typed_id`
+
+Typed wrappers around Sui object IDs
+While not always necessary, this is helpful for indicating the type of an object, particularly
+when storing its ID in another object.
+Additionally, it can be helpful for disambiguating between different IDs in an object.
+For example
+```
+struct MyObject has key {
+id: VersionedID,
+child1: TypedID<A>,
+child2: TypedID<B>,
+}
+```
+We then know that <code>child1</code> is an ID for an object of type <code>A</code> and that <code>child2</code> is an <code>ID</code>
+of an object of type <code>B</code>
+
+
+-  [Struct `TypedID`](#0x2_typed_id_TypedID)
+-  [Function `new`](#0x2_typed_id_new)
+-  [Function `as_id`](#0x2_typed_id_as_id)
+-  [Function `to_id`](#0x2_typed_id_to_id)
+-  [Function `equals_object`](#0x2_typed_id_equals_object)
+
+
+<pre><code><b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+</code></pre>
+
+
+
+<a name="0x2_typed_id_TypedID"></a>
+
+## Struct `TypedID`
+
+An ID of an of type <code>T</code>. See <code>ID</code> for more details
+By construction, it is guaranteed that the <code>ID</code> represents an object of type <code>T</code>
+
+
+<pre><code><b>struct</b> <a href="typed_id.md#0x2_typed_id_TypedID">TypedID</a>&lt;T: key&gt; <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_typed_id_new"></a>
+
+## Function `new`
+
+Get the underlying <code>ID</code> of <code>obj</code>, and remember the type
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="typed_id.md#0x2_typed_id_new">new</a>&lt;T: key&gt;(obj: &T): <a href="typed_id.md#0x2_typed_id_TypedID">typed_id::TypedID</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="typed_id.md#0x2_typed_id_new">new</a>&lt;T: key&gt;(obj: &T): <a href="typed_id.md#0x2_typed_id_TypedID">TypedID</a>&lt;T&gt; {
+    <a href="typed_id.md#0x2_typed_id_TypedID">TypedID</a> { id: <a href="object.md#0x2_object_id">object::id</a>(obj) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_typed_id_as_id"></a>
+
+## Function `as_id`
+
+Borrow the inner <code>ID</code> of <code><a href="typed_id.md#0x2_typed_id">typed_id</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="typed_id.md#0x2_typed_id_as_id">as_id</a>&lt;T: key&gt;(<a href="typed_id.md#0x2_typed_id">typed_id</a>: &<a href="typed_id.md#0x2_typed_id_TypedID">typed_id::TypedID</a>&lt;T&gt;): &<a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="typed_id.md#0x2_typed_id_as_id">as_id</a>&lt;T: key&gt;(<a href="typed_id.md#0x2_typed_id">typed_id</a>: &<a href="typed_id.md#0x2_typed_id_TypedID">TypedID</a>&lt;T&gt;): &ID {
+    &<a href="typed_id.md#0x2_typed_id">typed_id</a>.id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_typed_id_to_id"></a>
+
+## Function `to_id`
+
+Get the inner <code>ID</code> of <code><a href="typed_id.md#0x2_typed_id">typed_id</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="typed_id.md#0x2_typed_id_to_id">to_id</a>&lt;T: key&gt;(<a href="typed_id.md#0x2_typed_id">typed_id</a>: <a href="typed_id.md#0x2_typed_id_TypedID">typed_id::TypedID</a>&lt;T&gt;): <a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="typed_id.md#0x2_typed_id_to_id">to_id</a>&lt;T: key&gt;(<a href="typed_id.md#0x2_typed_id">typed_id</a>: <a href="typed_id.md#0x2_typed_id_TypedID">TypedID</a>&lt;T&gt;): ID {
+    <b>let</b> <a href="typed_id.md#0x2_typed_id_TypedID">TypedID</a> { id } = <a href="typed_id.md#0x2_typed_id">typed_id</a>;
+    id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_typed_id_equals_object"></a>
+
+## Function `equals_object`
+
+Check that underlying <code>ID</code> in the <code><a href="typed_id.md#0x2_typed_id">typed_id</a></code> equals the objects ID
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="typed_id.md#0x2_typed_id_equals_object">equals_object</a>&lt;T: key&gt;(<a href="typed_id.md#0x2_typed_id">typed_id</a>: &<a href="typed_id.md#0x2_typed_id_TypedID">typed_id::TypedID</a>&lt;T&gt;, obj: &T): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="typed_id.md#0x2_typed_id_equals_object">equals_object</a>&lt;T: key&gt;(<a href="typed_id.md#0x2_typed_id">typed_id</a>: &<a href="typed_id.md#0x2_typed_id_TypedID">TypedID</a>&lt;T&gt;, obj: &T): bool {
+    <a href="typed_id.md#0x2_typed_id">typed_id</a>.id == <a href="object.md#0x2_object_id">object::id</a>(obj)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/types.md
+++ b/crates/sui-framework-override/docs/types.md
@@ -1,0 +1,38 @@
+
+<a name="0x2_types"></a>
+
+# Module `0x2::types`
+
+Sui types helpers and utilities
+
+
+-  [Function `is_one_time_witness`](#0x2_types_is_one_time_witness)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_types_is_one_time_witness"></a>
+
+## Function `is_one_time_witness`
+
+Tests if the argument type is a one-time witness, that is a type with only one instantiation
+across the entire code base.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="types.md#0x2_types_is_one_time_witness">is_one_time_witness</a>&lt;T: drop&gt;(_: &T): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="types.md#0x2_types_is_one_time_witness">is_one_time_witness</a>&lt;T: drop&gt;(_: &T): bool;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/url.md
+++ b/crates/sui-framework-override/docs/url.md
@@ -1,0 +1,149 @@
+
+<a name="0x2_url"></a>
+
+# Module `0x2::url`
+
+URL: standard Uniform Resource Locator string
+
+
+-  [Struct `Url`](#0x2_url_Url)
+-  [Function `new_unsafe`](#0x2_url_new_unsafe)
+-  [Function `new_unsafe_from_bytes`](#0x2_url_new_unsafe_from_bytes)
+-  [Function `inner_url`](#0x2_url_inner_url)
+-  [Function `update`](#0x2_url_update)
+
+
+<pre><code><b>use</b> <a href="">0x1::ascii</a>;
+</code></pre>
+
+
+
+<a name="0x2_url_Url"></a>
+
+## Struct `Url`
+
+Standard Uniform Resource Locator (URL) string.
+
+
+<pre><code><b>struct</b> <a href="url.md#0x2_url_Url">Url</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="url.md#0x2_url">url</a>: <a href="_String">ascii::String</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_url_new_unsafe"></a>
+
+## Function `new_unsafe`
+
+Create a <code><a href="url.md#0x2_url_Url">Url</a></code>, with no validation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="url.md#0x2_url_new_unsafe">new_unsafe</a>(<a href="url.md#0x2_url">url</a>: <a href="_String">ascii::String</a>): <a href="url.md#0x2_url_Url">url::Url</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="url.md#0x2_url_new_unsafe">new_unsafe</a>(<a href="url.md#0x2_url">url</a>: String): <a href="url.md#0x2_url_Url">Url</a> {
+    <a href="url.md#0x2_url_Url">Url</a> { <a href="url.md#0x2_url">url</a> }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_url_new_unsafe_from_bytes"></a>
+
+## Function `new_unsafe_from_bytes`
+
+Create a <code><a href="url.md#0x2_url_Url">Url</a></code> with no validation from bytes
+Note: this will abort if <code>bytes</code> is not valid ASCII
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="url.md#0x2_url_new_unsafe_from_bytes">new_unsafe_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="url.md#0x2_url_Url">url::Url</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="url.md#0x2_url_new_unsafe_from_bytes">new_unsafe_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="url.md#0x2_url_Url">Url</a> {
+    <b>let</b> <a href="url.md#0x2_url">url</a> = <a href="_string">ascii::string</a>(bytes);
+    <a href="url.md#0x2_url_Url">Url</a> { <a href="url.md#0x2_url">url</a> }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_url_inner_url"></a>
+
+## Function `inner_url`
+
+Get inner URL
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="url.md#0x2_url_inner_url">inner_url</a>(self: &<a href="url.md#0x2_url_Url">url::Url</a>): <a href="_String">ascii::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="url.md#0x2_url_inner_url">inner_url</a>(self: &<a href="url.md#0x2_url_Url">Url</a>): String{
+    self.<a href="url.md#0x2_url">url</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_url_update"></a>
+
+## Function `update`
+
+Update the inner URL
+
+
+<pre><code><b>public</b> <b>fun</b> <b>update</b>(self: &<b>mut</b> <a href="url.md#0x2_url_Url">url::Url</a>, <a href="url.md#0x2_url">url</a>: <a href="_String">ascii::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <b>update</b>(self: &<b>mut</b> <a href="url.md#0x2_url_Url">Url</a>, <a href="url.md#0x2_url">url</a>: String) {
+    self.<a href="url.md#0x2_url">url</a> = <a href="url.md#0x2_url">url</a>;
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/validator.md
+++ b/crates/sui-framework-override/docs/validator.md
@@ -1,0 +1,1112 @@
+
+<a name="0x2_validator"></a>
+
+# Module `0x2::validator`
+
+
+
+-  [Struct `ValidatorMetadata`](#0x2_validator_ValidatorMetadata)
+-  [Struct `Validator`](#0x2_validator_Validator)
+-  [Constants](#@Constants_0)
+-  [Function `verify_proof_of_possession`](#0x2_validator_verify_proof_of_possession)
+-  [Function `new`](#0x2_validator_new)
+-  [Function `destroy`](#0x2_validator_destroy)
+-  [Function `request_add_stake`](#0x2_validator_request_add_stake)
+-  [Function `request_withdraw_stake`](#0x2_validator_request_withdraw_stake)
+-  [Function `adjust_stake_and_gas_price`](#0x2_validator_adjust_stake_and_gas_price)
+-  [Function `request_add_delegation`](#0x2_validator_request_add_delegation)
+-  [Function `request_withdraw_delegation`](#0x2_validator_request_withdraw_delegation)
+-  [Function `cancel_delegation_request`](#0x2_validator_cancel_delegation_request)
+-  [Function `decrease_next_epoch_delegation`](#0x2_validator_decrease_next_epoch_delegation)
+-  [Function `request_set_gas_price`](#0x2_validator_request_set_gas_price)
+-  [Function `request_set_commission_rate`](#0x2_validator_request_set_commission_rate)
+-  [Function `deposit_delegation_rewards`](#0x2_validator_deposit_delegation_rewards)
+-  [Function `process_pending_delegations_and_withdraws`](#0x2_validator_process_pending_delegations_and_withdraws)
+-  [Function `get_staking_pool_mut_ref`](#0x2_validator_get_staking_pool_mut_ref)
+-  [Function `metadata`](#0x2_validator_metadata)
+-  [Function `sui_address`](#0x2_validator_sui_address)
+-  [Function `total_stake_amount`](#0x2_validator_total_stake_amount)
+-  [Function `stake_amount`](#0x2_validator_stake_amount)
+-  [Function `delegate_amount`](#0x2_validator_delegate_amount)
+-  [Function `total_stake`](#0x2_validator_total_stake)
+-  [Function `voting_power`](#0x2_validator_voting_power)
+-  [Function `set_voting_power`](#0x2_validator_set_voting_power)
+-  [Function `pending_stake_amount`](#0x2_validator_pending_stake_amount)
+-  [Function `pending_withdraw`](#0x2_validator_pending_withdraw)
+-  [Function `gas_price`](#0x2_validator_gas_price)
+-  [Function `commission_rate`](#0x2_validator_commission_rate)
+-  [Function `pool_token_exchange_rate`](#0x2_validator_pool_token_exchange_rate)
+-  [Function `is_duplicate`](#0x2_validator_is_duplicate)
+
+
+<pre><code><b>use</b> <a href="">0x1::ascii</a>;
+<b>use</b> <a href="">0x1::bcs</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="bls12381.md#0x2_bls12381">0x2::bls12381</a>;
+<b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
+<b>use</b> <a href="stake.md#0x2_stake">0x2::stake</a>;
+<b>use</b> <a href="staking_pool.md#0x2_staking_pool">0x2::staking_pool</a>;
+<b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+<b>use</b> <a href="url.md#0x2_url">0x2::url</a>;
+</code></pre>
+
+
+
+<a name="0x2_validator_ValidatorMetadata"></a>
+
+## Struct `ValidatorMetadata`
+
+
+
+<pre><code><b>struct</b> <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>sui_address: <b>address</b></code>
+</dt>
+<dd>
+ The Sui Address of the validator. This is the sender that created the Validator object,
+ and also the address to send validator/coins to during withdraws.
+</dd>
+<dt>
+<code>pubkey_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The public key bytes corresponding to the private key that the validator
+ holds to sign transactions. For now, this is the same as AuthorityName.
+</dd>
+<dt>
+<code>network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The public key bytes corresponding to the private key that the validator
+ uses to establish TLS connections
+</dd>
+<dt>
+<code>worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The public key bytes correstponding to the Narwhal Worker
+</dd>
+<dt>
+<code>proof_of_possession: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ This is a proof that the validator has ownership of the private key
+</dd>
+<dt>
+<code>name: <a href="_String">string::String</a></code>
+</dt>
+<dd>
+ A unique human-readable name of this validator.
+</dd>
+<dt>
+<code>description: <a href="_String">string::String</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>image_url: <a href="url.md#0x2_url_Url">url::Url</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>project_url: <a href="url.md#0x2_url_Url">url::Url</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>net_address: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The network address of the validator (could also contain extra info such as port, DNS and etc.).
+</dd>
+<dt>
+<code>consensus_address: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The address of the narwhal primary
+</dd>
+<dt>
+<code>worker_address: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The address of the narwhal worker
+</dd>
+<dt>
+<code>next_epoch_stake: u64</code>
+</dt>
+<dd>
+ Total amount of validator stake that would be active in the next epoch.
+</dd>
+<dt>
+<code>next_epoch_delegation: u64</code>
+</dt>
+<dd>
+ Total amount of delegated stake that would be active in the next epoch.
+</dd>
+<dt>
+<code>next_epoch_gas_price: u64</code>
+</dt>
+<dd>
+ This validator's gas price quote for the next epoch.
+</dd>
+<dt>
+<code>next_epoch_commission_rate: u64</code>
+</dt>
+<dd>
+ The commission rate of the validator starting the next epoch, in basis point.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_validator_Validator"></a>
+
+## Struct `Validator`
+
+
+
+<pre><code><b>struct</b> <a href="validator.md#0x2_validator_Validator">Validator</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>metadata: <a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a></code>
+</dt>
+<dd>
+ Summary of the validator.
+</dd>
+<dt>
+<code><a href="voting_power.md#0x2_voting_power">voting_power</a>: u64</code>
+</dt>
+<dd>
+ The voting power of this validator, which might be different from its
+ stake amount.
+</dd>
+<dt>
+<code>stake_amount: u64</code>
+</dt>
+<dd>
+ The current active stake amount. This will not change during an epoch. It can only
+ be updated at the end of epoch.
+</dd>
+<dt>
+<code>pending_stake: u64</code>
+</dt>
+<dd>
+ Pending stake deposit amount, processed at end of epoch.
+</dd>
+<dt>
+<code>pending_withdraw: u64</code>
+</dt>
+<dd>
+ Pending withdraw amount, processed at end of epoch.
+</dd>
+<dt>
+<code>gas_price: u64</code>
+</dt>
+<dd>
+ Gas price quote, updated only at end of epoch.
+</dd>
+<dt>
+<code>delegation_staking_pool: <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a></code>
+</dt>
+<dd>
+ Staking pool for the stakes delegated to this validator.
+</dd>
+<dt>
+<code>commission_rate: u64</code>
+</dt>
+<dd>
+ Commission rate of the validator, in basis point.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_validator_PROOF_OF_POSSESSION_DOMAIN"></a>
+
+
+
+<pre><code><b>const</b> <a href="validator.md#0x2_validator_PROOF_OF_POSSESSION_DOMAIN">PROOF_OF_POSSESSION_DOMAIN</a>: <a href="">vector</a>&lt;u8&gt; = [107, 111, 115, 107];
+</code></pre>
+
+
+
+<a name="0x2_validator_verify_proof_of_possession"></a>
+
+## Function `verify_proof_of_possession`
+
+
+
+<pre><code><b>fun</b> <a href="validator.md#0x2_validator_verify_proof_of_possession">verify_proof_of_possession</a>(proof_of_possession: <a href="">vector</a>&lt;u8&gt;, sui_address: <b>address</b>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator.md#0x2_validator_verify_proof_of_possession">verify_proof_of_possession</a>(
+    proof_of_possession: <a href="">vector</a>&lt;u8&gt;,
+    sui_address: <b>address</b>,
+    pubkey_bytes: <a href="">vector</a>&lt;u8&gt;
+) {
+    // The proof of possession is the signature over ValidatorPK || AccountAddress.
+    // This proves that the account <b>address</b> is owned by the holder of ValidatorPK, and <b>ensures</b>
+    // that PK <b>exists</b>.
+    <b>let</b> signed_bytes = pubkey_bytes;
+    <b>let</b> address_bytes = <a href="_to_bytes">bcs::to_bytes</a>(&sui_address);
+    <a href="_append">vector::append</a>(&<b>mut</b> signed_bytes, address_bytes);
+    <b>assert</b>!(
+        bls12381_min_sig_verify_with_domain(&proof_of_possession, &pubkey_bytes, signed_bytes, <a href="validator.md#0x2_validator_PROOF_OF_POSSESSION_DOMAIN">PROOF_OF_POSSESSION_DOMAIN</a>) == <b>true</b>,
+        0
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_new"></a>
+
+## Function `new`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new">new</a>(sui_address: <b>address</b>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, consensus_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, <a href="stake.md#0x2_stake">stake</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, gas_price: u64, commission_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new">new</a>(
+    sui_address: <b>address</b>,
+    pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
+    network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
+    worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
+    proof_of_possession: <a href="">vector</a>&lt;u8&gt;,
+    name: <a href="">vector</a>&lt;u8&gt;,
+    description: <a href="">vector</a>&lt;u8&gt;,
+    image_url: <a href="">vector</a>&lt;u8&gt;,
+    project_url: <a href="">vector</a>&lt;u8&gt;,
+    net_address: <a href="">vector</a>&lt;u8&gt;,
+    consensus_address: <a href="">vector</a>&lt;u8&gt;,
+    worker_address: <a href="">vector</a>&lt;u8&gt;,
+    <a href="stake.md#0x2_stake">stake</a>: Balance&lt;SUI&gt;,
+    coin_locked_until_epoch: Option&lt;EpochTimeLock&gt;,
+    gas_price: u64,
+    commission_rate: u64,
+    ctx: &<b>mut</b> TxContext
+): <a href="validator.md#0x2_validator_Validator">Validator</a> {
+    <b>assert</b>!(
+        // TODO: These constants are arbitrary, will adjust once we know more.
+        <a href="_length">vector::length</a>(&net_address) &lt;= 128
+            && <a href="_length">vector::length</a>(&name) &lt;= 128
+            && <a href="_length">vector::length</a>(&description) &lt;= 150
+            && <a href="_length">vector::length</a>(&pubkey_bytes) &lt;= 128,
+        0
+    );
+    <a href="validator.md#0x2_validator_verify_proof_of_possession">verify_proof_of_possession</a>(
+        proof_of_possession,
+        sui_address,
+        pubkey_bytes
+    );
+    <b>let</b> stake_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&<a href="stake.md#0x2_stake">stake</a>);
+    <a href="stake.md#0x2_stake_create">stake::create</a>(<a href="stake.md#0x2_stake">stake</a>, sui_address, coin_locked_until_epoch, ctx);
+    <a href="validator.md#0x2_validator_Validator">Validator</a> {
+        metadata: <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> {
+            sui_address,
+            pubkey_bytes,
+            network_pubkey_bytes,
+            worker_pubkey_bytes,
+            proof_of_possession,
+            name: <a href="_from_ascii">string::from_ascii</a>(<a href="_string">ascii::string</a>(name)),
+            description: <a href="_from_ascii">string::from_ascii</a>(<a href="_string">ascii::string</a>(description)),
+            image_url: <a href="url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(image_url),
+            project_url: <a href="url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(project_url),
+            net_address,
+            consensus_address,
+            worker_address,
+            next_epoch_stake: stake_amount,
+            next_epoch_delegation: 0,
+            next_epoch_gas_price: gas_price,
+            next_epoch_commission_rate: commission_rate,
+        },
+        // Initialize the voting power <b>to</b> be the same <b>as</b> the <a href="stake.md#0x2_stake">stake</a> amount.
+        // At the epoch change <b>where</b> this <a href="validator.md#0x2_validator">validator</a> is actually added <b>to</b> the
+        // active <a href="validator.md#0x2_validator">validator</a> set, the voting power will be updated accordingly.
+        <a href="voting_power.md#0x2_voting_power">voting_power</a>: stake_amount,
+        stake_amount,
+        pending_stake: 0,
+        pending_withdraw: 0,
+        gas_price,
+        delegation_staking_pool: <a href="staking_pool.md#0x2_staking_pool_new">staking_pool::new</a>(sui_address, <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1, ctx),
+        commission_rate,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_destroy"></a>
+
+## Function `destroy`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_destroy">destroy</a>(self: <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_destroy">destroy</a>(self: <a href="validator.md#0x2_validator_Validator">Validator</a>, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> <a href="validator.md#0x2_validator_Validator">Validator</a> {
+        metadata: _,
+        <a href="voting_power.md#0x2_voting_power">voting_power</a>: _,
+        stake_amount: _,
+        pending_stake: _,
+        pending_withdraw: _,
+        gas_price: _,
+        delegation_staking_pool,
+        commission_rate: _,
+    } = self;
+    <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">staking_pool::deactivate_staking_pool</a>(delegation_staking_pool, ctx);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_request_add_stake"></a>
+
+## Function `request_add_stake`
+
+Add stake to an active validator. The new stake is added to the pending_stake field,
+which will be processed at the end of epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_add_stake">request_add_stake</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, new_stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_add_stake">request_add_stake</a>(
+    self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>,
+    new_stake: Balance&lt;SUI&gt;,
+    coin_locked_until_epoch: Option&lt;EpochTimeLock&gt;,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> new_stake_value = <a href="balance.md#0x2_balance_value">balance::value</a>(&new_stake);
+    self.pending_stake = self.pending_stake + new_stake_value;
+    self.metadata.next_epoch_stake = self.metadata.next_epoch_stake + new_stake_value;
+    <a href="stake.md#0x2_stake_create">stake::create</a>(new_stake, self.metadata.sui_address, coin_locked_until_epoch, ctx);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_request_withdraw_stake"></a>
+
+## Function `request_withdraw_stake`
+
+Withdraw stake from an active validator. Since it's active, we need
+to add it to the pending withdraw amount and process it at the end
+of epoch. We also need to make sure there is sufficient amount to withdraw such that the validator's
+stake still satisfy the minimum requirement.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_withdraw_stake">request_withdraw_stake</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, <a href="stake.md#0x2_stake">stake</a>: &<b>mut</b> <a href="stake.md#0x2_stake_Stake">stake::Stake</a>, withdraw_amount: u64, min_validator_stake: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_withdraw_stake">request_withdraw_stake</a>(
+    self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>,
+    <a href="stake.md#0x2_stake">stake</a>: &<b>mut</b> Stake,
+    withdraw_amount: u64,
+    min_validator_stake: u64,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>assert</b>!(self.metadata.next_epoch_stake &gt;= withdraw_amount + min_validator_stake, 0);
+    self.pending_withdraw = self.pending_withdraw + withdraw_amount;
+    self.metadata.next_epoch_stake = self.metadata.next_epoch_stake - withdraw_amount;
+    <a href="stake.md#0x2_stake_withdraw_stake">stake::withdraw_stake</a>(<a href="stake.md#0x2_stake">stake</a>, withdraw_amount, ctx);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_adjust_stake_and_gas_price"></a>
+
+## Function `adjust_stake_and_gas_price`
+
+Process pending stake and pending withdraws, and update the gas price.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_adjust_stake_and_gas_price">adjust_stake_and_gas_price</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_adjust_stake_and_gas_price">adjust_stake_and_gas_price</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>) {
+    self.stake_amount = self.stake_amount + self.pending_stake - self.pending_withdraw;
+    self.pending_stake = 0;
+    self.pending_withdraw = 0;
+    self.gas_price = self.metadata.next_epoch_gas_price;
+    self.commission_rate = self.metadata.next_epoch_commission_rate;
+    <b>assert</b>!(self.stake_amount == self.metadata.next_epoch_stake, 0);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_request_add_delegation"></a>
+
+## Function `request_add_delegation`
+
+Request to add delegation to the validator's staking pool, processed at the end of the epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_add_delegation">request_add_delegation</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, delegated_stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, locking_period: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, delegator: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_add_delegation">request_add_delegation</a>(
+    self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>,
+    delegated_stake: Balance&lt;SUI&gt;,
+    locking_period: Option&lt;EpochTimeLock&gt;,
+    delegator: <b>address</b>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> delegate_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&delegated_stake);
+    <b>assert</b>!(delegate_amount &gt; 0, 0);
+    <a href="staking_pool.md#0x2_staking_pool_request_add_delegation">staking_pool::request_add_delegation</a>(&<b>mut</b> self.delegation_staking_pool, delegated_stake, locking_period, delegator, ctx);
+    self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation + delegate_amount;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_request_withdraw_delegation"></a>
+
+## Function `request_withdraw_delegation`
+
+Request to withdraw delegation from the validator's staking pool, processed at the end of the epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_withdraw_delegation">request_withdraw_delegation</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_withdraw_delegation">request_withdraw_delegation</a>(
+    self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>,
+    delegation: Delegation,
+    staked_sui: StakedSui,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> principal_withdraw_amount = <a href="staking_pool.md#0x2_staking_pool_request_withdraw_delegation">staking_pool::request_withdraw_delegation</a>(
+            &<b>mut</b> self.delegation_staking_pool, delegation, staked_sui, ctx);
+    <a href="validator.md#0x2_validator_decrease_next_epoch_delegation">decrease_next_epoch_delegation</a>(self, principal_withdraw_amount);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_cancel_delegation_request"></a>
+
+## Function `cancel_delegation_request`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_cancel_delegation_request">cancel_delegation_request</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_cancel_delegation_request">cancel_delegation_request</a>(
+    self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>,
+    staked_sui: StakedSui,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> delegate_amount = <a href="staking_pool.md#0x2_staking_pool_staked_sui_amount">staking_pool::staked_sui_amount</a>(&staked_sui);
+    <a href="staking_pool.md#0x2_staking_pool_cancel_delegation_request">staking_pool::cancel_delegation_request</a>(&<b>mut</b> self.delegation_staking_pool, staked_sui, ctx);
+    self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation - delegate_amount;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_decrease_next_epoch_delegation"></a>
+
+## Function `decrease_next_epoch_delegation`
+
+Decrement the delegation amount for next epoch. Also called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></code> when handling delegation switches.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_decrease_next_epoch_delegation">decrease_next_epoch_delegation</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_decrease_next_epoch_delegation">decrease_next_epoch_delegation</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, amount: u64) {
+    self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation - amount;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_request_set_gas_price"></a>
+
+## Function `request_set_gas_price`
+
+Request to set new gas price for the next epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_set_gas_price">request_set_gas_price</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, new_price: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_set_gas_price">request_set_gas_price</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, new_price: u64) {
+    self.metadata.next_epoch_gas_price = new_price;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_request_set_commission_rate"></a>
+
+## Function `request_set_commission_rate`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_set_commission_rate">request_set_commission_rate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, new_commission_rate: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_set_commission_rate">request_set_commission_rate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, new_commission_rate: u64) {
+    self.metadata.next_epoch_commission_rate = new_commission_rate;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_deposit_delegation_rewards"></a>
+
+## Function `deposit_delegation_rewards`
+
+Deposit delegations rewards into the validator's staking pool, called at the end of the epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deposit_delegation_rewards">deposit_delegation_rewards</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, reward: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deposit_delegation_rewards">deposit_delegation_rewards</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, reward: Balance&lt;SUI&gt;) {
+    self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation + <a href="balance.md#0x2_balance_value">balance::value</a>(&reward);
+    <a href="staking_pool.md#0x2_staking_pool_deposit_rewards">staking_pool::deposit_rewards</a>(&<b>mut</b> self.delegation_staking_pool, reward);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_process_pending_delegations_and_withdraws"></a>
+
+## Function `process_pending_delegations_and_withdraws`
+
+Process pending delegations and withdraws, called at the end of the epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_process_pending_delegations_and_withdraws">process_pending_delegations_and_withdraws</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_process_pending_delegations_and_withdraws">process_pending_delegations_and_withdraws</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, ctx: &<b>mut</b> TxContext) {
+    <a href="staking_pool.md#0x2_staking_pool_process_pending_delegations">staking_pool::process_pending_delegations</a>(&<b>mut</b> self.delegation_staking_pool, ctx);
+    <b>let</b> reward_withdraw_amount = <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation_withdraws">staking_pool::process_pending_delegation_withdraws</a>(
+        &<b>mut</b> self.delegation_staking_pool, ctx);
+    self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation - reward_withdraw_amount;
+    // <b>assert</b>!(<a href="validator.md#0x2_validator_delegate_amount">delegate_amount</a>(self) == self.metadata.next_epoch_delegation, 0);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_get_staking_pool_mut_ref"></a>
+
+## Function `get_staking_pool_mut_ref`
+
+Called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></code> for handling delegation switches.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_get_staking_pool_mut_ref">get_staking_pool_mut_ref</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_get_staking_pool_mut_ref">get_staking_pool_mut_ref</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>) : &<b>mut</b> StakingPool {
+    &<b>mut</b> self.delegation_staking_pool
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_metadata"></a>
+
+## Function `metadata`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_metadata">metadata</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_metadata">metadata</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> {
+    &self.metadata
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_sui_address"></a>
+
+## Function `sui_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_sui_address">sui_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_sui_address">sui_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): <b>address</b> {
+    self.metadata.sui_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_total_stake_amount"></a>
+
+## Function `total_stake_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_total_stake_amount">total_stake_amount</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_total_stake_amount">total_stake_amount</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
+    self.stake_amount + <a href="staking_pool.md#0x2_staking_pool_sui_balance">staking_pool::sui_balance</a>(&self.delegation_staking_pool)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_stake_amount"></a>
+
+## Function `stake_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_stake_amount">stake_amount</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_stake_amount">stake_amount</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
+    self.stake_amount
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_delegate_amount"></a>
+
+## Function `delegate_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_delegate_amount">delegate_amount</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_delegate_amount">delegate_amount</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
+    <a href="staking_pool.md#0x2_staking_pool_sui_balance">staking_pool::sui_balance</a>(&self.delegation_staking_pool)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_total_stake"></a>
+
+## Function `total_stake`
+
+Return the total amount staked with this validator, including both validator stake and deledgated stake
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_total_stake">total_stake</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_total_stake">total_stake</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
+    <a href="validator.md#0x2_validator_stake_amount">stake_amount</a>(self) + <a href="validator.md#0x2_validator_delegate_amount">delegate_amount</a>(self)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_voting_power"></a>
+
+## Function `voting_power`
+
+Return the voting power of this validator.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting_power.md#0x2_voting_power">voting_power</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting_power.md#0x2_voting_power">voting_power</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
+    self.<a href="voting_power.md#0x2_voting_power">voting_power</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_voting_power"></a>
+
+## Function `set_voting_power`
+
+Set the voting power of this validator, called only from validator_set.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_set_voting_power">set_voting_power</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, new_voting_power: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_set_voting_power">set_voting_power</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, new_voting_power: u64) {
+    self.<a href="voting_power.md#0x2_voting_power">voting_power</a> = new_voting_power;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_pending_stake_amount"></a>
+
+## Function `pending_stake_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pending_stake_amount">pending_stake_amount</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pending_stake_amount">pending_stake_amount</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
+    self.pending_stake
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_pending_withdraw"></a>
+
+## Function `pending_withdraw`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pending_withdraw">pending_withdraw</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pending_withdraw">pending_withdraw</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
+    self.pending_withdraw
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_gas_price"></a>
+
+## Function `gas_price`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_gas_price">gas_price</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_gas_price">gas_price</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
+    self.gas_price
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_commission_rate"></a>
+
+## Function `commission_rate`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_commission_rate">commission_rate</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_commission_rate">commission_rate</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
+    self.commission_rate
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_pool_token_exchange_rate"></a>
+
+## Function `pool_token_exchange_rate`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pool_token_exchange_rate">pool_token_exchange_rate</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pool_token_exchange_rate">pool_token_exchange_rate</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): PoolTokenExchangeRate {
+    <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate">staking_pool::pool_token_exchange_rate</a>(&self.delegation_staking_pool)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_is_duplicate"></a>
+
+## Function `is_duplicate`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_is_duplicate">is_duplicate</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>, other: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_is_duplicate">is_duplicate</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>, other: &<a href="validator.md#0x2_validator_Validator">Validator</a>): bool {
+     self.metadata.sui_address == other.metadata.sui_address
+        || self.metadata.name == other.metadata.name
+        || self.metadata.net_address == other.metadata.net_address
+        || self.metadata.pubkey_bytes == other.metadata.pubkey_bytes
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/validator_set.md
+++ b/crates/sui-framework-override/docs/validator_set.md
@@ -1,0 +1,2000 @@
+
+<a name="0x2_validator_set"></a>
+
+# Module `0x2::validator_set`
+
+
+
+-  [Struct `ValidatorSet`](#0x2_validator_set_ValidatorSet)
+-  [Struct `ValidatorPair`](#0x2_validator_set_ValidatorPair)
+-  [Struct `DelegationRequestEvent`](#0x2_validator_set_DelegationRequestEvent)
+-  [Struct `ValidatorEpochInfo`](#0x2_validator_set_ValidatorEpochInfo)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x2_validator_set_new)
+-  [Function `request_add_validator`](#0x2_validator_set_request_add_validator)
+-  [Function `request_remove_validator`](#0x2_validator_set_request_remove_validator)
+-  [Function `request_add_stake`](#0x2_validator_set_request_add_stake)
+-  [Function `request_withdraw_stake`](#0x2_validator_set_request_withdraw_stake)
+-  [Function `request_add_delegation`](#0x2_validator_set_request_add_delegation)
+-  [Function `cancel_delegation_request`](#0x2_validator_set_cancel_delegation_request)
+-  [Function `request_withdraw_delegation`](#0x2_validator_set_request_withdraw_delegation)
+-  [Function `request_switch_delegation`](#0x2_validator_set_request_switch_delegation)
+-  [Function `request_set_gas_price`](#0x2_validator_set_request_set_gas_price)
+-  [Function `request_set_commission_rate`](#0x2_validator_set_request_set_commission_rate)
+-  [Function `advance_epoch`](#0x2_validator_set_advance_epoch)
+-  [Function `derive_reference_gas_price`](#0x2_validator_set_derive_reference_gas_price)
+-  [Function `total_validator_stake`](#0x2_validator_set_total_validator_stake)
+-  [Function `total_delegation_stake`](#0x2_validator_set_total_delegation_stake)
+-  [Function `validator_total_stake_amount`](#0x2_validator_set_validator_total_stake_amount)
+-  [Function `validator_stake_amount`](#0x2_validator_set_validator_stake_amount)
+-  [Function `validator_delegate_amount`](#0x2_validator_set_validator_delegate_amount)
+-  [Function `next_epoch_validator_count`](#0x2_validator_set_next_epoch_validator_count)
+-  [Function `is_active_validator`](#0x2_validator_set_is_active_validator)
+-  [Function `contains_duplicate_validator`](#0x2_validator_set_contains_duplicate_validator)
+-  [Function `find_validator`](#0x2_validator_set_find_validator)
+-  [Function `get_validator_indices`](#0x2_validator_set_get_validator_indices)
+-  [Function `get_validator_mut`](#0x2_validator_set_get_validator_mut)
+-  [Function `get_validator_ref`](#0x2_validator_set_get_validator_ref)
+-  [Function `process_pending_removals`](#0x2_validator_set_process_pending_removals)
+-  [Function `process_pending_validators`](#0x2_validator_set_process_pending_validators)
+-  [Function `sort_removal_list`](#0x2_validator_set_sort_removal_list)
+-  [Function `process_pending_delegation_switches`](#0x2_validator_set_process_pending_delegation_switches)
+-  [Function `process_pending_delegations_and_withdraws`](#0x2_validator_set_process_pending_delegations_and_withdraws)
+-  [Function `calculate_total_stakes`](#0x2_validator_set_calculate_total_stakes)
+-  [Function `adjust_stake_and_gas_price`](#0x2_validator_set_adjust_stake_and_gas_price)
+-  [Function `compute_reward_adjustments`](#0x2_validator_set_compute_reward_adjustments)
+-  [Function `compute_slashed_validators_and_total_stake`](#0x2_validator_set_compute_slashed_validators_and_total_stake)
+-  [Function `compute_unadjusted_reward_distribution`](#0x2_validator_set_compute_unadjusted_reward_distribution)
+-  [Function `compute_adjusted_reward_distribution`](#0x2_validator_set_compute_adjusted_reward_distribution)
+-  [Function `distribute_reward`](#0x2_validator_set_distribute_reward)
+-  [Function `derive_next_epoch_validators`](#0x2_validator_set_derive_next_epoch_validators)
+-  [Function `emit_validator_epoch_events`](#0x2_validator_set_emit_validator_epoch_events)
+-  [Function `sum_voting_power_by_addresses`](#0x2_validator_set_sum_voting_power_by_addresses)
+-  [Function `active_validators`](#0x2_validator_set_active_validators)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
+<b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
+<b>use</b> <a href="priority_queue.md#0x2_priority_queue">0x2::priority_queue</a>;
+<b>use</b> <a href="stake.md#0x2_stake">0x2::stake</a>;
+<b>use</b> <a href="staking_pool.md#0x2_staking_pool">0x2::staking_pool</a>;
+<b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="table_vec.md#0x2_table_vec">0x2::table_vec</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+<b>use</b> <a href="validator.md#0x2_validator">0x2::validator</a>;
+<b>use</b> <a href="vec_map.md#0x2_vec_map">0x2::vec_map</a>;
+<b>use</b> <a href="vec_set.md#0x2_vec_set">0x2::vec_set</a>;
+<b>use</b> <a href="voting_power.md#0x2_voting_power">0x2::voting_power</a>;
+</code></pre>
+
+
+
+<a name="0x2_validator_set_ValidatorSet"></a>
+
+## Struct `ValidatorSet`
+
+
+
+<pre><code><b>struct</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>total_validator_stake: u64</code>
+</dt>
+<dd>
+ Total amount of stake from all active validators (not including delegation),
+ at the beginning of the epoch.
+</dd>
+<dt>
+<code>total_delegation_stake: u64</code>
+</dt>
+<dd>
+ Total amount of stake from delegation, at the beginning of the epoch.
+</dd>
+<dt>
+<code>active_validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;</code>
+</dt>
+<dd>
+ The current list of active validators.
+</dd>
+<dt>
+<code>pending_validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;</code>
+</dt>
+<dd>
+ List of new validator candidates added during the current epoch.
+ They will be processed at the end of the epoch.
+</dd>
+<dt>
+<code>pending_removals: <a href="">vector</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+ Removal requests from the validators. Each element is an index
+ pointing to <code>active_validators</code>.
+</dd>
+<dt>
+<code>next_epoch_validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>&gt;</code>
+</dt>
+<dd>
+ The metadata of the validator set for the next epoch. This is kept up-to-dated.
+ Everytime a change request is received, this set is updated.
+ TODO: This is currently not used. We may use it latter for enforcing min/max stake.
+</dd>
+<dt>
+<code>pending_delegation_switches: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<a href="validator_set.md#0x2_validator_set_ValidatorPair">validator_set::ValidatorPair</a>, <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;<a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">staking_pool::PendingWithdrawEntry</a>&gt;&gt;</code>
+</dt>
+<dd>
+ Delegation switches requested during the current epoch, processed at epoch boundaries
+ so that all the rewards with be added to the new delegation.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_validator_set_ValidatorPair"></a>
+
+## Struct `ValidatorPair`
+
+
+
+<pre><code><b>struct</b> <a href="validator_set.md#0x2_validator_set_ValidatorPair">ValidatorPair</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>from: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><b>to</b>: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_validator_set_DelegationRequestEvent"></a>
+
+## Struct `DelegationRequestEvent`
+
+Event emitted when a new delegation request is received.
+
+
+<pre><code><b>struct</b> <a href="validator_set.md#0x2_validator_set_DelegationRequestEvent">DelegationRequestEvent</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>validator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delegator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_validator_set_ValidatorEpochInfo"></a>
+
+## Struct `ValidatorEpochInfo`
+
+Event containing staking and rewards related information of
+each validator, emitted during epoch advancement.
+
+
+<pre><code><b>struct</b> <a href="validator_set.md#0x2_validator_set_ValidatorEpochInfo">ValidatorEpochInfo</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>validator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>reference_gas_survey_quote: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>validator_stake: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delegated_stake: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>commission_rate: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>stake_rewards: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>pool_token_exchange_rate: <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>tallying_rule_reporters: <a href="">vector</a>&lt;<b>address</b>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>tallying_rule_global_score: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_validator_set_BASIS_POINT_DENOMINATOR"></a>
+
+
+
+<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>: u128 = 10000;
+</code></pre>
+
+
+
+<a name="0x2_validator_set_EINVALID_STAKE_ADJUSTMENT_AMOUNT"></a>
+
+
+
+<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_EINVALID_STAKE_ADJUSTMENT_AMOUNT">EINVALID_STAKE_ADJUSTMENT_AMOUNT</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_validator_set_ENON_VALIDATOR_IN_REPORT_RECORDS"></a>
+
+
+
+<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_ENON_VALIDATOR_IN_REPORT_RECORDS">ENON_VALIDATOR_IN_REPORT_RECORDS</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_validator_set_new"></a>
+
+## Function `new`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_new">new</a>(init_active_validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;): <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_new">new</a>(init_active_validators: <a href="">vector</a>&lt;Validator&gt;): <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a> {
+    <b>let</b> (total_validator_stake, total_delegation_stake) =
+        <a href="validator_set.md#0x2_validator_set_calculate_total_stakes">calculate_total_stakes</a>(&init_active_validators);
+    <b>let</b> validators = <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a> {
+        total_validator_stake,
+        total_delegation_stake,
+        active_validators: init_active_validators,
+        pending_validators: <a href="_empty">vector::empty</a>(),
+        pending_removals: <a href="_empty">vector::empty</a>(),
+        next_epoch_validators: <a href="_empty">vector::empty</a>(),
+        pending_delegation_switches: <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>(),
+    };
+    validators.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(&validators);
+    <a href="voting_power.md#0x2_voting_power_set_voting_power">voting_power::set_voting_power</a>(&<b>mut</b> validators.active_validators);
+    validators
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_request_add_validator"></a>
+
+## Function `request_add_validator`
+
+Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>, add a new validator to <code>pending_validators</code>, which will be
+processed at the end of epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, <a href="validator.md#0x2_validator">validator</a>: <a href="validator.md#0x2_validator_Validator">validator::Validator</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, <a href="validator.md#0x2_validator">validator</a>: Validator) {
+    <b>assert</b>!(
+        !<a href="validator_set.md#0x2_validator_set_contains_duplicate_validator">contains_duplicate_validator</a>(&self.active_validators, &<a href="validator.md#0x2_validator">validator</a>)
+            && !<a href="validator_set.md#0x2_validator_set_contains_duplicate_validator">contains_duplicate_validator</a>(&self.pending_validators, &<a href="validator.md#0x2_validator">validator</a>),
+        0
+    );
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> self.pending_validators, <a href="validator.md#0x2_validator">validator</a>);
+    self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_request_remove_validator"></a>
+
+## Function `request_remove_validator`
+
+Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>, to remove a validator.
+The index of the validator is added to <code>pending_removals</code> and
+will be processed at the end of epoch.
+Only an active validator can request to be removed.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_remove_validator">request_remove_validator</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_remove_validator">request_remove_validator</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    ctx: &TxContext,
+) {
+    <b>let</b> validator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address);
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&validator_index_opt), 0);
+    <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
+    <b>assert</b>!(
+        !<a href="_contains">vector::contains</a>(&self.pending_removals, &validator_index),
+        0
+    );
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> self.pending_removals, validator_index);
+    self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_request_add_stake"></a>
+
+## Function `request_add_stake`
+
+Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>, to add more stake to a validator.
+The new stake will be added to the validator's pending stake, which will be processed
+at the end of epoch.
+TODO: impl max stake requirement.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_stake">request_add_stake</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, new_stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_stake">request_add_stake</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    new_stake: Balance&lt;SUI&gt;,
+    coin_locked_until_epoch: Option&lt;EpochTimeLock&gt;,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> validator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
+    <a href="validator.md#0x2_validator_request_add_stake">validator::request_add_stake</a>(<a href="validator.md#0x2_validator">validator</a>, new_stake, coin_locked_until_epoch, ctx);
+    self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_request_withdraw_stake"></a>
+
+## Function `request_withdraw_stake`
+
+Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>, to withdraw stake from a validator.
+We send a withdraw request to the validator which will be processed at the end of epoch.
+The remaining stake of the validator cannot be lower than <code>min_validator_stake</code>.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_withdraw_stake">request_withdraw_stake</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, <a href="stake.md#0x2_stake">stake</a>: &<b>mut</b> <a href="stake.md#0x2_stake_Stake">stake::Stake</a>, withdraw_amount: u64, min_validator_stake: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_withdraw_stake">request_withdraw_stake</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    <a href="stake.md#0x2_stake">stake</a>: &<b>mut</b> Stake,
+    withdraw_amount: u64,
+    min_validator_stake: u64,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> validator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
+    <a href="validator.md#0x2_validator_request_withdraw_stake">validator::request_withdraw_stake</a>(<a href="validator.md#0x2_validator">validator</a>, <a href="stake.md#0x2_stake">stake</a>, withdraw_amount, min_validator_stake, ctx);
+    self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_request_add_delegation"></a>
+
+## Function `request_add_delegation`
+
+Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>, to add a new delegation to the validator.
+This request is added to the validator's staking pool's pending delegation entries, processed at the end
+of the epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_delegation">request_add_delegation</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>, delegated_stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, locking_period: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_delegation">request_add_delegation</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    validator_address: <b>address</b>,
+    delegated_stake: Balance&lt;SUI&gt;,
+    locking_period: Option&lt;EpochTimeLock&gt;,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
+    <b>let</b> delegator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&delegated_stake);
+    <a href="validator.md#0x2_validator_request_add_delegation">validator::request_add_delegation</a>(<a href="validator.md#0x2_validator">validator</a>, delegated_stake, locking_period, <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx), ctx);
+    self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
+    <a href="event.md#0x2_event_emit">event::emit</a>(
+        <a href="validator_set.md#0x2_validator_set_DelegationRequestEvent">DelegationRequestEvent</a> {
+            validator_address,
+            delegator_address,
+            epoch: <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
+            amount,
+        }
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_cancel_delegation_request"></a>
+
+## Function `cancel_delegation_request`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_cancel_delegation_request">cancel_delegation_request</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_cancel_delegation_request">cancel_delegation_request</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    staked_sui: StakedSui,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> validator_address = <a href="staking_pool.md#0x2_staking_pool_validator_address">staking_pool::validator_address</a>(&staked_sui);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
+    <a href="validator.md#0x2_validator_cancel_delegation_request">validator::cancel_delegation_request</a>(<a href="validator.md#0x2_validator">validator</a>, staked_sui, ctx);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_request_withdraw_delegation"></a>
+
+## Function `request_withdraw_delegation`
+
+Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>, to withdraw some share of a delegation from the validator. The share to withdraw
+is denoted by <code>principal_withdraw_amount</code>.
+This request is added to the validator's staking pool's pending delegation withdraw entries, processed at the end
+of the epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_withdraw_delegation">request_withdraw_delegation</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_withdraw_delegation">request_withdraw_delegation</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    delegation: Delegation,
+    staked_sui: StakedSui,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> validator_address = <a href="staking_pool.md#0x2_staking_pool_validator_address">staking_pool::validator_address</a>(&staked_sui);
+    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address);
+
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&validator_index_opt), 0);
+
+    <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.active_validators, validator_index);
+    <a href="validator.md#0x2_validator_request_withdraw_delegation">validator::request_withdraw_delegation</a>(<a href="validator.md#0x2_validator">validator</a>, delegation, staked_sui, ctx);
+    self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_request_switch_delegation"></a>
+
+## Function `request_switch_delegation`
+
+Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>, to switch some share of a delegation from one validator to another.
+The amount to switch is denoted by <code>switch_pool_token_amount</code>.
+Both the principal and reward portions of the withdrawn delegation should be added to the
+new validator's staking pool. We do that in two parts in this function. We first withdraw the
+principal portion from the current staking pool and call <code>request_add_delegation</code> to add the
+principal SUI to the new staking pool. The amount of rewards to switch is only known at the
+end of the epoch, so we bookkeep the switch requests in <code>pending_delegation_switches</code>, and
+process them in <code>advance_epoch</code> by calling <code>process_pending_delegation_switches</code> at epoch changes.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_switch_delegation">request_switch_delegation</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, new_validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_switch_delegation">request_switch_delegation</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    delegation: Delegation,
+    staked_sui: StakedSui,
+    new_validator_address: <b>address</b>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> current_validator_address = <a href="staking_pool.md#0x2_staking_pool_validator_address">staking_pool::validator_address</a>(&staked_sui);
+
+    // check that the validators are not the same and they are both active.
+    <b>assert</b>!(current_validator_address != new_validator_address, 0);
+    <b>assert</b>!(<a href="validator_set.md#0x2_validator_set_is_active_validator">is_active_validator</a>(self, new_validator_address), 0);
+
+    // withdraw principal from the current <a href="validator.md#0x2_validator">validator</a>'s pool
+    <b>let</b> current_validator = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, current_validator_address);
+    <b>let</b> (current_validator_pool_token, principal_stake, time_lock) =
+        <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">staking_pool::withdraw_from_principal</a>(<a href="validator.md#0x2_validator_get_staking_pool_mut_ref">validator::get_staking_pool_mut_ref</a>(current_validator), delegation, staked_sui);
+    <b>let</b> principal_sui_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&principal_stake);
+    <a href="validator.md#0x2_validator_decrease_next_epoch_delegation">validator::decrease_next_epoch_delegation</a>(current_validator, principal_sui_amount);
+
+    // and deposit into the new <a href="validator.md#0x2_validator">validator</a>'s pool
+    <a href="validator_set.md#0x2_validator_set_request_add_delegation">request_add_delegation</a>(self, new_validator_address, principal_stake, time_lock, ctx);
+
+    <b>let</b> delegator = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+
+    // add pending switch entry, <b>to</b> be processed at epoch boundaries.
+    <b>let</b> key = <a href="validator_set.md#0x2_validator_set_ValidatorPair">ValidatorPair</a> { from: current_validator_address, <b>to</b>: new_validator_address };
+    <b>let</b> entry = <a href="staking_pool.md#0x2_staking_pool_new_pending_withdraw_entry">staking_pool::new_pending_withdraw_entry</a>(delegator,principal_sui_amount, current_validator_pool_token);
+    <b>if</b> (!<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.pending_delegation_switches, &key)) {
+        <a href="vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(&<b>mut</b> self.pending_delegation_switches, key, <a href="table_vec.md#0x2_table_vec_singleton">table_vec::singleton</a>(entry, ctx));
+    } <b>else</b> {
+        <b>let</b> entries = <a href="vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(&<b>mut</b> self.pending_delegation_switches, &key);
+        <a href="table_vec.md#0x2_table_vec_push_back">table_vec::push_back</a>(entries, entry);
+    };
+
+    self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_request_set_gas_price"></a>
+
+## Function `request_set_gas_price`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_set_gas_price">request_set_gas_price</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, new_gas_price: u64, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_set_gas_price">request_set_gas_price</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    new_gas_price: u64,
+    ctx: &TxContext,
+) {
+    <b>let</b> validator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
+    <a href="validator.md#0x2_validator_request_set_gas_price">validator::request_set_gas_price</a>(<a href="validator.md#0x2_validator">validator</a>, new_gas_price);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_request_set_commission_rate"></a>
+
+## Function `request_set_commission_rate`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_set_commission_rate">request_set_commission_rate</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, new_commission_rate: u64, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_set_commission_rate">request_set_commission_rate</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    new_commission_rate: u64,
+    ctx: &TxContext,
+) {
+    <b>let</b> validator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
+    <a href="validator.md#0x2_validator_request_set_commission_rate">validator::request_set_commission_rate</a>(<a href="validator.md#0x2_validator">validator</a>, new_commission_rate);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_advance_epoch"></a>
+
+## Function `advance_epoch`
+
+Update the validator set at the end of epoch.
+It does the following things:
+1. Distribute stake award.
+2. Process pending stake deposits and withdraws for each validator (<code>adjust_stake</code>).
+3. Process pending delegation switches, deposits, and withdraws.
+4. Process pending validator application and withdraws.
+5. At the end, we calculate the total stake for the new epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_advance_epoch">advance_epoch</a>(new_epoch: u64, self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, computation_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, validator_report_records: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;, reward_slashing_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_advance_epoch">advance_epoch</a>(
+    new_epoch: u64,
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    computation_reward: &<b>mut</b> Balance&lt;SUI&gt;,
+    storage_fund_reward: &<b>mut</b> Balance&lt;SUI&gt;,
+    validator_report_records: VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
+    reward_slashing_rate: u64,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> total_stake = self.total_validator_stake + self.total_delegation_stake;
+
+    // Compute the reward distribution without taking into account the tallying rule slashing.
+    <b>let</b> (unadjusted_staking_reward_amounts, unadjusted_storage_fund_reward_amounts) = <a href="validator_set.md#0x2_validator_set_compute_unadjusted_reward_distribution">compute_unadjusted_reward_distribution</a>(
+        &self.active_validators,
+        total_stake,
+        <a href="balance.md#0x2_balance_value">balance::value</a>(computation_reward),
+        <a href="balance.md#0x2_balance_value">balance::value</a>(storage_fund_reward),
+    );
+
+    // Use the tallying rule report records for the epoch <b>to</b> compute validators that will be
+    // punished and the sum of their stakes.
+    <b>let</b> (slashed_validators, total_slashed_validator_stake) =
+        <a href="validator_set.md#0x2_validator_set_compute_slashed_validators_and_total_stake">compute_slashed_validators_and_total_stake</a>(
+            self,
+            <b>copy</b> validator_report_records,
+        );
+
+    // Compute the reward adjustments of slashed validators, <b>to</b> be taken into
+    // account in adjusted reward computation.
+    <b>let</b> (total_staking_reward_adjustment, individual_staking_reward_adjustments,
+         total_storage_fund_reward_adjustment, individual_storage_fund_reward_adjustments
+        ) =
+        <a href="validator_set.md#0x2_validator_set_compute_reward_adjustments">compute_reward_adjustments</a>(
+            <a href="validator_set.md#0x2_validator_set_get_validator_indices">get_validator_indices</a>(&self.active_validators, &slashed_validators),
+            reward_slashing_rate,
+            &unadjusted_staking_reward_amounts,
+            &unadjusted_storage_fund_reward_amounts,
+        );
+
+    // Compute the adjusted amounts of <a href="stake.md#0x2_stake">stake</a> each <a href="validator.md#0x2_validator">validator</a> should get given the tallying rule
+    // reward adjustments we computed before.
+    // `compute_adjusted_reward_distribution` must be called before `distribute_reward` and `adjust_stake_and_gas_price` <b>to</b>
+    // make sure we are using the current epoch's <a href="stake.md#0x2_stake">stake</a> information <b>to</b> compute reward distribution.
+    <b>let</b> (adjusted_staking_reward_amounts, adjusted_storage_fund_reward_amounts) = <a href="validator_set.md#0x2_validator_set_compute_adjusted_reward_distribution">compute_adjusted_reward_distribution</a>(
+        &self.active_validators,
+        total_stake,
+        total_slashed_validator_stake,
+        unadjusted_staking_reward_amounts,
+        unadjusted_storage_fund_reward_amounts,
+        total_staking_reward_adjustment,
+        individual_staking_reward_adjustments,
+        total_storage_fund_reward_adjustment,
+        individual_storage_fund_reward_adjustments
+    );
+
+    // Distribute the rewards before adjusting <a href="stake.md#0x2_stake">stake</a> so that we immediately start compounding
+    // the rewards for validators and delegators.
+    <a href="validator_set.md#0x2_validator_set_distribute_reward">distribute_reward</a>(
+        &<b>mut</b> self.active_validators,
+        &adjusted_staking_reward_amounts,
+        &adjusted_storage_fund_reward_amounts,
+        computation_reward,
+        storage_fund_reward,
+        ctx
+    );
+
+    <a href="validator_set.md#0x2_validator_set_adjust_stake_and_gas_price">adjust_stake_and_gas_price</a>(&<b>mut</b> self.active_validators);
+
+    // Delegation switches must be processed before delegation deposits and withdraws so that the
+    // rewards portion of the delegation switch can be added <b>to</b> the new <a href="validator.md#0x2_validator">validator</a>'s pool when we
+    // process pending delegations.
+    <a href="validator_set.md#0x2_validator_set_process_pending_delegation_switches">process_pending_delegation_switches</a>(self, ctx);
+
+    <a href="validator_set.md#0x2_validator_set_process_pending_delegations_and_withdraws">process_pending_delegations_and_withdraws</a>(&<b>mut</b> self.active_validators, ctx);
+
+    // Emit events after we have processed all the rewards distribution and pending delegations.
+    <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(new_epoch, &self.active_validators, &adjusted_staking_reward_amounts,
+        &validator_report_records, &slashed_validators);
+
+    <a href="validator_set.md#0x2_validator_set_process_pending_validators">process_pending_validators</a>(&<b>mut</b> self.active_validators, &<b>mut</b> self.pending_validators);
+
+    <a href="validator_set.md#0x2_validator_set_process_pending_removals">process_pending_removals</a>(self, ctx);
+
+    self.next_epoch_validators = <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self);
+
+    <b>let</b> (validator_stake, delegation_stake) = <a href="validator_set.md#0x2_validator_set_calculate_total_stakes">calculate_total_stakes</a>(&self.active_validators);
+    self.total_validator_stake = validator_stake;
+    self.total_delegation_stake = delegation_stake;
+
+    <a href="voting_power.md#0x2_voting_power_set_voting_power">voting_power::set_voting_power</a>(&<b>mut</b> self.active_validators);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_derive_reference_gas_price"></a>
+
+## Function `derive_reference_gas_price`
+
+Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code> to derive reference gas price for the new epoch.
+Derive the reference gas price based on the gas price quote submitted by each validator.
+The returned gas price should be greater than or equal to 2/3 of the validators submitted
+gas price, weighted by stake.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_derive_reference_gas_price">derive_reference_gas_price</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_derive_reference_gas_price">derive_reference_gas_price</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>): u64 {
+    <b>let</b> vs = &self.active_validators;
+    <b>let</b> num_validators = <a href="_length">vector::length</a>(vs);
+    <b>let</b> entries = <a href="_empty">vector::empty</a>();
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; num_validators) {
+        <b>let</b> v = <a href="_borrow">vector::borrow</a>(vs, i);
+        <a href="_push_back">vector::push_back</a>(
+            &<b>mut</b> entries,
+            pq::new_entry(<a href="validator.md#0x2_validator_gas_price">validator::gas_price</a>(v), <a href="validator.md#0x2_validator_voting_power">validator::voting_power</a>(v))
+        );
+        i = i + 1;
+    };
+    // Build a priority queue that will pop entries <b>with</b> gas price from the highest <b>to</b> the lowest.
+    <b>let</b> pq = pq::new(entries);
+    <b>let</b> sum = 0;
+    <b>let</b> threshold = <a href="voting_power.md#0x2_voting_power_total_voting_power">voting_power::total_voting_power</a>() - <a href="voting_power.md#0x2_voting_power_quorum_threshold">voting_power::quorum_threshold</a>();
+    <b>let</b> result = 0;
+    <b>while</b> (sum &lt; threshold) {
+        <b>let</b> (gas_price, <a href="stake.md#0x2_stake">stake</a>) = pq::pop_max(&<b>mut</b> pq);
+        result = gas_price;
+        sum = sum + <a href="stake.md#0x2_stake">stake</a>;
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_total_validator_stake"></a>
+
+## Function `total_validator_stake`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_total_validator_stake">total_validator_stake</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_total_validator_stake">total_validator_stake</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>): u64 {
+    self.total_validator_stake
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_total_delegation_stake"></a>
+
+## Function `total_delegation_stake`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_total_delegation_stake">total_delegation_stake</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_total_delegation_stake">total_delegation_stake</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>): u64 {
+    self.total_delegation_stake
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_validator_total_stake_amount"></a>
+
+## Function `validator_total_stake_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_validator_total_stake_amount">validator_total_stake_amount</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_validator_total_stake_amount">validator_total_stake_amount</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, validator_address: <b>address</b>): u64 {
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_ref">get_validator_ref</a>(&self.active_validators, validator_address);
+    <a href="validator.md#0x2_validator_total_stake_amount">validator::total_stake_amount</a>(<a href="validator.md#0x2_validator">validator</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_validator_stake_amount"></a>
+
+## Function `validator_stake_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_validator_stake_amount">validator_stake_amount</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_validator_stake_amount">validator_stake_amount</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, validator_address: <b>address</b>): u64 {
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_ref">get_validator_ref</a>(&self.active_validators, validator_address);
+    <a href="validator.md#0x2_validator_stake_amount">validator::stake_amount</a>(<a href="validator.md#0x2_validator">validator</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_validator_delegate_amount"></a>
+
+## Function `validator_delegate_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_validator_delegate_amount">validator_delegate_amount</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_validator_delegate_amount">validator_delegate_amount</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, validator_address: <b>address</b>): u64 {
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_ref">get_validator_ref</a>(&self.active_validators, validator_address);
+    <a href="validator.md#0x2_validator_delegate_amount">validator::delegate_amount</a>(<a href="validator.md#0x2_validator">validator</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_next_epoch_validator_count"></a>
+
+## Function `next_epoch_validator_count`
+
+Get the total number of validators in the next epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_next_epoch_validator_count">next_epoch_validator_count</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_next_epoch_validator_count">next_epoch_validator_count</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>): u64 {
+    <a href="_length">vector::length</a>(&self.next_epoch_validators)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_is_active_validator"></a>
+
+## Function `is_active_validator`
+
+Returns true iff <code>validator_address</code> is a member of the active validators.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_is_active_validator">is_active_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_is_active_validator">is_active_validator</a>(
+    self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    validator_address: <b>address</b>,
+): bool {
+    <a href="_is_some">option::is_some</a>(&<a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_contains_duplicate_validator"></a>
+
+## Function `contains_duplicate_validator`
+
+Checks whether a duplicate of <code>new_validator</code> is already in <code>validators</code>.
+Two validators duplicate if they share the same sui_address or same IP or same name.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_contains_duplicate_validator">contains_duplicate_validator</a>(validators: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, new_validator: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_contains_duplicate_validator">contains_duplicate_validator</a>(validators: &<a href="">vector</a>&lt;Validator&gt;, new_validator: &Validator): bool {
+    <b>let</b> len = <a href="_length">vector::length</a>(validators);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; len) {
+        <b>let</b> v = <a href="_borrow">vector::borrow</a>(validators, i);
+        <b>if</b> (<a href="validator.md#0x2_validator_is_duplicate">validator::is_duplicate</a>(v, new_validator)) {
+            <b>return</b> <b>true</b>
+        };
+        i = i + 1;
+    };
+    <b>false</b>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_find_validator"></a>
+
+## Function `find_validator`
+
+Find validator by <code>validator_address</code>, in <code>validators</code>.
+Returns (true, index) if the validator is found, and the index is its index in the list.
+If not found, returns (false, 0).
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(validators: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, validator_address: <b>address</b>): <a href="_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(validators: &<a href="">vector</a>&lt;Validator&gt;, validator_address: <b>address</b>): Option&lt;u64&gt; {
+    <b>let</b> length = <a href="_length">vector::length</a>(validators);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; length) {
+        <b>let</b> v = <a href="_borrow">vector::borrow</a>(validators, i);
+        <b>if</b> (<a href="validator.md#0x2_validator_sui_address">validator::sui_address</a>(v) == validator_address) {
+            <b>return</b> <a href="_some">option::some</a>(i)
+        };
+        i = i + 1;
+    };
+    <a href="_none">option::none</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_get_validator_indices"></a>
+
+## Function `get_validator_indices`
+
+Given a vector of validator addresses, return their indices in the validator set.
+Aborts if any address isn't in the given validator set.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_get_validator_indices">get_validator_indices</a>(validators: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, validator_addresses: &<a href="">vector</a>&lt;<b>address</b>&gt;): <a href="">vector</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_get_validator_indices">get_validator_indices</a>(validators: &<a href="">vector</a>&lt;Validator&gt;, validator_addresses: &<a href="">vector</a>&lt;<b>address</b>&gt;): <a href="">vector</a>&lt;u64&gt; {
+    <b>let</b> length = <a href="_length">vector::length</a>(validator_addresses);
+    <b>let</b> i = 0;
+    <b>let</b> res = <a href="">vector</a>[];
+    <b>while</b> (i &lt; length) {
+        <b>let</b> addr = *<a href="_borrow">vector::borrow</a>(validator_addresses, i);
+        <b>let</b> index_opt = <a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(validators, addr);
+        <b>assert</b>!(<a href="_is_some">option::is_some</a>(&index_opt), 0);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, <a href="_destroy_some">option::destroy_some</a>(index_opt));
+        i = i + 1;
+    };
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_get_validator_mut"></a>
+
+## Function `get_validator_mut`
+
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, validator_address: <b>address</b>): &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(
+    validators: &<b>mut</b> <a href="">vector</a>&lt;Validator&gt;,
+    validator_address: <b>address</b>,
+): &<b>mut</b> Validator {
+    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(validators, validator_address);
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&validator_index_opt), 0);
+    <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
+    <a href="_borrow_mut">vector::borrow_mut</a>(validators, validator_index)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_get_validator_ref"></a>
+
+## Function `get_validator_ref`
+
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_get_validator_ref">get_validator_ref</a>(validators: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, validator_address: <b>address</b>): &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_get_validator_ref">get_validator_ref</a>(
+    validators: &<a href="">vector</a>&lt;Validator&gt;,
+    validator_address: <b>address</b>,
+): &Validator {
+    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(validators, validator_address);
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&validator_index_opt), 0);
+    <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
+    <a href="_borrow">vector::borrow</a>(validators, validator_index)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_process_pending_removals"></a>
+
+## Function `process_pending_removals`
+
+Process the pending withdraw requests. For each pending request, the validator
+is removed from <code>validators</code> and sent back to the address of the validator.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_removals">process_pending_removals</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_removals">process_pending_removals</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <a href="validator_set.md#0x2_validator_set_sort_removal_list">sort_removal_list</a>(&<b>mut</b> self.pending_removals);
+    <b>while</b> (!<a href="_is_empty">vector::is_empty</a>(&self.pending_removals)) {
+        <b>let</b> index = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> self.pending_removals);
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="_remove">vector::remove</a>(&<b>mut</b> self.active_validators, index);
+        self.total_delegation_stake = self.total_delegation_stake - <a href="validator.md#0x2_validator_delegate_amount">validator::delegate_amount</a>(&<a href="validator.md#0x2_validator">validator</a>);
+        <a href="validator.md#0x2_validator_destroy">validator::destroy</a>(<a href="validator.md#0x2_validator">validator</a>, ctx);
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_process_pending_validators"></a>
+
+## Function `process_pending_validators`
+
+Process the pending new validators. They are simply inserted into <code>validators</code>.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_validators">process_pending_validators</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, pending_validators: &<b>mut</b> <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_validators">process_pending_validators</a>(
+    validators: &<b>mut</b> <a href="">vector</a>&lt;Validator&gt;, pending_validators: &<b>mut</b> <a href="">vector</a>&lt;Validator&gt;
+) {
+    <b>while</b> (!<a href="_is_empty">vector::is_empty</a>(pending_validators)) {
+        <b>let</b> v = <a href="_pop_back">vector::pop_back</a>(pending_validators);
+        <a href="_push_back">vector::push_back</a>(validators, v);
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_sort_removal_list"></a>
+
+## Function `sort_removal_list`
+
+Sort all the pending removal indexes.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_sort_removal_list">sort_removal_list</a>(withdraw_list: &<b>mut</b> <a href="">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_sort_removal_list">sort_removal_list</a>(withdraw_list: &<b>mut</b> <a href="">vector</a>&lt;u64&gt;) {
+    <b>let</b> length = <a href="_length">vector::length</a>(withdraw_list);
+    <b>let</b> i = 1;
+    <b>while</b> (i &lt; length) {
+        <b>let</b> cur = *<a href="_borrow">vector::borrow</a>(withdraw_list, i);
+        <b>let</b> j = i;
+        <b>while</b> (j &gt; 0) {
+            j = j - 1;
+            <b>if</b> (*<a href="_borrow">vector::borrow</a>(withdraw_list, j) &gt; cur) {
+                <a href="_swap">vector::swap</a>(withdraw_list, j, j + 1);
+            } <b>else</b> {
+                <b>break</b>
+            };
+        };
+        i = i + 1;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_process_pending_delegation_switches"></a>
+
+## Function `process_pending_delegation_switches`
+
+Go through all the delegation switches, withdraws the rewards portion of the switched stake from
+the <code>from</code> validator's pool, and deposits it into the <code><b>to</b></code> validator's pool.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_delegation_switches">process_pending_delegation_switches</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_delegation_switches">process_pending_delegation_switches</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, ctx: &<b>mut</b> TxContext) {
+    // for each pair of (from, <b>to</b>) validators, complete the delegation switch
+    <b>while</b> (!<a href="vec_map.md#0x2_vec_map_is_empty">vec_map::is_empty</a>(&self.pending_delegation_switches)) {
+        <b>let</b> (<a href="validator_set.md#0x2_validator_set_ValidatorPair">ValidatorPair</a> { from, <b>to</b> }, entries) = <a href="vec_map.md#0x2_vec_map_pop">vec_map::pop</a>(&<b>mut</b> self.pending_delegation_switches);
+        <b>let</b> from_validator = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, from);
+        <b>let</b> from_pool = <a href="validator.md#0x2_validator_get_staking_pool_mut_ref">validator::get_staking_pool_mut_ref</a>(from_validator);
+        // withdraw rewards from the <b>old</b> <a href="validator.md#0x2_validator">validator</a>'s pool
+        <b>let</b> (delegators, rewards, rewards_withdraw_amount) =
+            <a href="staking_pool.md#0x2_staking_pool_batch_withdraw_rewards_and_burn_pool_tokens">staking_pool::batch_withdraw_rewards_and_burn_pool_tokens</a>(from_pool, entries);
+        <a href="validator.md#0x2_validator_decrease_next_epoch_delegation">validator::decrease_next_epoch_delegation</a>(from_validator, rewards_withdraw_amount);
+
+        <b>assert</b>!(<a href="_length">vector::length</a>(&delegators) == <a href="_length">vector::length</a>(&rewards), 0);
+
+        <b>let</b> to_validator = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, <b>to</b>);
+        // add delegations <b>to</b> the new <a href="validator.md#0x2_validator">validator</a>
+        <b>while</b> (!<a href="_is_empty">vector::is_empty</a>(&rewards)) {
+            <b>let</b> delegator = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> delegators);
+            <b>let</b> new_stake = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> rewards);
+            <a href="validator.md#0x2_validator_request_add_delegation">validator::request_add_delegation</a>(
+                to_validator,
+                new_stake,
+                <a href="_none">option::none</a>(), // no time lock for rewards
+                delegator,
+                ctx
+            );
+        };
+        <a href="_destroy_empty">vector::destroy_empty</a>(rewards);
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_process_pending_delegations_and_withdraws"></a>
+
+## Function `process_pending_delegations_and_withdraws`
+
+Process all active validators' pending delegation deposits and withdraws.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_delegations_and_withdraws">process_pending_delegations_and_withdraws</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_delegations_and_withdraws">process_pending_delegations_and_withdraws</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;Validator&gt;, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> length = <a href="_length">vector::length</a>(validators);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; length) {
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="_borrow_mut">vector::borrow_mut</a>(validators, i);
+        <a href="validator.md#0x2_validator_process_pending_delegations_and_withdraws">validator::process_pending_delegations_and_withdraws</a>(<a href="validator.md#0x2_validator">validator</a>, ctx);
+        i = i + 1;
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_calculate_total_stakes"></a>
+
+## Function `calculate_total_stakes`
+
+Calculate the total active validator and delegated stake.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_calculate_total_stakes">calculate_total_stakes</a>(validators: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;): (u64, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_calculate_total_stakes">calculate_total_stakes</a>(validators: &<a href="">vector</a>&lt;Validator&gt;): (u64, u64) {
+    <b>let</b> validator_state = 0;
+    <b>let</b> delegate_stake = 0;
+    <b>let</b> length = <a href="_length">vector::length</a>(validators);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; length) {
+        <b>let</b> v = <a href="_borrow">vector::borrow</a>(validators, i);
+        validator_state = validator_state + <a href="validator.md#0x2_validator_stake_amount">validator::stake_amount</a>(v);
+        delegate_stake = delegate_stake + <a href="validator.md#0x2_validator_delegate_amount">validator::delegate_amount</a>(v);
+        i = i + 1;
+    };
+    (validator_state, delegate_stake)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_adjust_stake_and_gas_price"></a>
+
+## Function `adjust_stake_and_gas_price`
+
+Process the pending stake changes for each validator.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_adjust_stake_and_gas_price">adjust_stake_and_gas_price</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_adjust_stake_and_gas_price">adjust_stake_and_gas_price</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;Validator&gt;) {
+    <b>let</b> length = <a href="_length">vector::length</a>(validators);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; length) {
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="_borrow_mut">vector::borrow_mut</a>(validators, i);
+        <a href="validator.md#0x2_validator_adjust_stake_and_gas_price">validator::adjust_stake_and_gas_price</a>(<a href="validator.md#0x2_validator">validator</a>);
+        i = i + 1;
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_compute_reward_adjustments"></a>
+
+## Function `compute_reward_adjustments`
+
+Compute both the individual reward adjustments and total reward adjustment for staking rewards
+as well as storage fund rewards.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_reward_adjustments">compute_reward_adjustments</a>(slashed_validator_indices: <a href="">vector</a>&lt;u64&gt;, reward_slashing_rate: u64, unadjusted_staking_reward_amounts: &<a href="">vector</a>&lt;u64&gt;, unadjusted_storage_fund_reward_amounts: &<a href="">vector</a>&lt;u64&gt;): (u64, <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;u64, u64&gt;, u64, <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;u64, u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_reward_adjustments">compute_reward_adjustments</a>(
+    slashed_validator_indices: <a href="">vector</a>&lt;u64&gt;,
+    reward_slashing_rate: u64,
+    unadjusted_staking_reward_amounts: &<a href="">vector</a>&lt;u64&gt;,
+    unadjusted_storage_fund_reward_amounts: &<a href="">vector</a>&lt;u64&gt;,
+): (
+    u64, // sum of staking reward adjustments
+    VecMap&lt;u64, u64&gt;, // mapping of individual <a href="validator.md#0x2_validator">validator</a>'s staking reward adjustment from index -&gt; amount
+    u64, // sum of storage fund reward adjustments
+    VecMap&lt;u64, u64&gt;, // mapping of individual <a href="validator.md#0x2_validator">validator</a>'s storage fund reward adjustment from index -&gt; amount
+) {
+    <b>let</b> total_staking_reward_adjustment = 0;
+    <b>let</b> individual_staking_reward_adjustments = <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>();
+    <b>let</b> total_storage_fund_reward_adjustment = 0;
+    <b>let</b> individual_storage_fund_reward_adjustments = <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>();
+
+    <b>while</b> (!<a href="_is_empty">vector::is_empty</a>(&<b>mut</b> slashed_validator_indices)) {
+        <b>let</b> validator_index = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> slashed_validator_indices);
+
+        // Use the slashing rate <b>to</b> compute the amount of staking rewards slashed from this punished <a href="validator.md#0x2_validator">validator</a>.
+        <b>let</b> unadjusted_staking_reward = *<a href="_borrow">vector::borrow</a>(unadjusted_staking_reward_amounts, validator_index);
+        <b>let</b> staking_reward_adjustment_u128 =
+            (unadjusted_staking_reward <b>as</b> u128) * (reward_slashing_rate <b>as</b> u128)
+            / <a href="validator_set.md#0x2_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
+
+        // Insert into individual mapping and record into the total adjustment sum.
+        <a href="vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(&<b>mut</b> individual_staking_reward_adjustments, validator_index, (staking_reward_adjustment_u128 <b>as</b> u64));
+        total_staking_reward_adjustment = total_staking_reward_adjustment + (staking_reward_adjustment_u128 <b>as</b> u64);
+
+        // Do the same thing for storage fund rewards.
+        <b>let</b> unadjusted_storage_fund_reward = *<a href="_borrow">vector::borrow</a>(unadjusted_storage_fund_reward_amounts, validator_index);
+        <b>let</b> storage_fund_reward_adjustment_u128 =
+            (unadjusted_storage_fund_reward <b>as</b> u128) * (reward_slashing_rate <b>as</b> u128)
+            / <a href="validator_set.md#0x2_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
+        <a href="vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(&<b>mut</b> individual_storage_fund_reward_adjustments, validator_index, (storage_fund_reward_adjustment_u128 <b>as</b> u64));
+        total_storage_fund_reward_adjustment = total_storage_fund_reward_adjustment + (storage_fund_reward_adjustment_u128 <b>as</b> u64);
+    };
+
+    (
+        total_staking_reward_adjustment, individual_staking_reward_adjustments,
+        total_storage_fund_reward_adjustment, individual_storage_fund_reward_adjustments
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_compute_slashed_validators_and_total_stake"></a>
+
+## Function `compute_slashed_validators_and_total_stake`
+
+Process the validator report records of the epoch and return the addresses of the
+non-performant validators according to the input threshold.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_slashed_validators_and_total_stake">compute_slashed_validators_and_total_stake</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_report_records: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;): (<a href="">vector</a>&lt;<b>address</b>&gt;, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_slashed_validators_and_total_stake">compute_slashed_validators_and_total_stake</a>(
+    self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    validator_report_records: VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
+): (<a href="">vector</a>&lt;<b>address</b>&gt;, u64) {
+    <b>let</b> slashed_validators = <a href="">vector</a>[];
+    <b>let</b> sum_of_stake = 0;
+    <b>while</b> (!<a href="vec_map.md#0x2_vec_map_is_empty">vec_map::is_empty</a>(&validator_report_records)) {
+        <b>let</b> (validator_address, reporters) = <a href="vec_map.md#0x2_vec_map_pop">vec_map::pop</a>(&<b>mut</b> validator_report_records);
+        <b>assert</b>!(
+            <a href="validator_set.md#0x2_validator_set_is_active_validator">is_active_validator</a>(self, validator_address),
+            <a href="validator_set.md#0x2_validator_set_ENON_VALIDATOR_IN_REPORT_RECORDS">ENON_VALIDATOR_IN_REPORT_RECORDS</a>
+        );
+        // Sum up the voting power of validators that have reported this <a href="validator.md#0x2_validator">validator</a> and check <b>if</b> it <b>has</b>
+        // passed the slashing threshold.
+        <b>let</b> reporter_votes = <a href="validator_set.md#0x2_validator_set_sum_voting_power_by_addresses">sum_voting_power_by_addresses</a>(&self.active_validators, &<a href="vec_set.md#0x2_vec_set_into_keys">vec_set::into_keys</a>(reporters));
+        <b>if</b> (reporter_votes &gt;= <a href="voting_power.md#0x2_voting_power_quorum_threshold">voting_power::quorum_threshold</a>()) {
+            sum_of_stake = sum_of_stake + <a href="validator_set.md#0x2_validator_set_validator_total_stake_amount">validator_total_stake_amount</a>(self, validator_address);
+            <a href="_push_back">vector::push_back</a>(&<b>mut</b> slashed_validators, validator_address);
+        }
+    };
+    (slashed_validators, sum_of_stake)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_compute_unadjusted_reward_distribution"></a>
+
+## Function `compute_unadjusted_reward_distribution`
+
+Given the current list of active validators, the total stake and total reward,
+calculate the amount of reward each validator should get, without taking into
+account the tallyig rule results.
+Returns the unadjusted amounts of staking reward and storage fund reward for each validator.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_unadjusted_reward_distribution">compute_unadjusted_reward_distribution</a>(validators: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, total_stake: u64, total_staking_reward: u64, total_storage_fund_reward: u64): (<a href="">vector</a>&lt;u64&gt;, <a href="">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_unadjusted_reward_distribution">compute_unadjusted_reward_distribution</a>(
+    validators: &<a href="">vector</a>&lt;Validator&gt;,
+    total_stake: u64,
+    total_staking_reward: u64,
+    total_storage_fund_reward: u64,
+): (<a href="">vector</a>&lt;u64&gt;, <a href="">vector</a>&lt;u64&gt;) {
+    <b>let</b> staking_reward_amounts = <a href="_empty">vector::empty</a>();
+    <b>let</b> storage_fund_reward_amounts = <a href="_empty">vector::empty</a>();
+    <b>let</b> length = <a href="_length">vector::length</a>(validators);
+    <b>let</b> storage_fund_reward_per_validator = total_storage_fund_reward / length;
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; length) {
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="_borrow">vector::borrow</a>(validators, i);
+        // Integer divisions will truncate the results. Because of this, we expect that at the end
+        // there will be some reward remaining in `total_staking_reward`.
+        // Use u128 <b>to</b> avoid multiplication overflow.
+        <b>let</b> stake_amount: u128 = (<a href="validator.md#0x2_validator_total_stake_amount">validator::total_stake_amount</a>(<a href="validator.md#0x2_validator">validator</a>) <b>as</b> u128);
+        <b>let</b> reward_amount = stake_amount * (total_staking_reward <b>as</b> u128) / (total_stake <b>as</b> u128);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> staking_reward_amounts, (reward_amount <b>as</b> u64));
+        // Storage fund's share of the rewards are equally distributed among validators.
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> storage_fund_reward_amounts, storage_fund_reward_per_validator);
+        i = i + 1;
+    };
+    (staking_reward_amounts, storage_fund_reward_amounts)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_compute_adjusted_reward_distribution"></a>
+
+## Function `compute_adjusted_reward_distribution`
+
+Use the reward adjustment info to compute the adjusted rewards each validator should get.
+Returns the staking rewards each validator gets and the storage fund rewards each validator gets.
+The staking rewards are shared with the delegators while the storage fund ones are not.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_adjusted_reward_distribution">compute_adjusted_reward_distribution</a>(validators: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, total_stake: u64, total_slashed_validator_stake: u64, unadjusted_staking_reward_amounts: <a href="">vector</a>&lt;u64&gt;, unadjusted_storage_fund_reward_amounts: <a href="">vector</a>&lt;u64&gt;, total_staking_reward_adjustment: u64, individual_staking_reward_adjustments: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;u64, u64&gt;, total_storage_fund_reward_adjustment: u64, individual_storage_fund_reward_adjustments: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;u64, u64&gt;): (<a href="">vector</a>&lt;u64&gt;, <a href="">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_compute_adjusted_reward_distribution">compute_adjusted_reward_distribution</a>(
+    validators: &<a href="">vector</a>&lt;Validator&gt;,
+    total_stake: u64,
+    total_slashed_validator_stake: u64,
+    unadjusted_staking_reward_amounts: <a href="">vector</a>&lt;u64&gt;,
+    unadjusted_storage_fund_reward_amounts: <a href="">vector</a>&lt;u64&gt;,
+    total_staking_reward_adjustment: u64,
+    individual_staking_reward_adjustments: VecMap&lt;u64, u64&gt;,
+    total_storage_fund_reward_adjustment: u64,
+    individual_storage_fund_reward_adjustments: VecMap&lt;u64, u64&gt;,
+): (<a href="">vector</a>&lt;u64&gt;, <a href="">vector</a>&lt;u64&gt;) {
+    <b>let</b> total_unslashed_validator_stake = total_stake - total_slashed_validator_stake;
+    <b>let</b> adjusted_staking_reward_amounts = <a href="_empty">vector::empty</a>();
+    <b>let</b> adjusted_storage_fund_reward_amounts = <a href="_empty">vector::empty</a>();
+
+    <b>let</b> length = <a href="_length">vector::length</a>(validators);
+    <b>let</b> num_unslashed_validators = length - <a href="vec_map.md#0x2_vec_map_size">vec_map::size</a>(&individual_staking_reward_adjustments);
+
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; length) {
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="_borrow">vector::borrow</a>(validators, i);
+        // Integer divisions will truncate the results. Because of this, we expect that at the end
+        // there will be some reward remaining in `total_reward`.
+        // Use u128 <b>to</b> avoid multiplication overflow.
+        <b>let</b> stake_amount: u128 = (<a href="validator.md#0x2_validator_total_stake_amount">validator::total_stake_amount</a>(<a href="validator.md#0x2_validator">validator</a>) <b>as</b> u128);
+
+        // Compute adjusted staking reward.
+        <b>let</b> unadjusted_staking_reward_amount = *<a href="_borrow">vector::borrow</a>(&unadjusted_staking_reward_amounts, i);
+        <b>let</b> adjusted_staking_reward_amount =
+            // If the <a href="validator.md#0x2_validator">validator</a> is one of the slashed ones, then subtract the adjustment.
+            <b>if</b> (<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&individual_staking_reward_adjustments, &i)) {
+                <b>let</b> adjustment = *<a href="vec_map.md#0x2_vec_map_get">vec_map::get</a>(&individual_staking_reward_adjustments, &i);
+                unadjusted_staking_reward_amount - adjustment
+            } <b>else</b> {
+                // Otherwise the slashed rewards should be distributed among the unslashed
+                // validators so add the corresponding adjustment.
+                <b>let</b> adjustment = (total_staking_reward_adjustment <b>as</b> u128) * stake_amount
+                               / (total_unslashed_validator_stake <b>as</b> u128);
+                unadjusted_staking_reward_amount + (adjustment <b>as</b> u64)
+            };
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> adjusted_staking_reward_amounts, adjusted_staking_reward_amount);
+
+        // Compute adjusted storage fund reward.
+        <b>let</b> unadjusted_storage_fund_reward_amount = *<a href="_borrow">vector::borrow</a>(&unadjusted_storage_fund_reward_amounts, i);
+        <b>let</b> adjusted_storage_fund_reward_amount =
+            // If the <a href="validator.md#0x2_validator">validator</a> is one of the slashed ones, then subtract the adjustment.
+            <b>if</b> (<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&individual_storage_fund_reward_adjustments, &i)) {
+                <b>let</b> adjustment = *<a href="vec_map.md#0x2_vec_map_get">vec_map::get</a>(&individual_storage_fund_reward_adjustments, &i);
+                unadjusted_storage_fund_reward_amount - adjustment
+            } <b>else</b> {
+                // Otherwise the slashed rewards should be equally distributed among the unslashed validators.
+                <b>let</b> adjustment = total_storage_fund_reward_adjustment / num_unslashed_validators;
+                unadjusted_storage_fund_reward_amount + adjustment
+            };
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> adjusted_storage_fund_reward_amounts, adjusted_storage_fund_reward_amount);
+
+        i = i + 1;
+    };
+
+    (adjusted_staking_reward_amounts, adjusted_storage_fund_reward_amounts)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_distribute_reward"></a>
+
+## Function `distribute_reward`
+
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_distribute_reward">distribute_reward</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, adjusted_staking_reward_amounts: &<a href="">vector</a>&lt;u64&gt;, adjusted_storage_fund_reward_amounts: &<a href="">vector</a>&lt;u64&gt;, staking_rewards: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund_reward: &<b>mut</b> <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_distribute_reward">distribute_reward</a>(
+    validators: &<b>mut</b> <a href="">vector</a>&lt;Validator&gt;,
+    adjusted_staking_reward_amounts: &<a href="">vector</a>&lt;u64&gt;,
+    adjusted_storage_fund_reward_amounts: &<a href="">vector</a>&lt;u64&gt;,
+    staking_rewards: &<b>mut</b> Balance&lt;SUI&gt;,
+    storage_fund_reward: &<b>mut</b> Balance&lt;SUI&gt;,
+    ctx: &<b>mut</b> TxContext
+) {
+    <b>let</b> length = <a href="_length">vector::length</a>(validators);
+    <b>assert</b>!(length &gt; 0, 0);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; length) {
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="_borrow_mut">vector::borrow_mut</a>(validators, i);
+        <b>let</b> staking_reward_amount = *<a href="_borrow">vector::borrow</a>(adjusted_staking_reward_amounts, i);
+        <b>let</b> combined_stake = <a href="validator.md#0x2_validator_total_stake_amount">validator::total_stake_amount</a>(<a href="validator.md#0x2_validator">validator</a>);
+        <b>let</b> self_stake = <a href="validator.md#0x2_validator_stake_amount">validator::stake_amount</a>(<a href="validator.md#0x2_validator">validator</a>);
+        <b>let</b> validator_reward_amount = (staking_reward_amount <b>as</b> u128) * (self_stake <b>as</b> u128) / (combined_stake <b>as</b> u128);
+        <b>let</b> validator_reward = <a href="balance.md#0x2_balance_split">balance::split</a>(staking_rewards, (validator_reward_amount <b>as</b> u64));
+
+        <b>let</b> delegator_reward_amount = staking_reward_amount - (validator_reward_amount <b>as</b> u64);
+        <b>let</b> delegator_reward = <a href="balance.md#0x2_balance_split">balance::split</a>(staking_rewards, delegator_reward_amount);
+
+        // Validator takes a cut of the rewards <b>as</b> commission.
+        <b>let</b> commission_amount = (delegator_reward_amount <b>as</b> u128) * (<a href="validator.md#0x2_validator_commission_rate">validator::commission_rate</a>(<a href="validator.md#0x2_validator">validator</a>) <b>as</b> u128) / <a href="validator_set.md#0x2_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
+        <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> validator_reward, <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> delegator_reward, (commission_amount <b>as</b> u64)));
+
+        // Add storage fund rewards <b>to</b> the <a href="validator.md#0x2_validator">validator</a>'s reward.
+        <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> validator_reward, <a href="balance.md#0x2_balance_split">balance::split</a>(storage_fund_reward, *<a href="_borrow">vector::borrow</a>(adjusted_storage_fund_reward_amounts, i)));
+
+        // Add rewards <b>to</b> the <a href="validator.md#0x2_validator">validator</a>.
+        <a href="validator.md#0x2_validator_request_add_stake">validator::request_add_stake</a>(<a href="validator.md#0x2_validator">validator</a>, validator_reward, <a href="_none">option::none</a>(), ctx);
+        // Add rewards <b>to</b> delegation staking pool <b>to</b> auto compound for delegators.
+        <a href="validator.md#0x2_validator_deposit_delegation_rewards">validator::deposit_delegation_rewards</a>(<a href="validator.md#0x2_validator">validator</a>, delegator_reward);
+        i = i + 1;
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_derive_next_epoch_validators"></a>
+
+## Function `derive_next_epoch_validators`
+
+Upon any change to the validator set, derive and update the metadata of the validators for the new epoch.
+TODO: If we want to enforce a % on stake threshold, this is the function to do it.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>): <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_derive_next_epoch_validators">derive_next_epoch_validators</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>): <a href="">vector</a>&lt;ValidatorMetadata&gt; {
+    <b>let</b> active_count = <a href="_length">vector::length</a>(&self.active_validators);
+    <b>let</b> removal_count = <a href="_length">vector::length</a>(&self.pending_removals);
+    <b>let</b> result = <a href="_empty">vector::empty</a>();
+    <b>while</b> (active_count &gt; 0) {
+        <b>if</b> (removal_count &gt; 0) {
+            <b>let</b> removal_index = *<a href="_borrow">vector::borrow</a>(&self.pending_removals, removal_count - 1);
+            <b>if</b> (removal_index == active_count - 1) {
+                // This <a href="validator.md#0x2_validator">validator</a> will be removed, and hence we won't add it <b>to</b> the new <a href="validator.md#0x2_validator">validator</a> set.
+                removal_count = removal_count - 1;
+                active_count = active_count - 1;
+                <b>continue</b>
+            };
+        };
+        <b>let</b> metadata = <a href="validator.md#0x2_validator_metadata">validator::metadata</a>(
+            <a href="_borrow">vector::borrow</a>(&self.active_validators, active_count - 1),
+        );
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> result, *metadata);
+        active_count = active_count - 1;
+    };
+    <b>let</b> i = 0;
+    <b>let</b> pending_count = <a href="_length">vector::length</a>(&self.pending_validators);
+    <b>while</b> (i &lt; pending_count) {
+        <b>let</b> metadata = <a href="validator.md#0x2_validator_metadata">validator::metadata</a>(
+            <a href="_borrow">vector::borrow</a>(&self.pending_validators, i),
+        );
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> result, *metadata);
+        i = i + 1;
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_emit_validator_epoch_events"></a>
+
+## Function `emit_validator_epoch_events`
+
+Emit events containing information of each validator for the epoch,
+including stakes, rewards, performance, etc.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(new_epoch: u64, vs: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, reward_amounts: &<a href="">vector</a>&lt;u64&gt;, report_records: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;, slashed_validators: &<a href="">vector</a>&lt;<b>address</b>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(
+    new_epoch: u64,
+    vs: &<a href="">vector</a>&lt;Validator&gt;,
+    reward_amounts: &<a href="">vector</a>&lt;u64&gt;,
+    report_records: &VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
+    slashed_validators: &<a href="">vector</a>&lt;<b>address</b>&gt;,
+) {
+    <b>let</b> num_validators = <a href="_length">vector::length</a>(vs);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; num_validators) {
+        <b>let</b> v = <a href="_borrow">vector::borrow</a>(vs, i);
+        <b>let</b> validator_address = <a href="validator.md#0x2_validator_sui_address">validator::sui_address</a>(v);
+        <b>let</b> tallying_rule_reporters =
+            <b>if</b> (<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(report_records, &validator_address)) {
+                <a href="vec_set.md#0x2_vec_set_into_keys">vec_set::into_keys</a>(*<a href="vec_map.md#0x2_vec_map_get">vec_map::get</a>(report_records, &validator_address))
+            } <b>else</b> {
+                <a href="">vector</a>[]
+            };
+        <b>let</b> tallying_rule_global_score =
+            <b>if</b> (<a href="_contains">vector::contains</a>(slashed_validators, &validator_address)) 0
+            <b>else</b> 1;
+        <a href="event.md#0x2_event_emit">event::emit</a>(
+            <a href="validator_set.md#0x2_validator_set_ValidatorEpochInfo">ValidatorEpochInfo</a> {
+                epoch: new_epoch,
+                validator_address,
+                reference_gas_survey_quote: <a href="validator.md#0x2_validator_gas_price">validator::gas_price</a>(v),
+                validator_stake: <a href="validator.md#0x2_validator_stake_amount">validator::stake_amount</a>(v),
+                delegated_stake: <a href="validator.md#0x2_validator_delegate_amount">validator::delegate_amount</a>(v),
+                commission_rate: <a href="validator.md#0x2_validator_commission_rate">validator::commission_rate</a>(v),
+                stake_rewards: *<a href="_borrow">vector::borrow</a>(reward_amounts, i),
+                pool_token_exchange_rate: <a href="validator.md#0x2_validator_pool_token_exchange_rate">validator::pool_token_exchange_rate</a>(v),
+                tallying_rule_reporters,
+                tallying_rule_global_score,
+            }
+        );
+        i = i + 1;
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_sum_voting_power_by_addresses"></a>
+
+## Function `sum_voting_power_by_addresses`
+
+Sum up the total stake of a given list of validator addresses.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_sum_voting_power_by_addresses">sum_voting_power_by_addresses</a>(vs: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, addresses: &<a href="">vector</a>&lt;<b>address</b>&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_sum_voting_power_by_addresses">sum_voting_power_by_addresses</a>(vs: &<a href="">vector</a>&lt;Validator&gt;, addresses: &<a href="">vector</a>&lt;<b>address</b>&gt;): u64 {
+    <b>let</b> sum = 0;
+    <b>let</b> i = 0;
+    <b>let</b> length = <a href="_length">vector::length</a>(addresses);
+    <b>while</b> (i &lt; length) {
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_ref">get_validator_ref</a>(vs, *<a href="_borrow">vector::borrow</a>(addresses, i));
+        sum = sum + <a href="validator.md#0x2_validator_voting_power">validator::voting_power</a>(<a href="validator.md#0x2_validator">validator</a>);
+        i = i + 1;
+    };
+    sum
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_active_validators"></a>
+
+## Function `active_validators`
+
+Return the active validators in <code>self</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_active_validators">active_validators</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>): &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_active_validators">active_validators</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>): &<a href="">vector</a>&lt;Validator&gt; {
+    &self.active_validators
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/vec_map.md
+++ b/crates/sui-framework-override/docs/vec_map.md
@@ -1,0 +1,642 @@
+
+<a name="0x2_vec_map"></a>
+
+# Module `0x2::vec_map`
+
+
+
+-  [Struct `VecMap`](#0x2_vec_map_VecMap)
+-  [Struct `Entry`](#0x2_vec_map_Entry)
+-  [Constants](#@Constants_0)
+-  [Function `empty`](#0x2_vec_map_empty)
+-  [Function `insert`](#0x2_vec_map_insert)
+-  [Function `remove`](#0x2_vec_map_remove)
+-  [Function `pop`](#0x2_vec_map_pop)
+-  [Function `get_mut`](#0x2_vec_map_get_mut)
+-  [Function `get`](#0x2_vec_map_get)
+-  [Function `contains`](#0x2_vec_map_contains)
+-  [Function `size`](#0x2_vec_map_size)
+-  [Function `is_empty`](#0x2_vec_map_is_empty)
+-  [Function `destroy_empty`](#0x2_vec_map_destroy_empty)
+-  [Function `into_keys_values`](#0x2_vec_map_into_keys_values)
+-  [Function `keys`](#0x2_vec_map_keys)
+-  [Function `get_idx_opt`](#0x2_vec_map_get_idx_opt)
+-  [Function `get_idx`](#0x2_vec_map_get_idx)
+-  [Function `get_entry_by_idx`](#0x2_vec_map_get_entry_by_idx)
+-  [Function `get_entry_by_idx_mut`](#0x2_vec_map_get_entry_by_idx_mut)
+-  [Function `remove_entry_by_idx`](#0x2_vec_map_remove_entry_by_idx)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+</code></pre>
+
+
+
+<a name="0x2_vec_map_VecMap"></a>
+
+## Struct `VecMap`
+
+A map data structure backed by a vector. The map is guaranteed not to contain duplicate keys, but entries
+are *not* sorted by key--entries are included in insertion order.
+All operations are O(N) in the size of the map--the intention of this data structure is only to provide
+the convenience of programming against a map API.
+Large maps should use handwritten parent/child relationships instead.
+Maps that need sorted iteration rather than insertion order iteration should also be handwritten.
+
+
+<pre><code><b>struct</b> <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K: <b>copy</b>, V&gt; <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>contents: <a href="">vector</a>&lt;<a href="vec_map.md#0x2_vec_map_Entry">vec_map::Entry</a>&lt;K, V&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_vec_map_Entry"></a>
+
+## Struct `Entry`
+
+An entry in the map
+
+
+<pre><code><b>struct</b> <a href="vec_map.md#0x2_vec_map_Entry">Entry</a>&lt;K: <b>copy</b>, V&gt; <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>key: K</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>value: V</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_vec_map_EKeyAlreadyExists"></a>
+
+This key already exists in the map
+
+
+<pre><code><b>const</b> <a href="vec_map.md#0x2_vec_map_EKeyAlreadyExists">EKeyAlreadyExists</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_vec_map_EKeyDoesNotExist"></a>
+
+This key does not exist in the map
+
+
+<pre><code><b>const</b> <a href="vec_map.md#0x2_vec_map_EKeyDoesNotExist">EKeyDoesNotExist</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_vec_map_EIndexOutOfBounds"></a>
+
+Trying to access an element of the map at an invalid index
+
+
+<pre><code><b>const</b> <a href="vec_map.md#0x2_vec_map_EIndexOutOfBounds">EIndexOutOfBounds</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_vec_map_EMapEmpty"></a>
+
+Trying to pop from a map that is empty
+
+
+<pre><code><b>const</b> <a href="vec_map.md#0x2_vec_map_EMapEmpty">EMapEmpty</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x2_vec_map_EMapNotEmpty"></a>
+
+Trying to destroy a map that is not empty
+
+
+<pre><code><b>const</b> <a href="vec_map.md#0x2_vec_map_EMapNotEmpty">EMapNotEmpty</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_vec_map_empty"></a>
+
+## Function `empty`
+
+Create an empty <code><a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_empty">empty</a>&lt;K: <b>copy</b>, V&gt;(): <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_empty">empty</a>&lt;K: <b>copy</b>, V&gt;(): <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt; {
+    <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a> { contents: <a href="_empty">vector::empty</a>() }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_insert"></a>
+
+## Function `insert`
+
+Insert the entry <code>key</code> |-> <code>value</code> into <code>self</code>.
+Aborts if <code>key</code> is already bound in <code>self</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_insert">insert</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: K, value: V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_insert">insert</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: K, value: V) {
+    <b>assert</b>!(!<a href="vec_map.md#0x2_vec_map_contains">contains</a>(self, &key), <a href="vec_map.md#0x2_vec_map_EKeyAlreadyExists">EKeyAlreadyExists</a>);
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> self.contents, <a href="vec_map.md#0x2_vec_map_Entry">Entry</a> { key, value })
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_remove"></a>
+
+## Function `remove`
+
+Remove the entry <code>key</code> |-> <code>value</code> from self. Aborts if <code>key</code> is not bound in <code>self</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_remove">remove</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): (K, V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_remove">remove</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): (K, V) {
+    <b>let</b> idx = <a href="vec_map.md#0x2_vec_map_get_idx">get_idx</a>(self, key);
+    <b>let</b> <a href="vec_map.md#0x2_vec_map_Entry">Entry</a> { key, value } = <a href="_remove">vector::remove</a>(&<b>mut</b> self.contents, idx);
+    (key, value)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_pop"></a>
+
+## Function `pop`
+
+Pop the most recently inserted entry from the map. Aborts if the map is empty.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_pop">pop</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;): (K, V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_pop">pop</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;): (K, V) {
+    <b>assert</b>!(!<a href="_is_empty">vector::is_empty</a>(&self.contents), <a href="vec_map.md#0x2_vec_map_EMapEmpty">EMapEmpty</a>);
+    <b>let</b> <a href="vec_map.md#0x2_vec_map_Entry">Entry</a> { key, value } = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> self.contents);
+    (key, value)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_get_mut"></a>
+
+## Function `get_mut`
+
+Get a mutable reference to the value bound to <code>key</code> in <code>self</code>.
+Aborts if <code>key</code> is not bound in <code>self</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get_mut">get_mut</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): &<b>mut</b> V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get_mut">get_mut</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): &<b>mut</b> V {
+    <b>let</b> idx = <a href="vec_map.md#0x2_vec_map_get_idx">get_idx</a>(self, key);
+    <b>let</b> entry = <a href="_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.contents, idx);
+    &<b>mut</b> entry.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_get"></a>
+
+## Function `get`
+
+Get a reference to the value bound to <code>key</code> in <code>self</code>.
+Aborts if <code>key</code> is not bound in <code>self</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get">get</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): &V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get">get</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): &V {
+    <b>let</b> idx = <a href="vec_map.md#0x2_vec_map_get_idx">get_idx</a>(self, key);
+    <b>let</b> entry = <a href="_borrow">vector::borrow</a>(&self.contents, idx);
+    &entry.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_contains"></a>
+
+## Function `contains`
+
+Return true if <code>self</code> contains an entry for <code>key</code>, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_contains">contains</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_contains">contains</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, key: &K): bool {
+    <a href="_is_some">option::is_some</a>(&<a href="vec_map.md#0x2_vec_map_get_idx_opt">get_idx_opt</a>(self, key))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_size"></a>
+
+## Function `size`
+
+Return the number of entries in <code>self</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_size">size</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_size">size</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;): u64 {
+    <a href="_length">vector::length</a>(&self.contents)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_is_empty"></a>
+
+## Function `is_empty`
+
+Return true if <code>self</code> has 0 elements, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_is_empty">is_empty</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_is_empty">is_empty</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;): bool {
+    <a href="vec_map.md#0x2_vec_map_size">size</a>(self) == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_destroy_empty"></a>
+
+## Function `destroy_empty`
+
+Destroy an empty map. Aborts if <code>self</code> is not empty
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, V&gt;(self: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, V&gt;(self: <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a> { contents } = self;
+    <b>assert</b>!(<a href="_is_empty">vector::is_empty</a>(&contents), <a href="vec_map.md#0x2_vec_map_EMapNotEmpty">EMapNotEmpty</a>);
+    <a href="_destroy_empty">vector::destroy_empty</a>(contents)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_into_keys_values"></a>
+
+## Function `into_keys_values`
+
+Unpack <code>self</code> into vectors of its keys and values.
+The output keys and values are stored in insertion order, *not* sorted by key.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_into_keys_values">into_keys_values</a>&lt;K: <b>copy</b>, V&gt;(self: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;): (<a href="">vector</a>&lt;K&gt;, <a href="">vector</a>&lt;V&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_into_keys_values">into_keys_values</a>&lt;K: <b>copy</b>, V&gt;(self: <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;): (<a href="">vector</a>&lt;K&gt;, <a href="">vector</a>&lt;V&gt;) {
+    <b>let</b> <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a> { contents } = self;
+    // reverse the <a href="">vector</a> so the output keys and values will appear in insertion order
+    <a href="_reverse">vector::reverse</a>(&<b>mut</b> contents);
+    <b>let</b> i = 0;
+    <b>let</b> n = <a href="_length">vector::length</a>(&contents);
+    <b>let</b> keys = <a href="_empty">vector::empty</a>();
+    <b>let</b> values = <a href="_empty">vector::empty</a>();
+    <b>while</b> (i &lt; n) {
+        <b>let</b> <a href="vec_map.md#0x2_vec_map_Entry">Entry</a> { key, value } = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> contents);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> keys, key);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> values, value);
+        i = i + 1;
+    };
+    <a href="_destroy_empty">vector::destroy_empty</a>(contents);
+    (keys, values)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_keys"></a>
+
+## Function `keys`
+
+Returns a list of keys in the map.
+Do not assume any particular ordering.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_keys">keys</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;): <a href="">vector</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_keys">keys</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;): <a href="">vector</a>&lt;K&gt; {
+    <b>let</b> i = 0;
+    <b>let</b> n = <a href="_length">vector::length</a>(&self.contents);
+    <b>let</b> keys = <a href="_empty">vector::empty</a>();
+    <b>while</b> (i &lt; n) {
+        <b>let</b> entry = <a href="_borrow">vector::borrow</a>(&self.contents, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> keys, entry.key);
+        i = i + 1;
+    };
+    keys
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_get_idx_opt"></a>
+
+## Function `get_idx_opt`
+
+Find the index of <code>key</code> in <code>self</code>. Return <code>None</code> if <code>key</code> is not in <code>self</code>.
+Note that map entries are stored in insertion order, *not* sorted by key.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get_idx_opt">get_idx_opt</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): <a href="_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get_idx_opt">get_idx_opt</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): Option&lt;u64&gt; {
+    <b>let</b> i = 0;
+    <b>let</b> n = <a href="vec_map.md#0x2_vec_map_size">size</a>(self);
+    <b>while</b> (i &lt; n) {
+        <b>if</b> (&<a href="_borrow">vector::borrow</a>(&self.contents, i).key == key) {
+            <b>return</b> <a href="_some">option::some</a>(i)
+        };
+        i = i + 1;
+    };
+    <a href="_none">option::none</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_get_idx"></a>
+
+## Function `get_idx`
+
+Find the index of <code>key</code> in <code>self</code>. Aborts if <code>key</code> is not in <code>self</code>.
+Note that map entries are stored in insertion order, *not* sorted by key.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get_idx">get_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get_idx">get_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): u64 {
+    <b>let</b> idx_opt = <a href="vec_map.md#0x2_vec_map_get_idx_opt">get_idx_opt</a>(self, key);
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&idx_opt), <a href="vec_map.md#0x2_vec_map_EKeyDoesNotExist">EKeyDoesNotExist</a>);
+    <a href="_destroy_some">option::destroy_some</a>(idx_opt)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_get_entry_by_idx"></a>
+
+## Function `get_entry_by_idx`
+
+Return a reference to the <code>idx</code>th entry of <code>self</code>. This gives direct access into the backing array of the map--use with caution.
+Note that map entries are stored in insertion order, *not* sorted by key.
+Aborts if <code>idx</code> is greater than or equal to <code><a href="vec_map.md#0x2_vec_map_size">size</a>(self)</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get_entry_by_idx">get_entry_by_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, idx: u64): (&K, &V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get_entry_by_idx">get_entry_by_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, idx: u64): (&K, &V) {
+    <b>assert</b>!(idx &lt; <a href="vec_map.md#0x2_vec_map_size">size</a>(self), <a href="vec_map.md#0x2_vec_map_EIndexOutOfBounds">EIndexOutOfBounds</a>);
+    <b>let</b> entry = <a href="_borrow">vector::borrow</a>(&self.contents, idx);
+    (&entry.key, &entry.value)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_get_entry_by_idx_mut"></a>
+
+## Function `get_entry_by_idx_mut`
+
+Return a mutable reference to the <code>idx</code>th entry of <code>self</code>. This gives direct access into the backing array of the map--use with caution.
+Note that map entries are stored in insertion order, *not* sorted by key.
+Aborts if <code>idx</code> is greater than or equal to <code><a href="vec_map.md#0x2_vec_map_size">size</a>(self)</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get_entry_by_idx_mut">get_entry_by_idx_mut</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, idx: u64): (&K, &<b>mut</b> V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_get_entry_by_idx_mut">get_entry_by_idx_mut</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, idx: u64): (&K, &<b>mut</b> V) {
+    <b>assert</b>!(idx &lt; <a href="vec_map.md#0x2_vec_map_size">size</a>(self), <a href="vec_map.md#0x2_vec_map_EIndexOutOfBounds">EIndexOutOfBounds</a>);
+    <b>let</b> entry = <a href="_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.contents, idx);
+    (&entry.key, &<b>mut</b> entry.value)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_remove_entry_by_idx"></a>
+
+## Function `remove_entry_by_idx`
+
+Remove the entry at index <code>idx</code> from self.
+Aborts if <code>idx</code> is greater than or equal to <code><a href="vec_map.md#0x2_vec_map_size">size</a>(self)</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_remove_entry_by_idx">remove_entry_by_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, idx: u64): (K, V)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_map.md#0x2_vec_map_remove_entry_by_idx">remove_entry_by_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, idx: u64): (K, V) {
+    <b>assert</b>!(idx &lt; <a href="vec_map.md#0x2_vec_map_size">size</a>(self), <a href="vec_map.md#0x2_vec_map_EIndexOutOfBounds">EIndexOutOfBounds</a>);
+    <b>let</b> <a href="vec_map.md#0x2_vec_map_Entry">Entry</a> { key, value } = <a href="_remove">vector::remove</a>(&<b>mut</b> self.contents, idx);
+    (key, value)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/vec_set.md
+++ b/crates/sui-framework-override/docs/vec_set.md
@@ -1,0 +1,349 @@
+
+<a name="0x2_vec_set"></a>
+
+# Module `0x2::vec_set`
+
+
+
+-  [Struct `VecSet`](#0x2_vec_set_VecSet)
+-  [Constants](#@Constants_0)
+-  [Function `empty`](#0x2_vec_set_empty)
+-  [Function `singleton`](#0x2_vec_set_singleton)
+-  [Function `insert`](#0x2_vec_set_insert)
+-  [Function `remove`](#0x2_vec_set_remove)
+-  [Function `contains`](#0x2_vec_set_contains)
+-  [Function `size`](#0x2_vec_set_size)
+-  [Function `is_empty`](#0x2_vec_set_is_empty)
+-  [Function `into_keys`](#0x2_vec_set_into_keys)
+-  [Function `get_idx_opt`](#0x2_vec_set_get_idx_opt)
+-  [Function `get_idx`](#0x2_vec_set_get_idx)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+</code></pre>
+
+
+
+<a name="0x2_vec_set_VecSet"></a>
+
+## Struct `VecSet`
+
+A set data structure backed by a vector. The set is guaranteed not to contain duplicate keys.
+All operations are O(N) in the size of the set--the intention of this data structure is only to provide
+the convenience of programming against a set API.
+Sets that need sorted iteration rather than insertion order iteration should be handwritten.
+
+
+<pre><code><b>struct</b> <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K: <b>copy</b>, drop&gt; <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>contents: <a href="">vector</a>&lt;K&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_vec_set_EKeyAlreadyExists"></a>
+
+This key already exists in the map
+
+
+<pre><code><b>const</b> <a href="vec_set.md#0x2_vec_set_EKeyAlreadyExists">EKeyAlreadyExists</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_vec_set_EKeyDoesNotExist"></a>
+
+This key does not exist in the map
+
+
+<pre><code><b>const</b> <a href="vec_set.md#0x2_vec_set_EKeyDoesNotExist">EKeyDoesNotExist</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_vec_set_empty"></a>
+
+## Function `empty`
+
+Create an empty <code><a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_empty">empty</a>&lt;K: <b>copy</b>, drop&gt;(): <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_empty">empty</a>&lt;K: <b>copy</b> + drop&gt;(): <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt; {
+    <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a> { contents: <a href="_empty">vector::empty</a>() }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_singleton"></a>
+
+## Function `singleton`
+
+Create a singleton <code><a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a></code> that only contains one element.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_singleton">singleton</a>&lt;K: <b>copy</b>, drop&gt;(key: K): <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_singleton">singleton</a>&lt;K: <b>copy</b> + drop&gt;(key: K): <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt; {
+    <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a> { contents: <a href="_singleton">vector::singleton</a>(key) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_insert"></a>
+
+## Function `insert`
+
+Insert a <code>key</code> into self.
+Aborts if <code>key</code> is already present in <code>self</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_insert">insert</a>&lt;K: <b>copy</b>, drop&gt;(self: &<b>mut</b> <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: K)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_insert">insert</a>&lt;K: <b>copy</b> + drop&gt;(self: &<b>mut</b> <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;, key: K) {
+    <b>assert</b>!(!<a href="vec_set.md#0x2_vec_set_contains">contains</a>(self, &key), <a href="vec_set.md#0x2_vec_set_EKeyAlreadyExists">EKeyAlreadyExists</a>);
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> self.contents, key)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_remove"></a>
+
+## Function `remove`
+
+Remove the entry <code>key</code> from self. Aborts if <code>key</code> is not present in <code>self</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_remove">remove</a>&lt;K: <b>copy</b>, drop&gt;(self: &<b>mut</b> <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_remove">remove</a>&lt;K: <b>copy</b> + drop&gt;(self: &<b>mut</b> <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;, key: &K) {
+    <b>let</b> idx = <a href="vec_set.md#0x2_vec_set_get_idx">get_idx</a>(self, key);
+    <a href="_remove">vector::remove</a>(&<b>mut</b> self.contents, idx);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_contains"></a>
+
+## Function `contains`
+
+Return true if <code>self</code> contains an entry for <code>key</code>, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_contains">contains</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_contains">contains</a>&lt;K: <b>copy</b> + drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;, key: &K): bool {
+    <a href="_is_some">option::is_some</a>(&<a href="vec_set.md#0x2_vec_set_get_idx_opt">get_idx_opt</a>(self, key))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_size"></a>
+
+## Function `size`
+
+Return the number of entries in <code>self</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_size">size</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_size">size</a>&lt;K: <b>copy</b> + drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;): u64 {
+    <a href="_length">vector::length</a>(&self.contents)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_is_empty"></a>
+
+## Function `is_empty`
+
+Return true if <code>self</code> has 0 elements, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_is_empty">is_empty</a>&lt;K: <b>copy</b> + drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;): bool {
+    <a href="vec_set.md#0x2_vec_set_size">size</a>(self) == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_into_keys"></a>
+
+## Function `into_keys`
+
+Unpack <code>self</code> into vectors of keys.
+The output keys are stored in insertion order, *not* sorted.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_into_keys">into_keys</a>&lt;K: <b>copy</b>, drop&gt;(self: <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): <a href="">vector</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_into_keys">into_keys</a>&lt;K: <b>copy</b> + drop&gt;(self: <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;): <a href="">vector</a>&lt;K&gt; {
+    <b>let</b> <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a> { contents } = self;
+    contents
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_get_idx_opt"></a>
+
+## Function `get_idx_opt`
+
+Find the index of <code>key</code> in <code>self</code>. Return <code>None</code> if <code>key</code> is not in <code>self</code>.
+Note that keys are stored in insertion order, *not* sorted.
+
+
+<pre><code><b>fun</b> <a href="vec_set.md#0x2_vec_set_get_idx_opt">get_idx_opt</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K): <a href="_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="vec_set.md#0x2_vec_set_get_idx_opt">get_idx_opt</a>&lt;K: <b>copy</b> + drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;, key: &K): Option&lt;u64&gt; {
+    <b>let</b> i = 0;
+    <b>let</b> n = <a href="vec_set.md#0x2_vec_set_size">size</a>(self);
+    <b>while</b> (i &lt; n) {
+        <b>if</b> (<a href="_borrow">vector::borrow</a>(&self.contents, i) == key) {
+            <b>return</b> <a href="_some">option::some</a>(i)
+        };
+        i = i + 1;
+    };
+    <a href="_none">option::none</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_get_idx"></a>
+
+## Function `get_idx`
+
+Find the index of <code>key</code> in <code>self</code>. Aborts if <code>key</code> is not in <code>self</code>.
+Note that map entries are stored in insertion order, *not* sorted.
+
+
+<pre><code><b>fun</b> <a href="vec_set.md#0x2_vec_set_get_idx">get_idx</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="vec_set.md#0x2_vec_set_get_idx">get_idx</a>&lt;K: <b>copy</b> + drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;, key: &K): u64 {
+    <b>let</b> idx_opt = <a href="vec_set.md#0x2_vec_set_get_idx_opt">get_idx_opt</a>(self, key);
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&idx_opt), <a href="vec_set.md#0x2_vec_set_EKeyDoesNotExist">EKeyDoesNotExist</a>);
+    <a href="_destroy_some">option::destroy_some</a>(idx_opt)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/voting_power.md
+++ b/crates/sui-framework-override/docs/voting_power.md
@@ -1,0 +1,455 @@
+
+<a name="0x2_voting_power"></a>
+
+# Module `0x2::voting_power`
+
+
+
+-  [Struct `VotingPowerInfo`](#0x2_voting_power_VotingPowerInfo)
+-  [Constants](#@Constants_0)
+-  [Function `set_voting_power`](#0x2_voting_power_set_voting_power)
+-  [Function `init_voting_power_info`](#0x2_voting_power_init_voting_power_info)
+-  [Function `total_stake`](#0x2_voting_power_total_stake)
+-  [Function `insert`](#0x2_voting_power_insert)
+-  [Function `adjust_voting_power`](#0x2_voting_power_adjust_voting_power)
+-  [Function `update_voting_power`](#0x2_voting_power_update_voting_power)
+-  [Function `check_invariants`](#0x2_voting_power_check_invariants)
+-  [Function `total_voting_power`](#0x2_voting_power_total_voting_power)
+-  [Function `quorum_threshold`](#0x2_voting_power_quorum_threshold)
+
+
+<pre><code><b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="math.md#0x2_math">0x2::math</a>;
+<b>use</b> <a href="validator.md#0x2_validator">0x2::validator</a>;
+</code></pre>
+
+
+
+<a name="0x2_voting_power_VotingPowerInfo"></a>
+
+## Struct `VotingPowerInfo`
+
+
+
+<pre><code><b>struct</b> <a href="voting_power.md#0x2_voting_power_VotingPowerInfo">VotingPowerInfo</a> <b>has</b> drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>validator_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="voting_power.md#0x2_voting_power">voting_power</a>: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_voting_power_ERelativePowerMismatch"></a>
+
+
+
+<pre><code><b>const</b> <a href="voting_power.md#0x2_voting_power_ERelativePowerMismatch">ERelativePowerMismatch</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_voting_power_ETotalPowerMismatch"></a>
+
+
+
+<pre><code><b>const</b> <a href="voting_power.md#0x2_voting_power_ETotalPowerMismatch">ETotalPowerMismatch</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_voting_power_EVotingPowerOverThreshold"></a>
+
+
+
+<pre><code><b>const</b> <a href="voting_power.md#0x2_voting_power_EVotingPowerOverThreshold">EVotingPowerOverThreshold</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_voting_power_MAX_VOTING_POWER"></a>
+
+
+
+<pre><code><b>const</b> <a href="voting_power.md#0x2_voting_power_MAX_VOTING_POWER">MAX_VOTING_POWER</a>: u64 = 1000;
+</code></pre>
+
+
+
+<a name="0x2_voting_power_QUORUM_THRESHOLD"></a>
+
+Quorum threshold for our fixed voting power--any message signed by this much voting power can be trusted
+up to BFT assumptions
+
+
+<pre><code><b>const</b> <a href="voting_power.md#0x2_voting_power_QUORUM_THRESHOLD">QUORUM_THRESHOLD</a>: u64 = 6667;
+</code></pre>
+
+
+
+<a name="0x2_voting_power_TOTAL_VOTING_POWER"></a>
+
+Set total_voting_power as 10_000 by convention. Individual voting powers can be interpreted
+as easily understandable basis points (e.g., voting_power: 100 = 1%, voting_power: 1 = 0.01%) rather than
+opaque quantities whose meaning changes from epoch to epoch as the total amount staked shifts.
+Fixing the total voting power allows clients to hardcode the quorum threshold and total_voting power rather
+than recomputing these.
+
+
+<pre><code><b>const</b> <a href="voting_power.md#0x2_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a>: u64 = 10000;
+</code></pre>
+
+
+
+<a name="0x2_voting_power_set_voting_power"></a>
+
+## Function `set_voting_power`
+
+Set the voting power of all validators.
+Each validator's voting power is initialized using their stake. We then attempt to cap their voting power
+at <code><a href="voting_power.md#0x2_voting_power_MAX_VOTING_POWER">MAX_VOTING_POWER</a></code>. If <code><a href="voting_power.md#0x2_voting_power_MAX_VOTING_POWER">MAX_VOTING_POWER</a></code> is not a feasible cap, we pick the lowest possible cap.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting_power.md#0x2_voting_power_set_voting_power">set_voting_power</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting_power.md#0x2_voting_power_set_voting_power">set_voting_power</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;Validator&gt;) {
+    // If threshold_pct is too small, it's possible that even when all validators reach the threshold we still don't
+    // have 100%. So we bound the threshold_pct <b>to</b> be always enough <b>to</b> find a solution.
+    <b>let</b> threshold = <a href="math.md#0x2_math_min">math::min</a>(
+        <a href="voting_power.md#0x2_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a>,
+        <a href="math.md#0x2_math_max">math::max</a>(<a href="voting_power.md#0x2_voting_power_MAX_VOTING_POWER">MAX_VOTING_POWER</a>, divide_and_round_up(<a href="voting_power.md#0x2_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a>, <a href="_length">vector::length</a>(validators))),
+    );
+    <b>let</b> (info_list, remaining_power) = <a href="voting_power.md#0x2_voting_power_init_voting_power_info">init_voting_power_info</a>(validators, threshold);
+    <a href="voting_power.md#0x2_voting_power_adjust_voting_power">adjust_voting_power</a>(&<b>mut</b> info_list, threshold, remaining_power);
+    <a href="voting_power.md#0x2_voting_power_update_voting_power">update_voting_power</a>(validators, info_list);
+    // TODO: We could consider removing this once we are confident about the code.
+    <a href="voting_power.md#0x2_voting_power_check_invariants">check_invariants</a>(validators);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_voting_power_init_voting_power_info"></a>
+
+## Function `init_voting_power_info`
+
+Create the initial voting power of each validator, set using their stake, but capped using threshold.
+We also perform insertion sort while creating the voting power list, by maintaining the list in
+descending order using voting power.
+Anything beyond the threshold is added to the remaining_power, which is also returned.
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_init_voting_power_info">init_voting_power_info</a>(validators: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, threshold: u64): (<a href="">vector</a>&lt;<a href="voting_power.md#0x2_voting_power_VotingPowerInfo">voting_power::VotingPowerInfo</a>&gt;, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_init_voting_power_info">init_voting_power_info</a>(
+    validators: &<a href="">vector</a>&lt;Validator&gt;,
+    threshold: u64,
+): (<a href="">vector</a>&lt;<a href="voting_power.md#0x2_voting_power_VotingPowerInfo">VotingPowerInfo</a>&gt;, u64) {
+    <b>let</b> total_stake = <a href="voting_power.md#0x2_voting_power_total_stake">total_stake</a>(validators);
+    <b>let</b> i = 0;
+    <b>let</b> len = <a href="_length">vector::length</a>(validators);
+    <b>let</b> total_power = 0;
+    <b>let</b> result = <a href="">vector</a>[];
+    <b>while</b> (i &lt; len) {
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="_borrow">vector::borrow</a>(validators, i);
+        <b>let</b> <a href="stake.md#0x2_stake">stake</a> = <a href="validator.md#0x2_validator_total_stake">validator::total_stake</a>(<a href="validator.md#0x2_validator">validator</a>);
+        <b>let</b> adjusted_stake = (<a href="stake.md#0x2_stake">stake</a> <b>as</b> u128) * (<a href="voting_power.md#0x2_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a> <b>as</b> u128) / (total_stake <b>as</b> u128);
+        <b>let</b> <a href="voting_power.md#0x2_voting_power">voting_power</a> = <a href="math.md#0x2_math_min">math::min</a>((adjusted_stake <b>as</b> u64), threshold);
+        <b>let</b> info = <a href="voting_power.md#0x2_voting_power_VotingPowerInfo">VotingPowerInfo</a> {
+            validator_index: i,
+            <a href="voting_power.md#0x2_voting_power">voting_power</a>,
+        };
+        <a href="voting_power.md#0x2_voting_power_insert">insert</a>(&<b>mut</b> result, info);
+        total_power = total_power + <a href="voting_power.md#0x2_voting_power">voting_power</a>;
+        i = i + 1;
+    };
+    (result, <a href="voting_power.md#0x2_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a> - total_power)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_voting_power_total_stake"></a>
+
+## Function `total_stake`
+
+Sum up the total stake of all validators.
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_total_stake">total_stake</a>(validators: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_total_stake">total_stake</a>(validators: &<a href="">vector</a>&lt;Validator&gt;): u64 {
+    <b>let</b> i = 0;
+    <b>let</b> len = <a href="_length">vector::length</a>(validators);
+    <b>let</b> total_stake =0 ;
+    <b>while</b> (i &lt; len) {
+        total_stake = total_stake + <a href="validator.md#0x2_validator_total_stake">validator::total_stake</a>(<a href="_borrow">vector::borrow</a>(validators, i));
+        i = i + 1;
+    };
+    total_stake
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_voting_power_insert"></a>
+
+## Function `insert`
+
+Insert <code>new_info</code> to <code>info_list</code> as part of insertion sort, such that <code>info_list</code> is always sorted
+using voting_power, in descending order.
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_insert">insert</a>(info_list: &<b>mut</b> <a href="">vector</a>&lt;<a href="voting_power.md#0x2_voting_power_VotingPowerInfo">voting_power::VotingPowerInfo</a>&gt;, new_info: <a href="voting_power.md#0x2_voting_power_VotingPowerInfo">voting_power::VotingPowerInfo</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_insert">insert</a>(info_list: &<b>mut</b> <a href="">vector</a>&lt;<a href="voting_power.md#0x2_voting_power_VotingPowerInfo">VotingPowerInfo</a>&gt;, new_info: <a href="voting_power.md#0x2_voting_power_VotingPowerInfo">VotingPowerInfo</a>) {
+    <b>let</b> i = 0;
+    <b>let</b> len = <a href="_length">vector::length</a>(info_list);
+    <b>while</b> (i &lt; len && <a href="_borrow">vector::borrow</a>(info_list, i).<a href="voting_power.md#0x2_voting_power">voting_power</a> &gt; new_info.<a href="voting_power.md#0x2_voting_power">voting_power</a>) {
+        i = i + 1;
+    };
+    <a href="_insert">vector::insert</a>(info_list, new_info, i);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_voting_power_adjust_voting_power"></a>
+
+## Function `adjust_voting_power`
+
+Distribute remaining_power to validators that are not capped at threshold.
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_adjust_voting_power">adjust_voting_power</a>(info_list: &<b>mut</b> <a href="">vector</a>&lt;<a href="voting_power.md#0x2_voting_power_VotingPowerInfo">voting_power::VotingPowerInfo</a>&gt;, threshold: u64, remaining_power: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_adjust_voting_power">adjust_voting_power</a>(info_list: &<b>mut</b> <a href="">vector</a>&lt;<a href="voting_power.md#0x2_voting_power_VotingPowerInfo">VotingPowerInfo</a>&gt;, threshold: u64, remaining_power: u64) {
+    <b>let</b> i = 0;
+    <b>let</b> len = <a href="_length">vector::length</a>(info_list);
+    <b>while</b> (i &lt; len && remaining_power &gt; 0) {
+        <b>let</b> v = <a href="_borrow_mut">vector::borrow_mut</a>(info_list, i);
+        // planned is the amount of extra power we want <b>to</b> distribute <b>to</b> this <a href="validator.md#0x2_validator">validator</a>.
+        <b>let</b> planned = divide_and_round_up(remaining_power, len - i);
+        // target is the targeting power this <a href="validator.md#0x2_validator">validator</a> will reach, capped by threshold.
+        <b>let</b> target = <a href="math.md#0x2_math_min">math::min</a>(threshold, v.<a href="voting_power.md#0x2_voting_power">voting_power</a> + planned);
+        // actual is the actual amount of power we will be distributing <b>to</b> this <a href="validator.md#0x2_validator">validator</a>.
+        <b>let</b> actual = <a href="math.md#0x2_math_min">math::min</a>(remaining_power, target - v.<a href="voting_power.md#0x2_voting_power">voting_power</a>);
+        v.<a href="voting_power.md#0x2_voting_power">voting_power</a> = v.<a href="voting_power.md#0x2_voting_power">voting_power</a> + actual;
+        <b>assert</b>!(v.<a href="voting_power.md#0x2_voting_power">voting_power</a> &lt;= threshold, <a href="voting_power.md#0x2_voting_power_EVotingPowerOverThreshold">EVotingPowerOverThreshold</a>);
+        remaining_power = remaining_power - actual;
+        i = i + 1;
+    };
+    <b>assert</b>!(remaining_power == 0, <a href="voting_power.md#0x2_voting_power_ETotalPowerMismatch">ETotalPowerMismatch</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_voting_power_update_voting_power"></a>
+
+## Function `update_voting_power`
+
+Update validators with the decided voting power.
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_update_voting_power">update_voting_power</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, info_list: <a href="">vector</a>&lt;<a href="voting_power.md#0x2_voting_power_VotingPowerInfo">voting_power::VotingPowerInfo</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_update_voting_power">update_voting_power</a>(validators: &<b>mut</b> <a href="">vector</a>&lt;Validator&gt;, info_list: <a href="">vector</a>&lt;<a href="voting_power.md#0x2_voting_power_VotingPowerInfo">VotingPowerInfo</a>&gt;) {
+    <b>while</b> (!<a href="_is_empty">vector::is_empty</a>(&info_list)) {
+        <b>let</b> <a href="voting_power.md#0x2_voting_power_VotingPowerInfo">VotingPowerInfo</a> {
+            validator_index,
+            <a href="voting_power.md#0x2_voting_power">voting_power</a>,
+        } = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> info_list);
+        <b>let</b> v = <a href="_borrow_mut">vector::borrow_mut</a>(validators, validator_index);
+        <a href="validator.md#0x2_validator_set_voting_power">validator::set_voting_power</a>(v, <a href="voting_power.md#0x2_voting_power">voting_power</a>);
+    };
+    <a href="_destroy_empty">vector::destroy_empty</a>(info_list);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_voting_power_check_invariants"></a>
+
+## Function `check_invariants`
+
+Check a few invariants that must hold after setting the voting power.
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_check_invariants">check_invariants</a>(v: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="voting_power.md#0x2_voting_power_check_invariants">check_invariants</a>(v: &<a href="">vector</a>&lt;Validator&gt;) {
+    // First check that the total voting power must be <a href="voting_power.md#0x2_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a>.
+    <b>let</b> i = 0;
+    <b>let</b> len = <a href="_length">vector::length</a>(v);
+    <b>let</b> total = 0;
+    <b>while</b> (i &lt; len) {
+        <b>let</b> <a href="voting_power.md#0x2_voting_power">voting_power</a> = <a href="validator.md#0x2_validator_voting_power">validator::voting_power</a>(<a href="_borrow">vector::borrow</a>(v, i));
+        total = total + <a href="voting_power.md#0x2_voting_power">voting_power</a>;
+        i = i + 1;
+    };
+    <b>assert</b>!(total == <a href="voting_power.md#0x2_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a>, <a href="voting_power.md#0x2_voting_power_ETotalPowerMismatch">ETotalPowerMismatch</a>);
+
+    // Second check that <b>if</b> <a href="validator.md#0x2_validator">validator</a> A's <a href="stake.md#0x2_stake">stake</a> is larger than B's <a href="stake.md#0x2_stake">stake</a>, A's voting power must be no less
+    // than B's voting power; similarly, <b>if</b> A's <a href="stake.md#0x2_stake">stake</a> is less than B's <a href="stake.md#0x2_stake">stake</a>, A's voting power must be no larger
+    // than B's voting power.
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; len) {
+        <b>let</b> j = i + 1;
+        <b>while</b> (j &lt; len) {
+            <b>let</b> validator_i = <a href="_borrow">vector::borrow</a>(v, i);
+            <b>let</b> validator_j = <a href="_borrow">vector::borrow</a>(v, j);
+            <b>let</b> stake_i = <a href="validator.md#0x2_validator_total_stake">validator::total_stake</a>(validator_i);
+            <b>let</b> stake_j = <a href="validator.md#0x2_validator_total_stake">validator::total_stake</a>(validator_j);
+            <b>let</b> power_i = <a href="validator.md#0x2_validator_voting_power">validator::voting_power</a>(validator_i);
+            <b>let</b> power_j = <a href="validator.md#0x2_validator_voting_power">validator::voting_power</a>(validator_j);
+            <b>if</b> (stake_i &gt; stake_i) {
+                <b>assert</b>!(power_i &gt;= power_j, <a href="voting_power.md#0x2_voting_power_ERelativePowerMismatch">ERelativePowerMismatch</a>);
+            };
+            <b>if</b> (stake_i &lt; stake_j) {
+                <b>assert</b>!(power_i &lt;= power_j, <a href="voting_power.md#0x2_voting_power_ERelativePowerMismatch">ERelativePowerMismatch</a>);
+            };
+            j = j + 1;
+        };
+        i = i + 1;
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_voting_power_total_voting_power"></a>
+
+## Function `total_voting_power`
+
+Return the (constant) total voting power
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting_power.md#0x2_voting_power_total_voting_power">total_voting_power</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting_power.md#0x2_voting_power_total_voting_power">total_voting_power</a>(): u64 {
+    <a href="voting_power.md#0x2_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_voting_power_quorum_threshold"></a>
+
+## Function `quorum_threshold`
+
+Return the (constant) quorum threshold
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting_power.md#0x2_voting_power_quorum_threshold">quorum_threshold</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting_power.md#0x2_voting_power_quorum_threshold">quorum_threshold</a>(): u64 {
+    <a href="voting_power.md#0x2_voting_power_QUORUM_THRESHOLD">QUORUM_THRESHOLD</a>
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/wallet.md
+++ b/crates/sui-framework-override/docs/wallet.md
@@ -1,0 +1,209 @@
+
+<a name="0x2_wallet"></a>
+
+# Module `0x2::wallet`
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `split`](#0x2_wallet_split)
+-  [Function `split_vec`](#0x2_wallet_split_vec)
+-  [Function `split_n_to_vec`](#0x2_wallet_split_n_to_vec)
+-  [Function `split_n`](#0x2_wallet_split_n)
+-  [Function `join_vec`](#0x2_wallet_join_vec)
+
+
+<pre><code><b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_wallet_ENotEnough"></a>
+
+For when trying to split a coin more times than its balance allows.
+
+
+<pre><code><b>const</b> <a href="wallet.md#0x2_wallet_ENotEnough">ENotEnough</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_wallet_EInvalidArg"></a>
+
+For when invalid arguments are passed to a function.
+
+
+<pre><code><b>const</b> <a href="wallet.md#0x2_wallet_EInvalidArg">EInvalidArg</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_wallet_split"></a>
+
+## Function `split`
+
+Split coin <code>self</code> to two coins, one with balance <code>split_amount</code>,
+and the remaining balance is left is <code>self</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wallet.md#0x2_wallet_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="wallet.md#0x2_wallet_split">split</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> TxContext) {
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(
+        <a href="coin.md#0x2_coin_split">coin::split</a>(self, split_amount, ctx),
+        <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx)
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_wallet_split_vec"></a>
+
+## Function `split_vec`
+
+Split coin <code>self</code> into multiple coins, each with balance specified
+in <code>split_amounts</code>. Remaining balance is left in <code>self</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wallet.md#0x2_wallet_split_vec">split_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amounts: <a href="">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="wallet.md#0x2_wallet_split_vec">split_vec</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, split_amounts: <a href="">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> i = 0;
+    <b>let</b> len = <a href="_length">vector::length</a>(&split_amounts);
+    <b>while</b> (i &lt; len) {
+        <a href="wallet.md#0x2_wallet_split">split</a>(self, *<a href="_borrow">vector::borrow</a>(&split_amounts, i), ctx);
+        i = i + 1;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_wallet_split_n_to_vec"></a>
+
+## Function `split_n_to_vec`
+
+Split coin <code>self</code> into <code>n</code> coins with equal balances. If the balance is
+not evenly divisible by <code>n</code>, the remainder is left in <code>self</code>. Return
+newly created coins.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wallet.md#0x2_wallet_split_n_to_vec">split_n_to_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, n: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wallet.md#0x2_wallet_split_n_to_vec">split_n_to_vec</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, n: u64, ctx: &<b>mut</b> TxContext): <a href="">vector</a>&lt;Coin&lt;T&gt;&gt; {
+    <b>assert</b>!(n &gt; 0, <a href="wallet.md#0x2_wallet_EInvalidArg">EInvalidArg</a>);
+    <b>assert</b>!(n &lt;= <a href="coin.md#0x2_coin_value">coin::value</a>(self), <a href="wallet.md#0x2_wallet_ENotEnough">ENotEnough</a>);
+    <b>let</b> vec = <a href="_empty">vector::empty</a>&lt;Coin&lt;T&gt;&gt;();
+    <b>let</b> i = 0;
+    <b>let</b> split_amount = <a href="coin.md#0x2_coin_value">coin::value</a>(self) / n;
+    <b>while</b> (i &lt; n - 1) {
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> vec, <a href="coin.md#0x2_coin_split">coin::split</a>(self, split_amount, ctx));
+        i = i + 1;
+    };
+    vec
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_wallet_split_n"></a>
+
+## Function `split_n`
+
+Split coin <code>self</code> into <code>n</code> coins with equal balances. If the balance is
+not evenly divisible by <code>n</code>, the remainder is left in <code>self</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wallet.md#0x2_wallet_split_n">split_n</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, n: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="wallet.md#0x2_wallet_split_n">split_n</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, n: u64, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> vec: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt; = <a href="wallet.md#0x2_wallet_split_n_to_vec">split_n_to_vec</a>(self, n, ctx);
+    <b>let</b> i = 0;
+    <b>let</b> len = <a href="_length">vector::length</a>(&vec);
+    <b>while</b> (i &lt; len) {
+        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="_pop_back">vector::pop_back</a>(&<b>mut</b> vec), <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+        i = i + 1;
+    };
+    <a href="_destroy_empty">vector::destroy_empty</a>(vec);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_wallet_join_vec"></a>
+
+## Function `join_vec`
+
+Join everything in <code>coins</code> with <code>self</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wallet.md#0x2_wallet_join_vec">join_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, coins: <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="wallet.md#0x2_wallet_join_vec">join_vec</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, coins: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt;) {
+    <b>let</b> i = 0;
+    <b>let</b> len = <a href="_length">vector::length</a>(&coins);
+    <b>while</b> (i &lt; len) {
+        <b>let</b> <a href="coin.md#0x2_coin">coin</a> = <a href="_remove">vector::remove</a>(&<b>mut</b> coins, i);
+        <a href="coin.md#0x2_coin_join">coin::join</a>(self, <a href="coin.md#0x2_coin">coin</a>);
+        i = i + 1
+    };
+    // safe because we've drained the <a href="">vector</a>
+    <a href="_destroy_empty">vector::destroy_empty</a>(coins)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/docs/zkp.md
+++ b/crates/sui-framework-override/docs/zkp.md
@@ -1,0 +1,320 @@
+
+<a name="0x2_groth16"></a>
+
+# Module `0x2::groth16`
+
+
+
+-  [Struct `PreparedVerifyingKey`](#0x2_groth16_PreparedVerifyingKey)
+-  [Struct `PublicProofInputs`](#0x2_groth16_PublicProofInputs)
+-  [Struct `ProofPoints`](#0x2_groth16_ProofPoints)
+-  [Function `pvk_from_bytes`](#0x2_groth16_pvk_from_bytes)
+-  [Function `pvk_to_bytes`](#0x2_groth16_pvk_to_bytes)
+-  [Function `public_proof_inputs_from_bytes`](#0x2_groth16_public_proof_inputs_from_bytes)
+-  [Function `proof_points_from_bytes`](#0x2_groth16_proof_points_from_bytes)
+-  [Function `prepare_verifying_key`](#0x2_groth16_prepare_verifying_key)
+-  [Function `verify_groth16_proof`](#0x2_groth16_verify_groth16_proof)
+-  [Function `verify_groth16_proof_internal`](#0x2_groth16_verify_groth16_proof_internal)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_groth16_PreparedVerifyingKey"></a>
+
+## Struct `PreparedVerifyingKey`
+
+A <code><a href="zkp.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a></code> consisting of four components in serialized form.
+
+
+<pre><code><b>struct</b> <a href="zkp.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>vk_gamma_abc_g1_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>alpha_g1_beta_g2_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>gamma_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delta_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_groth16_PublicProofInputs"></a>
+
+## Struct `PublicProofInputs`
+
+A <code><a href="zkp.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a></code> wrapper around its serialized bytes.
+
+
+<pre><code><b>struct</b> <a href="zkp.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_groth16_ProofPoints"></a>
+
+## Struct `ProofPoints`
+
+A <code><a href="zkp.md#0x2_groth16_ProofPoints">ProofPoints</a></code> wrapper around the serialized form of three proof points.
+
+
+<pre><code><b>struct</b> <a href="zkp.md#0x2_groth16_ProofPoints">ProofPoints</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>bytes: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_groth16_pvk_from_bytes"></a>
+
+## Function `pvk_from_bytes`
+
+Creates a <code><a href="zkp.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a></code> from bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_pvk_from_bytes">pvk_from_bytes</a>(vk_gamma_abc_g1_bytes: <a href="">vector</a>&lt;u8&gt;, alpha_g1_beta_g2_bytes: <a href="">vector</a>&lt;u8&gt;, gamma_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;, delta_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;): <a href="zkp.md#0x2_groth16_PreparedVerifyingKey">groth16::PreparedVerifyingKey</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_pvk_from_bytes">pvk_from_bytes</a>(vk_gamma_abc_g1_bytes: <a href="">vector</a>&lt;u8&gt;, alpha_g1_beta_g2_bytes: <a href="">vector</a>&lt;u8&gt;, gamma_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;, delta_g2_neg_pc_bytes: <a href="">vector</a>&lt;u8&gt;): <a href="zkp.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a> {
+    <a href="zkp.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a> {
+        vk_gamma_abc_g1_bytes,
+        alpha_g1_beta_g2_bytes,
+        gamma_g2_neg_pc_bytes,
+        delta_g2_neg_pc_bytes
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_pvk_to_bytes"></a>
+
+## Function `pvk_to_bytes`
+
+Returns bytes of the four components of the <code><a href="zkp.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_pvk_to_bytes">pvk_to_bytes</a>(pvk: <a href="zkp.md#0x2_groth16_PreparedVerifyingKey">groth16::PreparedVerifyingKey</a>): <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_pvk_to_bytes">pvk_to_bytes</a>(pvk: <a href="zkp.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a>): <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    <b>let</b> res = <a href="_empty">vector::empty</a>();
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, pvk.vk_gamma_abc_g1_bytes);
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, pvk.alpha_g1_beta_g2_bytes);
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, pvk.gamma_g2_neg_pc_bytes);
+    <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, pvk.delta_g2_neg_pc_bytes);
+    res
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_public_proof_inputs_from_bytes"></a>
+
+## Function `public_proof_inputs_from_bytes`
+
+Creates a <code><a href="zkp.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a></code> wrapper from bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_public_proof_inputs_from_bytes">public_proof_inputs_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="zkp.md#0x2_groth16_PublicProofInputs">groth16::PublicProofInputs</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_public_proof_inputs_from_bytes">public_proof_inputs_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="zkp.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a> {
+    <a href="zkp.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_proof_points_from_bytes"></a>
+
+## Function `proof_points_from_bytes`
+
+Creates a Groth16 <code><a href="zkp.md#0x2_groth16_ProofPoints">ProofPoints</a></code> from bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_proof_points_from_bytes">proof_points_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="zkp.md#0x2_groth16_ProofPoints">groth16::ProofPoints</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_proof_points_from_bytes">proof_points_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="zkp.md#0x2_groth16_ProofPoints">ProofPoints</a> {
+    <a href="zkp.md#0x2_groth16_ProofPoints">ProofPoints</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_prepare_verifying_key"></a>
+
+## Function `prepare_verifying_key`
+
+@param veriyfing_key: An Arkworks canonical serialization of a verifying key.
+
+Returns four vectors of bytes representing the four components of a prepared verifying key.
+This step computes one pairing e(P, Q), and binds the verification to one particular proof statement.
+This can be used as inputs for the <code>verify_groth16_proof</code> function.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_prepare_verifying_key">prepare_verifying_key</a>(verifying_key: &<a href="">vector</a>&lt;u8&gt;): <a href="zkp.md#0x2_groth16_PreparedVerifyingKey">groth16::PreparedVerifyingKey</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="zkp.md#0x2_groth16_prepare_verifying_key">prepare_verifying_key</a>(verifying_key: &<a href="">vector</a>&lt;u8&gt;): <a href="zkp.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_verify_groth16_proof"></a>
+
+## Function `verify_groth16_proof`
+
+@param prepared_verifying_key: Consists of four vectors of bytes representing the four components of a prepared verifying key.
+@param public_proof_inputs: Represent inputs that are public.
+@param proof_points: Represent three proof points.
+
+Returns a boolean indicating whether the proof is valid.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_verify_groth16_proof">verify_groth16_proof</a>(prepared_verifying_key: <a href="zkp.md#0x2_groth16_PreparedVerifyingKey">groth16::PreparedVerifyingKey</a>, public_proof_inputs: <a href="zkp.md#0x2_groth16_PublicProofInputs">groth16::PublicProofInputs</a>, proof_points: <a href="zkp.md#0x2_groth16_ProofPoints">groth16::ProofPoints</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_verify_groth16_proof">verify_groth16_proof</a>(prepared_verifying_key: <a href="zkp.md#0x2_groth16_PreparedVerifyingKey">PreparedVerifyingKey</a>, public_proof_inputs: <a href="zkp.md#0x2_groth16_PublicProofInputs">PublicProofInputs</a>, proof_points: <a href="zkp.md#0x2_groth16_ProofPoints">ProofPoints</a>): bool {
+    <a href="zkp.md#0x2_groth16_verify_groth16_proof_internal">verify_groth16_proof_internal</a>(
+        &prepared_verifying_key.vk_gamma_abc_g1_bytes,
+        &prepared_verifying_key.alpha_g1_beta_g2_bytes,
+        &prepared_verifying_key.gamma_g2_neg_pc_bytes,
+        &prepared_verifying_key.delta_g2_neg_pc_bytes,
+        &public_proof_inputs.bytes,
+        &proof_points.bytes
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_groth16_verify_groth16_proof_internal"></a>
+
+## Function `verify_groth16_proof_internal`
+
+Native functions that flattens the inputs into arrays of vectors and passed to the Rust native function.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkp.md#0x2_groth16_verify_groth16_proof_internal">verify_groth16_proof_internal</a>(vk_gamma_abc_g1_bytes: &<a href="">vector</a>&lt;u8&gt;, alpha_g1_beta_g2_bytes: &<a href="">vector</a>&lt;u8&gt;, gamma_g2_neg_pc_bytes: &<a href="">vector</a>&lt;u8&gt;, delta_g2_neg_pc_bytes: &<a href="">vector</a>&lt;u8&gt;, public_proof_inputs: &<a href="">vector</a>&lt;u8&gt;, proof_points: &<a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="zkp.md#0x2_groth16_verify_groth16_proof_internal">verify_groth16_proof_internal</a>(vk_gamma_abc_g1_bytes: &<a href="">vector</a>&lt;u8&gt;, alpha_g1_beta_g2_bytes: &<a href="">vector</a>&lt;u8&gt;, gamma_g2_neg_pc_bytes: &<a href="">vector</a>&lt;u8&gt;, delta_g2_neg_pc_bytes: &<a href="">vector</a>&lt;u8&gt;, public_proof_inputs: &<a href="">vector</a>&lt;u8&gt;, proof_points: &<a href="">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework-override/sources/address.move
+++ b/crates/sui-framework-override/sources/address.move
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::address {
+    use sui::hex;
+    use std::ascii;
+    use std::bcs;
+    use std::string;
+
+    /// The length of an address, in bytes
+    const LENGTH: u64 = 20;
+
+    // The largest integer that can be represented with 20 bytes
+    const MAX: u256 = 1461501637330902918203684832716283019655932542975;
+
+    /// Error from `from_bytes` when it is supplied too many or too few bytes.
+    const EAddressParseError: u64 = 0;
+
+    /// Error from `from_u256` when 
+    const EU256TooBigToConvertToAddress: u64 = 1;
+
+    /// Convert `a` into a u256 by interpreting `a` as the bytes of a big-endian integer 
+    /// (e.g., `to_u256(0x1) == 1`)
+    public native fun to_u256(a: address): u256;
+
+    /// Convert `n` into an address by encoding it as a big-endian integer (e.g., `from_u256(1) = @0x1`)
+    /// Aborts if `n` > `MAX_ADDRESS`
+    public native fun from_u256(n: u256): address;
+
+    /// Convert `bytes` into an address.
+    /// Aborts with `EAddressParseError` if the length of `bytes` is not 20
+    public native fun from_bytes(bytes: vector<u8>): address;
+
+     /// Convert `a` into BCS-encoded bytes.
+    public fun to_bytes(a: address): vector<u8> {
+        bcs::to_bytes(&a)
+    }
+
+    /// Convert `a` to a hex-encoded ASCII string
+    public fun to_ascii_string(a: address): ascii::String {
+        ascii::string(hex::encode(to_bytes(a)))
+    }
+
+    /// Convert `a` to a hex-encoded ASCII string
+    public fun to_string(a: address): string::String {
+        string::from_ascii(to_ascii_string(a))
+    }
+
+    /// Length of a Sui address in bytes
+    public fun length(): u64 {
+        LENGTH
+    }
+
+    /// Largest possible address
+    public fun max(): u256 {
+        MAX
+    }
+
+    spec module { pragma verify = false; }
+}

--- a/crates/sui-framework-override/sources/bag.move
+++ b/crates/sui-framework-override/sources/bag.move
@@ -1,0 +1,114 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A bag is a heterogeneous map-like collection. The collection is similar to `sui::table` in that
+/// its keys and values are not stored within the `Bag` value, but instead are stored using Sui's
+/// object system. The `Bag` struct acts only as a handle into the object system to retrieve those
+/// keys and values.
+/// Note that this means that `Bag` values with exactly the same key-value mapping will not be
+/// equal, with `==`, at runtime. For example
+/// ```
+/// let bag1 = bag::new();
+/// let bag2 = bag::new();
+/// bag::add(&mut bag1, 0, false);
+/// bag::add(&mut bag1, 1, true);
+/// bag::add(&mut bag2, 0, false);
+/// bag::add(&mut bag2, 1, true);
+/// // bag1 does not equal bag2, despite having the same entries
+/// assert!(&bag1 != &bag2, 0);
+/// ```
+/// At it's core, `sui::bag` is a wrapper around `UID` that allows for access to
+/// `sui::dynamic_field` while preventing accidentally stranding field values. A `UID` can be
+/// deleted, even if it has dynamic fields associated with it, but a bag, on the other hand, must be
+/// empty to be destroyed.
+module sui::bag {
+
+use sui::object::{Self, UID};
+use sui::dynamic_field as field;
+use sui::tx_context::TxContext;
+
+// Attempted to destroy a non-empty bag
+const EBagNotEmpty: u64 = 0;
+
+struct Bag has key, store {
+    /// the ID of this bag
+    id: UID,
+    /// the number of key-value pairs in the bag
+    size: u64,
+}
+
+/// Creates a new, empty bag
+public fun new(ctx: &mut TxContext): Bag {
+    Bag {
+        id: object::new(ctx),
+        size: 0,
+    }
+}
+
+/// Adds a key-value pair to the bag `bag: &mut Bag`
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the bag already has an entry with
+/// that key `k: K`.
+public fun add<K: copy + drop + store, V: store>(bag: &mut Bag, k: K, v: V) {
+    field::add(&mut bag.id, k, v);
+    bag.size = bag.size + 1;
+}
+
+/// Immutable borrows the value associated with the key in the bag `bag: &Bag`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun borrow<K: copy + drop + store, V: store>(bag: &Bag, k: K): &V {
+    field::borrow(&bag.id, k)
+}
+
+/// Mutably borrows the value associated with the key in the bag `bag: &mut Bag`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun borrow_mut<K: copy + drop + store, V: store>(bag: &mut Bag, k: K): &mut V {
+    field::borrow_mut(&mut bag.id, k)
+}
+
+/// Mutably borrows the key-value pair in the bag `bag: &mut Bag` and returns the value.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun remove<K: copy + drop + store, V: store>(bag: &mut Bag, k: K): V {
+    let v = field::remove(&mut bag.id, k);
+    bag.size = bag.size - 1;
+    v
+}
+
+/// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &Bag`
+public fun contains<K: copy + drop + store>(bag: &Bag, k: K): bool {
+    field::exists_<K>(&bag.id, k)
+}
+
+/// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &Bag`
+/// with an assigned value of type `V`
+public fun contains_with_type<K: copy + drop + store, V: store>(bag: &Bag, k: K): bool {
+    field::exists_with_type<K, V>(&bag.id, k)
+}
+
+/// Returns the size of the bag, the number of key-value pairs
+public fun length(bag: &Bag): u64 {
+    bag.size
+}
+
+/// Returns true iff the bag is empty (if `length` returns `0`)
+public fun is_empty(bag: &Bag): bool {
+    bag.size == 0
+}
+
+/// Destroys an empty bag
+/// Aborts with `EBagNotEmpty` if the bag still contains values
+public fun destroy_empty(bag: Bag) {
+    let Bag { id, size } = bag;
+    assert!(size == 0, EBagNotEmpty);
+    object::delete(id)
+}
+
+}

--- a/crates/sui-framework-override/sources/balance.move
+++ b/crates/sui-framework-override/sources/balance.move
@@ -1,0 +1,175 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A storable handler for Balances in general. Is used in the `Coin`
+/// module to allow balance operations and can be used to implement
+/// custom coins with `Supply` and `Balance`s.
+module sui::balance {
+    friend sui::sui_system;
+
+    /// For when trying to destroy a non-zero balance.
+    const ENonZero: u64 = 0;
+
+    /// For when an overflow is happening on Supply operations.
+    const EOverflow: u64 = 1;
+
+    /// For when trying to withdraw more than there is.
+    const ENotEnough: u64 = 2;
+
+    /// A Supply of T. Used for minting and burning.
+    /// Wrapped into a `TreasuryCap` in the `Coin` module.
+    struct Supply<phantom T> has store {
+        value: u64
+    }
+
+    /// Storable balance - an inner struct of a Coin type.
+    /// Can be used to store coins which don't need the key ability.
+    struct Balance<phantom T> has store {
+        value: u64
+    }
+
+    /// Get the amount stored in a `Balance`.
+    public fun value<T>(self: &Balance<T>): u64 {
+        self.value
+    }
+
+    /// Get the `Supply` value.
+    public fun supply_value<T>(supply: &Supply<T>): u64 {
+        supply.value
+    }
+
+    /// Create a new supply for type T.
+    public fun create_supply<T: drop>(_: T): Supply<T> {
+        Supply { value: 0 }
+    }
+
+    /// Increase supply by `value` and create a new `Balance<T>` with this value.
+    public fun increase_supply<T>(self: &mut Supply<T>, value: u64): Balance<T> {
+        assert!(value < (18446744073709551615u64 - self.value), EOverflow);
+        self.value = self.value + value;
+        Balance { value }
+    }
+
+    /// Burn a Balance<T> and decrease Supply<T>.
+    public fun decrease_supply<T>(self: &mut Supply<T>, balance: Balance<T>): u64 {
+        let Balance { value } = balance;
+        assert!(self.value >= value, EOverflow);
+        self.value = self.value - value;
+        value
+    }
+
+    /// Create a zero `Balance` for type `T`.
+    public fun zero<T>(): Balance<T> {
+        Balance { value: 0 }
+    }
+
+    spec zero {
+        aborts_if false;
+        ensures result.value == 0;
+    }
+
+    /// Join two balances together.
+    public fun join<T>(self: &mut Balance<T>, balance: Balance<T>): u64 {
+        let Balance { value } = balance;
+        self.value = self.value + value;
+        self.value
+    }
+
+    spec join {
+        ensures self.value == old(self.value) + balance.value;
+        ensures result == self.value;
+    }
+
+    /// Split a `Balance` and take a sub balance from it.
+    public fun split<T>(self: &mut Balance<T>, value: u64): Balance<T> {
+        assert!(self.value >= value, ENotEnough);
+        self.value = self.value - value;
+        Balance { value }
+    }
+
+    spec split {
+        aborts_if self.value < value with ENotEnough;
+        ensures self.value == old(self.value) - value;
+        ensures result.value == value;
+    }
+
+    /// Destroy a zero `Balance`.
+    public fun destroy_zero<T>(balance: Balance<T>) {
+        assert!(balance.value == 0, ENonZero);
+        let Balance { value: _ } = balance;
+    }
+
+    spec destroy_zero {
+        aborts_if balance.value != 0 with ENonZero;
+    }
+
+    /// CAUTION: this function creates a `Balance` without increasing the supply. 
+    /// It should only be called by `sui_system::advance_epoch` to create staking rewards,
+    /// and nowhere else.
+    public(friend) fun create_staking_rewards<T>(value: u64): Balance<T> {
+        Balance { value }
+    }
+
+    /// CAUTION: this function destroys a `Balance` without decreasing the supply. 
+    /// It should only be called by `sui_system::advance_epoch` to destroy storage rebates,
+    /// and nowhere else.
+    public(friend) fun destroy_storage_rebates<T>(self: Balance<T>) {
+        let Balance { value: _ } = self;
+    }
+
+    #[test_only]
+    /// Create a `Balance` of any coin for testing purposes.
+    public fun create_for_testing<T>(value: u64): Balance<T> {
+        Balance { value }
+    }
+
+    #[test_only]
+    /// Destroy a `Balance` with any value in it for testing purposes.
+    public fun destroy_for_testing<T>(self: Balance<T>): u64 {
+        let Balance { value } = self;
+        value
+    }
+
+    #[test_only]
+    /// Destroy a `Supply` with any value in it for testing purposes.
+    public fun destroy_supply_for_testing<T>(self: Supply<T>): u64 {
+        let Supply { value } = self;
+        value
+    }
+
+    #[test_only]
+    /// Create a `Supply` of any coin for testing purposes.
+    public fun create_supply_for_testing<T>(value: u64): Supply<T> {
+        Supply { value }
+    }
+}
+
+#[test_only]
+module sui::balance_tests {
+    use sui::balance;
+    use sui::sui::SUI;
+
+    #[test]
+    fun test_balance() {
+        let balance = balance::zero<SUI>();
+        let another = balance::create_for_testing(1000);
+
+        balance::join(&mut balance, another);
+
+        assert!(balance::value(&balance) == 1000, 0);
+
+        let balance1 = balance::split(&mut balance, 333);
+        let balance2 = balance::split(&mut balance, 333);
+        let balance3 = balance::split(&mut balance, 334);
+
+        balance::destroy_zero(balance);
+
+        assert!(balance::value(&balance1) == 333, 1);
+        assert!(balance::value(&balance2) == 333, 2);
+        assert!(balance::value(&balance3) == 334, 3);
+
+        balance::destroy_for_testing(balance1);
+        balance::destroy_for_testing(balance2);
+        balance::destroy_for_testing(balance3);
+    }
+}

--- a/crates/sui-framework-override/sources/bcs.move
+++ b/crates/sui-framework-override/sources/bcs.move
@@ -1,0 +1,453 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This module implements BCS (de)serialization in Move.
+/// Full specification can be found here: https://github.com/diem/bcs
+///
+/// Short summary (for Move-supported types):
+///
+/// - address - sequence of X bytes
+/// - bool - byte with 0 or 1
+/// - u8 - a single u8 byte
+/// - u64 / u128 - LE bytes
+/// - vector - ULEB128 length + LEN elements
+/// - option - first byte bool: None (0) or Some (1), then value
+///
+/// Usage example:
+/// ```
+/// /// This function reads u8 and u64 value from the input
+/// /// and returns the rest of the bytes.
+/// fun deserialize(bytes: vector<u8>): (u8, u64, vector<u8>) {
+///     use sui::bcs::{Self, BCS};
+///
+///     let prepared: BCS = bcs::new(bytes);
+///     let (u8_value, u64_value) = (
+///         bcs::peel_u8(&mut prepared),
+///         bcs::peel_u64(&mut prepared)
+///     );
+///
+///     // unpack bcs struct
+///     let leftovers = bcs::into_remainder_bytes(prepared);
+///
+///     (u8_value, u64_value, leftovers)
+/// }
+/// ```
+module sui::bcs {
+    use std::option::{Self, Option};
+    use std::vector as v;
+    use sui::address;
+    use std::bcs;
+
+    /// For when bytes length is less than required for deserialization.
+    const EOutOfRange: u64 = 0;
+
+    /// For when the boolean value different than `0` or `1`.
+    const ENotBool: u64 = 1;
+
+    /// For when ULEB byte is out of range (or not found).
+    const ELenOutOfRange: u64 = 2;
+
+    /// A helper struct that saves resources on operations. For better
+    /// vector performance, it stores reversed bytes of the BCS and
+    /// enables use of `vector::pop_back`.
+    struct BCS has store, copy, drop {
+        bytes: vector<u8>
+    }
+
+    /// Get BCS serialized bytes for any value.
+    /// Re-exports stdlib `bcs::to_bytes`.
+    public fun to_bytes<T>(value: &T): vector<u8> {
+        bcs::to_bytes(value)
+    }
+
+    /// Creates a new instance of BCS wrapper that holds inversed
+    /// bytes for better performance.
+    public fun new(bytes: vector<u8>): BCS {
+        v::reverse(&mut bytes);
+        BCS { bytes }
+    }
+
+    /// Unpack the `BCS` struct returning the leftover bytes.
+    /// Useful for passing the data further after partial deserialization.
+    public fun into_remainder_bytes(bcs: BCS): vector<u8> {
+        let BCS { bytes } = bcs;
+        v::reverse(&mut bytes);
+        bytes
+    }
+
+    /// Read address from the bcs-serialized bytes.
+    public fun peel_address(bcs: &mut BCS): address {
+        assert!(v::length(&bcs.bytes) >= address::length(), EOutOfRange);
+        let (addr_bytes, i) = (v::empty(), 0);
+        while (i < 20) {
+            v::push_back(&mut addr_bytes, v::pop_back(&mut bcs.bytes));
+            i = i + 1;
+        };
+        address::from_bytes(addr_bytes)
+    }
+
+    /// Read a `bool` value from bcs-serialized bytes.
+    public fun peel_bool(bcs: &mut BCS): bool {
+        let value = peel_u8(bcs);
+        if (value == 0) {
+            false
+        } else if (value == 1) {
+            true
+        } else {
+            abort ENotBool
+        }
+    }
+
+    /// Read `u8` value from bcs-serialized bytes.
+    public fun peel_u8(bcs: &mut BCS): u8 {
+        assert!(v::length(&bcs.bytes) >= 1, EOutOfRange);
+        v::pop_back(&mut bcs.bytes)
+    }
+
+    /// Read `u64` value from bcs-serialized bytes.
+    public fun peel_u64(bcs: &mut BCS): u64 {
+        assert!(v::length(&bcs.bytes) >= 8, EOutOfRange);
+
+        let (value, i) = (0u64, 0u8);
+        while (i < 64) {
+            let byte = (v::pop_back(&mut bcs.bytes) as u64);
+            value = value + (byte << i);
+            i = i + 8;
+        };
+
+        value
+    }
+
+    /// Read `u128` value from bcs-serialized bytes.
+    public fun peel_u128(bcs: &mut BCS): u128 {
+        assert!(v::length(&bcs.bytes) >= 16, EOutOfRange);
+
+        let (value, i) = (0u128, 0u8);
+        while (i < 128) {
+            let byte = (v::pop_back(&mut bcs.bytes) as u128);
+            value = value + (byte << i);
+            i = i + 8;
+        };
+
+        value
+    }
+
+    // === Vector<T> ===
+
+    /// Read ULEB bytes expecting a vector length. Result should
+    /// then be used to perform `peel_*` operation LEN times.
+    ///
+    /// In BCS `vector` length is implemented with ULEB128;
+    /// See more here: https://en.wikipedia.org/wiki/LEB128
+    public fun peel_vec_length(bcs: &mut BCS): u64 {
+        let (total, shift, len) = (0u64, 0, 0);
+        while (true) {
+            assert!(len <= 4, ELenOutOfRange);
+            let byte = (v::pop_back(&mut bcs.bytes) as u64);
+            len = len + 1;
+            total = total | ((byte & 0x7f) << shift);
+            if ((byte & 0x80) == 0) {
+                break
+            };
+            shift = shift + 7;
+        };
+        total
+    }
+
+    /// Peel a vector of `address` from serialized bytes.
+    public fun peel_vec_address(bcs: &mut BCS): vector<address> {
+        let (len, i, res) = (peel_vec_length(bcs), 0, vector[]);
+        while (i < len) {
+            v::push_back(&mut res, peel_address(bcs));
+            i = i + 1;
+        };
+        res
+    }
+
+    /// Peel a vector of `address` from serialized bytes.
+    public fun peel_vec_bool(bcs: &mut BCS): vector<bool> {
+        let (len, i, res) = (peel_vec_length(bcs), 0, vector[]);
+        while (i < len) {
+            v::push_back(&mut res, peel_bool(bcs));
+            i = i + 1;
+        };
+        res
+    }
+
+    /// Peel a vector of `u8` (eg string) from serialized bytes.
+    public fun peel_vec_u8(bcs: &mut BCS): vector<u8> {
+        let (len, i, res) = (peel_vec_length(bcs), 0, vector[]);
+        while (i < len) {
+            v::push_back(&mut res, peel_u8(bcs));
+            i = i + 1;
+        };
+        res
+    }
+
+    /// Peel a `vector<vector<u8>>` (eg vec of string) from serialized bytes.
+    public fun peel_vec_vec_u8(bcs: &mut BCS): vector<vector<u8>> {
+        let (len, i, res) = (peel_vec_length(bcs), 0, vector[]);
+        while (i < len) {
+            v::push_back(&mut res, peel_vec_u8(bcs));
+            i = i + 1;
+        };
+        res
+    }
+
+    /// Peel a vector of `u64` from serialized bytes.
+    public fun peel_vec_u64(bcs: &mut BCS): vector<u64> {
+        let (len, i, res) = (peel_vec_length(bcs), 0, vector[]);
+        while (i < len) {
+            v::push_back(&mut res, peel_u64(bcs));
+            i = i + 1;
+        };
+        res
+    }
+
+    /// Peel a vector of `u128` from serialized bytes.
+    public fun peel_vec_u128(bcs: &mut BCS): vector<u128> {
+        let (len, i, res) = (peel_vec_length(bcs), 0, vector[]);
+        while (i < len) {
+            v::push_back(&mut res, peel_u128(bcs));
+            i = i + 1;
+        };
+        res
+    }
+
+    // === Option<T> ===
+
+    /// Peel `Option<address>` from serialized bytes.
+    public fun peel_option_address(bcs: &mut BCS): Option<address> {
+        if (peel_bool(bcs)) {
+            option::some(peel_address(bcs))
+        } else {
+            option::none()
+        }
+    }
+
+    /// Peel `Option<bool>` from serialized bytes.
+    public fun peel_option_bool(bcs: &mut BCS): Option<bool> {
+        if (peel_bool(bcs)) {
+            option::some(peel_bool(bcs))
+        } else {
+            option::none()
+        }
+    }
+
+    /// Peel `Option<u8>` from serialized bytes.
+    public fun peel_option_u8(bcs: &mut BCS): Option<u8> {
+        if (peel_bool(bcs)) {
+            option::some(peel_u8(bcs))
+        } else {
+            option::none()
+        }
+    }
+
+    /// Peel `Option<u64>` from serialized bytes.
+    public fun peel_option_u64(bcs: &mut BCS): Option<u64> {
+        if (peel_bool(bcs)) {
+            option::some(peel_u64(bcs))
+        } else {
+            option::none()
+        }
+    }
+
+    /// Peel `Option<u128>` from serialized bytes.
+    public fun peel_option_u128(bcs: &mut BCS): Option<u128> {
+        if (peel_bool(bcs)) {
+            option::some(peel_u128(bcs))
+        } else {
+            option::none()
+        }
+    }
+
+    // TODO: re-enable once bit-wise operators in peel_vec_length are supported in the prover
+    spec module { pragma verify = false; }
+
+    // === Tests ===
+
+    #[test_only]
+    struct Info has drop { a: bool, b: u8, c: u64, d: u128, k: vector<bool>, s: address }
+
+    #[test]
+    #[expected_failure(abort_code = ELenOutOfRange)]
+    fun test_uleb_len_fail() {
+        let value = vector[0xff, 0xff, 0xff, 0xff, 0xff];
+        let bytes = new(to_bytes(&value));
+        let _fail = peel_vec_length(&mut bytes);
+        abort 2 // TODO: make this test fail
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ENotBool)]
+    fun test_bool_fail() {
+        let bytes = new(to_bytes(&10u8));
+        let _fail = peel_bool(&mut bytes);
+    }
+
+    #[test]
+    fun test_option() {
+        {
+            let value = option::some(true);
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_option_bool(&mut bytes), 0);
+        };
+
+        {
+            let value = option::some(10u8);
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_option_u8(&mut bytes), 0);
+        };
+
+        {
+            let value = option::some(10000u64);
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_option_u64(&mut bytes), 0);
+        };
+
+        {
+            let value = option::some(10000999999u128);
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_option_u128(&mut bytes), 0);
+        };
+
+        {
+            let value = option::some(@0xC0FFEE);
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_option_address(&mut bytes), 0);
+        };
+
+        {
+            let value: Option<bool> = option::none();
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_option_bool(&mut bytes), 0);
+        };
+    }
+
+    #[test]
+    fun test_bcs() {
+        {
+            let value = @0xC0FFEE;
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_address(&mut bytes), 0);
+        };
+
+        { // boolean: true
+            let value = true;
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_bool(&mut bytes), 0);
+        };
+
+        { // boolean: false
+            let value = false;
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_bool(&mut bytes), 0);
+        };
+
+        { // u8
+            let value = 100u8;
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_u8(&mut bytes), 0);
+        };
+
+        { // u64 (4 bytes)
+            let value = 1000100u64;
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_u64(&mut bytes), 0);
+        };
+
+        { // u64 (8 bytes)
+            let value = 100000000000000u64;
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_u64(&mut bytes), 0);
+        };
+
+        { // u128 (16 bytes)
+            let value = 100000000000000000000000000u128;
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_u128(&mut bytes), 0);
+        };
+
+        { // vector length
+            let value = vector[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
+            let bytes = new(to_bytes(&value));
+            assert!(v::length(&value) == peel_vec_length(&mut bytes), 0);
+        };
+
+        { // vector length (more data)
+            let value = vector[
+                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+            ];
+
+            let bytes = new(to_bytes(&value));
+            assert!(v::length(&value) == peel_vec_length(&mut bytes), 0);
+        };
+
+        { // full deserialization test (ordering)
+            let info = Info { a: true, b: 100, c: 9999, d: 112333, k: vector[true, false, true, false], s: @0xAAAAAAAAAAA };
+            let bytes = new(to_bytes(&info));
+
+            assert!(info.a == peel_bool(&mut bytes), 0);
+            assert!(info.b == peel_u8(&mut bytes), 0);
+            assert!(info.c == peel_u64(&mut bytes), 0);
+            assert!(info.d == peel_u128(&mut bytes), 0);
+
+            let len = peel_vec_length(&mut bytes);
+
+            assert!(v::length(&info.k) == len, 0);
+
+            let i = 0;
+            while (i < v::length(&info.k)) {
+                assert!(*v::borrow(&info.k, i) == peel_bool(&mut bytes), 0);
+                i = i + 1;
+            };
+
+            assert!(info.s == peel_address(&mut bytes), 0);
+        };
+
+        { // read vector of bytes directly
+            let value = vector[
+                vector[1,2,3,4,5],
+                vector[1,2,3,4,5],
+                vector[1,2,3,4,5]
+            ];
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_vec_vec_u8(&mut bytes), 0);
+        };
+
+        { // read vector of bytes directly
+            let value = vector[1,2,3,4,5];
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_vec_u8(&mut bytes), 0);
+        };
+
+        { // read vector of bytes directly
+            let value = vector[1,2,3,4,5];
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_vec_u64(&mut bytes), 0);
+        };
+
+        { // read vector of bytes directly
+            let value = vector[1,2,3,4,5];
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_vec_u128(&mut bytes), 0);
+        };
+
+        { // read vector of bytes directly
+            let value = vector[true, false, true, false];
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_vec_bool(&mut bytes), 0);
+        };
+
+        { // read vector of address directly
+            let value = vector[@0x0, @0x1, @0x2, @0x3];
+            let bytes = new(to_bytes(&value));
+            assert!(value == peel_vec_address(&mut bytes), 0);
+        };
+    }
+}

--- a/crates/sui-framework-override/sources/coin.move
+++ b/crates/sui-framework-override/sources/coin.move
@@ -1,0 +1,442 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Defines the `Coin` type - platform wide representation of fungible
+/// tokens and coins. `Coin` can be described as a secure wrapper around
+/// `Balance` type.
+module sui::coin {
+    use std::string;
+    use std::ascii;
+    use std::option::{Self, Option};
+    use sui::balance::{Self, Balance, Supply};
+    use sui::tx_context::TxContext;
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::url::{Self, Url};
+    use std::vector;
+    use sui::event;
+
+    /// For when a type passed to create_supply is not a one-time witness.
+    const EBadWitness: u64 = 0;
+
+    /// For when invalid arguments are passed to a function.
+    const EInvalidArg: u64 = 1;
+
+    /// For when trying to split a coin more times than its balance allows.
+    const ENotEnough: u64 = 2;
+
+    /// A coin of type `T` worth `value`. Transferable and storable
+    struct Coin<phantom T> has key, store {
+        id: UID,
+        balance: Balance<T>
+    }
+
+    /// Each Coin type T created through `create_currency` function will have a
+    /// unique instance of CoinMetadata<T> that stores the metadata for this coin type.
+    struct CoinMetadata<phantom T> has key, store {
+        id: UID,
+        /// Number of decimal places the coin uses.
+        /// A coin with `value ` N and `decimals` D should be shown as N / 10^D
+        /// E.g., a coin with `value` 7002 and decimals 3 should be displayed as 7.002
+        /// This is metadata for display usage only.
+        decimals: u8,
+        /// Name for the token
+        name: string::String,
+        /// Symbol for the token
+        symbol: ascii::String,
+        /// Description of the token
+        description: string::String,
+        /// URL for the token logo
+        icon_url: Option<Url>
+    }
+
+    /// Capability allowing the bearer to mint and burn
+    /// coins of type `T`. Transferable
+    struct TreasuryCap<phantom T> has key, store {
+        id: UID,
+        total_supply: Supply<T>
+    }
+
+    // === Events ===
+
+    /// Emitted when new currency is created through the `create_currency` call.
+    /// Contains currency metadata for off-chain discovery. Type parameter `T`
+    /// matches the one in `Coin<T>`
+    struct CurrencyCreated<phantom T> has copy, drop {
+        /// Number of decimal places the coin uses.
+        /// A coin with `value ` N and `decimals` D should be shown as N / 10^D
+        /// E.g., a coin with `value` 7002 and decimals 3 should be displayed as 7.002
+        /// This is metadata for display usage only.
+        decimals: u8
+    }
+
+    // === Supply <-> TreasuryCap morphing and accessors  ===
+
+    /// Return the total number of `T`'s in circulation.
+    public fun total_supply<T>(cap: &TreasuryCap<T>): u64 {
+        balance::supply_value(&cap.total_supply)
+    }
+
+    /// Unwrap `TreasuryCap` getting the `Supply`.
+    ///
+    /// Operation is irreversible. Supply cannot be converted into a `TreasuryCap` due
+    /// to different security guarantees (TreasuryCap can be created only once for a type)
+    public fun treasury_into_supply<T>(treasury: TreasuryCap<T>): Supply<T> {
+        let TreasuryCap { id, total_supply } = treasury;
+        object::delete(id);
+        total_supply
+    }
+
+    /// Get immutable reference to the treasury's `Supply`.
+    public fun supply<T>(treasury: &mut TreasuryCap<T>): &Supply<T> {
+        &treasury.total_supply
+    }
+
+    /// Get mutable reference to the treasury's `Supply`.
+    public fun supply_mut<T>(treasury: &mut TreasuryCap<T>): &mut Supply<T> {
+        &mut treasury.total_supply
+    }
+
+    // === Balance <-> Coin accessors and type morphing ===
+
+    /// Public getter for the coin's value
+    public fun value<T>(self: &Coin<T>): u64 {
+        balance::value(&self.balance)
+    }
+
+    /// Get immutable reference to the balance of a coin.
+    public fun balance<T>(coin: &Coin<T>): &Balance<T> {
+        &coin.balance
+    }
+
+    /// Get a mutable reference to the balance of a coin.
+    public fun balance_mut<T>(coin: &mut Coin<T>): &mut Balance<T> {
+        &mut coin.balance
+    }
+
+    /// Wrap a balance into a Coin to make it transferable.
+    public fun from_balance<T>(balance: Balance<T>, ctx: &mut TxContext): Coin<T> {
+        Coin { id: object::new(ctx), balance }
+    }
+
+    /// Destruct a Coin wrapper and keep the balance.
+    public fun into_balance<T>(coin: Coin<T>): Balance<T> {
+        let Coin { id, balance } = coin;
+        object::delete(id);
+        balance
+    }
+
+    /// Take a `Coin` worth of `value` from `Balance`.
+    /// Aborts if `value > balance.value`
+    public fun take<T>(
+        balance: &mut Balance<T>, value: u64, ctx: &mut TxContext,
+    ): Coin<T> {
+        Coin {
+            id: object::new(ctx),
+            balance: balance::split(balance, value)
+        }
+    }
+
+    spec take {
+        let before_val = balance.value;
+        let post after_val = balance.value;
+        ensures after_val == before_val - value;
+
+        aborts_if value > before_val;
+        aborts_if ctx.ids_created + 1 > MAX_U64;
+    }
+
+    /// Put a `Coin<T>` to the `Balance<T>`.
+    public fun put<T>(balance: &mut Balance<T>, coin: Coin<T>) {
+        balance::join(balance, into_balance(coin));
+    }
+
+    spec put {
+        let before_val = balance.value;
+        let post after_val = balance.value;
+        ensures after_val == before_val + coin.balance.value;
+
+        aborts_if before_val + coin.balance.value > MAX_U64;
+    }
+
+    // === Base Coin functionality ===
+
+    /// Consume the coin `c` and add its value to `self`.
+    /// Aborts if `c.value + self.value > U64_MAX`
+    public entry fun join<T>(self: &mut Coin<T>, c: Coin<T>) {
+        let Coin { id, balance } = c;
+        object::delete(id);
+        balance::join(&mut self.balance, balance);
+    }
+
+    spec join {
+        let before_val = self.balance.value;
+        let post after_val = self.balance.value;
+        ensures after_val == before_val + c.balance.value;
+
+        aborts_if before_val + c.balance.value > MAX_U64;
+    }
+
+    /// Split coin `self` to two coins, one with balance `split_amount`,
+    /// and the remaining balance is left is `self`.
+    public fun split<T>(
+        self: &mut Coin<T>, split_amount: u64, ctx: &mut TxContext
+    ): Coin<T> {
+        take(&mut self.balance, split_amount, ctx)
+    }
+
+    spec split {
+        let before_val = self.balance.value;
+        let post after_val = self.balance.value;
+        ensures after_val == before_val - split_amount;
+
+        aborts_if split_amount > before_val;
+        aborts_if ctx.ids_created + 1 > MAX_U64;
+    }
+
+    /// Split coin `self` into `n - 1` coins with equal balances. The remainder is left in
+    /// `self`. Return newly created coins.
+    public fun divide_into_n<T>(
+        self: &mut Coin<T>, n: u64, ctx: &mut TxContext
+    ): vector<Coin<T>> {
+        assert!(n > 0, EInvalidArg);
+        assert!(n <= value(self), ENotEnough);
+
+        let vec = vector::empty<Coin<T>>();
+        let i = 0;
+        let split_amount = value(self) / n;
+        while ({
+            spec {
+                invariant i <= n-1;
+                invariant self.balance.value == old(self).balance.value - (i * split_amount);
+                invariant ctx.ids_created == old(ctx).ids_created + i;
+            };
+            i < n - 1
+        }) {
+            vector::push_back(&mut vec, split(self, split_amount, ctx));
+            i = i + 1;
+        };
+        vec
+    }
+
+    spec divide_into_n {
+        let before_val = self.balance.value;
+        let post after_val = self.balance.value;
+        let split_amount = before_val / n;
+        ensures after_val == before_val - ((n - 1) * split_amount);
+
+        aborts_if n == 0;
+        aborts_if self.balance.value < n;
+        aborts_if ctx.ids_created + n - 1 > MAX_U64;
+    }
+
+    /// Make any Coin with a zero value. Useful for placeholding
+    /// bids/payments or preemptively making empty balances.
+    public fun zero<T>(ctx: &mut TxContext): Coin<T> {
+        Coin { id: object::new(ctx), balance: balance::zero() }
+    }
+
+    /// Destroy a coin with value zero
+    public fun destroy_zero<T>(c: Coin<T>) {
+        let Coin { id, balance } = c;
+        object::delete(id);
+        balance::destroy_zero(balance)
+    }
+
+    // === Registering new coin types and managing the coin supply ===
+
+    /// Create a new currency type `T` as and return the `TreasuryCap` for
+    /// `T` to the caller. Can only be called with a `one-time-witness`
+    /// type, ensuring that there's only one `TreasuryCap` per `T`.
+    public fun create_currency<T: drop>(
+        witness: T,
+        decimals: u8,
+        symbol: vector<u8>,
+        name: vector<u8>,
+        description: vector<u8>,
+        icon_url: Option<Url>,
+        ctx: &mut TxContext
+    ): (TreasuryCap<T>, CoinMetadata<T>) {
+        // Make sure there's only one instance of the type T
+        assert!(sui::types::is_one_time_witness(&witness), EBadWitness);
+
+        // Emit Currency metadata as an event.
+        event::emit(CurrencyCreated<T> {
+            decimals
+        });
+
+        (
+            TreasuryCap {
+                id: object::new(ctx),
+                total_supply: balance::create_supply(witness)
+            },
+            CoinMetadata {
+                id: object::new(ctx),
+                decimals,
+                name: string::utf8(name),
+                symbol: ascii::string(symbol),
+                description: string::utf8(description),
+                icon_url
+            }
+        )
+    }
+
+    /// Create a coin worth `value`. and increase the total supply
+    /// in `cap` accordingly.
+    public fun mint<T>(
+        cap: &mut TreasuryCap<T>, value: u64, ctx: &mut TxContext,
+    ): Coin<T> {
+        Coin {
+            id: object::new(ctx),
+            balance: balance::increase_supply(&mut cap.total_supply, value)
+        }
+    }
+
+    spec schema MintBalance<T> {
+        cap: TreasuryCap<T>;
+        value: u64;
+
+        let before_supply = cap.total_supply.value;
+        let post after_supply = cap.total_supply.value;
+        ensures after_supply == before_supply + value;
+
+        aborts_if before_supply + value >= MAX_U64;
+    }
+
+    spec mint {
+        include MintBalance<T>;
+        aborts_if ctx.ids_created + 1 > MAX_U64;
+    }
+
+    /// Mint some amount of T as a `Balance` and increase the total
+    /// supply in `cap` accordingly.
+    /// Aborts if `value` + `cap.total_supply` >= U64_MAX
+    public fun mint_balance<T>(
+        cap: &mut TreasuryCap<T>, value: u64
+    ): Balance<T> {
+        balance::increase_supply(&mut cap.total_supply, value)
+    }
+
+    spec mint_balance {
+        include MintBalance<T>;
+    }
+
+    /// Destroy the coin `c` and decrease the total supply in `cap`
+    /// accordingly.
+    public fun burn<T>(cap: &mut TreasuryCap<T>, c: Coin<T>): u64 {
+        let Coin { id, balance } = c;
+        object::delete(id);
+        balance::decrease_supply(&mut cap.total_supply, balance)
+    }
+
+    spec schema Burn<T> {
+        cap: TreasuryCap<T>;
+        c: Coin<T>;
+
+        let before_supply = cap.total_supply.value;
+        let post after_supply = cap.total_supply.value;
+        ensures after_supply == before_supply - c.balance.value;
+
+        aborts_if before_supply < c.balance.value;
+    }
+
+    spec burn {
+        include Burn<T>;
+    }
+
+    // === Entrypoints ===
+
+    /// Mint `amount` of `Coin` and send it to `recipient`. Invokes `mint()`.
+    public entry fun mint_and_transfer<T>(
+        c: &mut TreasuryCap<T>, amount: u64, recipient: address, ctx: &mut TxContext
+    ) {
+        transfer::transfer(mint(c, amount, ctx), recipient)
+    }
+
+    /// Burn a Coin and reduce the total_supply. Invokes `burn()`.
+    public entry fun burn_<T>(cap: &mut TreasuryCap<T>, c: Coin<T>) {
+        burn(cap, c);
+    }
+
+    spec burn_ {
+        include Burn<T>;
+    }
+
+    // === Update coin metadata ===
+
+    /// Update name of the coin in `CoinMetadata`
+    public entry fun update_name<T>(
+        _treasury: &TreasuryCap<T>, metadata: &mut CoinMetadata<T>, name: string::String
+    ) {
+        metadata.name = name;
+    }
+
+    /// Update the symbol of the coin in `CoinMetadata`
+    public entry fun update_symbol<T>(
+        _treasury: &TreasuryCap<T>, metadata: &mut CoinMetadata<T>, symbol: ascii::String
+    ) {
+        metadata.symbol = symbol;
+    }
+
+    /// Update the description of the coin in `CoinMetadata`
+    public entry fun update_description<T>(
+        _treasury: &TreasuryCap<T>, metadata: &mut CoinMetadata<T>, description: string::String
+    ) {
+        metadata.description = description;
+    }
+
+    /// Update the url of the coin in `CoinMetadata`
+    public entry fun update_icon_url<T>(
+        _treasury: &TreasuryCap<T>, metadata: &mut CoinMetadata<T>, url: ascii::String
+    ) {
+        metadata.icon_url = option::some(url::new_unsafe(url));
+    }
+
+    // === Get coin metadata fields for on-chain consumption ===
+
+    public fun get_decimals<T>(
+        metadata: &CoinMetadata<T>
+    ): u8 {
+        metadata.decimals
+    }
+
+    public fun get_name<T>(
+        metadata: &CoinMetadata<T>
+    ): string::String {
+        metadata.name
+    }
+
+    public fun get_symbol<T>(
+        metadata: &CoinMetadata<T>
+    ): ascii::String {
+        metadata.symbol
+    }
+
+    public fun get_description<T>(
+        metadata: &CoinMetadata<T>
+    ): string::String {
+        metadata.description
+    }
+
+    public fun get_icon_url<T>(
+        metadata: &CoinMetadata<T>
+    ): Option<Url> {
+        metadata.icon_url
+    }
+
+    // === Test-only code ===
+
+    #[test_only]
+    /// Mint coins of any type for (obviously!) testing purposes only
+    public fun mint_for_testing<T>(value: u64, ctx: &mut TxContext): Coin<T> {
+        Coin { id: object::new(ctx), balance: balance::create_for_testing(value) }
+    }
+
+    #[test_only]
+    /// Destroy a `Coin` with any value in it for testing purposes.
+    public fun destroy_for_testing<T>(self: Coin<T>): u64 {
+        let Coin { id, balance } = self;
+        object::delete(id);
+        balance::destroy_for_testing(balance)
+    }
+}

--- a/crates/sui-framework-override/sources/crypto/bls12381.move
+++ b/crates/sui-framework-override/sources/crypto/bls12381.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::bls12381 {
+    friend sui::validator;
+
+    /// @param signature: A 48-bytes signature that is a point on the G1 subgroup.
+    /// @param public_key: A 96-bytes public key that is a point on the G2 subgroup.
+    /// @param msg: The message that we test the signature against.
+    ///
+    /// If the signature is a valid signature of the message and public key according to
+    /// BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return false.
+    public native fun bls12381_min_sig_verify(signature: &vector<u8>, public_key: &vector<u8>, msg: &vector<u8>): bool;
+
+    /// @param signature: A 48-bytes signature that is a point on the G1 subgroup.
+    /// @param public_key: A 96-bytes public key that is a point on the G2 subgroup.
+    /// @param msg: The message that we test the signature against.
+    /// @param domain: The domain that the signature is tested again. We essentially prepend this to the message.
+    ///
+    /// If the signature is a valid signature of the message and public key according to
+    /// BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return false.
+    public(friend) fun bls12381_min_sig_verify_with_domain(
+        signature: &vector<u8>,
+        public_key: &vector<u8>,
+        msg: vector<u8>,
+        domain: vector<u8>
+    ): bool {
+        std::vector::append(&mut domain, msg);
+        bls12381_min_sig_verify(signature, public_key, &domain)
+    }
+
+    /// @param signature: A 96-bytes signature that is a point on the G2 subgroup.
+    /// @param public_key: A 48-bytes public key that is a point on the G1 subgroup.
+    /// @param msg: The message that we test the signature against.
+    ///
+    /// If the signature is a valid signature of the message and public key according to
+    /// BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return false.
+    public native fun bls12381_min_pk_verify(signature: &vector<u8>, public_key: &vector<u8>, msg: &vector<u8>): bool;
+}

--- a/crates/sui-framework-override/sources/crypto/bls12381.spec.move
+++ b/crates/sui-framework-override/sources/crypto/bls12381.spec.move
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::bls12381 {
+    spec bls12381_min_sig_verify {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec bls12381_min_pk_verify {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework-override/sources/crypto/bulletproofs.move
+++ b/crates/sui-framework-override/sources/crypto/bulletproofs.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::bulletproofs {
+    use sui::elliptic_curve::{Self as ec, RistrettoPoint};
+
+    /// Only bit_length = 64, 32, 16, 8 will work.
+    native fun native_verify_full_range_proof(proof: &vector<u8>, commitment: &vector<u8>, bit_length: u64): bool;
+
+    /// @param proof: The bulletproof
+    /// @param commitment: The commitment which we are trying to verify the range proof for
+    /// @param bit_length: The bit length that we prove the committed value is whithin. Note that bit_length must be either 64, 32, 16, or 8.
+    ///
+    /// If the range proof is valid, execution succeeds, else panics.
+    public fun verify_full_range_proof(proof: &vector<u8>, commitment: &RistrettoPoint, bit_length: u64): bool {
+        native_verify_full_range_proof(proof, &ec::bytes(commitment), bit_length)
+    }
+}

--- a/crates/sui-framework-override/sources/crypto/bulletproofs.spec.move
+++ b/crates/sui-framework-override/sources/crypto/bulletproofs.spec.move
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::bulletproofs {
+    spec native_verify_full_range_proof {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework-override/sources/crypto/ecdsa_k1.move
+++ b/crates/sui-framework-override/sources/crypto/ecdsa_k1.move
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::ecdsa_k1 {
+
+    // TODO document this
+    const EFailToRecoverPubKey: u64 = 0;
+    const EInvalidSignature: u64 = 1;
+
+    /// @param signature: A 65-bytes signature in form (r, s, v) that is signed using
+    /// Secp256k1. Reference implementation on signature generation using RFC6979:
+    /// https://github.com/MystenLabs/narwhal/blob/5d6f6df8ccee94446ff88786c0dbbc98be7cfc09/crypto/src/secp256k1.rs
+    /// The accepted v values are {0, 1, 2, 3}.
+    ///
+    /// @param hashed_msg: the hashed 32-bytes message. The message must be hashed instead
+    /// of plain text to be secure.
+    ///
+    /// If the signature is valid, return the corresponding recovered Secpk256k1 public
+    /// key, otherwise throw error. This is similar to ecrecover in Ethereum, can only be
+    /// applied to Secp256k1 signatures.
+    public native fun ecrecover(signature: &vector<u8>, hashed_msg: &vector<u8>): vector<u8>;
+
+    /// @param pubkey: A 33-bytes compressed public key, a prefix either 0x02 or 0x03 and a 256-bit integer.
+    ///
+    /// If the compressed public key is valid, return the 65-bytes uncompressed public key,
+    /// otherwise throw error.
+    public native fun decompress_pubkey(pubkey: &vector<u8>): vector<u8>;
+
+    /// @param data: arbitrary bytes data to hash
+    /// Hash the input bytes using keccak256 and returns 32 bytes.
+    public native fun keccak256(data: &vector<u8>): vector<u8>;
+
+    /// @param signature: A 65-bytes signature in form (r, s, v) that is signed using
+    /// Secp256k1. Reference implementation on signature generation using RFC6979:
+    /// https://github.com/MystenLabs/narwhal/blob/5d6f6df8ccee94446ff88786c0dbbc98be7cfc09/crypto/src/secp256k1.rs
+    ///
+    /// @param public_key: The public key to verify the signature against
+    /// @param hashed_msg: The hashed 32-bytes message, same as what the signature is signed against.
+    ///
+    /// If the signature is valid to the pubkey and hashed message, return true. Else false.
+    public native fun secp256k1_verify(signature: &vector<u8>, public_key: &vector<u8>, hashed_msg: &vector<u8>): bool;
+}

--- a/crates/sui-framework-override/sources/crypto/ed25519.move
+++ b/crates/sui-framework-override/sources/crypto/ed25519.move
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::ed25519 {
+    friend sui::validator;
+    /// @param signature: 32-byte signature that is a point on the Ed25519 elliptic curve.
+    /// @param public_key: 32-byte signature that is a point on the Ed25519 elliptic curve.
+    /// @param msg: The message that we test the signature against.
+    ///
+    /// If the signature is a valid Ed25519 signature of the message and public key, return true.
+    /// Otherwise, return false.
+    public native fun ed25519_verify(signature: &vector<u8>, public_key: &vector<u8>, msg: &vector<u8>): bool;
+
+    /// @param signature: 32-byte signature that is a point on the Ed25519 elliptic curve.
+    /// @param public_key: 32-byte signature that is a point on the Ed25519 elliptic curve.
+    /// @param msg: The message that we test the signature against.
+    /// @param domain: The domain that the signature is tested again. We essentially prepend this to the message.
+    ///
+    /// If the signature is a valid Ed25519 signature of the message and public key, return true.
+    /// Otherwise, return false.
+    public(friend) fun ed25519_verify_with_domain(signature: &vector<u8>, public_key: &vector<u8>, msg: vector<u8>, domain: vector<u8>): bool {
+        std::vector::append(&mut domain, msg);
+        ed25519_verify(signature, public_key, &domain)
+    }
+
+}

--- a/crates/sui-framework-override/sources/crypto/ed25519.spec.move
+++ b/crates/sui-framework-override/sources/crypto/ed25519.spec.move
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::ed25519 {
+    spec ed25519_verify {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework-override/sources/crypto/elliptic_curve.move
+++ b/crates/sui-framework-override/sources/crypto/elliptic_curve.move
@@ -1,0 +1,122 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Library for Elliptic Curve operations for Pedersen Commitment on a prime order group.
+/// We specifically support the Ristretto-255 sub-group.
+
+module sui::elliptic_curve {
+    use std::vector;
+
+    ///////////////////////////////////
+    /// Elliptic Curve structs
+    ///////////////////////////////////
+
+    /// Represents a point on the Ristretto-255 subgroup.
+    struct RistrettoPoint has copy, drop, store {
+        // A 32-byte representation of the group element.
+        value: vector<u8>
+    }
+
+    /// Represents a scalar within the Curve25519 prime-order group.
+    struct Scalar has copy, drop, store {
+        // A 32-byte representation of the scalar
+        value: vector<u8>
+    }
+
+    ///////////////////////////////////
+    /// Private
+    ///////////////////////////////////
+
+    /// @param value: The value to commit to
+    /// @param blinding_factor: A random number used to ensure that the commitment is hiding.
+    native fun native_create_pedersen_commitment(value: vector<u8>, blinding_factor: vector<u8>): vector<u8>;
+
+    /// @param self: bytes representation of an EC point on the Ristretto-255 subgroup
+    /// @param other: bytes representation of an EC point on the Ristretto-255 subgroup
+    /// A native move wrapper around the addition of Ristretto points. Returns self + other.
+    native fun native_add_ristretto_point(point1: vector<u8>, point2: vector<u8>): vector<u8>;
+
+    /// @param self: bytes representation of an EC point on the Ristretto-255 subgroup
+    /// @param other: bytes representation of an EC point on the Ristretto-255 subgroup
+    /// A native move wrapper around the subtraction of Ristretto points. Returns self - other.
+    native fun native_subtract_ristretto_point(point1: vector<u8>, point2: vector<u8>): vector<u8>;
+
+    /// @param value: the value of the to-be-created scalar
+    /// TODO: Transfer this into a Move function some time in the future.
+    /// A native move wrapper for the creation of Scalars on Curve25519.
+    native fun native_scalar_from_u64(value: u64): vector<u8>;
+
+
+    /// @param value: the bytes representation of the scalar.
+    /// TODO: Transfer this into a Move function some time in the future.
+    /// A native move wrapper for the creation of Scalars on Curve25519.
+    native fun native_scalar_from_bytes(bytes: vector<u8>): vector<u8>;
+
+    ///////////////////////////////////
+    /// Public
+    ///////////////////////////////////
+
+    // Scalar
+    ///////////////////////
+
+    /// Create a field element from u64
+    public fun new_scalar_from_u64(value: u64): Scalar {
+        Scalar {
+            value: native_scalar_from_u64(value)
+        }
+    }
+
+    /// Create a pedersen commitment from two field elements
+    public fun create_pedersen_commitment(value: Scalar, blinding_factor: Scalar): RistrettoPoint {
+        return RistrettoPoint {
+            value: native_create_pedersen_commitment(value.value, blinding_factor.value)
+        }
+    }
+
+    /// Creates a new field element from byte representation. Note that
+    /// `value` must be 32-bytes
+    public fun new_scalar_from_bytes(value: vector<u8>): Scalar {
+        Scalar {
+            value: native_scalar_from_bytes(value)
+        }
+    }
+
+    /// Get the byte representation of the field element
+    public fun scalar_bytes(self: &Scalar): vector<u8> {
+        self.value
+    }
+
+    // EC Point
+    ///////////////////////
+
+    /// Get the underlying compressed byte representation of the group element
+    public fun bytes(self: &RistrettoPoint): vector<u8> {
+        self.value
+    }
+
+
+    /// Perform addition on two group elements
+    public fun add(self: &RistrettoPoint, other: &RistrettoPoint): RistrettoPoint {
+        RistrettoPoint {
+            value: native_add_ristretto_point(self.value, other.value)
+        }
+    }
+
+    /// Perform subtraction on two group elements
+    public fun subtract(self: &RistrettoPoint, other: &RistrettoPoint): RistrettoPoint {
+        RistrettoPoint {
+            value: native_subtract_ristretto_point(self.value, other.value)
+        }
+    }
+
+    /// Attempt to create a new group element from compressed bytes representation
+    public fun new_from_bytes(bytes: vector<u8>): RistrettoPoint {
+        assert!(vector::length(&bytes) == 32, 1);
+        RistrettoPoint {
+            value: bytes
+        }
+    }
+
+    // TODO: Add arithmetic for Scalar elements. We just need add, subtract, and multiply.
+    // TODO: Add scalar to point multiplication for group elements.
+}

--- a/crates/sui-framework-override/sources/crypto/elliptic_curve.spec.move
+++ b/crates/sui-framework-override/sources/crypto/elliptic_curve.spec.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::elliptic_curve {
+    spec native_create_pedersen_commitment {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec native_add_ristretto_point {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec native_subtract_ristretto_point {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec native_scalar_from_u64 {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec native_scalar_from_bytes {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework-override/sources/crypto/groth16.move
+++ b/crates/sui-framework-override/sources/crypto/groth16.move
@@ -1,0 +1,83 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::groth16 {
+    use std::vector;
+
+    // Error for input is not a valid Arkwork representation of a verifying key.
+    const EInvalidVerifyingKey: u64 = 0;
+
+    /// A `PreparedVerifyingKey` consisting of four components in serialized form.
+    struct PreparedVerifyingKey has store, copy, drop {
+        vk_gamma_abc_g1_bytes: vector<u8>,
+        alpha_g1_beta_g2_bytes: vector<u8>,
+        gamma_g2_neg_pc_bytes: vector<u8>,
+        delta_g2_neg_pc_bytes: vector<u8>
+    }
+
+    /// Creates a `PreparedVerifyingKey` from bytes.
+    public fun pvk_from_bytes(vk_gamma_abc_g1_bytes: vector<u8>, alpha_g1_beta_g2_bytes: vector<u8>, gamma_g2_neg_pc_bytes: vector<u8>, delta_g2_neg_pc_bytes: vector<u8>): PreparedVerifyingKey {
+        PreparedVerifyingKey {
+            vk_gamma_abc_g1_bytes,
+            alpha_g1_beta_g2_bytes,
+            gamma_g2_neg_pc_bytes,
+            delta_g2_neg_pc_bytes
+        }
+    }
+
+    /// Returns bytes of the four components of the `PreparedVerifyingKey`.
+    public fun pvk_to_bytes(pvk: PreparedVerifyingKey): vector<vector<u8>> {
+        let res = vector::empty();
+        vector::push_back(&mut res, pvk.vk_gamma_abc_g1_bytes);
+        vector::push_back(&mut res, pvk.alpha_g1_beta_g2_bytes);
+        vector::push_back(&mut res, pvk.gamma_g2_neg_pc_bytes);
+        vector::push_back(&mut res, pvk.delta_g2_neg_pc_bytes);
+        res
+    }
+
+    /// A `PublicProofInputs` wrapper around its serialized bytes.
+    struct PublicProofInputs has store, copy, drop {
+        bytes: vector<u8>,
+    }
+
+    /// Creates a `PublicProofInputs` wrapper from bytes.
+    public fun public_proof_inputs_from_bytes(bytes: vector<u8>): PublicProofInputs {
+        PublicProofInputs { bytes }
+    }
+
+    /// A `ProofPoints` wrapper around the serialized form of three proof points.
+    struct ProofPoints has store, copy, drop {
+        bytes: vector<u8>
+    }
+
+    /// Creates a Groth16 `ProofPoints` from bytes.
+    public fun proof_points_from_bytes(bytes: vector<u8>): ProofPoints {
+        ProofPoints { bytes }
+    }
+
+    /// @param veriyfing_key: An Arkworks canonical serialization of a verifying key.
+    ///
+    /// Returns four vectors of bytes representing the four components of a prepared verifying key.
+    /// This step computes one pairing e(P, Q), and binds the verification to one particular proof statement.
+    /// This can be used as inputs for the `verify_groth16_proof` function.
+    public native fun prepare_verifying_key(verifying_key: &vector<u8>): PreparedVerifyingKey;
+
+    /// @param prepared_verifying_key: Consists of four vectors of bytes representing the four components of a prepared verifying key.
+    /// @param public_proof_inputs: Represent inputs that are public.
+    /// @param proof_points: Represent three proof points.
+    ///
+    /// Returns a boolean indicating whether the proof is valid.
+    public fun verify_groth16_proof(prepared_verifying_key: &PreparedVerifyingKey, public_proof_inputs: &PublicProofInputs, proof_points: &ProofPoints): bool {
+        verify_groth16_proof_internal(
+            &prepared_verifying_key.vk_gamma_abc_g1_bytes,
+            &prepared_verifying_key.alpha_g1_beta_g2_bytes,
+            &prepared_verifying_key.gamma_g2_neg_pc_bytes,
+            &prepared_verifying_key.delta_g2_neg_pc_bytes,
+            &public_proof_inputs.bytes,
+            &proof_points.bytes
+        )
+    }
+
+    /// Native functions that flattens the inputs into arrays of vectors and passed to the Rust native function.
+    public native fun verify_groth16_proof_internal(vk_gamma_abc_g1_bytes: &vector<u8>, alpha_g1_beta_g2_bytes: &vector<u8>, gamma_g2_neg_pc_bytes: &vector<u8>, delta_g2_neg_pc_bytes: &vector<u8>, public_proof_inputs: &vector<u8>, proof_points: &vector<u8>): bool;
+}

--- a/crates/sui-framework-override/sources/crypto/groth16.spec.move
+++ b/crates/sui-framework-override/sources/crypto/groth16.spec.move
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::groth16 {
+    spec prepare_verifying_key {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec verify_groth16_proof_internal {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework-override/sources/crypto/hmac.move
+++ b/crates/sui-framework-override/sources/crypto/hmac.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::hmac {
+    use sui::digest;
+
+    /// @param key: HMAC key, arbitrary bytes.
+    /// @param msg: message to sign, arbitrary bytes.
+    /// A native move wrapper around the HMAC-SHA3-256. Returns the digest.
+    native fun native_hmac_sha3_256(key: &vector<u8>, msg: &vector<u8>): vector<u8>;
+
+    /// @param key: HMAC key, arbitrary bytes.
+    /// @param msg: message to sign, arbitrary bytes.
+    /// Returns the 32 bytes digest of HMAC-SHA3-256(key, msg).
+    public fun hmac_sha3_256(key: &vector<u8>, msg: &vector<u8>): digest::Sha3256Digest {
+        digest::sha3_256_digest_from_bytes(native_hmac_sha3_256(key, msg))
+    }
+}

--- a/crates/sui-framework-override/sources/crypto/hmac.spec.move
+++ b/crates/sui-framework-override/sources/crypto/hmac.spec.move
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+spec sui::hmac {
+    spec native_hmac_sha3_256 {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/crates/sui-framework-override/sources/devnet_nft.move
+++ b/crates/sui-framework-override/sources/devnet_nft.move
@@ -1,0 +1,127 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A minimalist example to demonstrate how to create an NFT like object
+/// on Sui. The user should be able to use the wallet command line tool
+/// (https://docs.sui.io/build/wallet) to mint an NFT. For example,
+/// `wallet example-nft --name <Name> --description <Description> --url <URL>`
+module sui::devnet_nft {
+    use sui::url::{Self, Url};
+    use std::string;
+    use sui::object::{Self, ID, UID};
+    use sui::event;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    /// An example NFT that can be minted by anybody
+    struct DevNetNFT has key, store {
+        id: UID,
+        /// Name for the token
+        name: string::String,
+        /// Description of the token
+        description: string::String,
+        /// URL for the token
+        url: Url,
+        // TODO: allow custom attributes
+    }
+
+    struct MintNFTEvent has copy, drop {
+        // The Object ID of the NFT
+        object_id: ID,
+        // The creator of the NFT
+        creator: address,
+        // The name of the NFT
+        name: string::String,
+    }
+
+    /// Create a new devnet_nft
+    public entry fun mint(
+        name: vector<u8>,
+        description: vector<u8>,
+        url: vector<u8>,
+        ctx: &mut TxContext
+    ) {
+        let nft = DevNetNFT {
+            id: object::new(ctx),
+            name: string::utf8(name),
+            description: string::utf8(description),
+            url: url::new_unsafe_from_bytes(url)
+        };
+        let sender = tx_context::sender(ctx);
+        event::emit(MintNFTEvent {
+            object_id: object::uid_to_inner(&nft.id),
+            creator: sender,
+            name: nft.name,
+        });
+        transfer::transfer(nft, sender);
+    }
+
+    /// Update the `description` of `nft` to `new_description`
+    public entry fun update_description(
+        nft: &mut DevNetNFT,
+        new_description: vector<u8>,
+    ) {
+        nft.description = string::utf8(new_description)
+    }
+
+    /// Permanently delete `nft`
+    public entry fun burn(nft: DevNetNFT) {
+        let DevNetNFT { id, name: _, description: _, url: _ } = nft;
+        object::delete(id)
+    }
+
+    /// Get the NFT's `name`
+    public fun name(nft: &DevNetNFT): &string::String {
+        &nft.name
+    }
+
+    /// Get the NFT's `description`
+    public fun description(nft: &DevNetNFT): &string::String {
+        &nft.description
+    }
+
+    /// Get the NFT's `url`
+    public fun url(nft: &DevNetNFT): &Url {
+        &nft.url
+    }
+}
+
+#[test_only]
+module sui::devnet_nftTests {
+    use sui::devnet_nft::{Self, DevNetNFT};
+    use sui::test_scenario as ts;
+    use sui::transfer;
+    use std::string;
+
+    #[test]
+    fun mint_transfer_update() {
+        let addr1 = @0xA;
+        let addr2 = @0xB;
+        // create the NFT
+        let scenario = ts::begin(addr1);
+        {
+            devnet_nft::mint(b"test", b"a test", b"https://www.sui.io", ts::ctx(&mut scenario))
+        };
+        // send it from A to B
+        ts::next_tx(&mut scenario, addr1);
+        {
+            let nft = ts::take_from_sender<DevNetNFT>(&mut scenario);
+            transfer::transfer(nft, addr2);
+        };
+        // update its description
+        ts::next_tx(&mut scenario, addr2);
+        {
+            let nft = ts::take_from_sender<DevNetNFT>(&mut scenario);
+            devnet_nft::update_description(&mut nft, b"a new description") ;
+            assert!(*string::bytes(devnet_nft::description(&nft)) == b"a new description", 0);
+            ts::return_to_sender(&mut scenario, nft);
+        };
+        // burn it
+        ts::next_tx(&mut scenario, addr2);
+        {
+            let nft = ts::take_from_sender<DevNetNFT>(&mut scenario);
+            devnet_nft::burn(nft)
+        };
+        ts::end(scenario);
+    }
+}

--- a/crates/sui-framework-override/sources/digest.move
+++ b/crates/sui-framework-override/sources/digest.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Sui types for message digests.
+module sui::digest {
+    use std::vector;
+
+    /// Length of the vector<u8> representing a SHA3-256 digest.
+    const SHA3_256_DIGEST_VECTOR_LENGTH: u64 = 32;
+
+    /// Error code when the length of the digest vector is invalid.
+    const EHashLengthMismatch: u64 = 0;
+
+    /// Sha3256Digest: An immutable wrapper of SHA3_256_DIGEST_VECTOR_LENGTH bytes.
+    struct Sha3256Digest has store, copy, drop {
+        digest: vector<u8>,
+    }
+
+    /// Create a `Sha3256Digest` from bytes. Aborts if `bytes` is not of length 32.
+    public fun sha3_256_digest_from_bytes(digest: vector<u8>): Sha3256Digest {
+        assert!(vector::length(&digest) == SHA3_256_DIGEST_VECTOR_LENGTH, EHashLengthMismatch);
+        Sha3256Digest { digest }
+    }
+
+    /// Get the digest.
+    public fun sha3_256_digest_to_bytes(self: &Sha3256Digest): vector<u8> {
+        self.digest
+    }
+}

--- a/crates/sui-framework-override/sources/dynamic_field.move
+++ b/crates/sui-framework-override/sources/dynamic_field.move
@@ -1,0 +1,163 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// In addition to the fields declared in its type definition, a Sui object can have dynamic fields
+/// that can be added after the object has been constructed. Unlike ordinary field names
+/// (which are always statically declared identifiers) a dynamic field name can be any value with
+/// the `copy`, `drop`, and `store` abilities, e.g. an integer, a boolean, or a string.
+/// This gives Sui programmers the flexibility to extend objects on-the-fly, and it also serves as a
+/// building block for core collection types
+module sui::dynamic_field {
+
+use sui::object::{Self, ID, UID};
+
+friend sui::dynamic_object_field;
+
+/// The object already has a dynamic field with this name (with the value and type specified)
+const EFieldAlreadyExists: u64 = 0;
+
+/// Cannot load dynamic field.
+/// The object does not have a dynamic field with this name (with the value and type specified)
+const EFieldDoesNotExist: u64 = 1;
+
+/// The object has a field with that name, but the value type does not match
+const EFieldTypeMismatch: u64 = 2;
+
+/// Failed to serialize the field's name
+const EBCSSerializationFailure: u64 = 3;
+
+/// Internal object used for storing the field and value
+struct Field<Name: copy + drop + store, Value: store> has key {
+    /// Determined by the hash of the object ID, the field name value and it's type,
+    /// i.e. hash(parent.id || name || Name)
+    id: UID,
+    /// The value for the name of this field
+    name: Name,
+    /// The value bound to this field
+    value: Value,
+}
+
+/// Adds a dynamic field to the object `object: &mut UID` at field specified by `name: Name`.
+/// Aborts with `EFieldAlreadyExists` if the object already has that field with that name.
+public fun add<Name: copy + drop + store, Value: store>(
+    // we use &mut UID in several spots for access control
+    object: &mut UID,
+    name: Name,
+    value: Value,
+) {
+    let object_addr = object::uid_to_address(object);
+    let hash = hash_type_and_key(object_addr, name);
+    assert!(!has_child_object(object_addr, hash), EFieldAlreadyExists);
+    let field = Field {
+        id: object::new_uid_from_hash(hash),
+        name,
+        value,
+    };
+    add_child_object(object_addr, field)
+}
+
+/// Immutably borrows the `object`s dynamic field with the name specified by `name: Name`.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
+public fun borrow<Name: copy + drop + store, Value: store>(
+    object: &UID,
+    name: Name,
+): &Value {
+    let object_addr = object::uid_to_address(object);
+    let hash = hash_type_and_key(object_addr, name);
+    let field = borrow_child_object<Field<Name, Value>>(object, hash);
+    &field.value
+}
+
+/// Mutably borrows the `object`s dynamic field with the name specified by `name: Name`.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
+public fun borrow_mut<Name: copy + drop + store, Value: store>(
+    object: &mut UID,
+    name: Name,
+): &mut Value {
+    let object_addr = object::uid_to_address(object);
+    let hash = hash_type_and_key(object_addr, name);
+    let field = borrow_child_object_mut<Field<Name, Value>>(object, hash);
+    &mut field.value
+}
+
+/// Removes the `object`s dynamic field with the name specified by `name: Name` and returns the
+/// bound value.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
+public fun remove<Name: copy + drop + store, Value: store>(
+    object: &mut UID,
+    name: Name,
+): Value {
+    let object_addr = object::uid_to_address(object);
+    let hash = hash_type_and_key(object_addr, name);
+    let Field { id, name: _, value } = remove_child_object<Field<Name, Value>>(object_addr, hash);
+    object::delete(id);
+    value
+}
+
+/// Returns true if and only if the `object` has a dynamic field with the name specified by
+/// `name: Name` but without specifying the `Value` type
+public fun exists_<Name: copy + drop + store>(
+    object: &UID,
+    name: Name,
+): bool {
+    let object_addr = object::uid_to_address(object);
+    let hash = hash_type_and_key(object_addr, name);
+    has_child_object(object_addr, hash)
+}
+
+/// Returns true if and only if the `object` has a dynamic field with the name specified by
+/// `name: Name` with an assigned value of type `Value`.
+public fun exists_with_type<Name: copy + drop + store, Value: store>(
+    object: &UID,
+    name: Name,
+): bool {
+    let object_addr = object::uid_to_address(object);
+    let hash = hash_type_and_key(object_addr, name);
+    has_child_object_with_ty<Field<Name, Value>>(object_addr, hash)
+}
+
+public(friend) fun field_info<Name: copy + drop + store>(
+    object: &UID,
+    name: Name,
+): (&UID, address) {
+    let object_addr = object::uid_to_address(object);
+    let hash = hash_type_and_key(object_addr, name);
+    let Field { id, name: _, value } = borrow_child_object<Field<Name, ID>>(object, hash);
+    (id, object::id_to_address(value))
+}
+
+public(friend) fun field_info_mut<Name: copy + drop + store>(
+    object: &mut UID,
+    name: Name,
+): (&mut UID, address) {
+    let object_addr = object::uid_to_address(object);
+    let hash = hash_type_and_key(object_addr, name);
+    let Field { id, name: _, value } = borrow_child_object_mut<Field<Name, ID>>(object, hash);
+    (id, object::id_to_address(value))
+}
+
+public(friend) native fun hash_type_and_key<K: copy + drop + store>(parent: address, k: K): address;
+
+public(friend) native fun add_child_object<Child: key>(parent: address, child: Child);
+
+/// throws `EFieldDoesNotExist` if a child does not exist with that ID
+/// or throws `EFieldTypeMismatch` if the type does not match
+/// we need two versions to return a reference or a mutable reference
+public(friend) native fun borrow_child_object<Child: key>(object: &UID, id: address): &Child;
+public(friend) native fun borrow_child_object_mut<Child: key>(object: &mut UID, id: address): &mut Child;
+
+/// throws `EFieldDoesNotExist` if a child does not exist with that ID
+/// or throws `EFieldTypeMismatch` if the type does not match
+public(friend) native fun remove_child_object<Child: key>(parent: address, id: address): Child;
+
+public(friend) native fun has_child_object(parent: address, id: address): bool;
+
+public(friend) native fun has_child_object_with_ty<Child: key>(parent: address, id: address): bool;
+
+}

--- a/crates/sui-framework-override/sources/dynamic_object_field.move
+++ b/crates/sui-framework-override/sources/dynamic_object_field.move
@@ -1,0 +1,117 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Similar to `sui::dynamic_field`, this module allows for the access of dynamic fields. But
+/// unlike, `sui::dynamic_field` the values bound to these dynamic fields _must_ be objects
+/// themselves. This allows for the objects to still exist within in storage, which may be important
+/// for external tools. The difference is otherwise not observable from within Move.
+module sui::dynamic_object_field {
+
+use std::option::{Self, Option};
+use sui::dynamic_field::{
+    Self as field,
+    add_child_object,
+    borrow_child_object,
+    borrow_child_object_mut,
+    remove_child_object,
+};
+use sui::object::{Self, UID, ID};
+
+// Internal object used for storing the field and the name associated with the value
+// The separate type is necessary to prevent key collision with direct usage of dynamic_field
+struct Wrapper<Name> has copy, drop, store {
+    name: Name,
+}
+
+/// Adds a dynamic object field to the object `object: &mut UID` at field specified by `name: Name`.
+/// Aborts with `EFieldAlreadyExists` if the object already has that field with that name.
+public fun add<Name: copy + drop + store, Value: key + store>(
+    // we use &mut UID in several spots for access control
+    object: &mut UID,
+    name: Name,
+    value: Value,
+) {
+    let key = Wrapper { name };
+    let id = object::id(&value);
+    field::add(object, key, id);
+    let (field, _) = field::field_info<Wrapper<Name>>(object, key);
+    add_child_object(object::uid_to_address(field), value);
+}
+
+/// Immutably borrows the `object`s dynamic object field with the name specified by `name: Name`.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
+public fun borrow<Name: copy + drop + store, Value: key + store>(
+    object: &UID,
+    name: Name,
+): &Value {
+    let key = Wrapper { name };
+    let (field, value_id) = field::field_info<Wrapper<Name>>(object, key);
+    borrow_child_object<Value>(field, value_id)
+}
+
+/// Mutably borrows the `object`s dynamic object field with the name specified by `name: Name`.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
+public fun borrow_mut<Name: copy + drop + store, Value: key + store>(
+    object: &mut UID,
+    name: Name,
+): &mut Value {
+    let key = Wrapper { name };
+    let (field, value_id) = field::field_info_mut<Wrapper<Name>>(object, key);
+    borrow_child_object_mut<Value>(field, value_id)
+}
+
+/// Removes the `object`s dynamic object field with the name specified by `name: Name` and returns
+/// the bound object.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
+public fun remove<Name: copy + drop + store, Value: key + store>(
+    object: &mut UID,
+    name: Name,
+): Value {
+    let key = Wrapper { name };
+    let (field, value_id) = field::field_info<Wrapper<Name>>(object, key);
+    let value = remove_child_object<Value>(object::uid_to_address(field), value_id);
+    field::remove<Wrapper<Name>, ID>(object, key);
+    value
+}
+
+/// Returns true if and only if the `object` has a dynamic object field with the name specified by
+/// `name: Name`.
+public fun exists_<Name: copy + drop + store>(
+    object: &UID,
+    name: Name,
+): bool {
+    let key = Wrapper { name };
+    field::exists_with_type<Wrapper<Name>, ID>(object, key)
+}
+
+/// Returns true if and only if the `object` has a dynamic field with the name specified by
+/// `name: Name` with an assigned value of type `Value`.
+public fun exists_with_type<Name: copy + drop + store, Value: key + store>(
+    object: &UID,
+    name: Name,
+): bool {
+    let key = Wrapper { name };
+    if (!field::exists_with_type<Wrapper<Name>, ID>(object, key)) return false;
+    let (field, value_id) = field::field_info<Wrapper<Name>>(object, key);
+    field::has_child_object_with_ty<Value>(object::uid_to_address(field), value_id)
+}
+
+/// Returns the ID of the object associated with the dynamic object field
+/// Returns none otherwise
+public fun id<Name: copy + drop + store>(
+    object: &UID,
+    name: Name,
+): Option<ID> {
+    let key = Wrapper { name };
+    if (!field::exists_with_type<Wrapper<Name>, ID>(object, key)) return option::none();
+    let (_field, value_id) = field::field_info<Wrapper<Name>>(object, key);
+    option::some(object::id_from_address(value_id))
+}
+
+}

--- a/crates/sui-framework-override/sources/epoch_time_lock.move
+++ b/crates/sui-framework-override/sources/epoch_time_lock.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::epoch_time_lock {
+    use sui::tx_context::{Self, TxContext};
+    friend sui::sui_system;
+
+    /// The epoch passed into the creation of a lock has already passed.
+    const EEpochAlreadyPassed: u64 = 0;
+
+    /// Attempt is made to unlock a lock that cannot be unlocked yet.
+    const EEpochNotYetEnded: u64 = 1;
+
+    /// Holder of an epoch number that can only be discarded in the epoch or
+    /// after the epoch has passed.
+    struct EpochTimeLock has store, copy {
+        epoch: u64
+    }
+
+    /// Create a new epoch time lock with `epoch`. Aborts if the current epoch is less than the input epoch.
+    public fun new(epoch: u64, ctx: &TxContext) : EpochTimeLock {
+        assert!(tx_context::epoch(ctx) < epoch, EEpochAlreadyPassed);
+        EpochTimeLock { epoch }
+    }
+
+    /// Destroys an epoch time lock. Aborts if the current epoch is less than the locked epoch.
+    public fun destroy(lock: EpochTimeLock, ctx: &TxContext) {
+        let EpochTimeLock { epoch } = lock;
+        assert!(tx_context::epoch(ctx) >= epoch, EEpochNotYetEnded);
+    }
+
+    /// Destroys an epoch time lock.
+    public(friend) fun destroy_unchecked(lock: EpochTimeLock) {
+        let EpochTimeLock { epoch: _ } = lock;
+    }
+
+    /// Getter for the epoch number.
+    public fun epoch(lock: &EpochTimeLock): u64 {
+        lock.epoch
+    }
+}

--- a/crates/sui-framework-override/sources/erc721_metadata.move
+++ b/crates/sui-framework-override/sources/erc721_metadata.move
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::erc721_metadata {
+    use std::ascii;
+    use sui::url::{Self, Url};
+    use std::string;
+
+    // TODO: add symbol()?
+    /// A wrapper type for the ERC721 metadata standard https://eips.ethereum.org/EIPS/eip-721
+    struct ERC721Metadata has store {
+        /// The token id associated with the source contract on Ethereum
+        token_id: TokenID,
+        /// A descriptive name for a collection of NFTs in this contract.
+        /// This corresponds to the `name()` method in the
+        /// ERC721Metadata interface in EIP-721.
+        name: string::String,
+        /// A distinct Uniform Resource Identifier (URI) for a given asset.
+        /// This corresponds to the `tokenURI()` method in the ERC721Metadata
+        /// interface in EIP-721.
+        token_uri: Url,
+    }
+
+    // TODO: replace u64 with u256 once the latter is supported
+    // <https://github.com/MystenLabs/fastnft/issues/618>
+    /// An ERC721 token ID
+    struct TokenID has store, copy {
+        id: u64,
+    }
+
+    /// Construct a new ERC721Metadata from the given inputs. Does not perform any validation
+    /// on `token_uri` or `name`
+    public fun new(token_id: TokenID, name: vector<u8>, token_uri: vector<u8>): ERC721Metadata {
+        // Note: this will abort if `token_uri` is not valid ASCII
+        let uri_str = ascii::string(token_uri);
+        ERC721Metadata {
+            token_id,
+            name: string::utf8(name),
+            token_uri: url::new_unsafe(uri_str),
+        }
+    }
+
+    public fun new_token_id(id: u64): TokenID {
+        TokenID { id }
+    }
+
+    public fun token_id(self: &ERC721Metadata): &TokenID {
+        &self.token_id
+    }
+
+    public fun token_uri(self: &ERC721Metadata): &Url {
+        &self.token_uri
+    }
+
+    public fun name(self: &ERC721Metadata): &string::String {
+        &self.name
+    }
+}

--- a/crates/sui-framework-override/sources/event.move
+++ b/crates/sui-framework-override/sources/event.move
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::event {
+
+    /// Add `t` to the event log of this transaction
+    // TODO(https://github.com/MystenLabs/sui/issues/19):
+    // restrict to internal types once we can express this in the ability system
+    public native fun emit<T: copy + drop>(event: T);
+}

--- a/crates/sui-framework-override/sources/governance/genesis.move
+++ b/crates/sui-framework-override/sources/governance/genesis.move
@@ -1,0 +1,129 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::genesis {
+    use std::vector;
+
+    use sui::balance;
+    use sui::sui;
+    use sui::sui_system;
+    use sui::tx_context::TxContext;
+    use sui::validator;
+    use std::option;
+
+    /// The initial amount of SUI locked in the storage fund.
+    const INIT_STORAGE_FUND: u64 = 1;
+
+    /// Initial value of the lower-bound on the amount of stake required to become a validator.
+    /// TODO: testnet only. Needs to be changed.
+    const INIT_MIN_VALIDATOR_STAKE: u64 = 1;
+
+    /// Initial value of the upper-bound on the number of validators.
+    const INIT_MAX_VALIDATOR_COUNT: u64 = 100;
+
+    /// Stake subisidy to be given out in the very first epoch. Placeholder value.
+    const INIT_STAKE_SUBSIDY_AMOUNT: u64 = 1000000;
+
+    /// This function will be explicitly called once at genesis.
+    /// It will create a singleton SuiSystemState object, which contains
+    /// all the information we need in the system.
+    fun create(
+        validator_pubkeys: vector<vector<u8>>,
+        validator_network_pubkeys: vector<vector<u8>>,
+        validator_worker_pubkeys: vector<vector<u8>>,
+        validator_proof_of_possessions: vector<vector<u8>>,
+        validator_sui_addresses: vector<address>,
+        validator_names: vector<vector<u8>>,
+        validator_descriptions: vector<vector<u8>>,
+        validator_image_urls: vector<vector<u8>>,
+        validator_project_urls: vector<vector<u8>>,
+        validator_net_addresses: vector<vector<u8>>,
+        validator_consensus_addresses: vector<vector<u8>>,
+        validator_worker_addresses: vector<vector<u8>>,
+        validator_stakes: vector<u64>,
+        validator_gas_prices: vector<u64>,
+        validator_commission_rates: vector<u64>,
+        ctx: &mut TxContext,
+    ) {
+        let sui_supply = sui::new(ctx);
+        let storage_fund = balance::increase_supply(&mut sui_supply, INIT_STORAGE_FUND);
+        let validators = vector::empty();
+        let count = vector::length(&validator_pubkeys);
+        assert!(
+            vector::length(&validator_sui_addresses) == count
+                && vector::length(&validator_stakes) == count
+                && vector::length(&validator_names) == count
+                && vector::length(&validator_descriptions) == count
+                && vector::length(&validator_image_urls) == count
+                && vector::length(&validator_project_urls) == count
+                && vector::length(&validator_net_addresses) == count
+                && vector::length(&validator_consensus_addresses) == count
+                && vector::length(&validator_worker_addresses) == count
+                && vector::length(&validator_gas_prices) == count
+                && vector::length(&validator_commission_rates) == count,
+            1
+        );
+        let i = 0;
+        while (i < count) {
+            let sui_address = *vector::borrow(&validator_sui_addresses, i);
+            let pubkey = *vector::borrow(&validator_pubkeys, i);
+            let network_pubkey = *vector::borrow(&validator_network_pubkeys, i);
+            let worker_pubkey = *vector::borrow(&validator_worker_pubkeys, i);
+            let proof_of_possession = *vector::borrow(&validator_proof_of_possessions, i);
+            let name = *vector::borrow(&validator_names, i);
+            let description = *vector::borrow(&validator_descriptions, i);
+            let image_url = *vector::borrow(&validator_image_urls, i);
+            let project_url = *vector::borrow(&validator_project_urls, i);
+            let net_address = *vector::borrow(&validator_net_addresses, i);
+            let consensus_address = *vector::borrow(&validator_consensus_addresses, i);
+            let worker_address = *vector::borrow(&validator_worker_addresses, i);
+            let stake = *vector::borrow(&validator_stakes, i);
+            let gas_price = *vector::borrow(&validator_gas_prices, i);
+            let commission_rate = *vector::borrow(&validator_commission_rates, i);
+            vector::push_back(&mut validators, validator::new(
+                sui_address,
+                pubkey,
+                network_pubkey,
+                worker_pubkey,
+                proof_of_possession,
+                name,
+                description,
+                image_url,
+                project_url,
+                net_address,
+                consensus_address,
+                worker_address,
+                balance::increase_supply(&mut sui_supply, stake),
+                option::none(),
+                gas_price,
+                commission_rate,
+                ctx
+            ));
+            i = i + 1;
+        };
+        sui_system::create(
+            validators,
+            sui_supply,
+            storage_fund,
+            INIT_MAX_VALIDATOR_COUNT,
+            INIT_MIN_VALIDATOR_STAKE,
+            INIT_STAKE_SUBSIDY_AMOUNT,
+        );
+    }
+
+    #[test_only]
+    public fun create_for_testing(ctx: &mut TxContext) {
+        let validators = vector[];
+        let sui_supply = sui::new(ctx);
+        let storage_fund = balance::increase_supply(&mut sui_supply, INIT_STORAGE_FUND);
+
+        sui_system::create(
+            validators,
+            sui_supply,
+            storage_fund,
+            INIT_MAX_VALIDATOR_COUNT,
+            INIT_MIN_VALIDATOR_STAKE,
+            INIT_STAKE_SUBSIDY_AMOUNT
+        )
+    }
+}

--- a/crates/sui-framework-override/sources/governance/stake.move
+++ b/crates/sui-framework-override/sources/governance/stake.move
@@ -1,0 +1,91 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::stake {
+    use std::option::{Self, Option};
+    use sui::balance::Balance;
+    use sui::object::{Self, UID};
+    use sui::locked_coin;
+    use sui::sui::SUI;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use sui::epoch_time_lock::EpochTimeLock;
+    use sui::epoch_time_lock;
+    use sui::balance;
+    use sui::math;
+
+    friend sui::sui_system;
+    friend sui::validator;
+
+    /// A custodial stake object holding the staked SUI coin.
+    struct Stake has key {
+        id: UID,
+        /// The staked SUI tokens.
+        balance: Balance<SUI>,
+        /// The epoch until which the staked coin is locked. If the stake
+        /// comes from a Coin<SUI>, this field is None. If it comes from a LockedCoin<SUI>, this
+        /// field will record the original lock expiration epoch, to be used when unstaking.
+        locked_until_epoch: Option<EpochTimeLock>,
+    }
+
+    /// The number of epochs the withdrawn stake is locked for.
+    /// TODO: this is a placehodler number and may be changed.
+    const BONDING_PERIOD: u64 = 1;
+
+    /// Error number for when a Stake with nonzero balance is burnt.
+    const ENONZERO_BALANCE: u64 = 0;
+
+    /// Create a stake object from a SUI balance. If the balance comes from a
+    /// `LockedCoin`, an EpochTimeLock is passed in to keep track of locking period.
+    public(friend) fun create(
+        balance: Balance<SUI>,
+        recipient: address,
+        locked_until_epoch: Option<EpochTimeLock>,
+        ctx: &mut TxContext,
+    ) {
+        let stake = Stake {
+            id: object::new(ctx),
+            balance,
+            locked_until_epoch,
+        };
+        transfer::transfer(stake, recipient)
+    }
+
+    /// Withdraw `amount` from the balance of `stake`.
+    public(friend) fun withdraw_stake(
+        self: &mut Stake,
+        amount: u64,
+        ctx: &mut TxContext,
+    ) {
+        let sender = tx_context::sender(ctx);
+        let unlock_epoch = tx_context::epoch(ctx) + BONDING_PERIOD;
+        let balance = balance::split(&mut self.balance, amount);
+
+        if (option::is_none(&self.locked_until_epoch)) {
+            // If the stake didn't come from a locked coin, we give back the stake and
+            // lock the coin for `BONDING_PERIOD`.
+            locked_coin::new_from_balance(balance, epoch_time_lock::new(unlock_epoch, ctx), sender, ctx);
+        } else {
+            // If the stake did come from a locked coin, we lock the coin for
+            // max(BONDING_PERIOD, remaining_lock_time).
+            let original_unlock_epoch = epoch_time_lock::epoch(option::borrow(&self.locked_until_epoch));
+            let unlock_epoch = math::max(original_unlock_epoch, unlock_epoch);
+            locked_coin::new_from_balance(balance, epoch_time_lock::new(unlock_epoch, ctx), sender, ctx);
+        };
+    }
+
+    /// Burn the stake object. This can be done only when the stake has a zero balance.
+    public entry fun burn(self: Stake, ctx: &mut TxContext) {
+        let Stake { id, balance, locked_until_epoch } = self;
+        object::delete(id);
+        balance::destroy_zero(balance);
+        if (option::is_some(&locked_until_epoch)) {
+            epoch_time_lock::destroy(option::extract(&mut locked_until_epoch), ctx);
+        };
+        option::destroy_none(locked_until_epoch);
+    }
+
+    public fun value(self: &Stake): u64 {
+        balance::value(&self.balance)
+    }
+}

--- a/crates/sui-framework-override/sources/governance/stake_subsidy.move
+++ b/crates/sui-framework-override/sources/governance/stake_subsidy.move
@@ -1,0 +1,70 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::stake_subsidy {
+    use sui::balance::{Self, Balance, Supply};
+    use sui::sui::SUI;
+
+    friend sui::sui_system;
+
+    struct StakeSubsidy has store {
+        /// This counter may be different from the current epoch number if
+        /// in some epochs we decide to skip the subsidy. 
+        epoch_counter: u64,
+        /// Balance storing the accumulated stake subsidy.
+        balance: Balance<SUI>,
+        /// The amount of stake subsidy to be minted this epoch.
+        current_epoch_amount: u64,
+    }
+
+    const BASIS_POINT_DENOMINATOR: u128 = 10000;
+
+    // Placeholder numbers.
+    const STAKE_SUBSIDY_DECREASE_RATE: u128 = 1000; // in basis point
+    const STAKE_SUBSIDY_PERIOD_LENGTH: u64 = 30; // in number of epochs
+
+    public(friend) fun create(initial_stake_subsidy_amount: u64): StakeSubsidy {
+        StakeSubsidy {
+            epoch_counter: 0,
+            balance: balance::zero(),
+            current_epoch_amount: initial_stake_subsidy_amount,
+        }
+    }
+
+    public(friend) fun mint_stake_subsidy_proportional_to_total_stake_testnet(
+        subsidy: &mut StakeSubsidy, supply: &mut Supply<SUI>, stake_subsidy_rate: u64, total_stake: u64
+    ) {
+        let amount_to_mint = ((total_stake as u128) * (stake_subsidy_rate as u128)) / BASIS_POINT_DENOMINATOR;
+        balance::join(
+            &mut subsidy.balance, 
+            balance::increase_supply(supply, (amount_to_mint as u64))
+        );
+    }
+
+    /// Advance the epoch counter and mint new subsidy for the epoch.
+    public(friend) fun advance_epoch(subsidy: &mut StakeSubsidy, supply: &mut Supply<SUI>) {
+        // Mint new subsidy for this epoch.
+        balance::join(
+            &mut subsidy.balance, 
+            balance::increase_supply(supply, subsidy.current_epoch_amount)
+        );
+        subsidy.epoch_counter = subsidy.epoch_counter + 1;
+        // Decrease the subsidy amount only when the current period ends.
+        if (subsidy.epoch_counter % STAKE_SUBSIDY_PERIOD_LENGTH == 0) {
+            let decrease_amount = (subsidy.current_epoch_amount as u128)
+                * STAKE_SUBSIDY_DECREASE_RATE / BASIS_POINT_DENOMINATOR;
+            subsidy.current_epoch_amount = subsidy.current_epoch_amount - (decrease_amount as u64)
+        };
+    }
+
+    /// Withdraw all the minted stake subsidy.
+    public(friend) fun withdraw_all(subsidy: &mut StakeSubsidy): Balance<SUI> {
+        let amount = balance::value(&subsidy.balance);
+        balance::split(&mut subsidy.balance, amount)
+    }
+
+    /// Returns the amount of stake subsidy to be added at the end of the current epoch.
+    public fun current_epoch_subsidy_amount(subsidy: &StakeSubsidy): u64 {
+        subsidy.current_epoch_amount
+    }
+}

--- a/crates/sui-framework-override/sources/governance/staking_pool.move
+++ b/crates/sui-framework-override/sources/governance/staking_pool.move
@@ -1,0 +1,511 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::staking_pool {
+    use sui::balance::{Self, Balance, Supply};
+    use sui::sui::SUI;
+    use std::option::{Self, Option};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+    use sui::epoch_time_lock::{EpochTimeLock};
+    use sui::object::{Self, ID, UID};
+    use sui::locked_coin;
+    use sui::coin;
+    use std::vector;
+    use sui::table_vec::{Self, TableVec};
+    use sui::linked_table::{Self, LinkedTable};
+
+    friend sui::validator;
+    friend sui::validator_set;
+    
+    const EINSUFFICIENT_POOL_TOKEN_BALANCE: u64 = 0;
+    const EWRONG_POOL: u64 = 1;
+    const EWITHDRAW_AMOUNT_CANNOT_BE_ZERO: u64 = 2;
+    const EINSUFFICIENT_SUI_TOKEN_BALANCE: u64 = 3;
+    const EINSUFFICIENT_REWARDS_POOL_BALANCE: u64 = 4;
+    const EDESTROY_NON_ZERO_BALANCE: u64 = 5;
+    const ETOKEN_TIME_LOCK_IS_SOME: u64 = 6;
+    const EWRONG_DELEGATION: u64 = 7;
+    const EPENDING_DELEGATION_DOES_NOT_EXIST: u64 = 8;
+
+    /// A staking pool embedded in each validator struct in the system state object.
+    struct StakingPool has store {
+        /// The sui address of the validator associated with this pool.
+        validator_address: address,
+        /// The epoch at which this pool started operating. Should be the epoch at which the validator became active.
+        starting_epoch: u64,
+        /// The total number of SUI tokens in this pool, including the SUI in the rewards_pool, as well as in all the principal
+        /// in the `Delegation` object, updated at epoch boundaries.
+        sui_balance: u64,
+        /// The epoch delegation rewards will be added here at the end of each epoch. 
+        rewards_pool: Balance<SUI>,
+        /// The number of delegation pool tokens we have issued so far. This number should equal the sum of
+        /// pool token balance in all the `Delegation` objects delegated to this pool. Updated at epoch boundaries.
+        delegation_token_supply: Supply<DelegationToken>,
+        /// Delegations requested during the current epoch. We will activate these delegation at the end of current epoch
+        /// and distribute staking pool tokens at the end-of-epoch exchange rate after the rewards for the current epoch
+        /// have been deposited.
+        pending_delegations: LinkedTable<ID, PendingDelegationEntry>,
+        /// Delegation withdraws requested during the current epoch. Similar to new delegation, the withdraws are processed
+        /// at epoch boundaries. Rewards are withdrawn and distributed after the rewards for the current epoch have come in. 
+        pending_withdraws: TableVec<PendingWithdrawEntry>,
+    }
+
+    /// Struct representing the exchange rate of the delegation pool token to SUI.
+    struct PoolTokenExchangeRate has copy, drop {
+        sui_amount: u64,
+        pool_token_amount: u64,
+    }
+
+    /// An inactive staking pool associated with an inactive validator.
+    /// Only withdraws can be made from this pool.
+    struct InactiveStakingPool has key {
+        id: UID, // TODO: inherit an ID from active staking pool?
+        pool: StakingPool,
+    }
+
+    /// The staking pool token.
+    struct DelegationToken has drop {}
+
+    /// Struct representing a pending delegation.
+    struct PendingDelegationEntry has store, drop {
+        delegator: address, 
+        sui_amount: u64,
+    }
+
+    /// Struct representing a pending delegation withdraw.
+    struct PendingWithdrawEntry has store {
+        delegator: address, 
+        principal_withdraw_amount: u64,
+        withdrawn_pool_tokens: Balance<DelegationToken>,
+    }
+
+    /// A self-custodial delegation object, serving as evidence that the delegator
+    /// has delegated to a staking pool.
+    struct Delegation has key {
+        id: UID,
+        /// The ID of the corresponding `StakedSui` object.
+        staked_sui_id: ID,
+        /// The pool tokens representing the amount of rewards the delegator can get back when they withdraw
+        /// from the pool.
+        pool_tokens: Balance<DelegationToken>,
+        /// Number of SUI token staked originally.
+        principal_sui_amount: u64,
+    }
+
+    /// A self-custodial object holding the staked SUI tokens.
+    struct StakedSui has key {
+        id: UID,
+        /// The validator we are staking with.
+        validator_address: address,
+        /// The epoch at which the staking pool started operating.
+        pool_starting_epoch: u64,
+        /// The epoch at which the delegation is requested.
+        delegation_request_epoch: u64,
+        /// The staked SUI tokens.
+        principal: Balance<SUI>,
+        /// If the stake comes from a Coin<SUI>, this field is None. If it comes from a LockedCoin<SUI>, this
+        /// field will record the original lock expiration epoch, to be used when unstaking.
+        sui_token_lock: Option<EpochTimeLock>,
+    }
+
+    // ==== initializer ====
+
+    /// Create a new, empty staking pool.
+    public(friend) fun new(validator_address: address, starting_epoch: u64, ctx: &mut TxContext) : StakingPool {
+        StakingPool {
+            validator_address,
+            starting_epoch,
+            sui_balance: 0,
+            rewards_pool: balance::zero(),
+            delegation_token_supply: balance::create_supply(DelegationToken {}),
+            pending_delegations: linked_table::new(ctx),
+            pending_withdraws: table_vec::empty(ctx),
+        }
+    }
+
+
+    // ==== delegation requests ====
+
+    // TODO: implement rate limiting new delegations per epoch.
+    /// Request to delegate to a staking pool. The delegation gets counted at the beginning of the next epoch,
+    /// when the delegation object containing the pool tokens is distributed to the delegator.
+    public(friend) fun request_add_delegation(
+        pool: &mut StakingPool, 
+        stake: Balance<SUI>, 
+        sui_token_lock: Option<EpochTimeLock>,
+        delegator: address,
+        ctx: &mut TxContext
+    ) {
+        let sui_amount = balance::value(&stake);
+        assert!(sui_amount > 0, 0);
+        let staked_sui = StakedSui {
+            id: object::new(ctx),
+            validator_address: pool.validator_address,
+            pool_starting_epoch: pool.starting_epoch,
+            delegation_request_epoch: tx_context::epoch(ctx),
+            principal: stake,
+            sui_token_lock,
+        };
+        // insert delegation info into the pending_delegations table.
+        linked_table::push_back(
+            &mut pool.pending_delegations,
+            object::id(&staked_sui),
+            PendingDelegationEntry { delegator, sui_amount }
+        );
+        transfer::transfer(staked_sui, delegator);
+    }
+
+    /// Request to withdraw `principal_withdraw_amount` of stake plus rewards from a staking pool.
+    /// This amount of principal in SUI is withdrawn and transferred to the delegator. A proportional amount
+    /// of pool tokens will be later burnt.
+    /// The rewards portion will be withdrawn at the end of the epoch, after the rewards have come in so we
+    /// can use the new exchange rate to calculate the rewards.
+    public(friend) fun request_withdraw_delegation(
+        pool: &mut StakingPool,  
+        delegation: Delegation, 
+        staked_sui: StakedSui,
+        ctx: &mut TxContext
+    ) : u64 {
+        let (withdrawn_pool_tokens, principal_withdraw, time_lock) = 
+            withdraw_from_principal(pool, delegation, staked_sui);
+        
+        let delegator = tx_context::sender(ctx);
+        let principal_withdraw_amount = balance::value(&principal_withdraw);
+        table_vec::push_back(&mut pool.pending_withdraws, PendingWithdrawEntry {
+            delegator, principal_withdraw_amount, withdrawn_pool_tokens });
+
+        // TODO: implement withdraw bonding period here.
+        if (option::is_some(&time_lock)) {
+            locked_coin::new_from_balance(principal_withdraw, option::destroy_some(time_lock), delegator, ctx);
+        } else {
+            transfer::transfer(coin::from_balance(principal_withdraw, ctx), delegator);
+            option::destroy_none(time_lock);
+        };
+        principal_withdraw_amount
+    }
+
+    public(friend) fun cancel_delegation_request(pool: &mut StakingPool, staked_sui: StakedSui, ctx: &mut TxContext) {
+        let delegator = tx_context::sender(ctx);
+        let staked_sui_id = object::id(&staked_sui);
+        assert!(linked_table::contains(&mut pool.pending_delegations, staked_sui_id), EPENDING_DELEGATION_DOES_NOT_EXIST);
+
+        linked_table::remove(&mut pool.pending_delegations, staked_sui_id);
+
+        let StakedSui { 
+            id,
+            validator_address,
+            pool_starting_epoch,
+            delegation_request_epoch: _,
+            principal,
+            sui_token_lock
+        } = staked_sui;
+
+        // sanity check that the StakedSui is indeed from this pool. Should never fail.
+        assert!(
+            validator_address == pool.validator_address &&
+            pool_starting_epoch == pool.starting_epoch,
+            EWRONG_POOL
+        );
+        object::delete(id);
+        if (option::is_some(&sui_token_lock)) {
+            locked_coin::new_from_balance(principal, option::destroy_some(sui_token_lock), delegator, ctx);
+        } else {
+            transfer::transfer(coin::from_balance(principal, ctx), delegator);
+            option::destroy_none(sui_token_lock);
+        };
+    }
+
+    /// Withdraw the requested amount of the principal SUI stored in the StakedSui object, as
+    /// well as a proportional amount of pool tokens from the delegation object.
+    /// For example, suppose the delegation object contains 15 pool tokens and the principal SUI 
+    /// amount is 21. Then if `principal_withdraw_amount` is 7, 5 pool tokens and 7 SUI tokens will
+    /// be withdrawn.
+    /// Returns values are withdrawn pool tokens, withdrawn principal portion of SUI, and its 
+    /// time lock if applicable.
+    public(friend) fun withdraw_from_principal(
+        pool: &mut StakingPool,  
+        delegation: Delegation, 
+        staked_sui: StakedSui,
+    ) : (Balance<DelegationToken>, Balance<SUI>, Option<EpochTimeLock>) {
+        // Check that the delegation and staked sui objects match.
+        assert!(object::id(&staked_sui) == delegation.staked_sui_id, EWRONG_DELEGATION);
+
+        // Check that the delegation information matches the pool. 
+        assert!(
+            staked_sui.validator_address == pool.validator_address &&
+            staked_sui.pool_starting_epoch == pool.starting_epoch,
+            EWRONG_POOL
+        );
+
+        assert!(delegation.principal_sui_amount == balance::value(&staked_sui.principal), EINSUFFICIENT_SUI_TOKEN_BALANCE);
+
+        let pool_tokens = destroy_delegation_and_return_pool_tokens(delegation);
+        let (principal_withdraw, time_lock) = unwrap_staked_sui(staked_sui);
+
+        (
+            pool_tokens,
+            principal_withdraw,
+            time_lock
+        )
+    }
+
+    fun destroy_delegation_and_return_pool_tokens(delegation: Delegation): Balance<DelegationToken> {
+        let Delegation { id, staked_sui_id: _, pool_tokens, principal_sui_amount: _ } = delegation;
+        object::delete(id);
+        pool_tokens
+    }
+
+    fun unwrap_staked_sui(staked_sui: StakedSui): (Balance<SUI>, Option<EpochTimeLock>) {
+        let StakedSui { 
+            id,
+            validator_address: _,
+            pool_starting_epoch: _,
+            delegation_request_epoch: _,
+            principal,
+            sui_token_lock
+        } = staked_sui;
+        object::delete(id);
+        (principal, sui_token_lock)
+    }
+
+    // ==== functions called at epoch boundaries ===
+
+    /// Called at epoch advancement times to add rewards (in SUI) to the staking pool. 
+    public(friend) fun deposit_rewards(pool: &mut StakingPool, rewards: Balance<SUI>) {
+        pool.sui_balance = pool.sui_balance + balance::value(&rewards);
+        balance::join(&mut pool.rewards_pool, rewards);
+    }
+
+    /// Called at epoch boundaries to process pending delegation withdraws requested during the epoch.
+    /// For each pending withdraw entry, we withdraw the rewards from the pool at the new exchange rate and burn the pool
+    /// tokens.
+    public(friend) fun process_pending_delegation_withdraws(pool: &mut StakingPool, ctx: &mut TxContext) : u64 {
+        let total_reward_withdraw = 0;
+
+        while (!table_vec::is_empty(&pool.pending_withdraws)) {
+            let PendingWithdrawEntry {
+                delegator, principal_withdraw_amount, withdrawn_pool_tokens
+            } = table_vec::pop_back(&mut pool.pending_withdraws);
+            let reward_withdraw = withdraw_rewards_and_burn_pool_tokens(pool, principal_withdraw_amount, withdrawn_pool_tokens);
+            total_reward_withdraw = total_reward_withdraw + balance::value(&reward_withdraw);
+            transfer::transfer(coin::from_balance(reward_withdraw, ctx), delegator);
+        };
+        total_reward_withdraw
+    }
+
+    /// Called at epoch boundaries to mint new pool tokens to new delegators at the new exchange rate.
+    /// New delegators include both entirely new delegations and delegations switched to this staking pool
+    /// during the previous epoch.
+    public(friend) fun process_pending_delegations(pool: &mut StakingPool, ctx: &mut TxContext) {
+        while (!linked_table::is_empty(&pool.pending_delegations)) {
+            let (staked_sui_id, PendingDelegationEntry { delegator, sui_amount }) =
+                linked_table::pop_back(&mut pool.pending_delegations);
+            mint_delegation_tokens_to_delegator(pool, delegator, sui_amount, staked_sui_id, ctx);
+            pool.sui_balance = pool.sui_balance + sui_amount;
+        };
+    }
+
+    /// Called by validator_set at epoch boundaries for delegation switches.
+    /// This function goes through the provided vector of pending withdraw entries, 
+    /// and for each entry, calls `withdraw_rewards_and_burn_pool_tokens` to withdraw
+    /// the rewards portion of the delegation and burn the pool tokens. We then aggregate
+    /// the delegator addresses and their rewards into vectors, as well as calculate 
+    /// the total amount of rewards SUI withdrawn. These three return values are then
+    /// used in `validator_set`'s delegation switching code to deposit the rewards part
+    /// into the new validator's staking pool.
+    public(friend) fun batch_withdraw_rewards_and_burn_pool_tokens(
+        pool: &mut StakingPool,
+        entries: TableVec<PendingWithdrawEntry>,
+    ) : (vector<address>, vector<Balance<SUI>>, u64) {
+        let (delegators, rewards, total_rewards_withdraw_amount) = (vector::empty(), vector::empty(), 0);
+        while (!table_vec::is_empty(&mut entries)) {
+            let PendingWithdrawEntry { delegator, principal_withdraw_amount, withdrawn_pool_tokens } 
+                = table_vec::pop_back(&mut entries);
+            let reward = withdraw_rewards_and_burn_pool_tokens(pool, principal_withdraw_amount, withdrawn_pool_tokens);
+            total_rewards_withdraw_amount = total_rewards_withdraw_amount + balance::value(&reward);
+            vector::push_back(&mut delegators, delegator);
+            vector::push_back(&mut rewards, reward);
+        };
+        table_vec::destroy_empty(entries);
+        (delegators, rewards, total_rewards_withdraw_amount)
+    }
+
+    /// This function does the following:
+    ///     1. Calculates the total amount of SUI (including principal and rewards) that the provided pool tokens represent
+    ///        at the current exchange rate.
+    ///     2. Using the above number and the given `principal_withdraw_amount`, calculates the rewards portion of the 
+    ///        delegation we should withdraw.
+    ///     3. Withdraws the rewards portion from the rewards pool at the current exchange rate. We only withdraw the rewards
+    ///        portion because the principal portion was already taken out of the delegator's self custodied StakedSui at request 
+    ///        time in `request_withdraw_stake`.
+    ///     4. Since SUI tokens are withdrawn, we need to burn the corresponding pool tokens to keep the exchange rate the same.
+    ///     5. Updates the SUI balance amount of the pool.
+    fun withdraw_rewards_and_burn_pool_tokens(
+        pool: &mut StakingPool, 
+        principal_withdraw_amount: u64, 
+        withdrawn_pool_tokens: Balance<DelegationToken>,
+    ) : Balance<SUI> {
+        let pool_token_amount = balance::value(&withdrawn_pool_tokens);
+        let total_sui_withdraw_amount = get_sui_amount(pool, pool_token_amount);
+        let reward_withdraw_amount =
+            if (total_sui_withdraw_amount >= principal_withdraw_amount)
+                total_sui_withdraw_amount - principal_withdraw_amount
+            else 0;
+        balance::decrease_supply(
+            &mut pool.delegation_token_supply, 
+            withdrawn_pool_tokens
+        );
+        pool.sui_balance = pool.sui_balance - (principal_withdraw_amount + reward_withdraw_amount);
+        balance::split(&mut pool.rewards_pool, reward_withdraw_amount)
+    }
+
+    /// Given the `sui_amount`, mint the corresponding amount of pool tokens at the current exchange
+    /// rate, puts the pool tokens in a delegation object, and gives the delegation object to the delegator.
+    fun mint_delegation_tokens_to_delegator(
+        pool: &mut StakingPool, 
+        delegator: address, 
+        sui_amount: u64, 
+        staked_sui_id: ID,
+        ctx: &mut TxContext
+    ) {
+        let new_pool_token_amount = get_token_amount(pool, sui_amount);   
+
+        // Mint new pool tokens at the current exchange rate.
+        let pool_tokens = balance::increase_supply(&mut pool.delegation_token_supply, new_pool_token_amount);
+
+        let delegation = Delegation {
+            id: object::new(ctx),
+            staked_sui_id,
+            pool_tokens,
+            principal_sui_amount: sui_amount,
+        };
+
+        transfer::transfer(delegation, delegator);
+    }
+
+
+    // ==== inactive pool related ====
+
+    /// Deactivate a staking pool by wrapping it in an `InactiveStakingPool` and sharing this newly created object. 
+    /// After this pool deactivation, the pool stops earning rewards. Only delegation withdraws can be made to the pool.
+    public(friend) fun deactivate_staking_pool(pool: StakingPool, ctx: &mut TxContext) {
+        let inactive_pool = InactiveStakingPool { id: object::new(ctx), pool};
+        transfer::share_object(inactive_pool);
+    }
+
+    /// Withdraw delegation from an inactive pool. Since no epoch rewards will be added to an inactive pool,
+    /// the exchange rate between pool tokens and SUI tokens stay the same. Therefore, unlike withdrawing
+    /// from an active pool, we can handle both principal and rewards withdraws directly here.
+    public entry fun withdraw_from_inactive_pool(
+        inactive_pool: &mut InactiveStakingPool, 
+        staked_sui: StakedSui, 
+        delegation: Delegation, 
+        ctx: &mut TxContext
+    ) {
+        let pool = &mut inactive_pool.pool;
+        let (withdrawn_pool_tokens, principal_withdraw, time_lock) = 
+            withdraw_from_principal(pool, delegation, staked_sui);
+        let principal_withdraw_amount = balance::value(&principal_withdraw);
+        let rewards_withdraw = withdraw_rewards_and_burn_pool_tokens(pool, principal_withdraw_amount, withdrawn_pool_tokens);
+        let total_withdraw_amount = principal_withdraw_amount + balance::value(&rewards_withdraw);
+        pool.sui_balance = pool.sui_balance - total_withdraw_amount;
+
+        let delegator = tx_context::sender(ctx);
+        // TODO: implement withdraw bonding period here.
+        if (option::is_some(&time_lock)) {
+            locked_coin::new_from_balance(principal_withdraw, option::destroy_some(time_lock), delegator, ctx);
+            transfer::transfer(coin::from_balance(rewards_withdraw, ctx), delegator);
+        } else {
+            balance::join(&mut principal_withdraw, rewards_withdraw);
+            transfer::transfer(coin::from_balance(principal_withdraw, ctx), delegator);
+            option::destroy_none(time_lock);
+        };
+    }
+
+
+    // ==== destroyers ====
+
+    /// Destroy an empty delegation that no longer contains any SUI or pool tokens.
+    public entry fun destroy_empty_delegation(delegation: Delegation) {
+        let Delegation {
+            id,
+            staked_sui_id: _,
+            pool_tokens,
+            principal_sui_amount,
+        } = delegation;
+        object::delete(id);
+        assert!(balance::value(&pool_tokens) == 0, EDESTROY_NON_ZERO_BALANCE);
+        assert!(principal_sui_amount == 0, EDESTROY_NON_ZERO_BALANCE);
+        balance::destroy_zero(pool_tokens);
+    }
+
+    /// Destroy an empty delegation that no longer contains any SUI or pool tokens.
+    public entry fun destroy_empty_staked_sui(staked_sui: StakedSui) {
+        let StakedSui {
+            id,
+            validator_address: _,
+            pool_starting_epoch: _,
+            delegation_request_epoch: _,
+            principal,
+            sui_token_lock
+        } = staked_sui;
+        object::delete(id);
+        assert!(balance::value(&principal) == 0, EDESTROY_NON_ZERO_BALANCE);
+        balance::destroy_zero(principal);
+        assert!(option::is_none(&sui_token_lock), ETOKEN_TIME_LOCK_IS_SOME);
+        option::destroy_none(sui_token_lock);
+    }
+
+
+    // ==== getters and misc utility functions ====
+
+    public fun sui_balance(pool: &StakingPool) : u64 { pool.sui_balance }
+
+    public fun validator_address(staked_sui: &StakedSui) : address { staked_sui.validator_address }
+
+    public fun staked_sui_amount(staked_sui: &StakedSui): u64 { balance::value(&staked_sui.principal) }
+
+    public fun delegation_request_epoch(staked_sui: &StakedSui): u64 {
+        staked_sui.delegation_request_epoch
+    }
+
+    public fun delegation_token_amount(delegation: &Delegation): u64 { balance::value(&delegation.pool_tokens) }
+
+    public fun pool_token_exchange_rate(pool: &StakingPool): PoolTokenExchangeRate {
+        PoolTokenExchangeRate {
+            sui_amount: pool.sui_balance,
+            pool_token_amount: balance::supply_value(&pool.delegation_token_supply),
+        }
+    }
+    /// Create a new pending withdraw entry.
+    public(friend) fun new_pending_withdraw_entry(
+        delegator: address, 
+        principal_withdraw_amount: u64,
+        withdrawn_pool_tokens: Balance<DelegationToken>,
+    ) : PendingWithdrawEntry {
+        PendingWithdrawEntry { delegator, principal_withdraw_amount, withdrawn_pool_tokens }
+    }
+
+    fun get_sui_amount(pool: &StakingPool, token_amount: u64): u64 {
+        let token_supply = balance::supply_value(&pool.delegation_token_supply);
+        if (token_supply == 0) { 
+            return token_amount 
+        };
+        let res = (pool.sui_balance as u128) 
+                * (token_amount as u128) 
+                / (token_supply as u128);
+        (res as u64)
+    }
+
+    fun get_token_amount(pool: &StakingPool, sui_amount: u64): u64 {
+        if (pool.sui_balance == 0) { 
+            return sui_amount
+        };
+        let token_supply = balance::supply_value(&pool.delegation_token_supply);
+        let res = (token_supply as u128) 
+                * (sui_amount as u128)
+                / (pool.sui_balance as u128);
+        (res as u64)
+    }    
+}

--- a/crates/sui-framework-override/sources/governance/sui_system.move
+++ b/crates/sui-framework-override/sources/governance/sui_system.move
@@ -1,0 +1,624 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::sui_system {
+    use sui::balance::{Self, Balance, Supply};
+    use sui::coin::{Self, Coin};
+    use sui::staking_pool::{Delegation, StakedSui};
+    use sui::object::{Self, UID};
+    use sui::locked_coin::{Self, LockedCoin};
+    use sui::sui::SUI;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use sui::validator::{Self, Validator};
+    use sui::validator_set::{Self, ValidatorSet};
+    use sui::stake::Stake;
+    use sui::stake_subsidy::{Self, StakeSubsidy};
+    use sui::vec_map::{Self, VecMap};
+    use sui::vec_set::{Self, VecSet};
+    use std::option;
+    use std::vector;
+    use sui::epoch_time_lock::EpochTimeLock;
+    use sui::epoch_time_lock;
+    use sui::pay;
+    use sui::event;
+    use sui::staking_pool;
+
+    friend sui::genesis;
+
+    #[test_only]
+    friend sui::governance_test_utils;
+
+    /// A list of system config parameters.
+    // TDOO: We will likely add more, a few potential ones:
+    // - the change in stake across epochs can be at most +/- x%
+    // - the change in the validator set across epochs can be at most x validators
+    //
+    // TODO: The stake threshold should be % threshold instead of amount threshold.
+    struct SystemParameters has store {
+        /// Lower-bound on the amount of stake required to become a validator.
+        min_validator_stake: u64,
+        /// Maximum number of validator candidates at any moment.
+        /// We do not allow the number of validators in any epoch to go above this.
+        max_validator_candidate_count: u64,
+    }
+
+    /// The top-level object containing all information of the Sui system.
+    struct SuiSystemState has key {
+        id: UID,
+        /// The current epoch ID, starting from 0.
+        epoch: u64,
+        /// Contains all information about the validators.
+        validators: ValidatorSet,
+        /// The SUI treasury capability needed to mint SUI.
+        sui_supply: Supply<SUI>,
+        /// The storage fund.
+        storage_fund: Balance<SUI>,
+        /// A list of system config parameters.
+        parameters: SystemParameters,
+        /// The reference gas price for the current epoch.
+        reference_gas_price: u64,
+        /// A map storing the records of validator reporting each other during the current epoch.
+        /// There is an entry in the map for each validator that has been reported
+        /// at least once. The entry VecSet contains all the validators that reported
+        /// them. If a validator has never been reported they don't have an entry in this map.
+        /// This map resets every epoch.
+        validator_report_records: VecMap<address, VecSet<address>>,
+        /// Schedule of stake subsidies given out each epoch.
+        stake_subsidy: StakeSubsidy,
+    }
+
+    /// Event containing system-level epoch information, emitted during
+    /// the epoch advancement transaction.
+    struct SystemEpochInfo has copy, drop {
+        epoch: u64,
+        reference_gas_price: u64,
+        total_stake: u64,
+        storage_fund_inflows: u64,
+        storage_fund_outflows: u64,
+        storage_fund_balance: u64,
+        stake_subsidy_amount: u64,
+        total_gas_fees: u64,
+        total_stake_rewards: u64,
+    }
+
+    // Errors
+    const ENOT_VALIDATOR: u64 = 0;
+    const ELIMIT_EXCEEDED: u64 = 1;
+    const EEPOCH_NUMBER_MISMATCH: u64 = 2;
+    const ECANNOT_REPORT_ONESELF: u64 = 3;
+    const EREPORT_RECORD_NOT_FOUND: u64 = 4;
+    const EBPS_TOO_LARGE: u64 = 5;
+    const ESTAKED_SUI_FROM_WRONG_EPOCH: u64 = 6;
+
+    const BASIS_POINT_DENOMINATOR: u128 = 10000;
+
+    // ==== functions that can only be called by genesis ====
+
+    /// Create a new SuiSystemState object and make it shared.
+    /// This function will be called only once in genesis.
+    public(friend) fun create(
+        validators: vector<Validator>,
+        sui_supply: Supply<SUI>,
+        storage_fund: Balance<SUI>,
+        max_validator_candidate_count: u64,
+        min_validator_stake: u64,
+        initial_stake_subsidy_amount: u64,
+    ) {
+        let validators = validator_set::new(validators);
+        let reference_gas_price = validator_set::derive_reference_gas_price(&validators);
+        let state = SuiSystemState {
+            // Use a hardcoded ID.
+            id: object::sui_system_state(),
+            epoch: 0,
+            validators,
+            sui_supply,
+            storage_fund,
+            parameters: SystemParameters {
+                min_validator_stake,
+                max_validator_candidate_count,
+            },
+            reference_gas_price,
+            validator_report_records: vec_map::empty(),
+            stake_subsidy: stake_subsidy::create(initial_stake_subsidy_amount),
+        };
+        transfer::share_object(state);
+    }
+
+    // ==== entry functions ====
+
+    /// Can be called by anyone who wishes to become a validator in the next epoch.
+    /// The `validator` object needs to be created before calling this.
+    /// The amount of stake in the `validator` object must meet the requirements.
+    // TODO: Does this need to go through a voting process? Any other criteria for
+    // someone to become a validator?
+    public entry fun request_add_validator(
+        self: &mut SuiSystemState,
+        pubkey_bytes: vector<u8>,
+        network_pubkey_bytes: vector<u8>,
+        worker_pubkey_bytes: vector<u8>,
+        proof_of_possession: vector<u8>,
+        name: vector<u8>,
+        description: vector<u8>,
+        image_url: vector<u8>,
+        project_url: vector<u8>,
+        net_address: vector<u8>,
+        consensus_address: vector<u8>,
+        worker_address: vector<u8>,
+        stake: Coin<SUI>,
+        gas_price: u64,
+        commission_rate: u64,
+        ctx: &mut TxContext,
+    ) {
+        assert!(
+            validator_set::next_epoch_validator_count(&self.validators) < self.parameters.max_validator_candidate_count,
+            ELIMIT_EXCEEDED,
+        );
+        let stake_amount = coin::value(&stake);
+        assert!(
+            stake_amount >= self.parameters.min_validator_stake,
+            ELIMIT_EXCEEDED,
+        );
+        let validator = validator::new(
+            tx_context::sender(ctx),
+            pubkey_bytes,
+            network_pubkey_bytes,
+            worker_pubkey_bytes,
+            proof_of_possession,
+            name,
+            description,
+            image_url,
+            project_url,
+            net_address,
+            consensus_address,
+            worker_address,
+            coin::into_balance(stake),
+            option::none(),
+            gas_price,
+            commission_rate,
+            ctx
+        );
+
+        // TODO: We need to verify the validator metadata.
+        // https://github.com/MystenLabs/sui/issues/7323
+
+        validator_set::request_add_validator(&mut self.validators, validator);
+    }
+
+    /// A validator can call this function to request a removal in the next epoch.
+    /// We use the sender of `ctx` to look up the validator
+    /// (i.e. sender must match the sui_address in the validator).
+    /// At the end of the epoch, the `validator` object will be returned to the sui_address
+    /// of the validator.
+    public entry fun request_remove_validator(
+        self: &mut SuiSystemState,
+        ctx: &mut TxContext,
+    ) {
+        validator_set::request_remove_validator(
+            &mut self.validators,
+            ctx,
+        )
+    }
+
+    /// A validator can call this entry function to submit a new gas price quote, to be
+    /// used for the reference gas price calculation at the end of the epoch.
+    public entry fun request_set_gas_price(
+        self: &mut SuiSystemState,
+        new_gas_price: u64,
+        ctx: &mut TxContext,
+    ) {
+        validator_set::request_set_gas_price(
+            &mut self.validators,
+            new_gas_price,
+            ctx
+        )
+    }
+
+    /// A validator can call this entry function to set a new commission rate, updated at the end of the epoch.
+    public entry fun request_set_commission_rate(
+        self: &mut SuiSystemState,
+        new_commission_rate: u64,
+        ctx: &mut TxContext,
+    ) {
+        validator_set::request_set_commission_rate(
+            &mut self.validators,
+            new_commission_rate,
+            ctx
+        )
+    }
+
+    /// A validator can request adding more stake. This will be processed at the end of epoch.
+    public entry fun request_add_stake(
+        self: &mut SuiSystemState,
+        new_stake: Coin<SUI>,
+        ctx: &mut TxContext,
+    ) {
+        validator_set::request_add_stake(
+            &mut self.validators,
+            coin::into_balance(new_stake),
+            option::none(),
+            ctx,
+        )
+    }
+
+    /// A validator can request adding more stake using a locked coin. This will be processed at the end of epoch.
+    public entry fun request_add_stake_with_locked_coin(
+        self: &mut SuiSystemState,
+        new_stake: LockedCoin<SUI>,
+        ctx: &mut TxContext,
+    ) {
+        let (balance, epoch_time_lock) = locked_coin::into_balance(new_stake);
+        validator_set::request_add_stake(
+            &mut self.validators,
+            balance,
+            option::some(epoch_time_lock),
+            ctx,
+        )
+    }
+
+    /// A validator can request to withdraw stake.
+    /// If the sender represents a pending validator (i.e. has just requested to become a validator
+    /// in the current epoch and hence is not active yet), the stake will be withdrawn immediately
+    /// and a coin with the withdraw amount will be sent to the validator's address.
+    /// If the sender represents an active validator, the request will be processed at the end of epoch.
+    public entry fun request_withdraw_stake(
+        self: &mut SuiSystemState,
+        stake: &mut Stake,
+        withdraw_amount: u64,
+        ctx: &mut TxContext,
+    ) {
+        validator_set::request_withdraw_stake(
+            &mut self.validators,
+            stake,
+            withdraw_amount,
+            self.parameters.min_validator_stake,
+            ctx,
+        )
+    }
+
+    /// Add delegated stake to a validator's staking pool.
+    public entry fun request_add_delegation(
+        self: &mut SuiSystemState,
+        delegate_stake: Coin<SUI>,
+        validator_address: address,
+        ctx: &mut TxContext,
+    ) {
+        validator_set::request_add_delegation(
+            &mut self.validators,
+            validator_address,
+            coin::into_balance(delegate_stake),
+            option::none(),
+            ctx,
+        );
+    }
+
+    /// Add delegated stake to a validator's staking pool using multiple coins.
+    public entry fun request_add_delegation_mul_coin(
+        self: &mut SuiSystemState,
+        delegate_stakes: vector<Coin<SUI>>,
+        stake_amount: option::Option<u64>,
+        validator_address: address,
+        ctx: &mut TxContext,
+    ) {
+        let balance = extract_coin_balance(delegate_stakes, stake_amount, ctx);
+        validator_set::request_add_delegation(&mut self.validators, validator_address, balance, option::none(), ctx);
+    }
+
+    /// Add delegated stake to a validator's staking pool using a locked SUI coin.
+    public entry fun request_add_delegation_with_locked_coin(
+        self: &mut SuiSystemState,
+        delegate_stake: LockedCoin<SUI>,
+        validator_address: address,
+        ctx: &mut TxContext,
+    ) {
+        let (balance, lock) = locked_coin::into_balance(delegate_stake);
+        validator_set::request_add_delegation(&mut self.validators, validator_address, balance, option::some(lock), ctx);
+    }
+
+    /// Add delegated stake to a validator's staking pool using multiple locked SUI coins.
+    public entry fun request_add_delegation_mul_locked_coin(
+        self: &mut SuiSystemState,
+        delegate_stakes: vector<LockedCoin<SUI>>,
+        stake_amount: option::Option<u64>,
+        validator_address: address,
+        ctx: &mut TxContext,
+    ) {
+        let (balance, lock) = extract_locked_coin_balance(delegate_stakes, stake_amount, ctx);
+        validator_set::request_add_delegation(
+            &mut self.validators,
+            validator_address,
+            balance,
+            option::some(lock),
+            ctx
+        );
+    }
+
+    /// Withdraw some portion of a delegation from a validator's staking pool.
+    public entry fun request_withdraw_delegation(
+        self: &mut SuiSystemState,
+        delegation: Delegation,
+        staked_sui: StakedSui,
+        ctx: &mut TxContext,
+    ) {
+        validator_set::request_withdraw_delegation(
+            &mut self.validators,
+            delegation,
+            staked_sui,
+            ctx,
+        );
+    }
+
+    // Switch delegation from the current validator to a new one.
+    public entry fun request_switch_delegation(
+        self: &mut SuiSystemState,
+        delegation: Delegation,
+        staked_sui: StakedSui,
+        new_validator_address: address,
+        ctx: &mut TxContext,
+    ) {
+        validator_set::request_switch_delegation(
+            &mut self.validators, delegation, staked_sui, new_validator_address, ctx
+        );
+    }
+
+    /// Cancel a delegation requests sent during the current epoch.
+    public entry fun cancel_delegation_request(
+        self: &mut SuiSystemState,
+        staked_sui: StakedSui,
+        ctx: &mut TxContext,
+    ) {
+        // The delegation request has to have happened within the current epoch.
+        assert!(staking_pool::delegation_request_epoch(&staked_sui) == self.epoch, ESTAKED_SUI_FROM_WRONG_EPOCH);
+        validator_set::cancel_delegation_request(
+            &mut self.validators, staked_sui, ctx
+        );
+    }
+
+
+    /// Report a validator as a bad or non-performant actor in the system.
+    /// Succeeds iff both the sender and the input `validator_addr` are active validators
+    /// and they are not the same address. This function is idempotent within an epoch.
+    public entry fun report_validator(
+        self: &mut SuiSystemState,
+        validator_addr: address,
+        ctx: &TxContext,
+    ) {
+        let sender = tx_context::sender(ctx);
+        // Both the reporter and the reported have to be validators.
+        assert!(validator_set::is_active_validator(&self.validators, sender), ENOT_VALIDATOR);
+        assert!(validator_set::is_active_validator(&self.validators, validator_addr), ENOT_VALIDATOR);
+        assert!(sender != validator_addr, ECANNOT_REPORT_ONESELF);
+
+        if (!vec_map::contains(&self.validator_report_records, &validator_addr)) {
+            vec_map::insert(&mut self.validator_report_records, validator_addr, vec_set::singleton(sender));
+        } else {
+            let reporters = vec_map::get_mut(&mut self.validator_report_records, &validator_addr);
+            if (!vec_set::contains(reporters, &sender)) {
+                vec_set::insert(reporters, sender);
+            }
+        }
+    }
+
+    /// Undo a `report_validator` action. Aborts if the sender has not reported the
+    /// `validator_addr` within this epoch.
+    public entry fun undo_report_validator(
+        self: &mut SuiSystemState,
+        validator_addr: address,
+        ctx: &TxContext,
+    ) {
+        let sender = tx_context::sender(ctx);
+
+        assert!(vec_map::contains(&self.validator_report_records, &validator_addr), EREPORT_RECORD_NOT_FOUND);
+        let reporters = vec_map::get_mut(&mut self.validator_report_records, &validator_addr);
+        assert!(vec_set::contains(reporters, &sender), EREPORT_RECORD_NOT_FOUND);
+        vec_set::remove(reporters, &sender);
+    }
+
+    /// This function should be called at the end of an epoch, and advances the system to the next epoch.
+    /// It does the following things:
+    /// 1. Add storage charge to the storage fund.
+    /// 2. Burn the storage rebates from the storage fund. These are already refunded to transaction sender's
+    ///    gas coins.
+    /// 3. Distribute computation charge to validator stake and delegation stake.
+    /// 4. Update all validators.
+    public entry fun advance_epoch(
+        self: &mut SuiSystemState,
+        new_epoch: u64,
+        storage_charge: u64,
+        computation_charge: u64,
+        storage_rebate: u64,
+        storage_fund_reinvest_rate: u64, // share of storage fund's rewards that's reinvested
+                                         // into storage fund, in basis point.
+        reward_slashing_rate: u64, // how much rewards are slashed to punish a validator, in bps.
+        stake_subsidy_rate: u64, // what percentage of the total stake do we mint as stake subsidy.
+        ctx: &mut TxContext,
+    ) {
+        // Validator will make a special system call with sender set as 0x0.
+        assert!(tx_context::sender(ctx) == @0x0, 0);
+
+        let bps_denominator_u64 = (BASIS_POINT_DENOMINATOR as u64);
+        // Rates can't be higher than 100%.
+        assert!(
+            storage_fund_reinvest_rate <= bps_denominator_u64
+            && reward_slashing_rate <= bps_denominator_u64,
+            EBPS_TOO_LARGE,
+        );
+
+        let delegation_stake = validator_set::total_delegation_stake(&self.validators);
+        let validator_stake = validator_set::total_validator_stake(&self.validators);
+        let storage_fund_balance = balance::value(&self.storage_fund);
+        let total_stake = delegation_stake + validator_stake + storage_fund_balance;
+
+        let storage_reward = balance::create_staking_rewards(storage_charge);
+        let computation_reward = balance::create_staking_rewards(computation_charge);
+
+        // Include stake subsidy in the rewards given out to validators and delegators.
+        stake_subsidy::mint_stake_subsidy_proportional_to_total_stake_testnet(
+            &mut self.stake_subsidy, &mut self.sui_supply, stake_subsidy_rate, delegation_stake + validator_stake);
+        let stake_subsidy = stake_subsidy::withdraw_all(&mut self.stake_subsidy);
+        let stake_subsidy_amount = balance::value(&stake_subsidy);
+        balance::join(&mut computation_reward, stake_subsidy);
+
+        let total_stake_u128 = (total_stake as u128);
+        let computation_charge_u128 = (computation_charge as u128);
+
+        balance::join(&mut self.storage_fund, storage_reward);
+
+        let storage_fund_reward_amount = (storage_fund_balance as u128) * computation_charge_u128 / total_stake_u128;
+        let storage_fund_reward = balance::split(&mut computation_reward, (storage_fund_reward_amount as u64));
+        let storage_fund_reinvestment_amount =
+            storage_fund_reward_amount * (storage_fund_reinvest_rate as u128) / BASIS_POINT_DENOMINATOR;
+        let storage_fund_reinvestment = balance::split(
+            &mut storage_fund_reward,
+            (storage_fund_reinvestment_amount as u64),
+        );
+        balance::join(&mut self.storage_fund, storage_fund_reinvestment);
+
+        self.epoch = self.epoch + 1;
+        // Sanity check to make sure we are advancing to the right epoch.
+        assert!(new_epoch == self.epoch, 0);
+        let total_rewards_amount =
+            balance::value(&computation_reward)+ balance::value(&storage_fund_reward);
+
+        validator_set::advance_epoch(
+            new_epoch,
+            &mut self.validators,
+            &mut computation_reward,
+            &mut storage_fund_reward,
+            self.validator_report_records,
+            reward_slashing_rate,
+            ctx,
+        );
+        // Derive the reference gas price for the new epoch
+        self.reference_gas_price = validator_set::derive_reference_gas_price(&self.validators);
+        // Because of precision issues with integer divisions, we expect that there will be some
+        // remaining balance in `storage_fund_reward` and `computation_reward`.
+        // All of these go to the storage fund.
+        balance::join(&mut self.storage_fund, storage_fund_reward);
+        balance::join(&mut self.storage_fund, computation_reward);
+
+        // Destroy the storage rebate.
+        assert!(balance::value(&self.storage_fund) >= storage_rebate, 0);
+        balance::destroy_storage_rebates(balance::split(&mut self.storage_fund, storage_rebate));
+
+        // Validator reports are only valid for the epoch.
+        // TODO: or do we want to make it persistent and validators have to explicitly change their scores?
+        self.validator_report_records = vec_map::empty();
+
+        let new_total_stake =
+            validator_set::total_delegation_stake(&self.validators)
+            + validator_set::total_validator_stake(&self.validators);
+
+        event::emit(
+            SystemEpochInfo {
+                epoch: self.epoch,
+                reference_gas_price: self.reference_gas_price,
+                total_stake: new_total_stake,
+                storage_fund_inflows: storage_charge + (storage_fund_reinvestment_amount as u64),
+                storage_fund_outflows: storage_rebate,
+                storage_fund_balance: balance::value(&self.storage_fund),
+                stake_subsidy_amount,
+                total_gas_fees: computation_charge,
+                total_stake_rewards: total_rewards_amount,
+            }
+        );
+    }
+
+    spec advance_epoch {
+        /// Total supply of SUI increases by the amount of stake subsidy we minted.
+        ensures balance::supply_value(self.sui_supply)
+            == old(balance::supply_value(self.sui_supply)) + old(stake_subsidy::current_epoch_subsidy_amount(self.stake_subsidy));
+    }
+
+    /// Return the current epoch number. Useful for applications that need a coarse-grained concept of time,
+    /// since epochs are ever-increasing and epoch changes are intended to happen every 24 hours.
+    public fun epoch(self: &SuiSystemState): u64 {
+        self.epoch
+    }
+
+    /// Returns the amount of stake delegated to `validator_addr`.
+    /// Aborts if `validator_addr` is not an active validator.
+    public fun validator_delegate_amount(self: &SuiSystemState, validator_addr: address): u64 {
+        validator_set::validator_delegate_amount(&self.validators, validator_addr)
+    }
+
+    /// Returns the amount of stake `validator_addr` has.
+    /// Aborts if `validator_addr` is not an active validator.
+    public fun validator_stake_amount(self: &SuiSystemState, validator_addr: address): u64 {
+        validator_set::validator_stake_amount(&self.validators, validator_addr)
+    }
+
+    /// Returns all the validators who have reported `addr` this epoch.
+    public fun get_reporters_of(self: &SuiSystemState, addr: address): VecSet<address> {
+        if (vec_map::contains(&self.validator_report_records, &addr)) {
+            *vec_map::get(&self.validator_report_records, &addr)
+        } else {
+            vec_set::empty()
+        }
+    }
+
+    /// Extract required Balance from vector of Coin<SUI>, transfer the remainder back to sender.
+    fun extract_coin_balance(coins: vector<Coin<SUI>>, amount: option::Option<u64>, ctx: &mut TxContext): Balance<SUI> {
+        let merged_coin = vector::pop_back(&mut coins);
+        pay::join_vec(&mut merged_coin, coins);
+
+        let total_balance = coin::into_balance(merged_coin);
+        // return the full amount if amount is not specified
+        if (option::is_some(&amount)) {
+            let amount = option::destroy_some(amount);
+            let balance = balance::split(&mut total_balance, amount);
+            // transfer back the remainder if non zero.
+            if (balance::value(&total_balance) > 0) {
+                transfer::transfer(coin::from_balance(total_balance, ctx), tx_context::sender(ctx));
+            } else {
+                balance::destroy_zero(total_balance);
+            };
+            balance
+        } else {
+            total_balance
+        }
+    }
+
+    /// Extract required Balance from vector of LockedCoin<SUI>, transfer the remainder back to sender.
+    fun extract_locked_coin_balance(
+        coins: vector<LockedCoin<SUI>>,
+        amount: option::Option<u64>,
+        ctx: &mut TxContext
+    ): (Balance<SUI>, EpochTimeLock) {
+        let (total_balance, first_lock) = locked_coin::into_balance(vector::pop_back(&mut coins));
+        let (i, len) = (0, vector::length(&coins));
+        while (i < len) {
+            let (balance, lock) = locked_coin::into_balance(vector::pop_back(&mut coins));
+            // Make sure all time locks are the same
+            assert!(epoch_time_lock::epoch(&lock) == epoch_time_lock::epoch(&first_lock), 0);
+            epoch_time_lock::destroy_unchecked(lock);
+            balance::join(&mut total_balance, balance);
+            i = i + 1
+        };
+        vector::destroy_empty(coins);
+
+        // return the full amount if amount is not specified
+        if (option::is_some(&amount)){
+            let amount = option::destroy_some(amount);
+            let balance = balance::split(&mut total_balance, amount);
+            if (balance::value(&total_balance) > 0) {
+                locked_coin::new_from_balance(total_balance, first_lock, tx_context::sender(ctx), ctx);
+            } else {
+                balance::destroy_zero(total_balance);
+            };
+            (balance, first_lock)
+        } else{
+            (total_balance, first_lock)
+        }
+    }
+
+    /// Return the current validator set
+    public fun validators(self: &SuiSystemState): &ValidatorSet {
+        &self.validators
+    }
+
+    #[test_only]
+    public fun set_epoch_for_testing(self: &mut SuiSystemState, epoch_num: u64) {
+        self.epoch = epoch_num
+    }
+}

--- a/crates/sui-framework-override/sources/governance/validator.move
+++ b/crates/sui-framework-override/sources/governance/validator.move
@@ -1,0 +1,422 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::validator {
+    use std::ascii;
+    use std::vector;
+    use std::bcs;
+
+    use sui::balance::{Self, Balance};
+    use sui::sui::SUI;
+    use sui::tx_context::{Self, TxContext};
+    use sui::stake;
+    use sui::stake::Stake;
+    use sui::epoch_time_lock::EpochTimeLock;
+    use std::option::Option;
+    use sui::bls12381::bls12381_min_sig_verify_with_domain;
+    use sui::staking_pool::{Self, Delegation, PoolTokenExchangeRate, StakedSui, StakingPool};
+    use std::string::{Self, String};
+    use sui::url::Url;
+    use sui::url;
+    friend sui::genesis;
+    friend sui::sui_system;
+    friend sui::validator_set;
+    friend sui::voting_power;
+
+    #[test_only]
+    friend sui::validator_tests;
+    #[test_only]
+    friend sui::validator_set_tests;
+    #[test_only]
+    friend sui::governance_test_utils;
+
+    struct ValidatorMetadata has store, drop, copy {
+        /// The Sui Address of the validator. This is the sender that created the Validator object,
+        /// and also the address to send validator/coins to during withdraws.
+        sui_address: address,
+        /// The public key bytes corresponding to the private key that the validator
+        /// holds to sign transactions. For now, this is the same as AuthorityName.
+        pubkey_bytes: vector<u8>,
+        /// The public key bytes corresponding to the private key that the validator
+        /// uses to establish TLS connections
+        network_pubkey_bytes: vector<u8>,
+        /// The public key bytes correstponding to the Narwhal Worker
+        worker_pubkey_bytes: vector<u8>,
+        /// This is a proof that the validator has ownership of the private key
+        proof_of_possession: vector<u8>,
+        /// A unique human-readable name of this validator.
+        name: String,
+        description: String,
+        image_url: Url,
+        project_url: Url,
+        /// The network address of the validator (could also contain extra info such as port, DNS and etc.).
+        net_address: vector<u8>,
+        /// The address of the narwhal primary
+        consensus_address: vector<u8>,
+        /// The address of the narwhal worker
+        worker_address: vector<u8>,
+        /// Total amount of validator stake that would be active in the next epoch.
+        next_epoch_stake: u64,
+        /// Total amount of delegated stake that would be active in the next epoch.
+        next_epoch_delegation: u64,
+        /// This validator's gas price quote for the next epoch.
+        next_epoch_gas_price: u64,
+        /// The commission rate of the validator starting the next epoch, in basis point.
+        next_epoch_commission_rate: u64,
+    }
+
+    struct Validator has store {
+        /// Summary of the validator.
+        metadata: ValidatorMetadata,
+        /// The voting power of this validator, which might be different from its
+        /// stake amount.
+        voting_power: u64,
+        /// The current active stake amount. This will not change during an epoch. It can only
+        /// be updated at the end of epoch.
+        stake_amount: u64,
+        /// Pending stake deposit amount, processed at end of epoch.
+        pending_stake: u64,
+        /// Pending withdraw amount, processed at end of epoch.
+        pending_withdraw: u64,
+        /// Gas price quote, updated only at end of epoch.
+        gas_price: u64,
+        /// Staking pool for the stakes delegated to this validator.
+        delegation_staking_pool: StakingPool,
+        /// Commission rate of the validator, in basis point.
+        commission_rate: u64,
+    }
+
+    const PROOF_OF_POSSESSION_DOMAIN: vector<u8> = vector[107, 111, 115, 107];
+
+    fun verify_proof_of_possession(
+        proof_of_possession: vector<u8>,
+        sui_address: address,
+        pubkey_bytes: vector<u8>
+    ) {
+        // The proof of possession is the signature over ValidatorPK || AccountAddress.
+        // This proves that the account address is owned by the holder of ValidatorPK, and ensures
+        // that PK exists.
+        let signed_bytes = pubkey_bytes;
+        let address_bytes = bcs::to_bytes(&sui_address);
+        vector::append(&mut signed_bytes, address_bytes);
+        assert!(
+            bls12381_min_sig_verify_with_domain(&proof_of_possession, &pubkey_bytes, signed_bytes, PROOF_OF_POSSESSION_DOMAIN) == true,
+            0
+        );
+    }
+
+    public(friend) fun new(
+        sui_address: address,
+        pubkey_bytes: vector<u8>,
+        network_pubkey_bytes: vector<u8>,
+        worker_pubkey_bytes: vector<u8>,
+        proof_of_possession: vector<u8>,
+        name: vector<u8>,
+        description: vector<u8>,
+        image_url: vector<u8>,
+        project_url: vector<u8>,
+        net_address: vector<u8>,
+        consensus_address: vector<u8>,
+        worker_address: vector<u8>,
+        stake: Balance<SUI>,
+        coin_locked_until_epoch: Option<EpochTimeLock>,
+        gas_price: u64,
+        commission_rate: u64,
+        ctx: &mut TxContext
+    ): Validator {
+        assert!(
+            // TODO: These constants are arbitrary, will adjust once we know more.
+            vector::length(&net_address) <= 128
+                && vector::length(&name) <= 128
+                && vector::length(&description) <= 150
+                && vector::length(&pubkey_bytes) <= 128,
+            0
+        );
+        verify_proof_of_possession(
+            proof_of_possession,
+            sui_address,
+            pubkey_bytes
+        );
+        let stake_amount = balance::value(&stake);
+        stake::create(stake, sui_address, coin_locked_until_epoch, ctx);
+        Validator {
+            metadata: ValidatorMetadata {
+                sui_address,
+                pubkey_bytes,
+                network_pubkey_bytes,
+                worker_pubkey_bytes,
+                proof_of_possession,
+                name: string::from_ascii(ascii::string(name)),
+                description: string::from_ascii(ascii::string(description)),
+                image_url: url::new_unsafe_from_bytes(image_url),
+                project_url: url::new_unsafe_from_bytes(project_url),
+                net_address,
+                consensus_address,
+                worker_address,
+                next_epoch_stake: stake_amount,
+                next_epoch_delegation: 0,
+                next_epoch_gas_price: gas_price,
+                next_epoch_commission_rate: commission_rate,
+            },
+            // Initialize the voting power to be the same as the stake amount.
+            // At the epoch change where this validator is actually added to the
+            // active validator set, the voting power will be updated accordingly.
+            voting_power: stake_amount,
+            stake_amount,
+            pending_stake: 0,
+            pending_withdraw: 0,
+            gas_price,
+            delegation_staking_pool: staking_pool::new(sui_address, tx_context::epoch(ctx) + 1, ctx),
+            commission_rate,
+        }
+    }
+
+    public(friend) fun destroy(self: Validator, ctx: &mut TxContext) {
+        let Validator {
+            metadata: _,
+            voting_power: _,
+            stake_amount: _,
+            pending_stake: _,
+            pending_withdraw: _,
+            gas_price: _,
+            delegation_staking_pool,
+            commission_rate: _,
+        } = self;
+        staking_pool::deactivate_staking_pool(delegation_staking_pool, ctx);
+    }
+
+    /// Add stake to an active validator. The new stake is added to the pending_stake field,
+    /// which will be processed at the end of epoch.
+    public(friend) fun request_add_stake(
+        self: &mut Validator,
+        new_stake: Balance<SUI>,
+        coin_locked_until_epoch: Option<EpochTimeLock>,
+        ctx: &mut TxContext,
+    ) {
+        let new_stake_value = balance::value(&new_stake);
+        self.pending_stake = self.pending_stake + new_stake_value;
+        self.metadata.next_epoch_stake = self.metadata.next_epoch_stake + new_stake_value;
+        stake::create(new_stake, self.metadata.sui_address, coin_locked_until_epoch, ctx);
+    }
+
+    /// Withdraw stake from an active validator. Since it's active, we need
+    /// to add it to the pending withdraw amount and process it at the end
+    /// of epoch. We also need to make sure there is sufficient amount to withdraw such that the validator's
+    /// stake still satisfy the minimum requirement.
+    public(friend) fun request_withdraw_stake(
+        self: &mut Validator,
+        stake: &mut Stake,
+        withdraw_amount: u64,
+        min_validator_stake: u64,
+        ctx: &mut TxContext,
+    ) {
+        assert!(self.metadata.next_epoch_stake >= withdraw_amount + min_validator_stake, 0);
+        self.pending_withdraw = self.pending_withdraw + withdraw_amount;
+        self.metadata.next_epoch_stake = self.metadata.next_epoch_stake - withdraw_amount;
+        stake::withdraw_stake(stake, withdraw_amount, ctx);
+    }
+
+    /// Process pending stake and pending withdraws, and update the gas price.
+    public(friend) fun adjust_stake_and_gas_price(self: &mut Validator) {
+        self.stake_amount = self.stake_amount + self.pending_stake - self.pending_withdraw;
+        self.pending_stake = 0;
+        self.pending_withdraw = 0;
+        self.gas_price = self.metadata.next_epoch_gas_price;
+        self.commission_rate = self.metadata.next_epoch_commission_rate;
+        assert!(self.stake_amount == self.metadata.next_epoch_stake, 0);
+    }
+
+    /// Request to add delegation to the validator's staking pool, processed at the end of the epoch.
+    public(friend) fun request_add_delegation(
+        self: &mut Validator,
+        delegated_stake: Balance<SUI>,
+        locking_period: Option<EpochTimeLock>,
+        delegator: address,
+        ctx: &mut TxContext,
+    ) {
+        let delegate_amount = balance::value(&delegated_stake);
+        assert!(delegate_amount > 0, 0);
+        staking_pool::request_add_delegation(&mut self.delegation_staking_pool, delegated_stake, locking_period, delegator, ctx);
+        self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation + delegate_amount;
+    }
+
+    /// Request to withdraw delegation from the validator's staking pool, processed at the end of the epoch.
+    public(friend) fun request_withdraw_delegation(
+        self: &mut Validator,
+        delegation: Delegation,
+        staked_sui: StakedSui,
+        ctx: &mut TxContext,
+    ) {
+        let principal_withdraw_amount = staking_pool::request_withdraw_delegation(
+                &mut self.delegation_staking_pool, delegation, staked_sui, ctx);
+        decrease_next_epoch_delegation(self, principal_withdraw_amount);
+    }
+
+    public (friend) fun cancel_delegation_request(
+        self: &mut Validator,
+        staked_sui: StakedSui,
+        ctx: &mut TxContext,
+    ) {
+        let delegate_amount = staking_pool::staked_sui_amount(&staked_sui);
+        staking_pool::cancel_delegation_request(&mut self.delegation_staking_pool, staked_sui, ctx);
+        self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation - delegate_amount;
+    }
+
+    /// Decrement the delegation amount for next epoch. Also called by `validator_set` when handling delegation switches.
+    public(friend) fun decrease_next_epoch_delegation(self: &mut Validator, amount: u64) {
+        self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation - amount;
+    }
+
+    /// Request to set new gas price for the next epoch.
+    public(friend) fun request_set_gas_price(self: &mut Validator, new_price: u64) {
+        self.metadata.next_epoch_gas_price = new_price;
+    }
+
+    public(friend) fun request_set_commission_rate(self: &mut Validator, new_commission_rate: u64) {
+        self.metadata.next_epoch_commission_rate = new_commission_rate;
+    }
+
+    /// Deposit delegations rewards into the validator's staking pool, called at the end of the epoch.
+    public(friend) fun deposit_delegation_rewards(self: &mut Validator, reward: Balance<SUI>) {
+        self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation + balance::value(&reward);
+        staking_pool::deposit_rewards(&mut self.delegation_staking_pool, reward);
+    }
+
+    /// Process pending delegations and withdraws, called at the end of the epoch.
+    public(friend) fun process_pending_delegations_and_withdraws(self: &mut Validator, ctx: &mut TxContext) {
+        staking_pool::process_pending_delegations(&mut self.delegation_staking_pool, ctx);
+        let reward_withdraw_amount = staking_pool::process_pending_delegation_withdraws(
+            &mut self.delegation_staking_pool, ctx);
+        self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation - reward_withdraw_amount;
+        // assert!(delegate_amount(self) == self.metadata.next_epoch_delegation, 0);
+    }
+
+    /// Called by `validator_set` for handling delegation switches.
+    public(friend) fun get_staking_pool_mut_ref(self: &mut Validator) : &mut StakingPool {
+        &mut self.delegation_staking_pool
+    }
+
+    public fun metadata(self: &Validator): &ValidatorMetadata {
+        &self.metadata
+    }
+
+    public fun sui_address(self: &Validator): address {
+        self.metadata.sui_address
+    }
+
+    public fun total_stake_amount(self: &Validator): u64 {
+        self.stake_amount + staking_pool::sui_balance(&self.delegation_staking_pool)
+    }
+
+    public fun stake_amount(self: &Validator): u64 {
+        self.stake_amount
+    }
+
+    public fun delegate_amount(self: &Validator): u64 {
+        staking_pool::sui_balance(&self.delegation_staking_pool)
+    }
+
+    /// Return the total amount staked with this validator, including both validator stake and deledgated stake
+    public fun total_stake(self: &Validator): u64 {
+        stake_amount(self) + delegate_amount(self)
+    }
+
+    /// Return the voting power of this validator.
+    public fun voting_power(self: &Validator): u64 {
+        self.voting_power
+    }
+
+    /// Set the voting power of this validator, called only from validator_set.
+    public(friend) fun set_voting_power(self: &mut Validator, new_voting_power: u64) {
+        self.voting_power = new_voting_power;
+    }
+
+    public fun pending_stake_amount(self: &Validator): u64 {
+        self.pending_stake
+    }
+
+    public fun pending_withdraw(self: &Validator): u64 {
+        self.pending_withdraw
+    }
+
+    public fun gas_price(self: &Validator): u64 {
+        self.gas_price
+    }
+
+    public fun commission_rate(self: &Validator): u64 {
+        self.commission_rate
+    }
+
+    public fun pool_token_exchange_rate(self: &Validator): PoolTokenExchangeRate {
+        staking_pool::pool_token_exchange_rate(&self.delegation_staking_pool)
+    }
+
+    public fun is_duplicate(self: &Validator, other: &Validator): bool {
+         self.metadata.sui_address == other.metadata.sui_address
+            || self.metadata.name == other.metadata.name
+            || self.metadata.net_address == other.metadata.net_address
+            || self.metadata.pubkey_bytes == other.metadata.pubkey_bytes
+    }
+
+    // CAUTION: THIS CODE IS ONLY FOR TESTING AND THIS MACRO MUST NEVER EVER BE REMOVED.
+    // Creates a validator - bypassing the proof of possession in check in the process.
+    // TODO: Refactor to share code with new().
+    #[test_only]
+    public(friend) fun new_for_testing(
+        sui_address: address,
+        pubkey_bytes: vector<u8>,
+        network_pubkey_bytes: vector<u8>,
+        worker_pubkey_bytes: vector<u8>,
+        proof_of_possession: vector<u8>,
+        name: vector<u8>,
+        description: vector<u8>,
+        image_url: vector<u8>,
+        project_url: vector<u8>,
+        net_address: vector<u8>,
+        consensus_address: vector<u8>,
+        worker_address: vector<u8>,
+        stake: Balance<SUI>,
+        coin_locked_until_epoch: Option<EpochTimeLock>,
+        gas_price: u64,
+        commission_rate: u64,
+        ctx: &mut TxContext
+    ): Validator {
+        assert!(
+            // TODO: These constants are arbitrary, will adjust once we know more.
+            vector::length(&net_address) <= 128
+                && vector::length(&name) <= 128
+                && vector::length(&description) <= 150
+                && vector::length(&pubkey_bytes) <= 128,
+            0
+        );
+        let stake_amount = balance::value(&stake);
+        stake::create(stake, sui_address, coin_locked_until_epoch, ctx);
+        Validator {
+            metadata: ValidatorMetadata {
+                sui_address,
+                pubkey_bytes,
+                network_pubkey_bytes,
+                worker_pubkey_bytes,
+                proof_of_possession,
+                name: string::from_ascii(ascii::string(name)),
+                description: string::from_ascii(ascii::string(description)),
+                image_url: url::new_unsafe_from_bytes(image_url),
+                project_url: url::new_unsafe_from_bytes(project_url),
+                net_address,
+                consensus_address,
+                worker_address,
+                next_epoch_stake: stake_amount,
+                next_epoch_delegation: 0,
+                next_epoch_gas_price: gas_price,
+                next_epoch_commission_rate: commission_rate,
+            },
+            stake_amount,
+            voting_power: stake_amount,
+            pending_stake: 0,
+            pending_withdraw: 0,
+            gas_price,
+            delegation_staking_pool: staking_pool::new(sui_address, tx_context::epoch(ctx) + 1, ctx),
+            commission_rate,
+        }
+    }
+}

--- a/crates/sui-framework-override/sources/governance/validator_set.move
+++ b/crates/sui-framework-override/sources/governance/validator_set.move
@@ -1,0 +1,978 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::validator_set {
+    use std::option::{Self, Option};
+    use std::vector;
+
+    use sui::balance::{Self, Balance};
+    use sui::sui::SUI;
+    use sui::tx_context::{Self, TxContext};
+    use sui::validator::{Self, Validator, ValidatorMetadata};
+    use sui::stake::Stake;
+    use sui::staking_pool::{Self, Delegation, PendingWithdrawEntry, PoolTokenExchangeRate, StakedSui};
+    use sui::epoch_time_lock::EpochTimeLock;
+    use sui::priority_queue as pq;
+    use sui::vec_map::{Self, VecMap};
+    use sui::vec_set::{Self, VecSet};
+    use sui::table_vec::{Self, TableVec};
+    use sui::event;
+    use sui::voting_power;
+
+    friend sui::sui_system;
+
+    #[test_only]
+    friend sui::validator_set_tests;
+
+    struct ValidatorSet has store {
+        /// Total amount of stake from all active validators (not including delegation),
+        /// at the beginning of the epoch.
+        total_validator_stake: u64,
+
+        /// Total amount of stake from delegation, at the beginning of the epoch.
+        total_delegation_stake: u64,
+
+        /// The current list of active validators.
+        active_validators: vector<Validator>,
+
+        /// List of new validator candidates added during the current epoch.
+        /// They will be processed at the end of the epoch.
+        pending_validators: vector<Validator>,
+
+        /// Removal requests from the validators. Each element is an index
+        /// pointing to `active_validators`.
+        pending_removals: vector<u64>,
+
+        /// The metadata of the validator set for the next epoch. This is kept up-to-dated.
+        /// Everytime a change request is received, this set is updated.
+        /// TODO: This is currently not used. We may use it latter for enforcing min/max stake.
+        next_epoch_validators: vector<ValidatorMetadata>,
+
+        /// Delegation switches requested during the current epoch, processed at epoch boundaries
+        /// so that all the rewards with be added to the new delegation.
+        pending_delegation_switches: VecMap<ValidatorPair, TableVec<PendingWithdrawEntry>>,
+    }
+
+    struct ValidatorPair has store, copy, drop {
+        from: address,
+        to: address,
+    }
+
+    /// Event emitted when a new delegation request is received.
+    struct DelegationRequestEvent has copy, drop {
+        validator_address: address,
+        delegator_address: address,
+        epoch: u64,
+        amount: u64,
+    }
+
+    /// Event containing staking and rewards related information of
+    /// each validator, emitted during epoch advancement.
+    struct ValidatorEpochInfo has copy, drop {
+        epoch: u64,
+        validator_address: address,
+        reference_gas_survey_quote: u64,
+        validator_stake: u64,
+        delegated_stake: u64,
+        commission_rate: u64,
+        stake_rewards: u64,
+        pool_token_exchange_rate: PoolTokenExchangeRate,
+        tallying_rule_reporters: vector<address>,
+        tallying_rule_global_score: u64,
+    }
+
+    const BASIS_POINT_DENOMINATOR: u128 = 10000;
+
+    // Errors
+    const ENON_VALIDATOR_IN_REPORT_RECORDS: u64 = 0;
+    const EINVALID_STAKE_ADJUSTMENT_AMOUNT: u64 = 1;
+
+    // ==== initialization at genesis ====
+
+    public(friend) fun new(init_active_validators: vector<Validator>): ValidatorSet {
+        let (total_validator_stake, total_delegation_stake) =
+            calculate_total_stakes(&init_active_validators);
+        let validators = ValidatorSet {
+            total_validator_stake,
+            total_delegation_stake,
+            active_validators: init_active_validators,
+            pending_validators: vector::empty(),
+            pending_removals: vector::empty(),
+            next_epoch_validators: vector::empty(),
+            pending_delegation_switches: vec_map::empty(),
+        };
+        validators.next_epoch_validators = derive_next_epoch_validators(&validators);
+        voting_power::set_voting_power(&mut validators.active_validators);
+        validators
+    }
+
+
+    // ==== functions to add or remove validators ====
+
+    /// Called by `sui_system`, add a new validator to `pending_validators`, which will be
+    /// processed at the end of epoch.
+    public(friend) fun request_add_validator(self: &mut ValidatorSet, validator: Validator) {
+        assert!(
+            !contains_duplicate_validator(&self.active_validators, &validator)
+                && !contains_duplicate_validator(&self.pending_validators, &validator),
+            0
+        );
+        vector::push_back(&mut self.pending_validators, validator);
+        self.next_epoch_validators = derive_next_epoch_validators(self);
+    }
+
+    /// Called by `sui_system`, to remove a validator.
+    /// The index of the validator is added to `pending_removals` and
+    /// will be processed at the end of epoch.
+    /// Only an active validator can request to be removed.
+    public(friend) fun request_remove_validator(
+        self: &mut ValidatorSet,
+        ctx: &TxContext,
+    ) {
+        let validator_address = tx_context::sender(ctx);
+        let validator_index_opt = find_validator(&self.active_validators, validator_address);
+        assert!(option::is_some(&validator_index_opt), 0);
+        let validator_index = option::extract(&mut validator_index_opt);
+        assert!(
+            !vector::contains(&self.pending_removals, &validator_index),
+            0
+        );
+        vector::push_back(&mut self.pending_removals, validator_index);
+        self.next_epoch_validators = derive_next_epoch_validators(self);
+    }
+
+
+    // ==== staking related functions ====
+
+    /// Called by `sui_system`, to add more stake to a validator.
+    /// The new stake will be added to the validator's pending stake, which will be processed
+    /// at the end of epoch.
+    /// TODO: impl max stake requirement.
+    public(friend) fun request_add_stake(
+        self: &mut ValidatorSet,
+        new_stake: Balance<SUI>,
+        coin_locked_until_epoch: Option<EpochTimeLock>,
+        ctx: &mut TxContext,
+    ) {
+        let validator_address = tx_context::sender(ctx);
+        let validator = get_validator_mut(&mut self.active_validators, validator_address);
+        validator::request_add_stake(validator, new_stake, coin_locked_until_epoch, ctx);
+        self.next_epoch_validators = derive_next_epoch_validators(self);
+    }
+
+    /// Called by `sui_system`, to withdraw stake from a validator.
+    /// We send a withdraw request to the validator which will be processed at the end of epoch.
+    /// The remaining stake of the validator cannot be lower than `min_validator_stake`.
+    public(friend) fun request_withdraw_stake(
+        self: &mut ValidatorSet,
+        stake: &mut Stake,
+        withdraw_amount: u64,
+        min_validator_stake: u64,
+        ctx: &mut TxContext,
+    ) {
+        let validator_address = tx_context::sender(ctx);
+        let validator = get_validator_mut(&mut self.active_validators, validator_address);
+        validator::request_withdraw_stake(validator, stake, withdraw_amount, min_validator_stake, ctx);
+        self.next_epoch_validators = derive_next_epoch_validators(self);
+    }
+
+    /// Called by `sui_system`, to add a new delegation to the validator.
+    /// This request is added to the validator's staking pool's pending delegation entries, processed at the end
+    /// of the epoch.
+    public(friend) fun request_add_delegation(
+        self: &mut ValidatorSet,
+        validator_address: address,
+        delegated_stake: Balance<SUI>,
+        locking_period: Option<EpochTimeLock>,
+        ctx: &mut TxContext,
+    ) {
+        let validator = get_validator_mut(&mut self.active_validators, validator_address);
+        let delegator_address = tx_context::sender(ctx);
+        let amount = balance::value(&delegated_stake);
+        validator::request_add_delegation(validator, delegated_stake, locking_period, tx_context::sender(ctx), ctx);
+        self.next_epoch_validators = derive_next_epoch_validators(self);
+        event::emit(
+            DelegationRequestEvent {
+                validator_address,
+                delegator_address,
+                epoch: tx_context::epoch(ctx),
+                amount,
+            }
+        );
+    }
+
+    public (friend) fun cancel_delegation_request(
+        self: &mut ValidatorSet,
+        staked_sui: StakedSui,
+        ctx: &mut TxContext,
+    ) {
+        let validator_address = staking_pool::validator_address(&staked_sui);
+        let validator = get_validator_mut(&mut self.active_validators, validator_address);
+        validator::cancel_delegation_request(validator, staked_sui, ctx);
+    }
+
+    /// Called by `sui_system`, to withdraw some share of a delegation from the validator. The share to withdraw
+    /// is denoted by `principal_withdraw_amount`.
+    /// This request is added to the validator's staking pool's pending delegation withdraw entries, processed at the end
+    /// of the epoch.
+    public(friend) fun request_withdraw_delegation(
+        self: &mut ValidatorSet,
+        delegation: Delegation,
+        staked_sui: StakedSui,
+        ctx: &mut TxContext,
+    ) {
+        let validator_address = staking_pool::validator_address(&staked_sui);
+        let validator_index_opt = find_validator(&self.active_validators, validator_address);
+
+        assert!(option::is_some(&validator_index_opt), 0);
+
+        let validator_index = option::extract(&mut validator_index_opt);
+        let validator = vector::borrow_mut(&mut self.active_validators, validator_index);
+        validator::request_withdraw_delegation(validator, delegation, staked_sui, ctx);
+        self.next_epoch_validators = derive_next_epoch_validators(self);
+    }
+
+    /// Called by `sui_system`, to switch some share of a delegation from one validator to another.
+    /// The amount to switch is denoted by `switch_pool_token_amount`.
+    /// Both the principal and reward portions of the withdrawn delegation should be added to the
+    /// new validator's staking pool. We do that in two parts in this function. We first withdraw the
+    /// principal portion from the current staking pool and call `request_add_delegation` to add the
+    /// principal SUI to the new staking pool. The amount of rewards to switch is only known at the
+    /// end of the epoch, so we bookkeep the switch requests in `pending_delegation_switches`, and
+    /// process them in `advance_epoch` by calling `process_pending_delegation_switches` at epoch changes.
+    public(friend) fun request_switch_delegation(
+        self: &mut ValidatorSet,
+        delegation: Delegation,
+        staked_sui: StakedSui,
+        new_validator_address: address,
+        ctx: &mut TxContext,
+    ) {
+        let current_validator_address = staking_pool::validator_address(&staked_sui);
+
+        // check that the validators are not the same and they are both active.
+        assert!(current_validator_address != new_validator_address, 0);
+        assert!(is_active_validator(self, new_validator_address), 0);
+
+        // withdraw principal from the current validator's pool
+        let current_validator = get_validator_mut(&mut self.active_validators, current_validator_address);
+        let (current_validator_pool_token, principal_stake, time_lock) =
+            staking_pool::withdraw_from_principal(validator::get_staking_pool_mut_ref(current_validator), delegation, staked_sui);
+        let principal_sui_amount = balance::value(&principal_stake);
+        validator::decrease_next_epoch_delegation(current_validator, principal_sui_amount);
+
+        // and deposit into the new validator's pool
+        request_add_delegation(self, new_validator_address, principal_stake, time_lock, ctx);
+
+        let delegator = tx_context::sender(ctx);
+
+        // add pending switch entry, to be processed at epoch boundaries.
+        let key = ValidatorPair { from: current_validator_address, to: new_validator_address };
+        let entry = staking_pool::new_pending_withdraw_entry(delegator,principal_sui_amount, current_validator_pool_token);
+        if (!vec_map::contains(&self.pending_delegation_switches, &key)) {
+            vec_map::insert(&mut self.pending_delegation_switches, key, table_vec::singleton(entry, ctx));
+        } else {
+            let entries = vec_map::get_mut(&mut self.pending_delegation_switches, &key);
+            table_vec::push_back(entries, entry);
+        };
+
+        self.next_epoch_validators = derive_next_epoch_validators(self);
+    }
+
+    // ==== validator config setting functions ====
+
+    public(friend) fun request_set_gas_price(
+        self: &mut ValidatorSet,
+        new_gas_price: u64,
+        ctx: &TxContext,
+    ) {
+        let validator_address = tx_context::sender(ctx);
+        let validator = get_validator_mut(&mut self.active_validators, validator_address);
+        validator::request_set_gas_price(validator, new_gas_price);
+    }
+
+    public(friend) fun request_set_commission_rate(
+        self: &mut ValidatorSet,
+        new_commission_rate: u64,
+        ctx: &TxContext,
+    ) {
+        let validator_address = tx_context::sender(ctx);
+        let validator = get_validator_mut(&mut self.active_validators, validator_address);
+        validator::request_set_commission_rate(validator, new_commission_rate);
+    }
+
+
+    // ==== epoch change functions ====
+
+    /// Update the validator set at the end of epoch.
+    /// It does the following things:
+    ///   1. Distribute stake award.
+    ///   2. Process pending stake deposits and withdraws for each validator (`adjust_stake`).
+    ///   3. Process pending delegation switches, deposits, and withdraws.
+    ///   4. Process pending validator application and withdraws.
+    ///   5. At the end, we calculate the total stake for the new epoch.
+    public(friend) fun advance_epoch(
+        new_epoch: u64,
+        self: &mut ValidatorSet,
+        computation_reward: &mut Balance<SUI>,
+        storage_fund_reward: &mut Balance<SUI>,
+        validator_report_records: VecMap<address, VecSet<address>>,
+        reward_slashing_rate: u64,
+        ctx: &mut TxContext,
+    ) {
+        let total_stake = self.total_validator_stake + self.total_delegation_stake;
+
+        // Compute the reward distribution without taking into account the tallying rule slashing.
+        let (unadjusted_staking_reward_amounts, unadjusted_storage_fund_reward_amounts) = compute_unadjusted_reward_distribution(
+            &self.active_validators,
+            total_stake,
+            balance::value(computation_reward),
+            balance::value(storage_fund_reward),
+        );
+
+        // Use the tallying rule report records for the epoch to compute validators that will be
+        // punished and the sum of their stakes.
+        let (slashed_validators, total_slashed_validator_stake) =
+            compute_slashed_validators_and_total_stake(
+                self,
+                copy validator_report_records,
+            );
+
+        // Compute the reward adjustments of slashed validators, to be taken into
+        // account in adjusted reward computation.
+        let (total_staking_reward_adjustment, individual_staking_reward_adjustments,
+             total_storage_fund_reward_adjustment, individual_storage_fund_reward_adjustments
+            ) =
+            compute_reward_adjustments(
+                get_validator_indices(&self.active_validators, &slashed_validators),
+                reward_slashing_rate,
+                &unadjusted_staking_reward_amounts,
+                &unadjusted_storage_fund_reward_amounts,
+            );
+
+        // Compute the adjusted amounts of stake each validator should get given the tallying rule
+        // reward adjustments we computed before.
+        // `compute_adjusted_reward_distribution` must be called before `distribute_reward` and `adjust_stake_and_gas_price` to
+        // make sure we are using the current epoch's stake information to compute reward distribution.
+        let (adjusted_staking_reward_amounts, adjusted_storage_fund_reward_amounts) = compute_adjusted_reward_distribution(
+            &self.active_validators,
+            total_stake,
+            total_slashed_validator_stake,
+            unadjusted_staking_reward_amounts,
+            unadjusted_storage_fund_reward_amounts,
+            total_staking_reward_adjustment,
+            individual_staking_reward_adjustments,
+            total_storage_fund_reward_adjustment,
+            individual_storage_fund_reward_adjustments
+        );
+
+        // Distribute the rewards before adjusting stake so that we immediately start compounding
+        // the rewards for validators and delegators.
+        distribute_reward(
+            &mut self.active_validators,
+            &adjusted_staking_reward_amounts,
+            &adjusted_storage_fund_reward_amounts,
+            computation_reward,
+            storage_fund_reward,
+            ctx
+        );
+
+        adjust_stake_and_gas_price(&mut self.active_validators);
+
+        // Delegation switches must be processed before delegation deposits and withdraws so that the
+        // rewards portion of the delegation switch can be added to the new validator's pool when we
+        // process pending delegations.
+        process_pending_delegation_switches(self, ctx);
+
+        process_pending_delegations_and_withdraws(&mut self.active_validators, ctx);
+
+        // Emit events after we have processed all the rewards distribution and pending delegations.
+        emit_validator_epoch_events(new_epoch, &self.active_validators, &adjusted_staking_reward_amounts,
+            &validator_report_records, &slashed_validators);
+
+        process_pending_validators(&mut self.active_validators, &mut self.pending_validators);
+
+        process_pending_removals(self, ctx);
+
+        self.next_epoch_validators = derive_next_epoch_validators(self);
+
+        let (validator_stake, delegation_stake) = calculate_total_stakes(&self.active_validators);
+        self.total_validator_stake = validator_stake;
+        self.total_delegation_stake = delegation_stake;
+
+        voting_power::set_voting_power(&mut self.active_validators);
+    }
+
+    /// Called by `sui_system` to derive reference gas price for the new epoch.
+    /// Derive the reference gas price based on the gas price quote submitted by each validator.
+    /// The returned gas price should be greater than or equal to 2/3 of the validators submitted
+    /// gas price, weighted by stake.
+    public fun derive_reference_gas_price(self: &ValidatorSet): u64 {
+        let vs = &self.active_validators;
+        let num_validators = vector::length(vs);
+        let entries = vector::empty();
+        let i = 0;
+        while (i < num_validators) {
+            let v = vector::borrow(vs, i);
+            vector::push_back(
+                &mut entries,
+                pq::new_entry(validator::gas_price(v), validator::voting_power(v))
+            );
+            i = i + 1;
+        };
+        // Build a priority queue that will pop entries with gas price from the highest to the lowest.
+        let pq = pq::new(entries);
+        let sum = 0;
+        let threshold = voting_power::total_voting_power() - voting_power::quorum_threshold();
+        let result = 0;
+        while (sum < threshold) {
+            let (gas_price, stake) = pq::pop_max(&mut pq);
+            result = gas_price;
+            sum = sum + stake;
+        };
+        result
+    }
+
+    // ==== getter functions ====
+
+    public fun total_validator_stake(self: &ValidatorSet): u64 {
+        self.total_validator_stake
+    }
+
+    public fun total_delegation_stake(self: &ValidatorSet): u64 {
+        self.total_delegation_stake
+    }
+
+    public fun validator_total_stake_amount(self: &ValidatorSet, validator_address: address): u64 {
+        let validator = get_validator_ref(&self.active_validators, validator_address);
+        validator::total_stake_amount(validator)
+    }
+
+    public fun validator_stake_amount(self: &ValidatorSet, validator_address: address): u64 {
+        let validator = get_validator_ref(&self.active_validators, validator_address);
+        validator::stake_amount(validator)
+    }
+
+    public fun validator_delegate_amount(self: &ValidatorSet, validator_address: address): u64 {
+        let validator = get_validator_ref(&self.active_validators, validator_address);
+        validator::delegate_amount(validator)
+    }
+
+    /// Get the total number of validators in the next epoch.
+    public(friend) fun next_epoch_validator_count(self: &ValidatorSet): u64 {
+        vector::length(&self.next_epoch_validators)
+    }
+
+    /// Returns true iff `validator_address` is a member of the active validators.
+    public(friend) fun is_active_validator(
+        self: &ValidatorSet,
+        validator_address: address,
+    ): bool {
+        option::is_some(&find_validator(&self.active_validators, validator_address))
+    }
+
+
+    // ==== private helpers ====
+
+    /// Checks whether a duplicate of `new_validator` is already in `validators`.
+    /// Two validators duplicate if they share the same sui_address or same IP or same name.
+    fun contains_duplicate_validator(validators: &vector<Validator>, new_validator: &Validator): bool {
+        let len = vector::length(validators);
+        let i = 0;
+        while (i < len) {
+            let v = vector::borrow(validators, i);
+            if (validator::is_duplicate(v, new_validator)) {
+                return true
+            };
+            i = i + 1;
+        };
+        false
+    }
+
+    /// Find validator by `validator_address`, in `validators`.
+    /// Returns (true, index) if the validator is found, and the index is its index in the list.
+    /// If not found, returns (false, 0).
+    fun find_validator(validators: &vector<Validator>, validator_address: address): Option<u64> {
+        let length = vector::length(validators);
+        let i = 0;
+        while (i < length) {
+            let v = vector::borrow(validators, i);
+            if (validator::sui_address(v) == validator_address) {
+                return option::some(i)
+            };
+            i = i + 1;
+        };
+        option::none()
+    }
+
+    /// Given a vector of validator addresses, return their indices in the validator set.
+    /// Aborts if any address isn't in the given validator set.
+    fun get_validator_indices(validators: &vector<Validator>, validator_addresses: &vector<address>): vector<u64> {
+        let length = vector::length(validator_addresses);
+        let i = 0;
+        let res = vector[];
+        while (i < length) {
+            let addr = *vector::borrow(validator_addresses, i);
+            let index_opt = find_validator(validators, addr);
+            assert!(option::is_some(&index_opt), 0);
+            vector::push_back(&mut res, option::destroy_some(index_opt));
+            i = i + 1;
+        };
+        res
+    }
+
+    fun get_validator_mut(
+        validators: &mut vector<Validator>,
+        validator_address: address,
+    ): &mut Validator {
+        let validator_index_opt = find_validator(validators, validator_address);
+        assert!(option::is_some(&validator_index_opt), 0);
+        let validator_index = option::extract(&mut validator_index_opt);
+        vector::borrow_mut(validators, validator_index)
+    }
+
+    fun get_validator_ref(
+        validators: &vector<Validator>,
+        validator_address: address,
+    ): &Validator {
+        let validator_index_opt = find_validator(validators, validator_address);
+        assert!(option::is_some(&validator_index_opt), 0);
+        let validator_index = option::extract(&mut validator_index_opt);
+        vector::borrow(validators, validator_index)
+    }
+
+    /// Process the pending withdraw requests. For each pending request, the validator
+    /// is removed from `validators` and sent back to the address of the validator.
+    fun process_pending_removals(
+        self: &mut ValidatorSet,
+        ctx: &mut TxContext,
+    ) {
+        sort_removal_list(&mut self.pending_removals);
+        while (!vector::is_empty(&self.pending_removals)) {
+            let index = vector::pop_back(&mut self.pending_removals);
+            let validator = vector::remove(&mut self.active_validators, index);
+            self.total_delegation_stake = self.total_delegation_stake - validator::delegate_amount(&validator);
+            validator::destroy(validator, ctx);
+        }
+    }
+
+    /// Process the pending new validators. They are simply inserted into `validators`.
+    fun process_pending_validators(
+        validators: &mut vector<Validator>, pending_validators: &mut vector<Validator>
+    ) {
+        while (!vector::is_empty(pending_validators)) {
+            let v = vector::pop_back(pending_validators);
+            vector::push_back(validators, v);
+        }
+    }
+
+    /// Sort all the pending removal indexes.
+    fun sort_removal_list(withdraw_list: &mut vector<u64>) {
+        let length = vector::length(withdraw_list);
+        let i = 1;
+        while (i < length) {
+            let cur = *vector::borrow(withdraw_list, i);
+            let j = i;
+            while (j > 0) {
+                j = j - 1;
+                if (*vector::borrow(withdraw_list, j) > cur) {
+                    vector::swap(withdraw_list, j, j + 1);
+                } else {
+                    break
+                };
+            };
+            i = i + 1;
+        };
+    }
+
+    /// Go through all the delegation switches, withdraws the rewards portion of the switched stake from
+    /// the `from` validator's pool, and deposits it into the `to` validator's pool.
+    fun process_pending_delegation_switches(self: &mut ValidatorSet, ctx: &mut TxContext) {
+        // for each pair of (from, to) validators, complete the delegation switch
+        while (!vec_map::is_empty(&self.pending_delegation_switches)) {
+            let (ValidatorPair { from, to }, entries) = vec_map::pop(&mut self.pending_delegation_switches);
+            let from_validator = get_validator_mut(&mut self.active_validators, from);
+            let from_pool = validator::get_staking_pool_mut_ref(from_validator);
+            // withdraw rewards from the old validator's pool
+            let (delegators, rewards, rewards_withdraw_amount) =
+                staking_pool::batch_withdraw_rewards_and_burn_pool_tokens(from_pool, entries);
+            validator::decrease_next_epoch_delegation(from_validator, rewards_withdraw_amount);
+
+            assert!(vector::length(&delegators) == vector::length(&rewards), 0);
+
+            let to_validator = get_validator_mut(&mut self.active_validators, to);
+            // add delegations to the new validator
+            while (!vector::is_empty(&rewards)) {
+                let delegator = vector::pop_back(&mut delegators);
+                let new_stake = vector::pop_back(&mut rewards);
+                validator::request_add_delegation(
+                    to_validator,
+                    new_stake,
+                    option::none(), // no time lock for rewards
+                    delegator,
+                    ctx
+                );
+            };
+            vector::destroy_empty(rewards);
+        };
+    }
+
+    /// Process all active validators' pending delegation deposits and withdraws.
+    fun process_pending_delegations_and_withdraws(validators: &mut vector<Validator>, ctx: &mut TxContext) {
+        let length = vector::length(validators);
+        let i = 0;
+        while (i < length) {
+            let validator = vector::borrow_mut(validators, i);
+            validator::process_pending_delegations_and_withdraws(validator, ctx);
+            i = i + 1;
+        }
+    }
+
+    /// Calculate the total active validator and delegated stake.
+    fun calculate_total_stakes(validators: &vector<Validator>): (u64, u64) {
+        let validator_state = 0;
+        let delegate_stake = 0;
+        let length = vector::length(validators);
+        let i = 0;
+        while (i < length) {
+            let v = vector::borrow(validators, i);
+            validator_state = validator_state + validator::stake_amount(v);
+            delegate_stake = delegate_stake + validator::delegate_amount(v);
+            i = i + 1;
+        };
+        (validator_state, delegate_stake)
+    }
+
+    /// Process the pending stake changes for each validator.
+    fun adjust_stake_and_gas_price(validators: &mut vector<Validator>) {
+        let length = vector::length(validators);
+        let i = 0;
+        while (i < length) {
+            let validator = vector::borrow_mut(validators, i);
+            validator::adjust_stake_and_gas_price(validator);
+            i = i + 1;
+        }
+    }
+
+    /// Compute both the individual reward adjustments and total reward adjustment for staking rewards
+    /// as well as storage fund rewards.
+    fun compute_reward_adjustments(
+        slashed_validator_indices: vector<u64>,
+        reward_slashing_rate: u64,
+        unadjusted_staking_reward_amounts: &vector<u64>,
+        unadjusted_storage_fund_reward_amounts: &vector<u64>,
+    ): (
+        u64, // sum of staking reward adjustments
+        VecMap<u64, u64>, // mapping of individual validator's staking reward adjustment from index -> amount
+        u64, // sum of storage fund reward adjustments
+        VecMap<u64, u64>, // mapping of individual validator's storage fund reward adjustment from index -> amount
+    ) {
+        let total_staking_reward_adjustment = 0;
+        let individual_staking_reward_adjustments = vec_map::empty();
+        let total_storage_fund_reward_adjustment = 0;
+        let individual_storage_fund_reward_adjustments = vec_map::empty();
+
+        while (!vector::is_empty(&mut slashed_validator_indices)) {
+            let validator_index = vector::pop_back(&mut slashed_validator_indices);
+
+            // Use the slashing rate to compute the amount of staking rewards slashed from this punished validator.
+            let unadjusted_staking_reward = *vector::borrow(unadjusted_staking_reward_amounts, validator_index);
+            let staking_reward_adjustment_u128 =
+                (unadjusted_staking_reward as u128) * (reward_slashing_rate as u128)
+                / BASIS_POINT_DENOMINATOR;
+
+            // Insert into individual mapping and record into the total adjustment sum.
+            vec_map::insert(&mut individual_staking_reward_adjustments, validator_index, (staking_reward_adjustment_u128 as u64));
+            total_staking_reward_adjustment = total_staking_reward_adjustment + (staking_reward_adjustment_u128 as u64);
+
+            // Do the same thing for storage fund rewards.
+            let unadjusted_storage_fund_reward = *vector::borrow(unadjusted_storage_fund_reward_amounts, validator_index);
+            let storage_fund_reward_adjustment_u128 =
+                (unadjusted_storage_fund_reward as u128) * (reward_slashing_rate as u128)
+                / BASIS_POINT_DENOMINATOR;
+            vec_map::insert(&mut individual_storage_fund_reward_adjustments, validator_index, (storage_fund_reward_adjustment_u128 as u64));
+            total_storage_fund_reward_adjustment = total_storage_fund_reward_adjustment + (storage_fund_reward_adjustment_u128 as u64);
+        };
+
+        (
+            total_staking_reward_adjustment, individual_staking_reward_adjustments,
+            total_storage_fund_reward_adjustment, individual_storage_fund_reward_adjustments
+        )
+    }
+
+    /// Process the validator report records of the epoch and return the addresses of the
+    /// non-performant validators according to the input threshold.
+    fun compute_slashed_validators_and_total_stake(
+        self: &ValidatorSet,
+        validator_report_records: VecMap<address, VecSet<address>>,
+    ): (vector<address>, u64) {
+        let slashed_validators = vector[];
+        let sum_of_stake = 0;
+        while (!vec_map::is_empty(&validator_report_records)) {
+            let (validator_address, reporters) = vec_map::pop(&mut validator_report_records);
+            assert!(
+                is_active_validator(self, validator_address),
+                ENON_VALIDATOR_IN_REPORT_RECORDS
+            );
+            // Sum up the voting power of validators that have reported this validator and check if it has
+            // passed the slashing threshold.
+            let reporter_votes = sum_voting_power_by_addresses(&self.active_validators, &vec_set::into_keys(reporters));
+            if (reporter_votes >= voting_power::quorum_threshold()) {
+                sum_of_stake = sum_of_stake + validator_total_stake_amount(self, validator_address);
+                vector::push_back(&mut slashed_validators, validator_address);
+            }
+        };
+        (slashed_validators, sum_of_stake)
+    }
+
+    /// Given the current list of active validators, the total stake and total reward,
+    /// calculate the amount of reward each validator should get, without taking into
+    /// account the tallyig rule results.
+    /// Returns the unadjusted amounts of staking reward and storage fund reward for each validator.
+    fun compute_unadjusted_reward_distribution(
+        validators: &vector<Validator>,
+        total_stake: u64,
+        total_staking_reward: u64,
+        total_storage_fund_reward: u64,
+    ): (vector<u64>, vector<u64>) {
+        let staking_reward_amounts = vector::empty();
+        let storage_fund_reward_amounts = vector::empty();
+        let length = vector::length(validators);
+        let storage_fund_reward_per_validator = total_storage_fund_reward / length;
+        let i = 0;
+        while (i < length) {
+            let validator = vector::borrow(validators, i);
+            // Integer divisions will truncate the results. Because of this, we expect that at the end
+            // there will be some reward remaining in `total_staking_reward`.
+            // Use u128 to avoid multiplication overflow.
+            let stake_amount: u128 = (validator::total_stake_amount(validator) as u128);
+            let reward_amount = stake_amount * (total_staking_reward as u128) / (total_stake as u128);
+            vector::push_back(&mut staking_reward_amounts, (reward_amount as u64));
+            // Storage fund's share of the rewards are equally distributed among validators.
+            vector::push_back(&mut storage_fund_reward_amounts, storage_fund_reward_per_validator);
+            i = i + 1;
+        };
+        (staking_reward_amounts, storage_fund_reward_amounts)
+    }
+
+    /// Use the reward adjustment info to compute the adjusted rewards each validator should get.
+    /// Returns the staking rewards each validator gets and the storage fund rewards each validator gets.
+    /// The staking rewards are shared with the delegators while the storage fund ones are not.
+    fun compute_adjusted_reward_distribution(
+        validators: &vector<Validator>,
+        total_stake: u64,
+        total_slashed_validator_stake: u64,
+        unadjusted_staking_reward_amounts: vector<u64>,
+        unadjusted_storage_fund_reward_amounts: vector<u64>,
+        total_staking_reward_adjustment: u64,
+        individual_staking_reward_adjustments: VecMap<u64, u64>,
+        total_storage_fund_reward_adjustment: u64,
+        individual_storage_fund_reward_adjustments: VecMap<u64, u64>,
+    ): (vector<u64>, vector<u64>) {
+        let total_unslashed_validator_stake = total_stake - total_slashed_validator_stake;
+        let adjusted_staking_reward_amounts = vector::empty();
+        let adjusted_storage_fund_reward_amounts = vector::empty();
+
+        let length = vector::length(validators);
+        let num_unslashed_validators = length - vec_map::size(&individual_staking_reward_adjustments);
+
+        let i = 0;
+        while (i < length) {
+            let validator = vector::borrow(validators, i);
+            // Integer divisions will truncate the results. Because of this, we expect that at the end
+            // there will be some reward remaining in `total_reward`.
+            // Use u128 to avoid multiplication overflow.
+            let stake_amount: u128 = (validator::total_stake_amount(validator) as u128);
+
+            // Compute adjusted staking reward.
+            let unadjusted_staking_reward_amount = *vector::borrow(&unadjusted_staking_reward_amounts, i);
+            let adjusted_staking_reward_amount =
+                // If the validator is one of the slashed ones, then subtract the adjustment.
+                if (vec_map::contains(&individual_staking_reward_adjustments, &i)) {
+                    let adjustment = *vec_map::get(&individual_staking_reward_adjustments, &i);
+                    unadjusted_staking_reward_amount - adjustment
+                } else {
+                    // Otherwise the slashed rewards should be distributed among the unslashed
+                    // validators so add the corresponding adjustment.
+                    let adjustment = (total_staking_reward_adjustment as u128) * stake_amount
+                                   / (total_unslashed_validator_stake as u128);
+                    unadjusted_staking_reward_amount + (adjustment as u64)
+                };
+            vector::push_back(&mut adjusted_staking_reward_amounts, adjusted_staking_reward_amount);
+
+            // Compute adjusted storage fund reward.
+            let unadjusted_storage_fund_reward_amount = *vector::borrow(&unadjusted_storage_fund_reward_amounts, i);
+            let adjusted_storage_fund_reward_amount =
+                // If the validator is one of the slashed ones, then subtract the adjustment.
+                if (vec_map::contains(&individual_storage_fund_reward_adjustments, &i)) {
+                    let adjustment = *vec_map::get(&individual_storage_fund_reward_adjustments, &i);
+                    unadjusted_storage_fund_reward_amount - adjustment
+                } else {
+                    // Otherwise the slashed rewards should be equally distributed among the unslashed validators.
+                    let adjustment = total_storage_fund_reward_adjustment / num_unslashed_validators;
+                    unadjusted_storage_fund_reward_amount + adjustment
+                };
+            vector::push_back(&mut adjusted_storage_fund_reward_amounts, adjusted_storage_fund_reward_amount);
+
+            i = i + 1;
+        };
+
+        (adjusted_staking_reward_amounts, adjusted_storage_fund_reward_amounts)
+    }
+
+    fun distribute_reward(
+        validators: &mut vector<Validator>,
+        adjusted_staking_reward_amounts: &vector<u64>,
+        adjusted_storage_fund_reward_amounts: &vector<u64>,
+        staking_rewards: &mut Balance<SUI>,
+        storage_fund_reward: &mut Balance<SUI>,
+        ctx: &mut TxContext
+    ) {
+        let length = vector::length(validators);
+        assert!(length > 0, 0);
+        let i = 0;
+        while (i < length) {
+            let validator = vector::borrow_mut(validators, i);
+            let staking_reward_amount = *vector::borrow(adjusted_staking_reward_amounts, i);
+            let combined_stake = validator::total_stake_amount(validator);
+            let self_stake = validator::stake_amount(validator);
+            let validator_reward_amount = (staking_reward_amount as u128) * (self_stake as u128) / (combined_stake as u128);
+            let validator_reward = balance::split(staking_rewards, (validator_reward_amount as u64));
+
+            let delegator_reward_amount = staking_reward_amount - (validator_reward_amount as u64);
+            let delegator_reward = balance::split(staking_rewards, delegator_reward_amount);
+
+            // Validator takes a cut of the rewards as commission.
+            let commission_amount = (delegator_reward_amount as u128) * (validator::commission_rate(validator) as u128) / BASIS_POINT_DENOMINATOR;
+            balance::join(&mut validator_reward, balance::split(&mut delegator_reward, (commission_amount as u64)));
+
+            // Add storage fund rewards to the validator's reward.
+            balance::join(&mut validator_reward, balance::split(storage_fund_reward, *vector::borrow(adjusted_storage_fund_reward_amounts, i)));
+
+            // Add rewards to the validator.
+            validator::request_add_stake(validator, validator_reward, option::none(), ctx);
+            // Add rewards to delegation staking pool to auto compound for delegators.
+            validator::deposit_delegation_rewards(validator, delegator_reward);
+            i = i + 1;
+        }
+    }
+
+    /// Upon any change to the validator set, derive and update the metadata of the validators for the new epoch.
+    /// TODO: If we want to enforce a % on stake threshold, this is the function to do it.
+    fun derive_next_epoch_validators(self: &ValidatorSet): vector<ValidatorMetadata> {
+        let active_count = vector::length(&self.active_validators);
+        let removal_count = vector::length(&self.pending_removals);
+        let result = vector::empty();
+        while (active_count > 0) {
+            if (removal_count > 0) {
+                let removal_index = *vector::borrow(&self.pending_removals, removal_count - 1);
+                if (removal_index == active_count - 1) {
+                    // This validator will be removed, and hence we won't add it to the new validator set.
+                    removal_count = removal_count - 1;
+                    active_count = active_count - 1;
+                    continue
+                };
+            };
+            let metadata = validator::metadata(
+                vector::borrow(&self.active_validators, active_count - 1),
+            );
+            vector::push_back(&mut result, *metadata);
+            active_count = active_count - 1;
+        };
+        let i = 0;
+        let pending_count = vector::length(&self.pending_validators);
+        while (i < pending_count) {
+            let metadata = validator::metadata(
+                vector::borrow(&self.pending_validators, i),
+            );
+            vector::push_back(&mut result, *metadata);
+            i = i + 1;
+        };
+        result
+    }
+
+    /// Emit events containing information of each validator for the epoch,
+    /// including stakes, rewards, performance, etc.
+    fun emit_validator_epoch_events(
+        new_epoch: u64,
+        vs: &vector<Validator>,
+        reward_amounts: &vector<u64>,
+        report_records: &VecMap<address, VecSet<address>>,
+        slashed_validators: &vector<address>,
+    ) {
+        let num_validators = vector::length(vs);
+        let i = 0;
+        while (i < num_validators) {
+            let v = vector::borrow(vs, i);
+            let validator_address = validator::sui_address(v);
+            let tallying_rule_reporters =
+                if (vec_map::contains(report_records, &validator_address)) {
+                    vec_set::into_keys(*vec_map::get(report_records, &validator_address))
+                } else {
+                    vector[]
+                };
+            let tallying_rule_global_score =
+                if (vector::contains(slashed_validators, &validator_address)) 0
+                else 1;
+            event::emit(
+                ValidatorEpochInfo {
+                    epoch: new_epoch,
+                    validator_address,
+                    reference_gas_survey_quote: validator::gas_price(v),
+                    validator_stake: validator::stake_amount(v),
+                    delegated_stake: validator::delegate_amount(v),
+                    commission_rate: validator::commission_rate(v),
+                    stake_rewards: *vector::borrow(reward_amounts, i),
+                    pool_token_exchange_rate: validator::pool_token_exchange_rate(v),
+                    tallying_rule_reporters,
+                    tallying_rule_global_score,
+                }
+            );
+            i = i + 1;
+        }
+    }
+
+    /// Sum up the total stake of a given list of validator addresses.
+    public fun sum_voting_power_by_addresses(vs: &vector<Validator>, addresses: &vector<address>): u64 {
+        let sum = 0;
+        let i = 0;
+        let length = vector::length(addresses);
+        while (i < length) {
+            let validator = get_validator_ref(vs, *vector::borrow(addresses, i));
+            sum = sum + validator::voting_power(validator);
+            i = i + 1;
+        };
+        sum
+    }
+
+    /// Return the active validators in `self`
+    public fun active_validators(self: &ValidatorSet): &vector<Validator> {
+        &self.active_validators
+    }
+
+    #[test_only]
+    public fun destroy_for_testing(
+        self: ValidatorSet,
+    ) {
+        let ValidatorSet {
+            total_validator_stake: _,
+            total_delegation_stake: _,
+            active_validators,
+            pending_validators,
+            pending_removals: _,
+            next_epoch_validators: _,
+            pending_delegation_switches,
+        } = self;
+        destroy_validators_for_testing(active_validators);
+        vector::destroy_empty(pending_validators);
+        vec_map::destroy_empty(pending_delegation_switches);
+    }
+
+    #[test_only]
+    public fun destroy_validators_for_testing(v: vector<Validator>) {
+        while (!vector::is_empty(&v)) {
+            let v = vector::pop_back(&mut v);
+            validator::destroy(v, &mut tx_context::dummy());
+        };
+        vector::destroy_empty(v)
+    }
+}

--- a/crates/sui-framework-override/sources/governance/voting_power.move
+++ b/crates/sui-framework-override/sources/governance/voting_power.move
@@ -1,0 +1,184 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::voting_power {
+    use sui::validator::Validator;
+    use std::vector;
+    use sui::validator;
+    use sui::math;
+    use sui::math::divide_and_round_up;
+
+    struct VotingPowerInfo has drop {
+        validator_index: u64,
+        voting_power: u64,
+    }
+
+    /// Set total_voting_power as 10_000 by convention. Individual voting powers can be interpreted
+    /// as easily understandable basis points (e.g., voting_power: 100 = 1%, voting_power: 1 = 0.01%) rather than
+    /// opaque quantities whose meaning changes from epoch to epoch as the total amount staked shifts.
+    /// Fixing the total voting power allows clients to hardcode the quorum threshold and total_voting power rather
+    /// than recomputing these.
+    const TOTAL_VOTING_POWER: u64 = 10_000;
+
+    /// Quorum threshold for our fixed voting power--any message signed by this much voting power can be trusted
+    /// up to BFT assumptions
+    const QUORUM_THRESHOLD: u64 = 6_667;
+
+    // Cap voting power of an individual validator at 10%.
+    // TODO: determine what this should be
+    const MAX_VOTING_POWER: u64 = 1_000;
+
+    const ETotalPowerMismatch: u64 = 1;
+    const ERelativePowerMismatch: u64 = 2;
+    const EVotingPowerOverThreshold: u64 = 3;
+
+    /// Set the voting power of all validators.
+    /// Each validator's voting power is initialized using their stake. We then attempt to cap their voting power
+    /// at `MAX_VOTING_POWER`. If `MAX_VOTING_POWER` is not a feasible cap, we pick the lowest possible cap.
+    public fun set_voting_power(validators: &mut vector<Validator>) {
+        // If threshold_pct is too small, it's possible that even when all validators reach the threshold we still don't
+        // have 100%. So we bound the threshold_pct to be always enough to find a solution.
+        let threshold = math::min(
+            TOTAL_VOTING_POWER,
+            math::max(MAX_VOTING_POWER, divide_and_round_up(TOTAL_VOTING_POWER, vector::length(validators))),
+        );
+        let (info_list, remaining_power) = init_voting_power_info(validators, threshold);
+        adjust_voting_power(&mut info_list, threshold, remaining_power);
+        update_voting_power(validators, info_list);
+        // TODO: We could consider removing this once we are confident about the code.
+        check_invariants(validators);
+    }
+
+    /// Create the initial voting power of each validator, set using their stake, but capped using threshold.
+    /// We also perform insertion sort while creating the voting power list, by maintaining the list in
+    /// descending order using voting power.
+    /// Anything beyond the threshold is added to the remaining_power, which is also returned.
+    fun init_voting_power_info(
+        validators: &vector<Validator>,
+        threshold: u64,
+    ): (vector<VotingPowerInfo>, u64) {
+        let total_stake = total_stake(validators);
+        let i = 0;
+        let len = vector::length(validators);
+        let total_power = 0;
+        let result = vector[];
+        while (i < len) {
+            let validator = vector::borrow(validators, i);
+            let stake = validator::total_stake(validator);
+            let adjusted_stake = (stake as u128) * (TOTAL_VOTING_POWER as u128) / (total_stake as u128);
+            let voting_power = math::min((adjusted_stake as u64), threshold);
+            let info = VotingPowerInfo {
+                validator_index: i,
+                voting_power,
+            };
+            insert(&mut result, info);
+            total_power = total_power + voting_power;
+            i = i + 1;
+        };
+        (result, TOTAL_VOTING_POWER - total_power)
+    }
+
+    /// Sum up the total stake of all validators.
+    fun total_stake(validators: &vector<Validator>): u64 {
+        let i = 0;
+        let len = vector::length(validators);
+        let total_stake =0 ;
+        while (i < len) {
+            total_stake = total_stake + validator::total_stake(vector::borrow(validators, i));
+            i = i + 1;
+        };
+        total_stake
+    }
+
+    /// Insert `new_info` to `info_list` as part of insertion sort, such that `info_list` is always sorted
+    /// using voting_power, in descending order.
+    fun insert(info_list: &mut vector<VotingPowerInfo>, new_info: VotingPowerInfo) {
+        let i = 0;
+        let len = vector::length(info_list);
+        while (i < len && vector::borrow(info_list, i).voting_power > new_info.voting_power) {
+            i = i + 1;
+        };
+        vector::insert(info_list, new_info, i);
+    }
+
+    /// Distribute remaining_power to validators that are not capped at threshold.
+    fun adjust_voting_power(info_list: &mut vector<VotingPowerInfo>, threshold: u64, remaining_power: u64) {
+        let i = 0;
+        let len = vector::length(info_list);
+        while (i < len && remaining_power > 0) {
+            let v = vector::borrow_mut(info_list, i);
+            // planned is the amount of extra power we want to distribute to this validator.
+            let planned = divide_and_round_up(remaining_power, len - i);
+            // target is the targeting power this validator will reach, capped by threshold.
+            let target = math::min(threshold, v.voting_power + planned);
+            // actual is the actual amount of power we will be distributing to this validator.
+            let actual = math::min(remaining_power, target - v.voting_power);
+            v.voting_power = v.voting_power + actual;
+            assert!(v.voting_power <= threshold, EVotingPowerOverThreshold);
+            remaining_power = remaining_power - actual;
+            i = i + 1;
+        };
+        assert!(remaining_power == 0, ETotalPowerMismatch);
+    }
+
+    /// Update validators with the decided voting power.
+    fun update_voting_power(validators: &mut vector<Validator>, info_list: vector<VotingPowerInfo>) {
+        while (!vector::is_empty(&info_list)) {
+            let VotingPowerInfo {
+                validator_index,
+                voting_power,
+            } = vector::pop_back(&mut info_list);
+            let v = vector::borrow_mut(validators, validator_index);
+            validator::set_voting_power(v, voting_power);
+        };
+        vector::destroy_empty(info_list);
+    }
+
+    /// Check a few invariants that must hold after setting the voting power.
+    fun check_invariants(v: &vector<Validator>) {
+        // First check that the total voting power must be TOTAL_VOTING_POWER.
+        let i = 0;
+        let len = vector::length(v);
+        let total = 0;
+        while (i < len) {
+            let voting_power = validator::voting_power(vector::borrow(v, i));
+            total = total + voting_power;
+            i = i + 1;
+        };
+        assert!(total == TOTAL_VOTING_POWER, ETotalPowerMismatch);
+
+        // Second check that if validator A's stake is larger than B's stake, A's voting power must be no less
+        // than B's voting power; similarly, if A's stake is less than B's stake, A's voting power must be no larger
+        // than B's voting power.
+        let i = 0;
+        while (i < len) {
+            let j = i + 1;
+            while (j < len) {
+                let validator_i = vector::borrow(v, i);
+                let validator_j = vector::borrow(v, j);
+                let stake_i = validator::total_stake(validator_i);
+                let stake_j = validator::total_stake(validator_j);
+                let power_i = validator::voting_power(validator_i);
+                let power_j = validator::voting_power(validator_j);
+                if (stake_i > stake_i) {
+                    assert!(power_i >= power_j, ERelativePowerMismatch);
+                };
+                if (stake_i < stake_j) {
+                    assert!(power_i <= power_j, ERelativePowerMismatch);
+                };
+                j = j + 1;
+            };
+            i = i + 1;
+        }
+    }
+
+    /// Return the (constant) total voting power
+    public fun total_voting_power(): u64 {
+        TOTAL_VOTING_POWER
+    }
+
+    /// Return the (constant) quorum threshold
+    public fun quorum_threshold(): u64 {
+        QUORUM_THRESHOLD
+    }
+}

--- a/crates/sui-framework-override/sources/hex.move
+++ b/crates/sui-framework-override/sources/hex.move
@@ -1,0 +1,111 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// HEX (Base16) encoding utility.
+module sui::hex {
+    use std::vector;
+
+    const EInvalidHexLength: u64 = 0;
+    const ENotValidHexCharacter: u64 = 1;
+
+    /// Vector of Base16 values from `00` to `FF`
+    const HEX: vector<vector<u8>> = vector[
+        b"00",b"01",b"02",b"03",b"04",b"05",b"06",b"07",b"08",b"09",b"0a",b"0b",b"0c",b"0d",b"0e",b"0f",b"10",b"11",b"12",b"13",b"14",b"15",b"16",b"17",b"18",b"19",b"1a",b"1b",b"1c",b"1d",b"1e",b"1f",b"20",b"21",b"22",b"23",b"24",b"25",b"26",b"27",b"28",b"29",b"2a",b"2b",b"2c",b"2d",b"2e",b"2f",b"30",b"31",b"32",b"33",b"34",b"35",b"36",b"37",b"38",b"39",b"3a",b"3b",b"3c",b"3d",b"3e",b"3f",b"40",b"41",b"42",b"43",b"44",b"45",b"46",b"47",b"48",b"49",b"4a",b"4b",b"4c",b"4d",b"4e",b"4f",b"50",b"51",b"52",b"53",b"54",b"55",b"56",b"57",b"58",b"59",b"5a",b"5b",b"5c",b"5d",b"5e",b"5f",b"60",b"61",b"62",b"63",b"64",b"65",b"66",b"67",b"68",b"69",b"6a",b"6b",b"6c",b"6d",b"6e",b"6f",b"70",b"71",b"72",b"73",b"74",b"75",b"76",b"77",b"78",b"79",b"7a",b"7b",b"7c",b"7d",b"7e",b"7f",b"80",b"81",b"82",b"83",b"84",b"85",b"86",b"87",b"88",b"89",b"8a",b"8b",b"8c",b"8d",b"8e",b"8f",b"90",b"91",b"92",b"93",b"94",b"95",b"96",b"97",b"98",b"99",b"9a",b"9b",b"9c",b"9d",b"9e",b"9f",b"a0",b"a1",b"a2",b"a3",b"a4",b"a5",b"a6",b"a7",b"a8",b"a9",b"aa",b"ab",b"ac",b"ad",b"ae",b"af",b"b0",b"b1",b"b2",b"b3",b"b4",b"b5",b"b6",b"b7",b"b8",b"b9",b"ba",b"bb",b"bc",b"bd",b"be",b"bf",b"c0",b"c1",b"c2",b"c3",b"c4",b"c5",b"c6",b"c7",b"c8",b"c9",b"ca",b"cb",b"cc",b"cd",b"ce",b"cf",b"d0",b"d1",b"d2",b"d3",b"d4",b"d5",b"d6",b"d7",b"d8",b"d9",b"da",b"db",b"dc",b"dd",b"de",b"df",b"e0",b"e1",b"e2",b"e3",b"e4",b"e5",b"e6",b"e7",b"e8",b"e9",b"ea",b"eb",b"ec",b"ed",b"ee",b"ef",b"f0",b"f1",b"f2",b"f3",b"f4",b"f5",b"f6",b"f7",b"f8",b"f9",b"fa",b"fb",b"fc",b"fd",b"fe",b"ff"
+    ];
+
+    /// Encode `bytes` in lowercase hex
+    public fun encode(bytes: vector<u8>): vector<u8> {
+        let (i, r, l) = (0, vector[], vector::length(&bytes));
+        while (i < l) {
+            vector::append(
+                &mut r, 
+                *vector::borrow(&HEX, (*vector::borrow(&bytes, i) as u64))
+            );
+            i = i + 1;
+        };
+        r
+    }
+
+    /// Decode hex into `bytes`
+    /// Takes a hex string (no 0x prefix) (e.g. b"0f3a")
+    /// Returns vector of `bytes` that represents the hex string (e.g. x"0f3a")
+    /// Hex string can be case insensitive (e.g. b"0F3A" and b"0f3a" both return x"0f3a")
+    /// Aborts if the hex string does not have an even number of characters (as each hex charater is 2 characters long)
+    /// Aborts if the hex string contains non-valid hex characters (valid charaters are 0 - 9, a - f, A - F)
+    public fun decode(hex: vector<u8>): vector<u8> {
+        let (i, r, l) = (0, vector[], vector::length(&hex));
+        assert!(l % 2 == 0, EInvalidHexLength); 
+        while (i < l) {
+            let decimal = (decode_byte(*vector::borrow(&hex, i)) * 16) + 
+                          decode_byte(*vector::borrow(&hex, i + 1));
+            vector::push_back(&mut r, decimal);
+            i = i + 2;
+        };
+        r
+    }
+    
+    fun decode_byte(hex: u8): u8 {
+        if (/* 0 .. 9 */ 48 <= hex && hex < 58) {
+            hex - 48
+        } else if (/* A .. F */ 65 <= hex && hex < 71) {
+            10 + hex - 65
+        } else if (/* a .. f */ 97 <= hex && hex < 103) {
+            10 + hex - 97
+        } else {
+            abort ENotValidHexCharacter
+        }
+    }
+
+    spec module { pragma verify = false; }
+
+    #[test]
+    fun test_hex_encode_string_literal() {
+        assert!(b"30" == encode(b"0"), 0);
+        assert!(b"61" == encode(b"a"), 0);       
+        assert!(b"666666" == encode(b"fff"), 0);
+    }
+
+    #[test]
+    fun test_hex_encode_hex_literal() {
+        assert!(b"ff" == encode(x"ff"), 0);
+        assert!(b"fe" == encode(x"fe"), 0);
+        assert!(b"00" == encode(x"00"), 0);
+    }
+
+    #[test]
+    fun test_hex_decode_string_literal() {
+        assert!(x"ff" == decode(b"ff"), 0);
+        assert!(x"fe" == decode(b"fe"), 0);
+        assert!(x"00" == decode(b"00"), 0);
+    }
+
+    #[test]
+    fun test_hex_decode_string_literal__lowercase_and_uppercase() {
+        assert!(x"ff" == decode(b"Ff"), 0);
+        assert!(x"ff" == decode(b"fF"), 0);
+        assert!(x"ff" == decode(b"FF"), 0);
+    }
+
+    #[test]
+    fun test_hex_decode_string_literal__long_hex() {
+        assert!(x"036d2416252ae1db8aedad59e14b007bee6ab94a3e77a3549a81137871604456f3" == decode(b"036d2416252ae1Db8aedAd59e14b007bee6aB94a3e77a3549a81137871604456f3"), 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EInvalidHexLength)]
+    fun test_hex_decode__invalid_length() {
+        decode(b"0");
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ENotValidHexCharacter)]
+    fun test_hex_decode__hex_literal() {
+        decode(x"ffff");
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ENotValidHexCharacter)]
+    fun test_hex_decode__invalid_string_literal() {
+        decode(b"0g");
+    }
+}

--- a/crates/sui-framework-override/sources/immutable_external_resource.move
+++ b/crates/sui-framework-override/sources/immutable_external_resource.move
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Sui types for specifying off-chain/external resources.
+///
+/// The keywords "MUST", "MUST NOT", "SHOULD", "SHOULD NOT" and "MAY" below should be interpreted as described in
+/// RFC 2119.
+///
+module sui::immutable_external_resource {
+    use sui::digest::Sha3256Digest;
+    use sui::url::{Url, inner_url};
+
+    /// ImmutableExternalResource: An arbitrary, mutable URL plus an immutable digest of the resource.
+    ///
+    /// Represents a resource that can move but must never change. Example use cases:
+    /// - NFT images.
+    /// - NFT metadata.
+    ///
+    /// `url` MUST follow RFC-3986. Clients MUST support (at least) the following schemes: ipfs, https.
+    /// `digest` MUST be set to SHA3-256(content of resource at `url`).
+    ///
+    /// Clients of this type MUST fetch the resource at `url`, compute its digest and compare it against `digest`. If
+    /// the result is false, clients SHOULD indicate that to users or ignore the resource.
+    struct ImmutableExternalResource has store, copy, drop {
+        url: Url,
+        digest: Sha3256Digest,
+    }
+
+    /// Create a `ImmutableExternalResource`, and set the immutable hash.
+    public fun new(url: Url, digest: Sha3256Digest): ImmutableExternalResource {
+        ImmutableExternalResource { url, digest }
+    }
+
+    /// Get the hash of the resource.
+    public fun digest(self: &ImmutableExternalResource): Sha3256Digest {
+        self.digest
+    }
+
+    /// Get the URL of the resource.
+    public fun url(self: &ImmutableExternalResource): Url {
+        self.url
+    }
+
+    /// Update the URL, but the digest of the resource must never change.
+    public fun update(self: &mut ImmutableExternalResource, url: Url) {
+        sui::url::update(&mut self.url, inner_url(&url))
+    }
+}

--- a/crates/sui-framework-override/sources/linked_table.move
+++ b/crates/sui-framework-override/sources/linked_table.move
@@ -1,0 +1,202 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Similar to `sui::table` but the values are linked together, allowing for ordered insertion and
+/// removal
+module sui::linked_table {
+
+use std::option::{Self, Option};
+use sui::object::{Self, UID};
+use sui::dynamic_field as field;
+use sui::tx_context::TxContext;
+
+// Attempted to destroy a non-empty table
+const ETableNotEmpty: u64 = 0;
+// Attempted to remove the front or back of an empty table
+const ETableIsEmpty: u64 = 1;
+
+struct LinkedTable<K: copy + drop + store, phantom V: store> has key, store {
+    /// the ID of this table
+    id: UID,
+    /// the number of key-value pairs in the table
+    size: u64,
+    /// the front of the table, i.e. the key of the first entry
+    head: Option<K>,
+    /// the back of the table, i.e. the key of the last entry
+    tail: Option<K>,
+}
+
+struct Node<K: copy + drop + store, V: store> has store {
+    /// the previous key
+    prev: Option<K>,
+    /// the next key
+    next: Option<K>,
+    /// the value being stored
+    value: V
+}
+
+/// Creates a new, empty table
+public fun new<K: copy + drop + store, V: store>(ctx: &mut TxContext): LinkedTable<K, V> {
+    LinkedTable {
+        id: object::new(ctx),
+        size: 0,
+        head: option::none(),
+        tail: option::none(),
+    }
+}
+
+/// Returns the key for the first element in the table, or None if the table is empty
+public fun front<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): &Option<K> {
+    &table.head
+}
+
+/// Returns the key for the last element in the table, or None if the table is empty
+public fun back<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): &Option<K> {
+    &table.tail
+}
+
+/// Inserts a key-value pair at the front of the table, i.e. the newly inserted pair will be
+/// the first element in the table
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
+/// that key `k: K`.
+public fun push_front<K: copy + drop + store, V: store>(
+    table: &mut LinkedTable<K, V>,
+    k: K,
+    value: V,
+) {
+    let old_head = option::swap_or_fill(&mut table.head, k);
+    if (option::is_none(&table.tail)) option::fill(&mut table.tail, k);
+    let prev = option::none();
+    let next = if (option::is_some(&old_head)) {
+        let old_head_k = option::destroy_some(old_head);
+        field::borrow_mut<K, Node<K, V>>(&mut table.id, old_head_k).prev = option::some(k);
+        option::some(old_head_k)
+    } else {
+        option::none()
+    };
+    field::add(&mut table.id, k, Node { prev, next, value });
+    table.size = table.size + 1;
+}
+
+/// Inserts a key-value pair at the back of the table, i.e. the newly inserted pair will be
+/// the last element in the table
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
+/// that key `k: K`.
+public fun push_back<K: copy + drop + store, V: store>(
+    table: &mut LinkedTable<K, V>,
+    k: K,
+    value: V,
+) {
+    if (option::is_none(&table.head)) option::fill(&mut table.head, k);
+    let old_tail = option::swap_or_fill(&mut table.tail, k);
+    let prev = if (option::is_some(&old_tail)) {
+        let old_tail_k = option::destroy_some(old_tail);
+        field::borrow_mut<K, Node<K, V>>(&mut table.id, old_tail_k).next = option::some(k);
+        option::some(old_tail_k)
+    } else {
+        option::none()
+    };
+    let next = option::none();
+    field::add(&mut table.id, k, Node { prev, next, value });
+    table.size = table.size + 1;
+}
+
+/// Immutable borrows the value associated with the key in the table `table: &LinkedTable<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): &V {
+    &field::borrow<K, Node<K, V>>(&table.id, k).value
+}
+
+/// Mutably borrows the value associated with the key in the table `table: &mut LinkedTable<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow_mut<K: copy + drop + store, V: store>(
+    table: &mut LinkedTable<K, V>,
+    k: K,
+): &mut V {
+    &mut field::borrow_mut<K, Node<K, V>>(&mut table.id, k).value
+}
+
+/// Borrows the key for the previous entry of the specified key `k: K` in the table
+/// `table: &LinkedTable<K, V>`. Returns None if the entry does not have a predecessor.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`
+public fun prev<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): &Option<K> {
+    &field::borrow<K, Node<K, V>>(&table.id, k).prev
+}
+
+/// Borrows the key for the next entry of the specified key `k: K` in the table
+/// `table: &LinkedTable<K, V>`. Returns None if the entry does not have a predecessor.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`
+public fun next<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): &Option<K> {
+    &field::borrow<K, Node<K, V>>(&table.id, k).next
+}
+
+/// Removes the key-value pair in the table `table: &mut LinkedTable<K, V>` and returns the value.
+/// This splices the element out of the ordering.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`. Note: this is also what happens when the table is empty.
+public fun remove<K: copy + drop + store, V: store>(table: &mut LinkedTable<K, V>, k: K): V {
+    let Node<K, V> { prev, next, value } = field::remove(&mut table.id, k);
+    table.size = table.size - 1;
+    if (option::is_some(&prev)) {
+        field::borrow_mut<K, Node<K, V>>(&mut table.id, *option::borrow(&prev)).next = next
+    };
+    if (option::is_some(&next)) {
+        field::borrow_mut<K, Node<K, V>>(&mut table.id, *option::borrow(&next)).prev = prev
+    };
+    if (option::borrow(&table.head) == &k) table.head = next;
+    if (option::borrow(&table.tail) == &k) table.tail = prev;
+    value
+}
+
+/// Removes the front of the table `table: &mut LinkedTable<K, V>` and returns the value.
+/// Aborts with `ETableIsEmpty` if the table is empty
+public fun pop_front<K: copy + drop + store, V: store>(table: &mut LinkedTable<K, V>): (K, V) {
+    assert!(option::is_some(&table.head), ETableIsEmpty);
+    let head = *option::borrow(&table.head);
+    (head, remove(table, head))
+}
+
+/// Removes the back of the table `table: &mut LinkedTable<K, V>` and returns the value.
+/// Aborts with `ETableIsEmpty` if the table is empty
+public fun pop_back<K: copy + drop + store, V: store>(table: &mut LinkedTable<K, V>): (K, V) {
+    assert!(option::is_some(&table.tail), ETableIsEmpty);
+    let tail = *option::borrow(&table.tail);
+    (tail, remove(table, tail))
+}
+
+/// Returns true iff there is a value associated with the key `k: K` in table
+/// `table: &LinkedTable<K, V>`
+public fun contains<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): bool {
+    field::exists_with_type<K, Node<K, V>>(&table.id, k)
+}
+
+/// Returns the size of the table, the number of key-value pairs
+public fun length<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): u64 {
+    table.size
+}
+
+/// Returns true iff the table is empty (if `length` returns `0`)
+public fun is_empty<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): bool {
+    table.size == 0
+}
+
+/// Destroys an empty table
+/// Aborts with `ETableNotEmpty` if the table still contains values
+public fun destroy_empty<K: copy + drop + store, V: store>(table: LinkedTable<K, V>) {
+    let LinkedTable { id, size, head: _, tail: _ } = table;
+    assert!(size == 0, ETableNotEmpty);
+    object::delete(id)
+}
+
+/// Drop a possibly non-empty table.
+/// Usable only if the value type `V` has the `drop` ability
+public fun drop<K: copy + drop + store, V: drop + store>(table: LinkedTable<K, V>) {
+    let LinkedTable { id, size: _, head: _, tail: _ } = table;
+    object::delete(id)
+}
+
+}

--- a/crates/sui-framework-override/sources/locked_coin.move
+++ b/crates/sui-framework-override/sources/locked_coin.move
@@ -1,0 +1,63 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::locked_coin {
+    use sui::balance::{Self, Balance};
+    use sui::coin::{Self, Coin};
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use sui::epoch_time_lock::{Self, EpochTimeLock};
+
+    friend sui::sui_system;
+
+    /// A coin of type `T` locked until `locked_until_epoch`.
+    struct LockedCoin<phantom T> has key {
+        id: UID,
+        balance: Balance<T>,
+        locked_until_epoch: EpochTimeLock
+    }
+
+    /// Create a LockedCoin from `balance` and transfer it to `owner`.
+    public fun new_from_balance<T>(balance: Balance<T>, locked_until_epoch: EpochTimeLock, owner: address, ctx: &mut TxContext) {
+        let locked_coin = LockedCoin {
+            id: object::new(ctx),
+            balance,
+            locked_until_epoch
+        };
+        transfer::transfer(locked_coin, owner);
+    }
+
+    /// Destruct a LockedCoin wrapper and keep the balance.
+    public(friend) fun into_balance<T>(coin: LockedCoin<T>): (Balance<T>, EpochTimeLock) {
+        let LockedCoin { id, locked_until_epoch, balance } = coin;
+        object::delete(id);
+        (balance, locked_until_epoch)
+    }
+
+    /// Public getter for the locked coin's value
+    public fun value<T>(self: &LockedCoin<T>): u64 {
+        balance::value(&self.balance)
+    }
+
+    /// Lock a coin up until `locked_until_epoch`. The input Coin<T> is deleted and a LockedCoin<T>
+    /// is transferred to the `recipient`. This function aborts if the `locked_until_epoch` is less than
+    /// or equal to the current epoch.
+    public entry fun lock_coin<T>(
+        coin: Coin<T>, recipient: address, locked_until_epoch: u64, ctx: &mut TxContext
+    ) {
+        let balance = coin::into_balance(coin);
+        new_from_balance(balance, epoch_time_lock::new(locked_until_epoch, ctx), recipient, ctx);
+    }
+
+    /// Unlock a locked coin. The function aborts if the current epoch is less than the `locked_until_epoch`
+    /// of the coin. If the check is successful, the locked coin is deleted and a Coin<T> is transferred back
+    /// to the sender.
+    public entry fun unlock_coin<T>(locked_coin: LockedCoin<T>, ctx: &mut TxContext) {
+        let LockedCoin { id, balance, locked_until_epoch } = locked_coin;
+        object::delete(id);
+        epoch_time_lock::destroy(locked_until_epoch, ctx);
+        let coin = coin::from_balance(balance, ctx);
+        transfer::transfer(coin, tx_context::sender(ctx));
+    }
+}

--- a/crates/sui-framework-override/sources/math.move
+++ b/crates/sui-framework-override/sources/math.move
@@ -1,0 +1,144 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Basic math for nicer programmability
+module sui::math {
+
+    /// Return the larger of `x` and `y`
+    public fun max(x: u64, y: u64): u64 {
+        if (x > y) {
+            x
+        } else {
+            y
+        }
+    }
+
+    /// Return the smaller of `x` and `y`
+    public fun min(x: u64, y: u64): u64 {
+        if (x < y) {
+            x
+        } else {
+            y
+        }
+    }
+
+    /// Return the absolute value of x - y
+    public fun diff(x: u64, y: u64): u64 {
+        if (x > y) {
+            x - y
+        } else {
+            y - x
+        }
+    }
+
+    /// Return the value of a base raised to a power
+    public fun pow(base: u64, exponent: u8): u64 {
+        let res = 1;
+        while (exponent >= 1) {
+            if (exponent % 2 == 0) {
+                base = base * base;
+                exponent = exponent / 2;
+            } else {
+                res = res * base;
+                exponent = exponent - 1;
+            }
+        };
+
+        res
+    }
+
+    /// Get a nearest lower integer Square Root for `x`. Given that this
+    /// function can only operate with integers, it is impossible
+    /// to get perfect (or precise) integer square root for some numbers.
+    ///
+    /// Example:
+    /// ```
+    /// math::sqrt(9) => 3
+    /// math::sqrt(8) => 2 // the nearest lower square root is 4;
+    /// ```
+    ///
+    /// In integer math, one of the possible ways to get results with more
+    /// precision is to use higher values or temporarily multiply the
+    /// value by some bigger number. Ideally if this is a square of 10 or 100.
+    ///
+    /// Example:
+    /// ```
+    /// math::sqrt(8) => 2;
+    /// math::sqrt(8 * 10000) => 282;
+    /// // now we can use this value as if it was 2.82;
+    /// // but to get the actual result, this value needs
+    /// // to be divided by 100 (because sqrt(10000)).
+    ///
+    ///
+    /// math::sqrt(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
+    /// ```
+    public fun sqrt(x: u64): u64 {
+        let bit = 1u128 << 64;
+        let res = 0u128;
+        let x = (x as u128);
+
+        while (bit != 0) {
+            if (x >= res + bit) {
+                x = x - (res + bit);
+                res = (res >> 1) + bit;
+            } else {
+                res = res >> 1;
+            };
+            bit = bit >> 2;
+        };
+
+        (res as u64)
+    }
+
+    /// Similar to math::sqrt, but for u128 numbers. Get a nearest lower integer Square Root for `x`. Given that this
+    /// function can only operate with integers, it is impossible
+    /// to get perfect (or precise) integer square root for some numbers.
+    ///
+    /// Example:
+    /// ```
+    /// math::sqrt_u128(9) => 3
+    /// math::sqrt_u128(8) => 2 // the nearest lower square root is 4;
+    /// ```
+    ///
+    /// In integer math, one of the possible ways to get results with more
+    /// precision is to use higher values or temporarily multiply the
+    /// value by some bigger number. Ideally if this is a square of 10 or 100.
+    ///
+    /// Example:
+    /// ```
+    /// math::sqrt_u128(8) => 2;
+    /// math::sqrt_u128(8 * 10000) => 282;
+    /// // now we can use this value as if it was 2.82;
+    /// // but to get the actual result, this value needs
+    /// // to be divided by 100 (because sqrt_u128(10000)).
+    ///
+    ///
+    /// math::sqrt_u128(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
+    /// ```
+    public fun sqrt_u128(x: u128): u128 {
+        let bit = 1u256 << 128;
+        let res = 0u256;
+        let x = (x as u256);
+
+        while (bit != 0) {
+            if (x >= res + bit) {
+                x = x - (res + bit);
+                res = (res >> 1) + bit;
+            } else {
+                res = res >> 1;
+            };
+            bit = bit >> 2;
+        };
+
+        (res as u128)
+    }
+
+    /// Calculate x / y, but round up the result.
+    public fun divide_and_round_up(x: u64, y: u64): u64 {
+        if (x % y == 0) {
+            x / y
+        } else {
+            x / y + 1
+        }
+    }
+}

--- a/crates/sui-framework-override/sources/object.move
+++ b/crates/sui-framework-override/sources/object.move
@@ -1,0 +1,193 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Sui object identifiers
+module sui::object {
+    use std::bcs;
+    use sui::address;
+    use sui::tx_context::{Self, TxContext};
+
+    friend sui::dynamic_field;
+    friend sui::dynamic_object_field;
+    friend sui::sui_system;
+    friend sui::transfer;
+
+    #[test_only]
+    friend sui::test_scenario;
+
+    /// The hardcoded ID for the singleton Sui System State Object.
+    const SUI_SYSTEM_STATE_OBJECT_ID: address = @0x5;
+
+    /// An object ID. This is used to reference Sui Objects.
+    /// This is *not* guaranteed to be globally unique--anyone can create an `ID` from a `UID` or
+    /// from an object, and ID's can be freely copied and dropped.
+    /// Here, the values are not globally unique because there can be multiple values of type `ID`
+    /// with the same underlying bytes. For example, `object::id(&obj)` can be called as many times
+    /// as you want for a given `obj`, and each `ID` value will be identical.
+    struct ID has copy, drop, store {
+        // We use `address` instead of `vector<u8>` here because `address` has a more
+        // compact serialization. `address` is serialized as a BCS fixed-length sequence,
+        // which saves us the length prefix we would pay for if this were `vector<u8>`.
+        // See https://github.com/diem/bcs#fixed-and-variable-length-sequences.
+        bytes: address
+    }
+
+    /// Globally unique IDs that define an object's ID in storage. Any Sui Object, that is a struct
+    /// with the `key` ability, must have `id: UID` as its first field.
+    /// These are globaly unique in the sense that no two values of type `UID` are ever equal, in
+    /// other words for any two values `id1: UID` and `id2: UID`, `id1` != `id2`.
+    /// This is a privileged type that can only be derived from a `TxContext`.
+    /// `UID` doesn't have the `drop` ability, so deleting a `UID` requires a call to `delete`.
+    struct UID has store {
+        id: ID,
+    }
+
+    // === id ===
+
+    /// Get the raw bytes of a `ID`
+    public fun id_to_bytes(id: &ID): vector<u8> {
+        bcs::to_bytes(&id.bytes)
+    }
+
+    /// Get the inner bytes of `id` as an address.
+    public fun id_to_address(id: &ID): address {
+        id.bytes
+    }
+
+    /// Make an `ID` from raw bytes.
+    public fun id_from_bytes(bytes: vector<u8>): ID {
+        id_from_address(address::from_bytes(bytes))
+    }
+
+    /// Make an `ID` from an address.
+    public fun id_from_address(bytes: address): ID {
+        ID { bytes }
+    }
+
+    // === uid ===
+
+    /// Create the `UID` for the singleton `SuiSystemState` object.
+    /// This should only be called once from `sui_system`.
+    public(friend) fun sui_system_state(): UID {
+        UID {
+            id: ID { bytes: SUI_SYSTEM_STATE_OBJECT_ID },
+        }
+    }
+
+    /// Get the inner `ID` of `uid`
+    public fun uid_as_inner(uid: &UID): &ID {
+        &uid.id
+    }
+
+    /// Get the raw bytes of a `uid`'s inner `ID`
+    public fun uid_to_inner(uid: &UID): ID {
+        uid.id
+    }
+
+    /// Get the raw bytes of a `UID`
+    public fun uid_to_bytes(uid: &UID): vector<u8> {
+        bcs::to_bytes(&uid.id.bytes)
+    }
+
+    /// Get the inner bytes of `id` as an address.
+    public fun uid_to_address(uid: &UID): address {
+        uid.id.bytes
+    }
+
+    // === any object ===
+
+    /// Create a new object. Returns the `UID` that must be stored in a Sui object.
+    /// This is the only way to create `UID`s.
+    public fun new(ctx: &mut TxContext): UID {
+        UID {
+            id: ID { bytes: tx_context::new_object(ctx) },
+        }
+    }
+
+    /// Delete the object and it's `UID`. This is the only way to eliminate a `UID`.
+    // This exists to inform Sui of object deletions. When an object
+    // gets unpacked, the programmer will have to do something with its
+    // `UID`. The implementation of this function emits a deleted
+    // system event so Sui knows to process the object deletion
+    public fun delete(id: UID) {
+        let UID { id: ID { bytes } } = id;
+        delete_impl(bytes)
+    }
+
+    /// Get the underlying `ID` of `obj`
+    public fun id<T: key>(obj: &T): ID {
+        borrow_uid(obj).id
+    }
+
+    /// Borrow the underlying `ID` of `obj`
+    public fun borrow_id<T: key>(obj: &T): &ID {
+        &borrow_uid(obj).id
+    }
+
+    /// Get the raw bytes for the underlying `ID` of `obj`
+    public fun id_bytes<T: key>(obj: &T): vector<u8> {
+        bcs::to_bytes(&borrow_uid(obj).id)
+    }
+
+    /// Get the inner bytes for the underlying `ID` of `obj`
+    public fun id_address<T: key>(obj: &T): address {
+        borrow_uid(obj).id.bytes
+    }
+
+    /// Get the `UID` for `obj`.
+    /// Safe because Sui has an extra bytecode verifier pass that forces every struct with
+    /// the `key` ability to have a distinguished `UID` field.
+    /// Cannot be made public as the access to `UID` for a given object must be privledged, and
+    /// restrictable in the object's module.
+    native fun borrow_uid<T: key>(obj: &T): &UID;
+
+    /// Generate a new UID specifically used for creating a UID from a hash
+    public(friend) fun new_uid_from_hash(bytes: address): UID {
+        record_new_uid(bytes);
+        UID { id: ID { bytes } }
+    }
+
+    // === internal functions ===
+
+    // helper for delete
+    native fun delete_impl(id: address);
+
+    // marks newly created UIDs from hash
+    native fun record_new_uid(id: address);
+
+    // Cost calibration functions
+    #[test_only]
+    public fun calibrate_address_from_bytes(bytes: vector<u8>) {
+        sui::address::from_bytes(bytes);
+    }
+    
+    #[test_only]
+    public fun calibrate_address_from_bytes_nop(bytes: vector<u8>) {
+        let _ = bytes;
+    }
+
+    #[test_only]
+    public fun calibrate_borrow_uid<T: key>(obj: &T) {
+        borrow_uid(obj);
+    }
+    #[test_only]
+    public fun calibrate_borrow_uid_nop<T: key>(obj: &T) {
+        let _ = obj;
+    }
+
+    // TBD
+
+    // #[test_only]
+    // public fun calibrate_delete_impl(id: UID) {
+    //     delete_impl(id);
+    // }
+    // #[test_only]
+    // public fun calibrate_delete_impl(_id: UID) {
+    // }
+
+    #[test_only]
+    /// Return the most recent created object ID.
+    public fun last_created(ctx: &TxContext): ID {
+        ID { bytes: tx_context::last_created_object_id(ctx) }
+    }
+}

--- a/crates/sui-framework-override/sources/object_bag.move
+++ b/crates/sui-framework-override/sources/object_bag.move
@@ -1,0 +1,105 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Similar to `sui::bag`, an `ObjectBag` is a heterogeneous map-like collection. But unlike
+/// `sui::bag`, the values bound to these dynamic fields _must_ be objects themselves. This allows
+/// for the objects to still exist in storage, which may be important for external tools.
+/// The difference is otherwise not observable from within Move.
+module sui::object_bag {
+
+use std::option::Option;
+use sui::object::{Self, ID, UID};
+use sui::dynamic_object_field as ofield;
+use sui::tx_context::TxContext;
+
+// Attempted to destroy a non-empty bag
+const EBagNotEmpty: u64 = 0;
+
+struct ObjectBag has key, store {
+    /// the ID of this bag
+    id: UID,
+    /// the number of key-value pairs in the bag
+    size: u64,
+}
+
+/// Creates a new, empty bag
+public fun new(ctx: &mut TxContext): ObjectBag {
+    ObjectBag {
+        id: object::new(ctx),
+        size: 0,
+    }
+}
+
+/// Adds a key-value pair to the bag `bag: &mut ObjectBag`
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the bag already has an entry with
+/// that key `k: K`.
+public fun add<K: copy + drop + store, V: key + store>(bag: &mut ObjectBag, k: K, v: V) {
+    ofield::add(&mut bag.id, k, v);
+    bag.size = bag.size + 1;
+}
+
+/// Immutably borrows the value associated with the key in the bag `bag: &ObjectBag`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun borrow<K: copy + drop + store, V: key + store>(bag: &ObjectBag, k: K): &V {
+    ofield::borrow(&bag.id, k)
+}
+
+/// Mutably borrows the value associated with the key in the bag `bag: &mut ObjectBag`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun borrow_mut<K: copy + drop + store, V: key + store>(bag: &mut ObjectBag, k: K): &mut V {
+    ofield::borrow_mut(&mut bag.id, k)
+}
+
+/// Mutably borrows the key-value pair in the bag `bag: &mut ObjectBag` and returns the value.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun remove<K: copy + drop + store, V: key + store>(bag: &mut ObjectBag, k: K): V {
+    let v = ofield::remove(&mut bag.id, k);
+    bag.size = bag.size - 1;
+    v
+}
+
+/// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &ObjectBag`
+public fun contains<K: copy + drop + store>(bag: &ObjectBag, k: K): bool {
+    ofield::exists_<K>(&bag.id, k)
+}
+
+/// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &ObjectBag`
+/// with an assigned value of type `V`
+public fun contains_with_type<K: copy + drop + store, V: key + store>(bag: &ObjectBag, k: K): bool {
+    ofield::exists_with_type<K, V>(&bag.id, k)
+}
+
+/// Returns the size of the bag, the number of key-value pairs
+public fun length(bag: &ObjectBag): u64 {
+    bag.size
+}
+
+/// Returns true iff the bag is empty (if `length` returns `0`)
+public fun is_empty(bag: &ObjectBag): bool {
+    bag.size == 0
+}
+
+/// Destroys an empty bag
+/// Aborts with `EBagNotEmpty` if the bag still contains values
+public fun destroy_empty(bag: ObjectBag) {
+    let ObjectBag { id, size } = bag;
+    assert!(size == 0, EBagNotEmpty);
+    object::delete(id)
+}
+
+/// Returns the ID of the object associated with the key if the bag has an entry with key `k: K`
+/// Returns none otherwise
+public fun value_id<K: copy + drop + store>(bag: &ObjectBag, k: K): Option<ID> {
+    ofield::id(&bag.id, k)
+}
+
+}

--- a/crates/sui-framework-override/sources/object_table.move
+++ b/crates/sui-framework-override/sources/object_table.move
@@ -1,0 +1,100 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Similar to `sui::table`, an `ObjectTable<K, V>` is a map-like collection. But unlike
+/// `sui::table`, the values bound to these dynamic fields _must_ be objects themselves. This allows
+/// for the objects to still exist within in storage, which may be important for external tools.
+/// The difference is otherwise not observable from within Move.
+module sui::object_table {
+
+use std::option::Option;
+use sui::object::{Self, ID, UID};
+use sui::dynamic_object_field as ofield;
+use sui::tx_context::TxContext;
+
+// Attempted to destroy a non-empty table
+const ETableNotEmpty: u64 = 0;
+
+struct ObjectTable<phantom K: copy + drop + store, phantom V: key + store> has key, store {
+    /// the ID of this table
+    id: UID,
+    /// the number of key-value pairs in the table
+    size: u64,
+}
+
+/// Creates a new, empty table
+public fun new<K: copy + drop + store, V: key + store>(ctx: &mut TxContext): ObjectTable<K, V> {
+    ObjectTable {
+        id: object::new(ctx),
+        size: 0,
+    }
+}
+
+/// Adds a key-value pair to the table `table: &mut ObjectTable<K, V>`
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
+/// that key `k: K`.
+public fun add<K: copy + drop + store, V: key + store>(table: &mut ObjectTable<K, V>, k: K, v: V) {
+    ofield::add(&mut table.id, k, v);
+    table.size = table.size + 1;
+}
+
+/// Immutable borrows the value associated with the key in the table `table: &ObjectTable<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>, k: K): &V {
+    ofield::borrow(&table.id, k)
+}
+
+/// Mutably borrows the value associated with the key in the table `table: &mut ObjectTable<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow_mut<K: copy + drop + store, V: key + store>(
+    table: &mut ObjectTable<K, V>,
+    k: K,
+): &mut V {
+    ofield::borrow_mut(&mut table.id, k)
+}
+
+/// Removes the key-value pair in the table `table: &mut ObjectTable<K, V>` and returns the value.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun remove<K: copy + drop + store, V: key + store>(table: &mut ObjectTable<K, V>, k: K): V {
+    let v = ofield::remove(&mut table.id, k);
+    table.size = table.size - 1;
+    v
+}
+
+/// Returns true iff there is a value associated with the key `k: K` in table
+/// `table: &ObjectTable<K, V>`
+public fun contains<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>, k: K): bool {
+    ofield::exists_<K>(&table.id, k)
+}
+
+/// Returns the size of the table, the number of key-value pairs
+public fun length<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>): u64 {
+    table.size
+}
+
+/// Returns true iff the table is empty (if `length` returns `0`)
+public fun is_empty<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>): bool {
+    table.size == 0
+}
+
+/// Destroys an empty table
+/// Aborts with `ETableNotEmpty` if the table still contains values
+public fun destroy_empty<K: copy + drop + store, V: key + store>(table: ObjectTable<K, V>) {
+    let ObjectTable { id, size } = table;
+    assert!(size == 0, ETableNotEmpty);
+    object::delete(id)
+}
+
+/// Returns the ID of the object associated with the key if the table has an entry with key `k: K`
+/// Returns none otherwise
+public fun value_id<K: copy + drop + store, V: key + store>(
+    table: &ObjectTable<K, V>,
+    k: K,
+): Option<ID> {
+    ofield::id(&table.id, k)
+}
+
+}

--- a/crates/sui-framework-override/sources/pay.move
+++ b/crates/sui-framework-override/sources/pay.move
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This module provides handy functionality for wallets and `sui::Coin` management.
+module sui::pay {
+    use sui::tx_context::{Self, TxContext};
+    use sui::coin::{Self, Coin};
+    use sui::transfer;
+    use std::vector;
+
+    /// For when empty vector is supplied into join function.
+    const ENoCoins: u64 = 0;
+
+    /// Transfer `c` to the sender of the current transaction
+    public fun keep<T>(c: Coin<T>, ctx: &TxContext) {
+        transfer::transfer(c, tx_context::sender(ctx))
+    }
+
+    /// Split coin `self` to two coins, one with balance `split_amount`,
+    /// and the remaining balance is left is `self`.
+    public entry fun split<T>(
+        self: &mut Coin<T>, split_amount: u64, ctx: &mut TxContext
+    ) {
+        keep(coin::split(self, split_amount, ctx), ctx)
+    }
+
+    /// Split coin `self` into multiple coins, each with balance specified
+    /// in `split_amounts`. Remaining balance is left in `self`.
+    public entry fun split_vec<T>(
+        self: &mut Coin<T>, split_amounts: vector<u64>, ctx: &mut TxContext
+    ) {
+        let (i, len) = (0, vector::length(&split_amounts));
+        while (i < len) {
+            split(self, *vector::borrow(&split_amounts, i), ctx);
+            i = i + 1;
+        };
+    }
+
+    /// Send `amount` units of `c` to `recipient`
+    /// Aborts with `EVALUE` if `amount` is greater than or equal to `amount`
+    public entry fun split_and_transfer<T>(
+        c: &mut Coin<T>, amount: u64, recipient: address, ctx: &mut TxContext
+    ) {
+        transfer::transfer(coin::split(c, amount, ctx), recipient)
+    }
+
+
+    /// Divide coin `self` into `n - 1` coins with equal balances. If the balance is
+    /// not evenly divisible by `n`, the remainder is left in `self`.
+    public entry fun divide_and_keep<T>(
+        self: &mut Coin<T>, n: u64, ctx: &mut TxContext
+    ) {
+        let vec: vector<Coin<T>> = coin::divide_into_n(self, n, ctx);
+        let (i, len) = (0, vector::length(&vec));
+        while (i < len) {
+            transfer::transfer(vector::pop_back(&mut vec), tx_context::sender(ctx));
+            i = i + 1;
+        };
+        vector::destroy_empty(vec);
+    }
+
+    /// Join `coin` into `self`. Re-exports `coin::join` function.
+    public entry fun join<T>(self: &mut Coin<T>, coin: Coin<T>) {
+        coin::join(self, coin)
+    }
+
+    /// Join everything in `coins` with `self`
+    public entry fun join_vec<T>(self: &mut Coin<T>, coins: vector<Coin<T>>) {
+        let (i, len) = (0, vector::length(&coins));
+        while (i < len) {
+            let coin = vector::pop_back(&mut coins);
+            coin::join(self, coin);
+            i = i + 1
+        };
+        // safe because we've drained the vector
+        vector::destroy_empty(coins)
+    }
+
+    /// Join a vector of `Coin` into a single object and transfer it to `receiver`.
+    public entry fun join_vec_and_transfer<T>(coins: vector<Coin<T>>, receiver: address) {
+        assert!(vector::length(&coins) > 0, ENoCoins);
+
+        let self = vector::pop_back(&mut coins);
+        join_vec(&mut self, coins);
+        transfer::transfer(self, receiver)
+    }
+}

--- a/crates/sui-framework-override/sources/priority_queue.move
+++ b/crates/sui-framework-override/sources/priority_queue.move
@@ -1,0 +1,137 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Priority queue implemented using a max heap.
+module sui::priority_queue {
+    use std::vector;
+
+    /// For when heap is empty and there's no data to pop.
+    const EPopFromEmptyHeap: u64 = 0;
+
+    struct PriorityQueue<T: drop> has store, drop {
+        entries: vector<Entry<T>>,
+    }
+
+    struct Entry<T: drop> has store, drop {
+        priority: u64, // higher value means higher priority and will be popped first
+        value: T,
+    }
+
+    /// Create a new priority queue from the entries.
+    public fun new<T: drop>(entries: vector<Entry<T>>) : PriorityQueue<T> {
+        let len = vector::length(&entries);
+        let i = len / 2;
+        while (i > 0) {
+            i = i - 1;
+            max_heapify_recursive(&mut entries, len, i);
+        };
+        PriorityQueue { entries }
+    }
+
+    /// Pop the entry with the highest priority value.
+    public fun pop_max<T: drop>(pq: &mut PriorityQueue<T>) : (u64, T) {
+        let len = vector::length(&pq.entries);
+        assert!(len > 0, EPopFromEmptyHeap);
+        let Entry { priority, value } = vector::remove(&mut pq.entries, 0);
+        max_heapify_recursive(&mut pq.entries, len - 1, 0);
+        (priority, value)
+    }
+
+    /// Insert a new entry into the queue.
+    public fun insert<T: drop>(pq: &mut PriorityQueue<T>, priority: u64, value: T) {
+        vector::push_back(&mut pq.entries, Entry { priority, value});
+        let index = vector::length(&pq.entries) - 1;
+        restore_heap_recursive(&mut pq.entries, index);
+    }
+
+    public fun new_entry<T: drop>(priority: u64, value: T): Entry<T> {
+        Entry { priority, value }
+    }
+
+    public fun create_entries<T: drop>(p: vector<u64>, v: vector<T>): vector<Entry<T>> {
+        let len = vector::length(&p);
+        assert!(vector::length(&v) == len, 0);
+        let res = vector::empty();
+        let i = 0;
+        while (i < len) {
+            let priority = vector::remove(&mut p, 0);
+            let value = vector::remove(&mut v, 0);
+            vector::push_back(&mut res, Entry { priority, value });
+            i = i + 1;
+        };
+        res
+    }
+
+    // TODO: implement iterative version too and see performance difference.
+    fun restore_heap_recursive<T: drop>(v: &mut vector<Entry<T>>, i: u64) {
+        if (i == 0) {
+            return
+        };
+        let parent = (i - 1) / 2;
+
+        // If new elem is greater than its parent, swap them and recursively
+        // do the restoration upwards.
+        if (vector::borrow(v, i).priority > vector::borrow(v, parent).priority) {
+            vector::swap(v, i, parent);
+            restore_heap_recursive(v, parent);
+        }
+    }
+
+    spec restore_heap_recursive {
+        pragma opaque;
+    }
+
+    fun max_heapify_recursive<T: drop>(v: &mut vector<Entry<T>>, len: u64, i: u64) {
+        if (len == 0) {
+            return
+        };
+        assert!(i < len, 1);
+        let left = i * 2 + 1;
+        let right = left + 1;
+        let max = i;
+        if (left < len && vector::borrow(v, left).priority> vector::borrow(v, max).priority) {
+            max = left;
+        };
+        if (right < len && vector::borrow(v, right).priority > vector::borrow(v, max).priority) {
+            max = right;
+        };
+        if (max != i) {
+            vector::swap(v, max, i);
+            max_heapify_recursive(v, len, max);
+        }
+    }
+
+    spec max_heapify_recursive {
+        pragma opaque;
+    }
+
+    #[test]
+    fun test_pq() {
+        let h = new(create_entries(vector[3,1,4,2,5,2], vector[10, 20, 30, 40, 50, 60]));
+        check_pop_max(&mut h, 5, 50);
+        check_pop_max(&mut h, 4, 30);
+        check_pop_max(&mut h, 3, 10);
+        insert(&mut h, 7, 70);
+        check_pop_max(&mut h, 7, 70);
+        check_pop_max(&mut h, 2, 40);
+        insert(&mut h, 0, 80);
+        check_pop_max(&mut h, 2, 60);
+        check_pop_max(&mut h, 1, 20);
+        check_pop_max(&mut h, 0, 80);
+
+
+        let h = new(create_entries(vector[5,3,1,2,4], vector[10, 20, 30, 40, 50]));
+        check_pop_max(&mut h, 5, 10);
+        check_pop_max(&mut h, 4, 50);
+        check_pop_max(&mut h, 3, 20);
+        check_pop_max(&mut h, 2, 40);
+        check_pop_max(&mut h, 1, 30);
+    }
+
+    #[test_only]
+    fun check_pop_max(h: &mut PriorityQueue<u64>, expected_priority: u64, expected_value: u64) {
+        let (priority, value) = pop_max(h);
+        assert!(priority == expected_priority, 0);
+        assert!(value == expected_value, 0);
+    }
+}

--- a/crates/sui-framework-override/sources/publisher.move
+++ b/crates/sui-framework-override/sources/publisher.move
@@ -1,0 +1,133 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module that allows creation and proof of publishing.
+/// Based on the type name reflection; requires an OTW to claim
+/// in the module initializer.
+module sui::publisher {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{TxContext, sender};
+    use std::ascii::String;
+    use std::type_name;
+    use sui::types;
+
+    /// Tried to claim ownership using a type that isn't a one-time witness.
+    const ENotOneTimeWitness: u64 = 0;
+
+    /// This type can only be created in the transaction that
+    /// generates a module, by consuming its one-time witness, so it
+    /// can be used to identify the address that published the package
+    /// a type originated from.
+    struct Publisher has key, store {
+        id: UID,
+        package: String,
+        module_name: String,
+    }
+
+    /// Claim a Publisher object.
+    /// Requires a One-Time-Witness to prove ownership. Due to this constraint
+    /// there can be only one Publisher object per module but multiple per package (!).
+    public fun claim<OTW: drop>(otw: OTW, ctx: &mut TxContext): Publisher {
+        assert!(types::is_one_time_witness(&otw), ENotOneTimeWitness);
+
+        let type = type_name::get<OTW>();
+
+        Publisher {
+            id: object::new(ctx),
+            package: type_name::get_address(&type),
+            module_name: type_name::get_module(&type),
+        }
+    }
+
+    /// Claim a Publisher object and send it to transaction sender.
+    /// Since this function can only be called in the module initializer,
+    /// the sender is the publisher.
+    public fun claim_and_keep<OTW: drop>(otw: OTW, ctx: &mut TxContext) {
+        sui::transfer::transfer(claim(otw, ctx), sender(ctx))
+    }
+
+    /// Destroy a Publisher object effectively removing all privileges
+    /// associated with it.
+    public fun burn(self: Publisher) {
+        let Publisher { id, package: _, module_name: _ } = self;
+        object::delete(id);
+    }
+
+    /// Check whether type belongs to the same package as the publisher object.
+    public fun is_package<T>(self: &Publisher): bool {
+        let type = type_name::get<T>();
+
+        (type_name::get_address(&type) == self.package)
+    }
+
+    /// Check whether a type belogs to the same module as the publisher object.
+    public fun is_module<T>(self: &Publisher): bool {
+        let type = type_name::get<T>();
+
+        (type_name::get_address(&type) == self.package)
+            && (type_name::get_module(&type) == self.module_name)
+    }
+
+    /// Read the name of the module.
+    public fun module_name(self: &Publisher): &String {
+        &self.module_name
+    }
+
+    /// Read the package address string.
+    public fun package(self: &Publisher): &String {
+        &self.package
+    }
+
+    #[test_only]
+    /// Test-only function to claim a Publisher object bypassing OTW check.
+    public fun test_claim<OTW: drop>(_: OTW, ctx: &mut TxContext): Publisher {
+        let type = type_name::get<OTW>();
+
+        Publisher {
+            id: object::new(ctx),
+            package: type_name::get_address(&type),
+            module_name: type_name::get_module(&type),
+        }
+    }
+}
+
+#[test_only]
+module sui::test_publisher {
+    use std::ascii;
+    use sui::publisher;
+    use sui::test_scenario::{Self as test, Scenario, ctx};
+
+    /// OTW for the test_publisher module
+    struct TEST_OTW has drop {}
+
+    /// Type to compare against
+    struct CustomType {}
+
+    #[test]
+    fun test_is_package() {
+        let test = test::begin(@0x1);
+        let pub = publisher::test_claim(TEST_OTW {}, ctx(&mut test));
+
+        assert!(publisher::is_package<CustomType>(&pub), 0);
+        assert!(publisher::is_package<Scenario>(&pub), 0);
+
+        assert!(&ascii::string(b"0000000000000000000000000000000000000002") == publisher::package(&pub), 0);
+
+        publisher::burn(pub);
+        test::end(test);
+    }
+
+    #[test]
+    fun test_is_module() {
+        let test = test::begin(@0x1);
+        let pub = publisher::test_claim(TEST_OTW {}, ctx(&mut test));
+
+        assert!(publisher::is_module<CustomType>(&pub), 0);
+        assert!(publisher::is_module<Scenario>(&pub) == false, 0);
+
+        assert!(&ascii::string(b"test_publisher") == publisher::module_name(&pub), 0);
+
+        publisher::burn(pub);
+        test::end(test);
+    }
+}

--- a/crates/sui-framework-override/sources/safe.move
+++ b/crates/sui-framework-override/sources/safe.move
@@ -1,0 +1,172 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// The Safe standard is a minimalistic shared wrapper around a coin. It provides a way for users to provide third-party dApps with
+/// the capability to transfer coins away from their wallets, if they are provided with the correct permission.
+module sui::safe {
+    use sui::object::{Self, ID, UID};
+    use sui::tx_context::{TxContext, sender};
+    use sui::transfer::Self;
+    use sui::balance::{Self, Balance};
+    use sui::coin::{Self, Coin};
+    use sui::vec_set::{Self, VecSet};
+
+    const MAX_CAPABILITY_ISSUABLE: u64 = 1000;
+
+    // Errors
+    const INVALID_TRANSFER_CAPABILITY: u64 = 0;
+    const INVALID_OWNER_CAPABILITY: u64 = 1;
+    const TRANSFER_CAPABILITY_REVOKED: u64 = 2;
+    const OVERDRAWN: u64 = 3;
+
+    //
+    /// Allows any holder of a capability to transfer a fixed amount of assets from the safe.
+    /// Useful in situations like an NFT marketplace where you wish to buy the NFTs at a specific price.
+    /// 
+    /// @ownership: Shared
+    /// 
+    struct Safe<phantom T> has key {
+        id: UID,
+        balance: Balance<T>,
+        allowed_safes: VecSet<ID>,
+    }
+
+    struct OwnerCapability<phantom T> has key, store {
+        id: UID,
+        safe_id: ID,
+    }
+
+    ///
+    /// Allows the owner of the capability to take `amount` of coins from the box.
+    ///
+    /// @ownership: Owned
+    ///
+    struct TransferCapability<phantom T> has store, key {
+        id: UID,
+        safe_id: ID,
+        // The amount that the user is able to transfer.
+        amount: u64,
+    }
+
+    //////////////////////////////////////////////////////
+    /// HELPER FUNCTIONS
+    //////////////////////////////////////////////////////
+    
+    /// Check that the capability has not yet been revoked by the owner.
+    fun check_capability_validity<T>(safe: &Safe<T>, capability: &TransferCapability<T>) {
+        // Check that the ids match
+        assert!(object::id(safe) == capability.safe_id, INVALID_TRANSFER_CAPABILITY);
+        // Check that it has not been cancelled
+        assert!(vec_set::contains(&safe.allowed_safes, &object::id(capability)), TRANSFER_CAPABILITY_REVOKED);
+    }
+
+    fun check_owner_capability_validity<T>(safe: &Safe<T>, capability: &OwnerCapability<T>) {
+        assert!(object::id(safe) == capability.safe_id, INVALID_OWNER_CAPABILITY);
+    }
+
+    /// Helper function to create a capability.
+    fun create_capability_<T>(safe: &mut Safe<T>, withdraw_amount: u64, ctx: &mut TxContext): TransferCapability<T> {
+        let cap_id = object::new(ctx);
+        vec_set::insert(&mut safe.allowed_safes, object::uid_to_inner(&cap_id));
+
+        let capability = TransferCapability {
+            id: cap_id,
+            safe_id: object::uid_to_inner(&safe.id),
+            amount: withdraw_amount,
+        };
+
+        capability
+    }
+
+    //////////////////////////////////////////////////////
+    /// PUBLIC FUNCTIONS
+    //////////////////////////////////////////////////////
+    
+    public fun balance<T>(safe: &Safe<T>): &Balance<T> {
+        &safe.balance
+    }
+
+    /// Wrap a coin around a safe.
+    /// a trusted party (or smart contract) to transfer the object out.
+    public fun create_<T>(balance: Balance<T>, ctx: &mut TxContext): OwnerCapability<T> {
+        let safe = Safe {
+            id: object::new(ctx),
+            balance,
+            allowed_safes: vec_set::empty(),
+        };
+        let cap = OwnerCapability {
+            id: object::new(ctx),
+            safe_id: object::id(&safe),
+        };
+        transfer::share_object(safe);
+        cap
+    }
+
+    public entry fun create<T>(coin: Coin<T>, ctx: &mut TxContext) {
+        let balance = coin::into_balance(coin);
+        let cap = create_<T>(balance, ctx);
+        transfer::transfer(cap, sender(ctx));
+    }
+
+    public entry fun create_empty<T>(ctx: &mut TxContext) {
+        let empty_balance = balance::zero<T>();
+        let cap = create_(empty_balance, ctx);
+        transfer::transfer(cap, sender(ctx));
+    }
+
+    /// Deposit funds to the safe
+    public fun deposit_<T>(safe: &mut Safe<T>, balance: Balance<T>) {
+        balance::join(&mut safe.balance, balance);
+    }
+
+    /// Deposit funds to the safe
+    public entry fun deposit<T>(safe: &mut Safe<T>, coin: Coin<T>) {
+        let balance = coin::into_balance(coin);
+        deposit_<T>(safe, balance);
+    }
+
+    /// Withdraw coins from the safe as a `OwnerCapability` holder
+    public fun withdraw_<T>(safe: &mut Safe<T>, capability: &OwnerCapability<T>, withdraw_amount: u64): Balance<T> {
+        // Ensures that only the owner can withdraw from the safe.
+        check_owner_capability_validity(safe, capability);
+        balance::split(&mut safe.balance, withdraw_amount)
+    }
+
+    /// Withdraw coins from the safe as a `OwnerCapability` holder
+    public entry fun withdraw<T>(safe: &mut Safe<T>, capability: &OwnerCapability<T>, withdraw_amount: u64, ctx: &mut TxContext) {
+        let balance = withdraw_(safe, capability, withdraw_amount);
+        let coin = coin::from_balance(balance, ctx);
+        transfer::transfer(coin, sender(ctx));
+    }
+
+    /// Withdraw coins from the safe as a `TransferCapability` holder.
+    public fun debit<T>(safe: &mut Safe<T>, capability: &mut TransferCapability<T>, withdraw_amount: u64): Balance<T> {
+        // Check the validity of the capability
+        check_capability_validity(safe, capability);
+
+        // Withdraw funds
+        assert!(capability.amount >= withdraw_amount, OVERDRAWN);
+        capability.amount = capability.amount - withdraw_amount;
+        balance::split(&mut safe.balance, withdraw_amount)
+    }
+
+    /// Revoke a `TransferCapability` as an `OwnerCapability` holder
+    public entry fun revoke_transfer_capability<T>(safe: &mut Safe<T>, capability: &OwnerCapability<T>, capability_id: ID) {
+        // Ensures that only the owner can withdraw from the safe.
+        check_owner_capability_validity(safe, capability);
+        vec_set::remove(&mut safe.allowed_safes, &capability_id);
+    }
+
+    /// Revoke a `TransferCapability` as its owner
+    public entry fun self_revoke_transfer_capability<T>(safe: &mut Safe<T>, capability: &TransferCapability<T>) {
+        check_capability_validity(safe, capability);
+        vec_set::remove(&mut safe.allowed_safes, &object::id(capability));
+    }
+
+    /// Create `TransferCapability` as an `OwnerCapability` holder
+    public fun create_transfer_capability<T>(safe: &mut Safe<T>, capability: &OwnerCapability<T>, withdraw_amount: u64, ctx: &mut TxContext): TransferCapability<T> {
+        // Ensures that only the owner can withdraw from the safe.
+        check_owner_capability_validity(safe, capability);
+        create_capability_(safe, withdraw_amount, ctx)
+    }
+}

--- a/crates/sui-framework-override/sources/sui.move
+++ b/crates/sui-framework-override/sources/sui.move
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Coin<SUI> is the token used to pay for gas in Sui.
+/// It has 9 decimals, and the smallest unit (10^-9) is called "mist".
+module sui::sui {
+    use std::option;
+    use sui::tx_context::TxContext;
+    use sui::balance::Supply;
+    use sui::transfer;
+    use sui::coin;
+    use sui::event;
+
+    friend sui::genesis;
+
+    /// Name of the coin
+    struct SUI has drop {}
+
+    struct Canary has copy, drop { value: u64 }
+    public entry fun coal_mine() {
+        event::emit(Canary { value: 43 })
+    }
+
+    /// Register the `SUI` Coin to acquire its `Supply`.
+    /// This should be called only once during genesis creation.
+    public(friend) fun new(ctx: &mut TxContext): Supply<SUI> {
+        let (treasury, metadata) = coin::create_currency(
+            SUI {}, 
+            9,
+            b"SUI",
+            b"Sui",
+            // TODO: add appropriate description and logo url
+            b"",
+            option::none(),
+            ctx
+        );
+        transfer::freeze_object(metadata);
+        coin::treasury_into_supply(treasury)
+    }
+
+    public entry fun transfer(c: coin::Coin<SUI>, recipient: address) {
+        transfer::transfer(c, recipient)
+    }
+}

--- a/crates/sui-framework-override/sources/table.move
+++ b/crates/sui-framework-override/sources/table.move
@@ -1,0 +1,104 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A table is a map-like collection. But unlike a traditional collection, it's keys and values are
+/// not stored within the `Table` value, but instead are stored using Sui's object system. The
+/// `Table` struct acts only as a handle into the object system to retrieve those keys and values.
+/// Note that this means that `Table` values with exactly the same key-value mapping will not be
+/// equal, with `==`, at runtime. For example
+/// ```
+/// let table1 = table::new<u64, bool>();
+/// let table2 = table::new<u64, bool>();
+/// table::add(&mut table1, 0, false);
+/// table::add(&mut table1, 1, true);
+/// table::add(&mut table2, 0, false);
+/// table::add(&mut table2, 1, true);
+/// // table1 does not equal table2, despite having the same entries
+/// assert!(&table1 != &table2, 0);
+/// ```
+module sui::table {
+
+use sui::object::{Self, UID};
+use sui::dynamic_field as field;
+use sui::tx_context::TxContext;
+
+// Attempted to destroy a non-empty table
+const ETableNotEmpty: u64 = 0;
+
+struct Table<phantom K: copy + drop + store, phantom V: store> has key, store {
+    /// the ID of this table
+    id: UID,
+    /// the number of key-value pairs in the table
+    size: u64,
+}
+
+/// Creates a new, empty table
+public fun new<K: copy + drop + store, V: store>(ctx: &mut TxContext): Table<K, V> {
+    Table {
+        id: object::new(ctx),
+        size: 0,
+    }
+}
+
+/// Adds a key-value pair to the table `table: &mut Table<K, V>`
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
+/// that key `k: K`.
+public fun add<K: copy + drop + store, V: store>(table: &mut Table<K, V>, k: K, v: V) {
+    field::add(&mut table.id, k, v);
+    table.size = table.size + 1;
+}
+
+/// Immutable borrows the value associated with the key in the table `table: &Table<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow<K: copy + drop + store, V: store>(table: &Table<K, V>, k: K): &V {
+    field::borrow(&table.id, k)
+}
+
+/// Mutably borrows the value associated with the key in the table `table: &mut Table<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow_mut<K: copy + drop + store, V: store>(table: &mut Table<K, V>, k: K): &mut V {
+    field::borrow_mut(&mut table.id, k)
+}
+
+/// Removes the key-value pair in the table `table: &mut Table<K, V>` and returns the value.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun remove<K: copy + drop + store, V: store>(table: &mut Table<K, V>, k: K): V {
+    let v = field::remove(&mut table.id, k);
+    table.size = table.size - 1;
+    v
+}
+
+/// Returns true iff there is a value associated with the key `k: K` in table `table: &Table<K, V>`
+public fun contains<K: copy + drop + store, V: store>(table: &Table<K, V>, k: K): bool {
+    field::exists_with_type<K, V>(&table.id, k)
+}
+
+/// Returns the size of the table, the number of key-value pairs
+public fun length<K: copy + drop + store, V: store>(table: &Table<K, V>): u64 {
+    table.size
+}
+
+/// Returns true iff the table is empty (if `length` returns `0`)
+public fun is_empty<K: copy + drop + store, V: store>(table: &Table<K, V>): bool {
+    table.size == 0
+}
+
+/// Destroys an empty table
+/// Aborts with `ETableNotEmpty` if the table still contains values
+public fun destroy_empty<K: copy + drop + store, V: store>(table: Table<K, V>) {
+    let Table { id, size } = table;
+    assert!(size == 0, ETableNotEmpty);
+    object::delete(id)
+}
+
+/// Drop a possibly non-empty table.
+/// Usable only if the value type `V` has the `drop` ability
+public fun drop<K: copy + drop + store, V: drop + store>(table: Table<K, V>) {
+    let Table { id, size: _ } = table;
+    object::delete(id)
+}
+
+}

--- a/crates/sui-framework-override/sources/table_vec.move
+++ b/crates/sui-framework-override/sources/table_vec.move
@@ -1,0 +1,77 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A basic scalable vector library implemented using `Table`.
+module sui::table_vec {
+    use sui::table::{Self, Table};
+    use sui::tx_context::TxContext;
+
+    struct TableVec<phantom Element: store> has store {
+        /// The contents of the table vector.
+        contents: Table<u64, Element>,
+    }
+
+    const EINDEX_OUT_OF_BOUND: u64 = 0;
+    const ETABLE_NONEMPTY: u64 = 1;
+
+    /// Create an empty TableVec.
+    public fun empty<Element: store>(ctx: &mut TxContext): TableVec<Element> {
+        TableVec {
+            contents: table::new(ctx)
+        }
+    }
+
+    /// Return a TableVec of size one containing element `e`.
+    public fun singleton<Element: store>(e: Element, ctx: &mut TxContext): TableVec<Element> {
+        let t = empty(ctx);
+        push_back(&mut t, e);
+        t
+    }
+
+    /// Return the length of the TableVec.
+    public fun length<Element: store>(t: &TableVec<Element>): u64 {
+        table::length(&t.contents)
+    }
+
+    /// Return if the TableVec is empty or not.
+    public fun is_empty<Element: store>(t: &TableVec<Element>): bool {
+        length(t) == 0
+    }
+
+    /// Acquire an immutable reference to the `i`th element of the TableVec `t`.
+    /// Aborts if `i` is out of bounds.
+    public fun borrow<Element: store>(t: &TableVec<Element>, i: u64): &Element {
+        assert!(length(t) > i, EINDEX_OUT_OF_BOUND);
+        table::borrow(&t.contents, i)
+    }
+
+    /// Add element `e` to the end of the TableVec `t`.
+    public fun push_back<Element: store>(t: &mut TableVec<Element>, e: Element) {
+        let key = length(t);
+        table::add(&mut t.contents, key, e);
+    }
+
+    /// Return a mutable reference to the `i`th element in the TableVec `t`.
+    /// Aborts if `i` is out of bounds.
+    public fun borrow_mut<Element: store>(t: &mut TableVec<Element>, i: u64): &mut Element {
+        assert!(length(t) > i, EINDEX_OUT_OF_BOUND);
+        table::borrow_mut(&mut t.contents, i)
+    }
+
+    /// Pop an element from the end of TableVec `t`.
+    /// Aborts if `t` is empty.
+    public fun pop_back<Element: store>(t: &mut TableVec<Element>): Element {
+        let length = length(t);
+        assert!(length > 0, EINDEX_OUT_OF_BOUND);
+        table::remove(&mut t.contents, length - 1)
+    }
+
+    /// Destroy the TableVec `t`.
+    /// Aborts if `t` is not empty.
+    public fun destroy_empty<Element: store>(t: TableVec<Element>) {
+        assert!(length(&t) == 0, ETABLE_NONEMPTY);
+        let TableVec { contents } = t;
+        table::destroy_empty(contents);
+    }
+
+}

--- a/crates/sui-framework-override/sources/test/test_scenario.move
+++ b/crates/sui-framework-override/sources/test/test_scenario.move
@@ -1,0 +1,346 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::test_scenario {
+    use std::option::{Self, Option};
+    use sui::object::{Self, ID, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::vec_map::VecMap;
+
+    /// the transaction failed when generating these effects. For example, a circular ownership
+    /// of objects was created
+    const ECouldNotGenerateEffects: u64 = 0;
+
+    /// Transaction ended without all shared and immutable objects being returned or with those
+    /// objects being transferred or wrapped
+    const EInvalidSharedOrImmutableUsage: u64 = 1;
+
+    /// Attempted to return an object to the inventory that was not previously removed from the
+    /// inventory during the current transaction. Can happen if the user attempts to call
+    /// `return_to_address` on a locally constructed object rather than one returned from a
+    /// `test_scenario` function such as `take_from_address`.
+    const ECantReturnObject: u64 = 2;
+
+    /// Attempted to retrieve an object of a particular type from the inventory, but it is empty.
+    /// Can happen if the user already transferred the object or a previous transaction failed to
+    /// transfer the object to the user.
+    const EEmptyInventory: u64 = 3;
+
+    /// Object of that ID was not found in that inventory. It was possibly already taken
+    const EObjectNotFound: u64 = 4;
+
+    /// Utility for mocking a multi-transaction Sui execution in a single Move procedure.
+    /// A `Scenario` maintains a view of the global object pool built up by the execution.
+    /// These objects can be accessed via functions like `take_from_sender`, which gives the
+    /// transaction sender access to objects in (only) their inventory.
+    /// Example usage:
+    /// ```
+    /// let addr1: address = 0;
+    /// let addr2: address = 1;
+    /// // begin a test scenario in a context where addr1 is the sender
+    /// let scenario = &mut test_scenario::begin(addr1);
+    /// // addr1 sends an object to addr2
+    /// {
+    ///     let some_object: SomeObject = ... // construct an object
+    ///     transfer::transfer(some_object, copy addr2)
+    /// };
+    /// // end the first transaction and begin a new one where addr2 is the sender
+    /// // Starting a new transaction moves any objects transferred into their respective
+    /// // inventiories. In other words, if you call `take_from_sender` before `next_tx`, `addr2`
+    /// // will not yet have `some_object`
+    /// test_scenario::next_tx(scenario, addr2);
+    /// {
+    ///     // remove the SomeObject value from addr2's inventory
+    ///     let obj = test_scenario::take_from_sender<SomeObject>(scenario);
+    ///     // use it to test some function that needs this value
+    ///     SomeObject::some_function(obj)
+    /// };
+    /// ... // more txes
+    /// test_scenario::end(scenario);
+    /// ```
+    struct Scenario {
+        txn_number: u64,
+        ctx: TxContext,
+    }
+
+    /// The effects of a transaction
+    struct TransactionEffects has drop {
+        /// The objects created this transaction
+        created: vector<ID>,
+        /// The objects written/modified this transaction
+        written: vector<ID>,
+        /// The objects deleted this transaction
+        deleted: vector<ID>,
+        /// The objects transferred to an account this transaction
+        transferred_to_account: VecMap<ID, /* owner */ address>,
+        /// The objects transferred to an object this transaction
+        transferred_to_object: VecMap<ID, /* owner */ ID>,
+        /// The objects shared this transaction
+        shared: vector<ID>,
+        /// The objects frozen this transaction
+        frozen: vector<ID>,
+        /// The number of user events emmitted this transaction
+        num_user_events: u64,
+    }
+
+    /// Begin a new multi-transaction test scenario in a context where `sender` is the tx sender
+    public fun begin(sender: address): Scenario {
+        Scenario {
+            txn_number: 0,
+            ctx: tx_context::new_from_hint(sender, 0, 0, 0),
+        }
+    }
+
+    /// Advance the scenario to a new transaction where `sender` is the transaction sender
+    /// All objects transferred will be moved into the inventories of the account or the global
+    /// inventory. In other words, in order to access an object with one of the various "take"
+    /// functions below, e.g. `take_from_address_by_id`, the transaction must first be ended via
+    /// `next_tx`.
+    /// Returns the results from the previous transaction
+    /// Will abort if shared or immutable objects were deleted, transferred, or wrapped.
+    /// Will abort if TransactionEffects cannot be generated
+    public fun next_tx(scenario: &mut Scenario, sender: address): TransactionEffects {
+        // create a seed for new transaction digest to ensure that this tx has a different
+        // digest (and consequently, different object ID's) than the previous tx
+        scenario.txn_number = scenario.txn_number + 1;
+        let epoch = tx_context::epoch(&scenario.ctx);
+        scenario.ctx = tx_context::new_from_hint(sender,  scenario.txn_number, epoch, 0);
+        // end the transaction
+        end_transaction()
+    }
+
+    /// Advance the scenario to a new epoch and end the transaction
+    /// See `next_transaction` for further details
+    public fun next_epoch(scenario: &mut Scenario, sender: address): TransactionEffects {
+        tx_context::increment_epoch_number(&mut scenario.ctx);
+        next_tx(scenario, sender)
+    }
+
+    /// Ends the test scenario
+    /// Returns the results from the final transaction
+    /// Will abort if shared or immutable objects were deleted, transferred, or wrapped.
+    /// Will abort if TransactionEffects cannot be generated
+    public fun end(scenario: Scenario): TransactionEffects {
+        let Scenario { txn_number: _, ctx: _ } = scenario;
+        end_transaction()
+    }
+
+    // == accessors and helpers ==
+
+    /// Return the `TxContext` associated with this `scenario`
+    public fun ctx(scenario: &mut Scenario): &mut TxContext {
+        &mut scenario.ctx
+    }
+
+    /// Generate a fresh ID for the current tx associated with this `scenario`
+    public fun new_object(scenario: &mut Scenario): UID {
+        object::new(&mut scenario.ctx)
+    }
+
+    /// Return the sender of the current tx in this `scenario`
+    public fun sender(scenario: &Scenario): address {
+        tx_context::sender(&scenario.ctx)
+    }
+
+    /// Return the number of concluded transactions in this scenario.
+    /// This does not include the current transaction, e.g. this will return 0 if `next_tx` has
+    /// not yet been called
+    public fun num_concluded_txes(scenario: &Scenario): u64 {
+        scenario.txn_number
+    }
+
+    /// Accessor for `created` field of `TransactionEffects`
+    public fun created(effects: &TransactionEffects): vector<ID> {
+        effects.created
+    }
+
+    /// Accessor for `written` field of `TransactionEffects`
+    public fun written(effects: &TransactionEffects): vector<ID> {
+        effects.written
+    }
+
+    /// Accessor for `deleted` field of `TransactionEffects`
+    public fun deleted(effects: &TransactionEffects): vector<ID> {
+        effects.deleted
+    }
+
+    /// Accessor for `transferred_to_account` field of `TransactionEffects`
+    public fun transferred_to_account(effects: &TransactionEffects): VecMap<ID, address> {
+        effects.transferred_to_account
+    }
+
+    /// Accessor for `transferred_to_object` field of `TransactionEffects`
+    public fun transferred_to_object(effects: &TransactionEffects): VecMap<ID, ID> {
+        effects.transferred_to_object
+    }
+
+    /// Accessor for `shared` field of `TransactionEffects`
+    public fun shared(effects: &TransactionEffects): vector<ID> {
+        effects.shared
+    }
+
+    /// Accessor for `frozen` field of `TransactionEffects`
+    public fun frozen(effects: &TransactionEffects): vector<ID> {
+        effects.frozen
+    }
+
+    /// Accessor for `num_user_events` field of `TransactionEffects`
+    public fun num_user_events(effects: &TransactionEffects): u64 {
+        effects.num_user_events
+    }
+
+    // == from address ==
+
+    /// Remove the object of type `T` with ID `id` from the inventory of the `account`
+    /// An object is in the address's inventory if the object was transferred to the `account`
+    /// in a previous transaction. Using `return_to_address` is similar to `transfer` and you
+    /// must wait until the next transaction to re-take the object.
+    /// Aborts if there is no object of type `T` in the inventory with ID `id`
+    public native fun take_from_address_by_id<T: key>(
+        scenario: &Scenario,
+        account: address,
+        id: ID,
+    ): T;
+
+    /// Returns the most recent object of type `T` transferred to address `account` that has not
+    /// been taken
+    public native fun most_recent_id_for_address<T: key>(account: address): Option<ID>;
+
+    /// Returns all ids of type `T` transferred to address `account`.
+    public native fun ids_for_address<T: key>(account: address): vector<ID>;
+
+    /// helper that returns true iff `most_recent_id_for_address` returns some
+    public fun has_most_recent_for_address<T: key>(account: address): bool {
+        option::is_some(&most_recent_id_for_address<T>(account))
+    }
+
+    /// Helper combining `take_from_address_by_id` and `most_recent_id_for_address`
+    /// Aborts if there is no object of type `T` in the inventory of `account`
+    public fun take_from_address<T: key>(scenario: &Scenario, account: address): T {
+        let id_opt = most_recent_id_for_address<T>(account);
+        assert!(option::is_some(&id_opt), EEmptyInventory);
+        take_from_address_by_id(scenario, account, option::destroy_some(id_opt))
+    }
+
+    /// Return `t` to the inventory of the `account`. `transfer` can be used directly instead,
+    /// but this function is helpful for test cleanliness as it will abort if the object was not
+    /// originally taken from this account
+    public fun return_to_address<T: key>(account: address, t: T) {
+        let id = object::id(&t);
+        assert!(was_taken_from_address(account, id), ECantReturnObject);
+        sui::transfer::transfer(t, account)
+    }
+
+    /// Returns true if the object with `ID` id was in the inventory for `account`
+    public native fun was_taken_from_address(account: address, id: ID): bool;
+
+    // == from sender ==
+
+    /// helper for `take_from_address_by_id` that operates over the transaction sender
+    public fun take_from_sender_by_id<T: key>(scenario: &Scenario, id: ID): T {
+        take_from_address_by_id(scenario, sender(scenario), id)
+    }
+
+    /// helper for `most_recent_id_for_address` that operates over the transaction sender
+    public fun most_recent_id_for_sender<T: key>(scenario: &Scenario): Option<ID> {
+        most_recent_id_for_address<T>(sender(scenario))
+    }
+
+    /// helper that returns true iff `most_recent_id_for_sender` returns some
+    public fun has_most_recent_for_sender<T: key>(scenario: &Scenario): bool {
+        option::is_some(&most_recent_id_for_address<T>(sender(scenario)))
+    }
+
+    /// helper for `take_from_address` that operates over the transaction sender
+    public fun take_from_sender<T: key>(scenario: &Scenario): T {
+        take_from_address(scenario, sender(scenario))
+    }
+
+    /// helper for `return_to_address` that operates over the transaction sender
+    public fun return_to_sender<T: key>(scenario: &Scenario, t: T) {
+        return_to_address(sender(scenario), t)
+    }
+
+    /// Returns true if the object with `ID` id was in the inventory for the sender
+    public fun was_taken_from_sender(scenario: &Scenario, id: ID): bool {
+        was_taken_from_address(sender(scenario), id)
+    }
+
+    /// Returns all ids of type `T` transferred to the sender.
+    public fun ids_for_sender<T: key>(scenario: &Scenario): vector<ID> {
+        ids_for_address<T>(sender(scenario))
+    }
+
+    // == immutable ==
+
+    /// Remove the immutable object of type `T` with ID `id` from the global inventory
+    /// Aborts if there is no object of type `T` in the inventory with ID `id`
+    public native fun take_immutable_by_id<T: key>(scenario: &Scenario, id: ID): T;
+
+    /// Returns the most recent immutable object of type `T` that has not been taken
+    public native fun most_recent_immutable_id<T: key>(): Option<ID>;
+
+    /// helper that returns true iff `most_recent_immutable_id` returns some
+    public fun has_most_recent_immutable<T: key>(): bool {
+        option::is_some(&most_recent_immutable_id<T>())
+    }
+
+    /// Helper combining `take_immutable_by_id` and `most_recent_immutable_id`
+    /// Aborts if there is no immutable object of type `T` in the global inventory
+    public fun take_immutable<T: key>(scenario: &Scenario): T {
+        let id_opt = most_recent_immutable_id<T>();
+        assert!(option::is_some(&id_opt), EEmptyInventory);
+        take_immutable_by_id(scenario, option::destroy_some(id_opt))
+    }
+
+    /// Return `t` to the global inventory
+    public fun return_immutable<T: key>(t: T) {
+        let id = object::id(&t);
+        assert!(was_taken_immutable(id), ECantReturnObject);
+        sui::transfer::freeze_object(t)
+    }
+
+    /// Returns true if the object with `ID` id was an immutable object in the global inventory
+    public native fun was_taken_immutable(id: ID): bool;
+
+    // == shared ==
+
+    /// Remove the shared object of type `T` with ID `id` from the global inventory
+    /// Aborts if there is no object of type `T` in the inventory with ID `id`
+    public native fun take_shared_by_id<T: key>(scenario: &Scenario, id: ID): T;
+
+    /// Returns the most recent shared object of type `T` that has not been taken
+    public native fun most_recent_id_shared<T: key>(): Option<ID>;
+
+    /// helper that returns true iff `most_recent_id_shared` returns some
+    public fun has_most_recent_shared<T: key>(): bool {
+        option::is_some(&most_recent_id_shared<T>())
+    }
+
+    /// Helper combining `take_shared_by_id` and `most_recent_id_shared`
+    /// Aborts if there is no shared object of type `T` in the global inventory
+    public fun take_shared<T: key>(scenario: &Scenario): T {
+        let id_opt = most_recent_id_shared<T>();
+        assert!(option::is_some(&id_opt), EEmptyInventory);
+        take_shared_by_id(scenario, option::destroy_some(id_opt))
+    }
+
+    /// Return `t` to the global inventory
+    public fun return_shared<T: key>(t: T) {
+        let id = object::id(&t);
+        assert!(was_taken_shared(id), ECantReturnObject);
+        sui::transfer::share_object(t)
+    }
+
+    /// Returns true if the object with `ID` id was an shared object in the global inventory
+    native fun was_taken_shared(id: ID): bool;
+
+    // == internal ==
+
+    // internal function that ends the transaction, realizing changes
+    native fun end_transaction(): TransactionEffects;
+
+    // TODO: Add API's for inspecting user events, printing the user's inventory, ...
+
+}

--- a/crates/sui-framework-override/sources/test/test_utils.move
+++ b/crates/sui-framework-override/sources/test/test_utils.move
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::test_utils {
+    public fun assert_eq<T: drop>(t1: T, t2: T) {
+        assert_ref_eq(&t1, &t2)
+    }
+
+    public fun assert_ref_eq<T>(t1: &T, t2: &T) {
+        let res = t1 == t2;
+        if (!res) {
+            print(b"Assertion failed:");
+            std::debug::print(t1);
+            print(b"!=");
+            std::debug::print(t2);
+            abort(0)
+        }
+    }
+
+    public fun print(str: vector<u8>) {
+        std::debug::print(&std::ascii::string(str))
+    }
+}

--- a/crates/sui-framework-override/sources/transfer.move
+++ b/crates/sui-framework-override/sources/transfer.move
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::transfer {
+
+    /// Shared an object that was previously created. Shared objects must currently
+    /// be constructed in the transaction they are created.
+    const ESharedNonNewObject: u64 = 0;
+
+    /// Transfer ownership of `obj` to `recipient`. `obj` must have the
+    /// `key` attribute, which (in turn) ensures that `obj` has a globally
+    /// unique ID.
+    public fun transfer<T: key>(obj: T, recipient: address) {
+        // TODO: emit event
+        transfer_internal(obj, recipient)
+    }
+
+    /// Freeze `obj`. After freezing `obj` becomes immutable and can no
+    /// longer be transferred or mutated.
+    public native fun freeze_object<T: key>(obj: T);
+
+    /// Turn the given object into a mutable shared object that everyone
+    /// can access and mutate. This is irreversible, i.e. once an object
+    /// is shared, it will stay shared forever.
+    /// Aborts with `ESharedNonNewObject` of the object being shared was not created
+    /// in this transaction. This restriction may be relaxed in the future.
+    public native fun share_object<T: key>(obj: T);
+
+    native fun transfer_internal<T: key>(obj: T, recipient: address);
+
+    // Cost calibration functions
+    #[test_only]
+    public fun calibrate_freeze_object<T: key>(obj: T) {
+        freeze_object(obj);
+    }
+    #[test_only]
+    public fun calibrate_freeze_object_nop<T: key + drop>(obj: T) {
+        let _ = obj;
+    }
+
+    #[test_only]
+    public fun calibrate_share_object<T: key>(obj: T) {
+        share_object(obj);
+    }
+    #[test_only]
+    public fun calibrate_share_object_nop<T: key + drop>(obj: T) {
+        let _ = obj;
+    }
+
+    #[test_only]
+    public fun calibrate_transfer_internal<T: key>(obj: T, recipient: address) {
+        transfer_internal(obj, recipient);
+    }
+    #[test_only]
+    public fun calibrate_transfer_internal_nop<T: key + drop>(obj: T, recipient: address) {
+        let _ = obj;
+        let _ = recipient;
+    }
+
+}

--- a/crates/sui-framework-override/sources/tx_context.move
+++ b/crates/sui-framework-override/sources/tx_context.move
@@ -1,0 +1,127 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::tx_context {
+
+    friend sui::object;
+
+    #[test_only]
+    use std::vector;
+
+    /// Number of bytes in an tx hash (which will be the transaction digest)
+    const TX_HASH_LENGTH: u64 = 32;
+
+    /// Expected an tx hash of length 32, but found a different length
+    const EBadTxHashLength: u64 = 0;
+
+    #[test_only]
+    /// Attempt to get the most recent created object ID when none has been created.
+    const ENoIDsCreated: u64 = 1;
+
+    /// Information about the transaction currently being executed.
+    /// This cannot be constructed by a transaction--it is a privileged object created by
+    /// the VM and passed in to the entrypoint of the transaction as `&mut TxContext`.
+    struct TxContext has drop {
+        /// The address of the user that signed the current transaction
+        sender: address,
+        /// Hash of the current transaction
+        tx_hash: vector<u8>,
+        /// The current epoch number.
+        epoch: u64,
+        /// Counter recording the number of fresh id's created while executing
+        /// this transaction. Always 0 at the start of a transaction
+        ids_created: u64
+    }
+
+    /// Return the address of the user that signed the current
+    /// transaction
+    public fun sender(self: &TxContext): address {
+        self.sender
+    }
+
+    /// Return the current epoch
+    public fun epoch(self: &TxContext): u64 {
+        self.epoch
+    }
+
+    /// Generate a new, globally unique object ID with version 0
+    public(friend) fun new_object(ctx: &mut TxContext): address {
+        let ids_created = ctx.ids_created;
+        let id = derive_id(*&ctx.tx_hash, ids_created);
+        ctx.ids_created = ids_created + 1;
+        id
+    }
+
+    /// Return the number of id's created by the current transaction.
+    /// Hidden for now, but may expose later
+    fun ids_created(self: &TxContext): u64 {
+        self.ids_created
+    }
+
+    /// Native function for deriving an ID via hash(tx_hash || ids_created)
+    native fun derive_id(tx_hash: vector<u8>, ids_created: u64): address;
+
+    // ==== test-only functions ====
+
+    #[test_only]
+    /// Create a `TxContext` for testing
+    public fun new(sender: address, tx_hash: vector<u8>, epoch: u64, ids_created: u64): TxContext {
+        assert!(vector::length(&tx_hash) == TX_HASH_LENGTH, EBadTxHashLength);
+        TxContext { sender, tx_hash, epoch, ids_created }
+    }
+
+    #[test_only]
+    /// Create a `TxContext` for testing, with a potentially non-zero epoch number.
+    public fun new_from_hint(addr: address, hint: u64, epoch: u64, ids_created: u64): TxContext {
+        new(addr, dummy_tx_hash_with_hint(hint), epoch, ids_created)
+    }
+
+    #[test_only]
+    /// Create a dummy `TxContext` for testing
+    public fun dummy(): TxContext {
+        let tx_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
+        new(@0x0, tx_hash, 0, 0)
+    }
+
+    #[test_only]
+    /// Utility for creating 256 unique input hashes
+    fun dummy_tx_hash_with_hint(hint: u64): vector<u8> {
+        let tx_hash = vector[];
+        let i = 1;
+        let hash_length = TX_HASH_LENGTH;
+        while (i <= hash_length) {
+            let value = i ^ hint % 256;
+            vector::push_back(&mut tx_hash, (value as u8));
+            i = i + 1;
+        };
+        tx_hash
+    }
+
+    #[test_only]
+    public fun get_ids_created(self: &TxContext): u64 {
+        ids_created(self)
+    }
+
+    #[test_only]
+    /// Return the most recent created object ID.
+    public fun last_created_object_id(self: &TxContext): address {
+        let ids_created = self.ids_created;
+        assert!(ids_created > 0, ENoIDsCreated);
+        derive_id(*&self.tx_hash, ids_created - 1)
+    }
+
+    #[test_only]
+    public fun increment_epoch_number(self: &mut TxContext) {
+        self.epoch = self.epoch + 1
+    }
+
+    // Cost calibration functions
+    #[test_only]
+    public fun calibrate_derive_id(tx_hash: vector<u8>, ids_created: u64) {
+        derive_id(tx_hash, ids_created);
+    }
+    #[test_only]
+    public fun calibrate_derive_id_nop(tx_hash: vector<u8>, ids_created: u64) {
+        let _ = tx_hash;
+        let _ = ids_created;
+    }}

--- a/crates/sui-framework-override/sources/typed_id.move
+++ b/crates/sui-framework-override/sources/typed_id.move
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Typed wrappers around Sui object IDs
+/// While not always necessary, this is helpful for indicating the type of an object, particularly
+/// when storing its ID in another object.
+/// Additionally, it can be helpful for disambiguating between different IDs in an object.
+/// For example
+/// ```
+/// struct MyObject has key {
+///   id: VersionedID,
+///   child1: TypedID<A>,
+///   child2: TypedID<B>,
+/// }
+/// ```
+/// We then know that `child1` is an ID for an object of type `A` and that `child2` is an `ID`
+/// of an object of type `B`
+module sui::typed_id {
+    use sui::object::{Self, ID};
+
+    /// An ID of an of type `T`. See `ID` for more details
+    /// By construction, it is guaranteed that the `ID` represents an object of type `T`
+    struct TypedID<phantom T: key> has copy, drop, store {
+        id: ID,
+    }
+
+    /// Get the underlying `ID` of `obj`, and remember the type
+    public fun new<T: key>(obj: &T): TypedID<T> {
+        TypedID { id: object::id(obj) }
+    }
+
+    /// Borrow the inner `ID` of `typed_id`
+    public fun as_id<T: key>(typed_id: &TypedID<T>): &ID {
+        &typed_id.id
+    }
+
+    /// Get the inner `ID` of `typed_id`
+    public fun to_id<T: key>(typed_id: TypedID<T>): ID {
+        let TypedID { id } = typed_id;
+        id
+    }
+
+    /// Check that underlying `ID` in the `typed_id` equals the objects ID
+    public fun equals_object<T: key>(typed_id: &TypedID<T>, obj: &T): bool {
+        typed_id.id == object::id(obj)
+    }
+}

--- a/crates/sui-framework-override/sources/types.move
+++ b/crates/sui-framework-override/sources/types.move
@@ -1,0 +1,11 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Sui types helpers and utilities
+module sui::types {
+    // === one-time witness ===
+
+    /// Tests if the argument type is a one-time witness, that is a type with only one instantiation
+    /// across the entire code base.
+    public native fun is_one_time_witness<T: drop>(_: &T): bool;
+}

--- a/crates/sui-framework-override/sources/url.move
+++ b/crates/sui-framework-override/sources/url.move
@@ -1,0 +1,35 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// URL: standard Uniform Resource Locator string
+module sui::url {
+    use std::ascii::{Self, String};
+
+    /// Standard Uniform Resource Locator (URL) string.
+    struct Url has store, copy, drop {
+        // TODO: validate URL format
+        url: String,
+    }
+
+    /// Create a `Url`, with no validation
+    public fun new_unsafe(url: String): Url {
+        Url { url }
+    }
+
+    /// Create a `Url` with no validation from bytes
+    /// Note: this will abort if `bytes` is not valid ASCII
+    public fun new_unsafe_from_bytes(bytes: vector<u8>): Url {
+        let url = ascii::string(bytes);
+        Url { url }
+    }
+
+    /// Get inner URL
+    public fun inner_url(self: &Url): String{
+        self.url
+    }
+
+    /// Update the inner URL
+    public fun update(self: &mut Url, url: String) {
+        self.url = url;
+    }
+}

--- a/crates/sui-framework-override/sources/vec_map.move
+++ b/crates/sui-framework-override/sources/vec_map.move
@@ -1,0 +1,184 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::vec_map {
+    use std::option::{Self, Option};
+    use std::vector;
+
+    /// This key already exists in the map
+    const EKeyAlreadyExists: u64 = 0;
+
+    /// This key does not exist in the map
+    const EKeyDoesNotExist: u64 = 1;
+
+    /// Trying to destroy a map that is not empty
+    const EMapNotEmpty: u64 = 2;
+
+    /// Trying to access an element of the map at an invalid index
+    const EIndexOutOfBounds: u64 = 3;
+
+    /// Trying to pop from a map that is empty
+    const EMapEmpty: u64 = 4;
+
+    /// A map data structure backed by a vector. The map is guaranteed not to contain duplicate keys, but entries
+    /// are *not* sorted by key--entries are included in insertion order.
+    /// All operations are O(N) in the size of the map--the intention of this data structure is only to provide
+    /// the convenience of programming against a map API.
+    /// Large maps should use handwritten parent/child relationships instead.
+    /// Maps that need sorted iteration rather than insertion order iteration should also be handwritten.
+    struct VecMap<K: copy, V> has copy, drop, store {
+        contents: vector<Entry<K, V>>,
+    }
+
+    /// An entry in the map
+    struct Entry<K: copy, V> has copy, drop, store {
+        key: K,
+        value: V,
+    }
+
+    /// Create an empty `VecMap`
+    public fun empty<K: copy, V>(): VecMap<K,V> {
+        VecMap { contents: vector::empty() }
+    }
+
+    /// Insert the entry `key` |-> `value` into `self`.
+    /// Aborts if `key` is already bound in `self`.
+    public fun insert<K: copy, V>(self: &mut VecMap<K,V>, key: K, value: V) {
+        assert!(!contains(self, &key), EKeyAlreadyExists);
+        vector::push_back(&mut self.contents, Entry { key, value })
+    }
+
+    /// Remove the entry `key` |-> `value` from self. Aborts if `key` is not bound in `self`.
+    public fun remove<K: copy, V>(self: &mut VecMap<K,V>, key: &K): (K, V) {
+        let idx = get_idx(self, key);
+        let Entry { key, value } = vector::remove(&mut self.contents, idx);
+        (key, value)
+    }
+
+    /// Pop the most recently inserted entry from the map. Aborts if the map is empty.
+    public fun pop<K: copy, V>(self: &mut VecMap<K,V>): (K, V) {
+        assert!(!vector::is_empty(&self.contents), EMapEmpty);
+        let Entry { key, value } = vector::pop_back(&mut self.contents);
+        (key, value)
+    }
+
+    /// Get a mutable reference to the value bound to `key` in `self`.
+    /// Aborts if `key` is not bound in `self`.
+    public fun get_mut<K: copy, V>(self: &mut VecMap<K,V>, key: &K): &mut V {
+        let idx = get_idx(self, key);
+        let entry = vector::borrow_mut(&mut self.contents, idx);
+        &mut entry.value
+    }
+
+    /// Get a reference to the value bound to `key` in `self`.
+    /// Aborts if `key` is not bound in `self`.
+    public fun get<K: copy, V>(self: &VecMap<K,V>, key: &K): &V {
+        let idx = get_idx(self, key);
+        let entry = vector::borrow(&self.contents, idx);
+        &entry.value
+    }
+
+    /// Return true if `self` contains an entry for `key`, false otherwise
+    public fun contains<K: copy, V>(self: &VecMap<K, V>, key: &K): bool {
+        option::is_some(&get_idx_opt(self, key))
+    }
+
+    /// Return the number of entries in `self`
+    public fun size<K: copy, V>(self: &VecMap<K,V>): u64 {
+        vector::length(&self.contents)
+    }
+
+    /// Return true if `self` has 0 elements, false otherwise
+    public fun is_empty<K: copy, V>(self: &VecMap<K,V>): bool {
+        size(self) == 0
+    }
+
+    /// Destroy an empty map. Aborts if `self` is not empty
+    public fun destroy_empty<K: copy, V>(self: VecMap<K, V>) {
+        let VecMap { contents } = self;
+        assert!(vector::is_empty(&contents), EMapNotEmpty);
+        vector::destroy_empty(contents)
+    }
+
+    /// Unpack `self` into vectors of its keys and values.
+    /// The output keys and values are stored in insertion order, *not* sorted by key.
+    public fun into_keys_values<K: copy, V>(self: VecMap<K, V>): (vector<K>, vector<V>) {
+        let VecMap { contents } = self;
+        // reverse the vector so the output keys and values will appear in insertion order
+        vector::reverse(&mut contents);
+        let i = 0;
+        let n = vector::length(&contents);
+        let keys = vector::empty();
+        let values = vector::empty();
+        while (i < n) {
+            let Entry { key, value } = vector::pop_back(&mut contents);
+            vector::push_back(&mut keys, key);
+            vector::push_back(&mut values, value);
+            i = i + 1;
+        };
+        vector::destroy_empty(contents);
+        (keys, values)
+    }
+
+    /// Returns a list of keys in the map.
+    /// Do not assume any particular ordering.
+    public fun keys<K: copy, V>(self: &VecMap<K, V>): vector<K> {
+        let i = 0;
+        let n = vector::length(&self.contents);
+        let keys = vector::empty();
+        while (i < n) {
+            let entry = vector::borrow(&self.contents, i);
+            vector::push_back(&mut keys, entry.key);
+            i = i + 1;
+        };
+        keys
+    }
+
+    /// Find the index of `key` in `self`. Return `None` if `key` is not in `self`.
+    /// Note that map entries are stored in insertion order, *not* sorted by key.
+    public fun get_idx_opt<K: copy, V>(self: &VecMap<K,V>, key: &K): Option<u64> {
+        let i = 0;
+        let n = size(self);
+        while (i < n) {
+            if (&vector::borrow(&self.contents, i).key == key) {
+                return option::some(i)
+            };
+            i = i + 1;
+        };
+        option::none()
+    }
+
+    /// Find the index of `key` in `self`. Aborts if `key` is not in `self`.
+    /// Note that map entries are stored in insertion order, *not* sorted by key.
+    public fun get_idx<K: copy, V>(self: &VecMap<K,V>, key: &K): u64 {
+        let idx_opt = get_idx_opt(self, key);
+        assert!(option::is_some(&idx_opt), EKeyDoesNotExist);
+        option::destroy_some(idx_opt)
+    }
+
+    /// Return a reference to the `idx`th entry of `self`. This gives direct access into the backing array of the map--use with caution.
+    /// Note that map entries are stored in insertion order, *not* sorted by key.
+    /// Aborts if `idx` is greater than or equal to `size(self)`
+    public fun get_entry_by_idx<K: copy, V>(self: &VecMap<K, V>, idx: u64): (&K, &V) {
+        assert!(idx < size(self), EIndexOutOfBounds);
+        let entry = vector::borrow(&self.contents, idx);
+        (&entry.key, &entry.value)
+    }
+
+    /// Return a mutable reference to the `idx`th entry of `self`. This gives direct access into the backing array of the map--use with caution.
+    /// Note that map entries are stored in insertion order, *not* sorted by key.
+    /// Aborts if `idx` is greater than or equal to `size(self)`
+    public fun get_entry_by_idx_mut<K: copy, V>(self: &mut VecMap<K, V>, idx: u64): (&K, &mut V) {
+        assert!(idx < size(self), EIndexOutOfBounds);
+        let entry = vector::borrow_mut(&mut self.contents, idx);
+        (&entry.key, &mut entry.value)
+    }
+
+    /// Remove the entry at index `idx` from self.
+    /// Aborts if `idx` is greater than or equal to `size(self)`
+    public fun remove_entry_by_idx<K: copy, V>(self: &mut VecMap<K, V>, idx: u64): (K, V) {
+        assert!(idx < size(self), EIndexOutOfBounds);
+        let Entry { key, value } = vector::remove(&mut self.contents, idx);
+        (key, value)
+    }
+}

--- a/crates/sui-framework-override/sources/vec_set.move
+++ b/crates/sui-framework-override/sources/vec_set.move
@@ -1,0 +1,90 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::vec_set {
+    use std::option::{Self, Option};
+    use std::vector;
+
+    /// This key already exists in the map
+    const EKeyAlreadyExists: u64 = 0;
+
+    /// This key does not exist in the map
+    const EKeyDoesNotExist: u64 = 1;
+
+    /// A set data structure backed by a vector. The set is guaranteed not to contain duplicate keys.
+    /// All operations are O(N) in the size of the set--the intention of this data structure is only to provide
+    /// the convenience of programming against a set API.
+    /// Sets that need sorted iteration rather than insertion order iteration should be handwritten.
+    struct VecSet<K: copy + drop> has copy, drop, store {
+        contents: vector<K>,
+    }
+
+    /// Create an empty `VecSet`
+    public fun empty<K: copy + drop>(): VecSet<K> {
+        VecSet { contents: vector::empty() }
+    }
+
+    /// Create a singleton `VecSet` that only contains one element.
+    public fun singleton<K: copy + drop>(key: K): VecSet<K> {
+        VecSet { contents: vector::singleton(key) }
+    }
+
+    /// Insert a `key` into self.
+    /// Aborts if `key` is already present in `self`.
+    public fun insert<K: copy + drop>(self: &mut VecSet<K>, key: K) {
+        assert!(!contains(self, &key), EKeyAlreadyExists);
+        vector::push_back(&mut self.contents, key)
+    }
+
+    /// Remove the entry `key` from self. Aborts if `key` is not present in `self`.
+    public fun remove<K: copy + drop>(self: &mut VecSet<K>, key: &K) {
+        let idx = get_idx(self, key);
+        vector::remove(&mut self.contents, idx);
+    }
+
+    /// Return true if `self` contains an entry for `key`, false otherwise
+    public fun contains<K: copy + drop>(self: &VecSet<K>, key: &K): bool {
+        option::is_some(&get_idx_opt(self, key))
+    }
+
+    /// Return the number of entries in `self`
+    public fun size<K: copy + drop>(self: &VecSet<K>): u64 {
+        vector::length(&self.contents)
+    }
+
+    /// Return true if `self` has 0 elements, false otherwise
+    public fun is_empty<K: copy + drop>(self: &VecSet<K>): bool {
+        size(self) == 0
+    }
+
+    /// Unpack `self` into vectors of keys.
+    /// The output keys are stored in insertion order, *not* sorted.
+    public fun into_keys<K: copy + drop>(self: VecSet<K>): vector<K> {
+        let VecSet { contents } = self;
+        contents
+    }
+
+    // == Helper functions ==
+
+    /// Find the index of `key` in `self`. Return `None` if `key` is not in `self`.
+    /// Note that keys are stored in insertion order, *not* sorted.
+    fun get_idx_opt<K: copy + drop>(self: &VecSet<K>, key: &K): Option<u64> {
+        let i = 0;
+        let n = size(self);
+        while (i < n) {
+            if (vector::borrow(&self.contents, i) == key) {
+                return option::some(i)
+            };
+            i = i + 1;
+        };
+        option::none()
+    }
+
+    /// Find the index of `key` in `self`. Aborts if `key` is not in `self`.
+    /// Note that map entries are stored in insertion order, *not* sorted.
+    fun get_idx<K: copy + drop>(self: &VecSet<K>, key: &K): u64 {
+        let idx_opt = get_idx_opt(self, key);
+        assert!(option::is_some(&idx_opt), EKeyDoesNotExist);
+        option::destroy_some(idx_opt)
+    }
+}

--- a/crates/sui-framework-override/src/cost_calib/mod.rs
+++ b/crates/sui-framework-override/src/cost_calib/mod.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use self::runner::run_calib;
+mod runner;
+
+pub fn run_calibration(runs: usize, summarize: bool) {
+    let res = run_calib(runs);
+
+    if summarize {
+        println!("-------------------------------------------------------------------");
+        println!("{:30} {:20}", "Operation", "Avg Unprocessed time");
+        println!("-------------------------------------------------------------------");
+        res.iter()
+            .for_each(|(oper, (_, summary))| println!("{:30} {:5} ", oper, summary));
+    } else {
+        for (oper, (values, summary)) in res {
+            println!("-------------------------------------------------------------------");
+            println!("{:10} {:10}", "Operation:", oper);
+            println!("-------------------------------------------------------------------");
+
+            println!("Subject    Baseline   Diff ({:5} avg)", summary);
+            for (subject, baseline) in values {
+                println!(
+                    "{:5}      {:5}  {:5}",
+                    subject,
+                    baseline,
+                    subject - baseline
+                );
+            }
+        }
+    }
+}

--- a/crates/sui-framework-override/src/cost_calib/runner.rs
+++ b/crates/sui-framework-override/src/cost_calib/runner.rs
@@ -1,0 +1,137 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::natives;
+use move_cli::base::test::UnitTestResult;
+use move_package::BuildConfig;
+use move_unit_test::UnitTestingConfig;
+use move_vm_test_utils::gas_schedule::INITIAL_COST_SCHEDULE;
+use std::{collections::HashMap, io::BufWriter, path::Path};
+use sui_types::{MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS};
+
+const MAX_UNIT_TEST_INSTRUCTIONS: u64 = 1_000_000_000;
+const CALIB_TEST_FILTER: &str = "calibrate";
+const CALIB_TEST_PREFIX: &str = "test_calibrate_";
+const CALIB_TEST_BASELINE_SUFFIX: &str = "__baseline";
+const FRAMEWORK_SOURCES_RELATIVE_PATH: &str = "../../crates/sui-framework/sources";
+
+#[derive(Debug)]
+pub struct CalibTestResult {
+    pub name: String,
+    pub baseline: f32,
+    pub subject: f32,
+}
+
+pub fn run_calib(runs: usize) -> HashMap<String, (Vec<(f32, f32)>, f32)> {
+    let res = run_calib_tests(None, runs);
+
+    res.into_iter()
+        .map(|q| (q.0, (q.1.clone(), summarize_values(&q.1))))
+        .collect()
+}
+fn summarize_values(v: &Vec<(f32, f32)>) -> f32 {
+    // Use average for now
+    // TODO: investigate other methods
+    v.iter().map(|a| a.0 - a.1).sum::<f32>() / v.len() as f32
+}
+
+pub fn run_calib_tests(
+    config: Option<UnitTestingConfig>,
+    runs: usize,
+) -> HashMap<String, Vec<(f32, f32)>> {
+    let pkg_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(FRAMEWORK_SOURCES_RELATIVE_PATH);
+
+    let config = config
+        .unwrap_or_else(|| UnitTestingConfig::default_with_bound(Some(MAX_UNIT_TEST_INSTRUCTIONS)));
+
+    let mut out_map: HashMap<_, Vec<_>> = HashMap::new();
+
+    for _ in 0..runs {
+        let config = config.clone();
+        let buf = Vec::new();
+        let mut test_output_buf = BufWriter::new(buf);
+        if move_cli::base::test::run_move_unit_tests(
+            &pkg_path,
+            BuildConfig::default(),
+            UnitTestingConfig {
+                report_stacktrace_on_abort: true,
+                report_statistics: true,
+                filter: Some(CALIB_TEST_FILTER.to_string()),
+                num_threads: 1,
+                ..config
+            },
+            natives::all_natives(MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS),
+            Some(INITIAL_COST_SCHEDULE.clone()),
+            false,
+            &mut test_output_buf,
+        )
+        .unwrap()
+            == UnitTestResult::Failure
+        {
+            panic!("Calibration unit test failed");
+        };
+
+        let out = extract_calib(String::from_utf8(test_output_buf.into_inner().unwrap()).unwrap());
+
+        out.iter().for_each(|q| {
+            out_map
+                .entry(q.name.clone())
+                .or_default()
+                .push((q.subject, q.baseline));
+        });
+    }
+
+    out_map
+}
+
+pub fn extract_calib(s: String) -> Vec<CalibTestResult> {
+    let test_output_prefix = format!("│ 0x{}::", SUI_FRAMEWORK_ADDRESS.short_str_lossless());
+    let lines = s.split('\n').filter(|x| x.starts_with(&test_output_prefix));
+
+    let mut mp = HashMap::new();
+
+    lines.for_each(|x| {
+        let tokens: Vec<_> = x.split('│').collect();
+        let name = tokens[1]
+            .trim()
+            .to_owned()
+            .split(CALIB_TEST_PREFIX)
+            .nth(1)
+            .unwrap()
+            .to_owned();
+        let val = tokens[2].trim().parse::<f32>().unwrap();
+        mp.insert(name, val);
+    });
+
+    let mut ret = vec![];
+
+    let mut mp_clone = mp.clone();
+
+    for (name, val) in &mp {
+        let name = name.to_owned();
+        let name_baseline = name.clone() + CALIB_TEST_BASELINE_SUFFIX;
+
+        if mp.contains_key(&name_baseline) {
+            // Remove pair from the map
+            mp_clone.remove(&name);
+            mp_clone.remove(&name_baseline);
+
+            ret.push(CalibTestResult {
+                name,
+                baseline: mp[&name_baseline],
+                subject: *val,
+            });
+        }
+    }
+
+    // Data without baseline
+    mp_clone.iter().for_each(|(name, val)| {
+        ret.push(CalibTestResult {
+            name: name.to_string(),
+            baseline: 0.0,
+            subject: *val,
+        })
+    });
+
+    ret
+}

--- a/crates/sui-framework-override/src/lib.rs
+++ b/crates/sui-framework-override/src/lib.rs
@@ -1,0 +1,217 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::CompiledModule;
+use move_cli::base::test::UnitTestResult;
+use move_core_types::gas_algebra::InternalGas;
+use move_package::BuildConfig as MoveBuildConfig;
+use move_unit_test::{extensions::set_extension_hook, UnitTestingConfig};
+use move_vm_runtime::native_extensions::NativeContextExtensions;
+use move_vm_test_utils::gas_schedule::INITIAL_COST_SCHEDULE;
+use natives::object_runtime::ObjectRuntime;
+use once_cell::sync::Lazy;
+use std::{collections::BTreeMap, path::Path};
+use sui_framework_build::compiled_package::{BuildConfig, CompiledPackage};
+use sui_types::{
+    base_types::TransactionDigest, error::SuiResult, in_memory_storage::InMemoryStorage,
+    messages::InputObjects, temporary_store::TemporaryStore, MOVE_STDLIB_ADDRESS,
+    SUI_FRAMEWORK_ADDRESS,
+};
+
+pub mod cost_calib;
+pub mod natives;
+
+// Move unit tests will halt after executing this many steps. This is a protection to avoid divergence
+const MAX_UNIT_TEST_INSTRUCTIONS: u64 = 100_000;
+
+static SUI_FRAMEWORK: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
+    const SUI_FRAMEWORK_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/sui-framework"));
+
+    let serialized_modules: Vec<Vec<u8>> = bcs::from_bytes(SUI_FRAMEWORK_BYTES).unwrap();
+
+    serialized_modules
+        .into_iter()
+        .map(|module| CompiledModule::deserialize(&module).unwrap())
+        .collect()
+});
+
+static SUI_FRAMEWORK_TEST: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
+    const SUI_FRAMEWORK_BYTES: &[u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/sui-framework-test"));
+
+    let serialized_modules: Vec<Vec<u8>> = bcs::from_bytes(SUI_FRAMEWORK_BYTES).unwrap();
+
+    serialized_modules
+        .into_iter()
+        .map(|module| CompiledModule::deserialize(&module).unwrap())
+        .collect()
+});
+
+static MOVE_STDLIB: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
+    const MOVE_STDLIB_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/move-stdlib"));
+
+    let serialized_modules: Vec<Vec<u8>> = bcs::from_bytes(MOVE_STDLIB_BYTES).unwrap();
+
+    serialized_modules
+        .into_iter()
+        .map(|module| CompiledModule::deserialize(&module).unwrap())
+        .collect()
+});
+
+static MOVE_STDLIB_TEST: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
+    const MOVE_STDLIB_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/move-stdlib-test"));
+
+    let serialized_modules: Vec<Vec<u8>> = bcs::from_bytes(MOVE_STDLIB_BYTES).unwrap();
+
+    serialized_modules
+        .into_iter()
+        .map(|module| CompiledModule::deserialize(&module).unwrap())
+        .collect()
+});
+
+static SET_EXTENSION_HOOK: Lazy<()> =
+    Lazy::new(|| set_extension_hook(Box::new(new_testing_object_runtime)));
+
+fn new_testing_object_runtime(ext: &mut NativeContextExtensions) {
+    let store = InMemoryStorage::new(vec![]);
+    let state_view = TemporaryStore::new(
+        store,
+        InputObjects::new(vec![]),
+        TransactionDigest::random(),
+    );
+    ext.add(ObjectRuntime::new(Box::new(state_view), BTreeMap::new()))
+}
+
+pub fn get_sui_framework() -> Vec<CompiledModule> {
+    Lazy::force(&SUI_FRAMEWORK).to_owned()
+}
+
+pub fn get_sui_framework_test() -> Vec<CompiledModule> {
+    Lazy::force(&SUI_FRAMEWORK_TEST).to_owned()
+}
+
+pub fn get_move_stdlib() -> Vec<CompiledModule> {
+    Lazy::force(&MOVE_STDLIB).to_owned()
+}
+
+pub fn get_move_stdlib_test() -> Vec<CompiledModule> {
+    Lazy::force(&MOVE_STDLIB_TEST).to_owned()
+}
+
+pub const DEFAULT_FRAMEWORK_PATH: &str = env!("CARGO_MANIFEST_DIR");
+
+// TODO: remove these in favor of new costs
+pub fn legacy_test_cost() -> InternalGas {
+    InternalGas::new(0)
+}
+
+pub fn legacy_emit_cost() -> InternalGas {
+    InternalGas::new(52)
+}
+
+pub fn legacy_create_signer_cost() -> InternalGas {
+    InternalGas::new(24)
+}
+
+pub fn legacy_empty_cost() -> InternalGas {
+    InternalGas::new(84)
+}
+
+pub fn legacy_length_cost() -> InternalGas {
+    InternalGas::new(98)
+}
+
+/// This function returns a result of UnitTestResult. The outer result indicates whether it
+/// successfully started running the test, and the inner result indicatests whether all tests pass.
+pub fn run_move_unit_tests(
+    path: &Path,
+    build_config: MoveBuildConfig,
+    config: Option<UnitTestingConfig>,
+    compute_coverage: bool,
+) -> anyhow::Result<UnitTestResult> {
+    // bind the extension hook if it has not yet been done
+    Lazy::force(&SET_EXTENSION_HOOK);
+
+    let config = config
+        .unwrap_or_else(|| UnitTestingConfig::default_with_bound(Some(MAX_UNIT_TEST_INSTRUCTIONS)));
+
+    move_cli::base::test::run_move_unit_tests(
+        path,
+        build_config,
+        UnitTestingConfig {
+            report_stacktrace_on_abort: true,
+            ..config
+        },
+        natives::all_natives(MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS),
+        Some(INITIAL_COST_SCHEDULE.clone()),
+        compute_coverage,
+        &mut std::io::stdout(),
+    )
+}
+
+/// Wrapper of the build command that verifies the framework version. Should eventually be removed once we can
+/// do this in the obvious way (via version checks)
+pub fn build_move_package(path: &Path, config: BuildConfig) -> SuiResult<CompiledPackage> {
+    //let test_mode = config.config.test_mode;
+    let pkg = config.build(path.to_path_buf())?;
+    /*if test_mode {
+        pkg.verify_framework_version(get_sui_framework_test(), get_move_stdlib_test())?;
+    } else {
+        pkg.verify_framework_version(get_sui_framework(), get_move_stdlib())?;
+    }*/
+    Ok(pkg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    #[cfg_attr(msim, ignore)]
+    fn run_framework_move_unit_tests() {
+        get_sui_framework();
+        get_move_stdlib();
+        let path = PathBuf::from(DEFAULT_FRAMEWORK_PATH);
+        BuildConfig::default().build(path.clone()).unwrap();
+        check_move_unit_tests(&path);
+    }
+
+    #[test]
+    #[cfg_attr(msim, ignore)]
+    fn run_examples_move_unit_tests() {
+        let examples = vec![
+            "basics",
+            "defi",
+            "capy",
+            "fungible_tokens",
+            "games",
+            "move_tutorial",
+            "nfts",
+            "objects_tutorial",
+        ];
+        for example in examples {
+            let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../sui_programmability/examples")
+                .join(example);
+            BuildConfig::default().build(path.clone()).unwrap();
+            check_move_unit_tests(&path);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(msim, ignore)]
+    fn run_book_examples_move_unit_tests() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../doc/book/examples");
+
+        BuildConfig::default().build(path.clone()).unwrap();
+        check_move_unit_tests(&path);
+    }
+
+    fn check_move_unit_tests(path: &Path) {
+        assert_eq!(
+            run_move_unit_tests(path, MoveBuildConfig::default(), None, false).unwrap(),
+            UnitTestResult::Success
+        );
+    }
+}

--- a/crates/sui-framework-override/src/natives/address.rs
+++ b/crates/sui-framework-override/src/natives/address.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::legacy_create_signer_cost;
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::{account_address::AccountAddress, u256::U256};
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+const E_ADDRESS_PARSE_ERROR: u64 = 0;
+
+const E_CANT_CONVERT_ADDRESS_TO_U256: u64 = 1;
+
+// Implementation of the Move native function address::from_bytes(bytes: vector<u8>): address;
+pub fn from_bytes(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let addr_bytes = pop_arg!(args, Vec<u8>);
+
+    // TODO: what should the cost of this be?
+    let cost = legacy_create_signer_cost();
+
+    // Address parsing can fail if fed the incorrect number of bytes.
+    Ok(match AccountAddress::from_bytes(addr_bytes) {
+        Ok(addr) => NativeResult::ok(cost, smallvec![Value::address(addr)]),
+        Err(_) => NativeResult::err(cost, E_ADDRESS_PARSE_ERROR),
+    })
+}
+
+/// Implementation of Move native function `address::to_u256(address): u256`
+pub fn to_u256(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let addr = pop_arg!(args, AccountAddress);
+    // convert the address into a u256 by padding out the lower 12 bytes with 0's
+    let mut addr_bytes_le = addr.to_vec();
+    addr_bytes_le.reverse();
+    addr_bytes_le.resize(32, 0);
+    // unwrap safe because we know addr_bytes_le is length 32
+    let u256_val = Value::u256(U256::from_le_bytes(&addr_bytes_le.try_into().unwrap()));
+    // TODO: what should the cost of this be?
+    let cost = legacy_create_signer_cost();
+    Ok(NativeResult::ok(cost, smallvec![u256_val]))
+}
+
+/// Implementation of Move native function `address::from_u256(u256): address`
+pub fn from_u256(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    // TODO: what should the cost of this be?
+    let cost = legacy_create_signer_cost();
+
+    let u256 = pop_arg!(args, U256);
+    let mut u256_bytes = u256.to_le_bytes().to_vec();
+    u256_bytes.reverse();
+    // check that this is representable as u256 by confirming that the higher-order 12 bytes are all zeros
+    for b in u256_bytes.iter().take(12) {
+        if *b != 0x0 {
+            return Ok(NativeResult::err(cost, E_CANT_CONVERT_ADDRESS_TO_U256));
+        }
+    }
+    // unwrap safe because we are passing a 20 byte slice
+    let addr_val = Value::address(AccountAddress::from_bytes(&u256_bytes[12..]).unwrap());
+    Ok(NativeResult::ok(cost, smallvec![addr_val]))
+}

--- a/crates/sui-framework-override/src/natives/crypto/bls12381.rs
+++ b/crates/sui-framework-override/src/natives/crypto/bls12381.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::legacy_empty_cost;
+use fastcrypto::{
+    bls12381::{min_pk, min_sig},
+    traits::ToFromBytes,
+    Verifier,
+};
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{Value, VectorRef},
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub fn bls12381_min_sig_verify(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 3);
+
+    let msg = pop_arg!(args, VectorRef);
+    let public_key_bytes = pop_arg!(args, VectorRef);
+    let signature_bytes = pop_arg!(args, VectorRef);
+
+    let msg_ref = msg.as_bytes_ref();
+    let public_key_bytes_ref = public_key_bytes.as_bytes_ref();
+    let signature_bytes_ref = signature_bytes.as_bytes_ref();
+
+    // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/3868
+    let cost = legacy_empty_cost();
+
+    let signature =
+        match <min_sig::BLS12381Signature as ToFromBytes>::from_bytes(&signature_bytes_ref) {
+            Ok(signature) => signature,
+            Err(_) => return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+        };
+
+    let public_key =
+        match <min_sig::BLS12381PublicKey as ToFromBytes>::from_bytes(&public_key_bytes_ref) {
+            Ok(public_key) => public_key,
+            Err(_) => return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+        };
+
+    match public_key.verify(&msg_ref, &signature) {
+        Ok(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(true)])),
+        Err(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    }
+}
+
+pub fn bls12381_min_pk_verify(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 3);
+
+    let msg = pop_arg!(args, VectorRef);
+    let public_key_bytes = pop_arg!(args, VectorRef);
+    let signature_bytes = pop_arg!(args, VectorRef);
+
+    let msg_ref = msg.as_bytes_ref();
+    let public_key_bytes_ref = public_key_bytes.as_bytes_ref();
+    let signature_bytes_ref = signature_bytes.as_bytes_ref();
+
+    // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/3868
+    let cost = legacy_empty_cost();
+
+    let signature =
+        match <min_pk::BLS12381Signature as ToFromBytes>::from_bytes(&signature_bytes_ref) {
+            Ok(signature) => signature,
+            Err(_) => return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+        };
+
+    let public_key =
+        match <min_pk::BLS12381PublicKey as ToFromBytes>::from_bytes(&public_key_bytes_ref) {
+            Ok(public_key) => public_key,
+            Err(_) => return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+        };
+
+    match public_key.verify(&msg_ref, &signature) {
+        Ok(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(true)])),
+        Err(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    }
+}

--- a/crates/sui-framework-override/src/natives/crypto/bulletproofs.rs
+++ b/crates/sui-framework-override/src/natives/crypto/bulletproofs.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::legacy_empty_cost;
+use fastcrypto::{
+    bulletproofs::{BulletproofsRangeProof, PedersenCommitment},
+    traits::ToFromBytes,
+};
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{Value, VectorRef},
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub const INVALID_BULLETPROOF: u64 = 0;
+pub const INVALID_RISTRETTO_GROUP_ELEMENT: u64 = 1;
+
+/// Using the word "sui" for nothing-up-my-sleeve number guarantees.
+pub const BP_DOMAIN: &[u8] = b"sui";
+
+pub fn verify_range_proof(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 3);
+
+    let bit_length = pop_arg!(args, u64);
+    let commitment_bytes = pop_arg!(args, VectorRef);
+    let proof_bytes = pop_arg!(args, VectorRef);
+    let cost = legacy_empty_cost();
+
+    let commitment_bytes_ref = commitment_bytes.as_bytes_ref();
+    let proof_bytes_ref = proof_bytes.as_bytes_ref();
+
+    let Ok(proof) = BulletproofsRangeProof::from_bytes(&proof_bytes_ref) else { return Ok(NativeResult::err(cost, INVALID_BULLETPROOF)); };
+
+    let Ok(commitment) = PedersenCommitment::from_bytes(&commitment_bytes_ref) else { return Ok(NativeResult::err(cost, INVALID_RISTRETTO_GROUP_ELEMENT)); };
+
+    match proof.verify_bit_length(&commitment, bit_length as usize, BP_DOMAIN) {
+        Ok(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(true)])),
+        _ => Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    }
+}

--- a/crates/sui-framework-override/src/natives/crypto/ecdsa_k1.rs
+++ b/crates/sui-framework-override/src/natives/crypto/ecdsa_k1.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::legacy_empty_cost;
+use fastcrypto::{
+    hash::{HashFunction, Keccak256},
+    secp256k1::{Secp256k1PublicKey, Secp256k1Signature},
+    traits::ToFromBytes,
+};
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{Value, VectorRef},
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+use sui_types::error::SuiError;
+
+pub const FAIL_TO_RECOVER_PUBKEY: u64 = 0;
+pub const INVALID_SIGNATURE: u64 = 1;
+pub const INVALID_PUBKEY: u64 = 2;
+
+pub fn ecrecover(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 2);
+
+    let hashed_msg = pop_arg!(args, VectorRef);
+    let signature = pop_arg!(args, VectorRef);
+
+    let hashed_msg_ref = hashed_msg.as_bytes_ref();
+    let signature_ref = signature.as_bytes_ref();
+
+    // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/3593
+    let cost = legacy_empty_cost();
+    match recover_pubkey(&signature_ref, &hashed_msg_ref) {
+        Ok(pubkey) => Ok(NativeResult::ok(
+            cost,
+            smallvec![Value::vector_u8(pubkey.as_bytes().to_vec())],
+        )),
+        Err(SuiError::InvalidSignature { error: _ }) => {
+            Ok(NativeResult::err(cost, INVALID_SIGNATURE))
+        }
+        Err(_) => Ok(NativeResult::err(cost, FAIL_TO_RECOVER_PUBKEY)),
+    }
+}
+
+fn recover_pubkey(signature: &[u8], hashed_msg: &[u8]) -> Result<Secp256k1PublicKey, SuiError> {
+    match <Secp256k1Signature as ToFromBytes>::from_bytes(signature) {
+        Ok(signature) => match signature.recover(hashed_msg) {
+            Ok(pubkey) => Ok(pubkey),
+            Err(e) => Err(SuiError::KeyConversionError(e.to_string())),
+        },
+        Err(e) => Err(SuiError::InvalidSignature {
+            error: e.to_string(),
+        }),
+    }
+}
+
+pub fn decompress_pubkey(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let pubkey = pop_arg!(args, VectorRef);
+    let pubkey_ref = pubkey.as_bytes_ref();
+
+    // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/3593
+    let cost = legacy_empty_cost();
+
+    match Secp256k1PublicKey::from_bytes(&pubkey_ref) {
+        Ok(pubkey) => {
+            let uncompressed = &pubkey.pubkey.serialize_uncompressed();
+            Ok(NativeResult::ok(
+                cost,
+                smallvec![Value::vector_u8(uncompressed.to_vec())],
+            ))
+        }
+        Err(_) => Ok(NativeResult::err(cost, INVALID_PUBKEY)),
+    }
+}
+
+pub fn keccak256(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/3593
+    let cost = legacy_empty_cost();
+    let msg = pop_arg!(args, VectorRef);
+    let msg_ref = msg.as_bytes_ref();
+
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::vector_u8(Keccak256::digest(&*msg_ref).to_vec())],
+    ))
+}
+
+pub fn secp256k1_verify(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 3);
+
+    let hashed_msg = pop_arg!(args, VectorRef);
+    let public_key_bytes = pop_arg!(args, VectorRef);
+    let signature_bytes = pop_arg!(args, VectorRef);
+
+    let hashed_msg_ref = hashed_msg.as_bytes_ref();
+    let public_key_bytes_ref = public_key_bytes.as_bytes_ref();
+    let signature_bytes_ref = signature_bytes.as_bytes_ref();
+
+    // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/4086
+    let cost = legacy_empty_cost();
+
+    let signature = match <Secp256k1Signature as ToFromBytes>::from_bytes(&signature_bytes_ref) {
+        Ok(signature) => signature,
+        Err(_) => return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    };
+
+    let public_key = match <Secp256k1PublicKey as ToFromBytes>::from_bytes(&public_key_bytes_ref) {
+        Ok(public_key) => public_key,
+        Err(_) => return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    };
+
+    match public_key.verify_hashed(&hashed_msg_ref, &signature) {
+        Ok(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(true)])),
+        Err(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    }
+}

--- a/crates/sui-framework-override/src/natives/crypto/ed25519.rs
+++ b/crates/sui-framework-override/src/natives/crypto/ed25519.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::legacy_empty_cost;
+use fastcrypto::{
+    ed25519::{Ed25519PublicKey, Ed25519Signature},
+    traits::ToFromBytes,
+    Verifier,
+};
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{Value, VectorRef},
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub fn ed25519_verify(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 3);
+
+    let msg = pop_arg!(args, VectorRef);
+    let msg_ref = msg.as_bytes_ref();
+    let public_key_bytes = pop_arg!(args, VectorRef);
+    let public_key_bytes_ref = public_key_bytes.as_bytes_ref();
+    let signature_bytes = pop_arg!(args, VectorRef);
+    let signature_bytes_ref = signature_bytes.as_bytes_ref();
+
+    let cost = legacy_empty_cost();
+
+    let signature = match <Ed25519Signature as ToFromBytes>::from_bytes(&signature_bytes_ref) {
+        Ok(signature) => signature,
+        Err(_) => return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    };
+
+    let public_key = match <Ed25519PublicKey as ToFromBytes>::from_bytes(&public_key_bytes_ref) {
+        Ok(public_key) => public_key,
+        Err(_) => return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    };
+
+    match public_key.verify(&msg_ref, &signature) {
+        Ok(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(true)])),
+        Err(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    }
+}

--- a/crates/sui-framework-override/src/natives/crypto/elliptic_curve.rs
+++ b/crates/sui-framework-override/src/natives/crypto/elliptic_curve.rs
@@ -1,0 +1,126 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::legacy_empty_cost;
+use curve25519_dalek_ng::scalar::Scalar;
+use fastcrypto::{bulletproofs::PedersenCommitment, traits::ToFromBytes};
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub const INVALID_RISTRETTO_GROUP_ELEMENT: u64 = 1;
+pub const INVALID_RISTRETTO_SCALAR: u64 = 2;
+
+/// Native implementations for Pedersen Commitment on a prime order group.
+
+pub fn add_ristretto_point(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 2);
+
+    let point_a = pop_arg!(args, Vec<u8>);
+    let point_b = pop_arg!(args, Vec<u8>);
+    let cost = legacy_empty_cost();
+
+    let Ok(rist_point_a) = PedersenCommitment::from_bytes(&point_a[..]) else { return Ok(NativeResult::err(cost, INVALID_RISTRETTO_GROUP_ELEMENT)); };
+    let Ok(rist_point_b) = PedersenCommitment::from_bytes(&point_b[..]) else { return Ok(NativeResult::err(cost, INVALID_RISTRETTO_GROUP_ELEMENT)); };
+
+    let sum = rist_point_a + rist_point_b;
+
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::vector_u8(sum.as_bytes().to_vec())],
+    ))
+}
+
+pub fn subtract_ristretto_point(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 2);
+
+    let point_b = pop_arg!(args, Vec<u8>);
+    let point_a = pop_arg!(args, Vec<u8>);
+    let cost = legacy_empty_cost();
+
+    let Ok(rist_point_a) = PedersenCommitment::from_bytes(&point_a[..]) else { return Ok(NativeResult::err(cost, INVALID_RISTRETTO_GROUP_ELEMENT)); };
+    let Ok(rist_point_b) = PedersenCommitment::from_bytes(&point_b[..]) else { return Ok(NativeResult::err(cost, INVALID_RISTRETTO_GROUP_ELEMENT)); };
+
+    let sum = rist_point_a - rist_point_b;
+
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::vector_u8(sum.as_bytes().to_vec())],
+    ))
+}
+
+pub fn pedersen_commit(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 2);
+
+    let blinding_factor_vec = pop_arg!(args, Vec<u8>);
+    let value_vec = pop_arg!(args, Vec<u8>);
+    let cost = legacy_empty_cost();
+
+    let Ok(blinding_factor) = blinding_factor_vec.try_into() else { return Ok(NativeResult::err(cost, INVALID_RISTRETTO_SCALAR)); };
+
+    let Ok(value) = value_vec.try_into() else { return Ok(NativeResult::err(cost, INVALID_RISTRETTO_SCALAR)); };
+
+    let commitment = PedersenCommitment::new(value, blinding_factor);
+
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::vector_u8(commitment.as_bytes().to_vec())],
+    ))
+}
+
+pub fn scalar_from_u64(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let value = pop_arg!(args, u64);
+    let cost = legacy_empty_cost();
+    let scalar = Scalar::from(value);
+
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::vector_u8(scalar.as_bytes().to_vec())],
+    ))
+}
+
+pub fn scalar_from_bytes(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let value = pop_arg!(args, Vec<u8>);
+    let cost = legacy_empty_cost();
+
+    let Ok(value) = value.try_into() else { return Ok(NativeResult::err(cost, INVALID_RISTRETTO_SCALAR)); };
+
+    let Some(scalar) = Scalar::from_canonical_bytes(value) else { return Ok(NativeResult::err(cost, INVALID_RISTRETTO_SCALAR)); };
+
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::vector_u8(scalar.as_bytes().to_vec())],
+    ))
+}

--- a/crates/sui-framework-override/src/natives/crypto/groth16.rs
+++ b/crates/sui-framework-override/src/natives/crypto/groth16.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::legacy_empty_cost;
+use fastcrypto_zkp::api::{prepare_pvk_bytes, verify_groth16_in_bytes};
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{self, Value, VectorRef},
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub const INVALID_VERIFYING_KEY: u64 = 0;
+
+pub fn prepare_verifying_key(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let bytes = pop_arg!(args, VectorRef);
+    let verifying_key = bytes.as_bytes_ref();
+
+    // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/3593
+    let cost = legacy_empty_cost();
+
+    match prepare_pvk_bytes(&verifying_key) {
+        Ok(pvk) => Ok(NativeResult::ok(
+            cost,
+            smallvec![Value::struct_(values::Struct::pack(vec![
+                Value::vector_u8(pvk[0].to_vec()),
+                Value::vector_u8(pvk[1].to_vec()),
+                Value::vector_u8(pvk[2].to_vec()),
+                Value::vector_u8(pvk[3].to_vec())
+            ]))],
+        )),
+        Err(_) => Ok(NativeResult::err(cost, INVALID_VERIFYING_KEY)),
+    }
+}
+
+pub fn verify_groth16_proof_internal(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 6);
+
+    let bytes5 = pop_arg!(args, VectorRef);
+    let proof_points = bytes5.as_bytes_ref();
+
+    let bytes4 = pop_arg!(args, VectorRef);
+    let public_proof_inputs = bytes4.as_bytes_ref();
+
+    let bytes3 = pop_arg!(args, VectorRef);
+    let delta_g2_neg_pc = bytes3.as_bytes_ref();
+
+    let bytes2 = pop_arg!(args, VectorRef);
+    let gamma_g2_neg_pc = bytes2.as_bytes_ref();
+
+    let byte1 = pop_arg!(args, VectorRef);
+    let alpha_g1_beta_g2 = byte1.as_bytes_ref();
+
+    let bytes = pop_arg!(args, VectorRef);
+    let vk_gamma_abc_g1 = bytes.as_bytes_ref();
+
+    // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/3593
+    let cost = legacy_empty_cost();
+
+    match verify_groth16_in_bytes(
+        &vk_gamma_abc_g1,
+        &alpha_g1_beta_g2,
+        &gamma_g2_neg_pc,
+        &delta_g2_neg_pc,
+        &public_proof_inputs,
+        &proof_points,
+    ) {
+        Ok(res) => {
+            if res {
+                Ok(NativeResult::ok(cost, smallvec![Value::bool(true)]))
+            } else {
+                Ok(NativeResult::ok(cost, smallvec![Value::bool(false)]))
+            }
+        }
+        Err(_) => Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    }
+}

--- a/crates/sui-framework-override/src/natives/crypto/hmac.rs
+++ b/crates/sui-framework-override/src/natives/crypto/hmac.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::legacy_empty_cost;
+use fastcrypto::{hmac, traits::ToFromBytes};
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{Value, VectorRef},
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub fn hmac_sha3_256(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 2);
+
+    let message = pop_arg!(args, VectorRef);
+    let key = pop_arg!(args, VectorRef);
+    let hmac_key = hmac::HmacKey::from_bytes(&key.as_bytes_ref()).unwrap();
+
+    // TODO: implement native gas cost estimation https://github.com/MystenLabs/sui/issues/3593
+    let cost = legacy_empty_cost();
+
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::vector_u8(
+            hmac::hmac_sha3_256(&hmac_key, &message.as_bytes_ref()).to_vec()
+        )],
+    ))
+}

--- a/crates/sui-framework-override/src/natives/crypto/mod.rs
+++ b/crates/sui-framework-override/src/natives/crypto/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod bls12381;
+pub mod bulletproofs;
+pub mod ecdsa_k1;
+pub mod ed25519;
+pub mod elliptic_curve;
+pub mod groth16;
+pub mod hmac;

--- a/crates/sui-framework-override/src/natives/dynamic_field.rs
+++ b/crates/sui-framework-override/src/natives/dynamic_field.rs
@@ -1,0 +1,278 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    legacy_emit_cost,
+    natives::{
+        get_nested_struct_field, get_object_id,
+        object_runtime::{object_store::ObjectResult, ObjectRuntime},
+    },
+};
+use fastcrypto::hash::{HashFunction, Sha3_256};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{StructTag, TypeTag},
+    value::MoveTypeLayout,
+    vm_status::StatusCode,
+};
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{StructRef, Value},
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+use sui_types::base_types::{ObjectID, SuiAddress};
+
+const E_KEY_DOES_NOT_EXIST: u64 = 1;
+const E_FIELD_TYPE_MISMATCH: u64 = 2;
+const E_BCS_SERIALIZATION_FAILURE: u64 = 3;
+
+macro_rules! get_or_fetch_object {
+    ($context:ident, $ty_args:ident, $parent:ident, $child_id:ident) => {{
+        let child_ty = $ty_args.pop().unwrap();
+        assert!($ty_args.is_empty());
+        let (layout, tag) = match get_tag_and_layout($context, &child_ty)? {
+            Some(res) => res,
+            None => {
+                return Ok(NativeResult::err(
+                    legacy_emit_cost(),
+                    E_BCS_SERIALIZATION_FAILURE,
+                ))
+            }
+        };
+        let object_runtime: &mut ObjectRuntime = $context.extensions_mut().get_mut();
+        object_runtime.get_or_fetch_child_object($parent, $child_id, &child_ty, layout, tag)?
+    }};
+}
+
+// native fun hash_type_and_key<K: copy + drop + store>(parent: address, k: K): address;
+pub fn hash_type_and_key(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 1);
+    assert!(args.len() == 2);
+    let k_ty = ty_args.pop().unwrap();
+    let k: Value = args.pop_back().unwrap();
+    let parent: SuiAddress = pop_arg!(args, AccountAddress).into();
+    let k_tag = context.type_to_type_tag(&k_ty)?;
+    // build bytes
+    let k_tag_bytes = match bcs::to_bytes(&k_tag) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return Ok(NativeResult::err(
+                legacy_emit_cost(),
+                E_BCS_SERIALIZATION_FAILURE,
+            ));
+        }
+    };
+    let k_layout = match context.type_to_type_layout(&k_ty) {
+        Ok(Some(layout)) => layout,
+        _ => {
+            return Ok(NativeResult::err(
+                legacy_emit_cost(),
+                E_BCS_SERIALIZATION_FAILURE,
+            ))
+        }
+    };
+    let k_bytes = match k.simple_serialize(&k_layout) {
+        Some(bytes) => bytes,
+        None => {
+            return Ok(NativeResult::err(
+                legacy_emit_cost(),
+                E_BCS_SERIALIZATION_FAILURE,
+            ))
+        }
+    };
+    // hash(parent || k || K)
+    let mut hasher = Sha3_256::default();
+    hasher.update(parent);
+    hasher.update(k_bytes);
+    hasher.update(k_tag_bytes);
+    let hash = hasher.finalize();
+
+    // truncate into an ObjectID and return
+    // OK to access slice because Sha3_256 should never be shorter than ObjectID::LENGTH.
+    let id = ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap();
+
+    Ok(NativeResult::ok(
+        legacy_emit_cost(),
+        smallvec![Value::address(id.into())],
+    ))
+}
+
+// throws `E_KEY_ALREADY_EXISTS` if a child already exists with that ID
+// native fun add_child_object<Child: key>(parent: address, child: Child);
+pub fn add_child_object(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 1);
+    assert!(args.len() == 2);
+    let child = args.pop_back().unwrap();
+    let parent = pop_arg!(args, AccountAddress).into();
+    assert!(args.is_empty());
+    // TODO remove this copy_value, which will require VM changes
+    let child_id = get_object_id(child.copy_value().unwrap())
+        .unwrap()
+        .value_as::<AccountAddress>()
+        .unwrap()
+        .into();
+    let child_ty = ty_args.pop().unwrap();
+    assert!(ty_args.is_empty());
+    let tag = match context.type_to_type_tag(&child_ty)? {
+        TypeTag::Struct(s) => s,
+        _ => {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("Sui verifier guarantees this is a struct".to_string()),
+            )
+        }
+    };
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    object_runtime.add_child_object(parent, child_id, &child_ty, *tag, child)?;
+    Ok(NativeResult::ok(legacy_emit_cost(), smallvec![]))
+}
+
+// throws `E_KEY_DOES_NOT_EXIST` if a child does not exist with that ID at that type
+// or throws `E_FIELD_TYPE_MISMATCH` if the type does not match
+// native fun borrow_child_object<Child: key>(parent: &UID, id: address): &Child;
+// and (as the runtime does not distinguish different reference types)
+// native fun borrow_child_object_mut<Child: key>(parent: &mut UID, id: address): &mut Child;
+pub fn borrow_child_object(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 1);
+    assert!(args.len() == 2);
+    let child_id = pop_arg!(args, AccountAddress).into();
+
+    let parent_uid = pop_arg!(args, StructRef).read_ref().unwrap();
+    // UID { id: ID { bytes: address } }
+    let parent = get_nested_struct_field(parent_uid, &[0, 0])
+        .unwrap()
+        .value_as::<AccountAddress>()
+        .unwrap()
+        .into();
+
+    assert!(args.is_empty());
+    let global_value_result = get_or_fetch_object!(context, ty_args, parent, child_id);
+    let global_value = match global_value_result {
+        ObjectResult::MismatchedType => {
+            return Ok(NativeResult::err(legacy_emit_cost(), E_FIELD_TYPE_MISMATCH))
+        }
+        ObjectResult::Loaded(gv) => gv,
+    };
+    if !global_value.exists()? {
+        return Ok(NativeResult::err(legacy_emit_cost(), E_KEY_DOES_NOT_EXIST));
+    }
+    let child_ref = global_value.borrow_global().map_err(|err| {
+        assert!(err.major_status() != StatusCode::MISSING_DATA);
+        err
+    })?;
+    Ok(NativeResult::ok(legacy_emit_cost(), smallvec![child_ref]))
+}
+
+// throws `E_KEY_DOES_NOT_EXIST` if a child does not exist with that ID at that type
+// or throws `E_FIELD_TYPE_MISMATCH` if the type does not match
+// native fun remove_child_object<Child: key>(parent: address, id: address): Child;
+pub fn remove_child_object(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 1);
+    assert!(args.len() == 2);
+    let child_id = pop_arg!(args, AccountAddress).into();
+    let parent = pop_arg!(args, AccountAddress).into();
+    assert!(args.is_empty());
+    let global_value_result = get_or_fetch_object!(context, ty_args, parent, child_id);
+    let global_value = match global_value_result {
+        ObjectResult::MismatchedType => {
+            return Ok(NativeResult::err(legacy_emit_cost(), E_FIELD_TYPE_MISMATCH))
+        }
+        ObjectResult::Loaded(gv) => gv,
+    };
+    if !global_value.exists()? {
+        return Ok(NativeResult::err(legacy_emit_cost(), E_KEY_DOES_NOT_EXIST));
+    }
+    let child = global_value.move_from().map_err(|err| {
+        assert!(err.major_status() != StatusCode::MISSING_DATA);
+        err
+    })?;
+    Ok(NativeResult::ok(legacy_emit_cost(), smallvec![child]))
+}
+
+//native fun has_child_object(parent: address, id: address): bool;
+pub fn has_child_object(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.is_empty());
+    assert!(args.len() == 2);
+    let child_id = pop_arg!(args, AccountAddress).into();
+    let parent = pop_arg!(args, AccountAddress).into();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let has_child = object_runtime.child_object_exists(parent, child_id)?;
+    Ok(NativeResult::ok(
+        legacy_emit_cost(),
+        smallvec![Value::bool(has_child)],
+    ))
+}
+
+//native fun has_child_object_with_ty<Child: key>(parent: address, id: address): bool;
+pub fn has_child_object_with_ty(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 1);
+    assert!(args.len() == 2);
+    let child_id = pop_arg!(args, AccountAddress).into();
+    let parent = pop_arg!(args, AccountAddress).into();
+    assert!(args.is_empty());
+    let ty = ty_args.pop().unwrap();
+    let tag = match context.type_to_type_tag(&ty)? {
+        TypeTag::Struct(s) => s,
+        _ => {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("Sui verifier guarantees this is a struct".to_string()),
+            )
+        }
+    };
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let has_child = object_runtime.child_object_exists_and_has_type(parent, child_id, *tag)?;
+    Ok(NativeResult::ok(
+        legacy_emit_cost(),
+        smallvec![Value::bool(has_child)],
+    ))
+}
+
+fn get_tag_and_layout(
+    context: &NativeContext,
+    ty: &Type,
+) -> PartialVMResult<Option<(MoveTypeLayout, StructTag)>> {
+    let layout = match context.type_to_type_layout(ty)? {
+        None => return Ok(None),
+        Some(layout) => layout,
+    };
+    let tag = match context.type_to_type_tag(ty)? {
+        TypeTag::Struct(s) => s,
+        _ => {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("Sui verifier guarantees this is a struct".to_string()),
+            )
+        }
+    };
+    Ok(Some((layout, *tag)))
+}

--- a/crates/sui-framework-override/src/natives/event.rs
+++ b/crates/sui-framework-override/src/natives/event.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{legacy_emit_cost, natives::object_runtime::ObjectRuntime};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{language_storage::TypeTag, vm_status::StatusCode};
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+/// Implementation of Move native function `event::emit<T: copy + drop>(event: T)`
+/// Adds an event to the transaction's event log
+pub fn emit(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let ty = ty_args.pop().unwrap();
+    let event = args.pop_back().unwrap();
+
+    // gas cost is proportional to size of event
+    let cost = legacy_emit_cost();
+    let tag = match context.type_to_type_tag(&ty)? {
+        TypeTag::Struct(s) => s,
+        _ => {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("Sui verifier guarantees this is a struct".to_string()),
+            )
+        }
+    };
+
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    obj_runtime.emit_event(ty, *tag, event);
+    Ok(NativeResult::ok(cost, smallvec![]))
+}

--- a/crates/sui-framework-override/src/natives/mod.rs
+++ b/crates/sui-framework-override/src/natives/mod.rs
@@ -1,0 +1,285 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod address;
+mod crypto;
+mod dynamic_field;
+mod event;
+mod object;
+pub mod object_runtime;
+mod test_scenario;
+mod transfer;
+mod tx_context;
+mod types;
+
+use crate::make_native;
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_stdlib::natives::{GasParameters, NurseryGasParameters};
+use move_vm_runtime::native_functions::{NativeFunction, NativeFunctionTable};
+use move_vm_types::{
+    natives::function::NativeResult,
+    values::{Struct, Value},
+};
+use std::sync::Arc;
+
+use self::crypto::{bls12381, bulletproofs, ecdsa_k1, ed25519, elliptic_curve, groth16, hmac};
+
+pub fn all_natives(
+    move_stdlib_addr: AccountAddress,
+    sui_framework_addr: AccountAddress,
+) -> NativeFunctionTable {
+    let sui_natives: &[(&str, &str, NativeFunction)] = &[
+        ("address", "from_bytes", make_native!(address::from_bytes)),
+        ("address", "to_u256", make_native!(address::to_u256)),
+        ("address", "from_u256", make_native!(address::from_u256)),
+        (
+            "bls12381",
+            "bls12381_min_sig_verify",
+            make_native!(bls12381::bls12381_min_sig_verify),
+        ),
+        (
+            "bls12381",
+            "bls12381_min_pk_verify",
+            make_native!(bls12381::bls12381_min_pk_verify),
+        ),
+        (
+            "bulletproofs",
+            "native_verify_full_range_proof",
+            make_native!(bulletproofs::verify_range_proof),
+        ),
+        (
+            "dynamic_field",
+            "hash_type_and_key",
+            make_native!(dynamic_field::hash_type_and_key),
+        ),
+        (
+            "dynamic_field",
+            "add_child_object",
+            make_native!(dynamic_field::add_child_object),
+        ),
+        (
+            "dynamic_field",
+            "borrow_child_object",
+            make_native!(dynamic_field::borrow_child_object),
+        ),
+        (
+            "dynamic_field",
+            "borrow_child_object_mut",
+            make_native!(dynamic_field::borrow_child_object),
+        ),
+        (
+            "dynamic_field",
+            "remove_child_object",
+            make_native!(dynamic_field::remove_child_object),
+        ),
+        (
+            "dynamic_field",
+            "has_child_object",
+            make_native!(dynamic_field::has_child_object),
+        ),
+        (
+            "dynamic_field",
+            "has_child_object_with_ty",
+            make_native!(dynamic_field::has_child_object_with_ty),
+        ),
+        ("ecdsa_k1", "ecrecover", make_native!(ecdsa_k1::ecrecover)),
+        (
+            "ecdsa_k1",
+            "decompress_pubkey",
+            make_native!(ecdsa_k1::decompress_pubkey),
+        ),
+        ("ecdsa_k1", "keccak256", make_native!(ecdsa_k1::keccak256)),
+        (
+            "ecdsa_k1",
+            "secp256k1_verify",
+            make_native!(ecdsa_k1::secp256k1_verify),
+        ),
+        (
+            "ed25519",
+            "ed25519_verify",
+            make_native!(ed25519::ed25519_verify),
+        ),
+        (
+            "elliptic_curve",
+            "native_add_ristretto_point",
+            make_native!(elliptic_curve::add_ristretto_point),
+        ),
+        (
+            "elliptic_curve",
+            "native_subtract_ristretto_point",
+            make_native!(elliptic_curve::subtract_ristretto_point),
+        ),
+        (
+            "elliptic_curve",
+            "native_create_pedersen_commitment",
+            make_native!(elliptic_curve::pedersen_commit),
+        ),
+        (
+            "elliptic_curve",
+            "native_scalar_from_u64",
+            make_native!(elliptic_curve::scalar_from_u64),
+        ),
+        (
+            "elliptic_curve",
+            "native_scalar_from_bytes",
+            make_native!(elliptic_curve::scalar_from_bytes),
+        ),
+        ("event", "emit", make_native!(event::emit)),
+        (
+            "groth16",
+            "verify_groth16_proof_internal",
+            make_native!(groth16::verify_groth16_proof_internal),
+        ),
+        (
+            "groth16",
+            "prepare_verifying_key",
+            make_native!(groth16::prepare_verifying_key),
+        ),
+        (
+            "hmac",
+            "native_hmac_sha3_256",
+            make_native!(hmac::hmac_sha3_256),
+        ),
+        ("object", "delete_impl", make_native!(object::delete_impl)),
+        ("object", "borrow_uid", make_native!(object::borrow_uid)),
+        (
+            "object",
+            "record_new_uid",
+            make_native!(object::record_new_uid),
+        ),
+        (
+            "test_scenario",
+            "take_from_address_by_id",
+            make_native!(test_scenario::take_from_address_by_id),
+        ),
+        (
+            "test_scenario",
+            "most_recent_id_for_address",
+            make_native!(test_scenario::most_recent_id_for_address),
+        ),
+        (
+            "test_scenario",
+            "was_taken_from_address",
+            make_native!(test_scenario::was_taken_from_address),
+        ),
+        (
+            "test_scenario",
+            "take_immutable_by_id",
+            make_native!(test_scenario::take_immutable_by_id),
+        ),
+        (
+            "test_scenario",
+            "most_recent_immutable_id",
+            make_native!(test_scenario::most_recent_immutable_id),
+        ),
+        (
+            "test_scenario",
+            "was_taken_immutable",
+            make_native!(test_scenario::was_taken_immutable),
+        ),
+        (
+            "test_scenario",
+            "take_shared_by_id",
+            make_native!(test_scenario::take_shared_by_id),
+        ),
+        (
+            "test_scenario",
+            "most_recent_id_shared",
+            make_native!(test_scenario::most_recent_id_shared),
+        ),
+        (
+            "test_scenario",
+            "was_taken_shared",
+            make_native!(test_scenario::was_taken_shared),
+        ),
+        (
+            "test_scenario",
+            "end_transaction",
+            make_native!(test_scenario::end_transaction),
+        ),
+        (
+            "test_scenario",
+            "ids_for_address",
+            make_native!(test_scenario::ids_for_address),
+        ),
+        (
+            "transfer",
+            "transfer_internal",
+            make_native!(transfer::transfer_internal),
+        ),
+        (
+            "transfer",
+            "freeze_object",
+            make_native!(transfer::freeze_object),
+        ),
+        (
+            "transfer",
+            "share_object",
+            make_native!(transfer::share_object),
+        ),
+        (
+            "tx_context",
+            "derive_id",
+            make_native!(tx_context::derive_id),
+        ),
+        (
+            "types",
+            "is_one_time_witness",
+            make_native!(types::is_one_time_witness),
+        ),
+    ];
+    sui_natives
+        .iter()
+        .cloned()
+        .map(|(module_name, func_name, func)| {
+            (
+                sui_framework_addr,
+                Identifier::new(module_name).unwrap(),
+                Identifier::new(func_name).unwrap(),
+                func,
+            )
+        })
+        .chain(move_stdlib::natives::all_natives(
+            move_stdlib_addr,
+            // TODO: tune gas params
+            GasParameters::zeros(),
+        ))
+        .chain(move_stdlib::natives::nursery_natives(
+            move_stdlib_addr,
+            // TODO: tune gas params
+            NurseryGasParameters::zeros(),
+        ))
+        .collect()
+}
+
+// Object { id: UID { id: ID { bytes: address } } .. }
+// Extract the first field of the struct 3 times to get the id bytes.
+pub fn get_object_id(object: Value) -> Result<Value, PartialVMError> {
+    get_nested_struct_field(object, &[0, 0, 0])
+}
+
+// Extract a field valye that's nested inside value `v`. The offset of each nesting
+// is determined by `offsets`.
+pub fn get_nested_struct_field(mut v: Value, offsets: &[usize]) -> Result<Value, PartialVMError> {
+    for offset in offsets {
+        v = get_nth_struct_field(v, *offset)?;
+    }
+    Ok(v)
+}
+
+pub fn get_nth_struct_field(v: Value, n: usize) -> Result<Value, PartialVMError> {
+    let mut itr = v.value_as::<Struct>()?.unpack()?;
+    Ok(itr.nth(n).unwrap())
+}
+
+#[macro_export]
+macro_rules! make_native {
+    ($native: expr) => {
+        Arc::new(
+            move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+                $native(context, ty_args, args)
+            },
+        )
+    };
+}

--- a/crates/sui-framework-override/src/natives/object.rs
+++ b/crates/sui-framework-override/src/natives/object.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{legacy_emit_cost, natives::object_runtime::ObjectRuntime};
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::account_address::AccountAddress;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{StructRef, Value},
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+// native fun borrow_uid<T: key>(obj: &T): &UID;
+pub fn borrow_uid(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let obj = pop_arg!(args, StructRef);
+    let id_field = obj.borrow_field(0)?;
+
+    // TODO: what should the cost of this be?
+    let cost = legacy_emit_cost();
+
+    Ok(NativeResult::ok(cost, smallvec![id_field]))
+}
+
+// native fun delete_impl(id: address);
+pub fn delete_impl(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    // unwrap safe because the interface of native function guarantees it.
+    let uid_bytes = pop_arg!(args, AccountAddress);
+
+    // TODO: what should the cost of this be?
+    let cost = legacy_emit_cost();
+
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    obj_runtime.delete_id(uid_bytes.into());
+    Ok(NativeResult::ok(cost, smallvec![]))
+}
+
+// native fun record_new_uid(id: address);
+pub fn record_new_uid(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+    // unwrap safe because the interface of native function guarantees it.
+    let uid_bytes = pop_arg!(args, AccountAddress);
+
+    // TODO: what should the cost of this be?
+    let cost = legacy_emit_cost();
+
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    obj_runtime.new_id(uid_bytes.into());
+    Ok(NativeResult::ok(cost, smallvec![]))
+}

--- a/crates/sui-framework-override/src/natives/object_runtime/mod.rs
+++ b/crates/sui-framework-override/src/natives/object_runtime/mod.rs
@@ -1,0 +1,401 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use better_any::{Tid, TidAble};
+use linked_hash_map::LinkedHashMap;
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::{
+    account_address::AccountAddress, effects::Op, language_storage::StructTag,
+    value::MoveTypeLayout,
+};
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    values::{GlobalValue, Value},
+};
+use std::collections::{BTreeMap, BTreeSet};
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber, SuiAddress},
+    error::{ExecutionError, ExecutionErrorKind},
+    object::{MoveObject, Owner},
+    storage::{ChildObjectResolver, DeleteKind, WriteKind},
+    SUI_SYSTEM_STATE_OBJECT_ID,
+};
+
+pub(crate) mod object_store;
+
+use object_store::ObjectStore;
+
+use self::object_store::{ChildObjectEffect, ObjectResult};
+
+use super::get_object_id;
+
+pub enum ObjectEvent {
+    /// Transfer to a new address or object. Or make it shared or immutable.
+    Transfer(Owner, MoveObject),
+    /// An object ID is deleted
+    DeleteObjectID(ObjectID),
+}
+
+// LinkedHashSet has a bug for accessing the back/last element
+type Set<K> = LinkedHashMap<K, ()>;
+
+#[derive(Default)]
+pub(crate) struct TestInventories {
+    pub(crate) objects: BTreeMap<ObjectID, Value>,
+    // address inventories. Most recent objects are at the back of the set
+    pub(crate) address_inventories: BTreeMap<SuiAddress, BTreeMap<Type, Set<ObjectID>>>,
+    // global inventories.Most recent objects are at the back of the set
+    pub(crate) shared_inventory: BTreeMap<Type, Set<ObjectID>>,
+    pub(crate) immutable_inventory: BTreeMap<Type, Set<ObjectID>>,
+    pub(crate) taken_immutable_values: BTreeMap<Type, BTreeMap<ObjectID, Value>>,
+    // object has been taken from the inventory
+    pub(crate) taken: BTreeMap<ObjectID, Owner>,
+}
+
+pub struct RuntimeResults {
+    pub writes: LinkedHashMap<ObjectID, (WriteKind, Owner, Type, StructTag, Value)>,
+    pub deletions: LinkedHashMap<ObjectID, DeleteKind>,
+    pub user_events: Vec<(Type, StructTag, Value)>,
+    // loaded child objects and their versions
+    pub loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
+}
+
+#[derive(Default)]
+pub(crate) struct ObjectRuntimeState {
+    pub(crate) input_objects: BTreeMap<ObjectID, (/* by_value */ bool, Owner)>,
+    // new ids from object::new
+    new_ids: Set<ObjectID>,
+    // ids passed to object::delete
+    deleted_ids: Set<ObjectID>,
+    // transfers to a new owner (shared, immutable, object, or account address)
+    // TODO these struct tags can be removed if type_to_type_tag was exposed in the session
+    transfers: LinkedHashMap<ObjectID, (Owner, Type, StructTag, Value)>,
+    events: Vec<(Type, StructTag, Value)>,
+}
+
+#[derive(Tid)]
+pub struct ObjectRuntime<'a> {
+    object_store: ObjectStore<'a>,
+    // inventories for test scenario
+    pub(crate) test_inventories: TestInventories,
+    // the internal state
+    pub(crate) state: ObjectRuntimeState,
+}
+
+pub enum TransferResult {
+    New,
+    SameOwner,
+    OwnerChanged,
+}
+
+impl TestInventories {
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<'a> ObjectRuntime<'a> {
+    pub fn new(
+        object_resolver: Box<dyn ChildObjectResolver + 'a>,
+        input_objects: BTreeMap<ObjectID, (/* by_value */ bool, Owner)>,
+    ) -> Self {
+        Self {
+            object_store: ObjectStore::new(object_resolver),
+            test_inventories: TestInventories::new(),
+            state: ObjectRuntimeState {
+                input_objects,
+                new_ids: Set::new(),
+                deleted_ids: Set::new(),
+                transfers: LinkedHashMap::new(),
+                events: vec![],
+            },
+        }
+    }
+
+    pub fn new_id(&mut self, id: ObjectID) {
+        // remove from deleted_ids for the case in dynamic fields where the Field object was deleted
+        // and then re-added in a single transaction
+        self.state.deleted_ids.remove(&id);
+        // mark the id as new
+        self.state.new_ids.insert(id, ());
+    }
+
+    pub fn delete_id(&mut self, id: ObjectID) {
+        let was_new = self.state.new_ids.remove(&id).is_some();
+        if !was_new {
+            self.state.deleted_ids.insert(id, ());
+        }
+    }
+
+    pub fn transfer(
+        &mut self,
+        owner: Owner,
+        ty: Type,
+        tag: StructTag,
+        obj: Value,
+    ) -> PartialVMResult<TransferResult> {
+        let id: ObjectID = get_object_id(obj.copy_value()?)?
+            .value_as::<AccountAddress>()?
+            .into();
+        // - an object is new if it is contained in the new ids or if it is the
+        //   SUI_SYSTEM_STATE_OBJECT_ID which is only transferred in genesis
+        // - Otherwise, check the input objects for the previous owner
+        // - If it was not in the input objects, it must have been wrapped or must have been a
+        //   child object
+        let transfer_result =
+            if self.state.new_ids.contains_key(&id) || id == SUI_SYSTEM_STATE_OBJECT_ID {
+                TransferResult::New
+            } else if let Some((_, prev_owner)) = self.state.input_objects.get(&id) {
+                match (&owner, prev_owner) {
+                    // don't use == for dummy values in Shared owner
+                    (Owner::Shared { .. }, Owner::Shared { .. }) => TransferResult::SameOwner,
+                    (new, old) if new == old => TransferResult::SameOwner,
+                    _ => TransferResult::OwnerChanged,
+                }
+            } else {
+                TransferResult::OwnerChanged
+            };
+        self.state.transfers.insert(id, (owner, ty, tag, obj));
+        Ok(transfer_result)
+    }
+
+    pub fn emit_event(&mut self, ty: Type, tag: StructTag, event: Value) {
+        self.state.events.push((ty, tag, event))
+    }
+
+    pub(crate) fn child_object_exists(
+        &mut self,
+        parent: ObjectID,
+        child: ObjectID,
+    ) -> PartialVMResult<bool> {
+        self.object_store.object_exists(parent, child)
+    }
+
+    pub(crate) fn child_object_exists_and_has_type(
+        &mut self,
+        parent: ObjectID,
+        child: ObjectID,
+        child_tag: StructTag,
+    ) -> PartialVMResult<bool> {
+        self.object_store
+            .object_exists_and_has_type(parent, child, child_tag)
+    }
+
+    pub(crate) fn get_or_fetch_child_object(
+        &mut self,
+        parent: ObjectID,
+        child: ObjectID,
+        child_ty: &Type,
+        child_layout: MoveTypeLayout,
+        child_tag: StructTag,
+    ) -> PartialVMResult<ObjectResult<&mut GlobalValue>> {
+        let res = self.object_store.get_or_fetch_object(
+            parent,
+            child,
+            child_ty,
+            child_layout,
+            child_tag,
+        )?;
+        Ok(match res {
+            ObjectResult::MismatchedType => ObjectResult::MismatchedType,
+            ObjectResult::Loaded(child_object) => ObjectResult::Loaded(&mut child_object.value),
+        })
+    }
+
+    pub(crate) fn add_child_object(
+        &mut self,
+        parent: ObjectID,
+        child: ObjectID,
+        child_ty: &Type,
+        child_tag: StructTag,
+        child_value: Value,
+    ) -> PartialVMResult<()> {
+        self.object_store
+            .add_object(parent, child, child_ty, child_tag, child_value)
+    }
+
+    // returns None if a child object is still borrowed
+    pub(crate) fn take_state(&mut self) -> ObjectRuntimeState {
+        std::mem::take(&mut self.state)
+    }
+
+    pub fn finish(mut self) -> Result<RuntimeResults, ExecutionError> {
+        let child_effects = self.object_store.take_effects();
+        self.state.finish(child_effects)
+    }
+
+    pub(crate) fn all_active_child_objects(
+        &self,
+    ) -> impl Iterator<Item = (&ObjectID, &Type, Value)> {
+        self.object_store.all_active_objects()
+    }
+}
+
+impl ObjectRuntimeState {
+    /// Update `state_view` with the effects of successfully executing a transaction:
+    /// - Given the effects `Op<Value>` of child objects, processes the changes in terms of
+    ///   object writes/deletes
+    /// - Process `transfers` and `input_objects` to determine whether the type of change
+    ///   (WriteKind) to the object
+    /// - Process `deleted_ids` with previously determined information to determine the
+    ///   DeleteKind
+    /// - Passes through user events
+    pub(crate) fn finish(
+        mut self,
+        child_object_effects: BTreeMap<ObjectID, ChildObjectEffect>,
+    ) -> Result<RuntimeResults, ExecutionError> {
+        let mut wrapped_children = BTreeSet::new();
+        let mut loaded_child_objects = BTreeMap::new();
+        for (child, child_object_effect) in child_object_effects {
+            let ChildObjectEffect {
+                owner: parent,
+                loaded_version,
+                ty,
+                tag,
+                effect,
+            } = child_object_effect;
+            if let Some(v) = loaded_version {
+                // remove if from new_ids if it was loaded for case in dynamic fields where the
+                // Field object was removed and then re-added in a single transaction
+                self.new_ids.remove(&child);
+                loaded_child_objects.insert(child, v);
+            }
+            match effect {
+                // was modified, so mark it as mutated and transferred
+                Op::Modify(v) => {
+                    debug_assert!(!self.transfers.contains_key(&child));
+                    debug_assert!(!self.new_ids.contains_key(&child));
+                    debug_assert!(loaded_version.is_some());
+                    self.transfers
+                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, tag, v));
+                }
+
+                Op::New(v) => {
+                    debug_assert!(!self.transfers.contains_key(&child));
+                    self.transfers
+                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, tag, v));
+                }
+                // was transferred so not actually deleted
+                Op::Delete if self.transfers.contains_key(&child) => {
+                    debug_assert!(!self.deleted_ids.contains_key(&child));
+                }
+                // ID was deleted too was deleted so mark as deleted
+                Op::Delete if self.deleted_ids.contains_key(&child) => {
+                    debug_assert!(!self.transfers.contains_key(&child));
+                    debug_assert!(!self.new_ids.contains_key(&child));
+                }
+                // was new so the object is transient and does not need to be marked as deleted
+                Op::Delete if self.new_ids.contains_key(&child) => {}
+                // otherwise it must have been wrapped
+                Op::Delete => {
+                    wrapped_children.insert(child);
+                }
+            }
+        }
+        let ObjectRuntimeState {
+            input_objects,
+            new_ids,
+            deleted_ids,
+            transfers,
+            events: user_events,
+        } = self;
+        let input_owner_map = input_objects
+            .iter()
+            .filter_map(|(id, (_by_value, owner))| match owner {
+                Owner::AddressOwner(_) | Owner::Shared { .. } | Owner::Immutable => None,
+                Owner::ObjectOwner(parent) => Some((*id, (*parent).into())),
+            })
+            .collect();
+        // update the input owners with the new owners from transfers
+        // reports an error on cycles
+        // TODO can we have cycles in the new system?
+        update_owner_map(
+            input_owner_map,
+            transfers.iter().map(|(id, (owner, _, _, _))| (*id, *owner)),
+        )?;
+        // determine write kinds
+        let writes: LinkedHashMap<_, _> = transfers
+            .into_iter()
+            .map(|(id, (owner, type_, tag, value))| {
+                let write_kind =
+                    if input_objects.contains_key(&id) || loaded_child_objects.contains_key(&id) {
+                        debug_assert!(!new_ids.contains_key(&id));
+                        WriteKind::Mutate
+                    } else if id == SUI_SYSTEM_STATE_OBJECT_ID || new_ids.contains_key(&id) {
+                        // SUI_SYSTEM_STATE_OBJECT_ID is only transferred during genesis
+                        // TODO find a way to insert this in the new_ids during genesis transactions
+                        WriteKind::Create
+                    } else {
+                        WriteKind::Unwrap
+                    };
+                (id, (write_kind, owner, type_, tag, value))
+            })
+            .collect();
+        // determine delete kinds
+        let mut deletions: LinkedHashMap<_, _> = deleted_ids
+            .into_iter()
+            .map(|(id, ())| {
+                debug_assert!(!new_ids.contains_key(&id));
+                let delete_kind =
+                    if input_objects.contains_key(&id) || loaded_child_objects.contains_key(&id) {
+                        DeleteKind::Normal
+                    } else {
+                        DeleteKind::UnwrapThenDelete
+                    };
+                (id, delete_kind)
+            })
+            .collect();
+        // remaining by value objects must be wrapped
+        let remaining_by_value_objects = input_objects
+            .into_iter()
+            .filter(|(id, (by_value, _))| {
+                *by_value && !writes.contains_key(id) && !deletions.contains_key(id)
+            })
+            .map(|(id, _)| id)
+            .collect::<Vec<_>>();
+        for id in remaining_by_value_objects {
+            deletions.insert(id, DeleteKind::Wrap);
+        }
+        // children that weren't deleted or transferred must be wrapped
+        for id in wrapped_children {
+            deletions.insert(id, DeleteKind::Wrap);
+        }
+
+        debug_assert!(writes.keys().all(|id| !deletions.contains_key(id)));
+        debug_assert!(deletions.keys().all(|id| !writes.contains_key(id)));
+        Ok(RuntimeResults {
+            writes,
+            deletions,
+            user_events,
+            loaded_child_objects,
+        })
+    }
+}
+
+fn update_owner_map(
+    mut object_owner_map: BTreeMap<ObjectID, ObjectID>,
+    transfers: impl IntoIterator<Item = (ObjectID, Owner)>,
+) -> Result<(), ExecutionError> {
+    for (id, recipient) in transfers {
+        object_owner_map.remove(&id);
+        match recipient {
+            Owner::AddressOwner(_) | Owner::Shared { .. } | Owner::Immutable => (),
+            Owner::ObjectOwner(new_owner) => {
+                let new_owner: ObjectID = new_owner.into();
+                let mut cur = new_owner;
+                loop {
+                    if cur == id {
+                        return Err(ExecutionErrorKind::circular_object_ownership(cur).into());
+                    }
+                    if let Some(parent) = object_owner_map.get(&cur) {
+                        cur = *parent;
+                    } else {
+                        break;
+                    }
+                }
+                object_owner_map.insert(id, new_owner);
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/sui-framework-override/src/natives/object_runtime/object_store.rs
+++ b/crates/sui-framework-override/src/natives/object_runtime/object_store.rs
@@ -1,0 +1,302 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{
+    effects::Op, language_storage::StructTag, value::MoveTypeLayout, vm_status::StatusCode,
+};
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    values::{GlobalValue, StructRef, Value},
+};
+use std::collections::{btree_map, BTreeMap};
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber},
+    object::{Data, MoveObject},
+    storage::ChildObjectResolver,
+};
+
+pub(super) struct ChildObject {
+    pub(super) owner: ObjectID,
+    pub(super) ty: Type,
+    pub(super) tag: StructTag,
+    pub(super) value: GlobalValue,
+}
+
+pub(crate) struct ChildObjectEffect {
+    pub(super) owner: ObjectID,
+    // none if it was an input object
+    pub(super) loaded_version: Option<SequenceNumber>,
+    pub(super) ty: Type,
+    pub(super) tag: StructTag,
+    pub(super) effect: Op<Value>,
+}
+
+struct Inner<'a> {
+    // used for loading child objects
+    resolver: Box<dyn ChildObjectResolver + 'a>,
+    // cached objects from the resolver. An object might be in this map but not in the store
+    // if it's existence was queried, but the value was not used.
+    cached_objects: BTreeMap<ObjectID, Option<MoveObject>>,
+}
+
+// maintains the runtime GlobalValues for child objects and manages the fetching of objects
+// from storage, through the `ChildObjectResolver`
+pub(super) struct ObjectStore<'a> {
+    // contains object resolver and object cache
+    // kept as a separate struct to deal with lifetime issues where the `store` is accessed
+    // at the same time as the `cached_objects` is populated
+    inner: Inner<'a>,
+    // Maps of populated GlobalValues, meaning the child object has been accessed in this
+    // transaction
+    store: BTreeMap<ObjectID, ChildObject>,
+}
+
+pub(crate) enum ObjectResult<V> {
+    // object exists but type does not match. Should result in an abort
+    MismatchedType,
+    Loaded(V),
+}
+
+impl<'a> Inner<'a> {
+    fn get_or_fetch_object_from_store(
+        &mut self,
+        parent: ObjectID,
+        child: ObjectID,
+    ) -> PartialVMResult<Option<&MoveObject>> {
+        if let btree_map::Entry::Vacant(e) = self.cached_objects.entry(child) {
+            let child_opt = self
+                .resolver
+                .read_child_object(&parent, &child)
+                .map_err(|msg| {
+                    PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(format!("{msg}"))
+                })?;
+            let obj_opt = if let Some(object) = child_opt {
+                match object.data {
+                    Data::Package(_) => {
+                        return Err(PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(
+                            format!(
+                                "Mismatched object type for {child}. \
+                                Expected a Move object but found a Move package"
+                            ),
+                        ))
+                    }
+                    Data::Move(mo @ MoveObject { .. }) => Some(mo),
+                }
+            } else {
+                None
+            };
+            e.insert(obj_opt);
+        }
+        Ok(self.cached_objects.get(&child).unwrap().as_ref())
+    }
+
+    fn fetch_object_impl(
+        &mut self,
+        parent: ObjectID,
+        child: ObjectID,
+        child_ty: &Type,
+        child_ty_layout: MoveTypeLayout,
+        child_tag: StructTag,
+    ) -> PartialVMResult<ObjectResult<(Type, StructTag, GlobalValue)>> {
+        let obj = match self.get_or_fetch_object_from_store(parent, child)? {
+            None => {
+                return Ok(ObjectResult::Loaded((
+                    child_ty.clone(),
+                    child_tag,
+                    GlobalValue::none(),
+                )))
+            }
+            Some(obj) => obj,
+        };
+        // object exists, but the type does not match
+        if obj.type_ != child_tag {
+            return Ok(ObjectResult::MismatchedType);
+        }
+        let v = match Value::simple_deserialize(obj.contents(), &child_ty_layout) {
+            Some(v) => v,
+            None => {
+                return Err(
+                    PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_RESOURCE).with_message(
+                        format!("Failed to deserialize object {child} with type {child_tag}",),
+                    ),
+                )
+            }
+        };
+        let global_value =
+            match GlobalValue::cached(v) {
+                Ok(gv) => gv,
+                Err(e) => {
+                    return Err(PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(
+                        format!("Object {child} did not deserialize to a struct Value. Error: {e}"),
+                    ))
+                }
+            };
+        Ok(ObjectResult::Loaded((
+            child_ty.clone(),
+            child_tag,
+            global_value,
+        )))
+    }
+}
+
+impl<'a> ObjectStore<'a> {
+    pub(super) fn new(resolver: Box<dyn ChildObjectResolver + 'a>) -> Self {
+        Self {
+            inner: Inner {
+                resolver,
+                cached_objects: BTreeMap::new(),
+            },
+            store: BTreeMap::new(),
+        }
+    }
+
+    pub(super) fn object_exists(
+        &mut self,
+        parent: ObjectID,
+        child: ObjectID,
+    ) -> PartialVMResult<bool> {
+        if let Some(child_object) = self.store.get(&child) {
+            return child_object.value.exists();
+        }
+        Ok(self
+            .inner
+            .get_or_fetch_object_from_store(parent, child)?
+            .is_some())
+    }
+
+    pub(super) fn object_exists_and_has_type(
+        &mut self,
+        parent: ObjectID,
+        child: ObjectID,
+        child_tag: StructTag,
+    ) -> PartialVMResult<bool> {
+        if let Some(child_object) = self.store.get(&child) {
+            // exists and has same type
+            return Ok(child_object.value.exists()? && child_object.tag == child_tag);
+        }
+        Ok(self
+            .inner
+            .get_or_fetch_object_from_store(parent, child)?
+            .map(|move_obj| move_obj.type_ == child_tag)
+            .unwrap_or(false))
+    }
+
+    pub(super) fn get_or_fetch_object(
+        &mut self,
+        parent: ObjectID,
+        child: ObjectID,
+        child_ty: &Type,
+        child_layout: MoveTypeLayout,
+        child_tag: StructTag,
+    ) -> PartialVMResult<ObjectResult<&mut ChildObject>> {
+        let child_object = match self.store.entry(child) {
+            btree_map::Entry::Vacant(e) => {
+                let (ty, tag, value) = match self.inner.fetch_object_impl(
+                    parent,
+                    child,
+                    child_ty,
+                    child_layout,
+                    child_tag,
+                )? {
+                    ObjectResult::MismatchedType => return Ok(ObjectResult::MismatchedType),
+                    ObjectResult::Loaded(res) => res,
+                };
+                e.insert(ChildObject {
+                    owner: parent,
+                    ty,
+                    tag,
+                    value,
+                })
+            }
+            btree_map::Entry::Occupied(e) => {
+                let child_object = e.into_mut();
+                if child_object.tag != child_tag {
+                    return Ok(ObjectResult::MismatchedType);
+                }
+                child_object
+            }
+        };
+        Ok(ObjectResult::Loaded(child_object))
+    }
+
+    pub(super) fn add_object(
+        &mut self,
+        parent: ObjectID,
+        child: ObjectID,
+        child_ty: &Type,
+        child_tag: StructTag,
+        child_value: Value,
+    ) -> PartialVMResult<()> {
+        let mut child_object = ChildObject {
+            owner: parent,
+            ty: child_ty.clone(),
+            tag: child_tag,
+            value: GlobalValue::none(),
+        };
+        child_object.value.move_to(child_value).unwrap();
+        if let Some(prev) = self.store.insert(child, child_object) {
+            if prev.value.exists()? {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(
+                            "Duplicate addition of a child object. \
+                            The previous value cannot be dropped. Indicates possible duplication \
+                            of objects as an object was fetched more than once from two different \
+                            parents, yet was not removed from one first"
+                                .to_string(),
+                        ),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    // retrieve the `Op` effects for the child objects
+    pub(super) fn take_effects(&mut self) -> BTreeMap<ObjectID, ChildObjectEffect> {
+        std::mem::take(&mut self.store)
+            .into_iter()
+            .filter_map(|(id, child_object)| {
+                let ChildObject {
+                    owner,
+                    ty,
+                    tag,
+                    value,
+                } = child_object;
+                let loaded_version = self
+                    .inner
+                    .cached_objects
+                    .get(&id)
+                    .and_then(|obj_opt| Some(obj_opt.as_ref()?.version()));
+                let effect = value.into_effect()?;
+                let child_effect = ChildObjectEffect {
+                    owner,
+                    loaded_version,
+                    ty,
+                    tag,
+                    effect,
+                };
+                Some((id, child_effect))
+            })
+            .collect()
+    }
+
+    pub(super) fn all_active_objects(&self) -> impl Iterator<Item = (&ObjectID, &Type, Value)> {
+        self.store.iter().filter_map(|(id, child_object)| {
+            let child_exists = child_object.value.exists().unwrap();
+            if !child_exists {
+                None
+            } else {
+                let copied_child_value = child_object
+                    .value
+                    .borrow_global()
+                    .unwrap()
+                    .value_as::<StructRef>()
+                    .unwrap()
+                    .read_ref()
+                    .unwrap();
+                Some((id, &child_object.ty, copied_child_value))
+            }
+        })
+    }
+}

--- a/crates/sui-framework-override/src/natives/test_scenario.rs
+++ b/crates/sui-framework-override/src/natives/test_scenario.rs
@@ -1,0 +1,803 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    legacy_test_cost,
+    natives::{
+        get_nth_struct_field,
+        object_runtime::{ObjectRuntime, RuntimeResults},
+    },
+};
+use linked_hash_map::LinkedHashMap;
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::StructTag,
+    value::{MoveStruct, MoveValue},
+    vm_status::StatusCode,
+};
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{self, StructRef, Value},
+};
+use smallvec::smallvec;
+use std::{
+    borrow::Borrow,
+    collections::{BTreeMap, BTreeSet, VecDeque},
+};
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber, SuiAddress},
+    id::UID,
+    object::Owner,
+    storage::WriteKind,
+};
+
+const E_COULD_NOT_GENERATE_EFFECTS: u64 = 0;
+const E_INVALID_SHARED_OR_IMMUTABLE_USAGE: u64 = 1;
+const E_OBJECT_NOT_FOUND_CODE: u64 = 4;
+
+// LinkedHashSet has a bug for accessing the back/last element
+type Set<K> = LinkedHashMap<K, ()>;
+
+// This function updates the inventories based on the transfers and deletes that occurred in the
+// transaction
+// native fun end_transaction(): TransactionResult;
+pub fn end_transaction(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.is_empty());
+    assert!(args.is_empty());
+    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let taken_shared_or_imm: BTreeMap<_, _> = object_runtime_ref
+        .test_inventories
+        .taken
+        .iter()
+        .filter(|(_id, owner)| matches!(owner, Owner::Shared { .. } | Owner::Immutable))
+        .map(|(id, owner)| (*id, *owner))
+        .collect();
+    // set to true if a shared or imm object was:
+    // - transferred in a way that changes it from its original shared/imm state
+    // - wraps the object
+    // if true, we will "abort"
+    let mut incorrect_shared_or_imm_handling = false;
+
+    let object_runtime_state = object_runtime_ref.take_state();
+    // Determine writes and deletes
+    // We pass an empty map as we do not expose dynamic field objects in the system
+    let results = object_runtime_state.finish(BTreeMap::new());
+    let RuntimeResults {
+        writes,
+        deletions,
+        user_events,
+        loaded_child_objects: _,
+    } = match results {
+        Ok(res) => res,
+        Err(_) => {
+            return Ok(NativeResult::err(
+                legacy_test_cost(),
+                E_COULD_NOT_GENERATE_EFFECTS,
+            ));
+        }
+    };
+    let all_active_child_objects = object_runtime_ref
+        .all_active_child_objects()
+        .map(|(id, _, _)| *id)
+        .collect::<BTreeSet<_>>();
+    let inventories = &mut object_runtime_ref.test_inventories;
+    let mut new_object_values = LinkedHashMap::new();
+    let mut transferred = vec![];
+    // cleanup inventories
+    // we will remove all changed objects
+    // - deleted objects need to be removed to mark deletions
+    // - written objects are removed and later replaced to mark new values and new owners
+    // - child objects will not be reflected in transfers, but need to be no longer retrievable
+    for id in deletions
+        .keys()
+        .chain(writes.keys())
+        .chain(&all_active_child_objects)
+    {
+        for addr_inventory in inventories.address_inventories.values_mut() {
+            for s in addr_inventory.values_mut() {
+                s.remove(id);
+            }
+        }
+        for s in &mut inventories.shared_inventory.values_mut() {
+            s.remove(id);
+        }
+        for s in &mut inventories.immutable_inventory.values_mut() {
+            s.remove(id);
+        }
+        inventories.taken.remove(id);
+    }
+    // handle transfers, inserting transferred/written objects into their respective inventory
+    let mut created = vec![];
+    let mut written = vec![];
+    for (id, (kind, owner, ty, _tag, value)) in writes {
+        new_object_values.insert(id, (ty.clone(), value.copy_value().unwrap()));
+        transferred.push((id, owner));
+        incorrect_shared_or_imm_handling = incorrect_shared_or_imm_handling
+            || taken_shared_or_imm
+                .get(&id)
+                .map(|shared_or_imm_owner| shared_or_imm_owner != &owner)
+                .unwrap_or(/* not incorrect */ false);
+        match kind {
+            WriteKind::Create => created.push(id),
+            WriteKind::Mutate | WriteKind::Unwrap => written.push(id),
+        }
+        match owner {
+            Owner::AddressOwner(a) => {
+                inventories
+                    .address_inventories
+                    .entry(a)
+                    .or_insert_with(BTreeMap::new)
+                    .entry(ty)
+                    .or_insert_with(Set::new)
+                    .insert(id, ());
+            }
+            Owner::ObjectOwner(_) => (),
+            Owner::Shared { .. } => {
+                inventories
+                    .shared_inventory
+                    .entry(ty)
+                    .or_insert_with(Set::new)
+                    .insert(id, ());
+            }
+            Owner::Immutable => {
+                inventories
+                    .immutable_inventory
+                    .entry(ty)
+                    .or_insert_with(Set::new)
+                    .insert(id, ());
+            }
+        }
+    }
+    // deletions already handled above, but we drop the delete kind for the effects
+    let mut deleted = vec![];
+    for (id, _) in deletions {
+        incorrect_shared_or_imm_handling =
+            incorrect_shared_or_imm_handling || taken_shared_or_imm.contains_key(&id);
+        deleted.push(id);
+    }
+    // find all wrapped objects
+    let mut all_wrapped = BTreeSet::new();
+    let object_runtime_ref: &ObjectRuntime = context.extensions().get();
+    find_all_wrapped_objects(
+        context,
+        &mut all_wrapped,
+        new_object_values
+            .iter()
+            .map(|(id, (ty, value))| (id, ty, value)),
+    );
+    find_all_wrapped_objects(
+        context,
+        &mut all_wrapped,
+        object_runtime_ref
+            .all_active_child_objects()
+            .map(|(id, ty, value)| (id, ty, value)),
+    );
+    // mark as "incorrect" if a shared/imm object was wrapped or is a child object
+    incorrect_shared_or_imm_handling = incorrect_shared_or_imm_handling
+        || taken_shared_or_imm
+            .keys()
+            .any(|id| all_wrapped.contains(id) || all_active_child_objects.contains(id));
+    // if incorrect handling, return with an 'abort'
+    if incorrect_shared_or_imm_handling {
+        return Ok(NativeResult::err(
+            legacy_test_cost(),
+            E_INVALID_SHARED_OR_IMMUTABLE_USAGE,
+        ));
+    }
+
+    // mark all wrapped as deleted
+    for wrapped in all_wrapped {
+        deleted.push(wrapped)
+    }
+
+    // new input objects are remaining taken objects not written/deleted
+    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    object_runtime_ref.state.input_objects = object_runtime_ref
+        .test_inventories
+        .taken
+        .iter()
+        .map(|(id, owner)| {
+            (*id, (/* by_value */ false, *owner))
+        })
+        .collect::<BTreeMap<_, _>>();
+    // update inventories
+    // check for bad updates to immutable values
+    for (id, (ty, value)) in new_object_values {
+        debug_assert!(!all_active_child_objects.contains(&id));
+        if let Some(prev_value) = object_runtime_ref
+            .test_inventories
+            .taken_immutable_values
+            .get(&ty)
+            .and_then(|values| values.get(&id))
+        {
+            if !value.equals(prev_value)? {
+                return Ok(NativeResult::err(
+                    legacy_test_cost(),
+                    E_INVALID_SHARED_OR_IMMUTABLE_USAGE,
+                ));
+            }
+        }
+        object_runtime_ref
+            .test_inventories
+            .objects
+            .insert(id, value);
+    }
+    // remove deleted
+    for id in &deleted {
+        object_runtime_ref.test_inventories.objects.remove(id);
+    }
+    // remove active child objects
+    for id in all_active_child_objects {
+        object_runtime_ref.test_inventories.objects.remove(&id);
+    }
+
+    let effects = transaction_effects(
+        created,
+        written,
+        deleted,
+        transferred,
+        user_events.len() as u64,
+    );
+    Ok(NativeResult::ok(legacy_test_cost(), smallvec![effects]))
+}
+
+// native fun take_from_address_by_id<T: key>(account: address, id: ID): T;
+pub fn take_from_address_by_id(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let specified_ty = get_specified_ty(ty_args);
+    let id = pop_id(&mut args)?;
+    let account: SuiAddress = pop_arg!(args, AccountAddress).into();
+    pop_arg!(args, StructRef);
+    assert!(args.is_empty());
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    let res = take_from_inventory(
+        |x| {
+            inventories
+                .address_inventories
+                .get(&account)
+                .and_then(|inv| inv.get(&specified_ty))
+                .map(|s| s.contains_key(x))
+                .unwrap_or(false)
+        },
+        &inventories.objects,
+        &mut inventories.taken,
+        &mut object_runtime.state.input_objects,
+        id,
+        Owner::AddressOwner(account),
+    );
+    Ok(match res {
+        Ok(value) => NativeResult::ok(legacy_test_cost(), smallvec![value]),
+        Err(native_err) => native_err,
+    })
+}
+
+// native fun ids_for_address<T: key>(account: address): vector<ID>;
+pub fn ids_for_address(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let specified_ty = get_specified_ty(ty_args);
+    let account: SuiAddress = pop_arg!(args, AccountAddress).into();
+    assert!(args.is_empty());
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    let ids = inventories
+        .address_inventories
+        .get(&account)
+        .and_then(|inv| inv.get(&specified_ty))
+        .map(|s| {
+            s.keys()
+                .map(|id| pack_id(*id))
+                .into_iter()
+                .collect::<Vec<Value>>()
+        })
+        .unwrap_or_default();
+    let ids_vector = Value::vector_for_testing_only(ids);
+    Ok(NativeResult::ok(legacy_test_cost(), smallvec![ids_vector]))
+}
+
+// native fun most_recent_id_for_address<T: key>(account: address): Option<ID>;
+pub fn most_recent_id_for_address(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let specified_ty = get_specified_ty(ty_args);
+    let account: SuiAddress = pop_arg!(args, AccountAddress).into();
+    assert!(args.is_empty());
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    let most_recent_id = match inventories.address_inventories.get(&account) {
+        None => pack_option(None),
+        Some(inv) => most_recent_at_ty(&inventories.taken, inv, specified_ty),
+    };
+    Ok(NativeResult::ok(
+        legacy_test_cost(),
+        smallvec![most_recent_id],
+    ))
+}
+
+// native fun was_taken_from_address(account: address, id: ID): bool;
+pub fn was_taken_from_address(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.is_empty());
+    let id = pop_id(&mut args)?;
+    let account: SuiAddress = pop_arg!(args, AccountAddress).into();
+    assert!(args.is_empty());
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    let was_taken = inventories
+        .taken
+        .get(&id)
+        .map(|owner| owner == &Owner::AddressOwner(account))
+        .unwrap_or(false);
+    Ok(NativeResult::ok(
+        legacy_test_cost(),
+        smallvec![Value::bool(was_taken)],
+    ))
+}
+
+// native fun take_immutable_by_id<T: key>(id: ID): T;
+pub fn take_immutable_by_id(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let specified_ty = get_specified_ty(ty_args);
+    let id = pop_id(&mut args)?;
+    pop_arg!(args, StructRef);
+    assert!(args.is_empty());
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    let res = take_from_inventory(
+        |x| {
+            inventories
+                .immutable_inventory
+                .get(&specified_ty)
+                .map(|s| s.contains_key(x))
+                .unwrap_or(false)
+        },
+        &inventories.objects,
+        &mut inventories.taken,
+        &mut object_runtime.state.input_objects,
+        id,
+        Owner::Immutable,
+    );
+    Ok(match res {
+        Ok(value) => {
+            inventories
+                .taken_immutable_values
+                .entry(specified_ty)
+                .or_default()
+                .insert(id, value.copy_value().unwrap());
+            NativeResult::ok(legacy_test_cost(), smallvec![value])
+        }
+        Err(native_err) => native_err,
+    })
+}
+
+// native fun most_recent_immutable_id<T: key>(): Option<ID>;
+pub fn most_recent_immutable_id(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let specified_ty = get_specified_ty(ty_args);
+    assert!(args.is_empty());
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    let most_recent_id = most_recent_at_ty(
+        &inventories.taken,
+        &inventories.immutable_inventory,
+        specified_ty,
+    );
+    Ok(NativeResult::ok(
+        legacy_test_cost(),
+        smallvec![most_recent_id],
+    ))
+}
+
+// native fun was_taken_immutable(id: ID): bool;
+pub fn was_taken_immutable(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.is_empty());
+    let id = pop_id(&mut args)?;
+    assert!(args.is_empty());
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    let was_taken = inventories
+        .taken
+        .get(&id)
+        .map(|owner| owner == &Owner::Immutable)
+        .unwrap_or(false);
+    Ok(NativeResult::ok(
+        legacy_test_cost(),
+        smallvec![Value::bool(was_taken)],
+    ))
+}
+
+// native fun take_shared_by_id<T: key>(id: ID): T;
+pub fn take_shared_by_id(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let specified_ty = get_specified_ty(ty_args);
+    let id = pop_id(&mut args)?;
+    pop_arg!(args, StructRef);
+    assert!(args.is_empty());
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    let res = take_from_inventory(
+        |x| {
+            inventories
+                .shared_inventory
+                .get(&specified_ty)
+                .map(|s| s.contains_key(x))
+                .unwrap_or(false)
+        },
+        &inventories.objects,
+        &mut inventories.taken,
+        &mut object_runtime.state.input_objects,
+        id,
+        Owner::Shared { initial_shared_version: /* dummy */ SequenceNumber::new() },
+    );
+    Ok(match res {
+        Ok(value) => NativeResult::ok(legacy_test_cost(), smallvec![value]),
+        Err(native_err) => native_err,
+    })
+}
+
+// native fun most_recent_id_shared<T: key>(): Option<ID>;
+pub fn most_recent_id_shared(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let specified_ty = get_specified_ty(ty_args);
+    assert!(args.is_empty());
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    let most_recent_id = most_recent_at_ty(
+        &inventories.taken,
+        &inventories.shared_inventory,
+        specified_ty,
+    );
+    Ok(NativeResult::ok(
+        legacy_test_cost(),
+        smallvec![most_recent_id],
+    ))
+}
+
+// native fun was_taken_shared(id: ID): bool;
+pub fn was_taken_shared(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.is_empty());
+    let id = pop_id(&mut args)?;
+    assert!(args.is_empty());
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    let was_taken = inventories
+        .taken
+        .get(&id)
+        .map(|owner| matches!(owner, Owner::Shared { .. }))
+        .unwrap_or(false);
+    Ok(NativeResult::ok(
+        legacy_test_cost(),
+        smallvec![Value::bool(was_taken)],
+    ))
+}
+
+// impls
+
+fn take_from_inventory(
+    is_in_inventory: impl FnOnce(&ObjectID) -> bool,
+    objects: &BTreeMap<ObjectID, Value>,
+    taken: &mut BTreeMap<ObjectID, Owner>,
+    input_objects: &mut BTreeMap<ObjectID, (/* by_value */ bool, Owner)>,
+    id: ObjectID,
+    owner: Owner,
+) -> Result<Value, NativeResult> {
+    let obj_opt = objects.get(&id);
+    let is_taken = taken.contains_key(&id);
+    if is_taken || !is_in_inventory(&id) || obj_opt.is_none() {
+        return Err(NativeResult::err(
+            legacy_test_cost(),
+            E_OBJECT_NOT_FOUND_CODE,
+        ));
+    }
+    taken.insert(id, owner);
+    // by_value will be set to true later, if wrapped
+    input_objects.insert(id, (false, owner));
+    let obj = obj_opt.unwrap();
+    Ok(obj.copy_value().unwrap())
+}
+
+fn most_recent_at_ty(
+    taken: &BTreeMap<ObjectID, Owner>,
+    inv: &BTreeMap<Type, Set<ObjectID>>,
+    ty: Type,
+) -> Value {
+    pack_option(most_recent_at_ty_opt(taken, inv, ty))
+}
+
+fn most_recent_at_ty_opt(
+    taken: &BTreeMap<ObjectID, Owner>,
+    inv: &BTreeMap<Type, Set<ObjectID>>,
+    ty: Type,
+) -> Option<Value> {
+    let s = inv.get(&ty)?;
+    let most_recent_id = s.keys().filter(|id| !taken.contains_key(id)).last()?;
+    Some(pack_id(*most_recent_id))
+}
+
+fn get_specified_ty(mut ty_args: Vec<Type>) -> Type {
+    assert!(ty_args.len() == 1);
+    ty_args.pop().unwrap()
+}
+
+// helpers
+fn pop_id(args: &mut VecDeque<Value>) -> PartialVMResult<ObjectID> {
+    let v = match args.pop_back() {
+        None => {
+            return Err(PartialVMError::new(
+                StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+            ))
+        }
+        Some(v) => v,
+    };
+    Ok(get_nth_struct_field(v, 0)?
+        .value_as::<AccountAddress>()?
+        .into())
+}
+
+fn pack_id(a: impl Into<AccountAddress>) -> Value {
+    Value::struct_(values::Struct::pack(vec![Value::address(a.into())]))
+}
+
+fn pack_ids(items: impl IntoIterator<Item = impl Into<AccountAddress>>) -> Value {
+    Value::vector_for_testing_only(items.into_iter().map(pack_id))
+}
+
+fn pack_vec_map(items: impl IntoIterator<Item = (Value, Value)>) -> Value {
+    Value::struct_(values::Struct::pack(vec![Value::vector_for_testing_only(
+        items
+            .into_iter()
+            .map(|(k, v)| Value::struct_(values::Struct::pack(vec![k, v]))),
+    )]))
+}
+
+fn transaction_effects(
+    created: impl IntoIterator<Item = impl Into<AccountAddress>>,
+    written: impl IntoIterator<Item = impl Into<AccountAddress>>,
+    deleted: impl IntoIterator<Item = impl Into<AccountAddress>>,
+    transferred: impl IntoIterator<Item = (ObjectID, Owner)>,
+    num_events: u64,
+) -> Value {
+    let mut transferred_to_account = vec![];
+    let mut transferred_to_object = vec![];
+    let mut shared = vec![];
+    let mut frozen = vec![];
+    for (id, owner) in transferred {
+        match owner {
+            Owner::AddressOwner(a) => {
+                transferred_to_account.push((pack_id(id), Value::address(a.into())))
+            }
+            Owner::ObjectOwner(o) => transferred_to_object.push((pack_id(id), pack_id(o))),
+            Owner::Shared { .. } => shared.push(id),
+            Owner::Immutable => frozen.push(id),
+        }
+    }
+
+    let created_field = pack_ids(created);
+    let written_field = pack_ids(written);
+    let deleted_field = pack_ids(deleted);
+    let transferred_to_account_field = pack_vec_map(transferred_to_account);
+    let transferred_to_object_field = pack_vec_map(transferred_to_object);
+    let shared_field = pack_ids(shared);
+    let frozen_field = pack_ids(frozen);
+    let num_events_field = Value::u64(num_events);
+    Value::struct_(values::Struct::pack(vec![
+        created_field,
+        written_field,
+        deleted_field,
+        transferred_to_account_field,
+        transferred_to_object_field,
+        shared_field,
+        frozen_field,
+        num_events_field,
+    ]))
+}
+
+fn pack_option(opt: Option<Value>) -> Value {
+    let item = match opt {
+        Some(v) => vec![v],
+        None => vec![],
+    };
+    Value::struct_(values::Struct::pack(vec![Value::vector_for_testing_only(
+        item,
+    )]))
+}
+
+fn find_all_wrapped_objects<'a>(
+    context: &NativeContext,
+    ids: &mut BTreeSet<ObjectID>,
+    new_object_values: impl IntoIterator<Item = (&'a ObjectID, &'a Type, impl Borrow<Value>)>,
+) {
+    for (_id, ty, value) in new_object_values {
+        let layout = match context.type_to_type_layout(ty) {
+            Ok(Some(layout)) => layout,
+            _ => {
+                debug_assert!(false);
+                continue;
+            }
+        };
+        let annotated_layout = match context.type_to_fully_annotated_layout(ty) {
+            Ok(Some(layout)) => layout,
+            _ => {
+                debug_assert!(false);
+                continue;
+            }
+        };
+        let blob = value.borrow().simple_serialize(&layout).unwrap();
+        let move_value = MoveValue::simple_deserialize(&blob, &annotated_layout).unwrap();
+        let uid = UID::type_();
+        visit_structs(
+            &move_value,
+            |_, _| panic!("unexpected struct without a struct tag. Layout: {}", layout),
+            |_, _| panic!("unexpected struct without a struct tag. Layout: {}", layout),
+            |depth, tag, fields| {
+                if tag != &uid {
+                    return if depth == 0 {
+                        debug_assert!(!fields.is_empty());
+                        // all object values so the first field is a UID that should be skipped
+                        &fields[1..]
+                    } else {
+                        fields
+                    };
+                }
+                debug_assert!(fields.len() == 1);
+                let id = &fields[0].1;
+                let addr_field = match &id {
+                    MoveValue::Struct(MoveStruct::WithTypes { fields, .. }) => {
+                        debug_assert!(fields.len() == 1);
+                        &fields[0].1
+                    }
+                    v => unreachable!("Not reachable via Move type system: {:?}", v),
+                };
+                let addr = match addr_field {
+                    MoveValue::Address(a) => *a,
+                    v => unreachable!("Not reachable via Move type system: {:?}", v),
+                };
+                ids.insert(addr.into());
+                fields
+            },
+        )
+    }
+}
+
+fn visit_structs<FVisitTypes>(
+    move_value: &MoveValue,
+    mut visit_runtime: impl FnMut(/* value depth */ usize, &Vec<MoveValue>) -> &[MoveValue],
+    mut visit_with_fields: impl FnMut(
+        /* value depth */ usize,
+        &Vec<(Identifier, MoveValue)>,
+    ) -> &[(Identifier, MoveValue)],
+    mut visit_with_types: FVisitTypes,
+) where
+    for<'a> FVisitTypes: FnMut(
+        /* value depth */ usize,
+        &StructTag,
+        &'a Vec<(Identifier, MoveValue)>,
+    ) -> &'a [(Identifier, MoveValue)],
+{
+    visit_structs_impl(
+        move_value,
+        &mut visit_runtime,
+        &mut visit_with_fields,
+        &mut visit_with_types,
+        0,
+    )
+}
+
+fn visit_structs_impl<FVisitTypes>(
+    move_value: &MoveValue,
+    visit_runtime: &mut impl FnMut(/* value depth */ usize, &Vec<MoveValue>) -> &[MoveValue],
+    visit_with_fields: &mut impl FnMut(
+        /* value depth */ usize,
+        &Vec<(Identifier, MoveValue)>,
+    ) -> &[(Identifier, MoveValue)],
+    visit_with_types: &mut FVisitTypes,
+    depth: usize,
+) where
+    for<'a> FVisitTypes: FnMut(
+        /* value depth */ usize,
+        &StructTag,
+        &'a Vec<(Identifier, MoveValue)>,
+    ) -> &'a [(Identifier, MoveValue)],
+{
+    let next_depth = depth + 1;
+    match move_value {
+        MoveValue::U8(_)
+        | MoveValue::U16(_)
+        | MoveValue::U32(_)
+        | MoveValue::U64(_)
+        | MoveValue::U128(_)
+        | MoveValue::U256(_)
+        | MoveValue::Bool(_)
+        | MoveValue::Address(_)
+        | MoveValue::Signer(_) => (),
+        MoveValue::Vector(vs) => {
+            for v in vs {
+                visit_structs_impl(
+                    v,
+                    visit_runtime,
+                    visit_with_fields,
+                    visit_with_types,
+                    next_depth,
+                )
+            }
+        }
+        MoveValue::Struct(s) => match s {
+            MoveStruct::Runtime(vs) => {
+                let vs = visit_runtime(depth, vs);
+                for v in vs {
+                    visit_structs_impl(
+                        v,
+                        visit_runtime,
+                        visit_with_fields,
+                        visit_with_types,
+                        next_depth,
+                    )
+                }
+            }
+            MoveStruct::WithFields(fields) => {
+                let fields = visit_with_fields(depth, fields);
+                for (_, v) in fields {
+                    visit_structs_impl(
+                        v,
+                        visit_runtime,
+                        visit_with_fields,
+                        visit_with_types,
+                        next_depth,
+                    )
+                }
+            }
+            MoveStruct::WithTypes { type_, fields } => {
+                let fields = visit_with_types(depth, type_, fields);
+                for (_, v) in fields {
+                    visit_structs_impl(
+                        v,
+                        visit_runtime,
+                        visit_with_fields,
+                        visit_with_types,
+                        next_depth,
+                    )
+                }
+            }
+        },
+    }
+}

--- a/crates/sui-framework-override/src/natives/transfer.rs
+++ b/crates/sui-framework-override/src/natives/transfer.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::object_runtime::{ObjectRuntime, TransferResult};
+use crate::legacy_emit_cost;
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{
+    account_address::AccountAddress, language_storage::TypeTag, vm_status::StatusCode,
+};
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+use sui_types::{base_types::SequenceNumber, object::Owner};
+
+const E_SHARED_NON_NEW_OBJECT: u64 = 0;
+
+/// Implementation of Move native function
+/// `transfer_internal<T: key>(obj: T, recipient: vector<u8>, to_object: bool)`
+/// Here, we simply emit this event. The sui adapter
+/// treats this as a special event that is handled
+/// differently from user events:
+/// the adapter will change the owner of the object
+/// in question to `recipient`.
+pub fn transfer_internal(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 2);
+
+    let ty = ty_args.pop().unwrap();
+    let recipient = pop_arg!(args, AccountAddress);
+    let obj = args.pop_back().unwrap();
+    let owner = Owner::AddressOwner(recipient.into());
+    object_runtime_transfer(context, owner, ty, obj)?;
+    // Charge a constant native gas cost here, since
+    // we will charge it properly when processing
+    // all the events in adapter.
+    // TODO: adjust native_gas cost size base.
+    let cost = legacy_emit_cost();
+    Ok(NativeResult::ok(cost, smallvec![]))
+}
+
+/// Implementation of Move native function
+/// `freeze_object<T: key>(obj: T)`
+pub fn freeze_object(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let ty = ty_args.pop().unwrap();
+    let obj = args.pop_back().unwrap();
+    object_runtime_transfer(context, Owner::Immutable, ty, obj)?;
+    let cost = legacy_emit_cost();
+    Ok(NativeResult::ok(cost, smallvec![]))
+}
+
+/// Implementation of Move native function
+/// `share_object<T: key>(obj: T)`
+pub fn share_object(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let ty = ty_args.pop().unwrap();
+    let obj = args.pop_back().unwrap();
+    let transfer_result = object_runtime_transfer(
+        context,
+        // Dummy version, to be filled with the correct initial version when the effects of the
+        // transaction are written to storage.
+        Owner::Shared {
+            initial_shared_version: SequenceNumber::new(),
+        },
+        ty,
+        obj,
+    )?;
+    let cost = legacy_emit_cost();
+    Ok(match transfer_result {
+        // New means the ID was created in this transaction
+        // SameOwner means the object was previously shared and was re-shared; since
+        // shared objects cannot be taken by-value in the adapter, this can only
+        // happen via test_scenario
+        TransferResult::New | TransferResult::SameOwner => NativeResult::ok(cost, smallvec![]),
+        TransferResult::OwnerChanged => NativeResult::err(cost, E_SHARED_NON_NEW_OBJECT),
+    })
+}
+
+fn object_runtime_transfer(
+    context: &mut NativeContext,
+    owner: Owner,
+    ty: Type,
+    obj: Value,
+) -> PartialVMResult<TransferResult> {
+    let tag = match context.type_to_type_tag(&ty)? {
+        TypeTag::Struct(s) => s,
+        _ => {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("Sui verifier guarantees this is a struct".to_string()),
+            )
+        }
+    };
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    obj_runtime.transfer(owner, ty, *tag, obj)
+}

--- a/crates/sui-framework-override/src/natives/tx_context.rs
+++ b/crates/sui-framework-override/src/natives/tx_context.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::account_address::AccountAddress;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+use smallvec::smallvec;
+use std::{collections::VecDeque, convert::TryFrom};
+use sui_types::base_types::TransactionDigest;
+
+use crate::{legacy_create_signer_cost, natives::object_runtime::ObjectRuntime};
+
+pub fn derive_id(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 2);
+
+    let ids_created = pop_arg!(args, u64);
+    let tx_hash = pop_arg!(args, Vec<u8>);
+
+    // TODO(https://github.com/MystenLabs/sui/issues/58): finalize digest format
+    // unwrap safe because all digests in Move are serialized from the Rust `TransactionDigest`
+    let digest = TransactionDigest::try_from(tx_hash.as_slice()).unwrap();
+    let address = AccountAddress::from(digest.derive_id(ids_created));
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    obj_runtime.new_id(address.into());
+
+    // TODO: choose cost
+    let cost = legacy_create_signer_cost();
+
+    Ok(NativeResult::ok(cost, smallvec![Value::address(address)]))
+}

--- a/crates/sui-framework-override/src/natives/types.rs
+++ b/crates/sui-framework-override/src/natives/types.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::legacy_length_cost;
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::{
+    language_storage::TypeTag,
+    value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
+};
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub fn is_one_time_witness(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    // unwrap safe because the interface of native function guarantees it.
+    let ty = ty_args.pop().unwrap();
+    let type_tag = context.type_to_type_tag(&ty)?;
+    let type_layout = context.type_to_type_layout(&ty)?;
+
+    // TODO: what should the cost of this be?
+    let cost = legacy_length_cost();
+    let struct_layout = match type_layout {
+        Some(MoveTypeLayout::Struct(l)) => l,
+        _ => return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)])),
+    };
+
+    let has_one_bool_field = match struct_layout {
+        MoveStructLayout::Runtime(vec) => matches!(vec.as_slice(), [MoveTypeLayout::Bool]),
+        MoveStructLayout::WithFields(vec) => matches!(
+            vec.as_slice(),
+            [MoveFieldLayout {
+                name: _,
+                layout: MoveTypeLayout::Bool
+            }]
+        ),
+        MoveStructLayout::WithTypes { type_: _, fields } => matches!(
+            fields.as_slice(),
+            [MoveFieldLayout {
+                name: _,
+                layout: MoveTypeLayout::Bool
+            }]
+        ),
+    };
+
+    // If a struct type has the same name as the module that defines it but capitalized, and it has
+    // a single field of type bool, it means that it's a one-time witness type. The remaining
+    // properties of a one-time witness type are checked in the one_time_witness_verifier pass in
+    // the Sui bytecode verifier (a type with this name and with a single bool field that does not
+    // have all the remaining properties of a one-time witness type will cause a verifier error).
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::bool(
+            matches!(type_tag, TypeTag::Struct(struct_tag) if has_one_bool_field && struct_tag.name.to_string() == struct_tag.module.to_string().to_ascii_uppercase())
+        )],
+    ))
+}

--- a/crates/sui-framework-override/tests/address_tests.move
+++ b/crates/sui-framework-override/tests/address_tests.move
@@ -1,0 +1,119 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::address_tests {
+    use std::ascii;
+    use std::string;
+    use std::vector;
+    use sui::address;
+    use sui::object;
+    use sui::tx_context;
+
+    #[test]
+    fun from_bytes_ok() {
+        assert!(address::from_bytes(x"0000000000000000000000000000000000000000") == @0x0, 0);
+        assert!(address::from_bytes(x"0000000000000000000000000000000000000001") == @0x1, 0);
+        assert!(address::from_bytes(x"0000000000000000000000000000000000000010") == @0x10, 0);
+        assert!(address::from_bytes(x"00000000000000000000000000000000000000ff") == @0xff, 0);
+        assert!(address::from_bytes(x"0000000000000000000000000000000000000100") == @0x100, 0);
+        assert!(address::from_bytes(x"fffffffffffffffffffffffffffffffffffffffe") == @0xfffffffffffffffffffffffffffffffffffffffe, 0);
+        assert!(address::from_bytes(x"ffffffffffffffffffffffffffffffffffffffff") == @0xffffffffffffffffffffffffffffffffffffffff, 0)
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::address::EAddressParseError)]
+    fun from_bytes_too_few_bytes() {
+        let ctx = tx_context::dummy();
+        let uid = object::new(&mut ctx);
+
+        let bytes = object::uid_to_bytes(&uid);
+        vector::pop_back(&mut bytes);
+
+        let _ = address::from_bytes(bytes);
+
+        object::delete(uid);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::address::EAddressParseError)]
+    fun test_from_bytes_too_many_bytes() {
+        let ctx = tx_context::dummy();
+        let uid = object::new(&mut ctx);
+
+        let bytes = object::uid_to_bytes(&uid);
+        vector::push_back(&mut bytes, 0x42);
+
+        let _ = address::from_bytes(bytes);
+
+        object::delete(uid);
+    }
+
+    #[test]
+    fun to_u256_ok() {
+        assert!(address::to_u256(address::from_bytes(x"0000000000000000000000000000000000000000")) == 0, 0);
+        assert!(address::to_u256(address::from_bytes(x"0000000000000000000000000000000000000001")) == 1, 0);
+        assert!(address::to_u256(address::from_bytes(x"0000000000000000000000000000000000000010")) == 16, 0);
+        assert!(address::to_u256(address::from_bytes(x"00000000000000000000000000000000000000ff")) == 255, 0);
+        assert!(address::to_u256(address::from_bytes(x"0000000000000000000000000000000000000100")) == 256, 0);
+        assert!(address::to_u256(address::from_bytes(x"fffffffffffffffffffffffffffffffffffffffe")) == address::max() - 1, 0);
+        assert!(address::to_u256(address::from_bytes(x"ffffffffffffffffffffffffffffffffffffffff")) == address::max(), 0);
+    }
+
+    #[test]
+    fun from_u256_ok() {
+        assert!(address::from_u256(0) == @0x0, 0);
+        assert!(address::from_u256(1) == @0x1, 0);
+        assert!(address::from_u256(16) == @0x10, 0);
+        assert!(address::from_u256(255) == @0xff, 0);
+        assert!(address::from_u256(256) == @0x100, 0);
+        assert!(address::from_u256(address::max() - 1) == @0xfffffffffffffffffffffffffffffffffffffffe, 0);
+        assert!(address::from_u256(address::max()) == @0xffffffffffffffffffffffffffffffffffffffff, 0);
+    }
+
+    #[expected_failure(abort_code = sui::address::EU256TooBigToConvertToAddress)]
+    #[test]
+    fun from_u256_tests_too_many_bytes1(): address {
+        address::from_u256(address::max() + 1)
+    }
+
+    #[expected_failure(abort_code = sui::address::EU256TooBigToConvertToAddress)]
+    #[test]
+    fun from_u256_tests_too_many_bytes2(): address {
+        let u256_max = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+        address::from_u256(u256_max)
+    }
+
+    #[test]
+    fun to_bytes_ok() {
+        assert!(address::to_bytes(@0x0) == x"0000000000000000000000000000000000000000", 0);
+        assert!(address::to_bytes(@0x1) == x"0000000000000000000000000000000000000001", 0);
+        assert!(address::to_bytes(@0x10) == x"0000000000000000000000000000000000000010", 0);
+        assert!(address::to_bytes(@0xff) == x"00000000000000000000000000000000000000ff", 0);
+        assert!(address::to_bytes(@0x101) == x"0000000000000000000000000000000000000101", 0);
+        assert!(address::to_bytes(@0xfffffffffffffffffffffffffffffffffffffffe) == x"fffffffffffffffffffffffffffffffffffffffe", 0);
+        assert!(address::to_bytes(@0xffffffffffffffffffffffffffffffffffffffff) == x"ffffffffffffffffffffffffffffffffffffffff", 0);
+    }
+
+    #[test]
+    fun to_ascii_string_ok() {
+        assert!(address::to_ascii_string(@0x0) == ascii::string(b"0000000000000000000000000000000000000000"), 0);
+        assert!(address::to_ascii_string(@0x1) == ascii::string(b"0000000000000000000000000000000000000001"), 0);
+        assert!(address::to_ascii_string(@0x10) == ascii::string(b"0000000000000000000000000000000000000010"), 0);
+        assert!(address::to_ascii_string(@0xff) == ascii::string(b"00000000000000000000000000000000000000ff"), 0);
+        assert!(address::to_ascii_string(@0x101) == ascii::string(b"0000000000000000000000000000000000000101"), 0);
+        assert!(address::to_ascii_string(@0xfffffffffffffffffffffffffffffffffffffffe) == ascii::string(b"fffffffffffffffffffffffffffffffffffffffe"), 0);
+        assert!(address::to_ascii_string(@0xffffffffffffffffffffffffffffffffffffffff) == ascii::string(b"ffffffffffffffffffffffffffffffffffffffff"), 0);
+    }
+
+     #[test]
+    fun to_string_ok() {
+        assert!(address::to_string(@0x0) == string::utf8(b"0000000000000000000000000000000000000000"), 0);
+        assert!(address::to_string(@0x1) == string::utf8(b"0000000000000000000000000000000000000001"), 0);
+        assert!(address::to_string(@0x10) == string::utf8(b"0000000000000000000000000000000000000010"), 0);
+        assert!(address::to_string(@0xff) == string::utf8(b"00000000000000000000000000000000000000ff"), 0);
+        assert!(address::to_string(@0x101) == string::utf8(b"0000000000000000000000000000000000000101"), 0);
+        assert!(address::to_string(@0xfffffffffffffffffffffffffffffffffffffffe) == string::utf8(b"fffffffffffffffffffffffffffffffffffffffe"), 0);
+        assert!(address::to_string(@0xffffffffffffffffffffffffffffffffffffffff) == string::utf8(b"ffffffffffffffffffffffffffffffffffffffff"), 0);
+    }
+}

--- a/crates/sui-framework-override/tests/bag_tests.move
+++ b/crates/sui-framework-override/tests/bag_tests.move
@@ -1,0 +1,169 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::bag_tests {
+
+use sui::bag::{Self, add, contains_with_type, borrow, borrow_mut, remove};
+use sui::test_scenario as ts;
+
+#[test]
+fun simple_all_functions() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    // add fields
+    add(&mut bag, b"hello", 0);
+    add(&mut bag, 1, 1u8);
+    // check they exist
+    assert!(contains_with_type<vector<u8>, u64>(&bag, b"hello"), 0);
+    assert!(contains_with_type<u64, u8>(&bag, 1), 0);
+    // check the values
+    assert!(*borrow(&bag, b"hello") == 0, 0);
+    assert!(*borrow(&bag, 1) == 1u8, 0);
+    // mutate them
+    *borrow_mut(&mut bag, b"hello") = *borrow(&bag, b"hello") * 2;
+    *borrow_mut(&mut bag, 1) = *borrow(&bag, 1) * 2u8;
+    // check the new value
+    assert!(*borrow(&bag, b"hello") == 0, 0);
+    assert!(*borrow(&bag, 1) == 2u8, 0);
+    // remove the value and check it
+    assert!(remove(&mut bag, b"hello") == 0, 0);
+    assert!(remove(&mut bag, 1) == 2u8, 0);
+    // verify that they are not there
+    assert!(!contains_with_type<vector<u8>, u64>(&bag, b"hello"), 0);
+    assert!(!contains_with_type<u64, u8>(&bag, 1), 0);
+    ts::end(scenario);
+    bag::destroy_empty(bag);
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun add_duplicate() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    add(&mut bag, b"hello", 0u8);
+    add(&mut bag, b"hello", 1u8);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun add_duplicate_mismatched_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    add(&mut bag, b"hello", 0u128);
+    add(&mut bag, b"hello", 1u8);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    borrow<u64, u64>(&bag, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+fun borrow_wrong_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    add(&mut bag, 0, 0);
+    borrow<u64, u8>(&mut bag, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_mut_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    borrow_mut<u64, u64>(&mut bag, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+fun borrow_mut_wrong_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    add(&mut bag, 0, 0);
+    borrow_mut<u64, u8>(&mut bag, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun remove_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    remove<u64, u64>(&mut bag, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+fun remove_wrong_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    add(&mut bag, 0, 0);
+    remove<u64, u8>(&mut bag, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::bag::EBagNotEmpty)]
+fun destroy_non_empty() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    add(&mut bag, 0, 0);
+    bag::destroy_empty(bag);
+    ts::end(scenario);
+}
+
+#[test]
+fun sanity_check_contains() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    assert!(!contains_with_type<u64, u64>(&mut bag, 0), 0);
+    add(&mut bag, 0, 0);
+    assert!(contains_with_type<u64, u64>(&mut bag, 0), 0);
+    assert!(!contains_with_type<u64, u64>(&mut bag, 1), 0);
+    ts::end(scenario);
+    bag::remove<u64, u64>(&mut bag, 0);
+    bag::destroy_empty(bag);
+}
+
+#[test]
+fun sanity_check_size() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = bag::new(ts::ctx(&mut scenario));
+    assert!(bag::is_empty(&bag), 0);
+    assert!(bag::length(&bag) == 0, 0);
+    add(&mut bag, 0, 0);
+    assert!(!bag::is_empty(&bag), 0);
+    assert!(bag::length(&bag) == 1, 0);
+    add(&mut bag, 1, 0);
+    assert!(!bag::is_empty(&bag), 0);
+    assert!(bag::length(&bag) == 2, 0);
+    bag::remove<u64, u64>(&mut bag, 0);
+    bag::remove<u64, u64>(&mut bag, 1);
+    ts::end(scenario);
+    bag::destroy_empty(bag);
+}
+
+}

--- a/crates/sui-framework-override/tests/bytecode_calibration_tests.move
+++ b/crates/sui-framework-override/tests/bytecode_calibration_tests.move
@@ -1,0 +1,916 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// This module attempts to find the computational cost of bytecode instructions by measuring the time
+// the instruction takes to execute.
+// Isolating the bytecode is tricky, so we run two functions with and without the bytecode instruction
+// The difference in execution times is the time the instruction takes
+// functions prefixed with __baseline do not have the bytecode under yesy
+// Many parts of the code are written in such a way that the bytecode diffs yield exactly the 
+// instruction/operation to be isolated
+
+
+#[test_only]
+module sui::bytecode_calibration_tests {
+    use std::vector;
+
+    // Number of times to run the inner loop of tests
+    // We set this value 1 to avoid long running tests
+    // But normally we want something like 1000000
+    const NUM_TRIALS: u64 = 1;
+    const U64_MAX: u64 = 18446744073709551615;
+
+    struct ObjectWithU8Field has store, drop{
+        f0: u8,
+    }
+
+    struct ObjectWithU64Field has store, drop{
+        f0: u64,
+    }
+
+    // Add operation
+    #[test]
+    public entry fun test_calibrate_add() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = 0;
+        while (trials > 0) {
+            num = num + 1 + 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_add__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = 0;
+        while (trials > 0) {
+            num = num + 1;
+            trials = trials - 1;
+        }
+    }
+
+    // Sub operation
+    #[test]
+    public entry fun test_calibrate_sub() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num - 1 - 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_sub__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num - 1;
+            trials = trials - 1;
+        }
+    }
+
+    // Mul operation
+    #[test]
+    public entry fun test_calibrate_mul() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = 0;
+        while (trials > 0) {
+            num = num * 1 * 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_mul__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = 0;
+        while (trials > 0) {
+            num = num * 1;
+            trials = trials - 1;
+        }
+    }
+
+    // Div operation
+    #[test]
+    public entry fun test_calibrate_div() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num / 1 / 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_div__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num / 1;
+            trials = trials - 1;
+        }
+    }
+
+    // Mod operation
+    #[test]
+    public entry fun test_calibrate_mod() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = 0;
+        while (trials > 0) {
+            num = num % 1 % 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_mod__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = 0;
+        while (trials > 0) {
+            num = num % 1;
+            trials = trials - 1;
+        }
+    }
+
+    // Logical And operation
+    #[test]
+    public entry fun test_calibrate_and() {
+        let trials: u64 = NUM_TRIALS;
+        let flag: bool = false;
+        while (trials > 0) {
+            flag = flag && false && false;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_and__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let flag: bool = false;
+        while (trials > 0) {
+            flag = flag && false;
+            trials = trials - 1;
+        }
+    }
+
+    // Logical Or operation
+    #[test]
+    public entry fun test_calibrate_or() {
+        let trials: u64 = NUM_TRIALS;
+        let flag: bool = false;
+        while (trials > 0) {
+            flag = flag || false || false;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_or__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let flag: bool = false;
+        while (trials > 0) {
+            flag = flag || false;
+            trials = trials - 1;
+        }
+    }
+
+    // Xor operation
+    #[test]
+    public entry fun test_calibrate_xor() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num ^ 1 ^ 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_xor__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num ^ 1;
+            trials = trials - 1;
+        }
+    }
+
+    // Shift Right operation
+    #[test]
+    public entry fun test_calibrate_shr() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num >> 1 >> 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_shr__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num >> 1;
+            trials = trials - 1;
+        }
+    }
+
+    // Shift num operation
+    #[test]
+    public entry fun test_calibrate_shl() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num << 1 << 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_shl__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num << 1;
+            trials = trials - 1;
+        }
+    }
+
+    // Bitwise And operation
+    #[test]
+    public entry fun test_calibrate_bitand() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num & 1 & 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_bitand__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num & 1;
+            trials = trials - 1;
+        }
+    }
+
+    // Bitwise Or operation
+    #[test]
+    public entry fun test_calibrate_bitor() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num | 1 | 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_bitor__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let num: u64 = U64_MAX;
+        while (trials > 0) {
+            num = num | 1;
+            trials = trials - 1;
+        }
+    }
+
+    // Eq operation
+    #[test]
+    public entry fun test_calibrate_eq() {
+        let trials: u64 = NUM_TRIALS;
+        let flag: bool = false;
+        while (trials > 0) {
+            flag = flag == true == true;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_eq__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let flag: bool = false;
+        while (trials > 0) {
+            flag = flag == true;
+            trials = trials - 1;
+        }
+    }
+
+    // Neq operation
+    #[test]
+    public entry fun test_calibrate_neq() {
+        let trials: u64 = NUM_TRIALS;
+        let flag: bool = false;
+        while (trials > 0) {
+            flag = flag != true != true;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_neq__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let flag: bool = false;
+        while (trials > 0) {
+            flag = flag != true;
+            trials = trials - 1;
+        }
+    }
+
+    // Lt operation
+    #[test]
+    public entry fun test_calibrate_lt() {
+        let trials: u64 = NUM_TRIALS;
+        let _flag: bool;
+        while (trials > 0) {
+            _flag = trials < 1;
+            trials = trials - 1;
+        }
+    }
+    // Lt operation
+    #[test]
+    public entry fun test_calibrate_lt__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _flag: bool;
+        while (trials > 0) {
+            let _ = trials;
+            trials = trials - 1;
+        }
+    }
+
+    // Gt operation
+    #[test]
+    public entry fun test_calibrate_gt() {
+        let trials: u64 = NUM_TRIALS;
+        let _flag: bool;
+        while (trials > 0) {
+            _flag = trials > 1;
+            trials = trials - 1;
+        }
+    }
+    // Gt operation
+    #[test]
+    public entry fun test_calibrate_gt__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _flag: bool;
+        while (trials > 0) {
+            let _ = trials;
+            trials = trials - 1;
+        }
+    }
+
+    // Le operation
+    #[test]
+    public entry fun test_calibrate_le() {
+        let trials: u64 = NUM_TRIALS;
+        let _flag: bool;
+        while (trials > 0) {
+            _flag = trials <= 1;
+            trials = trials - 1;
+        }
+    }
+    // Le operation
+    #[test]
+    public entry fun test_calibrate_le__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _flag: bool;
+        while (trials > 0) {
+            let _ = trials;
+            trials = trials - 1;
+        }
+    }
+
+    // Ge operation
+    #[test]
+    public entry fun test_calibrate_ge() {
+        let trials: u64 = NUM_TRIALS;
+        let _flag: bool;
+        while (trials > 0) {
+            _flag = trials >= 1;
+            trials = trials - 1;
+        }
+    }
+    // Ge operation
+    #[test]
+    public entry fun test_calibrate_ge__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _flag: bool;
+        while (trials > 0) {
+            let _ = trials;
+            trials = trials - 1;
+        }
+    }
+
+    // Not operation
+    #[test]
+    public entry fun test_calibrate_not() {
+        let trials: u64 = NUM_TRIALS;
+        let _flag: bool = false;
+        while (trials > 0) {
+            _flag = !!_flag;
+            trials = trials - 1;
+        }
+    }
+    // Not operation
+    #[test]
+    public entry fun test_calibrate_not__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _flag: bool = false;
+        while (trials > 0) {
+            _flag = !_flag;
+            trials = trials - 1;
+        }
+    }
+
+
+    // =================
+    // Memory access
+
+    // Immutable Borrow of local operation
+    #[test]
+    public entry fun test_calibrate_imm_borrow_loc() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let _r = &trials;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_imm_borrow_loc__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            trials = trials - 1;
+        }
+    }
+    // Mutable Borrow of local operation
+    #[test]
+    public entry fun test_calibrate_mut_borrow_loc() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let _r = &mut trials;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_mut_borrow_loc__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            trials = trials - 1;
+        }
+    }
+
+
+    // Immutable Borrow of field operation
+    #[test]
+    public entry fun test_calibrate_imm_borrow_field() {
+        let trials: u64 = NUM_TRIALS;
+        let obj = ObjectWithU64Field {f0: 0u64};
+        while (trials > 0) {
+            let _r = &obj.f0;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_imm_borrow_field__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let obj = ObjectWithU64Field {f0: 0u64};
+        while (trials > 0) {
+            let _r = &obj;
+            trials = trials - 1;
+        }
+    }
+    // Mutable Borrow of local operation
+    #[test]
+    public entry fun test_calibrate_mut_borrow_field() {
+        let trials: u64 = NUM_TRIALS;
+        let obj = ObjectWithU64Field {f0: 0u64};
+        while (trials > 0) {
+            let _r = &mut obj.f0;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_mut_borrow_field__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let obj = ObjectWithU64Field {f0: 0u64};
+        while (trials > 0) {
+            let _r = &mut obj;
+            trials = trials - 1;
+        }
+    }
+
+
+    #[test]
+    public entry fun test_calibrate_ldu8() {
+        let trials: u64 = NUM_TRIALS;
+        let _num = 0u8;
+        while (trials > 0) {
+            trials = trials - 1;
+            _num = 0u8;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_ldu8__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _num = 0u8;
+        while (trials > 0) {
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_ldu64() {
+        let trials: u64 = NUM_TRIALS;
+        let _num = 0u64;
+        while (trials > 0) {
+            trials = trials - 1;
+            _num = 0u64;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_ldu64__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _num = 0u64;
+        while (trials > 0) {
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_ldu128() {
+        let trials: u64 = NUM_TRIALS;
+        let _num = 0u128;
+        while (trials > 0) {
+            trials = trials - 1;
+            _num = 0u128;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_ldu128__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _num = 0u128;
+        while (trials > 0) {
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_ld_const() {
+        let trials: u64 = NUM_TRIALS;
+        let _num = 0u64;
+        while (trials > 0) {
+            trials = trials - 1;
+            _num = U64_MAX;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_ld_const__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _num = 0u64;
+        while (trials > 0) {
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_pack() {
+        let trials: u64 = NUM_TRIALS;
+        let _num: ObjectWithU8Field;
+        while (trials > 0) {
+            trials = trials - 1;
+            _num = ObjectWithU8Field {f0: 0u8};
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_pack__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _num: ObjectWithU8Field;
+        while (trials > 0) {
+            trials = trials - 1;
+            // This forces a u8 load to counter that in subject
+            let _ = 0u8;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_unpack() {
+        let trials: u64 = NUM_TRIALS;
+        let _num: ObjectWithU8Field;
+        while (trials > 0) {
+            trials = trials - 1;
+            _num = ObjectWithU8Field {f0: 0u8};
+            let ObjectWithU8Field { f0: _ } = _num;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_unpack__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let _num: ObjectWithU8Field;
+        while (trials > 0) {
+            trials = trials - 1;
+            _num = ObjectWithU8Field {f0: 0u8};
+        }
+    }
+
+
+    #[test]
+    public entry fun test_calibrate_read_ref() {
+        let trials: u64 = NUM_TRIALS;
+        let r = 0u64;
+        while (trials > 0) {
+            let _ = *&r;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_read_ref__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let r = 0u64;
+        while (trials > 0) {
+            let _ = &r;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_write_ref() {
+        let trials: u64 = NUM_TRIALS;
+        let r = 0u64;
+        while (trials > 0) {
+            *(&mut r) = trials;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_write_ref__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let r = 0u64;
+        while (trials > 0) {
+            let _ = trials;
+            let _ = &mut r;
+            trials = trials - 1;
+        }
+    }
+
+
+    #[test]
+    public entry fun test_calibrate_copy_loc() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let _ = trials;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_copy_loc__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_len() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            vector::length(&hash);
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_len__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            let _ = &hash;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_push_back() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            vector::push_back(&mut hash, 0);
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_push_back__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            let _ = &mut hash;
+            let _ = 0u8;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_pop_back() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            vector::push_back(&mut hash, 0);
+            trials = trials - 1;
+        };
+        trials = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            vector::pop_back(&mut hash);
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_pop_back__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            vector::push_back(&mut hash, 0);
+            trials = trials - 1;
+        };
+        trials = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            let _ = &mut hash;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_pack() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let _ = vector [trials];
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_vec_pack__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let _ = trials;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_swap() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            vector::swap(&mut hash, 0, 1);
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_vec_swap__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            let _ = &mut hash;
+            let _ = 0u64;
+            let _ = 1u64;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_imm_borrow() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            vector::borrow(&hash, 0u64);
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_vec_imm_borrow__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            let _ = &hash;
+            let _ = 0u64;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_mut_borrow() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            vector::borrow_mut(&mut hash, 0);
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_vec_mut_borrow__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash = x"0134";
+            let _ = &mut hash;
+            let _ = 0u64;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_cast_u8() {
+        let trials: u64 = NUM_TRIALS;
+        let val = 1u64;
+
+        while (trials > 0) {
+            let _ = (val as u8);
+            val = val * 1;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_cast_u8__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let val = 1u64;
+
+        while (trials > 0) {
+            let _ = val;
+            val = val * 1;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_cast_u64() {
+        let trials: u64 = NUM_TRIALS;
+        let val = 1u8;
+
+        while (trials > 0) {
+            let _ = (val as u64);
+            val = val * 1;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_cast_u64__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let val = 1u8;
+
+        while (trials > 0) {
+            let _ = val;
+            val = val * 1;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_cast_u128() {
+        let trials: u64 = NUM_TRIALS;
+        let val = 1u8;
+
+        while (trials > 0) {
+            let _ = (val as u128);
+            val = val * 1;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_cast_u128__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let val = 1u8;
+
+        while (trials > 0) {
+            let _ = val;
+            val = val * 1;
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_unpack() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let hash: vector<u8> = x"";
+            vector::destroy_empty(hash);
+            trials = trials - 1;
+        }
+    }
+
+    #[test]
+    public entry fun test_calibrate_vec_unpack__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let _hash: vector<u8> = x"";
+            trials = trials - 1;
+        }
+    }
+}
+
+// TODO:
+// MoveLoc, StLoc, BrTrue, BrFalse, Branch, Call, CallGeneric, Pop, Ret, MutBorrowFieldGeneric, ImmBorrowFieldGeneric, Abort, Nop
+
+// Not supported for Sui:
+// MutBorrowGlobal, MutBorrowGlobalGeneric, ImmBorrowGlobal, ImmBorrowGlobalGeneric, Exists, ExistsGeneric, MoveFrom, MoveFromGeneric, 
+// MoveTo, MoveToGeneric
+
+

--- a/crates/sui-framework-override/tests/coin_balance_tests.move
+++ b/crates/sui-framework-override/tests/coin_balance_tests.move
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::test_coin {
+    use sui::test_scenario::{Self, ctx};
+    use sui::pay;
+    use sui::coin;
+    use sui::balance;
+    use sui::sui::SUI;
+    use sui::locked_coin::LockedCoin;
+    use sui::tx_context;
+    use sui::locked_coin;
+    use sui::coin::Coin;
+
+    #[test]
+    fun type_morphing() {
+        let scenario = test_scenario::begin(@0x1);
+        let test = &mut scenario;
+
+        let balance = balance::zero<SUI>();
+        let coin = coin::from_balance(balance, ctx(test));
+        let balance = coin::into_balance(coin);
+
+        balance::destroy_zero(balance);
+
+        let coin = coin::mint_for_testing<SUI>(100, ctx(test));
+        let balance_mut = coin::balance_mut(&mut coin);
+        let sub_balance = balance::split(balance_mut, 50);
+
+        assert!(balance::value(&sub_balance) == 50, 0);
+        assert!(coin::value(&coin) == 50, 0);
+
+        let balance = coin::into_balance(coin);
+        balance::join(&mut balance, sub_balance);
+
+        assert!(balance::value(&balance) == 100, 0);
+
+        let coin = coin::from_balance(balance, ctx(test));
+        pay::keep(coin, ctx(test));
+        test_scenario::end(scenario);
+    }
+
+    const TEST_SENDER_ADDR: address = @0xA11CE;
+    const TEST_RECIPIENT_ADDR: address = @0xB0B;
+
+    #[test]
+    public entry fun test_locked_coin_valid() {
+        let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
+        let scenario = &mut scenario_val;
+        let ctx = test_scenario::ctx(scenario);
+        let coin = coin::mint_for_testing<SUI>(42, ctx);
+
+        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        // Lock up the coin until epoch 2.
+        locked_coin::lock_coin(coin, TEST_RECIPIENT_ADDR, 2, test_scenario::ctx(scenario));
+
+        // Advance the epoch by 2.
+        test_scenario::next_epoch(scenario, TEST_SENDER_ADDR);
+        test_scenario::next_epoch(scenario, TEST_SENDER_ADDR);
+        assert!(tx_context::epoch(test_scenario::ctx(scenario)) == 2, 1);
+
+        test_scenario::next_tx(scenario, TEST_RECIPIENT_ADDR);
+        let locked_coin = test_scenario::take_from_sender<LockedCoin<SUI>>(scenario);
+        // The unlock should go through since epoch requirement is met.
+        locked_coin::unlock_coin(locked_coin, test_scenario::ctx(scenario));
+
+        test_scenario::next_tx(scenario, TEST_RECIPIENT_ADDR);
+        let unlocked_coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+        assert!(coin::value(&unlocked_coin) == 42, 2);
+        coin::destroy_for_testing(unlocked_coin);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::epoch_time_lock::EEpochNotYetEnded)]
+    public entry fun test_locked_coin_invalid() {
+        let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
+        let scenario = &mut scenario_val;
+        let ctx = test_scenario::ctx(scenario);
+        let coin = coin::mint_for_testing<SUI>(42, ctx);
+
+        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        // Lock up the coin until epoch 2.
+        locked_coin::lock_coin(coin, TEST_RECIPIENT_ADDR, 2, test_scenario::ctx(scenario));
+
+        // Advance the epoch by 1.
+        test_scenario::next_epoch(scenario, TEST_SENDER_ADDR);
+        assert!(tx_context::epoch(test_scenario::ctx(scenario)) == 1, 1);
+
+        test_scenario::next_tx(scenario, TEST_RECIPIENT_ADDR);
+        let locked_coin = test_scenario::take_from_sender<LockedCoin<SUI>>(scenario);
+        // The unlock should fail.
+        locked_coin::unlock_coin(locked_coin, test_scenario::ctx(scenario));
+        test_scenario::end(scenario_val);
+    }
+}

--- a/crates/sui-framework-override/tests/crypto/bls12381_tests.move
+++ b/crates/sui-framework-override/tests/crypto/bls12381_tests.move
@@ -1,0 +1,100 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::bls12381_tests {
+    use sui::bls12381;
+    use std::vector;
+    use std::hash::sha2_256;
+    
+    #[test]
+    fun test_bls12381_min_sig_valid_sig() {
+        let msg = x"0101010101";
+        let pk = x"8df101606f91f3cad7f54b8aff0f0f64c41c482d9b9f9fe81d2b607bc5f611bdfa8017cf04b47b44b222c356ef555fbd11058c52c077f5a7ec6a15ccfd639fdc9bd47d005a111dd6cdb8c02fe49608df55a3c9822986ad0b86bdea3abfdfe464";
+        let sig = x"908e345f2e2803cd941ae88c218c96194233c9053fa1bca52124787d3cca141c36429d7652435a820c72992d5eee6317";
+
+        let verify = bls12381::bls12381_min_sig_verify(&sig, &pk, &msg);
+        assert!(verify == true, 0)
+    }
+
+    #[test]
+    fun test_bls12381_min_sig_invalid_sig() {
+        let msg = x"0201010101";
+        let pk = x"8df101606f91f3cad7f54b8aff0f0f64c41c482d9b9f9fe81d2b607bc5f611bdfa8017cf04b47b44b222c356ef555fbd11058c52c077f5a7ec6a15ccfd639fdc9bd47d005a111dd6cdb8c02fe49608df55a3c9822986ad0b86bdea3abfdfe464";
+        let sig = x"908e345f2e2803cd941ae88c218c96194233c9053fa1bca52124787d3cca141c36429d7652435a820c72992d5eee6317";
+
+        let verify = bls12381::bls12381_min_sig_verify(&sig, &pk, &msg);
+        assert!(verify == false, 0)
+    }
+
+    #[test]
+    fun test_bls12381_min_sig_invalid_signature_key_length() {
+        let msg = x"0201010101";
+        let pk = x"606f91f3cad7f54b8aff0f0f64c41c482d9b9f9fe81d2b607bc5f611bdfa8017cf04b47b44b222c356ef555fbd11058c52c077f5a7ec6a15ccfd639fdc9bd47d005a111dd6cdb8c02fe49608df55a3c9822986ad0b86bdea3abfdfe464";
+        let sig = x"908e34002e2803cd941ae88c218c96194233c9053fa1bca52124787d3cca141c36429d7652435a820c72992d5eee6317";
+
+        let verify = bls12381::bls12381_min_sig_verify(&sig, &pk, &msg);
+        assert!(verify == false, 0)
+    }
+
+    #[test]
+    fun test_bls12381_min_sig_invalid_public_key_length() {
+        let msg = x"0201010101";
+        let pk = x"606f91f3cad7f54b8aff0f0f64c41c482d9b9f9fe81d2b607bc5f611bdfa8017cf04b47b44b222c356ef555fbd11058c52c077f5a7ec6a15ccfd639fdc9bd47d005a111dd6cdb8c02fe49608df55a3c9822986ad0b86bdea3abfdfe464";
+        let sig = x"908e345f2e2803cd941ae88c218c96194233c9053fa1bca52124787d3cca141c36429d7652435a820c72992d5eee6317";
+
+        let verify = bls12381::bls12381_min_sig_verify(&sig, &pk, &msg);
+        assert!(verify == false, 0)
+    }
+
+    #[test]
+    fun test_bls12381_min_pk_valid_and_invalid_sig() {
+        // Test an actual Drand response.
+        let pk = x"868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31";
+        let sig = x"a2cd8577944b84484ef557a7f92f0d5092779497cc470b1b97680b8f7c807d97250d310b801c7c2185c7c8a21032d45403b97530ca87bd8f05d0cf4ffceb4bcb9bf7184fb604967db7e9e6ea555bc51b25a9e41fbd51181f712aa73aaec749fe";
+        let prev_sig = x"a96aace596906562dc525dba4dff734642d71b334d51324f9c9bcb5a3d6caf14b05cde91d6507bf4615cb4285e5b4efd1358ebc46b80b51e338f9dc46cca17cf2e046765ba857c04101a560887fa81aef101a5bb3b2350884558bd3adc72be37";
+        let round: u64 = 2373935;
+        assert!(verify_drand_round(pk, sig, prev_sig, round) == true, 0);
+        // Check invalid signatures.
+        let invalid_sig = x"11118577944b84484ef557a7f92f0d5092779497cc470b1b97680b8f7c807d97250d310b801c7c2185c7c8a21032d45403b97530ca87bd8f05d0cf4ffceb4bcb9bf7184fb604967db7e9e6ea555bc51b25a9e41fbd51181f712aa73aaec749fe";
+        assert!(verify_drand_round(pk, invalid_sig, prev_sig, round) == false, 0);
+        assert!(verify_drand_round(pk, sig, prev_sig, round + 1) == false, 0);
+    }
+
+    #[test]
+    fun test_bls12381_min_pk_invalid_signature_key_length() {
+        let pk = x"868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31";
+        let sig = x"cd8577944b84484ef557a7f92f0d5092779497cc470b1b97680b8f7c807d97250d310b801c7c2185c7c8a21032d45403b97530ca87bd8f05d0cf4ffceb4bcb9bf7184fb604967db7e9e6ea555bc51b25a9e41fbd51181f712aa73aaec749fe";
+        let prev_sig = x"a96aace596906562dc525dba4dff734642d71b334d51324f9c9bcb5a3d6caf14b05cde91d6507bf4615cb4285e5b4efd1358ebc46b80b51e338f9dc46cca17cf2e046765ba857c04101a560887fa81aef101a5bb3b2350884558bd3adc72be37";
+        let round: u64 = 2373935;
+        assert!(verify_drand_round(pk, sig, prev_sig, round) == false, 0);
+    }
+
+    #[test]
+    fun test_bls12381_min_pk_invalid_public_key_length() {
+        let pk = x"8f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31";
+        let sig = x"a2cd8577944b84484ef557a7f92f0d5092779497cc470b1b97680b8f7c807d97250d310b801c7c2185c7c8a21032d45403b97530ca87bd8f05d0cf4ffceb4bcb9bf7184fb604967db7e9e6ea555bc51b25a9e41fbd51181f712aa73aaec749fe";
+        let prev_sig = x"a96aace596906562dc525dba4dff734642d71b334d51324f9c9bcb5a3d6caf14b05cde91d6507bf4615cb4285e5b4efd1358ebc46b80b51e338f9dc46cca17cf2e046765ba857c04101a560887fa81aef101a5bb3b2350884558bd3adc72be37";
+        let round: u64 = 2373935;
+        assert!(verify_drand_round(pk, sig, prev_sig, round) == false, 0);
+    }
+    fun verify_drand_round(pk: vector<u8>, sig: vector<u8>, prev_sig: vector<u8>, round: u64): bool {
+        // The signed message can be computed in Rust using:
+        //  let mut sha = Sha256::new();
+        //  sha.update(&prev_sig);
+        //  sha.update(round.to_be_bytes());
+        //  let digest = sha.finalize().digest;
+        let round_bytes: vector<u8> = vector[0, 0, 0, 0, 0, 0, 0, 0];
+        let i = 7;
+        while (i > 0) {
+            let curr_byte = round % 0x100;
+            let curr_element = vector::borrow_mut(&mut round_bytes, i);
+            *curr_element = (curr_byte as u8);
+            round = round >> 8;
+            i = i - 1;
+        };
+        vector::append(&mut prev_sig, round_bytes);
+        let digest = sha2_256(prev_sig);
+        bls12381::bls12381_min_pk_verify(&sig, &pk, &digest)
+    }
+}

--- a/crates/sui-framework-override/tests/crypto/bulletproofs_tests.move
+++ b/crates/sui-framework-override/tests/crypto/bulletproofs_tests.move
@@ -1,0 +1,121 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::bulletproofs_tests {
+    use sui::bulletproofs;
+    use sui::elliptic_curve as ec;
+
+    #[test]
+    fun test_ristretto_point_addition() {
+        let committed_value_1 = 1000u64;
+        let blinding_value_1 = 100u64;
+        let committed_value_2 = 500u64;
+        let blinding_value_2 = 200u64;
+
+        let committed_sum = committed_value_1 + committed_value_2;
+        let blinding_sum = blinding_value_1 + blinding_value_2;
+
+        let point_1 = ec::create_pedersen_commitment(
+            ec::new_scalar_from_u64(committed_value_1),
+            ec::new_scalar_from_u64(blinding_value_1)
+        );
+
+        let point_2 = ec::create_pedersen_commitment(
+            ec::new_scalar_from_u64(committed_value_2),
+            ec::new_scalar_from_u64(blinding_value_2)
+        );
+
+        let point_sum_reference = ec::create_pedersen_commitment(
+            ec::new_scalar_from_u64(committed_sum),
+            ec::new_scalar_from_u64(blinding_sum)
+        );
+
+        let point_sum = ec::add(&point_1, &point_2);
+
+        assert!(ec::bytes(&point_sum) == ec::bytes(&point_sum_reference), 0)
+    }
+
+    #[test]
+    fun test_ristretto_point_subtraction() {
+        let committed_value_1 = 1000u64;
+        let blinding_value_1 = 100u64;
+        let committed_value_2 = 500u64;
+        let blinding_value_2 = 50u64;
+
+        let committed_diff = committed_value_1 - committed_value_2;
+        let blinding_diff = blinding_value_1 - blinding_value_2;
+
+        let point_1 = ec::create_pedersen_commitment(
+            ec::new_scalar_from_u64(committed_value_1),
+            ec::new_scalar_from_u64(blinding_value_1)
+        );
+
+        let point_2 = ec::create_pedersen_commitment(
+            ec::new_scalar_from_u64(committed_value_2),
+            ec::new_scalar_from_u64(blinding_value_2)
+        );
+
+        let point_diff_reference = ec::create_pedersen_commitment(
+            ec::new_scalar_from_u64(committed_diff),
+            ec::new_scalar_from_u64(blinding_diff)
+        );
+
+        let point_diff = ec::subtract(&point_1, &point_2);
+
+        assert!(ec::bytes(&point_diff) == ec::bytes(&point_diff_reference), 0)
+    }
+
+    #[test]
+    fun test_pedersen_commitment() {
+        // These are generated elsewhere;
+        let commitment = x"e0831c2a8caaacc9f33699776a61d77b407d065d09014eba061240dbd2e17d71";
+
+        let committed_value = 1000u64;
+        let blinding_factor = 10u64;
+
+        let point = ec::create_pedersen_commitment(
+            ec::new_scalar_from_u64(committed_value),
+            ec::new_scalar_from_u64(blinding_factor)
+        );
+
+        assert!(commitment == ec::bytes(&point), 0);
+    }
+
+    #[test]
+    fun test_bulletproof_standard_0_2pow64_proof() {
+        let bit_length: u64 = 64;
+
+        // This has been generated in fastcrypto.
+        let bulletproof = x"921bfb53ad5522ed84a1b62068edeee4bf36839051695b5c31cb0968907fe3387287ee055bf3070800e79eccee4acb5f25e8200830944ae07fda488cf066e320a69cf9f8f65373c153559fb6dd511ae7f070d29533c29fd3e83a39ae1cdf5d3f60e6894edc9c13dba28b3d93a37e9dd5039f78dc0661141a2fc3b68c9872d6400ec913bd102b26c901a6cdb8e4c546d74b1a0f3ea14b7ab44c2a612a450e69092d77442b5f4c8281e8fc51a18b2a874b4f1c17c567808406078fc532ce5a730193fee9d7bd0bee1e9564b2ef93adca4595cd83383798b555cf94da0dcdcd420b98d25d5758b4cc9221f82cd8bbb7efc2291b387d5435c6408928c740262ce956b4751bfee70d1175d7c6e269b4df25c2abbe9264620e15e680667392bcf75844808d9c5b55ad06f5686db286a90b8e74efd8b66dfa021d243f12a4248c87647eb01554b809db9a560f93e0a0c2a6c273f6bad3b16081e5a627f0b27c010a7c42fa13e0fe298e9362f629ba88e723a44d53e231d0f018b45d476f2c9bb21af30c76614cdb263ed7606955aa0b74483fe903f0fd7391ee70805dbb1c7e3e59a90758335e3ab13f07fc54fdb7ba05722615e29ca26a1727cd3d9a7e9325e0adeb28a8ee65890f0c6666342d8b65650c2d18f0700eac30585ae2b5e59c35e5504d5dc867093c4cc0a70b49342b6718981e19cdb166cb59359114187505198719ee2ad2f4f77fff907918fdfa42f572394c882b11e34f3512cc6d31ac99e27578aa2c30f85706ca26fdb1d3d538708f140a640bbc55a60059b01dc218d166a1a12e569a3ad535098db1add3aab2b7b704d5e22fcaa86fbb89430b7a6e20f66e0e65010e28dbeebac21b9136259e881506a1a74657362ca549bf80bba9a18210711e0859856040a28c743060bfec69a4e0741890ea3a708b95482d0dbb90df7a416701";
+
+        let committed_value = 1000u64;
+        let blinding_factor = 100u64;
+
+        let point = ec::create_pedersen_commitment(
+            ec::new_scalar_from_u64(committed_value),
+            ec::new_scalar_from_u64(blinding_factor)
+        );
+
+        assert!(bulletproofs::verify_full_range_proof(&bulletproof, &point, bit_length) == true, 0);
+    }
+
+    #[test]
+    fun test_bulletproof_standard_0_2pow64_invalid_proof() {
+        let bit_length: u64 = 64;
+
+        // This has been generated in fastcrypto and we just replaced the first byte to make it invalid.
+        let bulletproof = x"001bfb53ad5522ed84a1b62068edeee4bf36839051695b5c31cb0968907fe3387287ee055bf3070800e79eccee4acb5f25e8200830944ae07fda488cf066e320a69cf9f8f65373c153559fb6dd511ae7f070d29533c29fd3e83a39ae1cdf5d3f60e6894edc9c13dba28b3d93a37e9dd5039f78dc0661141a2fc3b68c9872d6400ec913bd102b26c901a6cdb8e4c546d74b1a0f3ea14b7ab44c2a612a450e69092d77442b5f4c8281e8fc51a18b2a874b4f1c17c567808406078fc532ce5a730193fee9d7bd0bee1e9564b2ef93adca4595cd83383798b555cf94da0dcdcd420b98d25d5758b4cc9221f82cd8bbb7efc2291b387d5435c6408928c740262ce956b4751bfee70d1175d7c6e269b4df25c2abbe9264620e15e680667392bcf75844808d9c5b55ad06f5686db286a90b8e74efd8b66dfa021d243f12a4248c87647eb01554b809db9a560f93e0a0c2a6c273f6bad3b16081e5a627f0b27c010a7c42fa13e0fe298e9362f629ba88e723a44d53e231d0f018b45d476f2c9bb21af30c76614cdb263ed7606955aa0b74483fe903f0fd7391ee70805dbb1c7e3e59a90758335e3ab13f07fc54fdb7ba05722615e29ca26a1727cd3d9a7e9325e0adeb28a8ee65890f0c6666342d8b65650c2d18f0700eac30585ae2b5e59c35e5504d5dc867093c4cc0a70b49342b6718981e19cdb166cb59359114187505198719ee2ad2f4f77fff907918fdfa42f572394c882b11e34f3512cc6d31ac99e27578aa2c30f85706ca26fdb1d3d538708f140a640bbc55a60059b01dc218d166a1a12e569a3ad535098db1add3aab2b7b704d5e22fcaa86fbb89430b7a6e20f66e0e65010e28dbeebac21b9136259e881506a1a74657362ca549bf80bba9a18210711e0859856040a28c743060bfec69a4e0741890ea3a708b95482d0dbb90df7a416701";
+
+        let committed_value = 1000u64;
+        let blinding_factor = 100u64;
+
+        let point = ec::create_pedersen_commitment(
+            ec::new_scalar_from_u64(committed_value),
+            ec::new_scalar_from_u64(blinding_factor)
+        );
+
+        assert!(bulletproofs::verify_full_range_proof(&bulletproof, &point, bit_length)== false, 0);
+    }
+
+}

--- a/crates/sui-framework-override/tests/crypto/ecdsa_k1_tests.move
+++ b/crates/sui-framework-override/tests/crypto/ecdsa_k1_tests.move
@@ -1,0 +1,167 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::ecdsa_tests {
+    use sui::ecdsa_k1;
+    use std::vector;
+    
+    #[test]
+    fun test_ecrecover_pubkey() {
+        // test case generated against https://docs.rs/secp256k1/latest/secp256k1/
+        let hashed_msg = x"57caa176af1ac0433c5df30e8dabcd2ec1af1e92a26eced5f719b88458777cd6";
+
+        let sig = x"84dc8043979a2d8f3238b086893adfa6bfe6b2b87b0b13453bcd48ce99bbb807104a492d26ee51608ae1eb8f5f8eb9386303611b42634fe18b1543fe4efbb0b000";
+        let pubkey_bytes = x"020257e02f7cff75df5bbcbe9717f1ad946b14673f9b6c97fb98cdcdef47e05609";
+
+        let pubkey = ecdsa_k1::ecrecover(&sig, &hashed_msg);
+        assert!(pubkey == pubkey_bytes, 0);
+    }
+
+    #[test]
+    fun test_ecrecover_pubkey_2() {
+        // Test case from go-ethereum: https://github.com/ethereum/go-ethereum/blob/master/crypto/signature_test.go#L37
+        let hashed_msg = x"ce0677bb30baa8cf067c88db9811f4333d131bf8bcf12fe7065d211dce971008";
+        let sig = x"90f27b8b488db00b00606796d2987f6a5f59ae62ea05effe84fef5b8b0e549984a691139ad57a3f0b906637673aa2f63d1f55cb1a69199d4009eea23ceaddc9301";
+        let pubkey_bytes = x"02e32df42865e97135acfb65f3bae71bdc86f4d49150ad6a440b6f15878109880a";
+
+        let pubkey = ecdsa_k1::ecrecover(&sig, &hashed_msg);
+        assert!(pubkey == pubkey_bytes, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ecdsa_k1::EFailToRecoverPubKey)]
+    fun test_ecrecover_pubkey_fail_to_recover() {
+        let hashed_msg = x"00";
+        let sig = x"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        ecdsa_k1::ecrecover(&sig, &hashed_msg);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ecdsa_k1::EInvalidSignature)]
+    fun test_ecrecover_pubkey_invalid_sig() {
+        let hashed_msg = x"ce0677bb30baa8cf067c88db9811f4333d131bf8bcf12fe7065d211dce971008";
+        // incorrect length sig
+        let sig = x"90f27b8b488db00b00606796d2987f6a5f59ae62ea05effe84fef5b8b0e549984a691139ad57a3f0b906637673aa2f63d1f55cb1a69199d4009eea23ceaddc93";
+        ecdsa_k1::ecrecover(&sig, &hashed_msg);
+    }
+
+    #[test]
+    fun test_secp256k1_valid_sig() {
+        let msg = x"57caa176af1ac0433c5df30e8dabcd2ec1af1e92a26eced5f719b88458777cd6";
+        let pk = x"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        let sig = x"9c7a72ff1e7db1646b9f9443cb1a3563aa3a6344e4e513efb96258c7676ac4895953629d409a832472b710a028285dfec4733a2c1bb0a2749e465a18292b8bd601";
+
+        let verify = ecdsa_k1::secp256k1_verify(&sig, &pk, &msg);
+        assert!(verify == true, 0)
+    }
+
+    #[test]
+    fun test_secp256k1_invalid_sig() {
+        let msg = x"57caa176af1ac0433c5df30e8dabcd2ec1af1e92a26eced5f719b88458777cd6";
+        let pk = x"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        // sig in the form of (r, s, 0) instead of (r, s, 1)
+        let sig = x"9c7a72ff1e7db1646b9f9443cb1a3563aa3a6344e4e513efb96258c7676ac4895953629d409a832472b710a028285dfec4733a2c1bb0a2749e465a18292b8bd600";
+
+        let verify = ecdsa_k1::secp256k1_verify(&sig, &pk, &msg);
+        assert!(verify == false, 0)
+    }
+
+    #[test]
+    fun test_secp256k1_invalid_sig_length() {
+        let msg = x"57caa176af1ac0433c5df30e8dabcd2ec1af1e92a26eced5f719b88458777cd6";
+        let pk = x"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        let sig = x"9c7a72ff1e7db1646b9f9443cb1a3563aa3a6344e4e513efb96258c7676ac4895953629d409a832472b710a028285dfec4733a2c1bb0a2749e465a18292b8bd6";
+        let verify = ecdsa_k1::secp256k1_verify(&sig, &pk, &msg);
+        assert!(verify == false, 0)
+    }
+
+    #[test]
+    fun test_secp256k1_invalid_hashed_msg_length() {
+        let msg = x"01";
+        let pk = x"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        let sig = x"9c7a72ff1e7db1646b9f9443cb1a3563aa3a6344e4e513efb96258c7676ac4895953629d409a832472b710a028285dfec4733a2c1bb0a2749e465a18292b8bd6";
+        
+        let verify = ecdsa_k1::secp256k1_verify(&sig, &pk, &msg);
+        assert!(verify == false, 0)
+    }
+
+    #[test]
+    fun test_secp256k1_invalid_public_key_length() {
+        let msg = x"57caa176af1ac0433c5df30e8dabcd2ec1af1e92a26eced5f719b88458777cd6";
+        let pk = x"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        let sig = x"9c7a72ff1e7db1646b9f9443cb1a3563aa3a6344e4e513efb96258c7676ac4895953629d409a832472b710a028285dfec4733a2c1bb0a2749e465a18292b8bd601";
+        
+        let verify = ecdsa_k1::secp256k1_verify(&sig, &pk, &msg);
+        assert!(verify == false, 0)
+    }
+
+    #[test]
+    fun test_ecrecover_eth_address() {
+        // Test case from https://web3js.readthedocs.io/en/v1.7.5/web3-eth-accounts.html#recover
+        let sig = x"b91467e570a6466aa9e9876cbcd013baba02900b8979d43fe208a4a4f339f5fd6007e74cd82e037b800186422fc2da167c747ef045e5d18a5f5d4300f8e1a0291c";
+        let hashed_msg = x"1da44b586eb0729ff70a73c326926f6ed5a25f5b056e7f47fbc6e58d86871655";
+
+        let addr1 = x"2c7536e3605d9c16a7a3d7b1898e529396a65c23";
+        let addr = ecrecover_eth_address(sig, hashed_msg);
+        assert!(addr == addr1, 0);
+
+        // Test case from https://etherscan.io/verifySig/9754
+        let sig = x"cb614cba67d6a37b9cb90d21635d81ed035b8ccb99f0befe05495b819111119b17ecf0c0cb4bcc781de387206f6dfcd9f1b99e1b54b44c376412d8f5c919b1981b";
+        let hashed_msg = x"1da44b586eb0729ff70a73c326926f6ed5a25f5b056e7f47fbc6e58d86871655";
+        let addr1 = x"4cbf668fca6f10d01f161122534044436b80702e";
+        let addr = ecrecover_eth_address(sig, hashed_msg);
+        assert!(addr == addr1, 0);
+
+        // Test case from https://goerli.etherscan.io/tx/0x18f72457b356f367db214de9dda07f5d253ebfeb5c426b0d9d5b346b4ba8d021
+        let sig = x"8e809da5ca76e6371ba8dcaa748fc2973f0d9862f76ed08f55b869f5e73591dd24a7367f1ee9e6e3723d13bb0a7092fafb8851f7eecd4a8d34c977013e1551482e";
+        let hashed_msg = x"529283629f75203330f0acf68bdbc4e879047fe75da8071c079c495bbb9fb78a";
+        let addr1 = x"4cbf668fca6f10d01f161122534044436b80702e";
+        let addr = ecrecover_eth_address(sig, hashed_msg);
+        assert!(addr == addr1, 0);
+    }
+
+    #[test]
+    fun test_keccak256_hash() {
+        let msg = b"hello world!";
+        let hashed_msg_bytes = x"57caa176af1ac0433c5df30e8dabcd2ec1af1e92a26eced5f719b88458777cd6";
+        let hashed_msg = ecdsa_k1::keccak256(&msg);
+        assert!(hashed_msg == hashed_msg_bytes, 0);
+    }
+
+    // Helper Move function to recover signature directly to an ETH address.
+    fun ecrecover_eth_address(sig: vector<u8>, hashed_msg: vector<u8>): vector<u8> {
+        // Normalize the last byte of the signature to be 0 or 1.
+        let v = vector::borrow_mut(&mut sig, 64);
+        if (*v == 27) {
+            *v = 0;
+        } else if (*v == 28) {
+            *v = 1;
+        } else if (*v > 35) {
+            *v = (*v - 1) % 2;
+        };
+
+        let pubkey = ecdsa_k1::ecrecover(&sig, &hashed_msg);
+        let uncompressed = ecdsa_k1::decompress_pubkey(&pubkey);
+
+        // Take the last 64 bytes of the uncompressed pubkey.
+        let uncompressed_64 = vector::empty<u8>();
+        let i = 1;
+        while (i < 65) {
+            let value = vector::borrow(&uncompressed, i);
+            vector::push_back(&mut uncompressed_64, *value);
+            i = i + 1;
+        };
+
+        // Take the last 20 bytes of the hash of the 64-bytes uncompressed pubkey.
+        let hashed = ecdsa_k1::keccak256(&uncompressed_64);
+        let addr = vector::empty<u8>();
+        let i = 12;
+        while (i < 32) {
+            let value = vector::borrow(&hashed, i);
+            vector::push_back(&mut addr, *value);
+            i = i + 1;
+        };
+        addr
+    }
+}

--- a/crates/sui-framework-override/tests/crypto/ed25519_tests.move
+++ b/crates/sui-framework-override/tests/crypto/ed25519_tests.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::ed25519_tests {
+    use sui::ed25519;
+
+    #[test]
+    fun test_ed25519_valid_sig() {
+        // Test generated from https://github.com/MystenLabs/fastcrypto/blob/874bb52ccadf9800b3bc21e640449705d7ff9ab0/fastcrypto/src/tests/ed25519_tests.rs
+        let msg = x"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3";
+        let pk = x"cc62332e34bb2d5cd69f60efbb2a36cb916c7eb458301ea36636c4dbb012bd88";
+        let sig = x"cce72947906dbae4c166fc01fd096432784032be43db540909bc901dbc057992b4d655ca4f4355cf0868e1266baacf6919902969f063e74162f8f04bc4056105";
+
+        let verify = ed25519::ed25519_verify(&sig, &pk, &msg);
+        assert!(verify == true, 0)
+    }
+
+    #[test]
+    fun test_ed25519_invalid_pubkey() {
+        let msg = x"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3";
+        let pk = x"";
+        let sig = x"cce72947906dbae4c166fc01fd096432784032be43db540909bc901dbc057992b4d655ca4f4355cf0868e1266baacf6919902969f063e74162f8f04bc4056105";
+
+        let verify = ed25519::ed25519_verify(&sig, &pk, &msg);
+        assert!(verify == false, 0)
+    }
+}

--- a/crates/sui-framework-override/tests/crypto/groth16_tests.move
+++ b/crates/sui-framework-override/tests/crypto/groth16_tests.move
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::groth16_tests {
+    use sui::groth16;
+    use std::vector;
+      #[test]
+    fun test_prepare_verifying_key() {
+        let vk = x"88c841f7013e91bc61827a64da5f372842e9be522513983253c2a9275e434d93130d100c4b8124fe55dc0dc1ef45918b4d07f0c8b3873b170af258021e71a4dc507aca4fdeafd5dc2f3ee8598117863a57fc25efc408d4227b22e60e8d84bb146e97637d3fbba78a8641f44cfff82cb894472075a6d3515c54ce9fa2ca186f2d5780747b5b7c85e88da7be1a815a3904f63b997d4f3d45ed3e20e5cb0e17b0b962b62e9d64d5bc825fe571ffc15f98b10605758eaf440fe16513386c086c9e0b0bea1c30f8f8bf1667dcc47514a9adc4cd1b2d854c0fd2291e0140b7f6d34f31c3cb6c8ee635b9394821369154dd520afdaacd48da6deedb190f27f59d9740c3607bbfcb2c0f8a590b4ee9071a9bda9532217f89aab2fd4e2d505f47cc113c00618849268b140fab6be405649a2d1d074983183287b8ee7a73c4dbb2ab4e7ba3bab7fa005a055a3dd26b4787fe11b5850200000000000000f675d896123954189d34681ef5ce47b5e3260247e4ea6817f19c410b9f6fe3deb086e165056c02216a0e12114a9b410d76805e906193c8cd44b02fcd9d9b34fdb6b275ef5c13e7056fb61aa1870409b8020810f9b29aab6b339fa3f853c0e103";
+        let arr = groth16::pvk_to_bytes(groth16::prepare_verifying_key(&vk));
+
+        let expected_vk_bytes = x"f675d896123954189d34681ef5ce47b5e3260247e4ea6817f19c410b9f6fe3deb086e165056c02216a0e12114a9b410d76805e906193c8cd44b02fcd9d9b34fdb6b275ef5c13e7056fb61aa1870409b8020810f9b29aab6b339fa3f853c0e103";
+        let expected_alpha_bytes = x"12168aa38a1ae0360550d0541002b024057ab689d45ce809f8ea36d5286eca9e2f18e70924ac69dcd432228a18036b146aa75a5c17430751f844f686c8ba210c7736adb1851f7afac7fbbc4ac78a01c7ca4508e3d45b5dd31e875c99b0c9d20004f4b3ad8e3c8842b6adc9c3797e3083a31b1ffe654dd4466743cd943b7d3185588a2d81da5f20b36593157c2429b21835964abb93670c81f4a9f230556dcedcc87a5c365613820e225225a650ba7d5a8d283db8317529b37297979ad7576405b26e53f2c162e35557eaf4e59e1b3d456d486291a644fe098f0d29c0435d46e35d114d7357188ed8a8fa26c807fa420e7bff7ce0c2a84a75f189cf6ed039564f36441236720be11bc53850f3700491f50430fe4729676564128f0bf326e67a0038975b396c6fd12c0cd8be75e5985e2841005640b6104b4e1e9817dd3b44e51aa4b0972489ad999bb8143a4e833110057ba32d1ff91c6707b07eab0605b9d6a2745aead54f16a968a4122fa8ca871b70a100b5fd854d4473ec7b519c04547f14b9aba6701e54e737161fc154cc3751f995c0c33d7ef74b893e6bc5514891d73af5543c4ed463e4aebe6cbbd97390bf0bf72075a0649e01a65fa2b7198bedac38406864dc780cb8789df0cb09cf532201d589bc40f84bf6a5816ccbd31ea85d0cf2e06c26037d6970caee38b507450bef282c40366bb4506408f17e331fde3211c0cb021c7858ba83e6a1f1d24bdf550b884d857ff0355ad83cd01346c62dca7197b4d54288ebc982d8228a8403e9a8bd95ef98775bf9c40004e2b5de3e663212";
+        let expected_gamma_bytes = x"f63b997d4f3d45ed3e20e5cb0e17b0b962b62e9d64d5bc825fe571ffc15f98b10605758eaf440fe16513386c086c9e0b0bea1c30f8f8bf1667dcc47514a9adc4cd1b2d854c0fd2291e0140b7f6d34f31c3cb6c8ee635b9394821369154dd528a";
+        let expected_delta_bytes = x"fdaacd48da6deedb190f27f59d9740c3607bbfcb2c0f8a590b4ee9071a9bda9532217f89aab2fd4e2d505f47cc113c00618849268b140fab6be405649a2d1d074983183287b8ee7a73c4dbb2ab4e7ba3bab7fa005a055a3dd26b4787fe11b505";
+
+        let delta_bytes = vector::pop_back(&mut arr);
+        assert!(delta_bytes == expected_delta_bytes, 0);
+
+        let gamma_bytes = vector::pop_back(&mut arr);
+        assert!(gamma_bytes == expected_gamma_bytes, 0);
+
+        let alpha_bytes = vector::pop_back(&mut arr);
+        assert!(alpha_bytes == expected_alpha_bytes, 0);
+
+        let vk_bytes = vector::pop_back(&mut arr);
+        assert!(vk_bytes == expected_vk_bytes, 0);
+   }
+
+    #[test]
+    #[expected_failure(abort_code = groth16::EInvalidVerifyingKey)]
+    fun test_prepare_verifying_key_invalid() {
+        let invalid_vk = x"";
+        groth16::prepare_verifying_key(&invalid_vk);
+    }
+
+    #[test]
+    fun test_verify_groth_16_proof() {
+        // Success case.
+        let vk_bytes = x"f675d896123954189d34681ef5ce47b5e3260247e4ea6817f19c410b9f6fe3deb086e165056c02216a0e12114a9b410d76805e906193c8cd44b02fcd9d9b34fdb6b275ef5c13e7056fb61aa1870409b8020810f9b29aab6b339fa3f853c0e103";
+        let alpha_bytes = x"12168aa38a1ae0360550d0541002b024057ab689d45ce809f8ea36d5286eca9e2f18e70924ac69dcd432228a18036b146aa75a5c17430751f844f686c8ba210c7736adb1851f7afac7fbbc4ac78a01c7ca4508e3d45b5dd31e875c99b0c9d20004f4b3ad8e3c8842b6adc9c3797e3083a31b1ffe654dd4466743cd943b7d3185588a2d81da5f20b36593157c2429b21835964abb93670c81f4a9f230556dcedcc87a5c365613820e225225a650ba7d5a8d283db8317529b37297979ad7576405b26e53f2c162e35557eaf4e59e1b3d456d486291a644fe098f0d29c0435d46e35d114d7357188ed8a8fa26c807fa420e7bff7ce0c2a84a75f189cf6ed039564f36441236720be11bc53850f3700491f50430fe4729676564128f0bf326e67a0038975b396c6fd12c0cd8be75e5985e2841005640b6104b4e1e9817dd3b44e51aa4b0972489ad999bb8143a4e833110057ba32d1ff91c6707b07eab0605b9d6a2745aead54f16a968a4122fa8ca871b70a100b5fd854d4473ec7b519c04547f14b9aba6701e54e737161fc154cc3751f995c0c33d7ef74b893e6bc5514891d73af5543c4ed463e4aebe6cbbd97390bf0bf72075a0649e01a65fa2b7198bedac38406864dc780cb8789df0cb09cf532201d589bc40f84bf6a5816ccbd31ea85d0cf2e06c26037d6970caee38b507450bef282c40366bb4506408f17e331fde3211c0cb021c7858ba83e6a1f1d24bdf550b884d857ff0355ad83cd01346c62dca7197b4d54288ebc982d8228a8403e9a8bd95ef98775bf9c40004e2b5de3e663212";
+        let gamma_bytes = x"f63b997d4f3d45ed3e20e5cb0e17b0b962b62e9d64d5bc825fe571ffc15f98b10605758eaf440fe16513386c086c9e0b0bea1c30f8f8bf1667dcc47514a9adc4cd1b2d854c0fd2291e0140b7f6d34f31c3cb6c8ee635b9394821369154dd528a";
+        let delta_bytes = x"fdaacd48da6deedb190f27f59d9740c3607bbfcb2c0f8a590b4ee9071a9bda9532217f89aab2fd4e2d505f47cc113c00618849268b140fab6be405649a2d1d074983183287b8ee7a73c4dbb2ab4e7ba3bab7fa005a055a3dd26b4787fe11b505";
+        let pvk = groth16::pvk_from_bytes(vk_bytes, alpha_bytes, gamma_bytes, delta_bytes);
+
+        let inputs_bytes = x"4af76d91d4bc9a3973c15e3aeb574f0f64547b838f950af35db97f0705c4214b";
+        let inputs = groth16::public_proof_inputs_from_bytes(inputs_bytes);
+
+        let proof_bytes = x"cf4321ae78c61edef79dd0c4b2e6c4a48c24914e9b2b8e6aa9ff0c5e141beae84b80b49510beb90218a76cedb39dcc97fc309ed6d911c8ad65975e081b51c089c95a70ea6dd516ca09c9a59c4ee4f624d645ecbc9fac020194cc0962ab4f040f4d765b0e69014a47bc9f1b06e0ba818bfff2a51f424e3eba325b514e0da88c4e0aae399231bfd8daa29536cf2ddca0986f88147b749d1be59437610aaf7d0c34b200f58e2d2a93f4ecd14208a314583804dd2a3bc283ec00de01ecf789384507";
+        let proof = groth16::proof_points_from_bytes(proof_bytes);
+
+        assert!(groth16::verify_groth16_proof(&pvk, &inputs, &proof) == true, 0);
+
+        // Invalid prepared verifying key.
+        vector::pop_back(&mut vk_bytes);
+        let invalid_pvk = groth16::pvk_from_bytes(vk_bytes, alpha_bytes, gamma_bytes, delta_bytes);
+        assert!(groth16::verify_groth16_proof(&invalid_pvk, &inputs, &proof) == false, 0);
+
+        // Invalid public inputs bytes.
+        let invalid_inputs = groth16::public_proof_inputs_from_bytes(x"cf");
+        assert!(groth16::verify_groth16_proof(&pvk, &invalid_inputs, &proof) == false, 0);
+
+        // Invalid proof bytes.
+        let invalid_proof = groth16::proof_points_from_bytes(x"4a");
+        assert!(groth16::verify_groth16_proof(&pvk, &inputs, &invalid_proof) == false, 0);
+    }
+}

--- a/crates/sui-framework-override/tests/crypto/hmac_tests.move
+++ b/crates/sui-framework-override/tests/crypto/hmac_tests.move
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::hmac_tests {
+    use sui::hmac;
+    use sui::digest;
+    
+    #[test]
+    fun test_hmac_sha3_256() {
+        let key = b"my key!";
+        let msg = b"hello world!";
+        // The next was calculated using python
+        // hmac.new(key, msg, digestmod=hashlib.sha3_256).digest()
+        let expected_output_bytes = x"f6d6ae02f426eb9664e89e3c6d86c60e6103ce22b916819219c26e34e8d236dc";
+        let output = hmac::hmac_sha3_256(&key, &msg);
+        let outout_bytes = digest::sha3_256_digest_to_bytes(&output);
+        assert!(outout_bytes == expected_output_bytes, 0);
+    }
+
+
+}

--- a/crates/sui-framework-override/tests/delegation_tests.move
+++ b/crates/sui-framework-override/tests/delegation_tests.move
@@ -1,0 +1,269 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::delegation_tests {
+    use sui::coin::{Self, Coin};
+    use sui::sui::SUI;
+    use sui::test_scenario::{Self, Scenario};
+    use sui::sui_system::{Self, SuiSystemState};
+    use sui::staking_pool::{Self, Delegation, StakedSui};
+    use std::vector;
+
+    use sui::governance_test_utils::{
+        Self,
+        create_validator_for_testing,
+        create_sui_system_state_for_testing,
+    };
+
+    const VALIDATOR_ADDR_1: address = @0x1;
+    const VALIDATOR_ADDR_2: address = @0x2;
+
+    const DELEGATOR_ADDR_1: address = @0x42;
+    const DELEGATOR_ADDR_2: address = @0x43;
+
+    #[test]
+    fun test_add_remove_delegation_flow() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let system_state_mut_ref = &mut system_state;
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Create a delegation to VALIDATOR_ADDR_1.
+            sui_system::request_add_delegation(
+                system_state_mut_ref, coin::mint_for_testing(60, ctx), VALIDATOR_ADDR_1, ctx);
+
+            assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_1) == 0, 101);
+            assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_2) == 0, 102);
+
+            test_scenario::return_shared(system_state);
+        };
+
+        governance_test_utils::advance_epoch(scenario);
+        
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+
+            let delegation = test_scenario::take_from_sender<Delegation>(scenario);
+            assert!(staking_pool::delegation_token_amount(&delegation) == 60, 105);
+
+            let staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
+            assert!(staking_pool::staked_sui_amount(&staked_sui) == 60, 105);
+
+
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let system_state_mut_ref = &mut system_state;
+
+            assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_1) == 60, 103);
+            assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_2) == 0, 104);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Undelegate from VALIDATOR_ADDR_1
+            sui_system::request_withdraw_delegation(
+                system_state_mut_ref, delegation, staked_sui, ctx);
+
+            assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_1) == 60, 107);            
+            test_scenario::return_shared(system_state);
+        };
+
+        governance_test_utils::advance_epoch(scenario);
+
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            assert!(sui_system::validator_delegate_amount(&mut system_state, VALIDATOR_ADDR_1) == 0, 107);
+            test_scenario::return_shared(system_state);
+        };
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_switch_delegation() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Create a delegation to VALIDATOR_ADDR_1.
+            sui_system::request_add_delegation(
+                &mut system_state, coin::mint_for_testing(50, ctx), VALIDATOR_ADDR_1, ctx);
+
+            test_scenario::return_shared(system_state);
+        };
+
+        // Advance the epoch so the delegation is activated.
+        governance_test_utils::advance_epoch(scenario);
+        // Advance epoch one more time to distribute some rewards.
+        // The delegator should get 7 SUI of rewards.
+        governance_test_utils::advance_epoch_with_reward_amounts(0, 49, scenario);
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            
+            let delegation = test_scenario::take_from_sender<Delegation>(scenario);
+            let staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
+            
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Switch stake from VALIDATOR_ADDR_1 to VALIDATOR_ADDR_2
+            sui_system::request_switch_delegation(
+                &mut system_state, delegation, staked_sui, VALIDATOR_ADDR_2, ctx);
+            test_scenario::return_shared(system_state);
+        };
+
+        // The delegator should get another 9 SUI of rewards, in total 16 SUI of rewards.
+        governance_test_utils::advance_epoch_with_reward_amounts(0, 57, scenario);
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let staked_sui_ids = test_scenario::ids_for_sender<StakedSui>(scenario);
+            assert!(vector::length(&staked_sui_ids) == 2, 0);
+            let staked_sui_0 = test_scenario::take_from_sender_by_id(scenario, *vector::borrow(&staked_sui_ids, 0));
+            assert!(staking_pool::staked_sui_amount(&staked_sui_0) == 50, 106); // principal with the new validator
+            let staked_sui_1 = test_scenario::take_from_sender_by_id(scenario, *vector::borrow(&staked_sui_ids, 1));
+            assert!(staking_pool::staked_sui_amount(&staked_sui_1) == 16, 106); // rewards (16 SUI) with the new validator
+            test_scenario::return_to_sender(scenario, staked_sui_0);
+            test_scenario::return_to_sender(scenario, staked_sui_1);
+        };
+
+        governance_test_utils::advance_epoch(scenario);
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+            // Check that the delegate amounts have been changed successfully.
+            assert!(sui_system::validator_delegate_amount(&system_state, VALIDATOR_ADDR_1) == 0, 107);
+            assert!(sui_system::validator_delegate_amount(&system_state, VALIDATOR_ADDR_2) == 66, 107);
+            test_scenario::return_shared(system_state);
+        };
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_cancel_delegation_request() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Create a delegation to VALIDATOR_ADDR_1.
+            sui_system::request_add_delegation(
+                &mut system_state, coin::mint_for_testing(40, ctx), VALIDATOR_ADDR_1, ctx);
+
+            test_scenario::return_shared(system_state);
+        };
+
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_2);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Create another delegation to VALIDATOR_ADDR_1.
+            sui_system::request_add_delegation(
+                &mut system_state, coin::mint_for_testing(60, ctx), VALIDATOR_ADDR_1, ctx);
+
+            test_scenario::return_shared(system_state);
+        };
+
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Now cancel the first one.
+            sui_system::cancel_delegation_request(
+                &mut system_state, staked_sui, ctx);
+
+            test_scenario::return_shared(system_state);
+        };
+
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+            // Check that we have the coin back.
+            assert!(coin::value(&coin) == 40, 100);
+            test_scenario::return_to_sender(scenario, coin);
+        };
+
+        governance_test_utils::advance_epoch(scenario);
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+            // Check that the delegate amounts have been changed successfully.
+            assert!(sui_system::validator_delegate_amount(&system_state, VALIDATOR_ADDR_1) == 60, 101);
+            test_scenario::return_shared(system_state);
+        };
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::sui_system::ESTAKED_SUI_FROM_WRONG_EPOCH)]
+    fun test_cancel_delegation_abort() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Create a delegation to VALIDATOR_ADDR_1.
+            sui_system::request_add_delegation(
+                &mut system_state, coin::mint_for_testing(40, ctx), VALIDATOR_ADDR_1, ctx);
+
+            test_scenario::return_shared(system_state);
+        };
+
+        // advance the epoch
+        governance_test_utils::advance_epoch(scenario);
+
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Cancellation should fail since we are no longer in the same epoch.
+            sui_system::cancel_delegation_request(
+                &mut system_state, staked_sui, ctx);
+
+            test_scenario::return_shared(system_state);
+        };
+
+        test_scenario::end(scenario_val);
+    }
+
+    fun set_up_sui_system_state(scenario: &mut Scenario) {
+        let ctx = test_scenario::ctx(scenario);
+
+        let validators = vector[
+            create_validator_for_testing(VALIDATOR_ADDR_1, 100, ctx),
+            create_validator_for_testing(VALIDATOR_ADDR_2, 100, ctx)
+        ];
+        create_sui_system_state_for_testing(validators, 300, 100);
+    }
+}

--- a/crates/sui-framework-override/tests/digest_tests.move
+++ b/crates/sui-framework-override/tests/digest_tests.move
@@ -1,0 +1,30 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::digest_tests {
+    use sui::digest::{sha3_256_digest_from_bytes, sha3_256_digest_to_bytes};
+
+    const EHASH_LENGTH_MISMATCH: u64 = 0;
+
+    #[test]
+    #[expected_failure(abort_code = sui::digest::EHashLengthMismatch)]
+    fun test_too_short_hash() {
+        let hash = x"badf012345";
+        let _ = sha3_256_digest_from_bytes(hash);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::digest::EHashLengthMismatch)]
+    fun test_too_long_hash() {
+        let hash = x"1234567890123456789012345678901234567890abcdefabcdefabcdefabcdef123456";
+        let _ = sha3_256_digest_from_bytes(hash);
+    }
+
+    #[test]
+    fun test_good_hash() {
+        let hash = x"1234567890123456789012345678901234567890abcdefabcdefabcdefabcdef";
+        let digest = sha3_256_digest_from_bytes(hash);
+        assert!(sha3_256_digest_to_bytes(&digest) == hash, EHASH_LENGTH_MISMATCH);
+    }
+}

--- a/crates/sui-framework-override/tests/dynamic_field_tests.move
+++ b/crates/sui-framework-override/tests/dynamic_field_tests.move
@@ -1,0 +1,158 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::dynamic_field_tests {
+
+use sui::dynamic_field::{add, exists_with_type, borrow, borrow_mut, remove};
+use sui::object;
+use sui::test_scenario as ts;
+
+#[test]
+fun simple_all_functions() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    // add fields
+    add<u64, u64>(&mut id, 0, 0);
+    add<vector<u8>, u64>(&mut id, b"", 1);
+    add<bool, u64>(&mut id, false, 2);
+    // check they exist
+    assert!(exists_with_type<u64, u64>(&id, 0), 0);
+    assert!(exists_with_type<vector<u8>, u64>(&id, b""), 0);
+    assert!(exists_with_type<bool, u64>(&id, false), 0);
+    // check the values
+    assert!(*borrow(&id, 0) == 0, 0);
+    assert!(*borrow(&id, b"") == 1, 0);
+    assert!(*borrow(&id, false) == 2, 0);
+    // mutate them
+    *borrow_mut(&mut id, 0) = 3 + *borrow(&id, 0);
+    *borrow_mut(&mut id, b"") = 4 + *borrow(&id, b"");
+    *borrow_mut(&mut id, false) = 5 + *borrow(&id, false);
+    // check the new value
+    assert!(*borrow(&id, 0) == 3, 0);
+    assert!(*borrow(&id, b"") == 5, 0);
+    assert!(*borrow(&id, false) == 7, 0);
+    // remove the value and check it
+    assert!(remove(&mut id, 0) == 3, 0);
+    assert!(remove(&mut id, b"") == 5, 0);
+    assert!(remove(&mut id, false) == 7, 0);
+    // verify that they are not there
+    assert!(!exists_with_type<u64, u64>(&id, 0), 0);
+    assert!(!exists_with_type<vector<u8>, u64>(&id, b""), 0);
+    assert!(!exists_with_type<bool, u64>(&id, false), 0);
+    ts::end(scenario);
+    object::delete(id);
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun add_duplicate() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add<u64, u64>(&mut id, 0, 0);
+    add<u64, u64>(&mut id, 0, 1);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun add_duplicate_mismatched_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add<u64, u64>(&mut id, 0, 0u64);
+    add<u64, u8>(&mut id, 0, 1u8);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    borrow<u64, u64>(&mut id, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+fun borrow_wrong_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add(&mut id, 0, 0);
+    borrow<u64, u8>(&mut id, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_mut_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    borrow_mut<u64, u64>(&mut id, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+fun borrow_mut_wrong_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add(&mut id, 0, 0);
+    borrow_mut<u64, u8>(&mut id, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun remove_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    remove<u64, u64>(&mut id, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+fun remove_wrong_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add(&mut id, 0, 0);
+    remove<u64, u8>(&mut id, 0);
+    abort 42
+}
+
+#[test]
+fun sanity_check_exists() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    assert!(!exists_with_type<u64, u64>(&mut id, 0), 0);
+    add(&mut id, 0, 0);
+    assert!(exists_with_type<u64, u64>(&mut id, 0), 0);
+    assert!(!exists_with_type<u64, u8>(&mut id, 0), 0);
+    ts::end(scenario);
+    object::delete(id);
+}
+
+// should be able to do delete a UID even though it has a dynamic field
+#[test]
+fun delete_uid_with_fields() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add(&mut id, 0, 0);
+    assert!(exists_with_type<u64, u64>(&mut id, 0), 0);
+    ts::end(scenario);
+    object::delete(id);
+}
+
+}

--- a/crates/sui-framework-override/tests/dynamic_object_field_tests.move
+++ b/crates/sui-framework-override/tests/dynamic_object_field_tests.move
@@ -1,0 +1,243 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::dynamic_object_field_tests {
+
+use std::option;
+use sui::dynamic_object_field::{
+    add,
+    borrow,
+    borrow_mut,
+    exists_,
+    exists_with_type,
+    remove,
+    id as field_id,
+};
+use sui::object::{Self, UID};
+use sui::test_scenario as ts;
+
+struct Counter has key, store {
+    id: UID,
+    count: u64,
+}
+
+struct Fake has key, store {
+    id: UID,
+}
+
+#[test]
+fun simple_all_functions() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    let uid1 = ts::new_object(&mut scenario);
+    let id1 = object::uid_to_inner(&uid1);
+    let uid2 = ts::new_object(&mut scenario);
+    let id2 = object::uid_to_inner(&uid2);
+    let uid3 = ts::new_object(&mut scenario);
+    let id3 = object::uid_to_inner(&uid3);
+    // add fields
+    add(&mut id, 0, new(uid1));
+    add(&mut id, b"", new(uid2));
+    add(&mut id, false, new(uid3));
+    // check they exist
+    assert!(exists_(&id, 0), 0);
+    assert!(exists_(&id, b""), 0);
+    assert!(exists_(&id, false), 0);
+    // check the IDs
+    assert!(option::borrow(&field_id(&id, 0)) == &id1, 0);
+    assert!(option::borrow(&field_id(&id, b"")) == &id2, 0);
+    assert!(option::borrow(&field_id(&id, false)) == &id3, 0);
+    // check the values
+    assert!(count(borrow(&id, 0)) == 0, 0);
+    assert!(count(borrow(&id, b"")) == 0, 0);
+    assert!(count(borrow(&id, false)) == 0, 0);
+    // mutate them
+    bump(borrow_mut(&mut id, 0));
+    bump(bump(borrow_mut(&mut id, b"")));
+    bump(bump(bump(borrow_mut(&mut id, false))));
+    // check the new value
+    assert!(count(borrow(&id, 0)) == 1, 0);
+    assert!(count(borrow(&id, b"")) == 2, 0);
+    assert!(count(borrow(&id, false)) == 3, 0);
+    // remove the value and check it
+    assert!(destroy(remove(&mut id, 0)) == 1, 0);
+    assert!(destroy(remove(&mut id, b"")) == 2, 0);
+    assert!(destroy(remove(&mut id, false)) == 3, 0);
+    // verify that they are not there
+    assert!(!exists_(&id, 0), 0);
+    assert!(!exists_(&id, b""), 0);
+    assert!(!exists_(&id, false), 0);
+    ts::end(scenario);
+    object::delete(id);
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun add_duplicate() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
+    add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun add_duplicate_mismatched_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
+    add<u64, Fake>(&mut id, 0, Fake { id: ts::new_object(&mut scenario) });
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    borrow<u64, Counter>(&mut id, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+fun borrow_wrong_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add(&mut id, 0, new(ts::new_object(&mut scenario)));
+    borrow<u64, Fake>(&mut id, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_mut_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    borrow_mut<u64, Counter>(&mut id, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+fun borrow_mut_wrong_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add(&mut id, 0, new(ts::new_object(&mut scenario)));
+    borrow_mut<u64, Fake>(&mut id, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun remove_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    destroy(remove<u64, Counter>(&mut id, 0));
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+fun remove_wrong_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add(&mut id, 0, new(ts::new_object(&mut scenario)));
+    let Fake { id } = remove<u64, Fake>(&mut id, 0);
+    object::delete(id);
+    abort 42
+}
+
+#[test]
+fun sanity_check_exists() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    assert!(!exists_<u64>(&id, 0), 0);
+    add(&mut id, 0, new(ts::new_object(&mut scenario)));
+    assert!(exists_<u64>(&id, 0), 0);
+    assert!(!exists_<u8>(&id, 0), 0);
+    ts::end(scenario);
+    object::delete(id);
+}
+
+#[test]
+fun sanity_check_exists_with_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    assert!(!exists_with_type<u64, Counter>(&id, 0), 0);
+    assert!(!exists_with_type<u64, Fake>(&id, 0), 0);
+    add(&mut id, 0, new(ts::new_object(&mut scenario)));
+    assert!(exists_with_type<u64, Counter>(&id, 0), 0);
+    assert!(!exists_with_type<u8, Counter>(&id, 0), 0);
+    assert!(!exists_with_type<u8, Fake>(&id, 0), 0);
+    ts::end(scenario);
+    object::delete(id);
+}
+
+// should be able to do delete a UID even though it has a dynamic field
+#[test]
+fun delete_uid_with_fields() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id = ts::new_object(&mut scenario);
+    add(&mut id, 0, new(ts::new_object(&mut scenario)));
+    assert!(exists_<u64>(&mut id, 0), 0);
+    ts::end(scenario);
+    object::delete(id);
+}
+
+// transfer an object field from one "parent" to another
+#[test]
+fun transfer_object() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let id1 = ts::new_object(&mut scenario);
+    let id2 = ts::new_object(&mut scenario);
+    add(&mut id1, 0, new(ts::new_object(&mut scenario)));
+    assert!(exists_<u64>(&mut id1, 0), 0);
+    assert!(!exists_<u64>(&mut id2, 0), 0);
+    bump(borrow_mut(&mut id1, 0));
+    let c: Counter = remove(&mut id1, 0);
+    add(&mut id2, 0, c);
+    assert!(!exists_<u64>(&mut id1, 0), 0);
+    assert!(exists_<u64>(&mut id2, 0), 0);
+    bump(borrow_mut(&mut id2, 0));
+    assert!(count(borrow(&id2, 0)) == 2, 0);
+    ts::end(scenario);
+    object::delete(id1);
+    object::delete(id2);
+}
+
+fun new(id: UID): Counter {
+    Counter { id, count: 0 }
+}
+
+fun count(counter: &Counter): u64 {
+    counter.count
+}
+
+fun bump(counter: &mut Counter): &mut Counter {
+    counter.count = counter.count + 1;
+    counter
+}
+
+fun destroy(counter: Counter): u64 {
+    let Counter { id, count } = counter;
+    object::delete(id);
+    count
+}
+
+}

--- a/crates/sui-framework-override/tests/governance_test_utils.move
+++ b/crates/sui-framework-override/tests/governance_test_utils.move
@@ -1,0 +1,211 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::governance_test_utils {
+    use sui::address;
+    use sui::balance;
+    use sui::sui::SUI;
+    use sui::coin::{Self, Coin};
+    use sui::stake::{Self, Stake};
+    use sui::staking_pool::{StakedSui, Delegation};
+    use sui::tx_context::{Self, TxContext};
+    use sui::validator::{Self, Validator};
+    use sui::sui_system::{Self, SuiSystemState};
+    use sui::test_scenario::{Self, Scenario};
+    use std::option;
+    use std::vector;
+
+    public fun create_validator_for_testing(
+        addr: address, init_stake_amount: u64, ctx: &mut TxContext
+    ): Validator {
+        validator::new_for_testing(
+            addr,
+            x"FF",
+            x"FF",
+            x"FF",
+            x"FF",
+            b"ValidatorName",
+            b"description",
+            b"image_url",
+            b"project_url",
+            x"FFFF",
+            x"FFFF",
+            x"FFFF",
+            balance::create_for_testing<SUI>(init_stake_amount),
+            option::none(),
+            1,
+            0,
+            ctx
+        )
+    }
+
+    /// Create a validator set with the given stake amounts
+    public fun create_validators_with_stakes(stakes: vector<u64>, ctx: &mut TxContext): vector<Validator> {
+        let i = 0;
+        let validators = vector[];
+        while (i < vector::length(&stakes)) {
+            let validator = create_validator_for_testing(address::from_u256((i as u256)), *vector::borrow(&stakes, i), ctx);
+            vector::push_back(&mut validators, validator);
+            i = i + 1
+        };
+        validators
+    }
+
+    public fun create_sui_system_state_for_testing(
+        validators: vector<Validator>, sui_supply_amount: u64, storage_fund_amount: u64
+    ) {
+        sui_system::create(
+            validators,
+            balance::create_supply_for_testing(sui_supply_amount), // sui_supply
+            balance::create_for_testing<SUI>(storage_fund_amount), // storage_fund
+            1024, // max_validator_candidate_count
+            0, // min_validator_stake
+            0, // stake subsidy
+        )
+    }
+
+    public fun set_up_sui_system_state(addrs: vector<address>, scenario: &mut Scenario) {
+        let ctx = test_scenario::ctx(scenario);
+        let validators = vector::empty();
+
+        while (!vector::is_empty(&addrs)) {
+            vector::push_back(
+                &mut validators,
+                create_validator_for_testing(vector::pop_back(&mut addrs), 100, ctx)
+            );
+        };
+
+        create_sui_system_state_for_testing(validators, 1000, 0);
+    }
+
+    public fun advance_epoch(scenario: &mut Scenario) {
+        advance_epoch_with_reward_amounts(0, 0, scenario);
+    }
+
+    public fun advance_epoch_with_reward_amounts(
+        storage_charge: u64, computation_charge: u64, scenario: &mut Scenario
+    ) {
+        test_scenario::next_epoch(scenario, @0x0);
+        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario));
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+        let ctx = test_scenario::ctx(scenario);
+
+        sui_system::advance_epoch(&mut system_state, new_epoch, storage_charge, computation_charge, 0, 0, 0, 0, ctx);
+        test_scenario::return_shared(system_state);
+    }
+
+    public fun advance_epoch_with_reward_amounts_and_subsidy_rate(
+        storage_charge: u64, computation_charge: u64, stake_subsidy_rate: u64, scenario: &mut Scenario
+    ) {
+        test_scenario::next_epoch(scenario, @0x0);
+        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario));
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+        let ctx = test_scenario::ctx(scenario);
+
+        sui_system::advance_epoch(&mut system_state, new_epoch, storage_charge, computation_charge, 0, 0, 0, stake_subsidy_rate, ctx);
+        test_scenario::return_shared(system_state);
+    }
+
+    public fun advance_epoch_with_reward_amounts_and_slashing_rates(
+        storage_charge: u64,
+        computation_charge: u64,
+        reward_slashing_rate: u64,
+        scenario: &mut Scenario
+    ) {
+        test_scenario::next_epoch(scenario, @0x0);
+        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario));
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+        let ctx = test_scenario::ctx(scenario);
+
+        sui_system::advance_epoch(
+            &mut system_state, new_epoch, storage_charge, computation_charge, 0, 0, reward_slashing_rate, 0, ctx
+        );
+        test_scenario::return_shared(system_state);
+    }
+
+    public fun delegate_to(
+        delegator: address, validator: address, amount: u64, scenario: &mut Scenario
+    ) {
+        test_scenario::next_tx(scenario, delegator);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+        let ctx = test_scenario::ctx(scenario);
+
+        sui_system::request_add_delegation(&mut system_state, coin::mint_for_testing(amount, ctx), validator, ctx);
+        test_scenario::return_shared(system_state);
+    }
+
+    public fun undelegate(
+        delegator: address, staked_sui_idx: u64, delegation_obj_idx: u64, scenario: &mut Scenario
+    ) {
+        test_scenario::next_tx(scenario, delegator);
+        let stake_sui_ids = test_scenario::ids_for_sender<StakedSui>(scenario);
+        let staked_sui = test_scenario::take_from_sender_by_id(scenario, *vector::borrow(&stake_sui_ids, staked_sui_idx));
+        let delegation_ids = test_scenario::ids_for_sender<Delegation>(scenario);
+        let delegation = test_scenario::take_from_sender_by_id(scenario, *vector::borrow(&delegation_ids, delegation_obj_idx));
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+        let ctx = test_scenario::ctx(scenario);
+        sui_system::request_withdraw_delegation(&mut system_state, delegation, staked_sui, ctx);
+        test_scenario::return_shared(system_state);
+    }
+
+    public fun assert_validator_stake_amounts(validator_addrs: vector<address>, stake_amounts: vector<u64>, scenario: &mut Scenario) {
+        let i = 0;
+        while (i < vector::length(&validator_addrs)) {
+            let validator_addr = *vector::borrow(&validator_addrs, i);
+            let amount = *vector::borrow(&stake_amounts, i);
+            assert!(sum_up_validator_stake_amounts(validator_addr, scenario) == amount, 0);
+
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            assert!(sui_system::validator_stake_amount(&mut system_state, validator_addr) == amount, 0);
+            test_scenario::return_shared(system_state);
+            i = i + 1;
+        };
+    }
+
+    public fun assert_validator_delegate_amounts(validator_addrs: vector<address>, delegate_amounts: vector<u64>, scenario: &mut Scenario) {
+        let i = 0;
+        while (i < vector::length(&validator_addrs)) {
+            let validator_addr = *vector::borrow(&validator_addrs, i);
+            let amount = *vector::borrow(&delegate_amounts, i);
+            test_scenario::next_tx(scenario, validator_addr);
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            assert!(sui_system::validator_delegate_amount(&mut system_state, validator_addr) == amount, 0);
+            test_scenario::return_shared(system_state);
+            i = i + 1;
+        };
+    }
+
+    public fun sum_up_validator_stake_amounts(addr: address, scenario: &mut Scenario): u64 {
+        let sum = 0;
+        test_scenario::next_tx(scenario, addr);
+        let stake_ids = test_scenario::ids_for_sender<Stake>(scenario);
+        let i = 0;
+        while (i < vector::length(&stake_ids)) {
+            let stake = test_scenario::take_from_sender_by_id(scenario, *vector::borrow(&stake_ids, i));
+            sum = sum + stake::value(&stake);
+            test_scenario::return_to_sender(scenario, stake);
+            i = i + 1;
+        };
+        sum
+    }
+
+    public fun total_sui_balance(addr: address, scenario: &mut Scenario): u64 {
+        let sum = 0;
+        test_scenario::next_tx(scenario, addr);
+        let coin_ids = test_scenario::ids_for_sender<Coin<SUI>>(scenario);
+        let i = 0;
+        while (i < vector::length(&coin_ids)) {
+            let coin = test_scenario::take_from_sender_by_id<Coin<SUI>>(scenario, *vector::borrow(&coin_ids, i));
+            sum = sum + coin::value(&coin);
+            test_scenario::return_to_sender(scenario, coin);
+            i = i + 1;
+        };
+        sum
+    }
+}

--- a/crates/sui-framework-override/tests/id_tests.move
+++ b/crates/sui-framework-override/tests/id_tests.move
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::id_tests {
+    use sui::object;
+    use sui::tx_context;
+
+    const ID_BYTES_MISMATCH: u64 = 0;
+
+    struct Object has key {
+        id: object::UID,
+    }
+
+    #[test]
+    fun test_get_id() {
+        let ctx = tx_context::dummy();
+        let id = object::new(&mut ctx);
+        let obj_id = object::uid_to_inner(&id);
+        let obj = Object { id };
+        assert!(object::id(&obj) == obj_id, ID_BYTES_MISMATCH);
+        let Object { id } = obj;
+        object::delete(id);
+    }
+}

--- a/crates/sui-framework-override/tests/immutable_external_resource_tests.move
+++ b/crates/sui-framework-override/tests/immutable_external_resource_tests.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::immutable_external_resource_tests {
+    use sui::immutable_external_resource;
+    use sui::url;
+    use std::ascii::Self;
+    use sui::digest;
+
+    const EHASH_LENGTH_MISMATCH: u64 = 0;
+    const URL_STRING_MISMATCH: u64 = 1;
+
+    #[test]
+    fun test_init() {
+        // url strings are not currently validated
+        let url_str = ascii::string(x"414243454647");
+        // 32 bytes
+        let hash = x"1234567890123456789012345678901234567890abcdefabcdefabcdefabcdef";
+
+        let url = url::new_unsafe(url_str);
+        let digest = digest::sha3_256_digest_from_bytes(hash);
+        let resource = immutable_external_resource::new(url, digest);
+
+        assert!(immutable_external_resource::url(&resource) == url, 0);
+        assert!(immutable_external_resource::digest(&resource) == digest, 0);
+
+        let new_url_str = ascii::string(x"37414243454647");
+        let new_url = url::new_unsafe(new_url_str);
+
+        immutable_external_resource::update(&mut resource, new_url);
+        assert!(immutable_external_resource::url(&resource) == new_url, 0);
+    }
+}

--- a/crates/sui-framework-override/tests/linked_table_tests.move
+++ b/crates/sui-framework-override/tests/linked_table_tests.move
@@ -1,0 +1,372 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::linked_table_tests {
+
+use std::option;
+use std::vector;
+use sui::linked_table::{
+    Self,
+    LinkedTable,
+    front,
+    back,
+    push_front,
+    push_back,
+    borrow,
+    borrow_mut,
+    prev,
+    next,
+    remove,
+    pop_front,
+    pop_back,
+    contains,
+    length,
+    is_empty,
+    destroy_empty,
+    drop,
+};
+use sui::test_scenario as ts;
+use sui::tx_context::TxContext;
+
+#[test]
+fun simple_all_functions() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new(ts::ctx(&mut scenario));
+    check_ordering(&table, &vector[]);
+    // add fields
+    push_back(&mut table, b"hello", 0);
+    check_ordering(&table, &vector[b"hello"]);
+    push_back(&mut table, b"goodbye", 1);
+    // check they exist
+    assert!(contains(&table, b"hello"), 0);
+    assert!(contains(&table, b"goodbye"), 0);
+    assert!(!is_empty(&table), 0);
+    // check the values
+    assert!(*borrow(&table, b"hello") == 0, 0);
+    assert!(*borrow(&table, b"goodbye") == 1, 0);
+    // mutate them
+    *borrow_mut(&mut table, b"hello") = *borrow(&table, b"hello") * 2;
+    *borrow_mut(&mut table, b"goodbye") = *borrow(&table, b"goodbye") * 2;
+    // check the new value
+    assert!(*borrow(&table, b"hello") == 0, 0);
+    assert!(*borrow(&table, b"goodbye") == 2, 0);
+    // check the ordering
+    check_ordering(&table, &vector[b"hello", b"goodbye"]);
+    // add to the front
+    push_front(&mut table, b"!!!", 2);
+    check_ordering(&table, &vector[b"!!!", b"hello", b"goodbye"]);
+    // add to the back
+    push_back(&mut table, b"?", 3);
+    check_ordering(&table, &vector[b"!!!", b"hello", b"goodbye", b"?"]);
+    // pop front
+    let (front_k, front_v) = pop_front(&mut table);
+    assert!(front_k == b"!!!", 0);
+    assert!(front_v == 2, 0);
+    check_ordering(&table, &vector[b"hello", b"goodbye", b"?"]);
+    // remove middle
+    assert!(remove(&mut table, b"goodbye") == 2, 0);
+    check_ordering(&table, &vector[b"hello", b"?"]);
+    // pop back
+    let (back_k, back_v) = pop_back(&mut table);
+    assert!(back_k == b"?", 0);
+    assert!(back_v == 3, 0);
+    check_ordering(&table, &vector[b"hello"]);
+    // remove the value and check it
+    assert!(remove(&mut table, b"hello") == 0, 0);
+    check_ordering(&table, &vector[]);
+    // verify that they are not there
+    assert!(!contains(&table, b"!!!"), 0);
+    assert!(!contains(&table, b"goodbye"), 0);
+    assert!(!contains(&table, b"hello"), 0);
+    assert!(!contains(&table, b"?"), 0);
+    assert!(is_empty(&table), 0);
+    ts::end(scenario);
+    destroy_empty(table);
+}
+
+#[test]
+fun front_back_empty() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+    assert!(option::is_none(front(&table)), 0);
+    assert!(option::is_none(back(&table)), 0);
+    ts::end(scenario);
+    drop(table)
+}
+
+#[test]
+fun push_front_singleton() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new(ts::ctx(&mut scenario));
+    check_ordering(&table, &vector[]);
+    push_front(&mut table, b"hello", 0);
+    assert!(contains(&table, b"hello"), 0);
+    check_ordering(&table, &vector[b"hello"]);
+    ts::end(scenario);
+    drop(table)
+}
+
+#[test]
+fun push_back_singleton() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new(ts::ctx(&mut scenario));
+    check_ordering(&table, &vector[]);
+    push_back(&mut table, b"hello", 0);
+    assert!(contains(&table, b"hello"), 0);
+    check_ordering(&table, &vector[b"hello"]);
+    ts::end(scenario);
+    drop(table)
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun push_front_duplicate() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new(ts::ctx(&mut scenario));
+    push_front(&mut table, b"hello", 0);
+    push_front(&mut table, b"hello", 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun push_back_duplicate() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new(ts::ctx(&mut scenario));
+    push_back(&mut table, b"hello", 0);
+    push_back(&mut table, b"hello", 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun push_mixed_duplicate() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new(ts::ctx(&mut scenario));
+    push_back(&mut table, b"hello", 0);
+    push_front(&mut table, b"hello", 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+    borrow(&table, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_mut_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+    borrow_mut(&mut table, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun remove_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+    remove(&mut table, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = linked_table::ETableIsEmpty)]
+fun pop_front_empty() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+    pop_front(&mut table);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = linked_table::ETableIsEmpty)]
+fun pop_back_empty() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+    pop_back(&mut table);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = linked_table::ETableNotEmpty)]
+fun destroy_non_empty() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new(ts::ctx(&mut scenario));
+    push_back(&mut table, 0, 0);
+    destroy_empty(table);
+    ts::end(scenario);
+}
+
+#[test]
+fun sanity_check_contains() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new(ts::ctx(&mut scenario));
+    assert!(!contains(&mut table, 0), 0);
+    push_back(&mut table, 0, 0);
+    assert!(contains<u64, u64>(&mut table, 0), 0);
+    assert!(!contains<u64, u64>(&mut table, 1), 0);
+    ts::end(scenario);
+    drop(table);
+}
+
+#[test]
+fun sanity_check_drop() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new(ts::ctx(&mut scenario));
+    push_back(&mut table, 0, 0);
+    assert!(length(&table) == 1, 0);
+    ts::end(scenario);
+    drop(table);
+}
+
+#[test]
+fun sanity_check_size() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = linked_table::new(ts::ctx(&mut scenario));
+    assert!(is_empty(&table), 0);
+    assert!(length(&table) == 0, 0);
+    push_back(&mut table, 0, 0);
+    assert!(!is_empty(&table), 0);
+    assert!(length(&table) == 1, 0);
+    push_back(&mut table, 1, 0);
+    assert!(!is_empty(&table), 0);
+    assert!(length(&table) == 2, 0);
+    ts::end(scenario);
+    drop(table);
+}
+
+#[test]
+fun test_all_orderings() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let ctx = ts::ctx(&mut scenario);
+    let keys = vector[b"a", b"b", b"c"];
+    let values = vector[3, 2, 1];
+    let all_bools = vector[
+        vector[true, true, true],
+        vector[true, false, true],
+        vector[true, true, false],
+        vector[true, false, false],
+        vector[false, false, true],
+        vector[false, false, false],
+    ];
+    let i = 0;
+    let j = 0;
+    let n = vector::length(&all_bools);
+    // all_bools indicate possible orderings of accessing the front vs the back of the
+    // table
+    // test all orderings of building up and tearing down the table, while mimicing
+    // the ordering in a vector, and checking the keys have the same order in the table
+    while (i < n) {
+        let pushes = vector::borrow(&all_bools, i);
+        while (j < n) {
+            let pops = vector::borrow(&all_bools, j);
+            build_up_and_tear_down(&keys, &values, pushes, pops, ctx);
+            j = j + 1;
+        };
+        i = i + 1;
+    };
+    ts::end(scenario);
+}
+
+fun build_up_and_tear_down<K: copy + drop + store, V: copy + drop + store>(
+    keys: &vector<K>,
+    values: &vector<V>,
+    // true for front, false for back
+    pushes: &vector<bool>,
+    // true for front, false for back
+    pops: &vector<bool>,
+    ctx: &mut TxContext,
+) {
+    let table = linked_table::new(ctx);
+    let n = vector::length(keys);
+    assert!(vector::length(values) == n, 0);
+    assert!(vector::length(pushes) == n, 0);
+    assert!(vector::length(pops) == n, 0);
+
+    let i = 0;
+    let order = vector[];
+    while (i < n) {
+        let k = *vector::borrow(keys, i);
+        let v = *vector::borrow(values, i);
+        if (*vector::borrow(pushes, i)) {
+            push_front(&mut table, k, v);
+            vector::insert(&mut order, k, 0);
+        } else {
+            push_front(&mut table, k, v);
+            vector::push_back(&mut order, k);
+        };
+        i = i + 1;
+    };
+
+    check_ordering(&table, &order);
+    let i = 0;
+    while (i < n) {
+        let (table_k, order_k) = if (*vector::borrow(pops, i)) {
+            let (table_k, _) = pop_front(&mut table);
+            (table_k, vector::remove(&mut order, 0))
+        } else {
+            let (table_k, _) = pop_back(&mut table);
+            (table_k, vector::pop_back(&mut order))
+        };
+        assert!(table_k == order_k, 0);
+        check_ordering(&table, &order);
+        i = i + 1;
+    };
+    destroy_empty(table)
+}
+
+fun check_ordering<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, keys: &vector<K>) {
+    let n = length(table);
+    assert!(n == vector::length(keys), 0);
+    if (n == 0) {
+        assert!(option::is_none(front(table)), 0);
+        assert!(option::is_none(back(table)), 0);
+        return
+    };
+
+    let i = 0;
+    while (i < n) {
+        let cur = *vector::borrow(keys, i);
+        if (i == 0) {
+            assert!(option::borrow(front(table)) == &cur, 0);
+            assert!(option::is_none(prev(table, cur)), 0);
+        } else {
+            assert!(option::borrow(prev(table, cur)) == vector::borrow(keys, i - 1), 0);
+        };
+        if (i + 1 == n) {
+            assert!(option::borrow(back(table)) == &cur, 0);
+            assert!(option::is_none(next(table, cur)), 0);
+        } else {
+            assert!(option::borrow(next(table, cur)) == vector::borrow(keys, i + 1), 0);
+        };
+
+        i = i + 1;
+    }
+}
+
+
+}

--- a/crates/sui-framework-override/tests/math_tests.move
+++ b/crates/sui-framework-override/tests/math_tests.move
@@ -1,0 +1,72 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::math_tests {
+    use sui::math;
+
+    #[test]
+    fun test_max() {
+        assert!(math::max(10, 100) == 100, 1);
+        assert!(math::max(100, 10) == 100, 2);
+        assert!(math::max(0, 0) == 0, 3);
+    }
+
+    #[test]
+    fun test_min() {
+        assert!(math::min(10, 100) == 10, 1);
+        assert!(math::min(100, 10) == 10, 2);
+        assert!(math::min(0, 0) == 0, 3);
+    }
+    
+    #[test]
+    fun test_pow() {
+        assert!(math::pow(1, 0) == 1, 0);
+        assert!(math::pow(3, 1) == 3, 0);
+        assert!(math::pow(2, 10) == 1024, 0);
+        assert!(math::pow(10, 6) == 1000000, 0);
+    }
+
+    #[test]
+    #[expected_failure]
+    fun test_pow_overflow() {
+        math::pow(10, 100);
+    }
+
+    #[test]
+    fun test_perfect_sqrt() {
+        let i = 0;
+        while (i < 1000) {
+            assert!(math::sqrt(i * i) == i, 1);
+            i = i + 1;
+        };
+        let i = 0xFFFFFFFFFu128;
+        while (i < 0xFFFFFFFFFu128 + 1) {
+            assert!(math::sqrt_u128(i * i) == i, 1);
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    // This function tests whether the (square root)^2 equals the
+    // initial value OR whether it is equal to the nearest lower
+    // number that does.
+    fun test_imperfect_sqrt() {
+        let i = 1;
+        let prev = 1;
+        while (i <= 1000) {
+            let root = math::sqrt(i);
+
+            assert!(i == root * root || root == prev, 0);
+
+            prev = root;
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    fun test_sqrt_big_numbers() {
+        let u64_max = 18446744073709551615;
+        assert!(4294967295 == math::sqrt(u64_max), 0)
+    }
+}

--- a/crates/sui-framework-override/tests/natives_calibration_tests.move
+++ b/crates/sui-framework-override/tests/natives_calibration_tests.move
@@ -1,0 +1,310 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// This module attempts to find the computational cost of native function by measuring the time
+// the native takes to execute.
+// Isolating the native function is tricky, so we run two functions with and without the native
+// The difference in execution times is the time the native takes
+// functions prefixed with __baseline do not have the natives
+// Many parts of the code are written in such a way that the bytecode diffs yield exactly the
+// native to be isolated
+
+// TBD: Try objects of different sizes in natives
+
+#[test_only]
+module sui::natives_calibration_tests {
+    use sui::object::{Self, UID};
+
+    use sui::test_scenario;
+    // use sui::transfer;
+    use sui::event;
+    use sui::tx_context;
+
+    // Number of times to run the inner loop of tests
+    // We set this value to 1 to avoid long running tests
+    // But normally we want something like 1000000
+    const NUM_TRIALS: u64 = 1;
+
+    // A very basic struct to be used in calls
+    struct StructSimple has store, drop, copy {
+    }
+    // A very basic object which has an Info to be used in calls
+    struct ObjectWithID has key, store{
+        id: UID,
+    }
+
+    // Cost calibration functions
+    #[test_only]
+    public fun calibrate_emit(obj: StructSimple) {
+        event::emit(obj);
+    }
+    #[test_only]
+    public fun calibrate_emit_nop(obj: StructSimple) {
+        let _ = obj;
+    }
+
+    // =================================================================
+    // Natives in the `event` module
+    // =================================================================
+
+    // =================================================================
+    // event::emit
+    // =================================================================
+    // This native emits an event given an object
+    // > Note: this function's execution time depends on the size of the object, however we assume
+    // > a flat cost for all operations
+
+    // This test function calls the native in a typical manner
+    #[test]
+    public entry fun test_calibrate_event_emit() {
+        let trials: u64 = NUM_TRIALS;
+
+        while (trials > 0) {
+            let str1 = StructSimple { };
+            calibrate_emit(str1);
+            trials = trials - 1;
+        }
+    }
+    // This test function excludes the natives
+    #[test]
+    public entry fun test_calibrate_event_emit__baseline() {
+        let trials: u64 = NUM_TRIALS;
+
+        while (trials > 0) {
+            let str1 = StructSimple { };
+            calibrate_emit_nop(str1);
+            trials = trials - 1;
+        }
+    }
+
+
+    // TODO simple object calibration not supported due to type system violations
+    // // =================================================================
+    // // Natives in the `transfer` module
+    // // =================================================================
+
+    // // =================================================================
+    // // transfer::freeze_object
+    // // =================================================================
+    // // This native freezes an object
+
+    // // This test function calls the native in a typical manner
+    // #[test]
+    // public entry fun test_calibrate_transfer_freeze_object() {
+    //     let trials: u64 = NUM_TRIALS;
+
+    //     while (trials > 0) {
+    //         let str1 = StructSimple { };
+    //         transfer::calibrate_freeze_object(str1);
+    //         trials = trials - 1;
+    //     }
+    // }
+    // // This test function excludes the natives
+    // #[test]
+    // public entry fun test_calibrate_transfer_freeze_object__baseline() {
+    //     let trials: u64 = NUM_TRIALS;
+
+    //     while (trials > 0) {
+    //         let str1 = StructSimple { };
+    //         transfer::calibrate_freeze_object_nop(str1);
+    //         trials = trials - 1;
+    //     }
+    // }
+
+    // // =================================================================
+    // // transfer::share_object
+    // // =================================================================
+    // // This native shares an object
+
+    // // This test function calls the native in a typical manner
+    // #[test]
+    // public entry fun test_calibrate_transfer_share_object() {
+    //     let trials: u64 = NUM_TRIALS;
+
+    //     while (trials > 0) {
+    //         let str1 = StructSimple { };
+    //         transfer::calibrate_share_object(str1);
+    //         trials = trials - 1;
+    //     }
+    // }
+    // // This test function excludes the natives
+    // #[test]
+    // public entry fun test_calibrate_transfer_share_object__baseline() {
+    //     let trials: u64 = NUM_TRIALS;
+
+    //     while (trials > 0) {
+    //         let str1 = StructSimple { };
+    //         transfer::calibrate_share_object_nop(str1);
+    //         trials = trials - 1;
+    //     }
+    // }
+
+    // // =================================================================
+    // // transfer::transfer_internal
+    // // =================================================================
+    // // This native transfers an object to an address
+
+    // // This test function calls the native in a typical manner
+    // #[test]
+    // public entry fun test_calibrate_transfer_transfer_internal() {
+    //     let trials: u64 = NUM_TRIALS;
+    //     while (trials > 0) {
+    //         let str1 = StructSimple { };
+    //         let addr = @0x0;
+    //         let to_object = false;
+    //         transfer::calibrate_transfer_internal(str1, addr, to_object);
+    //         trials = trials - 1;
+    //     }
+    // }
+    // // This test function excludes the natives
+    // #[test]
+    // public entry fun test_calibrate_transfer_transfer_internal__baseline() {
+    //     let trials: u64 = NUM_TRIALS;
+    //     while (trials > 0) {
+    //         let str1 = StructSimple { };
+    //         let addr = @0x0;
+    //         let to_object = false;
+    //         transfer::calibrate_transfer_internal_nop(str1, addr, to_object);
+    //         trials = trials - 1;
+    //     }
+    // }
+
+    // =================================================================
+    // transfer::delete_child_object_internal
+    // =================================================================
+    // TBD
+
+
+    // =================================================================
+    // Natives in the `id` module
+    // =================================================================
+
+    // =================================================================
+    // object::address_from_bytes
+    // =================================================================
+    // This native converts bytes to addresses
+
+    // This test function calls the native in a typical manner
+    #[test]
+    public entry fun test_calibrate_id_address_from_bytes() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let bytes = x"3a985da74fe225b2045c172d6bd390bd855f086e";
+            object::calibrate_address_from_bytes(bytes);
+            trials = trials - 1;
+        }
+    }
+    // This test function excludes the natives
+    #[test]
+    public entry fun test_calibrate_id_address_from_bytes__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let bytes = x"3a985da74fe225b2045c172d6bd390bd855f086e";
+            object::calibrate_address_from_bytes_nop(bytes);
+            trials = trials - 1;
+        }
+    }
+
+    // =================================================================
+    // object::get_versioned_id
+    // =================================================================
+    // This native extracts the versioned ID from an object
+
+    // This test function calls the native in a typical manner
+    #[test]
+    public entry fun test_calibrate_id_borrow_uid() {
+        let trials: u64 = NUM_TRIALS;
+        let sender = @0x0;
+        let scenario_val = test_scenario::begin(sender);
+        let scenario = &mut scenario_val;
+
+        while (trials > 0) {
+            let obj = ObjectWithID { id: object::new(test_scenario::ctx(scenario)) };
+            object::calibrate_borrow_uid(&obj);
+            let ObjectWithID { id } = obj;
+            object::delete(id);
+
+            trials = trials - 1;
+
+        };
+        test_scenario::end(scenario_val);
+    }
+    // This test function excludes the natives
+    #[test]
+    public entry fun test_calibrate_id_borrow_uid__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        let sender = @0x0;
+        let scenario_val = test_scenario::begin(sender);
+        let scenario = &mut scenario_val;
+
+        while (trials > 0) {
+            let obj = ObjectWithID { id: object::new(test_scenario::ctx(scenario)) };
+            object::calibrate_borrow_uid(&obj);
+            // This forces an immutable borrow to counter the ImmBorrowLoc in object::get_versioned_id
+            let _ = &obj;
+            let ObjectWithID { id } = obj;
+            object::delete(id);
+
+            trials = trials - 1;
+        };
+        test_scenario::end(scenario_val);
+    }
+
+
+    // =================================================================
+    // Natives in the `tx_context` module
+    // =================================================================
+
+    // =================================================================
+    // tx_context::derive_id
+    // =================================================================
+    // This native derives an ID from an object
+
+    // This test function calls the native in a typical manner
+    #[test]
+    public entry fun test_calibrate_tx_context_derive_id() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let tx_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
+            let created_num: u64 = 0;
+            tx_context::calibrate_derive_id(tx_hash, created_num);
+            trials = trials - 1;
+        }
+    }
+    // This test function excludes the natives
+    #[test]
+    public entry fun test_calibrate_tx_context_derive_id__baseline() {
+        let trials: u64 = NUM_TRIALS;
+        while (trials > 0) {
+            let tx_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
+            let created_num: u64 = 0;
+            tx_context::calibrate_derive_id_nop(tx_hash, created_num);
+            trials = trials - 1;
+        }
+    }
+
+
+    // =================================================================
+    // These calibrate the `Pop` bytecode instruction because it is needed
+    // to calculate the cost of popping unused variables in baseline functions
+    // =================================================================
+    #[test]
+    public entry fun test_calibrate_pop() {
+        let trials: u64 = NUM_TRIALS;
+
+        while (trials > 0) {
+            let _k = false;
+            trials = trials - 1;
+        }
+    }
+    #[test]
+    public entry fun test_calibrate_pop__baseline() {
+        let trials: u64 = NUM_TRIALS;
+
+        while (trials > 0) {
+            trials = trials - 1;
+        }
+    }
+
+}

--- a/crates/sui-framework-override/tests/object_bag_tests.move
+++ b/crates/sui-framework-override/tests/object_bag_tests.move
@@ -1,0 +1,220 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::object_bag_tests {
+
+use std::option;
+use sui::object_bag::{
+    Self,
+    add,
+    contains,
+    contains_with_type,
+    borrow,
+    borrow_mut,
+    remove,
+    value_id,
+};
+use sui::object::{Self, UID};
+use sui::test_scenario as ts;
+
+struct Counter has key, store {
+    id: UID,
+    count: u64,
+}
+
+struct Fake has key, store {
+    id: UID,
+}
+
+
+#[test]
+fun simple_all_functions() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = object_bag::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    let id1 = object::uid_to_inner(&uid1);
+    let uid2 = ts::new_object(&mut scenario);
+    let id2 = object::uid_to_inner(&uid2);
+    // add fields
+    add(&mut bag, b"hello", new(uid1));
+    add(&mut bag, 1, new(uid2));
+    // check they exist
+    assert!(contains(&bag, b"hello"), 0);
+    assert!(contains(&bag, 1), 0);
+    assert!(contains_with_type<vector<u8>, Counter>(&bag, b"hello"), 0);
+    assert!(contains_with_type<u64, Counter>(&bag, 1), 0);
+    // check the IDs
+    assert!(option::borrow(&value_id(&bag, b"hello")) == &id1, 0);
+    assert!(option::borrow(&value_id(&bag, 1)) == &id2, 0);
+    // check the values
+    assert!(count(borrow(&bag, b"hello")) == 0, 0);
+    assert!(count(borrow(&bag, 1)) == 0, 0);
+    // mutate them
+    bump(borrow_mut(&mut bag, b"hello"));
+    bump(bump(borrow_mut(&mut bag, 1)));
+    // check the new value
+    assert!(count(borrow(&bag, b"hello")) == 1, 0);
+    assert!(count(borrow(&bag, 1)) == 2, 0);
+    // remove the value and check it
+    assert!(destroy(remove(&mut bag, b"hello")) == 1, 0);
+    assert!(destroy(remove(&mut bag, 1)) == 2, 0);
+    // verify that they are not there
+    assert!(!contains(&bag, b"hello"), 0);
+    assert!(!contains(&bag, 1), 0);
+    ts::end(scenario);
+    object_bag::destroy_empty(bag);
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun add_duplicate() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = object_bag::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    let uid2 = ts::new_object(&mut scenario);
+    add(&mut bag, b"hello", new(uid1));
+    add(&mut bag, b"hello", new(uid2));
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = object_bag::new(ts::ctx(&mut scenario));
+    borrow<u64, Counter>(&bag, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_mut_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = object_bag::new(ts::ctx(&mut scenario));
+    borrow_mut<u64, Counter>(&mut bag, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun remove_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = object_bag::new(ts::ctx(&mut scenario));
+    destroy(remove<u64, Counter>(&mut bag, 0));
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::object_bag::EBagNotEmpty)]
+fun destroy_non_empty() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = object_bag::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    add(&mut bag, 0, new(uid1));
+    object_bag::destroy_empty(bag);
+    ts::end(scenario);
+}
+
+#[test]
+fun sanity_check_contains() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = object_bag::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    assert!(!contains(&mut bag, 0), 0);
+    add(&mut bag, 0, new(uid1));
+    assert!(contains(&mut bag, 0), 0);
+    assert!(!contains(&mut bag, 1), 0);
+    ts::end(scenario);
+    destroy(remove(&mut bag, 0));
+    object_bag::destroy_empty(bag)
+}
+
+#[test]
+fun sanity_check_contains_with_type() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = object_bag::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    assert!(!contains_with_type<u64, Counter>(&mut bag, 0), 0);
+    assert!(!contains_with_type<u64, Fake>(&mut bag, 0), 0);
+    add(&mut bag, 0, new(uid1));
+    assert!(contains_with_type<u64, Counter>(&bag, 0), 0);
+    assert!(!contains_with_type<u8, Counter>(&bag, 0), 0);
+    assert!(!contains_with_type<u8, Fake>(&bag, 0), 0);
+    ts::end(scenario);
+    destroy(remove(&mut bag, 0));
+    object_bag::destroy_empty(bag)
+}
+
+#[test]
+fun sanity_check_size() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag = object_bag::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    let uid2 = ts::new_object(&mut scenario);
+    assert!(object_bag::is_empty(&bag), 0);
+    assert!(object_bag::length(&bag) == 0, 0);
+    add(&mut bag, 0, new(uid1));
+    assert!(!object_bag::is_empty(&bag), 0);
+    assert!(object_bag::length(&bag) == 1, 0);
+    add(&mut bag, 1, new(uid2));
+    assert!(!object_bag::is_empty(&bag), 0);
+    assert!(object_bag::length(&bag) == 2, 0);
+    ts::end(scenario);
+    destroy(remove(&mut bag, 0));
+    destroy(remove(&mut bag, 1));
+    object_bag::destroy_empty(bag);
+}
+
+// transfer an object field from one "parent" to another
+#[test]
+fun transfer_object() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let bag1 = object_bag::new(ts::ctx(&mut scenario));
+    let bag2 = object_bag::new(ts::ctx(&mut scenario));
+    add(&mut bag1, 0, new(ts::new_object(&mut scenario)));
+    assert!(contains(&bag1, 0), 0);
+    assert!(!contains(&bag2, 0), 0);
+    bump(borrow_mut(&mut bag1, 0));
+    let c = remove<u64, Counter>(&mut bag1, 0);
+    add(&mut bag2, 0, c);
+    assert!(!contains(&bag1, 0), 0);
+    assert!(contains(&bag2, 0), 0);
+    bump(borrow_mut(&mut bag2, 0));
+    assert!(count(borrow(&bag2, 0)) == 2, 0);
+    ts::end(scenario);
+    destroy(remove(&mut bag2, 0));
+    object_bag::destroy_empty(bag1);
+    object_bag::destroy_empty(bag2);
+}
+
+fun new(id: UID): Counter {
+    Counter { id, count: 0 }
+}
+
+fun count(counter: &Counter): u64 {
+    counter.count
+}
+
+fun bump(counter: &mut Counter): &mut Counter {
+    counter.count = counter.count + 1;
+    counter
+}
+
+fun destroy(counter: Counter): u64 {
+    let Counter { id, count } = counter;
+    object::delete(id);
+    count
+}
+
+}

--- a/crates/sui-framework-override/tests/object_table_tests.move
+++ b/crates/sui-framework-override/tests/object_table_tests.move
@@ -1,0 +1,187 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::object_table_tests {
+
+use std::option;
+use sui::object_table::{Self, add, contains, borrow, borrow_mut, remove, value_id};
+use sui::object::{Self, UID};
+use sui::test_scenario as ts;
+
+struct Counter has key, store {
+    id: UID,
+    count: u64,
+}
+
+#[test]
+fun simple_all_functions() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = object_table::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    let id1 = object::uid_to_inner(&uid1);
+    let uid2 = ts::new_object(&mut scenario);
+    let id2 = object::uid_to_inner(&uid2);
+    // add fields
+    add(&mut table, b"hello", new(uid1));
+    add(&mut table, b"goodbye", new(uid2));
+    // check they exist
+    assert!(contains(&table, b"hello"), 0);
+    assert!(contains(&table, b"goodbye"), 0);
+    // check the IDs
+    assert!(option::borrow(&value_id(&table, b"hello")) == &id1, 0);
+    assert!(option::borrow(&value_id(&table, b"goodbye")) == &id2, 0);
+    // check the values
+    assert!(count(borrow(&table, b"hello")) == 0, 0);
+    assert!(count(borrow(&table, b"goodbye")) == 0, 0);
+    // mutate them
+    bump(borrow_mut(&mut table, b"hello"));
+    bump(bump(borrow_mut(&mut table, b"goodbye")));
+    // check the new value
+    assert!(count(borrow(&table, b"hello")) == 1, 0);
+    assert!(count(borrow(&table, b"goodbye")) == 2, 0);
+    // remove the value and check it
+    assert!(destroy(remove(&mut table, b"hello")) == 1, 0);
+    assert!(destroy(remove(&mut table, b"goodbye")) == 2, 0);
+    // verify that they are not there
+    assert!(!contains(&table, b"hello"), 0);
+    assert!(!contains(&table, b"goodbye"), 0);
+    ts::end(scenario);
+    object_table::destroy_empty(table);
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun add_duplicate() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = object_table::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    let uid2 = ts::new_object(&mut scenario);
+    add(&mut table, b"hello", new(uid1));
+    add(&mut table, b"hello", new(uid2));
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
+    borrow(&table, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_mut_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
+    borrow_mut(&mut table, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun remove_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
+    destroy(remove(&mut table, 0));
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::object_table::ETableNotEmpty)]
+fun destroy_non_empty() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = object_table::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    add(&mut table, 0, new(uid1));
+    object_table::destroy_empty(table);
+    ts::end(scenario);
+}
+
+#[test]
+fun sanity_check_contains() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = object_table::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    assert!(!contains(&mut table, 0), 0);
+    add(&mut table, 0, new(uid1));
+    assert!(contains(&mut table, 0), 0);
+    assert!(!contains(&mut table, 1), 0);
+    ts::end(scenario);
+    destroy(remove(&mut table, 0));
+    object_table::destroy_empty(table)
+}
+
+#[test]
+fun sanity_check_size() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = object_table::new(ts::ctx(&mut scenario));
+    let uid1 = ts::new_object(&mut scenario);
+    let uid2 = ts::new_object(&mut scenario);
+    assert!(object_table::is_empty(&table), 0);
+    assert!(object_table::length(&table) == 0, 0);
+    add(&mut table, 0, new(uid1));
+    assert!(!object_table::is_empty(&table), 0);
+    assert!(object_table::length(&table) == 1, 0);
+    add(&mut table, 1, new(uid2));
+    assert!(!object_table::is_empty(&table), 0);
+    assert!(object_table::length(&table) == 2, 0);
+    ts::end(scenario);
+    destroy(remove(&mut table, 0));
+    destroy(remove(&mut table, 1));
+    object_table::destroy_empty(table);
+}
+
+// transfer an object field from one "parent" to another
+#[test]
+fun transfer_object() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table1 = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
+    let table2 = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
+    add(&mut table1, 0, new(ts::new_object(&mut scenario)));
+    assert!(contains(&table1, 0), 0);
+    assert!(!contains(&table2, 0), 0);
+    bump(borrow_mut(&mut table1, 0));
+    let c = remove(&mut table1, 0);
+    add(&mut table2, 0, c);
+    assert!(!contains(&table1, 0), 0);
+    assert!(contains(&table2, 0), 0);
+    bump(borrow_mut(&mut table2, 0));
+    assert!(count(borrow(&table2, 0)) == 2, 0);
+    ts::end(scenario);
+    destroy(remove(&mut table2, 0));
+    object_table::destroy_empty(table1);
+    object_table::destroy_empty(table2);
+}
+
+fun new(id: UID): Counter {
+    Counter { id, count: 0 }
+}
+
+fun count(counter: &Counter): u64 {
+    counter.count
+}
+
+fun bump(counter: &mut Counter): &mut Counter {
+    counter.count = counter.count + 1;
+    counter
+}
+
+fun destroy(counter: Counter): u64 {
+    let Counter { id, count } = counter;
+    object::delete(id);
+    count
+}
+
+}

--- a/crates/sui-framework-override/tests/object_tests.move
+++ b/crates/sui-framework-override/tests/object_tests.move
@@ -1,0 +1,35 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::object_tests {
+    use sui::address;
+    use sui::object;
+    use sui::tx_context;
+
+    const EDifferentAddress: u64 = 0xF000;
+    const EDifferentBytes: u64 = 0xF001;
+    const EAddressRoundTrip: u64 = 0xF002;
+
+    #[test]
+    fun test_bytes_address_roundtrip() {
+        let ctx = tx_context::dummy();
+
+        let uid0 = object::new(&mut ctx);
+        let uid1 = object::new(&mut ctx);
+
+        let addr0 = object::uid_to_address(&uid0);
+        let byte0 = object::uid_to_bytes(&uid0);
+        let addr1 = object::uid_to_address(&uid1);
+        let byte1 = object::uid_to_bytes(&uid1);
+
+        assert!(addr0 != addr1, EDifferentAddress);
+        assert!(byte0 != byte1, EDifferentBytes);
+
+        assert!(addr0 == address::from_bytes(byte0), EAddressRoundTrip);
+        assert!(addr1 == address::from_bytes(byte1), EAddressRoundTrip);
+
+        object::delete(uid0);
+        object::delete(uid1);
+    }
+}

--- a/crates/sui-framework-override/tests/pay_tests.move
+++ b/crates/sui-framework-override/tests/pay_tests.move
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::pay_tests {
+    use std::vector;
+    use sui::test_scenario::{Self};
+    use sui::coin::{Self, Coin};
+    use sui::pay;
+    use sui::sui::SUI;
+
+    const TEST_SENDER_ADDR: address = @0xA11CE;
+
+    #[test]
+    public entry fun test_coin_split_n() {
+        let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
+        let scenario = &mut scenario_val;
+        let ctx = test_scenario::ctx(scenario);
+        let coin = coin::mint_for_testing<SUI>(10, ctx);
+
+        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        pay::divide_and_keep(&mut coin, 3, test_scenario::ctx(scenario));
+
+        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+
+        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        let coin2 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+
+        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        assert!(coin::value(&coin1) == 3, 0);
+        assert!(coin::value(&coin2) == 3, 0);
+        assert!(coin::value(&coin) == 4, 0);
+        assert!(
+            !test_scenario::has_most_recent_for_sender<Coin<SUI>>(scenario),
+            1
+        );
+
+        coin::destroy_for_testing(coin);
+        coin::destroy_for_testing(coin1);
+        coin::destroy_for_testing(coin2);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    public entry fun test_coin_split_n_to_vec() {
+        let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
+        let scenario = &mut scenario_val;
+        let ctx = test_scenario::ctx(scenario);
+        let coin = coin::mint_for_testing<SUI>(10, ctx);
+
+        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        let split_coins = coin::divide_into_n(&mut coin, 3, test_scenario::ctx(scenario));
+
+        assert!(vector::length(&split_coins) == 2, 0);
+        let coin1 = vector::pop_back(&mut split_coins);
+        let coin2 = vector::pop_back(&mut split_coins);
+        assert!(coin::value(&coin1) == 3, 0);
+        assert!(coin::value(&coin2) == 3, 0);
+        assert!(coin::value(&coin) == 4, 0);
+
+        vector::destroy_empty(split_coins);
+        coin::destroy_for_testing(coin);
+        coin::destroy_for_testing(coin1);
+        coin::destroy_for_testing(coin2);
+        test_scenario::end(scenario_val);
+    }
+}

--- a/crates/sui-framework-override/tests/rewards_distribution_tests.move
+++ b/crates/sui-framework-override/tests/rewards_distribution_tests.move
@@ -1,0 +1,310 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::rewards_distribution_tests {
+    use sui::coin;
+    use sui::test_scenario::{Self, Scenario};
+    use sui::sui_system::{Self, SuiSystemState};
+
+    use sui::governance_test_utils::{
+        Self,
+        advance_epoch,
+        advance_epoch_with_reward_amounts,
+        advance_epoch_with_reward_amounts_and_subsidy_rate,
+        advance_epoch_with_reward_amounts_and_slashing_rates,
+        assert_validator_delegate_amounts,
+        assert_validator_stake_amounts,
+        create_validator_for_testing,
+        create_sui_system_state_for_testing,
+        delegate_to,
+        total_sui_balance, undelegate
+    };
+
+    const VALIDATOR_ADDR_1: address = @0x1;
+    const VALIDATOR_ADDR_2: address = @0x2;
+    const VALIDATOR_ADDR_3: address = @0x3;
+    const VALIDATOR_ADDR_4: address = @0x4;
+
+    const DELEGATOR_ADDR_1: address = @0x42;
+    const DELEGATOR_ADDR_2: address = @0x43;
+
+    #[test]
+    fun test_validator_rewards() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        // need to advance epoch so validator's staking starts counting
+        governance_test_utils::advance_epoch(scenario);
+
+        advance_epoch_with_reward_amounts(0, 100, scenario);
+        assert_validator_stake_amounts(validator_addrs(), vector[110, 220, 330, 440], scenario);
+
+        test_scenario::next_tx(scenario, VALIDATOR_ADDR_2);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let ctx = test_scenario::ctx(scenario);
+            sui_system::request_add_stake(&mut system_state, coin::mint_for_testing(720, ctx), ctx);
+            test_scenario::return_shared(system_state);
+        };
+
+        advance_epoch_with_reward_amounts(0, 100, scenario);
+        // validator 2's new stake hasn' started counting yet so she only gets 20% of the rewards.
+        assert_validator_stake_amounts(validator_addrs(), vector[120, 960, 360, 480], scenario);
+
+        advance_epoch_with_reward_amounts(0, 100, scenario);
+        // validator 2's new stake started counting so she gets half of the rewards.
+        assert_validator_stake_amounts(validator_addrs(), vector[126, 1010, 378, 505], scenario);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_stake_subsidy() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state_with_big_amounts(scenario);
+
+        // need to advance epoch so validator's staking starts counting
+        governance_test_utils::advance_epoch(scenario);
+
+        advance_epoch_with_reward_amounts_and_subsidy_rate(0, 100, 1, scenario);
+        assert_validator_stake_amounts(validator_addrs(), vector[100_010_010, 200_020_020, 300_030_030, 400_040_040], scenario);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_delegation_rewards() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        // need to advance epoch so validator's staking starts counting
+
+        delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 200, scenario);
+        delegate_to(DELEGATOR_ADDR_2, VALIDATOR_ADDR_2, 100, scenario);
+        governance_test_utils::advance_epoch(scenario);
+
+        // 10 SUI rewards for each 100 SUI of stake
+        advance_epoch_with_reward_amounts(0, 130, scenario);
+        assert_validator_stake_amounts(validator_addrs(), vector[110, 220, 330, 440], scenario);
+        undelegate(DELEGATOR_ADDR_1, 0, 0, scenario);
+        delegate_to(DELEGATOR_ADDR_2, VALIDATOR_ADDR_1, 600, scenario);
+        // 10 SUI rewards for each 110 SUI of stake
+        advance_epoch_with_reward_amounts(0, 130, scenario);
+        assert!(total_sui_balance(DELEGATOR_ADDR_1, scenario) == 240, 0); // 40 SUI of rewards received
+        assert_validator_stake_amounts(validator_addrs(), vector[120, 240, 360, 480], scenario);
+        undelegate(DELEGATOR_ADDR_2, 0, 0, scenario);
+        governance_test_utils::advance_epoch(scenario); 
+        assert!(total_sui_balance(DELEGATOR_ADDR_2, scenario) == 120, 0); // 20 SUI of rewards received
+
+        // 10 SUI rewards for each 120 SUI of stake
+        advance_epoch_with_reward_amounts(0, 150, scenario);
+        undelegate(DELEGATOR_ADDR_2, 0, 0, scenario); // unstake 600 principal SUI
+        governance_test_utils::advance_epoch(scenario);
+        // additional 600 SUI of principal and 50 SUI of rewards withdrawn to Coin<SUI>
+        assert!(total_sui_balance(DELEGATOR_ADDR_2, scenario) == 770, 0);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_delegation_tiny_rewards() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state_with_big_amounts(scenario);
+
+        // delegate a large amount
+        delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 200000000, scenario);
+        
+        governance_test_utils::advance_epoch(scenario);
+
+        advance_epoch_with_reward_amounts(0, 150000, scenario);
+
+        // delegate a small amount
+        delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 10, scenario);
+        advance_epoch_with_reward_amounts(0, 130, scenario); 
+        
+        // undelegate the delegations
+        undelegate(DELEGATOR_ADDR_1, 1, 1, scenario);
+
+        // and advance epoch should succeed
+        advance_epoch_with_reward_amounts(0, 150, scenario);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_validator_commission() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
+        delegate_to(DELEGATOR_ADDR_2, VALIDATOR_ADDR_2, 100, scenario);
+        governance_test_utils::advance_epoch(scenario);
+
+        set_commission_rate_and_advance_epoch(VALIDATOR_ADDR_2, 5000, scenario); // 50% commission
+
+        // 10 SUI for each 100 SUI staked
+        advance_epoch_with_reward_amounts(0, 120, scenario);
+        // 5 SUI, or 50 % of delegator_2's rewards, goes to validator_2
+        assert_validator_delegate_amounts(validator_addrs(), vector[110, 105, 0, 0], scenario);
+        assert_validator_stake_amounts(validator_addrs(), vector[110, 225, 330, 440], scenario);
+
+        set_commission_rate_and_advance_epoch(VALIDATOR_ADDR_1, 1000, scenario); // 10% commission
+
+        // 20 SUI for each 110 SUI staked
+        advance_epoch_with_reward_amounts(0, 240, scenario);
+
+        // 2 SUI, or 10 % of delegator_1's rewards (20 SUI), goes to validator_1
+        // so delegator_1 now has 110 + 20 - 2 = 128 SUI.
+        // And 10 SUI, or 50% of delegator_2's rewards (20 SUI) goes to validator_2
+        // so delegator_2 now has 105 +20 - 10 = 115 SUI.
+        assert_validator_delegate_amounts(validator_addrs(), vector[128, 115, 0, 0], scenario);
+
+        // validator_1 gets 20 SUI of their own rewards and 2 SUI of commission
+        // so in total 110 + 20 + 2 = 132 SUI.
+        // validator_2 gets 40 SUI of their own rewards and 10 SUI of commission
+        // so in total 225 + 40 + 10 = 275 SUI.
+        // validator_3 and validator_4 just get their regular shares (60 SUI and 80 SUI).
+        assert_validator_stake_amounts(validator_addrs(), vector[132, 275, 390, 520], scenario);
+
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_rewards_slashing() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        advance_epoch(scenario);
+
+        delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
+        delegate_to(DELEGATOR_ADDR_2, VALIDATOR_ADDR_2, 100, scenario);
+
+        advance_epoch(scenario);
+
+        // validator_2 is reported by 3 other validators, so (200 + 300 + 400) / 1200 = 75% of total stake.
+        report_validator(VALIDATOR_ADDR_1, VALIDATOR_ADDR_2, scenario);
+        report_validator(VALIDATOR_ADDR_3, VALIDATOR_ADDR_2, scenario);
+        report_validator(VALIDATOR_ADDR_4, VALIDATOR_ADDR_2, scenario);
+
+        // validator_1 is reported by only 1 other validator, which is 300 / 1200 = 25% of total stake.
+        report_validator(VALIDATOR_ADDR_3, VALIDATOR_ADDR_1, scenario);
+
+        // 1200 SUI of total rewards, 50% threshold and 10% reward slashing.
+        // So validator_2 is the only one whose rewards should get slashed.
+        advance_epoch_with_reward_amounts_and_slashing_rates(
+            0, 1200, 1000, scenario
+        );
+
+        // Without reward slashing, the validator's stakes should be [200, 400, 600, 800]
+        // after the last epoch advancement.
+        // Since 20 SUI, or 10% of validator_2's rewards (200) are slashed, she only has 400 - 20 = 380 now.
+        // There are in total 30 SUI of rewards slashed (20 from the validator, and 10 from her delegator)
+        // so the unslashed validators each get their weighted share of additional rewards, which is
+        // 30 / 9 = 3, 30 * 3 / 9 = 10 and 30 * 4 / 9 = 13.
+        assert_validator_stake_amounts(validator_addrs(), vector[203, 380, 610, 813], scenario);
+
+        // Undelegate so we can check the delegation rewards as well.
+        undelegate(DELEGATOR_ADDR_1, 0, 0, scenario);
+        undelegate(DELEGATOR_ADDR_2, 0, 0, scenario);
+
+        advance_epoch(scenario);
+
+        // Same analysis as above. Delegator 1 has 3 additional SUI, and 10% of delegator 2's rewards are slashed.
+        assert!(total_sui_balance(DELEGATOR_ADDR_1, scenario) == 203, 0);
+        assert!(total_sui_balance(DELEGATOR_ADDR_2, scenario) == 190, 0);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_rewards_slashing_with_storage_fund() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        // Put 300 SUI into the storage fund.
+        advance_epoch_with_reward_amounts(300, 0, scenario);
+
+        // Add a few delegations.
+        delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_3, 100, scenario);
+        delegate_to(DELEGATOR_ADDR_2, VALIDATOR_ADDR_4, 100, scenario);
+        advance_epoch(scenario);
+
+        // validator_4 is reported by 3 other validators, so (100 + 200 + 400) / 1200 = 58% of total stake.
+        report_validator(VALIDATOR_ADDR_1, VALIDATOR_ADDR_4, scenario);
+        report_validator(VALIDATOR_ADDR_2, VALIDATOR_ADDR_4, scenario);
+        report_validator(VALIDATOR_ADDR_3, VALIDATOR_ADDR_4, scenario);
+
+        // 1000 SUI of storage rewards, 1500 SUI of computation rewards, 50% slashing threshold
+        // and 20% slashing rate
+        advance_epoch_with_reward_amounts_and_slashing_rates(
+            1000, 1500, 2000, scenario
+        );
+
+        // Validator 1 gets 100 SUI of computation rewards + 75 SUI of storage fund rewards +
+        // 14 SUI (1/7) of validator 4's slashed computation reward and 5 SUI (1/3) of validator 4's
+        // storage fund reward, so in total it gets 194 SUI of rewards. Same analysis for other 2
+        // unslashed validators too.
+        // Validator 4 should get 475 SUI of rewards without slashing. 20% is slashed so she gets
+        // 380 SUI of rewards.
+        assert_validator_stake_amounts(validator_addrs(), vector[294, 508, 722, 780], scenario);
+
+        // Undelegate so we can check the delegation rewards as well.
+        undelegate(DELEGATOR_ADDR_1, 0, 0, scenario);
+        undelegate(DELEGATOR_ADDR_2, 0, 0, scenario);
+
+        advance_epoch(scenario);
+
+        assert!(total_sui_balance(DELEGATOR_ADDR_1, scenario) == 215, 0);
+        assert!(total_sui_balance(DELEGATOR_ADDR_2, scenario) == 180, 0);
+
+        test_scenario::end(scenario_val);
+    }
+
+    fun set_up_sui_system_state(scenario: &mut Scenario) {
+        let ctx = test_scenario::ctx(scenario);
+
+        let validators = vector[
+            create_validator_for_testing(VALIDATOR_ADDR_1, 100, ctx),
+            create_validator_for_testing(VALIDATOR_ADDR_2, 200, ctx),
+            create_validator_for_testing(VALIDATOR_ADDR_3, 300, ctx),
+            create_validator_for_testing(VALIDATOR_ADDR_4, 400, ctx),
+        ];
+        create_sui_system_state_for_testing(validators, 1000, 0);
+    }
+
+    fun set_up_sui_system_state_with_big_amounts(scenario: &mut Scenario) {
+        let ctx = test_scenario::ctx(scenario);
+
+        let validators = vector[
+            create_validator_for_testing(VALIDATOR_ADDR_1, 100000000, ctx), 
+            create_validator_for_testing(VALIDATOR_ADDR_2, 200000000, ctx),
+            create_validator_for_testing(VALIDATOR_ADDR_3, 300000000, ctx),
+            create_validator_for_testing(VALIDATOR_ADDR_4, 400000000, ctx),
+        ];
+        create_sui_system_state_for_testing(validators, 1000000000, 0);
+    }
+
+    fun validator_addrs() : vector<address> {
+        vector[VALIDATOR_ADDR_1, VALIDATOR_ADDR_2, VALIDATOR_ADDR_3, VALIDATOR_ADDR_4]
+    }
+
+    fun set_commission_rate_and_advance_epoch(addr: address, commission_rate: u64, scenario: &mut Scenario) {
+        test_scenario::next_tx(scenario, addr);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let ctx = test_scenario::ctx(scenario);
+        sui_system::request_set_commission_rate(&mut system_state, commission_rate, ctx);
+        test_scenario::return_shared(system_state);
+        governance_test_utils::advance_epoch(scenario);
+    }
+
+    fun report_validator(reporter: address, reportee: address, scenario: &mut Scenario) {
+        test_scenario::next_tx(scenario, reporter);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let ctx = test_scenario::ctx(scenario);
+        sui_system::report_validator(&mut system_state, reportee, ctx);
+        test_scenario::return_shared(system_state);
+    }
+}

--- a/crates/sui-framework-override/tests/safe_tests.move
+++ b/crates/sui-framework-override/tests/safe_tests.move
@@ -1,0 +1,139 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::safe_tests {
+    use sui::safe::{Self, Safe, TransferCapability, OwnerCapability};
+    use sui::test_scenario::{Self as ts, Scenario, ctx};
+    use sui::coin;
+    use sui::object::{Self, ID};
+    use sui::balance;
+    use sui::sui::SUI;
+    use sui::transfer;
+
+    fun create_safe(scenario: &mut Scenario, owner: address, stored_amount: u64) {
+        ts::next_tx(scenario, owner);
+        {
+            let coin = coin::mint_for_testing<SUI>(stored_amount, ctx(scenario));
+            safe::create(coin, ctx(scenario));
+        };
+    }
+
+    // Delegates the safe to delegatee and return the capability ID.
+    fun delegate_safe(scenario: &mut Scenario, owner: address, delegate_to: address, delegate_amount: u64): ID {
+        let id;
+        ts::next_tx(scenario, owner);
+        let safe = ts::take_shared<Safe<SUI>>(scenario);
+        let cap = ts::take_from_sender<OwnerCapability<SUI>>(scenario);
+        let capability = safe::create_transfer_capability(&mut safe, &cap, delegate_amount, ctx(scenario));
+        id = object::id(&capability);
+        transfer::transfer(capability, delegate_to);
+        ts::return_to_sender(scenario, cap);
+        ts::return_shared(safe);
+        id
+    }
+
+    fun withdraw_as_delegatee(scenario: &mut Scenario, delegatee: address, withdraw_amount: u64) {
+        ts::next_tx(scenario, delegatee);
+        let safe = ts::take_shared<Safe<SUI>>(scenario);
+        let capability = ts::take_from_sender<TransferCapability<SUI>>(scenario);
+        let balance = safe::debit(&mut safe, &mut capability, withdraw_amount);
+        balance::destroy_for_testing(balance);
+
+        ts::return_to_sender(scenario, capability);
+        ts::return_shared(safe);
+    }
+
+    fun revoke_capability(scenario: &mut Scenario, owner: address, capability_id: ID) {
+        ts::next_tx(scenario, owner);
+        let safe = ts::take_shared<Safe<SUI>>(scenario);
+        let cap = ts::take_from_sender<OwnerCapability<SUI>>(scenario);
+        safe::revoke_transfer_capability(&mut safe, &cap, capability_id);
+
+        ts::return_to_sender(scenario, cap);
+        ts::return_shared(safe);
+    }
+
+    #[test]
+    /// Ensure that all funds can be withdrawn by the owners
+    fun test_safe_create_and_withdraw_funds_as_owner() {
+        let owner = @1337;
+        let scenario = ts::begin(@0x1);
+
+        let initial_funds = 1000u64;
+        create_safe(&mut scenario, owner, initial_funds);
+
+        ts::next_tx(&mut scenario, owner);
+        let safe = ts::take_shared<Safe<SUI>>(&mut scenario);
+        let cap = ts::take_from_sender<OwnerCapability<SUI>>(&mut scenario);
+
+        let balance = safe::withdraw_(&mut safe, &cap, initial_funds);
+        balance::destroy_for_testing(balance);
+
+        ts::return_to_sender(&mut scenario, cap);
+        ts::return_shared(safe);
+
+
+        ts::end(scenario);
+    }
+
+    #[test]
+    /// Ensure that all funds can be withdrawn to a delegator
+    fun test_safe_create_and_withdraw_funds_as_delegatee() {
+        let owner = @0x1337;
+        let delegatee = @0x1ce1ce1ce;
+        let scenario = ts::begin(@0x1);
+
+        let initial_funds = 1000u64;
+        let delegated_funds = 1000u64;
+        // Create Safe
+        create_safe(&mut scenario, owner, initial_funds);
+        delegate_safe(&mut scenario, owner, delegatee, delegated_funds);
+        withdraw_as_delegatee(&mut scenario, delegatee, delegated_funds);
+        ts::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = safe::OVERDRAWN)]
+    /// Ensure that funds cannot be over withdrawn
+    fun test_safe_attempt_to_over_withdraw() {
+        let owner = @0x1337;
+        let delegatee = @0x1ce1ce1ce;
+        let scenario = ts::begin(@0x1);
+
+        let initial_funds = 1000u64;
+        let delegated_funds = 1000u64;
+        // Create Safe
+        create_safe(&mut scenario, owner, initial_funds);
+        delegate_safe(&mut scenario, owner, delegatee, delegated_funds);
+
+        // Withdraw all funds
+        withdraw_as_delegatee(&mut scenario, delegatee, delegated_funds);
+        // Attempt to withdraw by 1 coin.
+        withdraw_as_delegatee(&mut scenario, delegatee, 1);
+
+        ts::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = safe::TRANSFER_CAPABILITY_REVOKED)]
+    /// Ensure that funds cannot be over withdrawn
+    fun test_safe_withdraw_revoked() {
+        let owner = @0x1337;
+        let delegatee = @0x1ce1ce1ce;
+        let scenario = ts::begin(@0x1);
+
+        let initial_funds = 1000u64;
+        let delegated_funds = 1000u64;
+        // Create Safe
+        create_safe(&mut scenario, owner, initial_funds);
+        let capability_id = delegate_safe(&mut scenario, owner, delegatee, delegated_funds);
+
+        revoke_capability(&mut scenario, owner, capability_id);
+
+        // Withdraw funds
+        withdraw_as_delegatee(&mut scenario, delegatee, delegated_funds);
+
+        ts::end(scenario);
+    }
+}

--- a/crates/sui-framework-override/tests/sui_system_tests.move
+++ b/crates/sui-framework-override/tests/sui_system_tests.move
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file contains tests testing functionalities in `sui_system` that are not
+// already tested by the other more themed tests such as `delegation_tests` or
+// `rewards_distribution_tests`.
+
+#[test_only]
+module sui::sui_system_tests {
+    use sui::test_scenario::{Self, Scenario};
+    use sui::governance_test_utils::{advance_epoch, set_up_sui_system_state};
+    use sui::sui_system::{Self, SuiSystemState};
+    use sui::vec_set;
+
+    #[test]
+    fun test_report_validator() {
+        let scenario_val = test_scenario::begin(@0x0);
+        let scenario = &mut scenario_val;
+
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+
+        report_helper(@0x1, @0x2, false, scenario);
+        assert!(get_reporters_of(@0x2, scenario) == vector[@0x1], 0);
+        report_helper(@0x3, @0x2, false, scenario);
+        assert!(get_reporters_of(@0x2, scenario) == vector[@0x1, @0x3], 0);
+
+        // Report again and result should stay the same.
+        report_helper(@0x1, @0x2, false, scenario);
+        assert!(get_reporters_of(@0x2, scenario) == vector[@0x1, @0x3], 0);
+
+        // Undo the report.
+        report_helper(@0x3, @0x2, true, scenario);
+        assert!(get_reporters_of(@0x2, scenario) == vector[@0x1], 0);
+
+        advance_epoch(scenario);
+
+        // After an epoch ends, report records are reset.
+        assert!(get_reporters_of(@0x2, scenario) == vector[], 0);
+
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui_system::ENOT_VALIDATOR)]
+    fun test_report_non_validator_failure() {
+        let scenario_val = test_scenario::begin(@0x0);
+        let scenario = &mut scenario_val;
+
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        report_helper(@0x1, @0x42, false, scenario);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui_system::ECANNOT_REPORT_ONESELF)]
+    fun test_report_self_failure() {
+        let scenario_val = test_scenario::begin(@0x0);
+        let scenario = &mut scenario_val;
+
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        report_helper(@0x1, @0x1, false, scenario);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui_system::EREPORT_RECORD_NOT_FOUND)]
+    fun test_undo_report_failure() {
+        let scenario_val = test_scenario::begin(@0x0);
+        let scenario = &mut scenario_val;
+
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        report_helper(@0x2, @0x1, true, scenario);
+        test_scenario::end(scenario_val);
+    }
+
+    fun report_helper(reporter: address, reported: address, is_undo: bool, scenario: &mut Scenario) {
+        test_scenario::next_tx(scenario, reporter);
+
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let ctx = test_scenario::ctx(scenario);
+        if (is_undo) {
+            sui_system::undo_report_validator(&mut system_state, reported, ctx);
+        } else {
+            sui_system::report_validator(&mut system_state, reported, ctx);
+        };
+        test_scenario::return_shared(system_state);
+    }
+
+    fun get_reporters_of(addr: address, scenario: &mut Scenario): vector<address> {
+        test_scenario::next_tx(scenario, addr);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let res = vec_set::into_keys(sui_system::get_reporters_of(&system_state, addr));
+        test_scenario::return_shared(system_state);
+        res
+    }
+
+}

--- a/crates/sui-framework-override/tests/table_tests.move
+++ b/crates/sui-framework-override/tests/table_tests.move
@@ -1,0 +1,133 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::table_tests {
+
+use sui::table::{Self, add, contains, borrow, borrow_mut, remove};
+use sui::test_scenario as ts;
+
+#[test]
+fun simple_all_functions() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = table::new(ts::ctx(&mut scenario));
+    // add fields
+    add(&mut table, b"hello", 0);
+    add(&mut table, b"goodbye", 1);
+    // check they exist
+    assert!(contains(&table, b"hello"), 0);
+    assert!(contains(&table, b"goodbye"), 0);
+    // check the values
+    assert!(*borrow(&table, b"hello") == 0, 0);
+    assert!(*borrow(&table, b"goodbye") == 1, 0);
+    // mutate them
+    *borrow_mut(&mut table, b"hello") = *borrow(&table, b"hello") * 2;
+    *borrow_mut(&mut table, b"goodbye") = *borrow(&table, b"goodbye") * 2;
+    // check the new value
+    assert!(*borrow(&table, b"hello") == 0, 0);
+    assert!(*borrow(&table, b"goodbye") == 2, 0);
+    // remove the value and check it
+    assert!(remove(&mut table, b"hello") == 0, 0);
+    assert!(remove(&mut table, b"goodbye") == 2, 0);
+    // verify that they are not there
+    assert!(!contains(&table, b"hello"), 0);
+    assert!(!contains(&table, b"goodbye"), 0);
+    ts::end(scenario);
+    table::destroy_empty(table);
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun add_duplicate() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = table::new(ts::ctx(&mut scenario));
+    add(&mut table, b"hello", 0);
+    add(&mut table, b"hello", 1);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+    borrow(&table, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun borrow_mut_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+    borrow_mut(&mut table, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+fun remove_missing() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+    remove(&mut table, 0);
+    abort 42
+}
+
+#[test]
+#[expected_failure(abort_code = sui::table::ETableNotEmpty)]
+fun destroy_non_empty() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+    add(&mut table, 0, 0);
+    table::destroy_empty(table);
+    ts::end(scenario);
+}
+
+#[test]
+fun sanity_check_contains() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+    assert!(!contains(&mut table, 0), 0);
+    add(&mut table, 0, 0);
+    assert!(contains<u64, u64>(&mut table, 0), 0);
+    assert!(!contains<u64, u64>(&mut table, 1), 0);
+    ts::end(scenario);
+    table::drop(table);
+}
+
+#[test]
+fun sanity_check_drop() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+    add(&mut table, 0, 0);
+    assert!(table::length(&table) == 1, 0);
+    ts::end(scenario);
+    table::drop(table);
+}
+
+#[test]
+fun sanity_check_size() {
+    let sender = @0x0;
+    let scenario = ts::begin(sender);
+    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+    assert!(table::is_empty(&table), 0);
+    assert!(table::length(&table) == 0, 0);
+    add(&mut table, 0, 0);
+    assert!(!table::is_empty(&table), 0);
+    assert!(table::length(&table) == 1, 0);
+    add(&mut table, 1, 0);
+    assert!(!table::is_empty(&table), 0);
+    assert!(table::length(&table) == 2, 0);
+    ts::end(scenario);
+    table::drop(table);
+}
+
+}

--- a/crates/sui-framework-override/tests/test_scenario_tests.move
+++ b/crates/sui-framework-override/tests/test_scenario_tests.move
@@ -1,0 +1,740 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::test_scenarioTests {
+    use sui::object;
+    use sui::test_scenario::{Self as ts, Scenario};
+    use sui::transfer;
+    use sui::tx_context;
+
+    const ID_BYTES_MISMATCH: u64 = 0;
+    const VALUE_MISMATCH: u64 = 1;
+    const OBJECT_ID_NOT_FOUND: u64 = 2;
+
+    struct Object has key, store {
+        id: object::UID,
+        value: u64,
+    }
+
+    struct Wrapper has key {
+        id: object::UID,
+        child: Object,
+    }
+
+    struct Parent has key {
+        id: object::UID,
+        child: object::ID,
+    }
+
+    struct MultiChildParent has key {
+        id: object::UID,
+        child1: object::ID,
+        child2: object::ID,
+    }
+
+    #[test]
+    fun test_wrap_unwrap() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        {
+            let id = ts::new_object(&mut scenario);
+            let obj = Object { id, value: 10 };
+            transfer::transfer(obj, copy sender);
+        };
+        // now, object gets wrapped
+        ts::next_tx(&mut scenario, sender);
+        {
+            let id = ts::new_object(&mut scenario);
+            let child = ts::take_from_sender<Object>(&mut scenario);
+            let wrapper = Wrapper { id, child };
+            transfer::transfer(wrapper, copy sender);
+        };
+        // wrapped object should no longer be removable, but wrapper should be
+        ts::next_tx(&mut scenario, sender);
+        {
+            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
+            assert!(ts::has_most_recent_for_sender<Wrapper>(&scenario), 1);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_remove_then_return() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        {
+            let id = ts::new_object(&mut scenario);
+            let obj = Object { id, value: 10 };
+            transfer::transfer(obj, copy sender);
+        };
+        // object gets removed, then returned
+        ts::next_tx(&mut scenario, sender);
+        {
+            let object = ts::take_from_sender<Object>(&mut scenario);
+            ts::return_to_sender(&mut scenario, object);
+        };
+        // Object should remain accessible
+        ts::next_tx(&mut scenario, sender);
+        {
+            assert!(ts::has_most_recent_for_sender<Object>(&scenario), 0);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_return_and_update() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        {
+            let id = ts::new_object(&mut scenario);
+            let obj = Object { id, value: 10 };
+            transfer::transfer(obj, copy sender);
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            let obj = ts::take_from_sender<Object>(&mut scenario);
+            assert!(obj.value == 10, 0);
+            obj.value = 100;
+            ts::return_to_sender(&mut scenario, obj);
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            let obj = ts::take_from_sender<Object>(&mut scenario);
+            assert!(obj.value == 100, 1);
+            ts::return_to_sender(&mut scenario, obj);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_remove_during_tx() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        {
+            let id = ts::new_object(&mut scenario);
+            let obj = Object { id, value: 10 };
+            transfer::transfer(obj, copy sender);
+            // an object transferred during the tx shouldn't be available in that tx
+            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0)
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EEmptyInventory)]
+    fun test_double_remove() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        {
+            let id = ts::new_object(&mut scenario);
+            let obj = Object { id, value: 10 };
+            transfer::transfer(obj, copy sender);
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            let obj1 = ts::take_from_sender<Object>(&mut scenario);
+            let obj2 = ts::take_from_sender<Object>(&mut scenario);
+            ts::return_to_sender(&mut scenario, obj1);
+            ts::return_to_sender(&mut scenario, obj2);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_three_owners() {
+        // make sure an object that goes from addr1 -> addr2 -> addr3 can only be accessed by
+        // the appropriate owner at each stage
+        let addr1 = @0x0;
+        let addr2 = @0x1;
+        let addr3 = @0x2;
+        let scenario = ts::begin(addr1);
+        {
+            let id = ts::new_object(&mut scenario);
+            let obj = Object { id, value: 10 };
+            // self-transfer
+            transfer::transfer(obj, copy addr1);
+        };
+        // addr1 -> addr2
+        ts::next_tx(&mut scenario, addr1);
+        {
+            let obj = ts::take_from_sender<Object>(&mut scenario);
+            transfer::transfer(obj, copy addr2)
+        };
+        // addr1 cannot access
+        ts::next_tx(&mut scenario, addr1);
+        {
+            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
+        };
+        // addr2 -> addr3
+        ts::next_tx(&mut scenario, addr2);
+        {
+            let obj = ts::take_from_sender<Object>(&mut scenario);
+            transfer::transfer(obj, copy addr3)
+        };
+        // addr1 cannot access
+        ts::next_tx(&mut scenario, addr1);
+        {
+            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
+        };
+        // addr2 cannot access
+        ts::next_tx(&mut scenario, addr2);
+        {
+            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
+        };
+        // addr3 *can* access
+        ts::next_tx(&mut scenario, addr3);
+        {
+            assert!(ts::has_most_recent_for_sender<Object>(&scenario), 0);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_transfer_then_delete() {
+        let tx1_sender = @0x0;
+        let tx2_sender = @0x1;
+        let scenario = ts::begin(tx1_sender);
+        // send an object to tx2_sender
+        let id_bytes;
+        {
+            let id = ts::new_object(&mut scenario);
+            id_bytes = object::uid_to_inner(&id);
+            let obj = Object { id, value: 100 };
+            transfer::transfer(obj, copy tx2_sender);
+            // sender cannot access the object
+            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
+        };
+        // check that tx2_sender can get the object, and it's the same one
+        ts::next_tx(&mut scenario, tx2_sender);
+        {
+            assert!(ts::has_most_recent_for_sender<Object>(&scenario), 1);
+            let received_obj = ts::take_from_sender<Object>(&mut scenario);
+            let Object { id: received_id, value } = received_obj;
+            assert!(object::uid_to_inner(&received_id) == id_bytes, ID_BYTES_MISMATCH);
+            assert!(value == 100, VALUE_MISMATCH);
+            object::delete(received_id);
+        };
+        // check that the object is no longer accessible after deletion
+        ts::next_tx(&mut scenario, tx2_sender);
+        {
+            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 2);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_get_owned_obj_ids() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid1 = ts::new_object(&mut scenario);
+        let uid2 = ts::new_object(&mut scenario);
+        let uid3 = ts::new_object(&mut scenario);
+        let id1 = object::uid_to_inner(&uid1);
+        let id2 = object::uid_to_inner(&uid2);
+        let id3 = object::uid_to_inner(&uid3);
+        {
+            let obj1 = Object { id: uid1, value: 10 };
+            let obj2 = Object { id: uid2, value: 20 };
+            let obj3 = Object { id: uid3, value: 30 };
+            transfer::transfer(obj1, copy sender);
+            transfer::transfer(obj2, copy sender);
+            transfer::transfer(obj3, copy sender);
+        };
+        ts::next_tx(&mut scenario, sender);
+        let ids = ts::ids_for_sender<Object>(&scenario);
+        assert!(ids == vector[id1, id2, id3], VALUE_MISMATCH);
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_take_owned_by_id() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid1 = ts::new_object(&mut scenario);
+        let uid2 = ts::new_object(&mut scenario);
+        let uid3 = ts::new_object(&mut scenario);
+        let id1 = object::uid_to_inner(&uid1);
+        let id2 = object::uid_to_inner(&uid2);
+        let id3 = object::uid_to_inner(&uid3);
+        {
+            let obj1 = Object { id: uid1, value: 10 };
+            let obj2 = Object { id: uid2, value: 20 };
+            let obj3 = Object { id: uid3, value: 30 };
+            transfer::transfer(obj1, copy sender);
+            transfer::transfer(obj2, copy sender);
+            transfer::transfer(obj3, copy sender);
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            let obj1 = ts::take_from_sender_by_id<Object>(&mut scenario, id1);
+            let obj3 = ts::take_from_sender_by_id<Object>(&mut scenario, id3);
+            let obj2 = ts::take_from_sender_by_id<Object>(&mut scenario, id2);
+            assert!(obj1.value == 10, VALUE_MISMATCH);
+            assert!(obj2.value == 20, VALUE_MISMATCH);
+            assert!(obj3.value == 30, VALUE_MISMATCH);
+            ts::return_to_sender(&mut scenario, obj1);
+            ts::return_to_sender(&mut scenario, obj2);
+            ts::return_to_sender(&mut scenario, obj3);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_get_last_created_object_id() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        {
+            let id = ts::new_object(&mut scenario);
+            let id_addr = object::uid_to_address(&id);
+            let obj = Object { id, value: 10 };
+            transfer::transfer(obj, copy sender);
+            let ctx = ts::ctx(&mut scenario);
+            assert!(id_addr == tx_context::last_created_object_id(ctx), 0);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_take_shared_by_id() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid1 = ts::new_object(&mut scenario);
+        let uid2 = ts::new_object(&mut scenario);
+        let uid3 = ts::new_object(&mut scenario);
+        let id1 = object::uid_to_inner(&uid1);
+        let id2 = object::uid_to_inner(&uid2);
+        let id3 = object::uid_to_inner(&uid3);
+        {
+            let obj1 = Object { id: uid1, value: 10 };
+            let obj2 = Object { id: uid2, value: 20 };
+            let obj3 = Object { id: uid3, value: 30 };
+            transfer::share_object(obj1);
+            transfer::share_object(obj2);
+            transfer::share_object(obj3)
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            let obj1 = ts::take_shared_by_id<Object>(&scenario, id1);
+            let obj3 = ts::take_shared_by_id<Object>(&scenario, id3);
+            let obj2 = ts::take_shared_by_id<Object>(&scenario, id2);
+            assert!(obj1.value == 10, VALUE_MISMATCH);
+            assert!(obj2.value == 20, VALUE_MISMATCH);
+            assert!(obj3.value == 30, VALUE_MISMATCH);
+            ts::return_shared(obj1);
+            ts::return_shared(obj2);
+            ts::return_shared(obj3);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_take_shared() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid1 = ts::new_object(&mut scenario);
+        {
+            let obj1 = Object { id: uid1, value: 10 };
+            transfer::share_object(obj1);
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            assert!(ts::has_most_recent_shared<Object>(), 1);
+            let obj1 = ts::take_shared<Object>(&mut scenario);
+            assert!(obj1.value == 10, VALUE_MISMATCH);
+            ts::return_shared(obj1);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_take_immutable_by_id() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid1 = ts::new_object(&mut scenario);
+        let uid2 = ts::new_object(&mut scenario);
+        let uid3 = ts::new_object(&mut scenario);
+        let id1 = object::uid_to_inner(&uid1);
+        let id2 = object::uid_to_inner(&uid2);
+        let id3 = object::uid_to_inner(&uid3);
+        {
+            let obj1 = Object { id: uid1, value: 10 };
+            let obj2 = Object { id: uid2, value: 20 };
+            let obj3 = Object { id: uid3, value: 30 };
+            transfer::freeze_object(obj1);
+            transfer::freeze_object(obj2);
+            transfer::freeze_object(obj3)
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            let obj1 = ts::take_immutable_by_id<Object>(&scenario, id1);
+            let obj3 = ts::take_immutable_by_id<Object>(&scenario, id3);
+            let obj2 = ts::take_immutable_by_id<Object>(&scenario, id2);
+            assert!(obj1.value == 10, VALUE_MISMATCH);
+            assert!(obj2.value == 20, VALUE_MISMATCH);
+            assert!(obj3.value == 30, VALUE_MISMATCH);
+            ts::return_immutable(obj1);
+            ts::return_immutable(obj2);
+            ts::return_immutable(obj3);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_take_immutable() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid1 = ts::new_object(&mut scenario);
+        {
+            let obj1 = Object { id: uid1, value: 10 };
+            transfer::freeze_object(obj1);
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            assert!(ts::has_most_recent_immutable<Object>(), 1);
+            let obj1 = ts::take_immutable<Object>(&mut scenario);
+            assert!(obj1.value == 10, VALUE_MISMATCH);
+            ts::return_immutable(obj1);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_unreturned_objects() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid1 = ts::new_object(&mut scenario);
+        let uid2 = ts::new_object(&mut scenario);
+        let uid3 = ts::new_object(&mut scenario);
+        {
+            transfer::share_object(Object { id: uid1, value: 10 });
+            transfer::freeze_object(Object { id: uid2, value: 10 });
+            transfer::transfer(Object { id: uid3, value: 10 }, sender);
+        };
+        ts::next_tx(&mut scenario, sender);
+        let shared = ts::take_shared<Object>(&scenario);
+        let imm = ts::take_immutable<Object>(&scenario);
+        let owned = ts::take_from_sender<Object>(&scenario);
+        ts::next_tx(&mut scenario, sender);
+        ts::next_epoch(&mut scenario, sender);
+        ts::next_tx(&mut scenario, sender);
+        ts::next_epoch(&mut scenario, sender);
+        ts::end(scenario);
+        transfer::share_object(shared);
+        transfer::freeze_object(imm);
+        transfer::transfer(owned, sender);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    fun test_invalid_shared_usage() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        {
+            let id = ts::new_object(&mut scenario);
+            let obj1 = Object { id, value: 10 };
+            transfer::share_object(obj1);
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            let obj1 = ts::take_shared<Object>(&mut scenario);
+            transfer::freeze_object(obj1);
+        };
+        ts::next_tx(&mut scenario, sender);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    fun test_invalid_immutable_usage() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        {
+            let id = ts::new_object(&mut scenario);
+            let obj1 = Object { id, value: 10 };
+            transfer::freeze_object(obj1);
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            let obj1 = ts::take_immutable<Object>(&mut scenario);
+            transfer::transfer(obj1, @0x0);
+        };
+        ts::next_tx(&mut scenario, sender);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    fun test_modify_immutable() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        {
+            let id = ts::new_object(&mut scenario);
+            let obj1 = Object { id, value: 10 };
+            transfer::freeze_object(obj1);
+        };
+        ts::next_tx(&mut scenario, sender);
+        let obj1 = ts::take_immutable<Object>(&mut scenario);
+        ts::next_tx(&mut scenario, sender);
+        obj1.value = 100;
+        ts::next_tx(&mut scenario, sender);
+        ts::return_immutable(obj1);
+        ts::next_tx(&mut scenario, sender);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::ECantReturnObject)]
+    fun test_invalid_address_return() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        ts::return_to_sender(&scenario, Object { id, value: 10 });
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::ECantReturnObject)]
+    fun test_invalid_shared_return() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        ts::return_shared(Object { id, value: 10 });
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::ECantReturnObject)]
+    fun test_invalid_immutable_return() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        ts::return_immutable(Object { id, value: 10 });
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EEmptyInventory)]
+    fun test_empty_inventory() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        ts::return_to_sender(&scenario, ts::take_from_sender<Object>(&scenario));
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EEmptyInventory)]
+    fun test_empty_inventory_shared() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        ts::return_to_sender(&scenario, ts::take_shared<Object>(&scenario));
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EEmptyInventory)]
+    fun test_empty_inventory_immutable() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        ts::return_to_sender(&scenario, ts::take_immutable<Object>(&scenario));
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    fun test_object_not_found() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid = ts::new_object(&mut scenario);
+        let id = object::uid_to_inner(&uid);
+        ts::return_to_sender(&scenario, ts::take_from_sender_by_id<Object>(&scenario, id));
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    fun test_object_not_found_shared() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid = ts::new_object(&mut scenario);
+        let id = object::uid_to_inner(&uid);
+        ts::return_to_sender(&scenario, ts::take_shared_by_id<Object>(&scenario, id));
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    fun test_object_not_found_immutable() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid = ts::new_object(&mut scenario);
+        let id = object::uid_to_inner(&uid);
+        ts::return_to_sender(&scenario, ts::take_immutable_by_id<Object>(&scenario, id));
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    fun test_wrong_object_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid = ts::new_object(&mut scenario);
+        let id = object::uid_to_inner(&uid);
+        transfer::transfer(Object { id: uid, value: 10 }, sender);
+        ts::return_to_sender(&scenario, ts::take_from_sender_by_id<Wrapper>(&scenario, id));
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    fun test_wrong_object_type_shared() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid = ts::new_object(&mut scenario);
+        let id = object::uid_to_inner(&uid);
+        transfer::share_object(Object { id: uid, value: 10 });
+        ts::return_shared(ts::take_shared_by_id<Wrapper>(&scenario, id));
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    fun test_wrong_object_type_immutable() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid = ts::new_object(&mut scenario);
+        let id = object::uid_to_inner(&uid);
+        transfer::freeze_object(Object { id: uid, value: 10 });
+        ts::return_immutable(ts::take_immutable_by_id<Wrapper>(&scenario, id));
+        abort 42
+    }
+
+    #[test]
+    fun test_dynamic_field_still_borrowed() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let parent = ts::new_object(&mut scenario);
+        sui::dynamic_field::add(&mut parent, b"", 10);
+        let r = sui::dynamic_field::borrow<vector<u8>, u64>(&mut parent, b"");
+        ts::end(scenario);
+        assert!(*r == 10, 0);
+        object::delete(parent);
+    }
+
+    #[test]
+    fun test_dynamic_object_field_still_borrowed() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let parent = ts::new_object(&mut scenario);
+        let id = ts::new_object(&mut scenario);
+        sui::dynamic_object_field::add(&mut parent, b"", Object { id, value: 10});
+        let obj = sui::dynamic_object_field::borrow<vector<u8>, Object>(&mut parent, b"");
+        ts::end(scenario);
+        assert!(obj.value == 10, 0);
+        object::delete(parent);
+    }
+
+    #[test]
+    fun test_dynamic_object_field_not_retrievable() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let parent = ts::new_object(&mut scenario);
+        let uid = ts::new_object(&mut scenario);
+        let obj = Object { id: uid, value: 10};
+        let id = object::id(&obj);
+        transfer::transfer(obj, sender);
+        ts::next_tx(&mut scenario, sender);
+        assert!(ts::has_most_recent_for_address<Object>(sender), 0);
+        let obj = ts::take_from_sender<Object>(&mut scenario);
+        assert!(object::id(&obj) == id, 0);
+        assert!(!ts::has_most_recent_for_address<Object>(sender), 0);
+        sui::dynamic_object_field::add(&mut parent, b"", obj);
+        ts::next_tx(&mut scenario, sender);
+        assert!(!ts::has_most_recent_for_address<Object>(sender), 0);
+        ts::end(scenario);
+        object::delete(parent);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    fun test_dynamic_field_shared_misuse() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let parent = ts::new_object(&mut scenario);
+        let uid = ts::new_object(&mut scenario);
+        let obj = Object { id: uid, value: 10};
+        let id = object::id(&obj);
+        transfer::share_object(obj);
+        ts::next_tx(&mut scenario, sender);
+        let obj = ts::take_shared<Object>(&mut scenario);
+        assert!(object::id(&obj) == id, 0);
+        // wraps the object
+        sui::dynamic_field::add(&mut parent, b"", obj);
+        ts::next_tx(&mut scenario, sender);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    fun test_dynamic_field_immutable_misuse() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let parent = ts::new_object(&mut scenario);
+        let uid = ts::new_object(&mut scenario);
+        let obj = Object { id: uid, value: 10};
+        let id = object::id(&obj);
+        transfer::freeze_object(obj);
+        ts::next_tx(&mut scenario, sender);
+        let obj = ts::take_immutable<Object>(&mut scenario);
+        assert!(object::id(&obj) == id, 0);
+        // wraps the object
+        sui::dynamic_field::add(&mut parent, b"", obj);
+        ts::next_tx(&mut scenario, sender);
+        abort 42
+    }
+
+        #[test]
+    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    fun test_dynamic_object_field_shared_misuse() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let parent = ts::new_object(&mut scenario);
+        let uid = ts::new_object(&mut scenario);
+        let obj = Object { id: uid, value: 10};
+        let id = object::id(&obj);
+        transfer::share_object(obj);
+        ts::next_tx(&mut scenario, sender);
+        let obj = ts::take_shared<Object>(&mut scenario);
+        assert!(object::id(&obj) == id, 0);
+        sui::dynamic_object_field::add(&mut parent, b"", obj);
+        ts::next_tx(&mut scenario, sender);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    fun test_dynamic_object_field_immutable_misuse() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let parent = ts::new_object(&mut scenario);
+        let uid = ts::new_object(&mut scenario);
+        let obj = Object { id: uid, value: 10};
+        let id = object::id(&obj);
+        transfer::freeze_object(obj);
+        ts::next_tx(&mut scenario, sender);
+        let obj = ts::take_immutable<Object>(&mut scenario);
+        assert!(object::id(&obj) == id, 0);
+        sui::dynamic_object_field::add(&mut parent, b"", obj);
+        ts::next_tx(&mut scenario, sender);
+        abort 42
+    }
+
+    /// Create an object and transfer it to the sender of `scenario`.
+    fun create_and_transfer_object(scenario: &mut Scenario, value: u64) {
+        let object = Object {
+            id: ts::new_object(scenario),
+            value,
+        };
+        transfer::transfer(object, ts::sender(scenario));
+    }
+}

--- a/crates/sui-framework-override/tests/tx_context_tests.move
+++ b/crates/sui-framework-override/tests/tx_context_tests.move
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::tx_context_tests {
+    use sui::object;
+    use sui::tx_context;
+
+    #[test]
+    fun test_id_generation() {
+        let ctx = tx_context::dummy();
+        assert!(tx_context::get_ids_created(&ctx) == 0, 0);
+
+        let id1 = object::new(&mut ctx);
+        let id2 = object::new(&mut ctx);
+
+        // new_id should always produce fresh ID's
+        assert!(&id1 != &id2, 1);
+        assert!(tx_context::get_ids_created(&ctx) == 2, 2);
+        object::delete(id1);
+        object::delete(id2);
+    }
+
+}

--- a/crates/sui-framework-override/tests/url_tests.move
+++ b/crates/sui-framework-override/tests/url_tests.move
@@ -1,0 +1,19 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::url_tests {
+    use sui::url;
+    use std::ascii::Self;
+
+    const URL_STRING_MISMATCH: u64 = 1;
+
+    #[test]
+    fun test_basic_url() {
+        // url strings are not currently validated
+        let url_str = ascii::string(x"414243454647");
+
+        let url = url::new_unsafe(url_str);
+        assert!(url::inner_url(&url) == url_str, URL_STRING_MISMATCH);
+    }
+}

--- a/crates/sui-framework-override/tests/validator_set_tests.move
+++ b/crates/sui-framework-override/tests/validator_set_tests.move
@@ -1,0 +1,232 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::validator_set_tests {
+    use sui::balance;
+    use sui::coin;
+    use sui::tx_context::TxContext;
+    use sui::validator::{Self, Validator};
+    use sui::validator_set::{Self, ValidatorSet};
+    use sui::test_scenario;
+    use sui::stake::Stake;
+    use sui::vec_map;
+    use std::ascii;
+    use std::option;
+    use sui::test_utils::assert_eq;
+
+    #[test]
+    fun test_validator_set_flow() {
+        let scenario = test_scenario::begin(@0x1);
+        let ctx1 = test_scenario::ctx(&mut scenario);
+
+        // Create 4 validators, with stake 100, 200, 300, 400.
+        let validator1 = create_validator(@0x1, 1, ctx1);
+        let validator2 = create_validator(@0x2, 2, ctx1);
+        let validator3 = create_validator(@0x3, 3, ctx1);
+        let validator4 = create_validator(@0x4, 4, ctx1);
+
+        // Create a validator set with only the first validator in it.
+        let validator_set = validator_set::new(vector[validator1]);
+        assert!(validator_set::next_epoch_validator_count(&validator_set) == 1, 0);
+        assert!(validator_set::total_validator_stake(&validator_set) == 100, 0);
+
+        // Add the other 3 validators one by one.
+        validator_set::request_add_validator(
+            &mut validator_set,
+            validator2,
+        );
+        // Adding validator during the epoch should not affect stake and quorum threshold.
+        assert!(validator_set::next_epoch_validator_count(&validator_set) == 2, 0);
+        assert!(validator_set::total_validator_stake(&validator_set) == 100, 0);
+
+        validator_set::request_add_validator(
+            &mut validator_set,
+            validator3,
+        );
+
+        test_scenario::next_tx(&mut scenario, @0x1);
+        {
+            let ctx1 = test_scenario::ctx(&mut scenario);
+            validator_set::request_add_stake(
+                &mut validator_set,
+                coin::into_balance(coin::mint_for_testing(500, ctx1)),
+                option::none(),
+                ctx1,
+            );
+            // Adding stake to existing active validator during the epoch
+            // should not change total stake.
+            assert!(validator_set::total_validator_stake(&validator_set) == 100, 0);
+        };
+
+        test_scenario::next_tx(&mut scenario, @0x1);
+        {
+            let stake1 = test_scenario::take_from_sender<Stake>(&mut scenario);
+            let ctx1 = test_scenario::ctx(&mut scenario);
+            validator_set::request_withdraw_stake(
+                &mut validator_set,
+                &mut stake1,
+                500,
+                100 /* min_validator_stake */,
+                ctx1,
+            );
+            test_scenario::return_to_sender(&mut scenario, stake1);
+            assert!(validator_set::total_validator_stake(&validator_set) == 100, 0);
+
+            validator_set::request_add_validator(
+                &mut validator_set,
+                validator4,
+            );
+        };
+
+        test_scenario::next_tx(&mut scenario, @0x1);
+        {
+            let ctx1 = test_scenario::ctx(&mut scenario);
+            advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
+            // The total stake and quorum should reflect 4 validators.
+            assert!(validator_set::next_epoch_validator_count(&validator_set) == 4, 0);
+            assert!(validator_set::total_validator_stake(&validator_set) == 1000, 0);
+
+            validator_set::request_remove_validator(
+                &mut validator_set,
+                ctx1,
+            );
+            // Total validator candidate count changes, but total stake remains during epoch.
+            assert!(validator_set::next_epoch_validator_count(&validator_set) == 3, 0);
+            assert!(validator_set::total_validator_stake(&validator_set) == 1000, 0);
+            advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
+            // Validator1 is gone.
+            assert!(validator_set::total_validator_stake(&validator_set) == 900, 0);
+        };
+
+        validator_set::destroy_for_testing(validator_set);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun test_reference_gas_price_derivation() {
+        let scenario = test_scenario::begin(@0x1);
+        let ctx1 = test_scenario::ctx(&mut scenario);
+        // Create 5 validators with different stakes and different gas prices.
+        let v1 = create_validator_with_gas_price(@0x1, 1, 45, ctx1);
+        let v2 = create_validator_with_gas_price(@0x2, 2, 42, ctx1);
+        let v3 = create_validator_with_gas_price(@0x3, 3, 40, ctx1);
+        let v4 = create_validator_with_gas_price(@0x4, 4, 41, ctx1);
+        let v5 = create_validator_with_gas_price(@0x5, 10, 43, ctx1);
+
+        // Create a validator set with only the first validator in it.
+        let validator_set = validator_set::new(vector[v1]);
+
+        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 45);
+
+        validator_set::request_add_validator(
+            &mut validator_set,
+            v2,
+        );
+        advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
+
+        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 45);
+
+        validator_set::request_add_validator(
+            &mut validator_set,
+            v3,
+        );
+        advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
+
+        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 42);
+
+        validator_set::request_add_validator(
+            &mut validator_set,
+            v4,
+        );
+        advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
+
+        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 42);
+
+        validator_set::request_add_validator(
+            &mut validator_set,
+            v5,
+        );
+        advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
+
+        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 43);
+
+        validator_set::destroy_for_testing(validator_set);
+        test_scenario::end(scenario);
+    }
+
+    fun create_validator(addr: address, hint: u8, ctx: &mut TxContext): Validator {
+        let stake_value = (hint as u64) * 100;
+        let init_stake = coin::mint_for_testing(stake_value, ctx);
+        let init_stake = coin::into_balance(init_stake);
+        let name = hint_to_ascii(hint);
+        validator::new_for_testing(
+            addr,
+            vector[hint],
+            vector[hint],
+            vector[hint],
+            vector[hint],
+            copy name,
+            copy name,
+            copy name,
+            name,
+            vector[hint],
+            vector[hint],
+            vector[hint],
+            init_stake,
+            option::none(),
+            1,
+            0,
+            ctx
+        )
+    }
+
+    fun create_validator_with_gas_price(addr: address, hint: u8, gas_price: u64, ctx: &mut TxContext): Validator {
+        let stake_value = (hint as u64) * 100;
+        let init_stake = coin::mint_for_testing(stake_value, ctx);
+        let init_stake = coin::into_balance(init_stake);
+        let name = hint_to_ascii(hint);
+        validator::new_for_testing(
+            addr,
+            vector[hint],
+            vector[hint],
+            vector[hint],
+            vector[hint],
+            copy name,
+            copy name,
+            copy name,
+            name,
+            vector[hint],
+            vector[hint],
+            vector[hint],
+            init_stake,
+            option::none(),
+            gas_price,
+            0,
+            ctx
+        )
+    }
+
+    fun hint_to_ascii(hint: u8): vector<u8> {
+        let ascii_bytes = vector[hint / 100 + 65, hint % 100 / 10 + 65, hint % 10 + 65];
+        ascii::into_bytes(ascii::string(ascii_bytes))
+    }
+
+    fun advance_epoch_with_dummy_rewards(validator_set: &mut ValidatorSet, ctx: &mut TxContext) {
+        let dummy_computation_reward = balance::zero();
+        let dummy_storage_fund_reward = balance::zero();
+
+        validator_set::advance_epoch(
+            1, // dummy new epoch number
+            validator_set,
+            &mut dummy_computation_reward,
+            &mut dummy_storage_fund_reward,
+            vec_map::empty(),
+            0,
+            ctx
+        );
+
+        balance::destroy_zero(dummy_computation_reward);
+        balance::destroy_zero(dummy_storage_fund_reward);
+    }
+}

--- a/crates/sui-framework-override/tests/validator_tests.move
+++ b/crates/sui-framework-override/tests/validator_tests.move
@@ -1,0 +1,126 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::validator_tests {
+    use sui::coin;
+    use sui::sui::SUI;
+    use sui::test_scenario;
+    use sui::validator;
+    use sui::stake::Stake;
+    use sui::locked_coin::{Self, LockedCoin};
+    use sui::stake;
+    use std::option;
+
+    #[test]
+    fun test_validator_owner_flow() {
+        let sender = @0x8feebb589ffa14667ff721b7cfb186cfad6530fc;
+
+        let scenario_val = test_scenario::begin(sender);
+        let scenario = &mut scenario_val;
+        {
+            let ctx = test_scenario::ctx(scenario);
+
+            let init_stake = coin::into_balance(coin::mint_for_testing(10, ctx));
+            let validator = validator::new(
+                sender,
+                vector[131, 117, 151, 65, 106, 116, 161, 1, 125, 44, 138, 143, 162, 193, 244, 241, 19, 159, 175, 120, 76, 35, 83, 213, 49, 79, 36, 21, 121, 79, 86, 242, 16, 1, 185, 176, 31, 191, 121, 156, 221, 167, 20, 33, 126, 19, 4, 105, 15, 229, 33, 187, 35, 99, 208, 103, 214, 176, 193, 196, 168, 154, 172, 78, 102, 5, 52, 113, 233, 213, 195, 23, 172, 220, 90, 232, 23, 17, 97, 66, 153, 105, 253, 219, 145, 125, 216, 254, 125, 49, 227, 8, 6, 206, 88, 13],
+                vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38],
+                vector[],
+                vector[150, 32, 70, 34, 231, 29, 255, 62, 248, 219, 245, 72, 85, 77, 190, 195, 251, 255, 166, 250, 229, 133, 29, 117, 17, 182, 0, 164, 162, 59, 36, 250, 78, 129, 8, 46, 106, 112, 197, 152, 219, 114, 241, 121, 242, 189, 75, 204],
+                b"Validator1",
+                b"Validator1",
+                b"Validator1",
+                b"Validator1",
+                x"FFFF",
+                x"FFFF",
+                x"FFFF",
+                init_stake,
+                option::none(),
+                1,
+                0,
+                ctx
+            );
+            assert!(validator::stake_amount(&validator) == 10, 0);
+            assert!(validator::sui_address(&validator) == sender, 0);
+
+            validator::destroy(validator, ctx);
+        };
+
+        // Check that after destroy, the original stake still exists.
+        test_scenario::next_tx(scenario, sender);
+        {
+            let stake = test_scenario::take_from_sender<Stake>(scenario);
+            assert!(stake::value(&stake) == 10, 0);
+            test_scenario::return_to_sender(scenario, stake);
+        };
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_pending_validator_flow() {
+        let sender = @0x8feebb589ffa14667ff721b7cfb186cfad6530fc;
+        let scenario_val = test_scenario::begin(sender);
+        let scenario = &mut scenario_val;
+        let ctx = test_scenario::ctx(scenario);
+        let init_stake = coin::into_balance(coin::mint_for_testing(10, ctx));
+
+        let validator = validator::new(
+            sender,
+            vector[131, 117, 151, 65, 106, 116, 161, 1, 125, 44, 138, 143, 162, 193, 244, 241, 19, 159, 175, 120, 76, 35, 83, 213, 49, 79, 36, 21, 121, 79, 86, 242, 16, 1, 185, 176, 31, 191, 121, 156, 221, 167, 20, 33, 126, 19, 4, 105, 15, 229, 33, 187, 35, 99, 208, 103, 214, 176, 193, 196, 168, 154, 172, 78, 102, 5, 52, 113, 233, 213, 195, 23, 172, 220, 90, 232, 23, 17, 97, 66, 153, 105, 253, 219, 145, 125, 216, 254, 125, 49, 227, 8, 6, 206, 88, 13],
+            vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38],
+            vector[],
+            vector[150, 32, 70, 34, 231, 29, 255, 62, 248, 219, 245, 72, 85, 77, 190, 195, 251, 255, 166, 250, 229, 133, 29, 117, 17, 182, 0, 164, 162, 59, 36, 250, 78, 129, 8, 46, 106, 112, 197, 152, 219, 114, 241, 121, 242, 189, 75, 204],
+            b"Validator1",
+            b"Validator1",
+            b"image_url1",
+            b"project_url1",
+            x"FFFF",
+            x"FFFF",
+            x"FFFF",
+            init_stake,
+            option::none(),
+            1,
+            0,
+            ctx
+        );
+
+        test_scenario::next_tx(scenario, sender);
+        {
+            let ctx = test_scenario::ctx(scenario);
+            let new_stake = coin::into_balance(coin::mint_for_testing(30, ctx));
+            validator::request_add_stake(&mut validator, new_stake, option::none(), ctx);
+
+            assert!(validator::stake_amount(&validator) == 10, 0);
+            assert!(validator::pending_stake_amount(&validator) == 30, 0);
+        };
+
+        test_scenario::next_tx(scenario, sender);
+        {
+            let stake = test_scenario::take_from_sender<Stake>(scenario);
+            let ctx = test_scenario::ctx(scenario);
+            validator::request_withdraw_stake(&mut validator, &mut stake, 5, 35, ctx);
+            test_scenario::return_to_sender(scenario, stake);
+            assert!(validator::stake_amount(&validator) == 10, 0);
+            assert!(validator::pending_stake_amount(&validator) == 30, 0);
+            assert!(validator::pending_withdraw(&validator) == 5, 0);
+
+            // Calling `adjust_stake_and_gas_price` will withdraw the coin and transfer to sender.
+            validator::adjust_stake_and_gas_price(&mut validator);
+
+            assert!(validator::stake_amount(&validator) == 35, 0);
+            assert!(validator::pending_stake_amount(&validator) == 0, 0);
+            assert!(validator::pending_withdraw(&validator) == 0, 0);
+        };
+
+        test_scenario::next_tx(scenario, sender);
+        {
+            let withdraw = test_scenario::take_from_sender<LockedCoin<SUI>>(scenario);
+            assert!(locked_coin::value(&withdraw) == 5, 0);
+            test_scenario::return_to_sender(scenario, withdraw);
+        };
+
+        validator::destroy(validator, test_scenario::ctx(scenario));
+        test_scenario::end(scenario_val);
+    }
+}

--- a/crates/sui-framework-override/tests/vec_map_tests.move
+++ b/crates/sui-framework-override/tests/vec_map_tests.move
@@ -1,0 +1,135 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::vec_map_tests {
+    use std::vector;
+    use sui::vec_map::{Self, VecMap};
+
+    #[test]
+    #[expected_failure(abort_code = vec_map::EKeyAlreadyExists)]
+    fun duplicate_key_abort() {
+        let m = vec_map::empty();
+        vec_map::insert(&mut m, 1, true);
+        vec_map::insert(&mut m, 1, false);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = vec_map::EKeyDoesNotExist)]
+    fun nonexistent_key_get() {
+        let m = vec_map::empty();
+        vec_map::insert(&mut m, 1, true);
+        let k = 2;
+        let _v = vec_map::get(&m, &k);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = vec_map::EKeyDoesNotExist)]
+    fun nonexistent_key_get_idx_or_abort() {
+        let m = vec_map::empty();
+        vec_map::insert(&mut m, 1, true);
+        let k = 2;
+        let _idx = vec_map::get_idx(&m, &k);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = vec_map::EIndexOutOfBounds)]
+    fun out_of_bounds_get_entry_by_idx() {
+        let m = vec_map::empty();
+        vec_map::insert(&mut m, 1, true);
+        let idx = 1;
+        let (_key, _val) = vec_map::get_entry_by_idx(&m, idx);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = vec_map::EIndexOutOfBounds)]
+    fun out_of_bounds_remove_entry_by_idx() {
+        let m = vec_map::empty();
+        vec_map::insert(&mut m, 10, true);
+        let idx = 1;
+        let (_key, _val) = vec_map::remove_entry_by_idx(&mut m, idx);
+    }
+
+    #[test]
+    fun remove_entry_by_idx() {
+        let m = vec_map::empty();
+        vec_map::insert(&mut m, 5, 50);
+        vec_map::insert(&mut m, 6, 60);
+        vec_map::insert(&mut m, 7, 70);
+
+        let (key, val) = vec_map::remove_entry_by_idx(&mut m, 0);
+        assert!(key == 5 && val == 50, 0);
+        assert!(vec_map::size(&m) == 2, 0);
+
+        let (key, val) = vec_map::remove_entry_by_idx(&mut m, 1);
+        assert!(key == 7 && val == 70, 0);
+        assert!(vec_map::size(&m) == 1, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = vec_map::EMapNotEmpty)]
+    fun destroy_non_empty() {
+        let m = vec_map::empty();
+        vec_map::insert(&mut m, 1, true);
+        vec_map::destroy_empty(m)
+    }
+
+    #[test]
+    fun destroy_empty() {
+        let m: VecMap<u64, u64> = vec_map::empty();
+        assert!(vec_map::is_empty(&m), 0);
+        vec_map::destroy_empty(m)
+    }
+
+    #[test]
+    fun smoke() {
+        let m = vec_map::empty();
+        let i = 0;
+        while (i < 10) {
+            let k = i + 2;
+            let v = i + 5;
+            vec_map::insert(&mut m, k, v);
+            i = i + 1;
+        };
+        assert!(!vec_map::is_empty(&m), 0);
+        assert!(vec_map::size(&m) == 10, 1);
+        let i = 0;
+        // make sure the elements are as expected in all of the getter APIs we expose
+        while (i < 10) {
+            let k = i + 2;
+            assert!(vec_map::contains(&m, &k), 2);
+            let v = *vec_map::get(&m, &k);
+            assert!(v == i + 5, 3);
+            assert!(vec_map::get_idx(&m, &k) == i, 4);
+            let (other_k, other_v) = vec_map::get_entry_by_idx(&m, i);
+            assert!(*other_k == k, 5);
+            assert!(*other_v == v, 6);
+            i = i + 1;
+        };
+        // remove all the elements
+        let (keys, values) = vec_map::into_keys_values(copy m);
+        let i = 0;
+        while (i < 10) {
+            let k = i + 2;
+            let (other_k, v) = vec_map::remove(&mut m, &k);
+            assert!(k == other_k, 7);
+            assert!(v == i + 5, 8);
+            assert!(*vector::borrow(&keys, i) == k, 9);
+            assert!(*vector::borrow(&values, i) == v, 10);
+
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    fun return_list_of_keys() {
+        let m = vec_map::empty();
+
+        assert!(vec_map::keys(&m) == vector[], 0);
+
+        vec_map::insert(&mut m, 1, true);
+        vec_map::insert(&mut m, 5, false);
+
+        assert!(vec_map::keys(&m) == vector[1, 5], 1);
+    }
+}

--- a/crates/sui-framework-override/tests/vec_set_tests.move
+++ b/crates/sui-framework-override/tests/vec_set_tests.move
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::vec_set_tests {
+    use std::vector;
+    use sui::vec_set;
+
+    fun key_contains() {
+        let m = vec_set::empty();
+        vec_set::insert(&mut m, 1);
+        assert!(vec_set::contains(&m, &1), 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = vec_set::EKeyAlreadyExists)]
+    fun duplicate_key_abort() {
+        let m = vec_set::empty();
+        vec_set::insert(&mut m, 1);
+        vec_set::insert(&mut m, 1);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = vec_set::EKeyDoesNotExist)]
+    fun nonexistent_key_remove() {
+        let m = vec_set::empty();
+        vec_set::insert(&mut m, 1);
+        let k = 2;
+        vec_set::remove(&mut m, &k);
+    }
+
+    #[test]
+    fun smoke() {
+        let m = vec_set::empty();
+        let i = 0;
+        while (i < 10) {
+            let k = i + 2;
+            vec_set::insert(&mut m, k);
+            i = i + 1;
+        };
+        assert!(!vec_set::is_empty(&m), 0);
+        assert!(vec_set::size(&m) == 10, 1);
+        let i = 0;
+        // make sure the elements are as expected in all of the getter APIs we expose
+        while (i < 10) {
+            let k = i + 2;
+            assert!(vec_set::contains(&m, &k), 2);
+            i = i + 1;
+        };
+        // remove all the elements
+        let keys = vec_set::into_keys(copy m);
+        let i = 0;
+        while (i < 10) {
+            let k = i + 2;
+            vec_set::remove(&mut m, &k);
+            assert!(*vector::borrow(&keys, i) == k, 9);
+            i = i + 1;
+        }
+    }
+
+}

--- a/crates/sui-framework-override/tests/voting_power_tests.move
+++ b/crates/sui-framework-override/tests/voting_power_tests.move
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::voting_power_tests {
+    use sui::governance_test_utils as gtu;
+    use sui::validator_set;
+    use sui::voting_power;
+    use sui::test_utils;
+    use sui::tx_context;
+    use std::vector;
+    use sui::validator::Validator;
+    use sui::validator;
+
+    const TOTAL_VOTING_POWER: u64 = 10_000;
+    const MAX_VOTING_POWER: u64 = 1_000;
+
+    fun check(stakes: vector<u64>, voting_power: vector<u64>) {
+        let ctx = tx_context::dummy();
+        let validators = gtu::create_validators_with_stakes(stakes, &mut ctx);
+        voting_power::set_voting_power(&mut validators);
+        test_utils::assert_eq(get_voting_power(&validators), voting_power);
+        validator_set::destroy_validators_for_testing(validators)
+    }
+
+    #[test]
+    fun test_small_validator_sets() {
+        check(vector[1], vector[TOTAL_VOTING_POWER]);
+        check(vector[77], vector[TOTAL_VOTING_POWER]);
+        check(vector[TOTAL_VOTING_POWER * 93], vector[TOTAL_VOTING_POWER]);
+        check(vector[1, 1], vector[5_000, 5_000]);
+        check(vector[1, 2], vector[5_000, 5_000]);
+        check(vector[1, 1, 1], vector[3_333, 3_333, 3_334]);
+        check(vector[1, 1, 2], vector[3_333, 3_333, 3_334]);
+        check(vector[1, 1, 1, 1], vector[2_500, 2_500, 2_500, 2_500]);
+        check(vector[1, 1, 1, 1, 1, 1], vector[1666, 1666, 1667, 1667, 1667, 1667]);
+        check(vector[1, 1, 1, 1, 1, 1, 1], vector[1428, 1428, 1428, 1429, 1429, 1429, 1429]);
+        check(vector[1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1111, 1111, 1111, 1111, 1111, 1111, 1111, 1111, 1112]);
+        // different stake distributions that all lead to 10 validators, all with max voting power
+        check(vector[1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000]);
+        check(vector[2, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000]);
+        check(vector[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vector[1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000]);
+    }
+
+    #[test]
+    fun test_medium_validator_sets() {
+        // >10 validators. now things get a bit more interesting because we can redistribute stake away from the max validators
+        check(vector[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[909, 909, 909, 909, 909, 909, 909, 909, 909, 909, 910]);
+        check(vector[2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900]);
+        check(vector[2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 1000, 888, 889, 889, 889, 889, 889, 889, 889, 889]);
+        check(vector[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], vector[522, 674, 826, 978, 1000, 1000, 1000, 1000, 1000, 1000, 1000]);
+
+        // more validators, harder to reach max
+        check(vector[2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[953, 953, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 477, 477]);
+        check(vector[4, 3, 3, 3, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 951, 951, 951, 639, 639, 639, 325, 325, 325, 325, 325, 325, 325, 325, 326, 326, 326, 326, 326]);
+    }
+
+    fun get_voting_power(validators: &vector<Validator>): vector<u64> {
+        let result = vector[];
+        let i = 0;
+        let len = vector::length(validators);
+        while (i < len) {
+            let voting_power = validator::voting_power(vector::borrow(validators, i));
+            vector::push_back(&mut result, voting_power);
+            i = i + 1;
+        };
+        result
+    }
+}

--- a/crates/sui-framework/docs/sui.md
+++ b/crates/sui-framework/docs/sui.md
@@ -8,6 +8,8 @@ It has 9 decimals, and the smallest unit (10^-9) is called "mist".
 
 
 -  [Struct `SUI`](#0x2_sui_SUI)
+-  [Struct `Canary`](#0x2_sui_Canary)
+-  [Function `coal_mine`](#0x2_sui_coal_mine)
 -  [Function `new`](#0x2_sui_new)
 -  [Function `transfer`](#0x2_sui_transfer)
 
@@ -15,6 +17,7 @@ It has 9 decimals, and the smallest unit (10^-9) is called "mist".
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="url.md#0x2_url">0x2::url</a>;
@@ -46,6 +49,57 @@ Name of the coin
 
 </dd>
 </dl>
+
+
+</details>
+
+<a name="0x2_sui_Canary"></a>
+
+## Struct `Canary`
+
+
+
+<pre><code><b>struct</b> <a href="sui.md#0x2_sui_Canary">Canary</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>value: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_sui_coal_mine"></a>
+
+## Function `coal_mine`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui.md#0x2_sui_coal_mine">coal_mine</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui.md#0x2_sui_coal_mine">coal_mine</a>() {
+    <a href="event.md#0x2_event_emit">event::emit</a>(<a href="sui.md#0x2_sui_Canary">Canary</a> { value: 42 })
+}
+</code></pre>
+
 
 
 </details>

--- a/crates/sui-framework/sources/sui.move
+++ b/crates/sui-framework/sources/sui.move
@@ -9,11 +9,17 @@ module sui::sui {
     use sui::balance::Supply;
     use sui::transfer;
     use sui::coin;
+    use sui::event;
 
     friend sui::genesis;
 
     /// Name of the coin
     struct SUI has drop {}
+
+    struct Canary has copy, drop { value: u64 }
+    public entry fun coal_mine() {
+        event::emit(Canary { value: 42 })
+    }
 
     /// Register the `SUI` Coin to acquire its `Supply`.
     /// This should be called only once during genesis creation.


### PR DESCRIPTION
First commit introduces a special escape hatch to inject new versions of Sui Framework at pre-determined epoch boundaries, by overwriting the package and then pushing the node over with a panic.

## Test Plan

The second commit demonstrates how to create an overridden sui-framework by:

- Introducing a new event type `sui::sui::Canary` and a new entry function, `sui::sui::coal_mine` which emits it.
- Copying `crates/sui-framework` to `crates/sui-framework-override` along with the new function, however the event emits  a different value.
- Setting an override for the framework on the boundary between epochs 4 and 5.

Can be tested locally by running a validator:

```
sui$ cargo build
sui$ rm -rf ~/.sui && ~/sui/target/debug/sui genesis -f
# Set checkpoints-per-epoch, to a smaller value in ~/.sui/sui_config/network.yaml (I chose 100)
sui$ ~/sui/target/debug/sui start --no-full-node
```

And a fullnode in another session:
```
sui$ ~/sui/target/debug/sui-node --config-path ~/.sui/sui_config/fullnode.yaml
```

And faucet in yet another session:
```
sui$ ~/sui/target/debug/sui-faucet --write-ahead-log /tmp/faucet.wal
```

And sending requests in yet another sesson:
```
sui$ ~/sui/target/debug/sui client call \
  --package "0x2" --module "sui" --function "coal_mine" --gas-budget 10000
```

When this request succeeds before the emergency upgrade, the event contains value 42, and when it succeeds after, it contains value 43.  When the upgrade epoch is hit, both the validators and fullnode will need to be restarted.