### PR TITLE
[docs] Call correct function

### DIFF
--- a/doc/src/build/programming-with-objects/ch2-using-objects.md
+++ b/doc/src/build/programming-with-objects/ch2-using-objects.md
@@ -149,9 +149,8 @@ let recipient = @0x2;
 test_scenario::next_tx(scenario, owner);
 {
     let object = test_scenario::take_from_sender<ColorObject>(scenario);
-    let ctx = test_scenario::ctx(scenario);
-    transfer::transfer(object, recipient, ctx);
-};
+    color_object::transfer(object, recipient);
+};          
 ```
 Note that in the second transaction, the sender of the transaction should still be `owner`, because only the `owner` can transfer the object that it owns. After the transfer, we can verify that `owner` no longer owns the object, while `recipient` now owns it:
 ```rust


### PR DESCRIPTION
The tutorial is testing the wrong function to show how user can transfer an object.

In the example, the method "transfer::transfer(object, recipient)" should not be used directly and is being wrapped by transfer method defined in the user module "color_object".

The official link: https://docs.sui.io/build/programming-with-objects/ch2-using-objects

![Frame 1 (1)](https://user-images.githubusercontent.com/48503371/213879821-25b392c5-3dc8-434f-8365-4b8b522ae4b8.png)


Code tested

```
fun test_transfer(){

            let owner = @0x1;
            // Create a ColorObject and transfer it to @owner.
            let scenario_val = test_scenario::begin(owner);
            let scenario = &mut scenario_val;
            {
            let ctx = test_scenario::ctx(scenario);
            color_object::create(255, 0, 255, ctx);
            };
            // Transfer the object to recipient.
           let recipient = @0x2;
            test_scenario::next_tx(scenario, owner);
                {
                let object = test_scenario::take_from_sender<ColorObject>(scenario);

                color_object::transfer(object, recipient);
                };

            // Check that owner no longer owns the object.
            test_scenario::next_tx(scenario, owner);
            {
            assert!(!test_scenario::has_most_recent_for_sender<ColorObject>(scenario), 0);
            };
            // Check that recipient now owns the object.
            test_scenario::next_tx(scenario, recipient);
            {
            assert!(test_scenario::has_most_recent_for_sender<ColorObject>(scenario), 0);
            };
            test_scenario::end(scenario_val);

    }

```

<img width="595" alt="Screen Shot 2023-01-21 at 19 00 41" src="https://user-images.githubusercontent.com/48503371/213880618-6810cfa5-5ffd-4480-834b-c861a5f21586.png">
