### PR TITLE
tracing: simplify tracing infra and support json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,12 +3667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "internment"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5994,110 +5988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "js-sys",
- "lazy_static 1.4.0",
- "percent-encoding",
- "pin-project",
- "rand 0.8.5",
- "thiserror",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-jaeger"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e785d273968748578931e4dc3b4f5ec86b26e09d9e0d66b55adda7fce742f7a"
-dependencies = [
- "async-trait",
- "futures",
- "futures-executor",
- "once_cell",
- "opentelemetry 0.18.0",
- "opentelemetry-semantic-conventions",
- "thiserror",
- "thrift",
- "tokio",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b02e0230abb0ab6636d18e2ba8fa02903ea63772281340ccac18e0af3ec9eeb"
-dependencies = [
- "opentelemetry 0.18.0",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
-dependencies = [
- "fnv",
- "futures-channel",
- "futures-util",
- "indexmap",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "dashmap",
- "fnv",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api",
- "percent-encoding",
- "rand 0.8.5",
- "thiserror",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "ordered-float"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
-dependencies = [
- "num-traits 0.2.15",
-]
-
-[[package]]
 name = "ordered-float"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7805,7 +7695,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.10.0",
+ "ordered-float",
  "serde 1.0.152",
 ]
 
@@ -9425,7 +9315,6 @@ dependencies = [
  "narwhal-crypto",
  "narwhal-executor",
  "once_cell",
- "opentelemetry 0.17.0",
  "proptest",
  "rand 0.8.5",
  "roaring",
@@ -9577,14 +9466,11 @@ dependencies = [
  "console-subscriber",
  "crossterm 0.25.0",
  "once_cell",
- "opentelemetry 0.18.0",
- "opentelemetry-jaeger",
  "prometheus",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-bunyan-formatter",
- "tracing-opentelemetry",
  "tracing-subscriber 0.3.16",
  "workspace-hack",
 ]
@@ -9801,19 +9687,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
-]
-
-[[package]]
-name = "thrift"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09678c4cdbb4eed72e18b7c2af1329c69825ed16fcbac62d083fc3e2b0590ff0"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "log",
- "ordered-float 1.1.1",
- "threadpool",
 ]
 
 [[package]]
@@ -10276,20 +10149,6 @@ dependencies = [
  "lazy_static 1.4.0",
  "log",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
-dependencies = [
- "once_cell",
- "opentelemetry 0.18.0",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber 0.3.16",
 ]
 
 [[package]]
@@ -11307,7 +11166,6 @@ dependencies = [
  "inout",
  "insta",
  "instant",
- "integer-encoding",
  "internment",
  "io-lifetimes",
  "ipnet",
@@ -11443,14 +11301,7 @@ dependencies = [
  "openssl-macros",
  "openssl-probe",
  "openssl-sys",
- "opentelemetry 0.17.0",
- "opentelemetry 0.18.0",
- "opentelemetry-jaeger",
- "opentelemetry-semantic-conventions",
- "opentelemetry_api",
- "opentelemetry_sdk",
- "ordered-float 1.1.1",
- "ordered-float 2.10.0",
+ "ordered-float",
  "os_str_bytes",
  "ouroboros 0.15.5",
  "ouroboros 0.9.5",
@@ -11689,7 +11540,6 @@ dependencies = [
  "thiserror-impl",
  "thread_local",
  "threadpool",
- "thrift",
  "time 0.1.45",
  "time 0.3.17",
  "time-core",
@@ -11724,7 +11574,6 @@ dependencies = [
  "tracing-core",
  "tracing-futures",
  "tracing-log",
- "tracing-opentelemetry",
  "tracing-subscriber 0.2.25",
  "tracing-subscriber 0.3.16",
  "tracing-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,20 +1662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,12 +3782,6 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "jsonrpsee"
@@ -9604,7 +9584,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-bunyan-formatter",
- "tracing-chrome",
  "tracing-opentelemetry",
  "tracing-subscriber 0.3.16",
  "workspace-hack",
@@ -10265,18 +10244,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.16",
-]
-
-[[package]]
-name = "tracing-chrome"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ac1f6a3a47e9c755e65ef974653c978da2246487a16044a8ee1d9a0a67257c"
-dependencies = [
- "crossbeam",
- "json",
- "tracing",
  "tracing-subscriber 0.3.16",
 ]
 
@@ -11163,7 +11130,6 @@ dependencies = [
  "crc32fast",
  "criterion",
  "criterion-plot",
- "crossbeam",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -11354,7 +11320,6 @@ dependencies = [
  "jemalloc-sys",
  "jobserver",
  "js-sys",
- "json",
  "jsonrpsee",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -11756,7 +11721,6 @@ dependencies = [
  "tracing-appender",
  "tracing-attributes",
  "tracing-bunyan-formatter",
- "tracing-chrome",
  "tracing-core",
  "tracing-futures",
  "tracing-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,16 +2965,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9470,7 +9460,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
- "tracing-bunyan-formatter",
  "tracing-subscriber 0.3.16",
  "workspace-hack",
 ]
@@ -10103,24 +10092,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-bunyan-formatter"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e1f01db95972374fa01ee6880105eb3b3867dacf87d3cccbac4bda9b8274b6"
-dependencies = [
- "ahash 0.8.2",
- "gethostname",
- "log",
- "serde 1.0.152",
- "serde_json",
- "time 0.3.17",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber 0.3.16",
-]
-
-[[package]]
 name = "tracing-core"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10152,6 +10123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde 1.0.152",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10170,6 +10151,8 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde 1.0.152",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -10177,6 +10160,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -11106,7 +11090,6 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "generic-array",
- "gethostname",
  "getrandom 0.1.16",
  "getrandom 0.2.8",
  "ghash",
@@ -11570,10 +11553,10 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-attributes",
- "tracing-bunyan-formatter",
  "tracing-core",
  "tracing-futures",
  "tracing-log",
+ "tracing-serde",
  "tracing-subscriber 0.2.25",
  "tracing-subscriber 0.3.16",
  "tracing-test",

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -49,7 +49,7 @@ use tokio::sync::Barrier;
 #[tokio::main]
 async fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
-    let mut config = telemetry_subscribers::TelemetryConfig::new("stress");
+    let mut config = telemetry_subscribers::TelemetryConfig::new();
     config.log_string = Some("warn".to_string());
     if !opts.log_path.is_empty() {
         config.log_file = Some(opts.log_path.clone());

--- a/crates/sui-cluster-test/src/main.rs
+++ b/crates/sui-cluster-test/src/main.rs
@@ -6,7 +6,7 @@ use sui_cluster_test::{config::ClusterTestOpt, ClusterTest};
 
 #[tokio::main]
 async fn main() {
-    let _guard = telemetry_subscribers::TelemetryConfig::new(env!("CARGO_BIN_NAME"))
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .init();
 

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -71,7 +71,7 @@ const PROM_PORT_ADDR: &str = "0.0.0.0:9184";
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // initialize tracing
-    let _guard = telemetry_subscribers::TelemetryConfig::new(env!("CARGO_BIN_NAME"))
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .init();
 

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
 use sui_indexer::errors::IndexerError;
 use sui_indexer::{new_pg_connection_pool, new_rpc_client};
 use sui_node::metrics::start_prometheus_server;
@@ -21,7 +20,7 @@ use processors::processor_orchestrator::ProcessorOrchestrator;
 
 #[tokio::main]
 async fn main() -> Result<(), IndexerError> {
-    let _guard = telemetry_subscribers::TelemetryConfig::new(env!("CARGO_BIN_NAME"))
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .init();
     info!("Sui indexer started...");

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -39,11 +39,10 @@ async fn main() -> Result<()> {
     let prometheus_registry = registry_service.default_registry();
 
     // Initialize logging
-    let (_guard, filter_handle) =
-        telemetry_subscribers::TelemetryConfig::new(env!("CARGO_BIN_NAME"))
-            .with_env()
-            .with_prom_registry(&prometheus_registry)
-            .init();
+    let (_guard, filter_handle) = telemetry_subscribers::TelemetryConfig::new()
+        .with_env()
+        .with_prom_registry(&prometheus_registry)
+        .init();
 
     info!(
         "Started Prometheus HTTP endpoint at {}",

--- a/crates/sui-rosetta/src/main.rs
+++ b/crates/sui-rosetta/src/main.rs
@@ -262,7 +262,7 @@ fn test_read_keystore() {
 async fn main() -> Result<(), anyhow::Error> {
     let cmd: RosettaServerCommand = RosettaServerCommand::parse();
 
-    let (_guard, _) = telemetry_subscribers::TelemetryConfig::new(env!("CARGO_BIN_NAME"))
+    let (_guard, _) = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .init();
 

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -38,10 +38,9 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let (_guard, _filter_handle) =
-        telemetry_subscribers::TelemetryConfig::new(env!("CARGO_BIN_NAME"))
-            .with_env()
-            .init();
+    let (_guard, _filter_handle) = telemetry_subscribers::TelemetryConfig::new()
+        .with_env()
+        .init();
 
     let args = Args::parse();
 

--- a/crates/sui-tool/src/main.rs
+++ b/crates/sui-tool/src/main.rs
@@ -14,9 +14,8 @@ async fn main() {
     #[cfg(windows)]
     colored::control::set_virtual_terminal(true).unwrap();
 
-    let bin_name = env!("CARGO_BIN_NAME");
     let cmd: ToolCommand = ToolCommand::parse();
-    let _guard = telemetry_subscribers::TelemetryConfig::new(bin_name)
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .init();
 

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -24,7 +24,6 @@ serde_with = "2.1.0"
 serde_repr = "0.1"
 signature = "1.6.0"
 static_assertions = "1.1.0"
-opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
 zeroize = "1.5.7"
 schemars ="0.8.10"
 tap = "1.0.1"

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -8,7 +8,6 @@ use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use move_core_types::language_storage::StructTag;
-use opentelemetry::{global, Context};
 use rand::Rng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -16,7 +15,6 @@ use serde_with::serde_as;
 use serde_with::Bytes;
 use std::borrow::Borrow;
 use std::cmp::max;
-use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::str::FromStr;
@@ -486,19 +484,6 @@ impl AsRef<[u8]> for TransactionDigest {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
-}
-
-/// Returns a Context for OpenTelemetry tracing from a TransactionDigest
-// NOTE: See https://github.com/MystenLabs/sui/issues/852
-// The current code doesn't really work.  Maybe the traceparent needs to be a specific format,
-// prohably needs to be the propagated trace ID from the source.
-pub fn context_from_digest(digest: TransactionDigest) -> Context {
-    // TODO: don't create a HashMap, that wastes memory and costs an allocation!
-    let mut carrier = HashMap::new();
-    // TODO: figure out exactly what key to use.  I suspect it has to be the parent span ID in OpenTelemetry format.
-    carrier.insert("traceparent".to_string(), Hex::encode(digest.0));
-
-    global::get_text_map_propagator(|propagator| propagator.extract(&carrier))
 }
 
 impl Borrow<[u8]> for TransactionDigest {

--- a/crates/sui/src/main.rs
+++ b/crates/sui/src/main.rs
@@ -20,12 +20,12 @@ async fn main() {
     let cmd: SuiCommand = SuiCommand::parse();
     let _guard = match cmd {
         SuiCommand::Console { .. } | SuiCommand::Client { .. } => {
-            telemetry_subscribers::TelemetryConfig::new(bin_name)
+            telemetry_subscribers::TelemetryConfig::new()
                 .with_log_file(&format!("{bin_name}.log"))
                 .with_env()
                 .init()
         }
-        _ => telemetry_subscribers::TelemetryConfig::new(bin_name)
+        _ => telemetry_subscribers::TelemetryConfig::new()
             .with_env()
             .init(),
     };

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -19,16 +19,14 @@ tokio = { workspace = true, features = ["sync", "macros", "rt", "rt-multi-thread
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-bunyan-formatter = "0.3.3"
-tracing-chrome = { version = "0.6.0", optional = true }
 tracing-opentelemetry = { version = "0.18.0", optional = true }
 tracing-subscriber = { version = "0.3.15", features = ["std", "time", "registry", "env-filter"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [features]
-default = ["jaeger", "chrome"]
+default = ["jaeger"]
 tokio-console = ["console-subscriber"]
 jaeger = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-jaeger"]
-chrome = ["tracing-chrome"]
 
 [dev-dependencies]
 camino = "1.0.9"

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -12,21 +12,17 @@ publish = false
 console-subscriber = { version = "0.1.6", optional = true }
 crossterm = "0.25.0"
 once_cell = "1.13.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"], optional = true }
-opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio"], optional = true }
 prometheus = "0.13.3"
 tokio = { workspace = true, features = ["sync", "macros", "rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-bunyan-formatter = "0.3.3"
-tracing-opentelemetry = { version = "0.18.0", optional = true }
 tracing-subscriber = { version = "0.3.15", features = ["std", "time", "registry", "env-filter"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [features]
-default = ["jaeger"]
+default = []
 tokio-console = ["console-subscriber"]
-jaeger = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-jaeger"]
 
 [dev-dependencies]
 camino = "1.0.9"

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -16,8 +16,7 @@ prometheus = "0.13.3"
 tokio = { workspace = true, features = ["sync", "macros", "rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
-tracing-bunyan-formatter = "0.3.3"
-tracing-subscriber = { version = "0.3.15", features = ["std", "time", "registry", "env-filter"] }
+tracing-subscriber = { version = "0.3.15", features = ["std", "time", "json", "registry", "env-filter"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [features]

--- a/crates/telemetry-subscribers/examples/easy-init.rs
+++ b/crates/telemetry-subscribers/examples/easy-init.rs
@@ -4,7 +4,7 @@
 use tracing::{debug, info, warn};
 
 fn main() {
-    let _guard = telemetry_subscribers::TelemetryConfig::new("my_app")
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .init();
 

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -247,7 +247,7 @@ impl TelemetryConfig {
             self.crash_on_panic = true
         }
 
-        if env::var("ENABLE_JSON_LOGS").is_ok() {
+        if env::var("RUST_LOG_JSON").is_ok() {
             self.json_log_output = true;
         }
 

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```rust
 //!   use telemetry_subscribers::TelemetryConfig;
-//!   let (_guard, _handle) = TelemetryConfig::new("my_app").init();
+//!   let (_guard, _handle) = TelemetryConfig::new().init();
 //! ```
 //!
 //! It is important to retain the guard until the end of the program.  Assign it in the main fn and keep it,
@@ -110,12 +110,8 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// - json_log_output: Output JSON logs to stdout only.
 /// - log_file: If defined, write output to a file starting with this name, ex app.log
 /// - log_level: error/warn/info/debug/trace, defaults to info
-/// - service_name:
 #[derive(Default, Clone, Debug)]
 pub struct TelemetryConfig {
-    /// The name of the service for Jaeger and Bunyan
-    pub service_name: String,
-
     /// Enables Tokio Console debugging on port 6669
     pub tokio_console: bool,
     /// Output JSON logs.
@@ -208,9 +204,8 @@ fn set_panic_hook(crash_on_panic: bool) {
 }
 
 impl TelemetryConfig {
-    pub fn new(service_name: &str) -> Self {
+    pub fn new() -> Self {
         Self {
-            service_name: service_name.to_owned(),
             tokio_console: false,
             json_log_output: false,
             log_file: None,
@@ -338,9 +333,7 @@ impl TelemetryConfig {
 
         // The guard must be returned and kept in the main fn of the app, as when it's dropped then the output
         // gets flushed and closed. If this is dropped too early then no output will appear!
-        let guards = TelemetryGuards {
-            worker_guard,
-        };
+        let guards = TelemetryGuards { worker_guard };
 
         (guards, filter_handle)
     }
@@ -380,7 +373,7 @@ mod tests {
     fn test_telemetry_init() {
         let registry = prometheus::Registry::new();
         // Default logging level is INFO, but here we set the span level to DEBUG.  TRACE spans should be ignored.
-        let config = TelemetryConfig::new("my_app")
+        let config = TelemetryConfig::new()
             .with_span_level(Level::DEBUG)
             .with_prom_registry(&registry);
         let _guard = config.init();

--- a/crates/telemetry-subscribers/tests/reload.rs
+++ b/crates/telemetry-subscribers/tests/reload.rs
@@ -10,7 +10,7 @@ use tracing::{debug, info};
 #[test]
 fn reload() {
     let log_file_prefix = "out.log";
-    let mut config = TelemetryConfig::new("test");
+    let mut config = TelemetryConfig::new();
     config.log_file = Some(log_file_prefix.to_owned());
     config.panic_hook = false;
 

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -138,7 +138,6 @@ crc-catalog = { version = "2", default-features = false }
 crc32fast = { version = "1" }
 criterion = { version = "0.4", features = ["async_tokio"] }
 criterion-plot = { version = "0.5", default-features = false }
-crossbeam = { version = "0.8" }
 crossbeam-channel = { version = "0.5" }
 crossbeam-deque = { version = "0.8" }
 crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"] }
@@ -293,7 +292,6 @@ itertools = { version = "0.10" }
 itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4" }
 itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
 js-sys = { version = "0.3", default-features = false }
-json = { version = "0.12", default-features = false }
 jsonrpsee = { git = "https://github.com/patrickkuo/jsonrpsee.git", rev = "adc19a124ed7045744442ca67f084ddfba4ba177", default-features = false, features = ["full"] }
 jsonrpsee-client-transport = { git = "https://github.com/patrickkuo/jsonrpsee.git", rev = "adc19a124ed7045744442ca67f084ddfba4ba177", default-features = false, features = ["tls", "web", "ws"] }
 jsonrpsee-core = { git = "https://github.com/patrickkuo/jsonrpsee.git", rev = "adc19a124ed7045744442ca67f084ddfba4ba177", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
@@ -610,7 +608,6 @@ tower-service = { version = "0.3", default-features = false }
 tracing = { version = "0.1", features = ["log"] }
 tracing-appender = { version = "0.2", default-features = false }
 tracing-bunyan-formatter = { version = "0.3" }
-tracing-chrome = { version = "0.6", default-features = false }
 tracing-core = { version = "0.1" }
 tracing-futures = { version = "0.2" }
 tracing-log = { version = "0.1" }
@@ -813,7 +810,6 @@ crc-catalog = { version = "2", default-features = false }
 crc32fast = { version = "1" }
 criterion = { version = "0.4", features = ["async_tokio"] }
 criterion-plot = { version = "0.5", default-features = false }
-crossbeam = { version = "0.8" }
 crossbeam-channel = { version = "0.5" }
 crossbeam-deque = { version = "0.8" }
 crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"] }
@@ -990,7 +986,6 @@ itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4" }
 itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
 jobserver = { version = "0.1", default-features = false }
 js-sys = { version = "0.3", default-features = false }
-json = { version = "0.12", default-features = false }
 jsonrpsee = { git = "https://github.com/patrickkuo/jsonrpsee.git", rev = "adc19a124ed7045744442ca67f084ddfba4ba177", default-features = false, features = ["full"] }
 jsonrpsee-client-transport = { git = "https://github.com/patrickkuo/jsonrpsee.git", rev = "adc19a124ed7045744442ca67f084ddfba4ba177", default-features = false, features = ["tls", "web", "ws"] }
 jsonrpsee-core = { git = "https://github.com/patrickkuo/jsonrpsee.git", rev = "adc19a124ed7045744442ca67f084ddfba4ba177", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
@@ -1364,7 +1359,6 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-appender = { version = "0.2", default-features = false }
 tracing-attributes = { version = "0.1", default-features = false }
 tracing-bunyan-formatter = { version = "0.3" }
-tracing-chrome = { version = "0.6", default-features = false }
 tracing-core = { version = "0.1" }
 tracing-futures = { version = "0.2" }
 tracing-log = { version = "0.1" }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -283,7 +283,6 @@ indicatif = { version = "0.17" }
 inout = { version = "0.1", default-features = false, features = ["std"] }
 insta = { version = "1", features = ["json", "redactions", "yaml"] }
 instant = { version = "0.1", default-features = false }
-integer-encoding = { version = "3", default-features = false }
 internment = { version = "0.5", default-features = false, features = ["arc"] }
 io-lifetimes = { version = "1" }
 iri-string = { version = "0.4" }
@@ -397,14 +396,7 @@ oid-registry = { version = "0.6", features = ["crypto", "x509"] }
 once_cell = { version = "1" }
 oorandom = { version = "11", default-features = false }
 opaque-debug = { version = "0.3", default-features = false }
-opentelemetry-9067fe90e8c1f593 = { package = "opentelemetry", version = "0.17", features = ["rt-tokio"] }
-opentelemetry-954333c9f9249c96 = { package = "opentelemetry", version = "0.18", features = ["metrics", "rt-tokio"] }
-opentelemetry-jaeger = { version = "0.17", features = ["rt-tokio"] }
-opentelemetry-semantic-conventions = { version = "0.10", default-features = false }
-opentelemetry_api = { version = "0.18", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.18", features = ["metrics", "rt-tokio"] }
-ordered-float-dff4ba8e3ae991db = { package = "ordered-float", version = "1" }
-ordered-float-f595c2ba2a3f28df = { package = "ordered-float", version = "2" }
+ordered-float = { version = "2" }
 os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
 ouroboros-3575ec1268b04181 = { package = "ouroboros", version = "0.15" }
 ouroboros-274715c4dabd11b0 = { package = "ouroboros", version = "0.9", default-features = false }
@@ -582,7 +574,6 @@ textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16" }
 thiserror = { version = "1", default-features = false }
 thread_local = { version = "1", default-features = false }
 threadpool = { version = "1", default-features = false }
-thrift = { version = "0.16" }
 time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
 time-468e82937335b1c9 = { package = "time", version = "0.3", features = ["formatting", "macros", "parsing"] }
 time-core = { version = "0.1", default-features = false }
@@ -611,7 +602,6 @@ tracing-bunyan-formatter = { version = "0.3" }
 tracing-core = { version = "0.1" }
 tracing-futures = { version = "0.2" }
 tracing-log = { version = "0.1" }
-tracing-opentelemetry = { version = "0.18" }
 tracing-subscriber-6f8ce4dd05d13bba = { package = "tracing-subscriber", version = "0.2", default-features = false }
 tracing-subscriber-468e82937335b1c9 = { package = "tracing-subscriber", version = "0.3", features = ["env-filter", "time"] }
 tracing-test = { version = "0.2", default-features = false }
@@ -976,7 +966,6 @@ indicatif = { version = "0.17" }
 inout = { version = "0.1", default-features = false, features = ["std"] }
 insta = { version = "1", features = ["json", "redactions", "yaml"] }
 instant = { version = "0.1", default-features = false }
-integer-encoding = { version = "3", default-features = false }
 internment = { version = "0.5", default-features = false, features = ["arc"] }
 io-lifetimes = { version = "1" }
 iri-string = { version = "0.4" }
@@ -1098,14 +1087,7 @@ oid-registry = { version = "0.6", features = ["crypto", "x509"] }
 once_cell = { version = "1" }
 oorandom = { version = "11", default-features = false }
 opaque-debug = { version = "0.3", default-features = false }
-opentelemetry-9067fe90e8c1f593 = { package = "opentelemetry", version = "0.17", features = ["rt-tokio"] }
-opentelemetry-954333c9f9249c96 = { package = "opentelemetry", version = "0.18", features = ["metrics", "rt-tokio"] }
-opentelemetry-jaeger = { version = "0.17", features = ["rt-tokio"] }
-opentelemetry-semantic-conventions = { version = "0.10", default-features = false }
-opentelemetry_api = { version = "0.18", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.18", features = ["metrics", "rt-tokio"] }
-ordered-float-dff4ba8e3ae991db = { package = "ordered-float", version = "1" }
-ordered-float-f595c2ba2a3f28df = { package = "ordered-float", version = "2" }
+ordered-float = { version = "2" }
 os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
 ouroboros-3575ec1268b04181 = { package = "ouroboros", version = "0.15" }
 ouroboros-274715c4dabd11b0 = { package = "ouroboros", version = "0.9", default-features = false }
@@ -1328,7 +1310,6 @@ thiserror = { version = "1", default-features = false }
 thiserror-impl = { version = "1", default-features = false }
 thread_local = { version = "1", default-features = false }
 threadpool = { version = "1", default-features = false }
-thrift = { version = "0.16" }
 time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
 time-468e82937335b1c9 = { package = "time", version = "0.3", features = ["formatting", "macros", "parsing"] }
 time-core = { version = "0.1", default-features = false }
@@ -1362,7 +1343,6 @@ tracing-bunyan-formatter = { version = "0.3" }
 tracing-core = { version = "0.1" }
 tracing-futures = { version = "0.2" }
 tracing-log = { version = "0.1" }
-tracing-opentelemetry = { version = "0.18" }
 tracing-subscriber-6f8ce4dd05d13bba = { package = "tracing-subscriber", version = "0.2", default-features = false }
 tracing-subscriber-468e82937335b1c9 = { package = "tracing-subscriber", version = "0.3", features = ["env-filter", "time"] }
 tracing-test = { version = "0.2", default-features = false }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -21,7 +21,6 @@ aead = { version = "0.5", default-features = false, features = ["alloc", "getran
 aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10" }
 ahash-ca01ad9e24f5d932 = { package = "ahash", version = "0.7" }
-ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 aho-corasick = { version = "0.7" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
@@ -232,7 +231,6 @@ futures-task = { version = "0.3", default-features = false, features = ["std", "
 futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "bilock", "channel", "io", "sink", "unstable"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde"] }
-gethostname = { version = "0.2", default-features = false }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 ghash = { version = "0.5", default-features = false }
@@ -598,12 +596,12 @@ tower-layer = { version = "0.3", default-features = false }
 tower-service = { version = "0.3", default-features = false }
 tracing = { version = "0.1", features = ["log"] }
 tracing-appender = { version = "0.2", default-features = false }
-tracing-bunyan-formatter = { version = "0.3" }
 tracing-core = { version = "0.1" }
 tracing-futures = { version = "0.2" }
 tracing-log = { version = "0.1" }
+tracing-serde = { version = "0.1", default-features = false }
 tracing-subscriber-6f8ce4dd05d13bba = { package = "tracing-subscriber", version = "0.2", default-features = false }
-tracing-subscriber-468e82937335b1c9 = { package = "tracing-subscriber", version = "0.3", features = ["env-filter", "time"] }
+tracing-subscriber-468e82937335b1c9 = { package = "tracing-subscriber", version = "0.3", features = ["env-filter", "json", "time"] }
 tracing-test = { version = "0.2", default-features = false }
 try-lock = { version = "0.2", default-features = false }
 tui = { version = "0.17" }
@@ -663,7 +661,6 @@ aead = { version = "0.5", default-features = false, features = ["alloc", "getran
 aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10" }
 ahash-ca01ad9e24f5d932 = { package = "ahash", version = "0.7" }
-ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 aho-corasick = { version = "0.7" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
@@ -908,7 +905,6 @@ futures-task = { version = "0.3", default-features = false, features = ["std", "
 futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "bilock", "channel", "io", "sink", "unstable"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde"] }
-gethostname = { version = "0.2", default-features = false }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 ghash = { version = "0.5", default-features = false }
@@ -1339,12 +1335,12 @@ tower-service = { version = "0.3", default-features = false }
 tracing = { version = "0.1", features = ["log"] }
 tracing-appender = { version = "0.2", default-features = false }
 tracing-attributes = { version = "0.1", default-features = false }
-tracing-bunyan-formatter = { version = "0.3" }
 tracing-core = { version = "0.1" }
 tracing-futures = { version = "0.2" }
 tracing-log = { version = "0.1" }
+tracing-serde = { version = "0.1", default-features = false }
 tracing-subscriber-6f8ce4dd05d13bba = { package = "tracing-subscriber", version = "0.2", default-features = false }
-tracing-subscriber-468e82937335b1c9 = { package = "tracing-subscriber", version = "0.3", features = ["env-filter", "time"] }
+tracing-subscriber-468e82937335b1c9 = { package = "tracing-subscriber", version = "0.3", features = ["env-filter", "json", "time"] }
 tracing-test = { version = "0.2", default-features = false }
 tracing-test-macro = { version = "0.2", default-features = false }
 try-lock = { version = "0.2", default-features = false }
@@ -1411,6 +1407,7 @@ zeroize_derive = { version = "1", default-features = false }
 zstd-sys = { version = "2" }
 
 [target.aarch64-apple-darwin.dependencies]
+ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 core-foundation = { version = "0.9", default-features = false }
 core-foundation-sys = { version = "0.8", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
@@ -1443,6 +1440,7 @@ tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
+ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 autotools = { version = "0.2", default-features = false }
 core-foundation = { version = "0.9", default-features = false }
 core-foundation-sys = { version = "0.8", default-features = false }
@@ -1477,6 +1475,7 @@ tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
+ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 cpufeatures = { version = "0.2", default-features = false }
 encoding_rs = { version = "0.8" }
 foreign-types = { version = "0.3", default-features = false }
@@ -1511,6 +1510,7 @@ tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
+ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 autotools = { version = "0.2", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
 encoding_rs = { version = "0.8" }
@@ -1558,7 +1558,6 @@ error-code = { version = "2", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 ipnet = { version = "2" }
 native-tls = { version = "0.2", default-features = false }
-once_cell = { version = "1", default-features = false, features = ["unstable"] }
 output_vt100 = { version = "0.1", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 raw-cpuid = { version = "10", default-features = false }
@@ -1586,7 +1585,6 @@ error-code = { version = "2", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 ipnet = { version = "2" }
 native-tls = { version = "0.2", default-features = false }
-once_cell = { version = "1", default-features = false, features = ["unstable"] }
 output_vt100 = { version = "0.1", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 raw-cpuid = { version = "10", default-features = false }

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -284,7 +284,7 @@ fn setup_tracing() -> TelemetryGuards {
 
     let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}");
 
-    telemetry_subscribers::TelemetryConfig::new("narwhal")
+    telemetry_subscribers::TelemetryConfig::new()
         // load env variables
         .with_env()
         // load special log filter

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -208,7 +208,7 @@ fn setup_tracing() -> TelemetryGuards {
 
     let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}");
 
-    telemetry_subscribers::TelemetryConfig::new("narwhal")
+    telemetry_subscribers::TelemetryConfig::new()
         // load env variables
         .with_env()
         // load special log filter

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -187,7 +187,7 @@ fn setup_telemetry(
 ) -> TelemetryGuards {
     let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level},quinn={network_tracing_level}");
 
-    let config = telemetry_subscribers::TelemetryConfig::new("narwhal")
+    let config = telemetry_subscribers::TelemetryConfig::new()
         // load env variables
         .with_env()
         // load special log filter

--- a/narwhal/test-utils/src/cluster.rs
+++ b/narwhal/test-utils/src/cluster.rs
@@ -798,7 +798,7 @@ pub fn setup_tracing() -> TelemetryGuards {
 
     let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level},quinn={network_tracing_level}");
 
-    telemetry_subscribers::TelemetryConfig::new("narwhal")
+    telemetry_subscribers::TelemetryConfig::new()
         // load env variables
         .with_env()
         // load special log filter


### PR DESCRIPTION
Enable output tracing log events in a JSON format  by setting the `RUST_LOG_JSON` envvar.