### PR TITLE
Some Quorum Driver/Transaction Orchestrator changes

### DIFF
--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -312,7 +312,8 @@ pub fn uptime_metric(version: &'static str) -> Box<dyn prometheus::core::Collect
 #[cfg(test)]
 mod tests {
     use crate::RegistryService;
-    use prometheus::{IntCounter, Registry};
+    use prometheus::IntCounter;
+    use prometheus::Registry;
 
     #[test]
     fn registry_service() {

--- a/crates/sui-core/src/quorum_driver/metrics.rs
+++ b/crates/sui-core/src/quorum_driver/metrics.rs
@@ -15,6 +15,7 @@ pub struct QuorumDriverMetrics {
     pub(crate) total_enqueued: IntCounter,
     pub(crate) total_ok_responses: IntCounter,
     pub(crate) total_err_responses_by_err: IntCounterVec,
+    pub(crate) total_validator_returned_err_by_err: IntCounterVec,
     pub(crate) attempt_times_ok_response: Histogram,
 
     // TODO: add histogram of attempt that tx succeeds
@@ -51,7 +52,14 @@ impl QuorumDriverMetrics {
             .unwrap(),
             total_err_responses_by_err: register_int_counter_vec_with_registry!(
                 "quorum_driver_total_err_responses_by_err",
-                "Total number of requests processed with Err responses group by error",
+                "Total number of requests returned with Err responses, grouped by error type",
+                &["error"],
+                registry,
+            )
+            .unwrap(),
+            total_validator_returned_err_by_err: register_int_counter_vec_with_registry!(
+                "quorum_driver_total_validator_returned_err_by_err",
+                "Total number of errors return from validators, grouped by error type",
                 &["error"],
                 registry,
             )

--- a/crates/sui-core/src/quorum_driver/metrics.rs
+++ b/crates/sui-core/src/quorum_driver/metrics.rs
@@ -14,8 +14,8 @@ pub struct QuorumDriverMetrics {
     pub(crate) total_requests: IntCounter,
     pub(crate) total_enqueued: IntCounter,
     pub(crate) total_ok_responses: IntCounter,
-    pub(crate) total_err_responses_by_err: IntCounterVec,
-    pub(crate) total_validator_returned_err_by_err: IntCounterVec,
+    pub(crate) total_err_responses: IntCounterVec,
+    pub(crate) total_aggregated_non_recoverable_err: IntCounterVec,
     pub(crate) attempt_times_ok_response: Histogram,
 
     // TODO: add histogram of attempt that tx succeeds
@@ -50,17 +50,17 @@ impl QuorumDriverMetrics {
                 registry,
             )
             .unwrap(),
-            total_err_responses_by_err: register_int_counter_vec_with_registry!(
-                "quorum_driver_total_err_responses_by_err",
+            total_err_responses: register_int_counter_vec_with_registry!(
+                "quorum_driver_total_err_responses",
                 "Total number of requests returned with Err responses, grouped by error type",
                 &["error"],
                 registry,
             )
             .unwrap(),
-            total_validator_returned_err_by_err: register_int_counter_vec_with_registry!(
-                "quorum_driver_total_validator_returned_err_by_err",
-                "Total number of errors return from validators, grouped by error type",
-                &["error"],
+            total_aggregated_non_recoverable_err: register_int_counter_vec_with_registry!(
+                "quorum_driver_total_aggregated_non_recoverable_err",
+                "Total number of errors return from validators per transaction, grouped by error type",
+                &["error", "tx_recoverable"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -162,6 +162,7 @@ where
             .verify()
             .map_err(QuorumDriverError::InvalidUserSignature)?;
         let tx_digest = *transaction.digest();
+        debug!(?tx_digest, "TO Received transaction execution request.");
 
         let _request_guard = self.metrics.request_latency.start_timer();
         let _wait_for_finality_guard = self.metrics.wait_for_finality_latency.start_timer();
@@ -226,14 +227,18 @@ where
         &self,
         transaction: VerifiedTransaction,
     ) -> SuiResult<Registration<TransactionDigest, QuorumDriverResult>> {
-        let ticket = self.notifier.register_one(transaction.digest());
+        let tx_digest = *transaction.digest();
+        let ticket = self.notifier.register_one(&tx_digest);
         if self
             .pending_tx_log
             .write_pending_transaction_maybe(&transaction)
             .await?
         {
-            self.quorum_driver().submit_transaction(transaction).await?;
+            self.quorum_driver()
+                .submit_transaction_no_ticket(transaction)
+                .await?;
         }
+        debug!(?tx_digest, "transaction request was already submitted");
         Ok(ticket)
     }
 

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -234,11 +234,11 @@ where
             .write_pending_transaction_maybe(&transaction)
             .await?
         {
+            debug!(?tx_digest, "no pending request in flight, submitting.");
             self.quorum_driver()
                 .submit_transaction_no_ticket(transaction)
                 .await?;
         }
-        debug!(?tx_digest, "transaction request was already submitted");
         Ok(ticket)
     }
 

--- a/crates/sui-storage/src/write_path_pending_tx_log.rs
+++ b/crates/sui-storage/src/write_path_pending_tx_log.rs
@@ -68,8 +68,7 @@ impl WritePathPendingTransactionLog {
     }
 
     // This function does not need to be behind a lock because:
-    // 1. there is supposed to be only one callsite; Even when there are
-    //    several, the deletion is idempotent.
+    // 1. there could be more than one callsite but the deletion is idempotent.
     // 2. it does not race with the insert (`write_pending_transaction_maybe`)
     //    in a way that we care.
     //    2.a. for one transaction, `finish_transaction` shouldn't predate

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -650,6 +650,35 @@ impl SuiError {
             errors: vec![error],
         }
     }
+
+    /// Returns if the error is retryable and if the error's retryability is
+    /// explicitly categorized.
+    /// There should be only a handful of retryable errors. For now we list common
+    /// non-retryable error below to help us find more retryable errors in logs.
+    pub fn is_retryable(&self) -> (bool, bool) {
+        match self {
+            // Network error
+            SuiError::RpcError { .. } => (true, true),
+
+            // Reconfig error
+            SuiError::ValidatorHaltedAtEpochEnd => (true, true),
+            SuiError::MissingCommitteeAtEpoch(..) => (true, true),
+            SuiError::WrongEpoch { .. } => (true, true),
+
+            // Non retryable error
+            SuiError::TransactionInputObjectsErrors { .. } => (false, true),
+            SuiError::ExecutionError(..) => (false, true),
+            SuiError::ByzantineAuthoritySuspicion { .. } => (false, true),
+            SuiError::QuorumFailedToGetEffectsQuorumWhenProcessingTransaction { .. } => {
+                (false, true)
+            }
+            SuiError::ObjectVersionUnavailableForConsumption { .. } => (false, true),
+            SuiError::GasBudgetTooHigh { .. } => (false, true),
+            SuiError::GasBudgetTooLow { .. } => (false, true),
+            SuiError::GasBalanceTooLowToCoverGasBudget { .. } => (false, true),
+            _ => (false, false),
+        }
+    }
 }
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;


### PR DESCRIPTION
including:
1. logs
2. categorize a few SuiErrors as non-retryable
3. in Transaction Orchestrator, use `submit_transaction_no_ticket` instead of `submit_transaction` because we already have the ticket upfront