### PR TITLE
[Narwhal] a few cleanup

### DIFF
--- a/narwhal/storage/src/certificate_store.rs
+++ b/narwhal/storage/src/certificate_store.rs
@@ -177,6 +177,18 @@ impl CertificateStore {
         }
     }
 
+    /// Retrieves a certificate from the store. If not found
+    /// then None is returned as result.
+    pub fn contains(&self, id: &CertificateDigest) -> StoreResult<bool> {
+        fail::fail_point!("certificate-store-panic", |_| {
+            Err(RocksDBError(format!(
+                "Injected error in certificate store contains_digest"
+            )))
+        });
+
+        self.certificates_by_id.contains_key(id)
+    }
+
     /// Retrieves multiple certificates by their provided ids. The results
     /// are returned in the same sequence as the provided keys.
     pub fn read_all(
@@ -500,6 +512,26 @@ mod test {
         }
 
         result
+    }
+
+    #[tokio::test]
+    async fn test_write_and_read() {
+        // GIVEN
+        let store = new_store(temp_dir());
+
+        // create certificates for 10 rounds
+        let certs = certificates(10);
+
+        // store them
+        for cert in &certs {
+            store.write(cert.clone()).unwrap();
+        }
+
+        // verify
+        for cert in &certs {
+            store.contains(&cert.digest()).unwrap();
+            assert_eq!(cert, &store.read(cert.digest()).unwrap().unwrap())
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
1. If a certificate is written to the local store but not sent to the DAG, there will be inconsistencies in the DAG if Narwhal continues to operate. A certificate may assume its parents exist in the DAG but actually not. So add a warning when this happens.
2. Logic to check existence of certificate parents can be simplified, since Narwhal no longer updates committee and epochs dynamically.