### PR TITLE
wallet-ext: button connected to component

### DIFF
--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -117,6 +117,7 @@
         "@growthbook/growthbook-react": "^0.10.1",
         "@metamask/browser-passworder": "^4.0.2",
         "@mysten/core": "workspace:*",
+        "@mysten/icons": "workspace:*",
         "@mysten/sui.js": "workspace:*",
         "@mysten/wallet-standard": "workspace:*",
         "@noble/hashes": "^1.1.5",

--- a/apps/wallet/src/ui/app/shared/button-connected-to/ButtonConnectedTo.stories.tsx
+++ b/apps/wallet/src/ui/app/shared/button-connected-to/ButtonConnectedTo.stories.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type Meta, type StoryObj } from '@storybook/react';
+
+import { ButtonConnectedTo } from './';
+
+export default {
+    component: ButtonConnectedTo,
+} as Meta<typeof ButtonConnectedTo>;
+
+export const Default: StoryObj<typeof ButtonConnectedTo> = {
+    args: {
+        text: 'Button',
+    },
+};
+
+export const LightGrey: StoryObj<typeof ButtonConnectedTo> = {
+    args: {
+        text: 'Button',
+        bgOnHover: 'grey',
+    },
+};
+
+export const Disabled: StoryObj<typeof ButtonConnectedTo> = {
+    args: {
+        text: 'Button',
+        bgOnHover: 'grey',
+        disabled: true,
+    },
+};

--- a/apps/wallet/src/ui/app/shared/button-connected-to/index.tsx
+++ b/apps/wallet/src/ui/app/shared/button-connected-to/index.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import { type ComponentProps, forwardRef, type ReactNode } from 'react';
+
+const styles = cva(
+    [
+        'cursor-pointer outline-0 flex flex-row items-center py-1 px-2 gap-1 rounded-2xl',
+        'transition text-body-small font-medium border border-solid',
+        'border-transparent bg-transparent',
+        'hover:text-hero hover:bg-sui-light hover:border-sui',
+        'focus:text-hero focus:bg-sui-light focus:border-sui',
+        'active:text-steel active:bg-gray-45 active:border-transparent',
+        'disabled:text-gray-60 disabled:bg-transparent disabled:border-transparent',
+    ],
+    {
+        variants: {
+            bgOnHover: {
+                blueLight: ['text-hero'],
+                grey: ['text-steel-dark'],
+            },
+        },
+        defaultVariants: {
+            bgOnHover: 'blueLight',
+        },
+    }
+);
+
+export interface ButtonConnectedToProps
+    extends VariantProps<typeof styles>,
+        Omit<ComponentProps<'button'>, 'ref' | 'className'> {
+    iconLeft?: ReactNode;
+    text?: string;
+    iconRight?: ReactNode;
+}
+
+export const ButtonConnectedTo = forwardRef<
+    HTMLButtonElement,
+    ButtonConnectedToProps
+>(({ bgOnHover, iconLeft, iconRight, text, ...rest }, ref) => {
+    return (
+        <button {...rest} ref={ref} className={styles({ bgOnHover })}>
+            {iconLeft}
+            {text}
+            {iconRight}
+        </button>
+    );
+});
+
+ButtonConnectedTo.displayName = 'ButtonConnectedTo';

--- a/apps/wallet/src/ui/app/shared/dapp-status/DappStatus.module.scss
+++ b/apps/wallet/src/ui/app/shared/dapp-status/DappStatus.module.scss
@@ -1,59 +1,12 @@
 @use '_values/colors';
 @use '_utils';
 
-.container {
-    display: flex;
-    flex-flow: row;
-    align-items: center;
-    background: transparent;
-    outline: none;
-    color: colors.$issue;
-    border: 1px solid colors.$gray-55;
-    border-radius: 20px;
-    padding: 4px 8px;
-    cursor: default;
-    overflow: hidden;
-    flex: 0 1 auto;
-    transition: all 150ms ease-in-out;
-
-    @include utils.typography('Primary/BodySmall-M');
-
-    &.connected {
-        background-color: colors.$sui-blue-light;
-        color: colors.$cta-blue;
-        border: none;
-        cursor: pointer;
-
-        &:hover,
-        &:focus {
-            border: 1px solid colors.$sui-blue;
-        }
-
-        &:active,
-        &.active {
-            color: colors.$sui-blue;
-            border: none;
-        }
-    }
-}
-
 .icon {
-    margin-right: 4px;
     font-size: 6px;
-
-    &.connected {
-        color: colors.$success;
-    }
-}
-
-.label {
-    white-space: nowrap;
-
-    @include utils.overflow-ellipsis;
+    color: colors.$success;
 }
 
 .chevron {
-    margin-left: 6px;
     font-size: 11px;
 }
 

--- a/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
+++ b/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
@@ -9,12 +9,12 @@ import {
     offset,
     arrow,
 } from '@floating-ui/react-dom-interactions';
-import cn from 'classnames';
+import { ChevronDown12, Dot12 } from '@mysten/icons';
 import { motion, AnimatePresence } from 'framer-motion';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
+import { ButtonConnectedTo } from '../button-connected-to';
 import { appDisconnect } from './actions';
-import Icon, { SuiIcons } from '_components/icon';
 import Loading from '_components/loading';
 import { useAppDispatch, useAppSelector } from '_hooks';
 import { createDappStatusSelector } from '_redux/slices/permissions';
@@ -44,7 +44,6 @@ function DappStatus() {
     const isConnected = useAppSelector(dappStatusSelector);
     const [disconnecting, setDisconnecting] = useState(false);
     const [visible, setVisible] = useState(false);
-    const Component = isConnected ? 'button' : 'span';
     const onHandleClick = useCallback(
         (e: boolean) => {
             if (!disconnecting) {
@@ -97,27 +96,13 @@ function DappStatus() {
     }
     return (
         <>
-            <Component
-                type="button"
-                className={cn(st.container, {
-                    [st.connected]: isConnected,
-                    [st.active]: visible,
-                })}
-                disabled={!isConnected}
+            <ButtonConnectedTo
+                iconLeft={<Dot12 className="text-success" />}
+                text={activeOrigin || ''}
+                iconRight={<ChevronDown12 />}
                 ref={reference}
                 {...getReferenceProps()}
-            >
-                <Icon
-                    icon="circle-fill"
-                    className={cn(st.icon, { [st.connected]: isConnected })}
-                />
-                <span className={st.label}>
-                    {(isConnected && activeOrigin) || 'Not connected'}
-                </span>
-                {isConnected ? (
-                    <Icon icon={SuiIcons.ChevronDown} className={st.chevron} />
-                ) : null}
-            </Component>
+            />
             <AnimatePresence>
                 {visible ? (
                     <motion.div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,7 @@ importers:
       '@growthbook/growthbook-react': ^0.10.1
       '@metamask/browser-passworder': ^4.0.2
       '@mysten/core': workspace:*
+      '@mysten/icons': workspace:*
       '@mysten/sui.js': workspace:*
       '@mysten/wallet-standard': workspace:*
       '@noble/hashes': ^1.1.5
@@ -319,6 +320,7 @@ importers:
       '@growthbook/growthbook-react': 0.10.1_react@18.2.0
       '@metamask/browser-passworder': 4.0.2
       '@mysten/core': link:../core
+      '@mysten/icons': link:../icons
       '@mysten/sui.js': link:../../sdk/typescript
       '@mysten/wallet-standard': link:../../sdk/wallet-adapter/wallet-standard
       '@noble/hashes': 1.1.5
@@ -347,7 +349,7 @@ importers:
       rxjs: 7.8.0
       semver: 7.3.8
       stream-browserify: 3.0.0
-      tailwindcss: 3.2.4_ts-node@10.9.1
+      tailwindcss: 3.2.4_aesdjsunmf4wiehhujt67my7tu
       throttle-debounce: 5.0.0
       tweetnacl: 1.0.3
       uuid: 8.3.2
@@ -4713,7 +4715,7 @@ packages:
       '@storybook/components': 7.0.0-beta.3_biqbaboplfbrettd7655fr4n2y
       '@storybook/csf-plugin': 7.0.0-beta.3
       '@storybook/csf-tools': 7.0.0-beta.3
-      '@storybook/mdx2-csf': 1.0.0-next.4
+      '@storybook/mdx2-csf': 1.0.0-next.5
       '@storybook/node-logger': 7.0.0-beta.3
       '@storybook/postinstall': 7.0.0-beta.3
       '@storybook/preview-api': 7.0.0-beta.3
@@ -5309,7 +5311,7 @@ packages:
       '@storybook/core-events': 7.0.0-beta.3
       '@storybook/csf': 0.0.2-next.8
       '@storybook/csf-tools': 7.0.0-beta.3
-      '@storybook/docs-mdx': 0.0.1-next.5
+      '@storybook/docs-mdx': 0.0.1-next.6
       '@storybook/node-logger': 7.0.0-beta.3
       '@storybook/preview-api': 7.0.0-beta.3
       '@storybook/telemetry': 7.0.0-beta.3_typescript@4.9.4
@@ -5395,8 +5397,8 @@ packages:
       type-fest: 2.19.0
     dev: true
 
-  /@storybook/docs-mdx/0.0.1-next.5:
-    resolution: {integrity: sha512-EowXFPq4TBZQguKCdU8y7EzpuSv2vSu5gy7pgF/1P5mq7LG9h8YIrerOW9DL4zfp9E0GHIWlSXR5KuFIqqKc/Q==}
+  /@storybook/docs-mdx/0.0.1-next.6:
+    resolution: {integrity: sha512-DjoSIXADmLJtdroXAjUotFiZlcZ2usWhqrS7aeOtZs0DVR0Ws5WQjnwtpDUXt8gryTSd+OZJ0cNsDcqg4JDEvQ==}
     dev: true
 
   /@storybook/docs-tools/7.0.0-beta.3_typescript@4.9.4:
@@ -5459,6 +5461,10 @@ packages:
 
   /@storybook/mdx2-csf/1.0.0-next.4:
     resolution: {integrity: sha512-nvRgYdpYvXsvSgCzKc4LQA1JxtJzmv47IsFAsh1rTz5FoHyK8watLU2WqX9T4w52fpFXBHx7RwGEsCRt0XgZlQ==}
+    dev: true
+
+  /@storybook/mdx2-csf/1.0.0-next.5:
+    resolution: {integrity: sha512-02w0sgGZaK1agT050yCVhJ+o4rLHANWvLKWjQjeAsYbjneLC5ITt+3GDB4jRiWwJboZ8dHW1fGSK1Vg5fA34aQ==}
     dev: true
 
   /@storybook/node-logger/7.0.0-beta.3:
@@ -17441,10 +17447,12 @@ packages:
       - ts-node
     dev: true
 
-  /tailwindcss/3.2.4_ts-node@10.9.1:
+  /tailwindcss/3.2.4_aesdjsunmf4wiehhujt67my7tu:
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3


### PR DESCRIPTION
* implement figma button component to reuse in dapp status and (later) for account selector

before


https://user-images.githubusercontent.com/10210143/214164424-b4fbe3c7-4fe2-4c60-ba99-099e379ee119.mov


after


https://user-images.githubusercontent.com/10210143/214164497-fda7e729-f8ec-45e7-b61f-98a53ec2c678.mov


part of APPS-296