### PR TITLE
indexer: read events from txn effects

### DIFF
--- a/crates/sui-indexer/migrations/2022-11-18-220045_events/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-220045_events/up.sql
@@ -1,11 +1,9 @@
 CREATE TABLE EVENTS (
     id BIGSERIAL PRIMARY KEY,
-    -- below 2 are from Event ID, tx_digest and event_seq
     transaction_digest VARCHAR(255) NOT NULL,
     event_sequence BIGINT NOT NULL,
     event_time TIMESTAMP,
     event_type VARCHAR NOT NULL,
     event_content VARCHAR NOT NULL,
-    next_cursor_transaction_digest VARCHAR(255),
-    next_cursor_event_sequence BIGINT
+    next_cursor_transaction_digest VARCHAR(255)
 );

--- a/crates/sui-indexer/src/handlers/event_handler.rs
+++ b/crates/sui-indexer/src/handlers/event_handler.rs
@@ -1,22 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use futures::future::join_all;
 use prometheus::Registry;
 use std::sync::Arc;
 use std::time::Duration;
-use sui_json_rpc_types::EventPage;
+use sui_json_rpc_types::SuiTransactionResponse;
 use sui_sdk::SuiClient;
-use sui_types::event::EventID;
-use sui_types::query::EventQuery;
 use tokio::time::sleep;
 use tracing::{error, info};
 
 use sui_indexer::errors::IndexerError;
 use sui_indexer::metrics::IndexerEventHandlerMetrics;
-use sui_indexer::models::events::{commit_events, read_last_event};
+use sui_indexer::models::events::{commit_events, read_last_event, IndexerEventEnvelope};
+use sui_indexer::utils::log_errors_to_pg;
 use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
 
-const EVENT_PAGE_SIZE: usize = 100;
+use crate::handlers::transaction_handler::{get_transaction_page, get_transaction_response};
 
 pub struct EventHandler {
     rpc_client: SuiClient,
@@ -45,31 +45,16 @@ impl EventHandler {
         let mut next_cursor = None;
         let last_event_opt = read_last_event(&mut pg_pool_conn)?;
         if let Some(last_event) = last_event_opt {
-            match (
-                last_event.next_cursor_transaction_digest,
-                last_event.next_cursor_event_sequence,
-            ) {
-                (Some(tx_digest_str), Some(event_seq)) => {
-                    let tx_digest = tx_digest_str.parse().map_err(|e| {
-                        IndexerError::TransactionDigestParsingError(format!(
-                            "Failed parsing transaction digest {:?} with error: {:?}",
-                            tx_digest_str, e
-                        ))
-                    })?;
-                    next_cursor = Some(EventID {
-                        tx_digest,
-                        event_seq,
-                    });
-                }
-                (Some(_), None) => {
-                    error!("Last event was found but it has no next cursor event sequence, this should never happen!");
-                }
-                (None, Some(_)) => {
-                    error!("Last event was found but it has no next cursor tx digest, this should never happen!");
-                }
-                (None, None) => {
-                    error!("Last event was found but it has no next cursor tx digest and no next cursor event sequence, this should never happen!");
-                }
+            if let Some(next_cursor_tx_dig) = last_event.next_cursor_transaction_digest {
+                let next_cursor_tx_digest = next_cursor_tx_dig.parse().map_err(|e| {
+                    IndexerError::TransactionDigestParsingError(format!(
+                        "Failed parsing transaction digest {:?} with error: {:?}",
+                        next_cursor_tx_dig, e
+                    ))
+                })?;
+                next_cursor = Some(next_cursor_tx_digest);
+            } else {
+                error!("Last event was found but it has no next cursor tx digest, this should never happen!");
             }
         }
 
@@ -77,17 +62,38 @@ impl EventHandler {
             self.event_handler_metrics
                 .total_event_page_fetch_attempt
                 .inc();
-            let event_page = fetch_event_page(self.rpc_client.clone(), next_cursor.clone()).await?;
+            let txn_page = get_transaction_page(self.rpc_client.clone(), next_cursor).await?;
+            let txn_digest_vec = txn_page.data;
+            let txn_response_res_vec = join_all(
+                txn_digest_vec
+                    .into_iter()
+                    .map(|tx_digest| get_transaction_response(self.rpc_client.clone(), tx_digest)),
+            )
+            .await;
             self.event_handler_metrics.total_event_page_received.inc();
-            let event_count = event_page.data.len();
             info!(
-                "Received event page with {} events, next cursor: {:?}",
-                event_count, event_page.next_cursor
+                "Received transaction page for events with {} txns, next cursor: {:?}",
+                txn_response_res_vec.len(),
+                txn_page.next_cursor.clone()
             );
-            self.event_handler_metrics
-                .total_events_received
-                .inc_by(event_count as u64);
-            let commit_result = commit_events(&mut pg_pool_conn, event_page.clone())?;
+
+            let mut errors = vec![];
+            let txn_resp_vec: Vec<SuiTransactionResponse> = txn_response_res_vec
+                .into_iter()
+                .filter_map(|f| f.map_err(|e| errors.push(e)).ok())
+                .collect();
+            let event_nested_vec: Vec<IndexerEventEnvelope> = txn_resp_vec
+                .into_iter()
+                .map(|txn_resp| IndexerEventEnvelope {
+                    transaction_digest: txn_resp.effects.transaction_digest,
+                    timestamp: txn_resp.timestamp_ms,
+                    events: txn_resp.effects.events,
+                    next_cursor: None,
+                })
+                .collect();
+            log_errors_to_pg(&mut pg_pool_conn, errors);
+            let commit_result =
+                commit_events(&mut pg_pool_conn, event_nested_vec, txn_page.next_cursor)?;
 
             if let Some((commit_count, next_cursor_val)) = commit_result {
                 next_cursor = Some(next_cursor_val);
@@ -102,30 +108,9 @@ impl EventHandler {
                 );
             }
 
-            if event_page.next_cursor.is_none() {
+            if txn_page.next_cursor.is_none() {
                 sleep(Duration::from_secs_f32(0.1)).await;
             }
         }
     }
-}
-
-async fn fetch_event_page(
-    rpc_client: SuiClient,
-    next_cursor: Option<EventID>,
-) -> Result<EventPage, IndexerError> {
-    rpc_client
-        .event_api()
-        .get_events(
-            EventQuery::All,
-            next_cursor.clone(),
-            Some(EVENT_PAGE_SIZE),
-            false,
-        )
-        .await
-        .map_err(|e| {
-            IndexerError::FullNodeReadingError(format!(
-                "Failed reading event page with cursor {:?} and error: {:?}",
-                next_cursor, e
-            ))
-        })
 }

--- a/crates/sui-indexer/src/handlers/transaction_handler.rs
+++ b/crates/sui-indexer/src/handlers/transaction_handler.rs
@@ -60,7 +60,7 @@ impl TransactionHandler {
             self.transaction_handler_metrics
                 .total_transaction_page_fetch_attempt
                 .inc();
-            let page = self.get_transaction_page(next_cursor).await?;
+            let page = get_transaction_page(self.rpc_client.clone(), next_cursor).await?;
             self.transaction_handler_metrics
                 .total_transaction_page_received
                 .inc();
@@ -72,7 +72,7 @@ impl TransactionHandler {
             let txn_response_res_vec = join_all(
                 txn_digest_vec
                     .into_iter()
-                    .map(|tx_digest| self.get_transaction_response(tx_digest)),
+                    .map(|tx_digest| get_transaction_response(self.rpc_client.clone(), tx_digest)),
             )
             .await;
             info!(
@@ -110,41 +110,41 @@ impl TransactionHandler {
             }
         }
     }
+}
 
-    async fn get_transaction_page(
-        &self,
-        cursor: Option<TransactionDigest>,
-    ) -> Result<TransactionsPage, IndexerError> {
-        self.rpc_client
-            .read_api()
-            .get_transactions(
-                TransactionQuery::All,
-                cursor,
-                Some(TRANSACTION_PAGE_SIZE),
-                false,
-            )
-            .await
-            .map_err(|e| {
-                IndexerError::FullNodeReadingError(format!(
-                    "Failed reading transaction page with cursor {:?} and err: {:?}",
-                    cursor, e
-                ))
-            })
-    }
+pub async fn get_transaction_page(
+    rpc_client: SuiClient,
+    cursor: Option<TransactionDigest>,
+) -> Result<TransactionsPage, IndexerError> {
+    rpc_client
+        .read_api()
+        .get_transactions(
+            TransactionQuery::All,
+            cursor,
+            Some(TRANSACTION_PAGE_SIZE),
+            false,
+        )
+        .await
+        .map_err(|e| {
+            IndexerError::FullNodeReadingError(format!(
+                "Failed reading transaction page with cursor {:?} and err: {:?}",
+                cursor, e
+            ))
+        })
+}
 
-    async fn get_transaction_response(
-        &self,
-        tx_digest: TransactionDigest,
-    ) -> Result<SuiTransactionResponse, IndexerError> {
-        self.rpc_client
-            .read_api()
-            .get_transaction(tx_digest)
-            .await
-            .map_err(|e| {
-                IndexerError::FullNodeReadingError(format!(
-                    "Failed reading transaction response with tx digest {:?} and err: {:?}",
-                    tx_digest, e
-                ))
-            })
-    }
+pub async fn get_transaction_response(
+    rpc_client: SuiClient,
+    tx_digest: TransactionDigest,
+) -> Result<SuiTransactionResponse, IndexerError> {
+    rpc_client
+        .read_api()
+        .get_transaction(tx_digest)
+        .await
+        .map_err(|e| {
+            IndexerError::FullNodeReadingError(format!(
+                "Failed reading transaction response with tx digest {:?} and err: {:?}",
+                tx_digest, e
+            ))
+        })
 }

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -55,7 +55,6 @@ diesel::table! {
         event_type -> Varchar,
         event_content -> Varchar,
         next_cursor_transaction_digest -> Nullable<Varchar>,
-        next_cursor_event_sequence -> Nullable<Int8>,
     }
 }
 


### PR DESCRIPTION
as the title says, this PR changes the underlying data source of event indexing from SQLite to txn effects, notable changes include:
- instead fetching X number of events, now indexer fetches X txns and commit all events related to the txns to DB
- as a result
  - the next cursor needs to be txn digest instead of Event ID
  - on private testnet, the first batch of txns has `26539 events` which is more than what Postgres can take in one DB write, so we have to split the commit into batches

Tested both locally and on private testnet to make sure that events can be committed correctly, error logs are empty.
Need to test on private testnet to see the throughput changes.