### PR TITLE
indexer: add auto-incremented id for faster count

### DIFF
--- a/crates/sui-indexer/migrations/2022-11-28-204251_addresses/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-28-204251_addresses/up.sql
@@ -1,8 +1,11 @@
 CREATE TABLE addresses (
-    account_address VARCHAR(255) PRIMARY KEY,
+    id BIGSERIAL PRIMARY KEY,
+    account_address VARCHAR(255) NOT NULL UNIQUE,
     first_appearance_tx VARCHAR(255) NOT NULL, 
     first_appearance_time TIMESTAMP
 );
+
+CREATE INDEX addresses_account_address ON addresses (account_address);
 
 CREATE TABLE address_logs (
     -- this is essentially BIGSERIAL starting from 1

--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE objects (
-    object_id VARCHAR(255) PRIMARY KEY,
+    id BIGSERIAL PRIMARY KEY,
+    object_id VARCHAR(255) NOT NULL UNIQUE,
     version BIGINT NOT NULL,
 
     -- owner related
@@ -20,6 +21,7 @@ CREATE TABLE objects (
 
 CREATE INDEX objects_owner_address ON objects (owner_address);
 CREATE INDEX objects_package_id ON objects (package_id);
+CREATE INDEX objects_object_id ON objects (object_id);
 
 CREATE TABLE object_logs (
     last_processed_id BIGINT PRIMARY KEY

--- a/crates/sui-indexer/migrations/2022-12-02-202249_packages/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-02-202249_packages/up.sql
@@ -1,11 +1,14 @@
 CREATE TABLE packages (
-    package_id TEXT PRIMARY KEY,
+    id BIGSERIAL PRIMARY KEY,
+    package_id TEXT NOT NULL UNIQUE,
     author TEXT NOT NULL,
     -- means the column cannot be null,
     -- the element in the array can still be null
     module_names TEXT[] NOT NULL,
     package_content TEXT NOT NULL
 );
+
+CREATE INDEX packages_package_id ON packages (package_id);
 
 CREATE TABLE package_logs (
     last_processed_id BIGINT PRIMARY KEY

--- a/crates/sui-indexer/src/models/addresses.rs
+++ b/crates/sui-indexer/src/models/addresses.rs
@@ -14,6 +14,7 @@ use diesel::result::Error;
 #[derive(Queryable, Debug)]
 #[diesel(primary_key(account_address))]
 pub struct Addresses {
+    pub id: i64,
     pub account_address: String,
     pub first_appearance_tx: String,
     pub first_appearance_time: Option<NaiveDateTime>,

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -19,6 +19,7 @@ use sui_types::object::Owner;
 #[derive(Queryable, Debug, Identifiable)]
 #[diesel(primary_key(object_id))]
 pub struct Object {
+    pub id: i64,
     pub object_id: String,
     pub version: i64,
     pub owner_type: String,

--- a/crates/sui-indexer/src/models/packages.rs
+++ b/crates/sui-indexer/src/models/packages.rs
@@ -21,6 +21,7 @@ use sui_types::base_types::{ObjectID, SuiAddress};
 #[derive(Queryable, Debug, Identifiable)]
 #[diesel(primary_key(package_id))]
 pub struct Package {
+    pub id: i64,
     pub package_id: String,
     pub author: String,
     pub module_names: Vec<Option<String>>,

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -9,7 +9,8 @@ diesel::table! {
 }
 
 diesel::table! {
-    addresses (account_address) {
+    addresses (id) {
+        id -> Int8,
         account_address -> Varchar,
         first_appearance_tx -> Varchar,
         first_appearance_time -> Nullable<Timestamp>,
@@ -85,7 +86,8 @@ diesel::table! {
 }
 
 diesel::table! {
-    objects (object_id) {
+    objects (id) {
+        id -> Int8,
         object_id -> Varchar,
         version -> Int8,
         owner_type -> Varchar,
@@ -105,7 +107,8 @@ diesel::table! {
 }
 
 diesel::table! {
-    packages (package_id) {
+    packages (id) {
+        id -> Int8,
         package_id -> Text,
         author -> Text,
         module_names -> Array<Nullable<Text>>,


### PR DESCRIPTION
before this PR, the count query of a table is slow, we can count on the auto-incremented id and query like
`select id from <TABLE> order by id desc limit 1` to get the count, which is faster.