### PR TITLE
send failures to effects queue to clear recovery log

### DIFF
--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -67,7 +67,12 @@ async fn test_quorum_driver_submit_transaction() {
         let QuorumDriverResponse {
             tx_cert,
             effects_cert,
-        } = qd_clone.subscribe_to_effects().recv().await.unwrap();
+        } = qd_clone
+            .subscribe_to_effects()
+            .recv()
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(*tx_cert.digest(), digest);
         assert_eq!(effects_cert.data().transaction_digest, digest);
     });
@@ -95,7 +100,12 @@ async fn test_quorum_driver_submit_transaction_no_ticket() {
         let QuorumDriverResponse {
             tx_cert,
             effects_cert,
-        } = qd_clone.subscribe_to_effects().recv().await.unwrap();
+        } = qd_clone
+            .subscribe_to_effects()
+            .recv()
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(*tx_cert.digest(), digest);
         assert_eq!(effects_cert.data().transaction_digest, digest);
     });
@@ -139,7 +149,12 @@ async fn test_quorum_driver_with_given_notify_read() {
         let QuorumDriverResponse {
             tx_cert,
             effects_cert,
-        } = qd_clone.subscribe_to_effects().recv().await.unwrap();
+        } = qd_clone
+            .subscribe_to_effects()
+            .recv()
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(*tx_cert.digest(), digest);
         assert_eq!(effects_cert.data().transaction_digest, digest);
     });

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -48,7 +48,7 @@ use sui_storage::{
 };
 use sui_types::committee::Committee;
 use sui_types::crypto::KeypairTraits;
-use sui_types::messages::QuorumDriverResponse;
+use sui_types::quorum_driver_types::QuorumDriverEffectsQueueResult;
 use tokio::sync::broadcast;
 use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
@@ -693,7 +693,7 @@ impl SuiNode {
 
     pub fn subscribe_to_transaction_orchestrator_effects(
         &self,
-    ) -> Result<tokio::sync::broadcast::Receiver<QuorumDriverResponse>> {
+    ) -> Result<tokio::sync::broadcast::Receiver<QuorumDriverEffectsQueueResult>> {
         self.transaction_orchestrator
             .as_ref()
             .map(|to| to.subscribe_to_effects_queue())

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -14,6 +14,9 @@ use thiserror::Error;
 
 pub type QuorumDriverResult = Result<QuorumDriverResponse, QuorumDriverError>;
 
+pub type QuorumDriverEffectsQueueResult =
+    Result<QuorumDriverResponse, (TransactionDigest, QuorumDriverError)>;
+
 /// Client facing errors regarding transaction submission via Quorum Driver.
 /// Every invariant needs detailed documents to instruct client handling.
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash, AsRefStr)]

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -952,7 +952,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let QuorumDriverResponse {
         tx_cert: certified_txn,
         effects_cert: certified_txn_effects,
-    } = rx.recv().await.unwrap();
+    } = rx.recv().await.unwrap().unwrap();
     let (ct, cte, is_executed_locally) = *res;
     assert_eq!(*ct.digest(), digest);
     assert_eq!(*certified_txn.digest(), digest);
@@ -977,7 +977,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let QuorumDriverResponse {
         tx_cert: certified_txn,
         effects_cert: certified_txn_effects,
-    } = rx.recv().await.unwrap();
+    } = rx.recv().await.unwrap().unwrap();
     let (ct, cte, is_executed_locally) = *res;
     assert_eq!(*ct.digest(), digest);
     assert_eq!(*certified_txn.digest(), digest);


### PR DESCRIPTION
The way that transaction orchestrator (TO) / quorum driver  (QD) handles transaction recovery log ("wal" log) is problematic. It only calls `finish_transaction` to clear the record when TO gets the effects sent by QD. However, if tx eventually yields an error, TO will not know about that. The consequence is, the tx also will not be erased in recovery log, and only the first transaction request gets a failure message, but others, including the future ones get `Timeout`. For clients that handles timeout correctly, it will keep retrying until it's resolved. Unfortunately, in this case they always get `Timeout`. 

This PR fixes that by making the QD effects queue transmit `Result` and push failure too so TO could clear the log as we want. Also we move `self.effects_subscribe_sender.send` in `fn notify` which is guaranteed to be called no matter if the transaction succeeds, fails or max out the attempts.