### PR TITLE
transpile icons lib in storybook

### DIFF
--- a/apps/wallet/.storybook/main.js
+++ b/apps/wallet/.storybook/main.js
@@ -5,6 +5,7 @@ const {
     default: getWebpackConfig,
 } = require('../configs/webpack/webpack.config.dev.ts');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const path = require('path');
 
 module.exports = {
     stories: ['../src/ui/**/*.mdx', '../src/ui/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -29,9 +30,14 @@ module.exports = {
         const cssRule = custom.module.rules.find((rule) =>
             rule.test.test('.css')
         );
+        const tsRule = custom.module.rules.find((rule) =>
+            rule.test.test('.tsx')
+        );
+        tsRule.include = path.resolve('../icons/src');
 
         config.module.rules = [
             ...config.module.rules.filter((rule) => !rule.test.test('.css')),
+            tsRule,
             cssRule,
         ];
 

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -117,6 +117,7 @@
         "@growthbook/growthbook-react": "^0.10.1",
         "@metamask/browser-passworder": "^4.0.2",
         "@mysten/core": "workspace:*",
+        "@mysten/icons": "workspace:*",
         "@mysten/sui.js": "workspace:*",
         "@mysten/wallet-standard": "workspace:*",
         "@noble/hashes": "^1.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,7 @@ importers:
       '@growthbook/growthbook-react': ^0.10.1
       '@metamask/browser-passworder': ^4.0.2
       '@mysten/core': workspace:*
+      '@mysten/icons': workspace:*
       '@mysten/sui.js': workspace:*
       '@mysten/wallet-standard': workspace:*
       '@noble/hashes': ^1.1.5
@@ -311,6 +312,7 @@ importers:
       '@growthbook/growthbook-react': 0.10.1_react@18.2.0
       '@metamask/browser-passworder': 4.0.2
       '@mysten/core': link:../core
+      '@mysten/icons': link:../icons
       '@mysten/sui.js': link:../../sdk/typescript
       '@mysten/wallet-standard': link:../../sdk/wallet-adapter/wallet-standard
       '@noble/hashes': 1.1.5


### PR DESCRIPTION
allows usage of @mysten/icons lib in storybook. I also tried driving this through the tsconfig file but wasn't having much luck, so this fix adds a rule in our storybook webpack config for the icons lib