### PR TITLE
test for structs

### DIFF
--- a/sdk/typescript/test/e2e/data/struct_metadata/Move.toml
+++ b/sdk/typescript/test/e2e/data/struct_metadata/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "struct_metadata"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../../crates/sui-framework"}
+
+[addresses]
+struct_metadata =  "0x0"

--- a/sdk/typescript/test/e2e/data/struct_metadata/sources/struct_metadata.move
+++ b/sdk/typescript/test/e2e/data/struct_metadata/sources/struct_metadata.move
@@ -1,0 +1,18 @@
+module struct_metadata::struct_metadata{
+  use std::string::{Self, String};
+  use sui::tx_context::{Self, TxContext};
+  use sui::object::{Self, UID};
+  use sui::transfer;
+  
+  struct Dummy  has key{
+    id: UID,
+    number: u64,
+    description: String,
+  }
+
+  fun init(ctx: &mut TxContext){
+    let id = object::new(ctx);
+    let dummy = Dummy{id, number: 1, description: string::utf8(b"Hello")};
+    transfer::transfer(dummy, tx_context::sender(ctx))
+  }
+}

--- a/sdk/typescript/test/e2e/struct-metadata.test.ts
+++ b/sdk/typescript/test/e2e/struct-metadata.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { publishPackage, setup, TestToolbox } from './utils/setup';
+import { RawSigner, ObjectId, LocalTxnDataSerializer } from '../../src';
+
+describe('Test Struct Metadata', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+  let packageId: ObjectId;
+  let objectId: string;
+
+  beforeAll(async () => {
+    toolbox = await setup();
+    signer = new RawSigner(
+      toolbox.keypair,
+      toolbox.provider,
+      new LocalTxnDataSerializer(toolbox.provider)
+    );
+
+    const packagePath = __dirname + '/./data/struct_metadata';
+    packageId = await publishPackage(signer, true, packagePath);
+  });
+
+  it('Test accessing struct metadata', async () => {
+
+    let address = await signer.getAddress();
+
+    const structMetadata = await toolbox.provider.getObjectsOwnedByAddress(
+      address
+    );
+
+    for (let object of structMetadata){
+      if (object.type == `${packageId}::struct_metadata::Dummy`){
+        objectId = object.objectId;
+      }
+    }
+    const dummyObject = await toolbox.provider.getObject(objectId);
+    expect(dummyObject.details.data.fields.description).to.equal("Hello");
+    expect(dummyObject.details.data.fields.number).to.equal('1');
+});
+
+});
+


### PR DESCRIPTION
Introductory ticket for good first issues.
Asserts that when publishing a smart contract which creates a struct, struct data is correct.