### PR TITLE
[1/2][client] Verify dependencies by default

### DIFF
--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -355,7 +355,8 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         build_config,
         gas: Some(gas_obj_id),
         gas_budget: 20_000,
-        verify_dependencies: true,
+        verify_dependencies: false,
+        skip_dependency_verification: false,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -520,7 +521,8 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
         build_config,
         gas: Some(gas_obj_id),
         gas_budget: 20_000,
-        verify_dependencies: true,
+        verify_dependencies: false,
+        skip_dependency_verification: false,
         with_unpublished_dependencies: false,
     }
     .execute(context)


### PR DESCRIPTION
`--verify-dependencies` has been available for some time without issue, enabling it by default with a flag to skip the feature.

The existing flag has been retained, and if it is used, the CLI will print a warning about its deprecation and subsequent removal in the next release.

## Breaking Changes

- `sui client publish` verifies dependencies by default, making `--verify-dependencies` a redundant flag, which will be removed.
- `--skip-dependency-verification` added as a new flag to turn off the now default behaviour.

## Test Plan

```
$ cargo nextest run
```