### PR TITLE
[2/2][client] Remove --verify-dependencies

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -134,10 +134,6 @@ pub enum SuiClientCommands {
         #[clap(long)]
         gas_budget: u64,
 
-        /// (Deprecated) This flag is deprecated, dependency verification is on by default.
-        #[clap(long)]
-        verify_dependencies: bool,
-
         /// Publish the package without checking whether compiling dependencies from source results
         /// in bytecode matching the dependencies found on-chain.
         #[clap(long)]
@@ -467,7 +463,6 @@ impl SuiClientCommands {
                 gas,
                 build_config,
                 gas_budget,
-                verify_dependencies,
                 skip_dependency_verification,
                 with_unpublished_dependencies,
             } => {
@@ -499,16 +494,6 @@ impl SuiClientCommands {
                 let client = context.get_client().await?;
                 let compiled_modules =
                     compiled_package.get_package_bytes(with_unpublished_dependencies);
-
-                if verify_dependencies {
-                    eprintln!(
-                        "{}",
-                        "Dependency verification is on by default. --verify-dependencies is \
-                         deprecated and will be removed in the next release."
-                            .bold()
-                            .yellow(),
-                    );
-                }
 
                 if !skip_dependency_verification {
                     BytecodeSourceVerifier::new(client.read_api(), false)

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -355,7 +355,6 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         build_config,
         gas: Some(gas_obj_id),
         gas_budget: 20_000,
-        verify_dependencies: false,
         skip_dependency_verification: false,
         with_unpublished_dependencies: false,
     }
@@ -521,7 +520,6 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
         build_config,
         gas: Some(gas_obj_id),
         gas_budget: 20_000,
-        verify_dependencies: false,
         skip_dependency_verification: false,
         with_unpublished_dependencies: false,
     }


### PR DESCRIPTION
Remove the `--verify-dependencies` flag, which was deprecated in the
previous release (see https://github.com/MystenLabs/sui/pull/7632).

## Breaking Changes

- `--verify-dependencies` flag for `sui client publish` is no longer
  accepted, after being deprecated for a release.

## Test Plan

```
$ cargo nextest run
```

## Stack

- #7632 