### PR TITLE
[RFC] Simplify checkpoint executor

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 pub struct CheckpointExecutorMetrics {
     pub last_executed_checkpoint: IntGauge,
     pub checkpoint_exec_errors: IntCounter,
-    pub checkpoint_exec_recv_channel_overflow: IntCounter,
     pub checkpoint_exec_epoch: IntGauge,
     pub checkpoint_transaction_count: Histogram,
 }
@@ -31,12 +30,6 @@ impl CheckpointExecutorMetrics {
                 registry
             )
             .unwrap(),
-            checkpoint_exec_recv_channel_overflow: register_int_counter_with_registry!(
-                "checkpoint_exec_recv_channel_overflow",
-                "Count of the number of times the recv channel from StateSync to CheckpointExecutor has been overflowed",
-                registry
-            )
-            .unwrap(),
             checkpoint_exec_epoch: register_int_gauge_with_registry!(
                 "current_local_epoch",
                 "Current epoch number in the checkpoint executor",
@@ -46,8 +39,8 @@ impl CheckpointExecutorMetrics {
             checkpoint_transaction_count: Histogram::new_in_registry(
                 "checkpoint_transaction_count",
                 "Number of transactions in the checkpoint",
-                registry
-            )
+                registry,
+            ),
         };
         Arc::new(this)
     }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -12,7 +12,7 @@ pub struct CheckpointExecutorMetrics {
     pub last_executed_checkpoint: IntGauge,
     pub checkpoint_exec_errors: IntCounter,
     pub checkpoint_exec_recv_channel_overflow: IntCounter,
-    pub current_local_epoch: IntGauge,
+    pub checkpoint_exec_epoch: IntGauge,
     pub checkpoint_transaction_count: Histogram,
 }
 
@@ -37,9 +37,9 @@ impl CheckpointExecutorMetrics {
                 registry
             )
             .unwrap(),
-            current_local_epoch: register_int_gauge_with_registry!(
+            checkpoint_exec_epoch: register_int_gauge_with_registry!(
                 "current_local_epoch",
-                "Current local epoch sequence number",
+                "Current epoch number in the checkpoint executor",
                 registry
             )
             .unwrap(),

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -161,10 +161,13 @@ pub async fn test_checkpoint_executor_cross_epoch() {
     .unwrap();
 
     // We should have synced up to epoch boundary
-    assert!(matches!(
-        checkpoint_store.get_highest_executed_checkpoint_seq_number().unwrap(),
-        Some(highest) if highest == (num_to_sync_per_epoch as u64),
-    ));
+    assert_eq!(
+        checkpoint_store
+            .get_highest_executed_checkpoint_seq_number()
+            .unwrap()
+            .unwrap(),
+        num_to_sync_per_epoch as u64,
+    );
 
     authority_state
         .reconfigure(second_committee.committee().clone())
@@ -181,10 +184,13 @@ pub async fn test_checkpoint_executor_cross_epoch() {
     .await
     .unwrap();
 
-    assert!(matches!(
-        checkpoint_store.get_highest_executed_checkpoint_seq_number().unwrap(),
-        Some(highest) if highest == (2 * num_to_sync_per_epoch as u64) + 1,
-    ));
+    assert_eq!(
+        checkpoint_store
+            .get_highest_executed_checkpoint_seq_number()
+            .unwrap()
+            .unwrap(),
+        2 * num_to_sync_per_epoch as u64 + 1,
+    );
 }
 
 /// Test that if we crash at end of epoch / during reconfig, we recover on startup

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -1,8 +1,7 @@
-extern crate core;
-
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 pub mod authority;
 pub mod authority_aggregator;
 pub mod authority_client;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -713,9 +713,15 @@ impl SuiNode {
         );
 
         loop {
-            let committee = checkpoint_executor
+            checkpoint_executor
                 .run_epoch(self.state.epoch_store().clone())
                 .await;
+            let committee = self
+                .state
+                .get_sui_system_state_object()
+                .unwrap()
+                .get_current_epoch_committee()
+                .committee;
             let next_epoch = committee.epoch();
 
             info!(

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -713,15 +713,9 @@ impl SuiNode {
         );
 
         loop {
-            checkpoint_executor
+            let committee = checkpoint_executor
                 .run_epoch(self.state.epoch_store().clone())
                 .await;
-            let committee = self
-                .state
-                .get_sui_system_state_object()
-                .unwrap()
-                .get_current_epoch_committee()
-                .committee;
             let next_epoch = committee.epoch();
 
             info!(


### PR DESCRIPTION
This PR does a few simplifications to the checkpoint executor:
1. We don't need `cold_start` as a member field of the executor. The logic of `run_epoch` should be always the same regardless of how/when we run it because it's always focusing on the current epoch specified by the epoch_store. Specifically, we always enter the schedule loop, and if we have executed the last checkpoint of the epoch, we terminate the loop and return the next epoch committee.
2. We don't need `highest_scheduled_seq_num` as a member field. Sepcifically, `highest_scheduled_seq_num` can be updated each time we finish scheduling a series of checkpoints, and passed around as a variable. There is no need for a global field member.
3. We don't need `latest_synced_checkpoint`. This is part of a larger simplification: a lot of the exiting code complexity comes from the desire to optimize db reads to get the latest synced checkpoint. The overhead of one read per checkpoint is negligible at the grand scheme. We don't need to rely on the channel between state_sync and checkpoint_executor to get the latest synced checkpoint. Instead we could use the channel purely as a notification channel, and when we wake up, we read from the db to get the latest synced checkpoint. Now, if we really really want to optimize this, a cleaner way would be that we read every synced checkpoint into memory, and schedule them as we go.

Let me know if this simplification makes sense.