### PR TITLE
[narwhal] tune connectivity parameters for primary & worker

### DIFF
--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -38,7 +38,7 @@ use sui_types::{
 use tokio::time::timeout;
 use tracing::{info, warn};
 
-const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(5);
+const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(10);
 /// The maximum gas per transaction.
 pub const MAX_GAS: u64 = 2_000;
 

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -38,7 +38,7 @@ use sui_types::{
 use tokio::time::timeout;
 use tracing::{info, warn};
 
-const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(15);
+const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(5);
 /// The maximum gas per transaction.
 pub const MAX_GAS: u64 = 2_000;
 

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -353,7 +353,7 @@ impl Primary {
             config.outbound_request_timeout_ms = Some(300_000);
             config.shutdown_idle_timeout_ms = Some(1_000);
             config.connectivity_check_interval_ms = Some(2_000);
-            config.connection_backoff_ms = Some(5_000);
+            config.connection_backoff_ms = Some(1_000);
             config.max_connection_backoff_ms = Some(20_000);
             config
         };

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -352,6 +352,8 @@ impl Primary {
             config.inbound_request_timeout_ms = Some(300_000);
             config.outbound_request_timeout_ms = Some(300_000);
             config.shutdown_idle_timeout_ms = Some(1_000);
+            config.connectivity_check_interval_ms = Some(2_000);
+            config.connection_backoff_ms = Some(5_000);
             config
         };
 

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -354,6 +354,7 @@ impl Primary {
             config.shutdown_idle_timeout_ms = Some(1_000);
             config.connectivity_check_interval_ms = Some(2_000);
             config.connection_backoff_ms = Some(5_000);
+            config.max_connection_backoff_ms = Some(20_000);
             config
         };
 

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -237,6 +237,7 @@ impl Worker {
             config.shutdown_idle_timeout_ms = Some(1_000);
             config.connectivity_check_interval_ms = Some(2_000);
             config.connection_backoff_ms = Some(5_000);
+            config.max_connection_backoff_ms = Some(20_000);
             config
         };
 

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -236,7 +236,7 @@ impl Worker {
             config.outbound_request_timeout_ms = Some(300_000);
             config.shutdown_idle_timeout_ms = Some(1_000);
             config.connectivity_check_interval_ms = Some(2_000);
-            config.connection_backoff_ms = Some(5_000);
+            config.connection_backoff_ms = Some(1_000);
             config.max_connection_backoff_ms = Some(20_000);
             config
         };

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -235,6 +235,8 @@ impl Worker {
             config.inbound_request_timeout_ms = Some(300_000);
             config.outbound_request_timeout_ms = Some(300_000);
             config.shutdown_idle_timeout_ms = Some(1_000);
+            config.connectivity_check_interval_ms = Some(2_000);
+            config.connection_backoff_ms = Some(5_000);
             config
         };
 


### PR DESCRIPTION
Reducing anemo connectivity properties to ensure that both primary & worker nodes will attempt to reconnect faster. 