### PR TITLE
indexer: add dedicated handler for move event

### DIFF
--- a/crates/sui-indexer/migrations/2023-01-24-204432_move_event/down.sql
+++ b/crates/sui-indexer/migrations/2023-01-24-204432_move_event/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE move_events;
+DROP TABLE move_event_logs;

--- a/crates/sui-indexer/migrations/2023-01-24-204432_move_event/up.sql
+++ b/crates/sui-indexer/migrations/2023-01-24-204432_move_event/up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE move_events (
+    id BIGSERIAL PRIMARY KEY,
+    transaction_digest VARCHAR(255),
+    event_sequence BIGINT NOT NULL,
+    event_time TIMESTAMP,
+    event_type VARCHAR NOT NULL,
+    event_content VARCHAR NOT NULL,
+    UNIQUE (transaction_digest, event_sequence)
+);
+
+
+CREATE INDEX move_events_transaction_digest ON move_events (transaction_digest);
+CREATE INDEX move_events_event_time ON move_events (event_time);
+
+CREATE TABLE move_event_logs (
+    id SERIAL PRIMARY KEY,
+    next_cursor_tx_dig TEXT,
+    next_cursor_event_seq BIGINT
+);
+
+INSERT INTO move_event_logs (id, next_cursor_tx_dig, next_cursor_event_seq) VALUES
+(1, NULL, NULL);

--- a/crates/sui-indexer/src/handlers/handler_orchestrator.rs
+++ b/crates/sui-indexer/src/handlers/handler_orchestrator.rs
@@ -15,6 +15,7 @@ use crate::handlers::checkpoint_handler::CheckpointHandler;
 use crate::handlers::event_handler::EventHandler;
 use crate::handlers::transaction_handler::TransactionHandler;
 
+use crate::handlers::move_event_handler::MoveEventHandler;
 use crate::handlers::object_event_handler::ObjectEventHandler;
 use crate::handlers::publish_event_handler::PublishEventHandler;
 const BACKOFF_MAX_INTERVAL_IN_SECS: u64 = 600;
@@ -62,6 +63,11 @@ impl HandlerOrchestrator {
             &self.prometheus_registry,
         );
         let txn_handler = TransactionHandler::new(
+            self.rpc_client.clone(),
+            self.pg_connection_pool.clone(),
+            &self.prometheus_registry,
+        );
+        let move_handler = MoveEventHandler::new(
             self.rpc_client.clone(),
             self.pg_connection_pool.clone(),
             &self.prometheus_registry,
@@ -197,12 +203,39 @@ impl HandlerOrchestrator {
                 );
             }
         });
+        let move_event_handle = tokio::task::spawn(async move {
+            let backoff_config = ExponentialBackoffBuilder::new()
+                .with_max_interval(std::time::Duration::from_secs(BACKOFF_MAX_INTERVAL_IN_SECS))
+                .build();
+            let move_event_res = retry(backoff_config, || async {
+                let move_event_handler_exec_res = move_handler.start().await;
+                if let Err(e) = move_event_handler_exec_res.clone() {
+                    move_handler
+                        .event_handler_metrics
+                        .total_move_event_handler_error
+                        .inc();
+                    warn!(
+                        "Indexer move event handler failed with error: {:?}, retrying...",
+                        e
+                    );
+                }
+                Ok(move_event_handler_exec_res?)
+            })
+            .await;
+            if let Err(e) = move_event_res {
+                error!(
+                    "Indexer move event handler failed after retrials with error: {:?}",
+                    e
+                );
+            }
+        });
         try_join_all(vec![
             txn_handle,
             event_handle,
             checkpoint_handle,
             object_event_handle,
             publish_event_handle,
+            move_event_handle,
         ])
         .await
         .expect("Handler orchestrator should not run into errors.");

--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -6,5 +6,6 @@ pub mod event_handler;
 pub mod handler_orchestrator;
 pub mod transaction_handler;
 // TODO: remove below after wave 2
+pub mod move_event_handler;
 pub mod object_event_handler;
 pub mod publish_event_handler;

--- a/crates/sui-indexer/src/handlers/move_event_handler.rs
+++ b/crates/sui-indexer/src/handlers/move_event_handler.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::Registry;
+use std::sync::Arc;
+use sui_json_rpc_types::EventPage;
+use sui_sdk::SuiClient;
+use sui_types::event::{EventID, EventType};
+use sui_types::query::EventQuery;
+use tracing::info;
+
+use sui_indexer::errors::IndexerError;
+use sui_indexer::metrics::IndexerMoveEventHandlerMetrics;
+use sui_indexer::models::move_event_logs::{commit_event_log, read_event_log};
+use sui_indexer::models::move_events::commit_events;
+use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
+
+const EVENT_PAGE_SIZE: usize = 100;
+
+pub struct MoveEventHandler {
+    rpc_client: SuiClient,
+    pg_connection_pool: Arc<PgConnectionPool>,
+    pub event_handler_metrics: IndexerMoveEventHandlerMetrics,
+}
+
+impl MoveEventHandler {
+    pub fn new(
+        rpc_client: SuiClient,
+        pg_connection_pool: Arc<PgConnectionPool>,
+        prometheus_registry: &Registry,
+    ) -> Self {
+        let event_handler_metrics = IndexerMoveEventHandlerMetrics::new(prometheus_registry);
+        Self {
+            rpc_client,
+            pg_connection_pool,
+            event_handler_metrics,
+        }
+    }
+
+    pub async fn start(&self) -> Result<(), IndexerError> {
+        info!("Indexer move event handler started...");
+        let mut pg_pool_conn = get_pg_pool_connection(self.pg_connection_pool.clone())?;
+
+        let mut next_cursor = None;
+        let event_log = read_event_log(&mut pg_pool_conn)?;
+        let (tx_dig_opt, event_seq_opt) = (
+            event_log.next_cursor_tx_dig,
+            event_log.next_cursor_event_seq,
+        );
+        if let (Some(tx_dig), Some(event_seq)) = (tx_dig_opt, event_seq_opt) {
+            let tx_digest = tx_dig.parse().map_err(|e| {
+                IndexerError::TransactionDigestParsingError(format!(
+                    "Failed parsing transaction digest {:?} with error: {:?}",
+                    tx_dig, e
+                ))
+            })?;
+            next_cursor = Some(EventID {
+                tx_digest,
+                event_seq,
+            });
+        }
+
+        loop {
+            let event_page =
+                fetch_move_event_page(self.rpc_client.clone(), next_cursor.clone()).await?;
+            let event_count = event_page.data.len();
+            self.event_handler_metrics
+                .total_move_events_received
+                .inc_by(event_count as u64);
+            info!(
+                "Received {} move events with next cursor {:?}",
+                event_count, next_cursor
+            );
+
+            commit_events(&mut pg_pool_conn, event_page.clone())?;
+            if let Some(next_cursor_val) = event_page.next_cursor.clone() {
+                commit_event_log(
+                    &mut pg_pool_conn,
+                    Some(next_cursor_val.tx_digest.base58_encode()),
+                    Some(next_cursor_val.event_seq),
+                )?;
+                self.event_handler_metrics
+                    .total_move_events_processed
+                    .inc_by(event_count as u64);
+                next_cursor = Some(next_cursor_val);
+            }
+        }
+    }
+}
+
+async fn fetch_move_event_page(
+    rpc_client: SuiClient,
+    next_cursor: Option<EventID>,
+) -> Result<EventPage, IndexerError> {
+    rpc_client
+        .event_api()
+        .get_events(
+            EventQuery::EventType(EventType::MoveEvent),
+            next_cursor.clone(),
+            Some(EVENT_PAGE_SIZE),
+            false,
+        )
+        .await
+        .map_err(|e| {
+            IndexerError::FullNodeReadingError(format!(
+                "Failed reading Move event page with cursor {:?} and error: {:?}",
+                next_cursor, e
+            ))
+        })
+}

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -181,6 +181,37 @@ impl IndexerPublishEventHandlerMetrics {
     }
 }
 
+pub struct IndexerMoveEventHandlerMetrics {
+    pub total_move_events_received: IntCounter,
+    pub total_move_events_processed: IntCounter,
+    pub total_move_event_handler_error: IntCounter,
+}
+
+impl IndexerMoveEventHandlerMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            total_move_events_received: register_int_counter_with_registry!(
+                "total_move_events_received",
+                "Total number of move events received",
+                registry,
+            )
+            .unwrap(),
+            total_move_events_processed: register_int_counter_with_registry!(
+                "total_move_events_processed",
+                "Total number of move events processed",
+                registry,
+            )
+            .unwrap(),
+            total_move_event_handler_error: register_int_counter_with_registry!(
+                "total_move_event_handler_error",
+                "Total number of move event handler error",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
 pub struct IndexerCheckpointHandlerMetrics {
     pub total_checkpoint_requested: IntCounter,
     pub total_checkpoint_received: IntCounter,

--- a/crates/sui-indexer/src/models/mod.rs
+++ b/crates/sui-indexer/src/models/mod.rs
@@ -14,6 +14,8 @@ pub mod packages;
 pub mod transaction_logs;
 pub mod transactions;
 // TODO: remove below after wave 2
+pub mod move_event_logs;
+pub mod move_events;
 pub mod object_event_logs;
 pub mod object_events;
 pub mod publish_event_logs;

--- a/crates/sui-indexer/src/models/move_event_logs.rs
+++ b/crates/sui-indexer/src/models/move_event_logs.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::move_event_logs;
+use crate::schema::move_event_logs::dsl::*;
+use crate::PgPoolConnection;
+
+use diesel::prelude::*;
+use diesel::result::Error;
+
+#[derive(Queryable, Debug, Identifiable)]
+#[diesel(primary_key(id))]
+pub struct MoveEventLog {
+    pub id: i32,
+    pub next_cursor_tx_dig: Option<String>,
+    pub next_cursor_event_seq: Option<i64>,
+}
+
+pub fn read_event_log(pg_pool_conn: &mut PgPoolConnection) -> Result<MoveEventLog, IndexerError> {
+    let event_log_read_result: Result<MoveEventLog, Error> = pg_pool_conn
+        .build_transaction()
+        .read_only()
+        .run::<_, Error, _>(|conn| move_event_logs.limit(1).first::<MoveEventLog>(conn));
+
+    event_log_read_result.map_err(|e| {
+        IndexerError::PostgresReadError(format!(
+            "Failed reading Move event log in PostgresDB with error {:?}",
+            e
+        ))
+    })
+}
+
+pub fn commit_event_log(
+    pg_pool_conn: &mut PgPoolConnection,
+    tx_digest: Option<String>,
+    event_seq: Option<i64>,
+) -> Result<usize, IndexerError> {
+    let event_log_commit_result: Result<usize, Error> = pg_pool_conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|conn| {
+            diesel::update(move_event_logs::table)
+                .set((
+                    next_cursor_tx_dig.eq(tx_digest.clone()),
+                    next_cursor_event_seq.eq(event_seq),
+                ))
+                .execute(conn)
+        });
+
+    event_log_commit_result.map_err(|e| IndexerError::PostgresWriteError(format!(
+        "Failed updating Move event log in PostgresDB with tx seq {:?}, event seq {:?} and error {:?}",
+        tx_digest.clone(), event_seq, e
+    )))
+}

--- a/crates/sui-indexer/src/models/object_events.rs
+++ b/crates/sui-indexer/src/models/object_events.rs
@@ -47,7 +47,7 @@ fn event_to_new_object_event(e: SuiEventEnvelope) -> Result<NewObjectEvent, Inde
     })?;
 
     Ok(NewObjectEvent {
-        transaction_digest: format!("{:?}", e.tx_digest),
+        transaction_digest: e.tx_digest.base58_encode(),
         event_sequence: e.id.event_seq,
         event_time: Some(timestamp),
         event_type: e.event.get_event_type(),

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -61,6 +61,25 @@ diesel::table! {
 }
 
 diesel::table! {
+    move_event_logs (id) {
+        id -> Int4,
+        next_cursor_tx_dig -> Nullable<Text>,
+        next_cursor_event_seq -> Nullable<Int8>,
+    }
+}
+
+diesel::table! {
+    move_events (id) {
+        id -> Int8,
+        transaction_digest -> Nullable<Varchar>,
+        event_sequence -> Int8,
+        event_time -> Nullable<Timestamp>,
+        event_type -> Varchar,
+        event_content -> Varchar,
+    }
+}
+
+diesel::table! {
     object_event_logs (id) {
         id -> Int4,
         next_cursor_tx_dig -> Nullable<Text>,
@@ -174,6 +193,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     checkpoints,
     error_logs,
     events,
+    move_event_logs,
+    move_events,
     object_event_logs,
     object_events,
     object_logs,


### PR DESCRIPTION
tested with private testnet, restarted indexer and made sure that move_events table can be populated as expected