### PR TITLE
[Rust SDK] - introduce SuiClientBuilder for setting client config parameters

### DIFF
--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -11,7 +11,7 @@ use sui_core::{
     quorum_driver::{reconfig_observer::ReconfigObserver, QuorumDriver},
     safe_client::SafeClientMetricsBase,
 };
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SuiClientBuilder};
 use sui_types::committee::Committee;
 use tracing::{debug, error, trace};
 
@@ -36,7 +36,8 @@ impl FullNodeReconfigObserver {
         auth_agg_metrics: AuthAggMetrics,
     ) -> Self {
         Self {
-            fullnode_client: SuiClient::new(fullnode_rpc_url, None, None)
+            fullnode_client: SuiClientBuilder::default()
+                .build(fullnode_rpc_url)
                 .await
                 .unwrap_or_else(|e| {
                     panic!(

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -16,7 +16,7 @@ use sui_core::{
     },
 };
 use sui_json_rpc_types::{SuiCertifiedTransaction, SuiObjectRead, SuiTransactionEffects};
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SuiClientBuilder};
 use sui_types::base_types::SuiAddress;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::{
@@ -268,7 +268,7 @@ pub struct FullNodeProxy {
 impl FullNodeProxy {
     pub async fn from_url(http_url: &str) -> Result<Self, anyhow::Error> {
         // Each request times out after 60s (default value)
-        let sui_client = SuiClient::new(http_url, None, None).await?;
+        let sui_client = SuiClientBuilder::default().build(http_url).await?;
 
         let resp = sui_client.read_api().get_committee_info(None).await?;
         let epoch = resp.epoch;

--- a/crates/sui-cluster-test/src/wallet_client.rs
+++ b/crates/sui-cluster-test/src/wallet_client.rs
@@ -6,7 +6,7 @@ use crate::cluster::new_wallet_context_from_cluster;
 use super::Cluster;
 use sui::client_commands::WalletContext;
 use sui_keys::keystore::AccountKeystore;
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SuiClientBuilder};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{KeypairTraits, Signature};
 use sui_types::intent::Intent;
@@ -30,7 +30,7 @@ impl WalletClient {
 
         let rpc_url = String::from(cluster.fullnode_url());
         info!("Use fullnode rpc: {}", &rpc_url);
-        let fullnode_client = SuiClient::new(&rpc_url, None, None).await.unwrap();
+        let fullnode_client = SuiClientBuilder::default().build(rpc_url).await.unwrap();
 
         Self {
             wallet_context,

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SuiClientBuilder};
 
 use backoff::retry;
 use backoff::ExponentialBackoff;
@@ -24,7 +24,8 @@ use errors::IndexerError;
 
 pub async fn new_rpc_client(http_url: String) -> Result<SuiClient, IndexerError> {
     info!("Getting new RPC client...");
-    SuiClient::new(http_url.as_str(), None, None)
+    SuiClientBuilder::default()
+        .build(http_url)
         .await
         .map_err(|e| {
             warn!("Failed to get new RPC client with error: {:?}", e);

--- a/crates/sui-rosetta/src/main.rs
+++ b/crates/sui-rosetta/src/main.rs
@@ -20,7 +20,7 @@ use sui_config::{sui_config_dir, Config, NodeConfig, SUI_FULLNODE_CONFIG, SUI_KE
 use sui_node::{metrics, SuiNode};
 use sui_rosetta::types::{CurveType, PrefundedAccount, SuiEnv};
 use sui_rosetta::{RosettaOfflineServer, RosettaOnlineServer, SUI};
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SuiClientBuilder};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{EncodeDecodeBase64, KeypairTraits, SuiKeyPair, ToFromBytes};
 
@@ -175,7 +175,11 @@ impl RosettaServerCommand {
 
 async fn wait_for_sui_client(rpc_address: String) -> SuiClient {
     loop {
-        match SuiClient::new(&rpc_address, None, None).await {
+        match SuiClientBuilder::default()
+            .max_concurrent_requests(usize::MAX)
+            .build(&rpc_address)
+            .await
+        {
             Ok(client) => return client,
             Err(e) => {
                 warn!("Error connecting to Sui RPC server [{rpc_address}]: {e}, retrying in 5 seconds.");

--- a/crates/sui-sdk/examples/event_subscription.rs
+++ b/crates/sui-sdk/examples/event_subscription.rs
@@ -3,11 +3,14 @@
 
 use futures::StreamExt;
 use sui_sdk::rpc_types::SuiEventFilter;
-use sui_sdk::SuiClient;
+use sui_sdk::SuiClientBuilder;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new("http://127.0.0.1:5001", Some("ws://127.0.0.1:9001"), None).await?;
+    let sui = SuiClientBuilder::default()
+        .ws_url("ws://127.0.0.1:9001")
+        .build("http://127.0.0.1:5001")
+        .await?;
     let mut subscribe_all = sui
         .event_api()
         .subscribe_event(SuiEventFilter::All(vec![]))

--- a/crates/sui-sdk/examples/get_owned_objects.rs
+++ b/crates/sui-sdk/examples/get_owned_objects.rs
@@ -3,11 +3,13 @@
 
 use std::str::FromStr;
 use sui_sdk::types::base_types::SuiAddress;
-use sui_sdk::SuiClient;
+use sui_sdk::SuiClientBuilder;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", None, None).await?;
+    let sui = SuiClientBuilder::default()
+        .build("https://fullnode.devnet.sui.io:443")
+        .await?;
     let address = SuiAddress::from_str("0xec11cad080d0496a53bafcea629fcbcfff2a9866")?;
     let objects = sui.read_api().get_objects_owned_by_address(address).await?;
     println!("{:?}", objects);

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -22,7 +22,7 @@ use sui_sdk::{
         id::UID,
         messages::Transaction,
     },
-    SuiClient,
+    SuiClient, SuiClientBuilder,
 };
 use sui_types::intent::Intent;
 use sui_types::messages::ExecuteTransactionRequestType;
@@ -35,7 +35,9 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let game = TicTacToe {
         game_package_id: opts.game_package_id,
-        client: SuiClient::new(&opts.rpc_server_url, None, None).await?,
+        client: SuiClientBuilder::default()
+            .build(opts.rpc_server_url)
+            .await?,
         keystore,
     };
 

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -8,14 +8,16 @@ use sui_sdk::{
         base_types::{ObjectID, SuiAddress},
         messages::Transaction,
     },
-    SuiClient,
+    SuiClientBuilder,
 };
 use sui_types::intent::Intent;
 use sui_types::messages::ExecuteTransactionRequestType;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", None, None).await?;
+    let sui = SuiClientBuilder::default()
+        .build("https://fullnode.devnet.sui.io:443")
+        .await?;
     // Load keystore from ~/.sui/sui_config/sui.keystore
     let keystore_path = match dirs::home_dir() {
         Some(v) => v.join(".sui").join("sui_config").join("sui.keystore"),

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use jsonrpsee::core::client::ClientT;
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::http_client::{HeaderMap, HeaderValue, HttpClient, HttpClientBuilder};
 use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 
@@ -40,63 +40,85 @@ pub struct TransactionExecutionResult {
     pub parsed_data: Option<SuiParsedTransactionResponse>,
 }
 
-#[derive(Clone)]
-pub struct SuiClient {
-    api: Arc<RpcClient>,
-    transaction_builder: TransactionBuilder<Normal>,
-    read_api: Arc<ReadApi>,
-    coin_read_api: CoinReadApi,
-    event_api: EventApi,
-    quorum_driver: QuorumDriver,
-    governance_api: GovernanceApi,
+pub struct SuiClientBuilder {
+    request_timeout: Duration,
+    max_concurrent_requests: usize,
+    ws_url: Option<String>,
 }
 
-pub(crate) struct RpcClient {
-    http: HttpClient,
-    ws: Option<WsClient>,
-    info: ServerInfo,
-}
-
-impl Debug for RpcClient {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "RPC client. Http: {:?}, Websocket: {:?}",
-            self.http, self.ws
-        )
+impl Default for SuiClientBuilder {
+    fn default() -> Self {
+        Self {
+            request_timeout: Duration::from_secs(60),
+            max_concurrent_requests: 256,
+            ws_url: None,
+        }
     }
 }
 
-struct ServerInfo {
-    rpc_methods: Vec<String>,
-    subscriptions: Vec<String>,
-    version: String,
-}
+impl SuiClientBuilder {
+    pub fn request_timeout(mut self, request_timeout: Duration) -> Self {
+        self.request_timeout = request_timeout;
+        self
+    }
 
-impl RpcClient {
-    pub async fn new(
-        http: &str,
-        ws: Option<&str>,
-        request_timeout: Option<Duration>,
-    ) -> Result<Self, Error> {
-        let mut http_builder = HttpClientBuilder::default();
-        if let Some(request_timeout) = request_timeout {
-            http_builder = http_builder.request_timeout(request_timeout);
-        }
-        let http = http_builder.build(http)?;
+    pub fn max_concurrent_requests(mut self, max_concurrent_requests: usize) -> Self {
+        self.max_concurrent_requests = max_concurrent_requests;
+        self
+    }
 
-        let ws = if let Some(url) = ws {
-            let mut ws_builder = WsClientBuilder::default();
-            if let Some(request_timeout) = request_timeout {
-                ws_builder = ws_builder.request_timeout(request_timeout);
-            }
-            let ws = ws_builder.build(url).await?;
-            Some(ws)
+    pub fn ws_url(mut self, url: impl AsRef<str>) -> Self {
+        self.ws_url = Some(url.as_ref().to_string());
+        self
+    }
+
+    pub async fn build(self, http: impl AsRef<str>) -> SuiRpcResult<SuiClient> {
+        let client_version = env!("CARGO_PKG_VERSION");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "client_api_version",
+            HeaderValue::from_static(client_version),
+        );
+        headers.insert("client_type", HeaderValue::from_static("rust_sdk"));
+
+        let ws = if let Some(url) = self.ws_url {
+            Some(
+                WsClientBuilder::default()
+                    .set_headers(headers.clone())
+                    .request_timeout(self.request_timeout)
+                    .build(url)
+                    .await?,
+            )
         } else {
             None
         };
+
+        let http = HttpClientBuilder::default()
+            .set_headers(headers.clone())
+            .request_timeout(self.request_timeout)
+            .max_concurrent_requests(self.max_concurrent_requests)
+            .build(http)?;
+
         let info = Self::get_server_info(&http, &ws).await?;
-        Ok(Self { http, ws, info })
+
+        let rpc = RpcClient { http, ws, info };
+        let api = Arc::new(rpc);
+        let read_api = Arc::new(ReadApi::new(api.clone()));
+        let quorum_driver = QuorumDriver::new(api.clone());
+        let event_api = EventApi::new(api.clone());
+        let transaction_builder = TransactionBuilder::new(read_api.clone());
+        let coin_read_api = CoinReadApi::new(api.clone());
+        let governance_api = GovernanceApi::new(api.clone());
+
+        Ok(SuiClient {
+            api,
+            transaction_builder,
+            read_api,
+            coin_read_api,
+            event_api,
+            quorum_driver,
+            governance_api,
+        })
     }
 
     async fn get_server_info(
@@ -143,30 +165,54 @@ impl RpcClient {
     }
 }
 
+#[derive(Clone)]
+pub struct SuiClient {
+    api: Arc<RpcClient>,
+    transaction_builder: TransactionBuilder<Normal>,
+    read_api: Arc<ReadApi>,
+    coin_read_api: CoinReadApi,
+    event_api: EventApi,
+    quorum_driver: QuorumDriver,
+    governance_api: GovernanceApi,
+}
+
+pub(crate) struct RpcClient {
+    http: HttpClient,
+    ws: Option<WsClient>,
+    info: ServerInfo,
+}
+
+impl Debug for RpcClient {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "RPC client. Http: {:?}, Websocket: {:?}",
+            self.http, self.ws
+        )
+    }
+}
+
+struct ServerInfo {
+    rpc_methods: Vec<String>,
+    subscriptions: Vec<String>,
+    version: String,
+}
+
 impl SuiClient {
+    #[deprecated(since = "0.23.0", note = "Please use `SuiClientBuilder` instead.")]
     pub async fn new(
         http_url: &str,
         ws_url: Option<&str>,
         request_timeout: Option<Duration>,
     ) -> Result<Self, Error> {
-        let rpc = RpcClient::new(http_url, ws_url, request_timeout).await?;
-        let api = Arc::new(rpc);
-        let read_api = Arc::new(ReadApi::new(api.clone()));
-        let quorum_driver = QuorumDriver::new(api.clone());
-        let event_api = EventApi::new(api.clone());
-        let transaction_builder = TransactionBuilder::new(read_api.clone());
-        let coin_read_api = CoinReadApi::new(api.clone());
-        let governance_api = GovernanceApi::new(api.clone());
-
-        Ok(SuiClient {
-            api,
-            transaction_builder,
-            read_api,
-            coin_read_api,
-            event_api,
-            quorum_driver,
-            governance_api,
-        })
+        let mut builder = SuiClientBuilder::default();
+        if let Some(ws_url) = ws_url {
+            builder = builder.ws_url(ws_url);
+        }
+        if let Some(request_timeout) = request_timeout {
+            builder = builder.request_timeout(request_timeout);
+        }
+        builder.build(http_url).await
     }
 
     pub fn available_rpc_methods(&self) -> &Vec<String> {

--- a/crates/sui-sdk/tests/stream_tests.rs
+++ b/crates/sui-sdk/tests/stream_tests.rs
@@ -4,7 +4,7 @@
 use futures::StreamExt;
 use std::future;
 use sui::client_commands::SuiClientCommands;
-use sui_sdk::{SuiClient, SUI_COIN_TYPE};
+use sui_sdk::{SuiClientBuilder, SUI_COIN_TYPE};
 use sui_types::event::EventType;
 use sui_types::query::{EventQuery, TransactionQuery};
 use test_utils::network::TestClusterBuilder;
@@ -14,7 +14,7 @@ async fn test_transactions_stream() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await?;
     let rpc_url = test_cluster.rpc_url();
 
-    let client = SuiClient::new(rpc_url, None, None).await?;
+    let client = SuiClientBuilder::default().build(rpc_url).await?;
     let txs = client
         .read_api()
         .get_transactions_stream(TransactionQuery::All, None, true)
@@ -52,7 +52,7 @@ async fn test_events_stream() -> Result<(), anyhow::Error> {
         .await?;
     let rpc_url = test_cluster.rpc_url();
 
-    let client = SuiClient::new(rpc_url, None, None).await?;
+    let client = SuiClientBuilder::default().build(rpc_url).await?;
     let events = client
         .event_api()
         .get_events_stream(EventQuery::All, None, true)
@@ -125,7 +125,7 @@ async fn test_coins_stream() -> Result<(), anyhow::Error> {
     let address = test_cluster.get_address_0();
     let rpc_url = test_cluster.rpc_url();
 
-    let client = SuiClient::new(rpc_url, None, None).await?;
+    let client = SuiClientBuilder::default().build(rpc_url).await?;
     let coins = client
         .coin_read_api()
         .get_coins_stream(address, Some(SUI_COIN_TYPE.to_string()))

--- a/crates/sui/src/config/mod.rs
+++ b/crates/sui/src/config/mod.rs
@@ -14,7 +14,7 @@ pub use sui_config::PersistedConfig;
 use sui_config::SUI_DEV_NET_URL;
 use sui_keys::keystore::AccountKeystore;
 use sui_keys::keystore::Keystore;
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SuiClientBuilder};
 use sui_types::base_types::*;
 
 #[serde_as]
@@ -76,7 +76,14 @@ impl SuiEnv {
         &self,
         request_timeout: Option<std::time::Duration>,
     ) -> Result<SuiClient, anyhow::Error> {
-        Ok(SuiClient::new(&self.rpc, self.ws.as_deref(), request_timeout).await?)
+        let mut builder = SuiClientBuilder::default();
+        if let Some(request_timeout) = request_timeout {
+            builder = builder.request_timeout(request_timeout);
+        }
+        if let Some(ws_url) = &self.ws {
+            builder = builder.ws_url(ws_url);
+        }
+        Ok(builder.build(&self.rpc).await?)
     }
 
     pub fn devnet() -> Self {

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -23,7 +23,7 @@ use sui_config::{FullnodeConfigBuilder, NodeConfig, PersistedConfig, SUI_KEYSTOR
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_node::SuiNode;
 use sui_node::SuiNodeHandle;
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SuiClientBuilder};
 use sui_swarm::memory::{Swarm, SwarmBuilder};
 use sui_types::base_types::{AuthorityName, SuiAddress};
 use sui_types::committee::EpochId;
@@ -321,7 +321,10 @@ pub async fn start_fullnode_from_config(
 
     let ws_url = format!("ws://{}", config.json_rpc_address);
     let ws_client = WsClientBuilder::default().build(&ws_url).await?;
-    let sui_client = SuiClient::new(&rpc_url, Some(&ws_url), None).await?;
+    let sui_client = SuiClientBuilder::default()
+        .ws_url(&ws_url)
+        .build(&rpc_url)
+        .await?;
 
     Ok(FullNodeHandle {
         sui_node,


### PR DESCRIPTION
Summary:

I am exposing the `max_concurrent_requests` http client config parameter in this PR because Sui-rosetta is reaching the limit during integration testing (default 256), instead of adding more and more params to the `new` methods, I have added the `SuiClientBuilder` to enable setting various config parameters. 

I have also added client api version and client type to the request headers, these can be use for metrics and API versioning in the future.