### PR TITLE
[explorer] Stake button on validator page

### DIFF
--- a/apps/explorer/src/components/validator/StakeButton.tsx
+++ b/apps/explorer/src/components/validator/StakeButton.tsx
@@ -1,0 +1,98 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useFeature } from '@growthbook/growthbook-react';
+import {
+    ConnectButton,
+    useWalletKit,
+    type StandardWalletAdapter,
+    type WalletWithFeatures,
+} from '@mysten/wallet-kit';
+import { useParams } from 'react-router-dom';
+
+import { Button } from '~/ui/Button';
+import { GROWTHBOOK_FEATURES } from '~/utils/growthbook';
+
+// This is a custom feature supported by the Sui Wallet:
+type StakeInput = { validatorAddress: string };
+type SuiWalletStakeFeature = {
+    'suiWallet:stake': {
+        version: '0.0.1';
+        stake: (input: StakeInput) => Promise<void>;
+    };
+};
+
+type StakeWallet = WalletWithFeatures<Partial<SuiWalletStakeFeature>>;
+
+export function StakeButton() {
+    const stakeButtonEnabled = useFeature(
+        GROWTHBOOK_FEATURES.VALIDATOR_PAGE_STAKING
+    ).on;
+    const { id } = useParams();
+    const { wallets, currentWallet, connect } = useWalletKit();
+
+    if (!stakeButtonEnabled) return null;
+
+    const stakeSupportedWallets = wallets.filter((wallet) => {
+        if (!('wallet' in wallet)) {
+            return false;
+        }
+
+        const standardWallet = wallet.wallet as StakeWallet;
+        return 'suiWallet:stake' in standardWallet.features;
+    });
+
+    const currentWalletSupportsStake =
+        currentWallet &&
+        !!stakeSupportedWallets.find(({ name }) => currentWallet.name === name);
+
+    if (!stakeSupportedWallets.length) {
+        return (
+            <Button
+                size="lg"
+                variant="outline"
+                href="https://chrome.google.com/webstore/detail/sui-wallet/opcgpfmipidbgpenhmajoajpbobppdil"
+            >
+                Install Sui Wallet to stake SUI
+            </Button>
+        );
+    }
+
+    if (!currentWallet) {
+        return (
+            <ConnectButton
+                className="!border !border-solid !border-steel-dark !bg-transparent !px-4 !py-3 !text-body !font-semibold !text-steel-dark !shadow-none"
+                connectText="Stake SUI"
+            />
+        );
+    }
+
+    if (!currentWalletSupportsStake) {
+        return (
+            <Button
+                size="lg"
+                variant="outline"
+                onClick={() => {
+                    // Always just assume we should connect to the first stake supported wallet for now:
+                    connect(stakeSupportedWallets[0].name);
+                }}
+            >
+                Stake SUI on a supported wallet
+            </Button>
+        );
+    }
+
+    return (
+        <Button
+            size="lg"
+            onClick={() => {
+                (
+                    (currentWallet as StandardWalletAdapter)
+                        .wallet as StakeWallet
+                ).features['suiWallet:stake']?.stake({ validatorAddress: id! });
+            }}
+        >
+            Stake SUI
+        </Button>
+    );
+}

--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -4,6 +4,8 @@
 import { Base64DataBuffer } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
+import { StakeButton } from './StakeButton';
+
 import type { ActiveValidator } from '~/pages/validator/ValidatorDataTypes';
 
 import { DescriptionList, DescriptionItem } from '~/ui/DescriptionList';
@@ -12,27 +14,43 @@ import { ImageIcon } from '~/ui/ImageIcon';
 import { AddressLink } from '~/ui/InternalLink';
 import { Text } from '~/ui/Text';
 import { getName } from '~/utils/getName';
+import { Link } from '~/ui/Link';
+import { ArrowUpRight12 } from '@mysten/icons';
 
 type ValidatorMetaProps = {
     validatorData: ActiveValidator;
 };
 
 export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
-    const validatorName = useMemo(() => {
-        return getName(validatorData.fields.metadata.fields.name);
-    }, [validatorData]);
+    const metadata = validatorData.fields.metadata.fields;
 
-    const logo = null;
+    const validatorName = useMemo(() => {
+        return getName(metadata.name);
+    }, [metadata]);
 
     const validatorPublicKey = useMemo(
         () =>
             new Base64DataBuffer(
-                new Uint8Array(
-                    validatorData.fields.metadata.fields.pubkey_bytes
-                )
+                new Uint8Array(metadata.pubkey_bytes)
             ).toString(),
-        [validatorData]
+        [metadata]
     );
+
+    // NOTE: We only support the string-encoded metadata fields, which will become the only encoding soon:
+    const logo =
+        !metadata.image_url || typeof metadata.image_url !== 'string'
+            ? null
+            : metadata.image_url;
+
+    const description =
+        !metadata.description || typeof metadata.description !== 'string'
+            ? null
+            : metadata.description;
+
+    const projectUrl =
+        !metadata.project_url || typeof metadata.project_url !== 'string'
+            ? null
+            : metadata.project_url;
 
     return (
         <>
@@ -47,13 +65,27 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
                     <Heading as="h1" variant="heading2/bold" color="gray-90">
                         {validatorName}
                     </Heading>
+                    {projectUrl && (
+                        <a
+                            href={projectUrl}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                            className="mt-2.5 inline-flex items-center gap-1.5 text-body font-medium text-sui-dark no-underline"
+                        >
+                            {projectUrl}
+                            <ArrowUpRight12 className="text-steel" />
+                        </a>
+                    )}
+                    <div className="mt-3.5">
+                        <StakeButton />
+                    </div>
                 </div>
             </div>
             <div className="basis-full break-all md:basis-2/3">
                 <DescriptionList>
                     <DescriptionItem title="Description">
                         <Text variant="p1/medium" color="gray-90">
-                            --
+                            {description || '--'}
                         </Text>
                     </DescriptionItem>
                     <DescriptionItem title="Location">

--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ArrowUpRight12 } from '@mysten/icons';
 import { Base64DataBuffer } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
@@ -14,8 +15,6 @@ import { ImageIcon } from '~/ui/ImageIcon';
 import { AddressLink } from '~/ui/InternalLink';
 import { Text } from '~/ui/Text';
 import { getName } from '~/utils/getName';
-import { Link } from '~/ui/Link';
-import { ArrowUpRight12 } from '@mysten/icons';
 
 type ValidatorMetaProps = {
     validatorData: ActiveValidator;

--- a/apps/explorer/src/pages/validator/ValidatorDataTypes.ts
+++ b/apps/explorer/src/pages/validator/ValidatorDataTypes.ts
@@ -143,9 +143,9 @@ export interface NextEpochValidator {
 export interface NextEpochValidatorFields {
     consensus_address: number[];
     name: number[] | string;
-    image_url: number[] | string;
-    description: number[] | string;
-    project_url: number[] | string;
+    image_url?: number[] | string;
+    description?: number[] | string;
+    project_url?: number[] | string;
     net_address: number[];
     network_pubkey_bytes: number[];
     next_epoch_commission_rate: string;

--- a/apps/explorer/src/pages/validator/ValidatorDataTypes.ts
+++ b/apps/explorer/src/pages/validator/ValidatorDataTypes.ts
@@ -142,7 +142,10 @@ export interface NextEpochValidator {
 
 export interface NextEpochValidatorFields {
     consensus_address: number[];
-    name: number[];
+    name: number[] | string;
+    image_url: number[] | string;
+    description: number[] | string;
+    project_url: number[] | string;
     net_address: number[];
     network_pubkey_bytes: number[];
     next_epoch_commission_rate: string;

--- a/apps/explorer/src/utils/growthbook.ts
+++ b/apps/explorer/src/utils/growthbook.ts
@@ -36,4 +36,5 @@ export async function loadFeatures() {
 
 export enum GROWTHBOOK_FEATURES {
     USE_TEST_NET_ENDPOINT = 'testnet-selection',
+    VALIDATOR_PAGE_STAKING = 'validator-page-staking',
 }

--- a/apps/wallet/src/ui/app/index.tsx
+++ b/apps/wallet/src/ui/app/index.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFeature } from '@growthbook/growthbook-react';
 import { useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
@@ -31,7 +30,6 @@ import SelectPage from '_pages/initialize/select';
 import SiteConnectPage from '_pages/site-connect';
 import WelcomePage from '_pages/welcome';
 import { setNavVisibility } from '_redux/slices/app';
-import { FEATURES } from '_src/shared/experimentation/features';
 
 const HIDDEN_MENU_PATHS = [
     '/nft-details',
@@ -59,8 +57,6 @@ const App = () => {
         dispatch(setNavVisibility(menuVisible));
     }, [location, dispatch]);
 
-    const stakingEnabled = useFeature(FEATURES.STAKING_ENABLED).on;
-
     return (
         <Routes>
             <Route path="/*" element={<HomePage />}>
@@ -75,9 +71,7 @@ const App = () => {
                 <Route path="transactions" element={<TransactionsPage />} />
                 <Route path="send" element={<TransferCoinPage />} />
                 <Route path="send/select" element={<CoinsSelectorPage />} />
-                {stakingEnabled ? (
-                    <Route path="stake/*" element={<Staking />} />
-                ) : null}
+                <Route path="stake/*" element={<Staking />} />
                 <Route
                     path="tx/:txDigest"
                     element={<TransactionDetailsPage />}

--- a/apps/wallet/src/ui/app/staking/home/index.tsx
+++ b/apps/wallet/src/ui/app/staking/home/index.tsx
@@ -1,12 +1,39 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Route, Routes } from 'react-router-dom';
+import { useFeature } from '@growthbook/growthbook-react';
+import { useEffect } from 'react';
+import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
 
 import { DelegationDetail } from '../delegation-detail';
 import StakePage from '../stake';
 import { Validators } from '../validators';
+import { FEATURES } from '_src/shared/experimentation/features';
+
 export function Staking() {
+    const navigate = useNavigate();
+    const { source, on } = useFeature(FEATURES.STAKING_ENABLED);
+
+    // Handle the case where features take too long to load, and we'll just navigate home:
+    useEffect(() => {
+        if (source !== 'defaultValue') return;
+
+        const timeout = setTimeout(() => {
+            navigate('/', { replace: true });
+        }, 5000);
+
+        return () => {
+            clearTimeout(timeout);
+        };
+    }, [source, navigate]);
+
+    // Wait for features to load
+    if (source === 'defaultValue') {
+        return null;
+    }
+
+    if (!on) return <Navigate to="/" replace />;
+
     return (
         <Routes>
             <Route path="/*" element={<Validators />} />

--- a/apps/wallet/src/ui/app/staking/home/index.tsx
+++ b/apps/wallet/src/ui/app/staking/home/index.tsx
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useFeature } from '@growthbook/growthbook-react';
-import { useEffect } from 'react';
-import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 
 import { DelegationDetail } from '../delegation-detail';
 import StakePage from '../stake';
@@ -11,28 +10,9 @@ import { Validators } from '../validators';
 import { FEATURES } from '_src/shared/experimentation/features';
 
 export function Staking() {
-    const navigate = useNavigate();
-    const { source, on } = useFeature(FEATURES.STAKING_ENABLED);
+    const stakingEnabled = useFeature(FEATURES.STAKING_ENABLED).on;
 
-    // Handle the case where features take too long to load, and we'll just navigate home:
-    useEffect(() => {
-        if (source !== 'defaultValue') return;
-
-        const timeout = setTimeout(() => {
-            navigate('/', { replace: true });
-        }, 5000);
-
-        return () => {
-            clearTimeout(timeout);
-        };
-    }, [source, navigate]);
-
-    // Wait for features to load
-    if (source === 'defaultValue') {
-        return null;
-    }
-
-    if (!on) return <Navigate to="/" replace />;
+    if (!stakingEnabled) return <Navigate to="/" replace />;
 
     return (
         <Routes>

--- a/apps/wallet/src/ui/index.tsx
+++ b/apps/wallet/src/ui/index.tsx
@@ -9,6 +9,7 @@ import { Provider } from 'react-redux';
 import { HashRouter } from 'react-router-dom';
 
 import App from './app';
+import { API_ENV } from './app/ApiProvider';
 import { growthbook } from './app/experimentation/feature-gating';
 import { queryClient } from './app/helpers/queryClient';
 import { ErrorBoundary } from '_components/error-boundary';
@@ -31,6 +32,12 @@ async function init() {
     store.dispatch(initAppType(getFromLocationSearch(window.location.search)));
     await thunkExtras.background.init(store.dispatch);
     await store.dispatch(initNetworkFromStorage()).unwrap();
+    const { apiEnv, customRPC } = store.getState().app;
+
+    // NOTE: This duplicates the attribute set in `usePageView`, but is done so that we can initially render based on the selected network correctly.
+    const network =
+        apiEnv === API_ENV.customRPC ? customRPC : apiEnv.toUpperCase();
+    growthbook.setAttributes({ network });
 }
 
 function renderApp() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,6 +648,7 @@ importers:
       '@mysten/wallet-adapter-unsafe-burner': workspace:*
       '@mysten/wallet-adapter-wallet-standard': workspace:*
       '@mysten/wallet-kit-core': workspace:*
+      '@mysten/wallet-standard': workspace:*
       '@stitches/react': ^1.2.8
       '@types/react': ^18.0.26
       '@types/react-dom': ^18.0.10
@@ -662,6 +663,7 @@ importers:
       '@mysten/wallet-adapter-unsafe-burner': link:../adapters/unsafe-burner
       '@mysten/wallet-adapter-wallet-standard': link:../adapters/wallet-standard-adapter
       '@mysten/wallet-kit-core': link:../wallet-kit-core
+      '@mysten/wallet-standard': link:../wallet-standard
       '@stitches/react': 1.2.8_react@18.2.0
     devDependencies:
       '@types/react': 18.0.26
@@ -6777,7 +6779,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.12
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.0.4
+      vite: 4.0.4_@types+node@18.11.18
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -121,7 +121,7 @@ export const ValidatorReportRecords = object({
 
 export const NextEpochValidatorFields = object({
   consensus_address: array(number()),
-  name: array(number()),
+  name: union([string(), array(number())]),
   net_address: array(number()),
   network_pubkey_bytes: array(number()),
   next_epoch_commission_rate: string(),

--- a/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/index.ts
+++ b/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/index.ts
@@ -15,6 +15,8 @@ type Events = {
   changed: void;
 };
 
+export { StandardWalletAdapter };
+
 export class WalletStandardAdapterProvider implements WalletAdapterProvider {
   #wallets: Wallets;
   #adapters: Map<StandardWalletAdapterWallet, StandardWalletAdapter>;

--- a/sdk/wallet-adapter/wallet-kit/package.json
+++ b/sdk/wallet-adapter/wallet-kit/package.json
@@ -36,6 +36,7 @@
     "@mysten/wallet-adapter-unsafe-burner": "workspace:*",
     "@mysten/wallet-adapter-wallet-standard": "workspace:*",
     "@mysten/wallet-kit-core": "workspace:*",
+    "@mysten/wallet-standard": "workspace:*",
     "@stitches/react": "^1.2.8"
   },
   "devDependencies": {

--- a/sdk/wallet-adapter/wallet-kit/src/index.tsx
+++ b/sdk/wallet-adapter/wallet-kit/src/index.tsx
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+export { StandardWalletAdapter } from "@mysten/wallet-adapter-wallet-standard";
+export type { StandardWalletAdapterWallet, WalletWithFeatures } from '@mysten/wallet-standard';
+
 export * from "./ConnectButton";
 export * from "./ConnectModal";
 export * from "./WalletKitContext";

--- a/sdk/wallet-adapter/wallet-kit/tsconfig.json
+++ b/sdk/wallet-adapter/wallet-kit/tsconfig.json
@@ -9,6 +9,7 @@
   "references": [
     { "path": "../../typescript" },
     { "path": "../wallet-kit-core" },
+    { "path": "../wallet-standard" },
     { "path": "../adapters/base-adapter" },
     { "path": "../adapters/wallet-standard-adapter" },
     { "path": "../adapters/unsafe-burner" },


### PR DESCRIPTION
This adds the stake button to the validator page, flagged by a feature flag disabled in prod for now. I also updated to pull the latest validator metadata.

This also fixes a bug in wallet where the features have not yet been loaded causing a redirect to the token pages when trying to stake.