### PR TITLE
[Narwhal] parallelize certificate verification

### DIFF
--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -2,9 +2,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::metrics::PrimaryMetrics;
-use config::Committee;
+use config::{Committee, SharedWorkerCache};
 use crypto::{NetworkPublicKey, PublicKey};
 use futures::{stream::FuturesUnordered, StreamExt};
+use itertools::Itertools;
 use mysten_metrics::{monitored_future, monitored_scope, spawn_logged_monitored_task};
 use network::PrimaryToPrimaryRpc;
 use rand::{rngs::ThreadRng, seq::SliceRandom};
@@ -14,7 +15,7 @@ use std::{
     time::Duration,
 };
 use storage::CertificateStore;
-use tokio::task::JoinSet;
+use tokio::task::{spawn_blocking, JoinSet};
 use tokio::{
     sync::{oneshot, watch},
     task::JoinHandle,
@@ -33,12 +34,16 @@ use types::{
 pub mod certificate_fetcher_tests;
 
 // Maximum number of certificates to fetch with one request.
-const MAX_CERTIFICATES_TO_FETCH: usize = 1000;
+const MAX_CERTIFICATES_TO_FETCH: usize = 2000;
 // Seconds to wait for a response before issuing another parallel fetch request.
 const PARALLEL_FETCH_REQUEST_INTERVAL_SECS: Duration = Duration::from_secs(5);
 // The timeout for an iteration of parallel fetch requests over all peers would be
 // num peers * PARALLEL_FETCH_REQUEST_INTERVAL_SECS + PARALLEL_FETCH_REQUEST_ADDITIONAL_TIMEOUT
 const PARALLEL_FETCH_REQUEST_ADDITIONAL_TIMEOUT: Duration = Duration::from_secs(15);
+// Number of certificates to verify in a batch. Verifications in each batch run serially.
+// Batch size is chosen so that verifying a batch takes non-trival
+// time (verifying a batch of 200 certificates should take > 100ms).
+const VERIFY_CERTIFICATES_BATCH_SIZE: usize = 200;
 
 /// Message format from CertificateFetcher to core on the loopback channel.
 pub struct CertificateLoopbackMessage {
@@ -60,6 +65,8 @@ pub(crate) struct CertificateFetcher {
     state: Arc<CertificateFetcherState>,
     /// The committee information.
     committee: Committee,
+    /// The worker information.
+    worker_cache: SharedWorkerCache,
     /// Persistent storage for certificates. Read-only usage.
     certificate_store: CertificateStore,
     /// Receiver for signal of round changes. Used for calculating gc_round.
@@ -98,6 +105,7 @@ impl CertificateFetcher {
     pub fn spawn(
         name: PublicKey,
         committee: Committee,
+        worker_cache: SharedWorkerCache,
         network: anemo::Network,
         certificate_store: CertificateStore,
         rx_consensus_round_updates: watch::Receiver<u64>,
@@ -119,6 +127,7 @@ impl CertificateFetcher {
                 Self {
                     state,
                     committee,
+                    worker_cache,
                     certificate_store,
                     rx_consensus_round_updates,
                     gc_depth,
@@ -256,6 +265,7 @@ impl CertificateFetcher {
 
         let state = self.state.clone();
         let committee = self.committee.clone();
+        let worker_cache = self.worker_cache.clone();
 
         debug!(
             "Starting task to fetch missing certificates: max target {}, gc round {:?}",
@@ -268,8 +278,14 @@ impl CertificateFetcher {
                 state.metrics.certificate_fetcher_inflight_fetch.inc();
 
                 let now = Instant::now();
-                match run_fetch_task(state.clone(), committee.clone(), gc_round, written_rounds)
-                    .await
+                match run_fetch_task(
+                    state.clone(),
+                    committee,
+                    worker_cache,
+                    gc_round,
+                    written_rounds,
+                )
+                .await
                 {
                     Ok(_) => {
                         debug!(
@@ -299,6 +315,7 @@ impl CertificateFetcher {
 async fn run_fetch_task(
     state: Arc<CertificateFetcherState>,
     committee: Committee,
+    worker_cahce: SharedWorkerCache,
     gc_round: Round,
     written_rounds: BTreeMap<PublicKey, BTreeSet<Round>>,
 ) -> DagResult<()> {
@@ -313,7 +330,13 @@ async fn run_fetch_task(
 
     // Process and store fetched certificates.
     let num_certs_fetched = response.certificates.len();
-    process_certificates_helper(response, &state.tx_certificates_loopback).await?;
+    process_certificates_helper(
+        response,
+        &state.tx_certificates_loopback,
+        &committee,
+        &worker_cahce,
+    )
+    .await?;
     state
         .metrics
         .certificate_fetcher_num_certificates_processed
@@ -406,6 +429,8 @@ async fn fetch_certificates_helper(
 async fn process_certificates_helper(
     response: FetchCertificatesResponse,
     tx_certificates_loopback: &Sender<CertificateLoopbackMessage>,
+    committee: &Committee,
+    worker_cache: &SharedWorkerCache,
 ) -> DagResult<()> {
     trace!("Start sending fetched certificates to processing");
     if response.certificates.len() > MAX_CERTIFICATES_TO_FETCH {
@@ -414,26 +439,56 @@ async fn process_certificates_helper(
             MAX_CERTIFICATES_TO_FETCH,
         ));
     }
-    let (tx_done, rx_done) = oneshot::channel();
-    if let Err(e) = tx_certificates_loopback
-        .send(CertificateLoopbackMessage {
-            certificates: response.certificates,
-            done: tx_done,
+    // Verify certificates in parallel.
+    // In PrimaryReceiverHandler, certificates already in storage are ignored.
+    // The check is unnecessary here, because there is no concurrent processing of older
+    // certificates. For byzantine failures, the check will not be effective anyway.
+    let all_certificates = response.certificates;
+    let verify_tasks = all_certificates
+        .chunks(VERIFY_CERTIFICATES_BATCH_SIZE)
+        .map(|certs| {
+            let certs = certs.to_vec();
+            let committee = committee.clone();
+            let worker_cache = worker_cache.clone();
+            // Use threads dedicated to computation heavy work.
+            spawn_blocking(move || {
+                for c in &certs {
+                    let worker_cache = worker_cache.clone();
+                    c.verify(&committee, worker_cache)?;
+                }
+                Ok::<Vec<Certificate>, DagError>(certs)
+            })
         })
-        .await
-    {
-        return Err(DagError::ClosedChannel(format!(
-            "Failed to send fetched certificate to processing. tx_certificates_loopback error: {}",
-            e
-        )));
+        .collect_vec();
+    // Send verified certificates to core for processing, in the same order as received.
+    let mut processing_tasks = JoinSet::new();
+    for task in verify_tasks {
+        let certificates = task.await.map_err(|_| DagError::Canceled)??;
+        let (tx_done, rx_done) = oneshot::channel();
+        if let Err(e) = tx_certificates_loopback
+            .send(CertificateLoopbackMessage {
+                certificates,
+                done: tx_done,
+            })
+            .await
+        {
+            return Err(DagError::ClosedChannel(format!(
+                "Failed to send fetched certificate to processing. tx_certificates_loopback error: {}",
+                e
+            )));
+        }
+        processing_tasks.spawn(rx_done);
     }
-    if let Err(e) = rx_done.await {
-        return Err(DagError::ClosedChannel(format!(
-            "Failed to wait for core to process loopback certificates: {}",
-            e
-        )));
+    // Wait for core to finish processing the certificates.
+    while let Some(result) = processing_tasks.join_next().await {
+        if let Err(e) = result {
+            return Err(DagError::ClosedChannel(format!(
+                "Failed to wait for core to process loopback certificates: {}",
+                e
+            )));
+        }
     }
-    trace!("Fetched certificates have finished processing");
+    trace!("Fetched certificates have been processed");
 
     Ok(())
 }

--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use anyhow::Result;
-use config::{Committee, Epoch, SharedWorkerCache};
+use config::{Committee, Epoch};
 use crypto::{NetworkPublicKey, PublicKey, Signature};
 use fastcrypto::{hash::Hash as _, signature_service::SignatureService};
 use futures::StreamExt;
@@ -43,8 +43,6 @@ pub struct Core {
     name: PublicKey,
     /// The committee information.
     committee: Committee,
-    /// The worker information cache.
-    worker_cache: SharedWorkerCache,
     /// The persistent storage keyed to headers.
     header_store: Store<HeaderDigest, Header>,
     /// The persistent storage keyed to certificates.
@@ -104,7 +102,6 @@ impl Core {
     pub fn spawn(
         name: PublicKey,
         committee: Committee,
-        worker_cache: SharedWorkerCache,
         header_store: Store<HeaderDigest, Header>,
         certificate_store: CertificateStore,
         synchronizer: Arc<Synchronizer>,
@@ -126,7 +123,6 @@ impl Core {
                 Self {
                     name,
                     committee,
-                    worker_cache,
                     header_store,
                     certificate_store,
                     synchronizer,
@@ -490,6 +486,9 @@ impl Core {
         Ok(())
     }
 
+    /// Checks if all parents of the certificate exist, such that the certificate can be added to
+    /// header parents and inserted into the dag.
+    /// The certificate must have been verified.
     #[instrument(level = "debug", skip_all, fields(certificate_digest = ?certificate.digest()))]
     async fn process_certificate(
         &mut self,
@@ -497,22 +496,6 @@ impl Core {
         notify: Option<oneshot::Sender<DagResult<()>>>,
     ) -> DagResult<()> {
         let digest = certificate.digest();
-        if self.certificate_store.read(digest)?.is_some() {
-            trace!("Certificate {digest:?} has already been processed. Skip processing.");
-            self.metrics.duplicate_certificates_processed.inc();
-            if let Some(notify) = notify {
-                let _ = notify.send(Ok(())); // no problem if remote side isn't listening
-            }
-            return Ok(());
-        }
-
-        if let Err(e) = self.sanitize_certificate(&certificate).await {
-            if let Some(notify) = notify {
-                let _ = notify.send(Err(e.clone())); // no problem if remote side isn't listening
-            }
-            return Err(e);
-        }
-
         match self.process_certificate_internal(certificate).await {
             Err(DagError::Suspended) => {
                 if let Some(notify) = notify {
@@ -520,8 +503,10 @@ impl Core {
                         .entry(digest)
                         .or_insert_with(Vec::new)
                         .push(notify);
+                    Ok(())
+                } else {
+                    Err(DagError::Suspended)
                 }
-                Ok(())
             }
             result => {
                 if let Some(notify) = notify {
@@ -539,6 +524,22 @@ impl Core {
 
     #[instrument(level = "debug", skip_all, fields(certificate_digest = ?certificate.digest()))]
     async fn process_certificate_internal(&mut self, certificate: Certificate) -> DagResult<()> {
+        // Ok to ignore a certificate early than gc_round, because it will never be included into
+        // the consensus dag.
+        ensure!(
+            self.gc_round < certificate.round(),
+            DagError::TooOld(
+                certificate.digest().into(),
+                certificate.round(),
+                self.gc_round
+            )
+        );
+        let digest = certificate.digest();
+        if self.certificate_store.contains(&digest)? {
+            trace!("Certificate {digest:?} has already been processed. Skip processing.");
+            self.metrics.duplicate_certificates_processed.inc();
+            return Ok(());
+        }
         debug!(
             "Processing certificate {:?} round:{:?}",
             certificate,
@@ -656,29 +657,6 @@ impl Core {
         }
 
         Ok(())
-    }
-
-    async fn sanitize_certificate(&mut self, certificate: &Certificate) -> DagResult<()> {
-        ensure!(
-            self.committee.epoch() == certificate.epoch(),
-            DagError::InvalidEpoch {
-                expected: self.committee.epoch(),
-                received: certificate.epoch()
-            }
-        );
-        // Ok to drop old certificate, because it will never be included into the consensus dag.
-        ensure!(
-            self.gc_round < certificate.round(),
-            DagError::TooOld(
-                certificate.digest().into(),
-                certificate.round(),
-                self.gc_round
-            )
-        );
-        // Verify the certificate (and the embedded header).
-        certificate
-            .verify(&self.committee, self.worker_cache.clone())
-            .map_err(DagError::from)
     }
 
     // Logs Core errors as appropriate.

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -52,7 +52,7 @@ use store::Store;
 use tokio::{sync::oneshot, time::Instant};
 use tokio::{sync::watch, task::JoinHandle};
 use tower::ServiceBuilder;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 pub use types::PrimaryMessage;
 use types::{
@@ -459,7 +459,6 @@ impl Primary {
         let core_handle = Core::spawn(
             name.clone(),
             (**committee.load()).clone(),
-            worker_cache.clone(),
             header_store.clone(),
             certificate_store.clone(),
             synchronizer,
@@ -482,6 +481,7 @@ impl Primary {
         let certificate_fetcher_handle = CertificateFetcher::spawn(
             name.clone(),
             (**committee.load()).clone(),
+            worker_cache.clone(),
             network.clone(),
             certificate_store.clone(),
             rx_consensus_round_updates,
@@ -672,6 +672,17 @@ impl PrimaryReceiverHandler {
         Ok(None)
     }
 
+    fn deduplicate_and_verify(&self, certificate: &Certificate) -> DagResult<bool> {
+        let digest = certificate.digest();
+        if self.certificate_store.contains(&digest)? {
+            trace!("Certificate {digest:?} has already been processed. Skip processing.");
+            self.metrics.duplicate_certificates_processed.inc();
+            return Ok(false);
+        }
+        certificate.verify(&self.committee.load(), self.worker_cache.clone())?;
+        Ok(true)
+    }
+
     #[allow(clippy::mutable_key_type)]
     async fn process_request_vote(
         &self,
@@ -731,6 +742,9 @@ impl PrimaryReceiverHandler {
         // before proceeding.
         let mut notifies = Vec::new();
         for certificate in request.body().parents.clone() {
+            if !self.deduplicate_and_verify(&certificate)? {
+                continue;
+            }
             let (tx_notify, rx_notify) = oneshot::channel();
             notifies.push(rx_notify);
             self.tx_certificates
@@ -906,12 +920,18 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
         request: anemo::Request<PrimaryMessage>,
     ) -> Result<anemo::Response<()>, anemo::rpc::Status> {
         let PrimaryMessage::Certificate(certificate) = request.into_body();
-        let (tx_ack, rx_ack) = oneshot::channel();
+        if !self
+            .deduplicate_and_verify(&certificate)
+            .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?
+        {
+            return Ok(anemo::Response::new(()));
+        }
+        let (tx_notify, rx_notify) = oneshot::channel();
         self.tx_certificates
-            .send((certificate, Some(tx_ack)))
+            .send((certificate, Some(tx_notify)))
             .await
             .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
-        rx_ack
+        rx_notify
             .await
             .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?
             .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -210,6 +210,7 @@ async fn fetch_certificates_basic() {
     let _certificate_fetcher_handle = CertificateFetcher::spawn(
         name.clone(),
         fixture.committee(),
+        fixture.shared_worker_cache(),
         client_network.clone(),
         certificate_store.clone(),
         rx_consensus_round_updates.clone(),
@@ -224,7 +225,6 @@ async fn fetch_certificates_basic() {
     let _core_handle = Core::spawn(
         name.clone(),
         fixture.committee(),
-        worker_cache,
         store.header_store.clone(),
         certificate_store.clone(),
         synchronizer.clone(),

--- a/narwhal/primary/src/tests/core_tests.rs
+++ b/narwhal/primary/src/tests/core_tests.rs
@@ -102,7 +102,6 @@ async fn propose_header() {
     let _core_handle = Core::spawn(
         name,
         committee.clone(),
-        worker_cache,
         header_store.clone(),
         certificate_store.clone(),
         synchronizer,
@@ -199,7 +198,6 @@ async fn propose_header_failure() {
     let _core_handle = Core::spawn(
         name,
         committee.clone(),
-        worker_cache,
         header_store.clone(),
         certificate_store.clone(),
         synchronizer,
@@ -271,7 +269,6 @@ async fn process_certificates() {
     let _core_handle = Core::spawn(
         name,
         committee.clone(),
-        worker_cache,
         header_store.clone(),
         certificate_store.clone(),
         synchronizer,
@@ -383,7 +380,6 @@ async fn recover_core() {
     let _core_handle = Core::spawn(
         name.clone(),
         committee.clone(),
-        worker_cache.clone(),
         header_store.clone(),
         certificate_store.clone(),
         synchronizer.clone(),
@@ -427,7 +423,6 @@ async fn recover_core() {
     let _core_handle = Core::spawn(
         name,
         committee.clone(),
-        worker_cache,
         header_store.clone(),
         certificate_store.clone(),
         synchronizer.clone(),
@@ -522,7 +517,6 @@ async fn recover_core_partial_certs() {
     let _core_handle = Core::spawn(
         name.clone(),
         committee.clone(),
-        worker_cache.clone(),
         header_store.clone(),
         certificate_store.clone(),
         synchronizer.clone(),
@@ -568,7 +562,6 @@ async fn recover_core_partial_certs() {
     let _core_handle = Core::spawn(
         name.clone(),
         committee.clone(),
-        worker_cache.clone(),
         header_store.clone(),
         certificate_store.clone(),
         synchronizer.clone(),
@@ -655,7 +648,6 @@ async fn recover_core_expecting_header_of_previous_round() {
     let _core_handle = Core::spawn(
         name.clone(),
         committee.clone(),
-        worker_cache.clone(),
         header_store.clone(),
         certificate_store.clone(),
         synchronizer.clone(),
@@ -712,7 +704,6 @@ async fn recover_core_expecting_header_of_previous_round() {
     let _core_handle = Core::spawn(
         name.clone(),
         committee.clone(),
-        worker_cache.clone(),
         header_store.clone(),
         certificate_store.clone(),
         synchronizer.clone(),
@@ -790,7 +781,6 @@ async fn shutdown_core() {
     let handle = Core::spawn(
         name.clone(),
         committee.clone(),
-        worker_cache.clone(),
         header_store.clone(),
         certificate_store.clone(),
         synchronizer.clone(),

--- a/narwhal/types/Cargo.toml
+++ b/narwhal/types/Cargo.toml
@@ -63,3 +63,7 @@ test = []
 [[bench]]
 name = "batch_digest"
 harness = false
+
+[[bench]]
+name = "verify_certificate"
+harness = false

--- a/narwhal/types/benches/verify_certificate.rs
+++ b/narwhal/types/benches/verify_certificate.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{
+    criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
+};
+use fastcrypto::hash::Hash;
+use narwhal_types::Certificate;
+use std::collections::BTreeSet;
+use test_utils::{make_optimal_certificates, CommitteeFixture};
+
+pub fn verify_certificates(c: &mut Criterion) {
+    let mut bench_group = c.benchmark_group("verify_certificate");
+    bench_group.sampling_mode(SamplingMode::Flat);
+
+    static COMMITTEE_SIZES: [usize; 4] = [4, 10, 40, 100];
+    for committee_size in COMMITTEE_SIZES {
+        let fixture = CommitteeFixture::builder()
+            .committee_size(committee_size.try_into().unwrap())
+            .build();
+        let committee = fixture.committee();
+        let keys: Vec<_> = fixture.authorities().map(|a| a.public_key()).collect();
+
+        // process certificates for rounds, check we don't grow the dag too much
+        let genesis = Certificate::genesis(&committee)
+            .iter()
+            .map(|x| x.digest())
+            .collect::<BTreeSet<_>>();
+        let (certificates, _next_parents) =
+            make_optimal_certificates(&committee, 1..=1, &genesis, &keys);
+        let certificate = certificates.front().unwrap().clone();
+
+        let data_size: usize = bincode::serialize(&certificate).unwrap().len();
+        bench_group.throughput(Throughput::Bytes(data_size as u64));
+
+        bench_group.bench_with_input(
+            BenchmarkId::new("with_committee_size", committee_size),
+            &certificate,
+            |b, cert| {
+                b.iter(|| {
+                    let worker_cache = fixture.shared_worker_cache();
+                    let _ = cert.verify(&committee, worker_cache);
+                })
+            },
+        );
+    }
+}
+
+criterion_group! {
+    name = verify_certificate;
+    config = Criterion::default().sample_size(1000).noise_threshold(0.1);
+    targets = verify_certificates
+}
+criterion_main!(verify_certificate);

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -646,6 +646,8 @@ impl Certificate {
         (weight, pks)
     }
 
+    /// Verifies the validaity of the certificate.
+    /// TODO: Output a different type, similar to Sui VerifiedCertificate.
     pub fn verify(&self, committee: &Committee, worker_cache: SharedWorkerCache) -> DagResult<()> {
         // Ensure the header is from the correct epoch.
         ensure!(
@@ -657,7 +659,7 @@ impl Certificate {
         );
 
         // Genesis certificates are always valid.
-        if Self::genesis(committee).contains(self) {
+        if self.round() == 0 && Self::genesis(committee).contains(self) {
             return Ok(());
         }
 


### PR DESCRIPTION
Certificate verification takes 600us ~ 700us. So single threaded certificate verification in `Core` can process at most ~ 1600 certificates per sec. This can become a bottleneck during catch up or when there are more validators in the network. This PR parallelizes certificate verification in `PrimaryReceiverHandler` and `CertificateFetcher`.