### PR TITLE
ts-sdk: fix getCoins response validation

### DIFF
--- a/.changeset/large-garlics-explode.md
+++ b/.changeset/large-garlics-explode.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Make previousTransaction optional for CoinStruct to support v0.22 network where it doesn't exist

--- a/sdk/typescript/src/types/coin.ts
+++ b/sdk/typescript/src/types/coin.ts
@@ -11,7 +11,8 @@ export const CoinStruct = object({
     digest: TransactionDigest,
     balance: number(),
     lockedUntilEpoch: nullable(number()),
-    previousTransaction: TransactionDigest,
+    // TODO: remove optional when it is supported from all deployed networks
+    previousTransaction: optional(TransactionDigest),
 });
 
   


### PR DESCRIPTION
* previousTransaction does not exist in v0.22

before


https://user-images.githubusercontent.com/10210143/214604875-8f608794-0f2a-454c-a1bc-9a542cc26757.mov


after


https://user-images.githubusercontent.com/10210143/214605102-5e56bc00-fde1-4b3f-9906-f04cc6e775ef.mov


closes: APPS-410