### PR TITLE
wallet-ext: hide max stake button

### DIFF
--- a/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
@@ -15,6 +15,8 @@ import { DEFAULT_GAS_BUDGET_FOR_STAKE } from '_redux/slices/sui-objects/Coin';
 
 import type { FormValues } from './StakingCard';
 
+const HIDE_MAX = true;
+
 export type StakeFromProps = {
     submitError: string | null;
     coinBalance: bigint;
@@ -69,15 +71,16 @@ function StakeForm({
                                 className="w-full border-none text-hero-dark text-heading4 font-semibold bg-white placeholder:text-gray-70 placeholder:font-semibold"
                                 decimals
                             />
-
-                            <button
-                                className="bg-white border border-solid border-gray-60 hover:border-steel-dark rounded-2xl h-6 w-11 flex justify-center items-center cursor-pointer text-steel-darker hover:text-steel-darker text-bodySmall font-medium disabled:opacity-50 disabled:cursor-auto"
-                                onClick={setMaxToken}
-                                disabled={queryResult.isLoading}
-                                type="button"
-                            >
-                                Max
-                            </button>
+                            {!HIDE_MAX ? (
+                                <button
+                                    className="bg-white border border-solid border-gray-60 hover:border-steel-dark rounded-2xl h-6 w-11 flex justify-center items-center cursor-pointer text-steel-darker hover:text-steel-darker text-bodySmall font-medium disabled:opacity-50 disabled:cursor-auto"
+                                    onClick={setMaxToken}
+                                    disabled={queryResult.isLoading}
+                                    type="button"
+                                >
+                                    Max
+                                </button>
+                            ) : null}
                         </div>
                     }
                     footer={


### PR DESCRIPTION
* hide the max stake button for now since most of the time using the max stake amount that it sets causes the stake transaction to fail

| before | after |
| - | - |
| <img width="394" alt="Screenshot 2023-01-25 at 16 17 41" src="https://user-images.githubusercontent.com/10210143/214617037-fd643aca-bf52-4dbb-bd24-2cc0aac855ae.png"> | <img width="394" alt="Screenshot 2023-01-25 at 16 17 02" src="https://user-images.githubusercontent.com/10210143/214617102-16357e12-e64b-4283-b743-ae3630228026.png"> |

part of: APPS-387