### PR TITLE
[object] Store package version in object

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -102,6 +102,8 @@ use crate::{
 };
 use sui_adapter::execution_engine;
 
+use self::authority_store::InputKey;
+
 #[cfg(test)]
 #[path = "unit_tests/authority_tests.rs"]
 pub mod authority_tests;
@@ -853,7 +855,7 @@ impl AuthorityState {
         let output_keys: Vec<_> = inner_temporary_store
             .written
             .iter()
-            .map(|(_, ((id, seq, _), _, _))| ObjectKey(*id, *seq))
+            .map(|(_, ((id, seq, _), obj, _))| InputKey(*id, (!obj.is_package()).then_some(*seq)))
             .collect();
 
         self.commit_certificate(

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -17,7 +17,6 @@ use sui_storage::mutex_table::{LockGuard, MutexTable};
 use sui_types::accumulator::Accumulator;
 use sui_types::message_envelope::Message;
 use sui_types::object::Owner;
-use sui_types::object::PACKAGE_VERSION;
 use sui_types::storage::{BackingPackageStore, ChildObjectResolver, DeleteKind, ObjectKey};
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -373,8 +372,9 @@ impl AuthorityStore {
                     }
                 }
                 InputObjectKind::MovePackage(id) => {
-                    if !self.object_version_exists(id, PACKAGE_VERSION)? {
-                        missing.push(ObjectKey(*id, PACKAGE_VERSION));
+                    if !self.object_exists(*id)? {
+                        // The cert cannot have been formed if the package was missing.
+                        missing.push(ObjectKey::max_for_id(id));
                     }
                 }
                 InputObjectKind::ImmOrOwnedMoveObject(objref) => {

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -333,6 +333,8 @@ MovePackage:
   STRUCT:
     - id:
         TYPENAME: ObjectID
+    - version:
+        TYPENAME: SequenceNumber
     - module_map:
         MAP:
           KEY: STR

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -10,7 +10,7 @@ expression: common_costs_actual
   },
   "Publish": {
     "computation_cost": 326,
-    "storage_cost": 119,
+    "storage_cost": 120,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -550,6 +550,7 @@ impl TryInto<Object> for SuiObject<SuiRawData> {
             }
             SuiRawData::Package(p) => Data::Package(MovePackage::new(
                 p.id,
+                self.reference.version,
                 &p.module_map,
                 protocol_config.max_move_package_size(),
             )?),

--- a/crates/sui-storage/src/event_store/test_utils.rs
+++ b/crates/sui-storage/src/event_store/test_utils.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use sui_types::base_types::SuiAddress;
 use sui_types::event::{Event, EventEnvelope};
 use sui_types::gas_coin::GAS;
-use sui_types::object::{Owner, PACKAGE_VERSION};
+use sui_types::object::{Owner, OBJECT_START_VERSION};
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 
 use super::*;
@@ -63,7 +63,7 @@ pub fn new_test_publish_event(
         Event::Publish {
             sender: sender.unwrap_or_else(SuiAddress::random_for_testing_only),
             package_id: ObjectID::random(),
-            version: PACKAGE_VERSION,
+            version: OBJECT_START_VERSION,
             digest: ObjectDigest::random(),
         },
         None,

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -348,14 +348,15 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         type_args: &[TypeTag],
         json_args: Vec<SuiJsonValue>,
     ) -> Result<Vec<CallArg>, anyhow::Error> {
-        let package = self.0.get_object(package_id).await?.into_object()?;
-        let package = package
+        let object = self.0.get_object(package_id).await?.into_object()?;
+        let package = object
             .data
             .try_as_package()
             .cloned()
             .ok_or_else(|| anyhow!("Object [{}] is not a move package.", package_id))?;
         let package: MovePackage = MovePackage::new(
             package.id,
+            object.version(),
             &package.module_map,
             ProtocolConfig::get_for_min_version().max_move_package_size(),
         )?;

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -12,7 +12,7 @@ use crate::gas::GasCostSummary;
 use crate::intent::{Intent, IntentMessage};
 use crate::message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope};
 use crate::messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage};
-use crate::object::{MoveObject, Object, ObjectFormatOptions, Owner, PACKAGE_VERSION};
+use crate::object::{MoveObject, Object, ObjectFormatOptions, Owner};
 use crate::signature::{AuthenticatorTrait, GenericSignature};
 use crate::storage::{DeleteKind, WriteKind};
 use crate::{
@@ -2685,7 +2685,7 @@ impl InputObjectKind {
 
     pub fn version(&self) -> Option<SequenceNumber> {
         match self {
-            Self::MovePackage(..) => Some(PACKAGE_VERSION),
+            Self::MovePackage(..) => None,
             Self::ImmOrOwnedMoveObject((_, version, _)) => Some(*version),
             Self::SharedMoveObject { .. } => None,
         }

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    base_types::ObjectID,
+    base_types::{ObjectID, SequenceNumber},
     error::{ExecutionError, ExecutionErrorKind, SuiError, SuiResult},
 };
 use move_binary_format::access::ModuleAccess;
@@ -45,6 +45,7 @@ pub type FnInfoMap = BTreeMap<FnInfoKey, FnInfo>;
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MovePackage {
     id: ObjectID,
+    version: SequenceNumber,
     // TODO use session cache
     #[serde_as(as = "BTreeMap<_, Bytes>")]
     module_map: BTreeMap<String, Vec<u8>>,
@@ -53,11 +54,13 @@ pub struct MovePackage {
 impl MovePackage {
     pub fn new(
         id: ObjectID,
+        version: SequenceNumber,
         module_map: &BTreeMap<String, Vec<u8>>,
         max_move_package_size: u64,
     ) -> Result<Self, ExecutionError> {
         let pkg = Self {
             id,
+            version,
             module_map: module_map.clone(),
         };
         let object_size = pkg.size() as u64;
@@ -72,6 +75,7 @@ impl MovePackage {
     }
 
     pub fn from_module_iter<T: IntoIterator<Item = CompiledModule>>(
+        version: SequenceNumber,
         iter: T,
         max_move_package_size: u64,
     ) -> Result<Self, ExecutionError> {
@@ -86,6 +90,7 @@ impl MovePackage {
 
         Self::new(
             id,
+            version,
             &iter
                 .map(|module| {
                     let mut bytes = Vec::new();
@@ -105,6 +110,20 @@ impl MovePackage {
 
     pub fn id(&self) -> ObjectID {
         self.id
+    }
+
+    pub fn version(&self) -> SequenceNumber {
+        self.version
+    }
+
+    /// Approximate size of the package in bytes. This is used for gas metering.
+    pub fn object_size_for_gas_metering(&self) -> usize {
+        // + 8 for version
+        self.serialized_module_map()
+            .iter()
+            .map(|(name, module)| name.len() + module.len())
+            .sum::<usize>()
+            + 8
     }
 
     pub fn serialized_module_map(&self) -> &BTreeMap<String, Vec<u8>> {

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -45,6 +45,16 @@ pub type FnInfoMap = BTreeMap<FnInfoKey, FnInfo>;
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MovePackage {
     id: ObjectID,
+    /// Most move packages are uniquely identified by their ID (i.e. there is only one version per
+    /// ID), but the version is still stored because one package may be an upgrade of another (at a
+    /// different ID), in which case its version will be one greater than the version of the
+    /// upgraded package.
+    ///
+    /// Framework packages are an exception to this rule -- all versions of the framework packages
+    /// exist at the same ID, at increasing versions.
+    ///
+    /// In all cases, packages are referred to by move calls using just their ID, and they are
+    /// always loaded at their latest version.
     version: SequenceNumber,
     // TODO use session cache
     #[serde_as(as = "BTreeMap<_, Bytes>")]

--- a/crates/sui-types/src/unit_tests/event_filter_tests.rs
+++ b/crates/sui-types/src/unit_tests/event_filter_tests.rs
@@ -12,7 +12,7 @@ use crate::event::EventType;
 use crate::event::{Event, EventEnvelope};
 use crate::filter::{EventFilter, Filter};
 use crate::gas_coin::GasCoin;
-use crate::object::{Owner, PACKAGE_VERSION};
+use crate::object::{Owner, OBJECT_START_VERSION};
 use crate::{ObjectID, MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS};
 
 #[test]
@@ -117,7 +117,7 @@ fn test_transfer_filter() {
 fn test_publish_filter() {
     let package_id = ObjectID::random();
     let sender = SuiAddress::random_for_testing_only();
-    let version = PACKAGE_VERSION;
+    let version = OBJECT_START_VERSION;
     let digest = ObjectDigest::random();
     // Create a test publish event.
     let move_event = Event::Publish {
@@ -207,7 +207,7 @@ fn test_new_object_filter() {
         recipient,
         object_type: "0x2::example::Object".into(),
         object_id,
-        version: PACKAGE_VERSION,
+        version: OBJECT_START_VERSION,
     };
     let envelope = EventEnvelope {
         timestamp: 0,


### PR DESCRIPTION
Soon it will no longer be the case that a package's version is always `1`, because:

- Framework Upgrades will write new versions of the framework at increasing versions in the store.
- Package Upgrades will pun the package's version in storage with its version in the chain of upgrades (Even though subsequent versions will exist at distinct ObjectIDs).

This PR retires `PACKAGE_VERSION` and stores the package version in `MovePackage` instead (although initially, it will still always be 1).

This change also means that it is no longer possible to ascertain a package's version, when it is passed in as an input object.

## Test Plan

```
$ cargo nextest run
```

## Stack

- #7597