### PR TITLE
wallet validator link should link to validator page not address

### DIFF
--- a/apps/wallet/src/ui/app/components/explorer-link/Explorer.ts
+++ b/apps/wallet/src/ui/app/components/explorer-link/Explorer.ts
@@ -56,3 +56,11 @@ export function getAddressUrl(
 ) {
     return getExplorerUrl(`/address/${address}`, apiEnv, customRPC);
 }
+
+export function getValidatorUrl(
+    address: SuiAddress,
+    apiEnv: API_ENV,
+    customRPC: string
+) {
+    return getExplorerUrl(`/validator/${address}`, apiEnv, customRPC);
+}

--- a/apps/wallet/src/ui/app/components/explorer-link/ExplorerLinkType.ts
+++ b/apps/wallet/src/ui/app/components/explorer-link/ExplorerLinkType.ts
@@ -5,4 +5,5 @@ export enum ExplorerLinkType {
     address,
     object,
     transaction,
+    validator,
 }

--- a/apps/wallet/src/ui/app/components/explorer-link/index.tsx
+++ b/apps/wallet/src/ui/app/components/explorer-link/index.tsx
@@ -3,7 +3,12 @@
 
 import { memo, useCallback, useMemo } from 'react';
 
-import { getObjectUrl, getAddressUrl, getTransactionUrl } from './Explorer';
+import {
+    getObjectUrl,
+    getAddressUrl,
+    getTransactionUrl,
+    getValidatorUrl,
+} from './Explorer';
 import { ExplorerLinkType } from './ExplorerLinkType';
 import ExternalLink from '_components/external-link';
 import Icon, { SuiIcons } from '_components/icon';
@@ -28,6 +33,7 @@ export type ExplorerLinkProps = (
       }
     | { type: ExplorerLinkType.object; objectID: ObjectId }
     | { type: ExplorerLinkType.transaction; transactionID: TransactionDigest }
+    | { type: ExplorerLinkType.validator; validator: SuiAddress }
 ) & {
     track?: boolean;
     children?: ReactNode;
@@ -55,6 +61,8 @@ function ExplorerLink(props: ExplorerLinkProps) {
     const objectID = type === ExplorerLinkType.object ? props.objectID : null;
     const transactionID =
         type === ExplorerLinkType.transaction ? props.transactionID : null;
+    const validator =
+        type === ExplorerLinkType.validator ? props.validator : null;
 
     // fallback to localhost if customRPC is not set
     const customRPCUrl = customRPC || 'http://localhost:3000/';
@@ -79,8 +87,21 @@ function ExplorerLink(props: ExplorerLinkProps) {
                         customRPCUrl
                     )
                 );
+            case ExplorerLinkType.validator:
+                return (
+                    validator &&
+                    getValidatorUrl(validator, selectedApiEnv, customRPCUrl)
+                );
         }
-    }, [type, address, selectedApiEnv, objectID, transactionID, customRPCUrl]);
+    }, [
+        type,
+        address,
+        selectedApiEnv,
+        customRPCUrl,
+        objectID,
+        transactionID,
+        validator,
+    ]);
 
     const handleclick = useCallback(() => {
         if (props.track) {

--- a/apps/wallet/src/ui/app/staking/validators/ValidatorListItem.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/ValidatorListItem.tsx
@@ -74,8 +74,8 @@ export function ValidatorListItem({
                                 {validatorName}
                             </Text>
                             <ExplorerLink
-                                type={ExplorerLinkType.address}
-                                address={validatorAddress}
+                                type={ExplorerLinkType.validator}
+                                validator={validatorAddress}
                                 className={cl(
                                     selected && 'text-hero-dark',
                                     'text-steel-dark no-underline font-mono font-medium group-hover:text-hero-dark'


### PR DESCRIPTION
Currently, the wallet explorer link for validators points to their Sui address instead of the validator page. This fixes it 