### PR TITLE
[RWLocks] Add ObjectArg::SharedObject::mutable

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -341,6 +341,7 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
     let system_object_arg = CallArg::Object(ObjectArg::SharedObject {
         id: SUI_SYSTEM_STATE_OBJECT_ID,
         initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+        mutable: true,
     });
     let result = adapter::execute::<execution_mode::Normal, _, _>(
         move_vm,
@@ -888,6 +889,36 @@ fn get_coin_balance(store: &InnerTemporaryStore, id: &ObjectID) -> u64 {
         .unwrap()
 }
 
+#[cfg(test)]
+fn input_object_kind(object: &Object) -> sui_types::messages::InputObjectKind {
+    match &object.owner {
+        Owner::Shared {
+            initial_shared_version,
+            ..
+        } => sui_types::messages::InputObjectKind::SharedMoveObject {
+            id: object.id(),
+            initial_shared_version: *initial_shared_version,
+            mutable: true,
+        },
+        Owner::ObjectOwner(_) | Owner::AddressOwner(_) | Owner::Immutable => {
+            sui_types::messages::InputObjectKind::ImmOrOwnedMoveObject(
+                object.compute_object_reference(),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+/// Test only method that return mutable InputObjects from given objects
+fn input_objects_from_objects(objects: Vec<Object>) -> InputObjects {
+    InputObjects::new(
+        objects
+            .into_iter()
+            .map(|o| (input_object_kind(&o), o))
+            .collect(),
+    )
+}
+
 #[test]
 fn test_pay_success_without_delete() {
     // supplied one coin and only needed to use part of it. should
@@ -900,8 +931,9 @@ fn test_pay_success_without_delete() {
     let recipient2 = SuiAddress::random_for_testing_only();
     let recipients = vec![recipient1, recipient2];
     let amounts = vec![6, 3];
-    let mut store: TemporaryStore<()> =
-        temporary_store::with_input_objects_for_testing(InputObjects::from(coin_objects.clone()));
+    let mut store: TemporaryStore<()> = temporary_store::with_input_objects_for_testing(
+        input_objects_from_objects(coin_objects.clone()),
+    );
     let mut ctx = TxContext::with_sender_for_testing_only(&sender);
 
     assert!(pay(&mut store, coin_objects, recipients, amounts, &mut ctx).is_ok());
@@ -936,8 +968,9 @@ fn test_pay_success_delete_one() {
     let recipient = SuiAddress::random_for_testing_only();
     let recipients = vec![recipient];
     let amounts = vec![11];
-    let mut store: TemporaryStore<()> =
-        temporary_store::with_input_objects_for_testing(InputObjects::from(coin_objects.clone()));
+    let mut store: TemporaryStore<()> = temporary_store::with_input_objects_for_testing(
+        input_objects_from_objects(coin_objects.clone()),
+    );
     let mut ctx = TxContext::random_for_testing_only();
 
     assert!(pay(&mut store, coin_objects, recipients, amounts, &mut ctx).is_ok());
@@ -971,8 +1004,9 @@ fn test_pay_success_delete_all() {
     let recipient2 = SuiAddress::random_for_testing_only();
     let recipients = vec![recipient1, recipient2];
     let amounts = vec![4, 11];
-    let mut store: TemporaryStore<()> =
-        temporary_store::with_input_objects_for_testing(InputObjects::from(coin_objects.clone()));
+    let mut store: TemporaryStore<()> = temporary_store::with_input_objects_for_testing(
+        input_objects_from_objects(coin_objects.clone()),
+    );
     let mut ctx = TxContext::with_sender_for_testing_only(&sender);
 
     assert!(pay(&mut store, coin_objects, recipients, amounts, &mut ctx).is_ok());
@@ -1006,8 +1040,9 @@ fn test_pay_sui_success_one_input_coin() {
     let recipients = vec![recipient1, recipient2];
     let amounts = vec![8, 6];
 
-    let mut store: TemporaryStore<()> =
-        temporary_store::with_input_objects_for_testing(InputObjects::from(coin_objects.clone()));
+    let mut store: TemporaryStore<()> = temporary_store::with_input_objects_for_testing(
+        input_objects_from_objects(coin_objects.clone()),
+    );
     let mut ctx = TxContext::with_sender_for_testing_only(&sender);
     assert!(pay_sui(&mut store, &mut coin_objects, recipients, amounts, &mut ctx).is_ok());
     let (store, _events) = store.into_inner();
@@ -1044,8 +1079,9 @@ fn test_pay_sui_success_multiple_input_coins() {
     let recipients = vec![recipient1, recipient2, recipient3];
     let amounts = vec![5, 15, 25];
 
-    let mut store: TemporaryStore<()> =
-        temporary_store::with_input_objects_for_testing(InputObjects::from(coin_objects.clone()));
+    let mut store: TemporaryStore<()> = temporary_store::with_input_objects_for_testing(
+        input_objects_from_objects(coin_objects.clone()),
+    );
     let mut ctx = TxContext::with_sender_for_testing_only(&sender);
     assert!(pay_sui(&mut store, &mut coin_objects, recipients, amounts, &mut ctx).is_ok());
     let (store, _events) = store.into_inner();
@@ -1083,8 +1119,9 @@ fn test_pay_all_sui_success_multiple_input_coins() {
 
     let recipient = SuiAddress::random_for_testing_only();
 
-    let mut store: TemporaryStore<()> =
-        temporary_store::with_input_objects_for_testing(InputObjects::from(coin_objects.clone()));
+    let mut store: TemporaryStore<()> = temporary_store::with_input_objects_for_testing(
+        input_objects_from_objects(coin_objects.clone()),
+    );
     assert!(pay_all_sui(sender, &mut store, &mut coin_objects, recipient).is_ok());
     let (store, _events) = store.into_inner();
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -85,6 +85,7 @@ impl TestCallArg {
             } => ObjectArg::SharedObject {
                 id: object_id,
                 initial_shared_version: *initial_shared_version,
+                mutable: true,
             },
         }
     }
@@ -198,6 +199,7 @@ async fn construct_shared_object_transaction_with_sequence_number(
             CallArg::Object(ObjectArg::SharedObject {
                 id: shared_object_id,
                 initial_shared_version,
+                mutable: true,
             }),
             CallArg::Pure(16u64.to_le_bytes().to_vec()),
         ],
@@ -3837,6 +3839,7 @@ async fn make_test_transaction(
             CallArg::Object(ObjectArg::SharedObject {
                 id: shared_object_id,
                 initial_shared_version: shared_object_initial_shared_version,
+                mutable: true,
             }),
             CallArg::Pure(arg_value.to_le_bytes().to_vec()),
         ],
@@ -4091,6 +4094,7 @@ async fn test_blocked_move_calls() {
             vec![CallArg::Object(ObjectArg::SharedObject {
                 id: SUI_SYSTEM_STATE_OBJECT_ID,
                 initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                mutable: true,
             })],
             MAX_GAS,
         ),

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -45,6 +45,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
     let shared_object_arg = ObjectArg::SharedObject {
         id: shared_object.id(),
         initial_shared_version: shared_object.version(),
+        mutable: true,
     };
     for gas_object in test_gas_objects() {
         // Make a sample transaction.

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -83,6 +83,8 @@ EntryArgumentErrorKind:
       UnsupportedPureArg: UNIT
     5:
       ArityMismatch: UNIT
+    6:
+      ObjectMutabilityMismatch: UNIT
 EntryTypeArgumentError:
   STRUCT:
     - argument_idx: U16
@@ -358,6 +360,7 @@ ObjectArg:
               TYPENAME: ObjectID
           - initial_shared_version:
               TYPENAME: SequenceNumber
+          - mutable: BOOL
 ObjectDigest:
   NEWTYPESTRUCT: BYTES
 ObjectFormatOptions:

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -225,6 +225,7 @@ async fn create_txes(
     let counter_object_arg = ObjectArg::SharedObject {
         id: counter_id,
         initial_shared_version: counter_initial_shared_version,
+        mutable: true,
     };
 
     ret.insert(CommonTransactionCosts::SharedCounterCreate, transaction);

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -2759,7 +2759,13 @@ pub enum SuiInputObjectKind {
     SharedMoveObject {
         id: ObjectID,
         initial_shared_version: SequenceNumber,
+        #[serde(default = "default_shared_object_mutability")]
+        mutable: bool,
     },
+}
+
+const fn default_shared_object_mutability() -> bool {
+    true
 }
 
 impl From<InputObjectKind> for SuiInputObjectKind {
@@ -2770,9 +2776,11 @@ impl From<InputObjectKind> for SuiInputObjectKind {
             InputObjectKind::SharedMoveObject {
                 id,
                 initial_shared_version,
+                mutable,
             } => Self::SharedMoveObject {
                 id,
                 initial_shared_version,
+                mutable,
             },
         }
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4360,6 +4360,10 @@
                   },
                   "initial_shared_version": {
                     "$ref": "#/components/schemas/SequenceNumber"
+                  },
+                  "mutable": {
+                    "default": true,
+                    "type": "boolean"
                   }
                 }
               }

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -896,6 +896,7 @@ impl InternalOperation {
                         CallArg::Object(ObjectArg::SharedObject {
                             id: SUI_SYSTEM_STATE_OBJECT_ID,
                             initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                            mutable: true,
                         }),
                         CallArg::ObjVec(
                             coins.into_iter().map(ObjectArg::ImmOrOwnedObject).collect(),

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -331,6 +331,8 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             } => ObjectArg::SharedObject {
                 id,
                 initial_shared_version,
+                // todo(RWLocks) - do we want to parametrise this?
+                mutable: true, // using mutable reference by default here.
             },
             Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
                 ObjectArg::ImmOrOwnedObject(obj_ref)
@@ -628,6 +630,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 CallArg::Object(ObjectArg::SharedObject {
                     id: SUI_SYSTEM_STATE_OBJECT_ID,
                     initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                    mutable: true,
                 }),
                 CallArg::ObjVec(obj_vec),
                 CallArg::Pure(bcs::to_bytes(&amount)?),
@@ -661,6 +664,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 CallArg::Object(ObjectArg::SharedObject {
                     id: SUI_SYSTEM_STATE_OBJECT_ID,
                     initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                    mutable: true,
                 }),
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(delegation)),
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(staked_sui)),
@@ -694,6 +698,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 CallArg::Object(ObjectArg::SharedObject {
                     id: SUI_SYSTEM_STATE_OBJECT_ID,
                     initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                    mutable: true,
                 }),
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(delegation)),
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(staked_sui)),

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -119,6 +119,7 @@ impl SuiValue {
             } => Ok(ObjectArg::SharedObject {
                 id,
                 initial_shared_version,
+                mutable: true,
             }),
             Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
                 let obj_ref = obj.compute_object_reference();

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -81,10 +81,12 @@ pub enum CallArg {
 pub enum ObjectArg {
     // A Move object, either immutable, or owned mutable.
     ImmOrOwnedObject(ObjectRef),
-    // A Move object that's shared and mutable.
+    // A Move object that's shared.
+    // SharedObject::mutable controls whether caller asks for a mutable reference to shared object.
     SharedObject {
         id: ObjectID,
         initial_shared_version: SequenceNumber,
+        mutable: bool,
     },
 }
 
@@ -252,12 +254,15 @@ impl MoveCall {
                 CallArg::Object(ObjectArg::SharedObject {
                     id,
                     initial_shared_version,
+                    mutable,
                 }) => {
                     let id = *id;
                     let initial_shared_version = *initial_shared_version;
+                    let mutable = *mutable;
                     Some(vec![InputObjectKind::SharedMoveObject {
                         id,
                         initial_shared_version,
+                        mutable,
                     }])
                 }
                 CallArg::ObjVec(vec) => Some(
@@ -269,12 +274,15 @@ impl MoveCall {
                             ObjectArg::SharedObject {
                                 id,
                                 initial_shared_version,
+                                mutable,
                             } => {
                                 let id = *id;
                                 let initial_shared_version = *initial_shared_version;
+                                let mutable = *mutable;
                                 InputObjectKind::SharedMoveObject {
                                     id,
                                     initial_shared_version,
+                                    mutable,
                                 }
                             }
                         })
@@ -319,6 +327,7 @@ impl SingleTransactionKind {
                         CallArg::Object(ObjectArg::SharedObject {
                             id,
                             initial_shared_version,
+                            .. // todo (RWLocks) - differentiate immutable shared refs
                         }) => Some(vec![(id, initial_shared_version)]),
                         CallArg::ObjVec(vec) => Some(
                             vec.iter()
@@ -326,6 +335,7 @@ impl SingleTransactionKind {
                                     if let ObjectArg::SharedObject {
                                         id,
                                         initial_shared_version,
+                                        .. // todo (RWLocks) - differentiate immutable shared refs
                                     } = obj_arg
                                     {
                                         Some((id, initial_shared_version))
@@ -400,6 +410,7 @@ impl SingleTransactionKind {
                 vec![InputObjectKind::SharedMoveObject {
                     id: SUI_SYSTEM_STATE_OBJECT_ID,
                     initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                    mutable: true,
                 }]
             }
             Self::Genesis(_) => {
@@ -1502,6 +1513,7 @@ pub enum EntryArgumentErrorKind {
     ObjectKindMismatch,
     UnsupportedPureArg,
     ArityMismatch,
+    ObjectMutabilityMismatch,
 }
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Serialize, Deserialize, Hash)]
@@ -1757,6 +1769,12 @@ impl Display for EntryArgumentErrorKind {
                 write!(
                     f,
                     "Mismatch between the number of actual versus expected arguments."
+                )
+            }
+            EntryArgumentErrorKind::ObjectMutabilityMismatch => {
+                write!(
+                    f,
+                    "Mismatch between the mutability of actual versus expected arguments."
                 )
             }
         }
@@ -2090,6 +2108,7 @@ pub enum InputObjectKind {
     SharedMoveObject {
         id: ObjectID,
         initial_shared_version: SequenceNumber,
+        mutable: bool,
     },
 }
 
@@ -2215,17 +2234,6 @@ impl InputObjects {
             .into_iter()
             .map(|(_, object)| (object.id(), object))
             .collect()
-    }
-}
-
-impl From<Vec<Object>> for InputObjects {
-    fn from(objects: Vec<Object>) -> Self {
-        Self::new(
-            objects
-                .into_iter()
-                .map(|o| (o.input_object_kind(), o))
-                .collect(),
-        )
     }
 }
 

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -19,7 +19,6 @@ use serde_with::Bytes;
 use crate::crypto::{deterministic_random_account_key, sha3_hash};
 use crate::error::{ExecutionError, ExecutionErrorKind};
 use crate::error::{SuiError, SuiResult};
-use crate::messages::InputObjectKind;
 use crate::move_package::MovePackage;
 use crate::{
     base_types::{
@@ -480,21 +479,6 @@ impl Object {
 
     pub fn digest(&self) -> ObjectDigest {
         ObjectDigest::new(sha3_hash(self))
-    }
-
-    pub fn input_object_kind(&self) -> InputObjectKind {
-        match &self.owner {
-            Owner::Shared {
-                initial_shared_version,
-                ..
-            } => InputObjectKind::SharedMoveObject {
-                id: self.id(),
-                initial_shared_version: *initial_shared_version,
-            },
-            Owner::ObjectOwner(_) | Owner::AddressOwner(_) | Owner::Immutable => {
-                InputObjectKind::ImmOrOwnedMoveObject(self.compute_object_reference())
-            }
-        }
     }
 
     /// Approximate size of the object in bytes. This is used for gas metering.

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -89,6 +89,7 @@ async fn call_shared_object_contract() {
     let counter_object_arg = ObjectArg::SharedObject {
         id: counter_id,
         initial_shared_version: counter_initial_shared_version,
+        mutable: true,
     };
 
     // Ensure the value of the counter is `0`.
@@ -167,6 +168,7 @@ async fn shared_object_flood() {
     let counter_object_arg = ObjectArg::SharedObject {
         id: counter_id,
         initial_shared_version: counter_initial_shared_version,
+        mutable: true,
     };
 
     // Ensure the value of the counter is `0`.
@@ -247,6 +249,7 @@ async fn shared_object_sync() {
     let counter_object_arg = ObjectArg::SharedObject {
         id: counter_id,
         initial_shared_version: counter_initial_shared_version,
+        mutable: true,
     };
 
     // Check that the counter object exists in at least one of the validators the transaction was

--- a/crates/sui/tests/shared_objects_version_tests.rs
+++ b/crates/sui/tests/shared_objects_version_tests.rs
@@ -245,6 +245,7 @@ impl TestEnvironment {
                 vec![CallArg::Object(ObjectArg::SharedObject {
                     id: counter,
                     initial_shared_version,
+                    mutable: true,
                 })],
             )
             .await?;

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -192,6 +192,7 @@ pub async fn make_counter_increment_transaction_with_wallet_context(
         vec![CallArg::Object(ObjectArg::SharedObject {
             id: counter_id,
             initial_shared_version: counter_initial_shared_version,
+            mutable: true,
         })],
         MAX_GAS,
     );
@@ -264,6 +265,7 @@ pub fn test_shared_object_transactions() -> Vec<VerifiedTransaction> {
                 CallArg::Object(ObjectArg::SharedObject {
                     id: shared_object_id,
                     initial_shared_version,
+                    mutable: true,
                 }),
                 CallArg::Pure(16u64.to_le_bytes().to_vec()),
                 CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
@@ -377,6 +379,7 @@ pub fn make_counter_increment_transaction(
         vec![CallArg::Object(ObjectArg::SharedObject {
             id: counter_id,
             initial_shared_version: counter_initial_shared_version,
+            mutable: true,
         })],
         MAX_GAS,
     );
@@ -402,6 +405,7 @@ pub fn make_delegation_transaction(
             CallArg::Object(ObjectArg::SharedObject {
                 id: SUI_SYSTEM_STATE_OBJECT_ID,
                 initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                mutable: true,
             }),
             CallArg::Object(ObjectArg::ImmOrOwnedObject(coin)),
             CallArg::Pure(bcs::to_bytes(&validator).unwrap()),


### PR DESCRIPTION
This PR does the following:

* Updates sui API by adding `mutable: bool` to the `SharedObject`.

* The move integration enforces that if client pass immutable shared object arg, it translates to immutable reference on the move call. It is an error to pass immutable shared arg as mutable arg to move, but not the vise versa - user can specify SharedObject::mutable=true but then pass it as immutable `&` reference to move call - this is to make sure existing clients do not break if they don't set `SharedObject::mutable` field.

This PR focuses on API change and does not yet update scheduling - under the hood immutable SharedObject still acquire a mutable lock - change for that coming in next PR.

Compatibility note:

* For JSON-RPC `SharedObject::mutable` has `serde_default` set to `true` - if client does not specify `SharedObject::mutable` they will get mutable reference by default (which is current behaviour)