### PR TITLE
[icons] Remove icons from build

### DIFF
--- a/apps/icons/README.md
+++ b/apps/icons/README.md
@@ -4,5 +4,5 @@
 
 1. Clean the project by running `pnpm icons clean:all` from the repo root.
 1. Open Figma Icons file. Create a mass export using `cmd` + `shift` + `e`. Save the SVGs to `sui/apps/icons/svgs`.
-1. Run `pnpm icons build` to generate the new icon library.
+1. Run `pnpm icons generate` to generate the new icon library.
 1. Commit the changes and submit a PR.

--- a/apps/icons/package.json
+++ b/apps/icons/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
-    "clean": "rimraf src/**",
+    "clean:src": "rimraf src/**",
     "clean:svgs": "rimraf svgs/**",
-    "clean:all": "pnpm clean && pnpm clean:svgs",
-    "build": "node scripts/preprocess.mjs && svgr --config-file svgrrc.config.js svgs"
+    "clean:all": "pnpm clean:src && pnpm clean:svgs",
+    "generate": "node scripts/preprocess.mjs && svgr --config-file svgrrc.config.js svgs"
   },
   "devDependencies": {
     "@svgr/cli": "^6.5.1",


### PR DESCRIPTION
This changes icons to use `generate` instead of `build` so that it's no longer included in turbo builds. The build artifact is the source, and is checked-in, so this should not be needed.