### PR TITLE
[TypeScript SDK] Adding checkpoint apis in typescript sdk

### DIFF
--- a/.changeset/breezy-walls-beg.md
+++ b/.changeset/breezy-walls-beg.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Adding Checkpoint APIs for ts sdk

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -52,6 +52,10 @@ import {
   ValidatorMetaData,
   CoinBalance,
   CoinSupply,
+  CheckpointSummary,
+  CheckpointContents,
+  CheckpointDigest,
+  CheckPointContentsDigest,
 } from '../types';
 import { DynamicFieldPage } from '../types/dynamic_fields'
 import {
@@ -946,4 +950,92 @@ export class JsonRpcProvider extends Provider {
       throw new Error(`Error in getValidators: ${err}`);
     }
   }
+
+  // Checkpoints
+  async getLatestCheckpointSequenceNumber(): Promise<number> {
+    try {
+      const resp = await this.client.requestWithType(
+        'sui_getLatestCheckpointSequenceNumber',
+        [],
+        number(),
+        this.options.skipDataValidation
+      );
+      return resp;
+    } catch (err) {
+      throw new Error(`Error fetching latest checkpoint sequence number: ${err}`);
+    }
+  }
+
+  async getCheckpointSummary(
+    sequence_number: number,
+  ): Promise<CheckpointSummary> {
+    try {
+      const resp = await this.client.requestWithType(
+        'sui_getCheckpointSummary',
+        [sequence_number],
+        CheckpointSummary,
+        this.options.skipDataValidation
+      );
+      return resp;
+    } catch (err) {
+      throw new Error(
+        `Error getting checkpoint summary with request type: ${err} for sequence number: ${sequence_number}.`
+      );
+    }
+  }
+
+  async getCheckpointSummaryByDigest(
+    digest: CheckpointDigest,
+  ): Promise<CheckpointSummary> {
+    try {
+      const resp = await this.client.requestWithType(
+        'sui_getCheckpointSummaryByDigest',
+        [digest],
+        CheckpointSummary,
+        this.options.skipDataValidation
+      );
+      return resp;
+    } catch (err) {
+      throw new Error(
+        `Error getting checkpoint summary with request type: ${err} for digest: ${digest}.`
+      );
+    }
+  }
+
+  async getCheckpointContents(
+    sequence_number: number,
+  ): Promise<CheckpointContents> {
+    try {
+      const resp = await this.client.requestWithType(
+        'sui_getCheckpointContents',
+        [sequence_number],
+        CheckpointContents,
+        this.options.skipDataValidation
+      );
+      return resp;
+    } catch (err) {
+      throw new Error(
+        `Error getting checkpoint contents with request type: ${err} for sequence number: ${sequence_number}.`
+      );
+    }
+  }
+
+  async getCheckpointContentsByDigest(
+    digest: CheckPointContentsDigest,
+  ): Promise<CheckpointContents> {
+    try {
+      const resp = await this.client.requestWithType(
+        'sui_getCheckpointContentsByDigest',
+        [digest],
+        CheckpointContents,
+        this.options.skipDataValidation
+      );
+      return resp;
+    } catch (err) {
+      throw new Error(
+        `Error getting checkpoint summary with request type: ${err} for digest: ${digest}.`
+      );
+    }
+  }
+
 }

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -38,6 +38,10 @@ import {
   PaginatedCoins,
   CoinBalance,
   CoinSupply,
+  CheckpointSummary,
+  CheckpointContents,
+  CheckpointDigest,
+  CheckPointContentsDigest,
 } from '../types';
 
 import { DynamicFieldPage } from '../types/dynamic_fields';
@@ -67,7 +71,7 @@ export abstract class Provider {
 
   // RPC Endpoint
   /**
-   * Invoke any RPC endpoint 
+   * Invoke any RPC endpoint
    * @param endpoint the endpoint to be invoked
    * @param params the arguments to be passed to the RPC request
    */
@@ -75,10 +79,10 @@ export abstract class Provider {
     endpoint: string,
     params: Array<any>
   ) : Promise<any>;
-  
+
   // Coins
   /**
-   * Get all Coin<`coin_type`> objects owned by an address. 
+   * Get all Coin<`coin_type`> objects owned by an address.
    * @param coinType optional fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC), default to 0x2::sui::SUI if not specified.
    * @param cursor optional paging cursor
    * @param limit maximum number of items per page
@@ -349,7 +353,7 @@ export abstract class Provider {
 
   /**
    * Return the dynamic field object information for a specified object
-   * @param parent_object_id - The ID od the quered parent object
+   * @param parent_object_id - The ID of the quered parent object
    * @param name - The name of the dynamic field
    */
   abstract getDynamicFieldObject(
@@ -362,4 +366,42 @@ export abstract class Provider {
    */
   abstract getReferenceGasPrice(): Promise<number>;
   // TODO: add more interface methods
+
+  /**
+   * Get the sequence number of the latest checkpoint that has been executed
+   */
+  abstract getLatestCheckpointSequenceNumber(): Promise<number>;
+
+  /**
+   * Returns checkpoint summary based on a checkpoint sequence number
+   * @param sequence_number - The sequence number of the desired checkpoint summary
+   */
+  abstract getCheckpointSummary(
+    sequenceNumber: number
+  ): Promise<CheckpointSummary>;
+
+  /**
+   * Returns checkpoint summary based on a checkpoint digest
+   * @param digest - The checkpoint digest
+   */
+  abstract getCheckpointSummaryByDigest(
+    digest: CheckpointDigest
+  ): Promise<CheckpointSummary>;
+
+  /**
+   * Return contents of a checkpoint, namely a list of execution digests
+   * @param sequence_number - The sequence number of the desired checkpoint contents
+   */
+  abstract getCheckpointContents(
+    sequenceNumber: number
+  ): Promise<CheckpointContents>;
+
+  /**
+   * Returns checkpoint summary based on a checkpoint content digest
+   * @param digest - The checkpoint summary digest
+   */
+  abstract getCheckpointContentsByDigest(
+    digest: CheckPointContentsDigest
+  ): Promise<CheckpointContents>;
+
 }

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -39,6 +39,10 @@ import {
   PaginatedCoins,
   CoinBalance,
   CoinSupply,
+  CheckpointSummary,
+  CheckpointContents,
+  CheckpointDigest,
+  CheckPointContentsDigest,
 } from '../types';
 import { Provider } from './provider';
 
@@ -288,5 +292,34 @@ export class VoidProvider extends Provider {
     _order: Order
   ): Promise<PaginatedEvents> {
     throw this.newError('getEvents');
+  }
+
+  // Checkpoints
+  async getLatestCheckpointSequenceNumber(): Promise<number> {
+    throw this.newError('getLatestCheckpointSequenceNumber');
+  }
+
+  async getCheckpointSummary(
+    _sequenceNumber: number,
+  ): Promise<CheckpointSummary> {
+    throw this.newError('getCheckpointSummary');
+  }
+
+  async getCheckpointSummaryByDigest(
+    _digest: CheckpointDigest,
+  ): Promise<CheckpointSummary> {
+    throw this.newError('getCheckpointSummaryByDigest');
+  }
+
+  async getCheckpointContents(
+    _sequenceNumber: number,
+  ): Promise<CheckpointContents> {
+    throw this.newError('getCheckpointContents');
+  }
+
+  async getCheckpointContentsByDigest(
+    _digest: CheckPointContentsDigest,
+  ): Promise<CheckpointContents> {
+    throw this.newError('getCheckpointContentsByDigest');
   }
 }

--- a/sdk/typescript/src/types/checkpoints.ts
+++ b/sdk/typescript/src/types/checkpoints.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    array,
+    Infer,
+    literal,
+    number,
+    object,
+    string,
+    union,
+    tuple,
+  } from 'superstruct';
+
+import {
+    TransactionDigest,
+    TransactionEffectsDigest,
+} from './common';
+
+export const GasCostSummary = object({
+    computation_cost: number(),
+    storage_cost: number(),
+    storage_rebate: number(),
+  });
+export type GasCostSummary = Infer<typeof GasCostSummary>;
+
+export const CheckPointContentsDigest = string();
+export type CheckPointContentsDigest = Infer<typeof CheckPointContentsDigest>;
+
+export const CheckpointDigest = string();
+export type CheckpointDigest = Infer<typeof CheckpointDigest>;
+
+export const CheckpointSummary = object({
+    epoch: number(),
+    sequence_number: number(),
+    network_total_transactions: number(),
+    content_digest: CheckPointContentsDigest,
+    previous_digest: union([CheckpointDigest, literal(null)]),
+    epoch_rolling_gas_cost_summary: GasCostSummary,
+    next_epoch_committee: union([array(tuple([string(), number()])), literal(null)]),
+    timestamp_ms: union([number(), literal(null)]),
+});
+export type CheckpointSummary = Infer<typeof CheckpointSummary>;
+
+export const ExecutionDigests = object({
+    transaction: TransactionDigest,
+    effects: TransactionEffectsDigest
+});
+
+export const CheckpointContents = object({
+    transactions: array(ExecutionDigests),
+    user_signatures: array(string()),
+});
+export type CheckpointContents = Infer<typeof CheckpointContents>;

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -26,6 +26,9 @@ import { Base64DataBuffer } from '../serialization/base64';
 export const TransactionDigest = string();
 export type TransactionDigest = Infer<typeof TransactionDigest>;
 
+export const TransactionEffectsDigest = string();
+export type TransactionEffectsDigest = Infer<typeof TransactionEffectsDigest>;
+
 export const ObjectId = string();
 export type ObjectId = Infer<typeof ObjectId>;
 

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -12,3 +12,4 @@ export * from './faucet';
 export * from './normalized';
 export * from './validator';
 export * from './coin';
+export { GasCostSummary, CheckpointSummary, CheckpointContents, CheckpointDigest, CheckPointContentsDigest } from './checkpoints';

--- a/sdk/typescript/test/e2e/checkpoint.test.ts
+++ b/sdk/typescript/test/e2e/checkpoint.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { setup, TestToolbox } from './utils/setup';
+
+describe('Checkpoints Reading API', () => {
+    let toolbox: TestToolbox;
+
+    beforeAll(async () => {
+      toolbox = await setup();
+    });
+
+    it('Get latest checkpoint sequence number', async () => {
+        const checkpointSequenceNumber = await toolbox.provider.getLatestCheckpointSequenceNumber();
+        expect(checkpointSequenceNumber).to.greaterThan(0);
+    });
+
+    it('Get checkpoint summary', async () => {
+        const resp = await toolbox.provider.getCheckpointSummary(0);
+        expect(resp.epoch).to.not.be.null;
+        expect(resp.sequence_number).to.not.be.null;
+        expect(resp.network_total_transactions).to.not.be.null;
+        expect(resp.content_digest).to.not.be.null;
+        expect(resp.epoch_rolling_gas_cost_summary).to.not.be.null;
+        expect(resp.timestamp_ms).to.not.be.null;
+    });
+
+    it('get checkpoint summary by digest', async () => {
+        const checkpoint_resp = await toolbox.provider.getCheckpointSummary(1);
+        const digest = checkpoint_resp.previous_digest;
+        expect(digest).to.not.be.null;
+        const resp = await toolbox.provider.getCheckpointSummaryByDigest(digest!);
+        expect(resp.epoch).to.not.be.null;
+        expect(resp.sequence_number).to.not.be.null;
+        expect(resp.network_total_transactions).to.not.be.null;
+        expect(resp.content_digest).to.not.be.null;
+        expect(resp.epoch_rolling_gas_cost_summary).to.not.be.null;
+        expect(resp.timestamp_ms).to.not.be.null; 
+    });
+
+    it('get checkpoint contents', async () => {
+        const resp = await toolbox.provider.getCheckpointContents(0);
+        expect(resp.transactions.length).greaterThan(0);
+    });
+
+    it('get checkpoint contents by digest', async () => {
+        const checkpoint_resp = await toolbox.provider.getCheckpointSummary(0);
+        const digest = checkpoint_resp.content_digest;
+        const resp = await toolbox.provider.getCheckpointContentsByDigest(digest);
+        expect(resp.transactions.length).greaterThan(0);
+    });
+});


### PR DESCRIPTION
PR for #7652 

- Added methods for getLatestCheckpointSequenceNumber, getCheckpointSummary, getCheckpointSummaryByDigest, getCheckpointContents, getCheckpointContentsByDigest
- Added checkpoint types in ts sdk
- Added e2e tests on the SDK