### PR TITLE
Find reference gas price from system state object in stress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8392,6 +8392,7 @@ dependencies = [
  "multiaddr",
  "narwhal-node",
  "num_cpus",
+ "once_cell",
  "prometheus",
  "rand 0.8.5",
  "rand_distr",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -18,6 +18,7 @@ tempfile = "3.3.0"
 tokio = { workspace = true, features = ["full"] }
 strum = "0.24.1"
 strum_macros = "0.24.3"
+once_cell = "1.15.0"
 num_cpus = "1.14.0"
 rocksdb = "0.19.0"
 serde_with = { version = "2.1.0", features = ["hex"] }

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -19,6 +19,7 @@ use sui_benchmark::options::Opts;
 
 use sui_benchmark::workloads::workload_configuration::WorkloadConfiguration;
 
+use sui_benchmark::system_state_observer::SystemStateObserver;
 use tokio::runtime::Builder;
 use tokio::sync::Barrier;
 
@@ -67,6 +68,16 @@ async fn main() -> Result<()> {
     let cloned_barrier = barrier.clone();
     let env = if opts.local { Env::Local } else { Env::Remote };
     let benchmark_setup = env.setup(cloned_barrier, &registry, &opts).await?;
+    let system_state_observer = {
+        let mut system_state_observer =
+            SystemStateObserver::new(benchmark_setup.validator_proxy.clone());
+        system_state_observer.reference_gas_price.changed().await?;
+        eprintln!(
+            "Found reference gas price from system state object = {:?}",
+            *system_state_observer.reference_gas_price.borrow()
+        );
+        Arc::new(system_state_observer)
+    };
     let stress_stat_collection = opts.stress_stat_collection;
     barrier.wait().await;
     // create client runtime
@@ -93,6 +104,7 @@ async fn main() -> Result<()> {
                     benchmark_setup.pay_coin_type_tag,
                     benchmark_setup.validator_proxy.clone(),
                     &opts,
+                    system_state_observer.clone(),
                 )
                 .await?;
             let interval = opts.run_duration;
@@ -106,6 +118,7 @@ async fn main() -> Result<()> {
                 .run(
                     workloads,
                     benchmark_setup.validator_proxy.clone(),
+                    system_state_observer,
                     &registry_clone,
                     show_progress,
                     interval,

--- a/crates/sui-benchmark/src/drivers/driver.rs
+++ b/crates/sui-benchmark/src/drivers/driver.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use crate::drivers::Interval;
+use crate::system_state_observer::SystemStateObserver;
 use crate::ValidatorProxy;
 use async_trait::async_trait;
 use prometheus::Registry;
@@ -16,6 +17,7 @@ pub trait Driver<T> {
         &self,
         workload: Vec<WorkloadInfo>,
         proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+        system_state_observer: Arc<SystemStateObserver>,
         registry: &Registry,
         show_progress: bool,
         run_duration: Interval,

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -37,6 +37,7 @@ pub mod drivers;
 pub mod embedded_reconfig_observer;
 pub mod fullnode_reconfig_observer;
 pub mod options;
+pub mod system_state_observer;
 pub mod util;
 pub mod workloads;
 

--- a/crates/sui-benchmark/src/system_state_observer.rs
+++ b/crates/sui-benchmark/src/system_state_observer.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ValidatorProxy;
+use std::sync::Arc;
+use std::time::Duration;
+use sui_types::{sui_system_state::SuiSystemState, SUI_SYSTEM_STATE_OBJECT_ID};
+use tokio::sync::oneshot::Sender;
+use tokio::sync::watch;
+use tokio::sync::watch::Receiver;
+use tokio::time;
+use tokio::time::Instant;
+use tracing::info;
+
+pub struct SystemStateObserver {
+    pub reference_gas_price: Receiver<u64>,
+    pub _sender: Sender<()>,
+}
+
+impl SystemStateObserver {
+    pub fn new(proxy: Arc<dyn ValidatorProxy + Send + Sync>) -> Self {
+        let (sender, mut recv) = tokio::sync::oneshot::channel();
+        let mut interval = tokio::time::interval_at(Instant::now(), Duration::from_secs(60));
+        interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+        let (tx, rx) = watch::channel(1u64);
+        tokio::task::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        if let Ok(system_state) = proxy.get_object(SUI_SYSTEM_STATE_OBJECT_ID).await {
+                            let move_obj = system_state.data.try_as_move().unwrap();
+                            if let Ok(result) = bcs::from_bytes::<SuiSystemState>(move_obj.contents()) {
+                                if tx.send(result.reference_gas_price).is_ok() {
+                                    info!("Reference gas price = {:?}", result.reference_gas_price);
+                                }
+                            }
+                        }
+                    }
+                    _ = &mut recv => break,
+                }
+            }
+        });
+        Self {
+            reference_gas_price: rx,
+            _sender: sender,
+        }
+    }
+}

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -12,7 +12,9 @@ use move_core_types::language_storage::TypeTag;
 use std::path::PathBuf;
 use std::sync::Arc;
 use sui_types::base_types::ObjectRef;
-use sui_types::messages::{CallArg, ObjectArg, TransactionData, VerifiedTransaction};
+use sui_types::messages::{
+    CallArg, ObjectArg, TransactionData, VerifiedTransaction, DUMMY_GAS_PRICE,
+};
 use sui_types::utils::to_sender_signed_transaction;
 use tracing::log::info;
 
@@ -45,8 +47,9 @@ pub fn make_split_coin_tx(
     split_amounts: Vec<u64>,
     gas: ObjectRef,
     keypair: &AccountKeyPair,
+    gas_price: Option<u64>,
 ) -> Result<VerifiedTransaction> {
-    let split_coin = TransactionData::new_move_call_with_dummy_gas_price(
+    let split_coin = TransactionData::new_move_call(
         sender,
         SUI_FRAMEWORK_OBJECT_ID,
         coin::PAY_MODULE_NAME.to_owned(),
@@ -58,6 +61,7 @@ pub fn make_split_coin_tx(
             CallArg::Pure(bcs::to_bytes(&split_amounts).unwrap()),
         ],
         1000000,
+        gas_price.unwrap_or(DUMMY_GAS_PRICE),
     );
     let verified_tx = to_sender_signed_transaction(split_coin, keypair);
     Ok(verified_tx)
@@ -70,14 +74,16 @@ pub fn make_pay_tx(
     split_amounts: Vec<u64>,
     gas: ObjectRef,
     keypair: &AccountKeyPair,
+    gas_price: Option<u64>,
 ) -> VerifiedTransaction {
-    let pay = TransactionData::new_pay_with_dummy_gas_price(
+    let pay = TransactionData::new_pay(
         sender,
         input_coins,
         addresses,
         split_amounts,
         gas,
         1000000,
+        gas_price.unwrap_or(DUMMY_GAS_PRICE),
     );
     to_sender_signed_transaction(pay, keypair)
 }
@@ -89,6 +95,7 @@ pub async fn split_coin_and_pay(
     coin_type_tag: TypeTag,
     coin_configs: Vec<GasCoinConfig>,
     gas: Gas,
+    gas_price: u64,
 ) -> Result<UpdatedAndNewlyMintedGasCoins> {
     // split one coin into smaller coins of different amounts and send them to recipients
     let split_amounts: Vec<u64> = coin_configs.iter().map(|c| c.amount).collect();
@@ -102,6 +109,7 @@ pub async fn split_coin_and_pay(
         split_amounts.clone(),
         gas.0,
         &gas.2,
+        Some(gas_price),
     )?;
     let (_, effects) = proxy.execute_transaction(verified_tx.into()).await?;
     let updated_gas = effects
@@ -120,6 +128,7 @@ pub async fn split_coin_and_pay(
         split_amounts,
         updated_gas.0,
         &gas.2,
+        Some(gas_price),
     );
     let (_, effects) = proxy.execute_transaction(verified_tx.into()).await?;
     let address_map: HashMap<SuiAddress, Arc<AccountKeyPair>> = coin_configs
@@ -153,6 +162,7 @@ pub async fn generate_all_gas_for_test(
     coin: Gas,
     coin_type_tag: TypeTag,
     workload_gas_config: WorkloadGasConfig,
+    gas_price: u64,
 ) -> Result<(WorkloadInitGas, WorkloadPayloadGas)> {
     info!(
         "Generating gas with number of coins for shared counter init = {:?}, number of coins for \
@@ -203,6 +213,7 @@ pub async fn generate_all_gas_for_test(
         coin_type_tag,
         coin_configs,
         gas,
+        gas_price,
     )
     .await?;
 

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -7,6 +7,7 @@ use move_core_types::language_storage::TypeTag;
 use std::sync::Arc;
 
 use crate::options::{Opts, RunSpec};
+use crate::system_state_observer::SystemStateObserver;
 use crate::util::generate_all_gas_for_test;
 use crate::workloads::shared_counter::SharedCounterWorkload;
 use crate::workloads::transfer_object::TransferObjectWorkload;
@@ -34,6 +35,7 @@ impl WorkloadConfiguration {
         pay_coin_type_tag: TypeTag,
         proxy: Arc<dyn ValidatorProxy + Send + Sync>,
         opts: &Opts,
+        system_state_observer: Arc<SystemStateObserver>,
     ) -> Result<Vec<WorkloadInfo>> {
         match opts.run_spec {
             RunSpec::Bench {
@@ -60,6 +62,7 @@ impl WorkloadConfiguration {
                         pay_coin,
                         pay_coin_type_tag,
                         proxy,
+                        system_state_observer,
                     )
                     .await
                 }
@@ -77,6 +80,7 @@ impl WorkloadConfiguration {
                         pay_coin,
                         pay_coin_type_tag,
                         proxy,
+                        system_state_observer,
                     )
                     .await
                 }
@@ -98,6 +102,7 @@ impl WorkloadConfiguration {
         coin: Gas,
         coin_type_tag: TypeTag,
         proxy: Arc<dyn ValidatorProxy + Send + Sync>,
+        system_state_observer: Arc<SystemStateObserver>,
     ) -> Result<Vec<WorkloadInfo>> {
         let shared_counter_ratio =
             1.0 - (std::cmp::min(shared_counter_hotness_factor as u32, 100) as f32 / 100.0);
@@ -145,6 +150,7 @@ impl WorkloadConfiguration {
                 transfer_object_workload_payload_gas_config,
                 delegation_gas_configs,
             },
+            *system_state_observer.reference_gas_price.borrow(),
         )
         .await?;
         let mut combination_workload = make_combination_workload(
@@ -159,7 +165,7 @@ impl WorkloadConfiguration {
         );
         combination_workload
             .workload
-            .init(workload_init_gas, proxy)
+            .init(workload_init_gas, proxy, system_state_observer.clone())
             .await;
         Ok(vec![combination_workload])
     }
@@ -178,6 +184,7 @@ impl WorkloadConfiguration {
         coin: Gas,
         coin_type_tag: TypeTag,
         proxy: Arc<dyn ValidatorProxy + Send + Sync>,
+        system_state_observer: Arc<SystemStateObserver>,
     ) -> Result<Vec<WorkloadInfo>> {
         let mut workloads = vec![];
         let shared_counter_weight_ratio = shared_counter_weight as f32
@@ -251,6 +258,7 @@ impl WorkloadConfiguration {
                 transfer_object_workload_payload_gas_config,
                 delegation_gas_configs,
             },
+            *system_state_observer.reference_gas_price.borrow(),
         )
         .await?;
         if let Some(mut shared_counter_workload) = make_shared_counter_workload(
@@ -266,7 +274,11 @@ impl WorkloadConfiguration {
         ) {
             shared_counter_workload
                 .workload
-                .init(workload_init_gas, proxy.clone())
+                .init(
+                    workload_init_gas,
+                    proxy.clone(),
+                    system_state_observer.clone(),
+                )
                 .await;
             workloads.push(shared_counter_workload);
         }
@@ -289,6 +301,7 @@ impl WorkloadConfiguration {
                         shared_counter_init_gas: vec![],
                     },
                     proxy.clone(),
+                    system_state_observer.clone(),
                 )
                 .await;
             workloads.push(transfer_object_workload);

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -45,6 +45,7 @@ fn make_tx(gas: &Object, sender: SuiAddress, keypair: &AccountKeyPair) -> Verifi
         None,
         sender,
         keypair,
+        None,
     )
 }
 

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -21,7 +21,7 @@ use sui_types::crypto::{
     generate_proof_of_possession, get_key_pair, AccountKeyPair, AuthorityPublicKeyBytes,
     NetworkKeyPair, SuiKeyPair,
 };
-use sui_types::messages::{TransactionData, VerifiedTransaction};
+use sui_types::messages::{TransactionData, VerifiedTransaction, DUMMY_GAS_PRICE};
 use sui_types::utils::create_fake_transaction;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
@@ -265,9 +265,15 @@ pub fn make_transfer_sui_transaction(
     amount: Option<u64>,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
+    gas_price: Option<u64>,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_transfer_sui_with_dummy_gas_price(
-        recipient, sender, amount, gas_object, MAX_GAS,
+    let data = TransactionData::new_transfer_sui(
+        recipient,
+        sender,
+        amount,
+        gas_object,
+        MAX_GAS,
+        gas_price.unwrap_or(DUMMY_GAS_PRICE),
     );
     to_sender_signed_transaction(data, keypair)
 }
@@ -278,9 +284,15 @@ pub fn make_transfer_object_transaction(
     sender: SuiAddress,
     keypair: &AccountKeyPair,
     recipient: SuiAddress,
+    gas_price: Option<u64>,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_transfer_with_dummy_gas_price(
-        recipient, object_ref, sender, gas_object, MAX_GAS,
+    let data = TransactionData::new_transfer(
+        recipient,
+        object_ref,
+        sender,
+        gas_object,
+        MAX_GAS,
+        gas_price.unwrap_or(DUMMY_GAS_PRICE),
     );
     to_sender_signed_transaction(data, keypair)
 }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -974,6 +974,7 @@ async fn test_handle_transaction_response() {
         None,
         sender,
         &sender_kp,
+        None,
     );
     // Case 0
     // Validators give invalid response because of the initial value set for their responses.

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -320,7 +320,7 @@ async fn test_transaction_manager() {
 
     // Initialize a shared counter, re-using gas_ref_0 so it has to execute after tx1.
     let gas_ref = get_latest_ref(authority_clients[0], gas_objects[0][0].id()).await;
-    let tx2 = make_counter_create_transaction(gas_ref, package, *addr1, key1);
+    let tx2 = make_counter_create_transaction(gas_ref, package, *addr1, key1, None);
     let (cert, effects2) =
         execute_owned_on_first_three_authorities(&authority_clients, &aggregator.committee, &tx2)
             .await;
@@ -381,6 +381,7 @@ async fn test_transaction_manager() {
             shared_counter_initial_version,
             *source_addr,
             source_key,
+            None,
         );
         let (cert, effects) = execute_shared_on_first_three_authorities(
             &authority_clients,
@@ -463,7 +464,7 @@ async fn test_per_object_overload() {
 
     // Create a shared counter.
     let gas_ref = get_latest_ref(authority_clients[0], gas_objects[0].id()).await;
-    let create_counter_txn = make_counter_create_transaction(gas_ref, package, addr, &key);
+    let create_counter_txn = make_counter_create_transaction(gas_ref, package, addr, &key, None);
     let create_counter_cert = try_sign_on_first_three_authorities(
         &authority_clients,
         &aggregator.committee,
@@ -524,6 +525,7 @@ async fn test_per_object_overload() {
             shared_counter_initial_version,
             addr,
             &key,
+            None,
         );
         let shared_cert = try_sign_on_first_three_authorities(
             &authority_clients,
@@ -549,6 +551,7 @@ async fn test_per_object_overload() {
         shared_counter_initial_version,
         addr,
         &key,
+        None,
     );
     let sign_result = authority_clients[3]
         .handle_transaction(shared_txn.clone())

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -127,6 +127,7 @@ async fn create_txes(
         None,
         sender,
         keypair,
+        None,
     );
     let partial_sui_coin_tx = make_transfer_sui_transaction(
         gas_objects.pop().unwrap().compute_object_reference(),
@@ -134,6 +135,7 @@ async fn create_txes(
         Some(100),
         sender,
         keypair,
+        None,
     );
     ret.insert(
         CommonTransactionCosts::TransferWholeSuiCoin,
@@ -153,6 +155,7 @@ async fn create_txes(
         sender,
         keypair,
         SuiAddress::default(),
+        None,
     );
 
     ret.insert(CommonTransactionCosts::TransferWholeCoin, whole_coin_tx);

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -43,7 +43,7 @@ use strum::IntoStaticStr;
 use tap::Pipe;
 use tracing::debug;
 
-const DUMMY_GAS_PRICE: u64 = 1;
+pub const DUMMY_GAS_PRICE: u64 = 1;
 
 const BLOCKED_MOVE_FUNCTIONS: [(ObjectID, &str, &str); 3] = [
     (

--- a/crates/sui/tests/checkpoint_tests.rs
+++ b/crates/sui/tests/checkpoint_tests.rs
@@ -31,6 +31,7 @@ async fn basic_checkpoints_integration_test() {
         None,
         sender,
         &keypair,
+        None,
     );
     let net = AuthorityAggregator::new_from_local_system_state(
         &authorities[0].with(|node| node.state().db()),

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -137,6 +137,7 @@ async fn reconfig_with_revert_end_to_end_test() {
         None,
         sender,
         &keypair,
+        None,
     );
     let net = AuthorityAggregator::new_from_local_system_state(
         &authorities[0].with(|node| node.state().db()),
@@ -159,6 +160,7 @@ async fn reconfig_with_revert_end_to_end_test() {
         None,
         sender,
         &keypair,
+        None,
     );
     let cert = net.process_transaction(tx.clone()).await.unwrap();
 
@@ -309,6 +311,7 @@ async fn test_validator_resign_effects() {
         None,
         sender,
         &keypair,
+        None,
     );
     let registry = Registry::new();
     let mut net = AuthorityAggregator::new_from_local_system_state(

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -21,8 +21,8 @@ use sui_types::crypto::{
     AuthorityPublicKeyBytes, AuthoritySignInfo, KeypairTraits,
 };
 use sui_types::gas_coin::GasCoin;
-use sui_types::messages::CallArg;
 use sui_types::messages::SignedTransactionEffects;
+use sui_types::messages::{CallArg, DUMMY_GAS_PRICE};
 use sui_types::messages::{
     CertifiedTransaction, ObjectArg, TransactionData, VerifiedCertificate,
     VerifiedSignedTransaction, VerifiedTransaction,
@@ -280,16 +280,18 @@ pub fn create_publish_move_package_transaction(
     path: PathBuf,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
+    gas_price: Option<u64>,
 ) -> VerifiedTransaction {
     let build_config = BuildConfig::default();
     let all_module_bytes = sui_framework::build_move_package(&path, build_config)
         .unwrap()
         .get_package_bytes(/* with_unpublished_deps */ false);
-    let data = TransactionData::new_module_with_dummy_gas_price(
+    let data = TransactionData::new_module(
         sender,
         gas_object_ref,
         all_module_bytes,
         MAX_GAS,
+        gas_price.unwrap_or(DUMMY_GAS_PRICE),
     );
     to_sender_signed_transaction(data, keypair)
 }
@@ -344,8 +346,9 @@ pub fn make_counter_create_transaction(
     package_id: ObjectID,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
+    gas_price: Option<u64>,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_move_call_with_dummy_gas_price(
+    let data = TransactionData::new_move_call(
         sender,
         package_id,
         "counter".parse().unwrap(),
@@ -354,6 +357,7 @@ pub fn make_counter_create_transaction(
         gas_object,
         vec![],
         MAX_GAS,
+        gas_price.unwrap_or(DUMMY_GAS_PRICE),
     );
     to_sender_signed_transaction(data, keypair)
 }
@@ -365,8 +369,9 @@ pub fn make_counter_increment_transaction(
     counter_initial_shared_version: SequenceNumber,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
+    gas_price: Option<u64>,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_move_call_with_dummy_gas_price(
+    let data = TransactionData::new_move_call(
         sender,
         package_id,
         "counter".parse().unwrap(),
@@ -378,6 +383,7 @@ pub fn make_counter_increment_transaction(
             initial_shared_version: counter_initial_shared_version,
         })],
         MAX_GAS,
+        gas_price.unwrap_or(1),
     );
     to_sender_signed_transaction(data, keypair)
 }
@@ -388,8 +394,9 @@ pub fn make_delegation_transaction(
     validator: SuiAddress,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
+    gas_price: Option<u64>,
 ) -> VerifiedTransaction {
-    let data = TransactionData::new_move_call_with_dummy_gas_price(
+    let data = TransactionData::new_move_call(
         sender,
         SUI_FRAMEWORK_OBJECT_ID,
         SUI_SYSTEM_MODULE_NAME.to_owned(),
@@ -405,6 +412,7 @@ pub fn make_delegation_transaction(
             CallArg::Pure(bcs::to_bytes(&validator).unwrap()),
         ],
         MAX_GAS,
+        gas_price.unwrap_or(DUMMY_GAS_PRICE),
     );
     to_sender_signed_transaction(data, keypair)
 }

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -47,6 +47,7 @@ pub fn make_publish_package(gas_object: Object, path: PathBuf) -> VerifiedTransa
         path,
         sender,
         &keypair,
+        None,
     )
 }
 


### PR DESCRIPTION
Works fine when i run it locally:
```
stress --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 --primary-gas-id 0x59931dcac57ba20d75321acaf55e8eb5a2c47e9f --genesis-blob-path /tmp/genesis.blob --keystore-path /tmp/sui.keystore bench --target-qps 10 --num-workers 10 --shared-counter 0 --transfer-object 100 --run-duration 200s`
Found reference gas price from system state object = 1
```