### PR TITLE
Update install.md

### DIFF
--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -113,6 +113,20 @@ For more information, see [Install Git on Linux](https://github.com/git-guides/i
 
 Install CMake using the instructions at [Installing CMake](https://cmake.org/install/) on the CMake website.
 
+Or you can use the following command
+
+```shell
+sudo apt-get install cmake
+```
+
+### GCC
+
+Use the following command to install `gcc`:
+
+```shell
+sudo apt-get install gcc
+```
+
 ### libssl-dev
 
 Use the following command to install `libssl-dev`:


### PR DESCRIPTION
put a more easily way for installing the `cmake` and deal with the potential issue `linker ‘cc’ not found`