### PR TITLE
[bugfix] - Sui Json shouldn't zero trim output addresses

### DIFF
--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -267,7 +267,8 @@ fn try_from_bcs_bytes(bytes: &[u8]) -> Result<JsonValue, anyhow::Error> {
     if let Ok(v) = bcs::from_bytes::<String>(bytes) {
         Ok(JsonValue::String(v))
     } else if let Ok(v) = bcs::from_bytes::<AccountAddress>(bytes) {
-        Ok(JsonValue::String(v.to_hex_literal()))
+        // Converting address to string without trimming 0
+        Ok(JsonValue::String(format!("{v:#x}")))
     } else if let Ok(v) = bcs::from_bytes::<u8>(bytes) {
         Ok(JsonValue::Number(Number::from(v)))
     } else if let Ok(v) = bcs::from_bytes::<u16>(bytes) {

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -680,6 +680,19 @@ fn test_convert_number_from_bcs() {
 }
 
 #[test]
+fn test_no_address_zero_trimming() {
+    let bcs_bytes = bcs::to_bytes(
+        &AccountAddress::from_str("0x0000011111111111111111111111111111111111").unwrap(),
+    )
+    .unwrap();
+    let value = SuiJsonValue::from_bcs_bytes(&bcs_bytes).unwrap();
+    assert_eq!(
+        "0x0000011111111111111111111111111111111111",
+        value.0.as_str().unwrap()
+    );
+}
+
+#[test]
 fn test_convert_number_array_from_bcs() {
     let bcs_bytes = [
         5, 80, 195, 0, 0, 80, 195, 0, 0, 80, 195, 0, 0, 80, 195, 0, 0, 80, 195, 0, 0,


### PR DESCRIPTION
Zero trimming causes parsed move object output to have shorter object id/address if it have leading zeros.