### PR TITLE
wallet-ext: toasts less margin

### DIFF
--- a/apps/wallet/src/ui/app/shared/toaster/index.tsx
+++ b/apps/wallet/src/ui/app/shared/toaster/index.tsx
@@ -13,7 +13,7 @@ export type ToasterProps = {
     bottomNavEnabled: boolean;
 };
 const commonToastClasses =
-    '!text-p2 !font-medium !rounded-2lg !shadow-notification';
+    '!px-0 !py-1 !text-p2 !font-medium !rounded-2lg !shadow-notification';
 export function Toaster({ bottomNavEnabled }: ToasterProps) {
     const { pathname } = useLocation();
     const isExtraNavTabsVisible = pathname.startsWith('/apps');


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="417" alt="Screenshot 2023-01-26 at 18 13 51" src="https://user-images.githubusercontent.com/10210143/214917095-59a744a2-d728-48db-875f-a41f93a52f01.png"> | <img width="417" alt="Screenshot 2023-01-26 at 18 14 05" src="https://user-images.githubusercontent.com/10210143/214917146-6999f18b-95fc-48da-bf04-e5fc45ee1afa.png"> |

addresses https://github.com/MystenLabs/sui/pull/7583#issuecomment-1400912818