### PR TITLE
[move] Adding support for Sui storage to the Prover

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -91,7 +91,6 @@ mod test {
     }
 
     #[sim_test(config = "test_config()")]
-    #[ignore]
     async fn test_simulated_load_reconfig_crashes() {
         let test_cluster = build_test_cluster(4, 1000).await;
 

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -91,6 +91,7 @@ mod test {
     }
 
     #[sim_test(config = "test_config()")]
+    #[ignore]
     async fn test_simulated_load_reconfig_crashes() {
         let test_cluster = build_test_cluster(4, 1000).await;
 

--- a/crates/sui-framework/docs/address.md
+++ b/crates/sui-framework/docs/address.md
@@ -93,6 +93,19 @@ Convert <code>a</code> into a u256 by interpreting <code>a</code> as the bytes o
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_address_from_u256"></a>
 
 ## Function `from_u256`
@@ -117,6 +130,19 @@ Aborts if <code>n</code> > <code>MAX_ADDRESS</code>
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_address_from_bytes"></a>
 
 ## Function `from_bytes`
@@ -135,6 +161,19 @@ Aborts with <code><a href="address.md#0x2_address_EAddressParseError">EAddressPa
 
 
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="address.md#0x2_address_from_bytes">from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <b>address</b>;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/bls12381.md
+++ b/crates/sui-framework/docs/bls12381.md
@@ -49,6 +49,7 @@ BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 
@@ -126,6 +127,7 @@ BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/bulletproofs.md
+++ b/crates/sui-framework/docs/bulletproofs.md
@@ -43,6 +43,7 @@ Only bit_length = 64, 32, 16, 8 will work.
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/dynamic_field.md
+++ b/crates/sui-framework/docs/dynamic_field.md
@@ -161,6 +161,18 @@ Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExist
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> intrinsic;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_dynamic_field_borrow"></a>
 
 ## Function `borrow`

--- a/crates/sui-framework/docs/dynamic_field.md
+++ b/crates/sui-framework/docs/dynamic_field.md
@@ -168,13 +168,16 @@ Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExist
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
-<b>ensures</b> [abstract] <a href="object.md#0x2_object">object</a>.id == <b>old</b>(<a href="object.md#0x2_object">object</a>.id);
-<b>ensures</b> [abstract] <b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names
-    == concat(
-        <b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes)).names,
-        vec(name)
-    );
-<b>ensures</b> [abstract] len(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names) == len(<b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names)) + 1;
+<b>modifies</b> [abstract] <b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
+<b>ensures</b> [abstract] <a href="object.md#0x2_object">object</a> == <b>old</b>(<a href="object.md#0x2_object">object</a>);
+<b>ensures</b> [abstract] <b>exists</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
+<b>ensures</b> [abstract] (!<b>old</b>(<b>exists</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes)))
+    ==&gt; <b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names == vec(name);
+<b>ensures</b> [abstract] <b>old</b>(<b>exists</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes))
+    ==&gt; <b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names == concat(
+            <b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names),
+            vec(name)
+        );
 </code></pre>
 
 
@@ -318,12 +321,12 @@ type.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] !sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
+<b>modifies</b> [abstract] <b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
 <b>ensures</b> [abstract] <a href="object.md#0x2_object">object</a>.id == <b>old</b>(<a href="object.md#0x2_object">object</a>.id);
+<b>ensures</b> [abstract] <b>exists</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
 <b>ensures</b> [abstract] sui::prover::vec_remove(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names,
-    index_of(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names, name),
-    0) ==
+    index_of(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names, name), 0) ==
       <b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names);
-<b>ensures</b> [abstract] len(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names) == len(<b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names)) - 1;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/dynamic_field.md
+++ b/crates/sui-framework/docs/dynamic_field.md
@@ -168,14 +168,14 @@ Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExist
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
-<b>modifies</b> [abstract] <b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
+<b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
 <b>ensures</b> [abstract] <a href="object.md#0x2_object">object</a> == <b>old</b>(<a href="object.md#0x2_object">object</a>);
-<b>ensures</b> [abstract] <b>exists</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
-<b>ensures</b> [abstract] (!<b>old</b>(<b>exists</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes)))
-    ==&gt; <b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names == vec(name);
-<b>ensures</b> [abstract] <b>old</b>(<b>exists</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes))
-    ==&gt; <b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names == concat(
-            <b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names),
+<b>ensures</b> [abstract] <b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
+<b>ensures</b> [abstract] (!<b>old</b>(<b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes)))
+    ==&gt; <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names == vec(name);
+<b>ensures</b> [abstract] <b>old</b>(<b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes))
+    ==&gt; <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names == concat(
+            <b>old</b>(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names),
             vec(name)
         );
 </code></pre>
@@ -321,12 +321,12 @@ type.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] !sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
-<b>modifies</b> [abstract] <b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
+<b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
 <b>ensures</b> [abstract] <a href="object.md#0x2_object">object</a>.id == <b>old</b>(<a href="object.md#0x2_object">object</a>.id);
-<b>ensures</b> [abstract] <b>exists</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
-<b>ensures</b> [abstract] sui::prover::vec_remove(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names,
-    index_of(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names, name), 0) ==
-      <b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names);
+<b>ensures</b> [abstract] <b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
+<b>ensures</b> [abstract] sui::prover::vec_remove(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names,
+    index_of(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names, name), 0) ==
+      <b>old</b>(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names);
 </code></pre>
 
 

--- a/crates/sui-framework/docs/dynamic_field.md
+++ b/crates/sui-framework/docs/dynamic_field.md
@@ -323,12 +323,13 @@ type.
 <b>aborts_if</b> [abstract] !<a href="prover.md#0x2_prover_uid_has_field">prover::uid_has_field</a>(<a href="object.md#0x2_object">object</a>, name);
 <b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>));
 <b>ensures</b> [abstract] <a href="object.md#0x2_object">object</a>.id == <b>old</b>(<a href="object.md#0x2_object">object</a>.id);
-<b>ensures</b> [abstract] <b>old</b>(<a href="prover.md#0x2_prover_uid_num_fields">prover::uid_num_fields</a>&lt;Name&gt;(<a href="object.md#0x2_object">object</a>)) == 0
+<b>ensures</b> [abstract] <b>old</b>(<a href="prover.md#0x2_prover_uid_num_fields">prover::uid_num_fields</a>&lt;Name&gt;(<a href="object.md#0x2_object">object</a>)) == 1
     ==&gt; !<b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>));
-<b>ensures</b> [abstract] <b>old</b>(<a href="prover.md#0x2_prover_uid_num_fields">prover::uid_num_fields</a>&lt;Name&gt;(<a href="object.md#0x2_object">object</a>)) &gt; 0
+<b>ensures</b> [abstract] <b>old</b>(<a href="prover.md#0x2_prover_uid_num_fields">prover::uid_num_fields</a>&lt;Name&gt;(<a href="object.md#0x2_object">object</a>)) &gt; 1
     ==&gt; <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>)).names ==
             <b>old</b>(<a href="prover.md#0x2_prover_vec_remove">prover::vec_remove</a>(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>)).names,
                 index_of(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>)).names, name)));
+<b>ensures</b> [abstract] !<a href="prover.md#0x2_prover_uid_has_field">prover::uid_has_field</a>(<a href="object.md#0x2_object">object</a>, name);
 </code></pre>
 
 

--- a/crates/sui-framework/docs/dynamic_field.md
+++ b/crates/sui-framework/docs/dynamic_field.md
@@ -477,6 +477,19 @@ Returns true if and only if the <code><a href="object.md#0x2_object">object</a><
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_dynamic_field_add_child_object"></a>
 
 ## Function `add_child_object`
@@ -493,6 +506,19 @@ Returns true if and only if the <code><a href="object.md#0x2_object">object</a><
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_add_child_object">add_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, child: Child);
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 
@@ -524,6 +550,19 @@ we need two versions to return a reference or a mutable reference
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_dynamic_field_borrow_child_object_mut"></a>
 
 ## Function `borrow_child_object_mut`
@@ -540,6 +579,19 @@ we need two versions to return a reference or a mutable reference
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;Child: key&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> UID, id: <b>address</b>): &<b>mut</b> Child;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 
@@ -570,6 +622,19 @@ or throws <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_dynamic_field_has_child_object"></a>
 
 ## Function `has_child_object`
@@ -592,6 +657,19 @@ or throws <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_dynamic_field_has_child_object_with_ty"></a>
 
 ## Function `has_child_object_with_ty`
@@ -608,6 +686,19 @@ or throws <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_has_child_object_with_ty">has_child_object_with_ty</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): bool;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/dynamic_field.md
+++ b/crates/sui-framework/docs/dynamic_field.md
@@ -167,17 +167,17 @@ Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExist
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> [abstract] sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
-<b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
+<b>aborts_if</b> [abstract] <a href="prover.md#0x2_prover_uid_has_field">prover::uid_has_field</a>(<a href="object.md#0x2_object">object</a>, name);
+<b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>));
 <b>ensures</b> [abstract] <a href="object.md#0x2_object">object</a> == <b>old</b>(<a href="object.md#0x2_object">object</a>);
-<b>ensures</b> [abstract] <b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
-<b>ensures</b> [abstract] (!<b>old</b>(<b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes)))
-    ==&gt; <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names == vec(name);
-<b>ensures</b> [abstract] <b>old</b>(<b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes))
-    ==&gt; <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names == concat(
-            <b>old</b>(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names),
+<b>ensures</b> [abstract] <b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>));
+<b>ensures</b> [abstract] (!<b>old</b>(<b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>))))
+    ==&gt; <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>)).names == vec(name);
+<b>ensures</b> [abstract] <b>old</b>(<b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>)))
+    ==&gt; <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>)).names == <b>old</b>(concat(
+            <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>)).names,
             vec(name)
-        );
+        ));
 </code></pre>
 
 
@@ -224,7 +224,7 @@ type.
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> [abstract] !sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
+<b>aborts_if</b> [abstract] !<a href="prover.md#0x2_prover_uid_has_field">prover::uid_has_field</a>(<a href="object.md#0x2_object">object</a>, name);
 </code></pre>
 
 
@@ -271,7 +271,7 @@ type.
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> [abstract] !sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
+<b>aborts_if</b> [abstract] !<a href="prover.md#0x2_prover_uid_has_field">prover::uid_has_field</a>(<a href="object.md#0x2_object">object</a>, name);
 </code></pre>
 
 
@@ -320,13 +320,15 @@ type.
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> [abstract] !sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
-<b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
+<b>aborts_if</b> [abstract] !<a href="prover.md#0x2_prover_uid_has_field">prover::uid_has_field</a>(<a href="object.md#0x2_object">object</a>, name);
+<b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>));
 <b>ensures</b> [abstract] <a href="object.md#0x2_object">object</a>.id == <b>old</b>(<a href="object.md#0x2_object">object</a>.id);
-<b>ensures</b> [abstract] <b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes);
-<b>ensures</b> [abstract] sui::prover::vec_remove(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names,
-    index_of(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names, name), 0) ==
-      <b>old</b>(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names);
+<b>ensures</b> [abstract] <b>old</b>(<a href="prover.md#0x2_prover_uid_num_fields">prover::uid_num_fields</a>&lt;Name&gt;(<a href="object.md#0x2_object">object</a>)) == 0
+    ==&gt; !<b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>));
+<b>ensures</b> [abstract] <b>old</b>(<a href="prover.md#0x2_prover_uid_num_fields">prover::uid_num_fields</a>&lt;Name&gt;(<a href="object.md#0x2_object">object</a>)) &gt; 0
+    ==&gt; <b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>)).names ==
+            <b>old</b>(<a href="prover.md#0x2_prover_vec_remove">prover::vec_remove</a>(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>)).names,
+                index_of(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;Name&gt;&gt;(<a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>)).names, name)));
 </code></pre>
 
 

--- a/crates/sui-framework/docs/dynamic_field.md
+++ b/crates/sui-framework/docs/dynamic_field.md
@@ -166,7 +166,15 @@ Aborts with <code><a href="dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExist
 
 
 
-<pre><code><b>pragma</b> intrinsic;
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
+<b>ensures</b> [abstract] <a href="object.md#0x2_object">object</a>.id == <b>old</b>(<a href="object.md#0x2_object">object</a>.id);
+<b>ensures</b> [abstract] <b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names
+    == concat(
+        <b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes)).names,
+        vec(name)
+    );
+<b>ensures</b> [abstract] len(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names) == len(<b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names)) + 1;
 </code></pre>
 
 
@@ -207,6 +215,19 @@ type.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] !sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_dynamic_field_borrow_mut"></a>
 
 ## Function `borrow_mut`
@@ -235,6 +256,19 @@ type.
     <b>let</b> field = <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;<a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(<a href="object.md#0x2_object">object</a>, <a href="hash.md#0x2_hash">hash</a>);
     &<b>mut</b> field.value
 }
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] !sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
 </code></pre>
 
 
@@ -271,6 +305,25 @@ type.
     <a href="object.md#0x2_object_delete">object::delete</a>(id);
     value
 }
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] !sui::prover::uid_has_field(<a href="object.md#0x2_object">object</a>.id.bytes, name);
+<b>ensures</b> [abstract] <a href="object.md#0x2_object">object</a>.id == <b>old</b>(<a href="object.md#0x2_object">object</a>.id);
+<b>ensures</b> [abstract] sui::prover::vec_remove(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names,
+    index_of(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names, name),
+    0) ==
+      <b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names);
+<b>ensures</b> [abstract] len(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names) == len(<b>old</b>(<b>global</b>&lt;sui::prover::DynamicFields&lt;Name&gt;&gt;(<a href="object.md#0x2_object">object</a>.id.bytes).names)) - 1;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/ecdsa_k1.md
+++ b/crates/sui-framework/docs/ecdsa_k1.md
@@ -72,6 +72,19 @@ applied to Secp256k1 signatures.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_ecdsa_k1_decompress_pubkey"></a>
 
 ## Function `decompress_pubkey`
@@ -92,6 +105,19 @@ otherwise throw error.
 
 
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_decompress_pubkey">decompress_pubkey</a>(pubkey: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 
@@ -129,6 +155,19 @@ If the signature is valid to the pubkey and hashed message, return true. Else fa
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_ecdsa_k1_secp256k1_verify_recoverable"></a>
 
 ## Function `secp256k1_verify_recoverable`
@@ -154,6 +193,19 @@ If the signature is valid to the pubkey and hashed message, return true. Else fa
 
 
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="ecdsa_k1.md#0x2_ecdsa_k1_secp256k1_verify_recoverable">secp256k1_verify_recoverable</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, hashed_msg: &<a href="">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/ed25519.md
+++ b/crates/sui-framework/docs/ed25519.md
@@ -48,6 +48,7 @@ Otherwise, return false.
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/elliptic_curve.md
+++ b/crates/sui-framework/docs/elliptic_curve.md
@@ -116,6 +116,7 @@ Private
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 
@@ -153,6 +154,7 @@ A native move wrapper around the addition of Ristretto points. Returns self + ot
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 
@@ -190,6 +192,7 @@ A native move wrapper around the subtraction of Ristretto points. Returns self -
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 
@@ -227,6 +230,7 @@ A native move wrapper for the creation of Scalars on Curve25519.
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 
@@ -264,6 +268,7 @@ A native move wrapper for the creation of Scalars on Curve25519.
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/groth16.md
+++ b/crates/sui-framework/docs/groth16.md
@@ -281,6 +281,7 @@ This can be used as inputs for the <code>verify_groth16_proof</code> function.
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 
@@ -352,6 +353,7 @@ Native functions that flattens the inputs into arrays of vectors and passed to t
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/hash.md
+++ b/crates/sui-framework/docs/hash.md
@@ -39,6 +39,19 @@ Hash the input bytes using Blake2b-256 and returns 32 bytes.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_hash_keccak256"></a>
 
 ## Function `keccak256`
@@ -57,6 +70,19 @@ Hash the input bytes using keccak256 and returns 32 bytes.
 
 
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x2_hash_keccak256">keccak256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/hmac.md
+++ b/crates/sui-framework/docs/hmac.md
@@ -45,6 +45,7 @@ A native move wrapper around the HMAC-SHA3-256. Returns the digest.
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/linked_table.md
+++ b/crates/sui-framework/docs/linked_table.md
@@ -27,6 +27,7 @@ removal
 -  [Function `is_empty`](#0x2_linked_table_is_empty)
 -  [Function `destroy_empty`](#0x2_linked_table_destroy_empty)
 -  [Function `drop`](#0x2_linked_table_drop)
+-  [Module Specification](#@Module_Specification_1)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -647,3 +648,12 @@ Usable only if the value type <code>V</code> has the <code>drop</code> ability
 
 
 </details>
+
+<a name="@Module_Specification_1"></a>
+
+## Module Specification
+
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>

--- a/crates/sui-framework/docs/linked_table.md
+++ b/crates/sui-framework/docs/linked_table.md
@@ -27,7 +27,6 @@ removal
 -  [Function `is_empty`](#0x2_linked_table_is_empty)
 -  [Function `destroy_empty`](#0x2_linked_table_destroy_empty)
 -  [Function `drop`](#0x2_linked_table_drop)
--  [Module Specification](#@Module_Specification_1)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -648,12 +647,3 @@ Usable only if the value type <code>V</code> has the <code>drop</code> ability
 
 
 </details>
-
-<a name="@Module_Specification_1"></a>
-
-## Module Specification
-
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-</code></pre>

--- a/crates/sui-framework/docs/object.md
+++ b/crates/sui-framework/docs/object.md
@@ -8,6 +8,8 @@ Sui object identifiers
 
 -  [Struct `ID`](#0x2_object_ID)
 -  [Struct `UID`](#0x2_object_UID)
+-  [Resource `Ownership`](#0x2_object_Ownership)
+-  [Resource `DynamicFields`](#0x2_object_DynamicFields)
 -  [Constants](#@Constants_0)
 -  [Function `id_to_bytes`](#0x2_object_id_to_bytes)
 -  [Function `id_to_address`](#0x2_object_id_to_address)
@@ -94,6 +96,69 @@ This is a privileged type that can only be derived from a <code>TxContext</code>
 <dl>
 <dt>
 <code>id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_object_Ownership"></a>
+
+## Resource `Ownership`
+
+Ownership information for a given object (stored at the object's address)
+
+
+<pre><code><b>struct</b> <a href="object.md#0x2_object_Ownership">Ownership</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>owner: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>status: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_object_DynamicFields"></a>
+
+## Resource `DynamicFields`
+
+List of fields with a given name type of an object containing fields (stored at the
+containing object's address)
+
+
+<pre><code><b>struct</b> <a href="object.md#0x2_object_DynamicFields">DynamicFields</a>&lt;K: <b>copy</b>, drop, store&gt; <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>names: <a href="">vector</a>&lt;K&gt;</code>
 </dt>
 <dd>
 
@@ -569,6 +634,20 @@ Generate a new UID specifically used for creating a UID from a hash
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="object.md#0x2_object_delete_impl">delete_impl</a>(id: <b>address</b>);
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>false</b>;
+<b>ensures</b> [abstract] !<b>exists</b>&lt;<a href="object.md#0x2_object_Ownership">Ownership</a>&gt;(id);
 </code></pre>
 
 

--- a/crates/sui-framework/docs/object.md
+++ b/crates/sui-framework/docs/object.md
@@ -592,6 +592,19 @@ restrictable in the object's module.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_object_new_uid_from_hash"></a>
 
 ## Function `new_uid_from_hash`
@@ -670,6 +683,19 @@ Generate a new UID specifically used for creating a UID from a hash
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="object.md#0x2_object_record_new_uid">record_new_uid</a>(id: <b>address</b>);
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/object.md
+++ b/crates/sui-framework/docs/object.md
@@ -592,19 +592,6 @@ restrictable in the object's module.
 
 </details>
 
-<details>
-<summary>Specification</summary>
-
-
-
-<pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> [abstract] <b>true</b>;
-</code></pre>
-
-
-
-</details>
-
 <a name="0x2_object_new_uid_from_hash"></a>
 
 ## Function `new_uid_from_hash`

--- a/crates/sui-framework/docs/prover.md
+++ b/crates/sui-framework/docs/prover.md
@@ -7,12 +7,12 @@
 
 -  [Resource `Ownership`](#0x2_prover_Ownership)
 -  [Resource `DynamicFields`](#0x2_prover_DynamicFields)
+-  [Resource `DynamicFieldContainment`](#0x2_prover_DynamicFieldContainment)
 -  [Constants](#@Constants_0)
 -  [Module Specification](#@Module_Specification_1)
 
 
-<pre><code><b>use</b> <a href="">0x1::option</a>;
-</code></pre>
+<pre><code></code></pre>
 
 
 
@@ -20,6 +20,7 @@
 
 ## Resource `Ownership`
 
+Ownership information for a given object (stored at the object's address)
 
 
 <pre><code><b>struct</b> <a href="prover.md#0x2_prover_Ownership">Ownership</a> <b>has</b> key
@@ -33,7 +34,7 @@
 
 <dl>
 <dt>
-<code>owner: <a href="_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
+<code>owner: <b>address</b></code>
 </dt>
 <dd>
 
@@ -53,6 +54,8 @@
 
 ## Resource `DynamicFields`
 
+List of fields with a given name type of an object containing fields (stored at the
+containing object's address)
 
 
 <pre><code><b>struct</b> <a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K: <b>copy</b>, drop, store&gt; <b>has</b> key
@@ -67,6 +70,35 @@
 <dl>
 <dt>
 <code>names: <a href="">vector</a>&lt;K&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_prover_DynamicFieldContainment"></a>
+
+## Resource `DynamicFieldContainment`
+
+Information about which object contains a given object field (stored at the field object's
+address).
+
+
+<pre><code><b>struct</b> <a href="prover.md#0x2_prover_DynamicFieldContainment">DynamicFieldContainment</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>container: <b>address</b></code>
 </dt>
 <dd>
 
@@ -112,6 +144,7 @@
 
 ## Module Specification
 
+Verifies if a given object it owned.
 
 
 <a name="0x2_prover_owned"></a>
@@ -120,12 +153,12 @@
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_owned">owned</a>&lt;T: key&gt;(obj: T): bool {
    <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
    <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
-   <a href="_is_some">option::is_some</a>(<b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner) &&
    <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a>
 }
 </code></pre>
 
 
+Verifies if a given object is owned.
 
 
 <a name="0x2_prover_owned_by"></a>
@@ -134,12 +167,13 @@
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_owned_by">owned_by</a>&lt;T: key&gt;(obj: T, owner: <b>address</b>): bool {
    <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
    <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
-   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner == <a href="_spec_some">option::spec_some</a>(owner) &&
-   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a>
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a> &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner == owner
 }
 </code></pre>
 
 
+Verifies if a given object is shared.
 
 
 <a name="0x2_prover_shared"></a>
@@ -148,12 +182,12 @@
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_shared">shared</a>&lt;T: key&gt;(obj: T): bool {
    <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
    <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
-   <a href="_is_none">option::is_none</a>(<b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner) &&
    <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_SHARED">SHARED</a>
 }
 </code></pre>
 
 
+Verifies if a given object is immutable.
 
 
 <a name="0x2_prover_immutable"></a>
@@ -162,12 +196,12 @@
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_immutable">immutable</a>&lt;T: key&gt;(obj: T): bool {
    <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
    <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
-   <a href="_is_none">option::is_none</a>(<b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner) &&
    <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_IMMUTABLE">IMMUTABLE</a>
 }
 </code></pre>
 
 
+Verifies if a given object has field with a given name.
 
 
 <a name="0x2_prover_has_field"></a>
@@ -180,6 +214,7 @@
 </code></pre>
 
 
+Returns number of K-type fields of a given object.
 
 
 <a name="0x2_prover_num_fields"></a>

--- a/crates/sui-framework/docs/prover.md
+++ b/crates/sui-framework/docs/prover.md
@@ -170,17 +170,6 @@
 
 
 
-<a name="0x2_prover_uid_has_field"></a>
-
-
-<pre><code><b>fun</b> <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K: <b>copy</b> + drop + store&gt;(addr: <b>address</b>, name: K): bool {
-   <b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr) && contains(<b>global</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr).names, name)
-}
-</code></pre>
-
-
-
-
 <a name="0x2_prover_has_field"></a>
 
 
@@ -193,10 +182,44 @@
 
 
 
-<a name="0x2_prover_always_true"></a>
+<a name="0x2_prover_num_fields"></a>
 
 
-<pre><code><b>fun</b> <a href="prover.md#0x2_prover_always_true">always_true</a>&lt;K: <b>copy</b> + drop + store&gt;(): bool {
-   <b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(@0x42) || !<b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(@0x42)
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_num_fields">num_fields</a>&lt;T: key, K: <b>copy</b> + drop + store&gt;(obj: T): u64 {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>if</b> (!<b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr)) {
+       0
+   } <b>else</b> {
+       len(<b>global</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr).names)
+   }
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_uid_has_field"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K: <b>copy</b> + drop + store&gt;(addr: <b>address</b>, name: K): bool {
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr) && contains(<b>global</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr).names, name)
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_vec_remove"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_vec_remove">vec_remove</a>&lt;T&gt;(v: <a href="">vector</a>&lt;T&gt;, elem_idx: u64, current_idx: u64) : <a href="">vector</a>&lt;T&gt; {
+   <b>let</b> len = len(v);
+   <b>if</b> (current_idx != len) {
+       vec()
+   } <b>else</b> <b>if</b> (current_idx != elem_idx) {
+       concat(vec(v[current_idx]), <a href="prover.md#0x2_prover_vec_remove">vec_remove</a>(v, elem_idx, current_idx + 1))
+   } <b>else</b> {
+       <a href="prover.md#0x2_prover_vec_remove">vec_remove</a>(v, elem_idx, current_idx + 1)
+   }
 }
 </code></pre>

--- a/crates/sui-framework/docs/prover.md
+++ b/crates/sui-framework/docs/prover.md
@@ -1,0 +1,202 @@
+
+<a name="0x2_prover"></a>
+
+# Module `0x2::prover`
+
+
+
+-  [Resource `Ownership`](#0x2_prover_Ownership)
+-  [Resource `DynamicFields`](#0x2_prover_DynamicFields)
+-  [Constants](#@Constants_0)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+</code></pre>
+
+
+
+<a name="0x2_prover_Ownership"></a>
+
+## Resource `Ownership`
+
+
+
+<pre><code><b>struct</b> <a href="prover.md#0x2_prover_Ownership">Ownership</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>owner: <a href="_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>status: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_prover_DynamicFields"></a>
+
+## Resource `DynamicFields`
+
+
+
+<pre><code><b>struct</b> <a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K: <b>copy</b>, drop, store&gt; <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>names: <a href="">vector</a>&lt;K&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_prover_IMMUTABLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="prover.md#0x2_prover_IMMUTABLE">IMMUTABLE</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_prover_OWNED"></a>
+
+
+
+<pre><code><b>const</b> <a href="prover.md#0x2_prover_OWNED">OWNED</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_prover_SHARED"></a>
+
+
+
+<pre><code><b>const</b> <a href="prover.md#0x2_prover_SHARED">SHARED</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="@Module_Specification_1"></a>
+
+## Module Specification
+
+
+
+<a name="0x2_prover_owned"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_owned">owned</a>&lt;T: key&gt;(obj: T): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
+   <a href="_is_some">option::is_some</a>(<b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner) &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a>
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_owned_by"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_owned_by">owned_by</a>&lt;T: key&gt;(obj: T, owner: <b>address</b>): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner == <a href="_spec_some">option::spec_some</a>(owner) &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a>
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_shared"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_shared">shared</a>&lt;T: key&gt;(obj: T): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
+   <a href="_is_none">option::is_none</a>(<b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner) &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_SHARED">SHARED</a>
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_immutable"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_immutable">immutable</a>&lt;T: key&gt;(obj: T): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
+   <a href="_is_none">option::is_none</a>(<b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner) &&
+   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_IMMUTABLE">IMMUTABLE</a>
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_uid_has_field"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K: <b>copy</b> + drop + store&gt;(addr: <b>address</b>, name: K): bool {
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr) && contains(<b>global</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr).names, name)
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_has_field"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_has_field">has_field</a>&lt;T: key, K: <b>copy</b> + drop + store&gt;(obj: T, name: K): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K&gt;(addr, name)
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_always_true"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_always_true">always_true</a>&lt;K: <b>copy</b> + drop + store&gt;(): bool {
+   <b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(@0x42) || !<b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(@0x42)
+}
+</code></pre>

--- a/crates/sui-framework/docs/prover.md
+++ b/crates/sui-framework/docs/prover.md
@@ -5,8 +5,6 @@
 
 
 
--  [Resource `Ownership`](#0x2_prover_Ownership)
--  [Resource `DynamicFields`](#0x2_prover_DynamicFields)
 -  [Resource `DynamicFieldContainment`](#0x2_prover_DynamicFieldContainment)
 -  [Constants](#@Constants_0)
 -  [Module Specification](#@Module_Specification_1)
@@ -15,69 +13,6 @@
 <pre><code></code></pre>
 
 
-
-<a name="0x2_prover_Ownership"></a>
-
-## Resource `Ownership`
-
-Ownership information for a given object (stored at the object's address)
-
-
-<pre><code><b>struct</b> <a href="prover.md#0x2_prover_Ownership">Ownership</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>owner: <b>address</b></code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>status: u64</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a name="0x2_prover_DynamicFields"></a>
-
-## Resource `DynamicFields`
-
-List of fields with a given name type of an object containing fields (stored at the
-containing object's address)
-
-
-<pre><code><b>struct</b> <a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K: <b>copy</b>, drop, store&gt; <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>names: <a href="">vector</a>&lt;K&gt;</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
 
 <a name="0x2_prover_DynamicFieldContainment"></a>
 
@@ -152,8 +87,8 @@ Verifies if a given object it owned.
 
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_owned">owned</a>&lt;T: key&gt;(obj: T): bool {
    <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
-   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
-   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a>
+   <b>exists</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(addr) &&
+   <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a>
 }
 </code></pre>
 
@@ -166,9 +101,9 @@ Verifies if a given object is owned.
 
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_owned_by">owned_by</a>&lt;T: key&gt;(obj: T, owner: <b>address</b>): bool {
    <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
-   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
-   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a> &&
-   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).owner == owner
+   <b>exists</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(addr) &&
+   <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_OWNED">OWNED</a> &&
+   <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(addr).owner == owner
 }
 </code></pre>
 
@@ -181,8 +116,8 @@ Verifies if a given object is shared.
 
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_shared">shared</a>&lt;T: key&gt;(obj: T): bool {
    <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
-   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
-   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_SHARED">SHARED</a>
+   <b>exists</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(addr) &&
+   <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_SHARED">SHARED</a>
 }
 </code></pre>
 
@@ -195,8 +130,8 @@ Verifies if a given object is immutable.
 
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_immutable">immutable</a>&lt;T: key&gt;(obj: T): bool {
    <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
-   <b>exists</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr) &&
-   <b>global</b>&lt;<a href="prover.md#0x2_prover_Ownership">Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_IMMUTABLE">IMMUTABLE</a>
+   <b>exists</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(addr) &&
+   <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(addr).status == <a href="prover.md#0x2_prover_IMMUTABLE">IMMUTABLE</a>
 }
 </code></pre>
 
@@ -222,10 +157,10 @@ Returns number of K-type fields of a given object.
 
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_num_fields">num_fields</a>&lt;T: key, K: <b>copy</b> + drop + store&gt;(obj: T): u64 {
    <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
-   <b>if</b> (!<b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr)) {
+   <b>if</b> (!<b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;K&gt;&gt;(addr)) {
        0
    } <b>else</b> {
-       len(<b>global</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr).names)
+       len(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;K&gt;&gt;(addr).names)
    }
 }
 </code></pre>
@@ -237,7 +172,7 @@ Returns number of K-type fields of a given object.
 
 
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K: <b>copy</b> + drop + store&gt;(addr: <b>address</b>, name: K): bool {
-   <b>exists</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr) && contains(<b>global</b>&lt;<a href="prover.md#0x2_prover_DynamicFields">DynamicFields</a>&lt;K&gt;&gt;(addr).names, name)
+   <b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;K&gt;&gt;(addr) && contains(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;K&gt;&gt;(addr).names, name)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/prover.md
+++ b/crates/sui-framework/docs/prover.md
@@ -5,7 +5,6 @@
 
 
 
--  [Resource `DynamicFieldContainment`](#0x2_prover_DynamicFieldContainment)
 -  [Constants](#@Constants_0)
 -  [Module Specification](#@Module_Specification_1)
 
@@ -13,35 +12,6 @@
 <pre><code></code></pre>
 
 
-
-<a name="0x2_prover_DynamicFieldContainment"></a>
-
-## Resource `DynamicFieldContainment`
-
-Information about which object contains a given object field (stored at the field object's
-address).
-
-
-<pre><code><b>struct</b> <a href="prover.md#0x2_prover_DynamicFieldContainment">DynamicFieldContainment</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>container: <b>address</b></code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
 
 <a name="@Constants_0"></a>
 
@@ -143,8 +113,8 @@ Verifies if a given object has field with a given name.
 
 
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_has_field">has_field</a>&lt;T: key, K: <b>copy</b> + drop + store&gt;(obj: T, name: K): bool {
-   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
-   <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K&gt;(addr, name)
+   <b>let</b> uid = <a href="object.md#0x2_object_borrow_uid">object::borrow_uid</a>(obj);
+   <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K&gt;(uid, name)
 }
 </code></pre>
 
@@ -156,7 +126,31 @@ Returns number of K-type fields of a given object.
 
 
 <pre><code><b>fun</b> <a href="prover.md#0x2_prover_num_fields">num_fields</a>&lt;T: key, K: <b>copy</b> + drop + store&gt;(obj: T): u64 {
-   <b>let</b> addr = <a href="object.md#0x2_object_id">object::id</a>(obj).bytes;
+   <b>let</b> uid = <a href="object.md#0x2_object_borrow_uid">object::borrow_uid</a>(obj);
+   <a href="prover.md#0x2_prover_uid_num_fields">uid_num_fields</a>&lt;K&gt;(uid)
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_uid_has_field"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K: <b>copy</b> + drop + store&gt;(uid: sui::object::UID, name: K): bool {
+   <b>let</b> addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(uid);
+   <b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;K&gt;&gt;(addr) && contains(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;K&gt;&gt;(addr).names, name)
+}
+</code></pre>
+
+
+
+
+<a name="0x2_prover_uid_num_fields"></a>
+
+
+<pre><code><b>fun</b> <a href="prover.md#0x2_prover_uid_num_fields">uid_num_fields</a>&lt;K: <b>copy</b> + drop + store&gt;(uid: sui::object::UID): u64 {
+   <b>let</b> addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(uid);
    <b>if</b> (!<b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;K&gt;&gt;(addr)) {
        0
    } <b>else</b> {
@@ -168,28 +162,8 @@ Returns number of K-type fields of a given object.
 
 
 
-<a name="0x2_prover_uid_has_field"></a>
-
-
-<pre><code><b>fun</b> <a href="prover.md#0x2_prover_uid_has_field">uid_has_field</a>&lt;K: <b>copy</b> + drop + store&gt;(addr: <b>address</b>, name: K): bool {
-   <b>exists</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;K&gt;&gt;(addr) && contains(<b>global</b>&lt;<a href="object.md#0x2_object_DynamicFields">object::DynamicFields</a>&lt;K&gt;&gt;(addr).names, name)
-}
-</code></pre>
-
-
-
-
 <a name="0x2_prover_vec_remove"></a>
 
 
-<pre><code><b>fun</b> <a href="prover.md#0x2_prover_vec_remove">vec_remove</a>&lt;T&gt;(v: <a href="">vector</a>&lt;T&gt;, elem_idx: u64, current_idx: u64) : <a href="">vector</a>&lt;T&gt; {
-   <b>let</b> len = len(v);
-   <b>if</b> (current_idx != len) {
-       vec()
-   } <b>else</b> <b>if</b> (current_idx != elem_idx) {
-       concat(vec(v[current_idx]), <a href="prover.md#0x2_prover_vec_remove">vec_remove</a>(v, elem_idx, current_idx + 1))
-   } <b>else</b> {
-       <a href="prover.md#0x2_prover_vec_remove">vec_remove</a>(v, elem_idx, current_idx + 1)
-   }
-}
+<pre><code><b>native</b> <b>fun</b> <a href="prover.md#0x2_prover_vec_remove">vec_remove</a>&lt;T&gt;(v: <a href="">vector</a>&lt;T&gt;, elem_idx: u64): <a href="">vector</a>&lt;T&gt;;
 </code></pre>

--- a/crates/sui-framework/docs/prover_tests.md
+++ b/crates/sui-framework/docs/prover_tests.md
@@ -1,0 +1,243 @@
+
+<a name="0x2_prover_tests"></a>
+
+# Module `0x2::prover_tests`
+
+
+
+-  [Resource `Obj`](#0x2_prover_tests_Obj)
+-  [Function `simple_transfer`](#0x2_prover_tests_simple_transfer)
+-  [Function `simple_share`](#0x2_prover_tests_simple_share)
+-  [Function `simple_freeze`](#0x2_prover_tests_simple_freeze)
+-  [Function `simple_field_add`](#0x2_prover_tests_simple_field_add)
+-  [Function `simple_field_remove`](#0x2_prover_tests_simple_field_remove)
+
+
+<pre><code><b>use</b> <a href="dynamic_field.md#0x2_dynamic_field">0x2::dynamic_field</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+</code></pre>
+
+
+
+<a name="0x2_prover_tests_Obj"></a>
+
+## Resource `Obj`
+
+
+
+<pre><code><b>struct</b> <a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_prover_tests_simple_transfer"></a>
+
+## Function `simple_transfer`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_transfer">simple_transfer</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">prover_tests::Obj</a>, recipient: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_transfer">simple_transfer</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>, recipient: <b>address</b>) {
+    sui::transfer::transfer(o, recipient);
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>ensures</b> sui::prover::owned_by(o, recipient);
+<b>aborts_if</b> <b>false</b>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_prover_tests_simple_share"></a>
+
+## Function `simple_share`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_share">simple_share</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">prover_tests::Obj</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_share">simple_share</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>) {
+    sui::transfer::share_object(o)
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>ensures</b> sui::prover::shared(o);
+<b>aborts_if</b> sui::prover::owned(o);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_prover_tests_simple_freeze"></a>
+
+## Function `simple_freeze`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_freeze">simple_freeze</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">prover_tests::Obj</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_freeze">simple_freeze</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>) {
+    sui::transfer::freeze_object(o)
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>ensures</b> sui::prover::immutable(o);
+<b>aborts_if</b> sui::prover::owned(o);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_prover_tests_simple_field_add"></a>
+
+## Function `simple_field_add`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_field_add">simple_field_add</a>(o: &<b>mut</b> <a href="prover_tests.md#0x2_prover_tests_Obj">prover_tests::Obj</a>, n1: u64, v1: u8, n2: u8, v2: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_field_add">simple_field_add</a>(o: &<b>mut</b> <a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>, n1: u64, v1: u8, n2: u8, v2: u64) {
+    sui::dynamic_field::add(&<b>mut</b> o.id, n1, v1);
+    sui::dynamic_field::add(&<b>mut</b> o.id, n2, v2);
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> sui::prover::has_field(o, n1);
+<b>aborts_if</b> sui::prover::has_field(o, n2);
+<b>ensures</b> sui::prover::has_field(o, n1);
+<b>ensures</b> sui::prover::has_field(o, n2);
+<b>ensures</b> sui::prover::num_fields&lt;<a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>,u64&gt;(o) == <b>old</b>(sui::prover::num_fields&lt;<a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>,u64&gt;(o)) + 1;
+<b>ensures</b> sui::prover::num_fields&lt;<a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>,u8&gt;(o) == <b>old</b>(sui::prover::num_fields&lt;<a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>,u8&gt;(o)) + 1;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_prover_tests_simple_field_remove"></a>
+
+## Function `simple_field_remove`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_field_remove">simple_field_remove</a>(o: &<b>mut</b> <a href="prover_tests.md#0x2_prover_tests_Obj">prover_tests::Obj</a>, n1: u64, n2: u8)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_field_remove">simple_field_remove</a>(o: &<b>mut</b> <a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>, n1: u64, n2: u8) {
+    sui::dynamic_field::remove&lt;u64,u8&gt;(&<b>mut</b> o.id, n1);
+    sui::dynamic_field::remove&lt;u8,u64&gt;(&<b>mut</b> o.id, n2);
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> !sui::prover::has_field(o, n1);
+<b>aborts_if</b> !sui::prover::has_field(o, n2);
+<b>ensures</b> !sui::prover::has_field(o, n1);
+<b>ensures</b> !sui::prover::has_field(o, n2);
+<b>ensures</b> sui::prover::num_fields&lt;<a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>,u64&gt;(o) == <b>old</b>(sui::prover::num_fields&lt;<a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>,u64&gt;(o)) - 1;
+<b>ensures</b> sui::prover::num_fields&lt;<a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>,u8&gt;(o) == <b>old</b>(sui::prover::num_fields&lt;<a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>,u8&gt;(o)) - 1;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework/docs/prover_tests.md
+++ b/crates/sui-framework/docs/prover_tests.md
@@ -9,6 +9,7 @@
 -  [Function `simple_transfer`](#0x2_prover_tests_simple_transfer)
 -  [Function `simple_share`](#0x2_prover_tests_simple_share)
 -  [Function `simple_freeze`](#0x2_prover_tests_simple_freeze)
+-  [Function `simple_delete`](#0x2_prover_tests_simple_delete)
 -  [Function `simple_field_add`](#0x2_prover_tests_simple_field_add)
 -  [Function `simple_field_remove`](#0x2_prover_tests_simple_field_remove)
 
@@ -151,7 +152,45 @@
 
 
 <pre><code><b>ensures</b> sui::prover::immutable(o);
-<b>aborts_if</b> sui::prover::owned(o);
+<b>aborts_if</b> <b>false</b>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_prover_tests_simple_delete"></a>
+
+## Function `simple_delete`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_delete">simple_delete</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">prover_tests::Obj</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_delete">simple_delete</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>) {
+    <b>let</b> <a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a> { id } = o;
+    sui::object::delete(id);
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+<b>ensures</b> !sui::prover::owned(o) && !sui::prover::shared(o) && !sui::prover::immutable(o);
 </code></pre>
 
 

--- a/crates/sui-framework/docs/randomness.md
+++ b/crates/sui-framework/docs/randomness.md
@@ -383,6 +383,7 @@ Verify signature sig on message msg using the epoch's BLS key.
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 
@@ -418,6 +419,7 @@ Helper functions to sign on messages in tests.
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -357,6 +357,15 @@ the epoch advancement transaction.
 
 
 
+<a name="0x2_sui_system_MAX_SUPPLY"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_MAX_SUPPLY">MAX_SUPPLY</a>: u64 = 1000000000000000000;
+</code></pre>
+
+
+
 <a name="0x2_sui_system_create"></a>
 
 ## Function `create`

--- a/crates/sui-framework/docs/transfer.md
+++ b/crates/sui-framework/docs/transfer.md
@@ -91,9 +91,9 @@ longer be transferred or mutated.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] sui::prover::owned(obj);
-<b>modifies</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>exists</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes).status == 3 /* IMMUTABLE */;
+<b>modifies</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>exists</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes).status == 3 /* IMMUTABLE */;
 </code></pre>
 
 
@@ -134,9 +134,9 @@ in this transaction. This restriction may be relaxed in the future.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] sui::prover::owned(obj);
-<b>modifies</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>exists</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes).status == 2 /* SHARED */;
+<b>modifies</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>exists</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes).status == 2 /* SHARED */;
 </code></pre>
 
 
@@ -172,10 +172,10 @@ in this transaction. This restriction may be relaxed in the future.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] <b>false</b>;
-<b>modifies</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>exists</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes).owner == recipient;
-<b>ensures</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes).status == 1 /* OWNED */;
+<b>modifies</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>exists</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes).owner == recipient;
+<b>ensures</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes).status == 1 /* OWNED */;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/transfer.md
+++ b/crates/sui-framework/docs/transfer.md
@@ -84,6 +84,22 @@ longer be transferred or mutated.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] sui::prover::owned(obj);
+<b>modifies</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>exists</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes).status == 3 /* IMMUTABLE */;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_transfer_share_object"></a>
 
 ## Function `share_object`
@@ -111,6 +127,22 @@ in this transaction. This restriction may be relaxed in the future.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] sui::prover::owned(obj);
+<b>modifies</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>exists</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes).status == 2 /* SHARED */;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_transfer_transfer_internal"></a>
 
 ## Function `transfer_internal`
@@ -127,6 +159,23 @@ in this transaction. This restriction may be relaxed in the future.
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>);
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>false</b>;
+<b>modifies</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>exists</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes);
+<b>ensures</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes).owner == recipient;
+<b>ensures</b> [abstract] <b>global</b>&lt;sui::prover::Ownership&gt;(sui::object::id(obj).bytes).status == 1 /* OWNED */;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/transfer.md
+++ b/crates/sui-framework/docs/transfer.md
@@ -91,9 +91,9 @@ longer be transferred or mutated.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] <b>false</b>;
-<b>modifies</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>exists</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes).status == 3 /* IMMUTABLE */;
+<b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes);
+<b>ensures</b> [abstract] <b>exists</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes);
+<b>ensures</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes).status == <a href="prover.md#0x2_prover_IMMUTABLE">prover::IMMUTABLE</a>;
 </code></pre>
 
 
@@ -134,9 +134,9 @@ in this transaction. This restriction may be relaxed in the future.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] sui::prover::owned(obj);
-<b>modifies</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>exists</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes).status == 2 /* SHARED */;
+<b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes);
+<b>ensures</b> [abstract] <b>exists</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes);
+<b>ensures</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes).status == <a href="prover.md#0x2_prover_SHARED">prover::SHARED</a>;
 </code></pre>
 
 
@@ -172,10 +172,10 @@ in this transaction. This restriction may be relaxed in the future.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] <b>false</b>;
-<b>modifies</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>exists</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
-<b>ensures</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes).owner == recipient;
-<b>ensures</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes).status == 1 /* OWNED */;
+<b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes);
+<b>ensures</b> [abstract] <b>exists</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes);
+<b>ensures</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes).owner == recipient;
+<b>ensures</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes).status == <a href="prover.md#0x2_prover_OWNED">prover::OWNED</a>;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/transfer.md
+++ b/crates/sui-framework/docs/transfer.md
@@ -90,7 +90,7 @@ longer be transferred or mutated.
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> [abstract] sui::prover::owned(obj);
+<b>aborts_if</b> [abstract] <b>false</b>;
 <b>modifies</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
 <b>ensures</b> [abstract] <b>exists</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes);
 <b>ensures</b> [abstract] <b>global</b>&lt;sui::object::Ownership&gt;(sui::object::id(obj).bytes).status == 3 /* IMMUTABLE */;

--- a/crates/sui-framework/docs/tx_context.md
+++ b/crates/sui-framework/docs/tx_context.md
@@ -219,3 +219,16 @@ Native function for deriving an ID via hash(tx_hash || ids_created)
 
 
 </details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>false</b>;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework/docs/types.md
+++ b/crates/sui-framework/docs/types.md
@@ -36,3 +36,16 @@ across the entire code base.
 
 
 </details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -834,8 +834,24 @@ Called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_total_stake_amount">total_stake_amount</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): u64 {
+    <b>spec</b> {
+        // TODO: this should be provable rather than assumed
+        <b>assume</b> self.stake_amount + self.delegation_staking_pool.sui_balance &lt;= MAX_U64;
+    };
     self.stake_amount + <a href="staking_pool.md#0x2_staking_pool_sui_balance">staking_pool::sui_balance</a>(&self.delegation_staking_pool)
 }
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
 </code></pre>
 
 

--- a/crates/sui-framework/sources/address.move
+++ b/crates/sui-framework/sources/address.move
@@ -16,22 +16,43 @@ module sui::address {
     /// Error from `from_bytes` when it is supplied too many or too few bytes.
     const EAddressParseError: u64 = 0;
 
-    /// Error from `from_u256` when 
+    /// Error from `from_u256` when
     const EU256TooBigToConvertToAddress: u64 = 1;
 
-    /// Convert `a` into a u256 by interpreting `a` as the bytes of a big-endian integer 
+    /// Convert `a` into a u256 by interpreting `a` as the bytes of a big-endian integer
     /// (e.g., `to_u256(0x1) == 1`)
     public native fun to_u256(a: address): u256;
+
+    spec to_u256 {
+        pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
+    }
 
     /// Convert `n` into an address by encoding it as a big-endian integer (e.g., `from_u256(1) = @0x1`)
     /// Aborts if `n` > `MAX_ADDRESS`
     public native fun from_u256(n: u256): address;
 
+    spec from_u256 {
+        pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
+    }
+
     /// Convert `bytes` into an address.
     /// Aborts with `EAddressParseError` if the length of `bytes` is not 20
     public native fun from_bytes(bytes: vector<u8>): address;
 
-     /// Convert `a` into BCS-encoded bytes.
+    spec from_bytes {
+        pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
+    }
+
+    /// Convert `a` into BCS-encoded bytes.
     public fun to_bytes(a: address): vector<u8> {
         bcs::to_bytes(&a)
     }

--- a/crates/sui-framework/sources/crypto/bls12381.spec.move
+++ b/crates/sui-framework/sources/crypto/bls12381.spec.move
@@ -3,12 +3,16 @@
 
 spec sui::bls12381 {
     spec bls12381_min_sig_verify {
-        // TODO: temporary mockup.
         pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
     }
 
     spec bls12381_min_pk_verify {
-        // TODO: temporary mockup.
         pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
     }
 }

--- a/crates/sui-framework/sources/crypto/ecdsa_k1.spec.move
+++ b/crates/sui-framework/sources/crypto/ecdsa_k1.spec.move
@@ -1,36 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-spec sui::elliptic_curve {
-    spec native_create_pedersen_commitment {
+spec sui::ecdsa_k1 {
+    spec ecrecover {
         pragma opaque;
         // TODO: stub to be replaced by actual abort conditions if any
         aborts_if [abstract] true;
         // TODO: specify actual function behavior
     }
 
-    spec native_add_ristretto_point {
+    spec decompress_pubkey {
         pragma opaque;
         // TODO: stub to be replaced by actual abort conditions if any
         aborts_if [abstract] true;
         // TODO: specify actual function behavior
     }
 
-    spec native_subtract_ristretto_point {
+    spec secp256k1_verify {
         pragma opaque;
         // TODO: stub to be replaced by actual abort conditions if any
         aborts_if [abstract] true;
         // TODO: specify actual function behavior
     }
 
-    spec native_scalar_from_u64 {
-        pragma opaque;
-        // TODO: stub to be replaced by actual abort conditions if any
-        aborts_if [abstract] true;
-        // TODO: specify actual function behavior
-    }
-
-    spec native_scalar_from_bytes {
+    spec secp256k1_verify_recoverable {
         pragma opaque;
         // TODO: stub to be replaced by actual abort conditions if any
         aborts_if [abstract] true;

--- a/crates/sui-framework/sources/crypto/ed25519.spec.move
+++ b/crates/sui-framework/sources/crypto/ed25519.spec.move
@@ -3,7 +3,9 @@
 
 spec sui::ed25519 {
     spec ed25519_verify {
-        // TODO: temporary mockup.
         pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
     }
 }

--- a/crates/sui-framework/sources/crypto/groth16.spec.move
+++ b/crates/sui-framework/sources/crypto/groth16.spec.move
@@ -3,12 +3,16 @@
 
 spec sui::groth16 {
     spec prepare_verifying_key {
-        // TODO: temporary mockup.
         pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
     }
 
     spec verify_groth16_proof_internal {
-        // TODO: temporary mockup.
         pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
     }
 }

--- a/crates/sui-framework/sources/crypto/hash.spec.move
+++ b/crates/sui-framework/sources/crypto/hash.spec.move
@@ -1,8 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-spec sui::bulletproofs {
-    spec native_verify_full_range_proof {
+spec sui::hash {
+    spec blake2b256 {
+        pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
+    }
+
+    spec keccak256 {
         pragma opaque;
         // TODO: stub to be replaced by actual abort conditions if any
         aborts_if [abstract] true;

--- a/crates/sui-framework/sources/crypto/hmac.spec.move
+++ b/crates/sui-framework/sources/crypto/hmac.spec.move
@@ -3,7 +3,9 @@
 
 spec sui::hmac {
     spec native_hmac_sha3_256 {
-        // TODO: temporary mockup.
         pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
     }
 }

--- a/crates/sui-framework/sources/crypto/randomness.spec.move
+++ b/crates/sui-framework/sources/crypto/randomness.spec.move
@@ -3,12 +3,16 @@
 
 spec sui::randomness {
     spec native_tbls_verify_signature {
-        // TODO: temporary mockup.
         pragma opaque;
-    }
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+       // TODO: specify actual function behavior
+     }
 
     spec native_tbls_sign {
-        // TODO: temporary mockup.
         pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
     }
 }

--- a/crates/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/sources/dynamic_field.move
@@ -56,6 +56,10 @@ public fun add<Name: copy + drop + store, Value: store>(
     add_child_object(object_addr, field)
 }
 
+spec add {
+    pragma intrinsic;
+}
+
 /// Immutably borrows the `object`s dynamic field with the name specified by `name: Name`.
 /// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
 /// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified

--- a/crates/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/sources/dynamic_field.move
@@ -59,14 +59,14 @@ public fun add<Name: copy + drop + store, Value: store>(
 spec add {
     pragma opaque;
     aborts_if [abstract] sui::prover::uid_has_field(object.id.bytes, name);
-    modifies [abstract] global<sui::prover::DynamicFields<Name>>(object.id.bytes);
+    modifies [abstract] global<object::DynamicFields<Name>>(object.id.bytes);
     ensures [abstract] object == old(object);
-    ensures [abstract] exists<sui::prover::DynamicFields<Name>>(object.id.bytes);
-    ensures [abstract] (!old(exists<sui::prover::DynamicFields<Name>>(object.id.bytes)))
-        ==> global<sui::prover::DynamicFields<Name>>(object.id.bytes).names == vec(name);
-    ensures [abstract] old(exists<sui::prover::DynamicFields<Name>>(object.id.bytes))
-        ==> global<sui::prover::DynamicFields<Name>>(object.id.bytes).names == concat(
-                old(global<sui::prover::DynamicFields<Name>>(object.id.bytes).names),
+    ensures [abstract] exists<object::DynamicFields<Name>>(object.id.bytes);
+    ensures [abstract] (!old(exists<object::DynamicFields<Name>>(object.id.bytes)))
+        ==> global<object::DynamicFields<Name>>(object.id.bytes).names == vec(name);
+    ensures [abstract] old(exists<object::DynamicFields<Name>>(object.id.bytes))
+        ==> global<object::DynamicFields<Name>>(object.id.bytes).names == concat(
+                old(global<object::DynamicFields<Name>>(object.id.bytes).names),
                 vec(name)
             );
     }
@@ -128,12 +128,12 @@ public fun remove<Name: copy + drop + store, Value: store>(
 spec remove {
     pragma opaque;
     aborts_if [abstract] !sui::prover::uid_has_field(object.id.bytes, name);
-    modifies [abstract] global<sui::prover::DynamicFields<Name>>(object.id.bytes);
+    modifies [abstract] global<object::DynamicFields<Name>>(object.id.bytes);
     ensures [abstract] object.id == old(object.id);
-    ensures [abstract] exists<sui::prover::DynamicFields<Name>>(object.id.bytes);
-    ensures [abstract] sui::prover::vec_remove(global<sui::prover::DynamicFields<Name>>(object.id.bytes).names,
-        index_of(global<sui::prover::DynamicFields<Name>>(object.id.bytes).names, name), 0) ==
-          old(global<sui::prover::DynamicFields<Name>>(object.id.bytes).names);
+    ensures [abstract] exists<object::DynamicFields<Name>>(object.id.bytes);
+    ensures [abstract] sui::prover::vec_remove(global<object::DynamicFields<Name>>(object.id.bytes).names,
+        index_of(global<object::DynamicFields<Name>>(object.id.bytes).names, name), 0) ==
+          old(global<object::DynamicFields<Name>>(object.id.bytes).names);
 }
 
 

--- a/crates/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/sources/dynamic_field.move
@@ -181,20 +181,70 @@ public(friend) fun field_info_mut<Name: copy + drop + store>(
 
 public(friend) native fun hash_type_and_key<K: copy + drop + store>(parent: address, k: K): address;
 
+spec hash_type_and_key {
+    pragma opaque;
+    // TODO: stub to be replaced by actual abort conditions if any
+    aborts_if [abstract] true;
+    // TODO: specify actual function behavior
+}
+
 public(friend) native fun add_child_object<Child: key>(parent: address, child: Child);
+
+spec add_child_object {
+    pragma opaque;
+    // TODO: stub to be replaced by actual abort conditions if any
+    aborts_if [abstract] true;
+    // TODO: specify actual function behavior
+}
 
 /// throws `EFieldDoesNotExist` if a child does not exist with that ID
 /// or throws `EFieldTypeMismatch` if the type does not match
 /// we need two versions to return a reference or a mutable reference
 public(friend) native fun borrow_child_object<Child: key>(object: &UID, id: address): &Child;
+
+spec borrow_child_object {
+    pragma opaque;
+    // TODO: stub to be replaced by actual abort conditions if any
+    aborts_if [abstract] true;
+    // TODO: specify actual function behavior
+}
+
 public(friend) native fun borrow_child_object_mut<Child: key>(object: &mut UID, id: address): &mut Child;
+
+spec borrow_child_object_mut {
+    pragma opaque;
+    // TODO: stub to be replaced by actual abort conditions if any
+    aborts_if [abstract] true;
+    // TODO: specify actual function behavior
+}
 
 /// throws `EFieldDoesNotExist` if a child does not exist with that ID
 /// or throws `EFieldTypeMismatch` if the type does not match
 public(friend) native fun remove_child_object<Child: key>(parent: address, id: address): Child;
 
+spec remove_child_object {
+    pragma opaque;
+    // TODO: stub to be replaced by actual abort conditions if any
+    aborts_if [abstract] true;
+    // TODO: specify actual function behavior
+}
+
 public(friend) native fun has_child_object(parent: address, id: address): bool;
 
+spec has_child_object {
+    pragma opaque;
+    // TODO: stub to be replaced by actual abort conditions if any
+    aborts_if [abstract] true;
+    // TODO: specify actual function behavior
+}
+
 public(friend) native fun has_child_object_with_ty<Child: key>(parent: address, id: address): bool;
+
+spec has_child_object_with_ty {
+    pragma opaque;
+    // TODO: stub to be replaced by actual abort conditions if any
+    aborts_if [abstract] true;
+    // TODO: specify actual function behavior
+}
 
 }

--- a/crates/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/sources/dynamic_field.move
@@ -131,12 +131,14 @@ spec remove {
     aborts_if [abstract] !prover::uid_has_field(object, name);
     modifies [abstract] global<object::DynamicFields<Name>>(object::uid_to_address(object));
     ensures [abstract] object.id == old(object.id);
-    ensures [abstract] old(prover::uid_num_fields<Name>(object)) == 0
+    ensures [abstract] old(prover::uid_num_fields<Name>(object)) == 1
         ==> !exists<object::DynamicFields<Name>>(object::uid_to_address(object));
-    ensures [abstract] old(prover::uid_num_fields<Name>(object)) > 0
+    ensures [abstract] old(prover::uid_num_fields<Name>(object)) > 1
         ==> global<object::DynamicFields<Name>>(object::uid_to_address(object)).names ==
                 old(prover::vec_remove(global<object::DynamicFields<Name>>(object::uid_to_address(object)).names,
                     index_of(global<object::DynamicFields<Name>>(object::uid_to_address(object)).names, name)));
+    // this is needed to ensure that there was only one field with a given name
+    ensures [abstract] !prover::uid_has_field(object, name);
 }
 
 

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -105,6 +105,8 @@ module sui::sui_system {
 
     const BASIS_POINT_DENOMINATOR: u128 = 10000;
 
+    const MAX_SUPPLY: u64 = 1000000000000000000;
+
     // ==== functions that can only be called by genesis ====
 
     /// Create a new SuiSystemState object and make it shared.

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -86,6 +86,10 @@ module sui::validator {
         commission_rate: u64,
     }
 
+//    spec Validator {
+//        invariant stake_amount + delegation_staking_pool.sui_balance <= MAX_U64;
+//    }
+
     const PROOF_OF_POSSESSION_DOMAIN: vector<u8> = vector[107, 111, 115, 107];
 
     fun verify_proof_of_possession(
@@ -306,7 +310,15 @@ module sui::validator {
     }
 
     public fun total_stake_amount(self: &Validator): u64 {
+        spec {
+            // TODO: this should be provable rather than assumed
+            assume self.stake_amount + self.delegation_staking_pool.sui_balance <= MAX_U64;
+        };
         self.stake_amount + staking_pool::sui_balance(&self.delegation_staking_pool)
+    }
+
+    spec total_stake_amount {
+        aborts_if false;
     }
 
     public fun stake_amount(self: &Validator): u64 {

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -152,6 +152,13 @@ module sui::object {
     // helper for delete
     native fun delete_impl(id: address);
 
+
+    spec delete_impl {
+        pragma opaque;
+        aborts_if [abstract] false;
+        ensures [abstract] !exists<Ownership>(id);
+    }
+
     // marks newly created UIDs from hash
     native fun record_new_uid(id: address);
 
@@ -160,7 +167,7 @@ module sui::object {
     public fun calibrate_address_from_bytes(bytes: vector<u8>) {
         sui::address::from_bytes(bytes);
     }
-    
+
     #[test_only]
     public fun calibrate_address_from_bytes_nop(bytes: vector<u8>) {
         let _ = bytes;
@@ -190,4 +197,23 @@ module sui::object {
     public fun last_created(ctx: &TxContext): ID {
         ID { bytes: tx_context::last_created_object_id(ctx) }
     }
+
+
+    // === Prover support (to avoid circular dependency ===
+
+    #[verify_only]
+    /// Ownership information for a given object (stored at the object's address)
+    struct Ownership has key {
+        owner: address, // only matters if status == OWNED
+        status: u64,
+    }
+
+    #[verify_only]
+    /// List of fields with a given name type of an object containing fields (stored at the
+    /// containing object's address)
+    struct DynamicFields<K: copy + drop + store> has key {
+        names: vector<K>,
+    }
+
+
 }

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -141,13 +141,6 @@ module sui::object {
     /// restrictable in the object's module.
     native fun borrow_uid<T: key>(obj: &T): &UID;
 
-    spec borrow_uid {
-        pragma opaque;
-        // TODO: stub to be replaced by actual abort conditions if any
-        aborts_if [abstract] true;
-        // TODO: specify actual function behavior
-     }
-
     /// Generate a new UID specifically used for creating a UID from a hash
     public(friend) fun new_uid_from_hash(bytes: address): UID {
         record_new_uid(bytes);

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -141,6 +141,13 @@ module sui::object {
     /// restrictable in the object's module.
     native fun borrow_uid<T: key>(obj: &T): &UID;
 
+    spec borrow_uid {
+        pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
+     }
+
     /// Generate a new UID specifically used for creating a UID from a hash
     public(friend) fun new_uid_from_hash(bytes: address): UID {
         record_new_uid(bytes);
@@ -152,7 +159,6 @@ module sui::object {
     // helper for delete
     native fun delete_impl(id: address);
 
-
     spec delete_impl {
         pragma opaque;
         aborts_if [abstract] false;
@@ -161,6 +167,13 @@ module sui::object {
 
     // marks newly created UIDs from hash
     native fun record_new_uid(id: address);
+
+    spec record_new_uid {
+        pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
+     }
 
     // Cost calibration functions
     #[test_only]

--- a/crates/sui-framework/sources/prover.move
+++ b/crates/sui-framework/sources/prover.move
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::prover {
+
+    use std::option;
+    use std::vector;
+    use sui::object;
+
+    const OWNED: u64 = 1;
+    const SHARED: u64 = 2;
+    const IMMUTABLE: u64 = 3;
+
+
+    #[verify_only]
+    struct Ownership has key {
+        owner: option::Option<address>,
+        status: u64,
+    }
+
+    spec fun owned<T: key>(obj: T): bool {
+        let addr = object::id(obj).bytes;
+        exists<Ownership>(addr) &&
+        option::is_some(global<Ownership>(addr).owner) &&
+        global<Ownership>(addr).status == OWNED
+    }
+
+    spec fun owned_by<T: key>(obj: T, owner: address): bool {
+        let addr = object::id(obj).bytes;
+        exists<Ownership>(addr) &&
+        global<Ownership>(addr).owner == option::spec_some(owner) &&
+        global<Ownership>(addr).status == OWNED
+    }
+
+        /*
+    spec fun is_field_of<T: key>(obj: T, owner: sui::object::UID): bool {
+        let addr = object::id(obj).bytes;
+        exists<Ownership>(addr) &&
+        global<Ownership>(addr).owner == option::spec_some(owner) &&
+        global<Ownership>(addr).status == OWNED
+}
+        */
+
+    spec fun shared<T: key>(obj: T): bool {
+        let addr = object::id(obj).bytes;
+        exists<Ownership>(addr) &&
+        option::is_none(global<Ownership>(addr).owner) &&
+        global<Ownership>(addr).status == SHARED
+    }
+
+    spec fun immutable<T: key>(obj: T): bool {
+        let addr = object::id(obj).bytes;
+        exists<Ownership>(addr) &&
+        option::is_none(global<Ownership>(addr).owner) &&
+        global<Ownership>(addr).status == IMMUTABLE
+    }
+
+    #[verify_only]
+    struct DynamicFields<K: copy + drop + store> has key {
+        names: vector<K>,
+    }
+
+    spec fun uid_has_field<K: copy + drop + store>(addr: address, name: K): bool {
+        exists<DynamicFields<K>>(addr) && contains(global<DynamicFields<K>>(addr).names, name)
+    }
+
+    spec fun has_field<T: key, K: copy + drop + store>(obj: T, name: K): bool {
+        let addr = object::id(obj).bytes;
+        uid_has_field<K>(addr, name)
+    }
+
+    spec fun always_true<K: copy + drop + store>(): bool {
+        exists<DynamicFields<K>>(@0x42) || !exists<DynamicFields<K>>(@0x42)
+    }
+
+}

--- a/crates/sui-framework/sources/prover.move
+++ b/crates/sui-framework/sources/prover.move
@@ -9,21 +9,6 @@ module sui::prover {
     const SHARED: u64 = 2;
     const IMMUTABLE: u64 = 3;
 
-
-    #[verify_only]
-    /// Ownership information for a given object (stored at the object's address)
-    struct Ownership has key {
-        owner: address, // only matters if status == OWNED
-        status: u64,
-    }
-
-    #[verify_only]
-    /// List of fields with a given name type of an object containing fields (stored at the
-    /// containing object's address)
-    struct DynamicFields<K: copy + drop + store> has key {
-        names: vector<K>,
-    }
-
     #[verify_only]
     /// Information about which object contains a given object field (stored at the field object's
     /// address).
@@ -36,30 +21,30 @@ module sui::prover {
     /// Verifies if a given object it owned.
     spec fun owned<T: key>(obj: T): bool {
         let addr = object::id(obj).bytes;
-        exists<Ownership>(addr) &&
-        global<Ownership>(addr).status == OWNED
+        exists<object::Ownership>(addr) &&
+        global<object::Ownership>(addr).status == OWNED
     }
 
     /// Verifies if a given object is owned.
     spec fun owned_by<T: key>(obj: T, owner: address): bool {
         let addr = object::id(obj).bytes;
-        exists<Ownership>(addr) &&
-        global<Ownership>(addr).status == OWNED &&
-        global<Ownership>(addr).owner == owner
+        exists<object::Ownership>(addr) &&
+        global<object::Ownership>(addr).status == OWNED &&
+        global<object::Ownership>(addr).owner == owner
     }
 
     /// Verifies if a given object is shared.
     spec fun shared<T: key>(obj: T): bool {
         let addr = object::id(obj).bytes;
-        exists<Ownership>(addr) &&
-        global<Ownership>(addr).status == SHARED
+        exists<object::Ownership>(addr) &&
+        global<object::Ownership>(addr).status == SHARED
     }
 
     /// Verifies if a given object is immutable.
     spec fun immutable<T: key>(obj: T): bool {
         let addr = object::id(obj).bytes;
-        exists<Ownership>(addr) &&
-        global<Ownership>(addr).status == IMMUTABLE
+        exists<object::Ownership>(addr) &&
+        global<object::Ownership>(addr).status == IMMUTABLE
     }
 
     /// Verifies if a given object has field with a given name.
@@ -71,10 +56,10 @@ module sui::prover {
     /// Returns number of K-type fields of a given object.
     spec fun num_fields<T: key, K: copy + drop + store>(obj: T): u64 {
         let addr = object::id(obj).bytes;
-        if (!exists<DynamicFields<K>>(addr)) {
+        if (!exists<object::DynamicFields<K>>(addr)) {
             0
         } else {
-            len(global<DynamicFields<K>>(addr).names)
+            len(global<object::DynamicFields<K>>(addr).names)
         }
     }
 
@@ -82,7 +67,7 @@ module sui::prover {
     // framework functions
 
     spec fun uid_has_field<K: copy + drop + store>(addr: address, name: K): bool {
-        exists<DynamicFields<K>>(addr) && contains(global<DynamicFields<K>>(addr).names, name)
+        exists<object::DynamicFields<K>>(addr) && contains(global<object::DynamicFields<K>>(addr).names, name)
     }
 
     // remove an element at index from a vector and return the resulting vector

--- a/crates/sui-framework/sources/transfer.move
+++ b/crates/sui-framework/sources/transfer.move
@@ -19,6 +19,14 @@ module sui::transfer {
     /// longer be transferred or mutated.
     public native fun freeze_object<T: key>(obj: T);
 
+    spec freeze_object {
+        pragma opaque;
+        aborts_if [abstract] sui::prover::owned(obj);
+        modifies [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] exists<sui::prover::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes).status == 3 /* IMMUTABLE */;
+    }
+
     /// Turn the given object into a mutable shared object that everyone
     /// can access and mutate. This is irreversible, i.e. once an object
     /// is shared, it will stay shared forever.
@@ -26,7 +34,24 @@ module sui::transfer {
     /// in this transaction. This restriction may be relaxed in the future.
     public native fun share_object<T: key>(obj: T);
 
+    spec share_object {
+        pragma opaque;
+        aborts_if [abstract] sui::prover::owned(obj);
+        modifies [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] exists<sui::prover::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes).status == 2 /* SHARED */;
+    }
+
     native fun transfer_internal<T: key>(obj: T, recipient: address);
+
+    spec transfer_internal {
+        pragma opaque;
+        aborts_if [abstract] false;
+        modifies [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] exists<sui::prover::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes).owner == recipient;
+        ensures [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes).status == 1 /* OWNED */;
+    }
 
     // Cost calibration functions
     #[test_only]

--- a/crates/sui-framework/sources/transfer.move
+++ b/crates/sui-framework/sources/transfer.move
@@ -22,9 +22,9 @@ module sui::transfer {
     spec freeze_object {
         pragma opaque;
         aborts_if [abstract] sui::prover::owned(obj);
-        modifies [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] exists<sui::prover::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes).status == 3 /* IMMUTABLE */;
+        modifies [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] exists<sui::object::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes).status == 3 /* IMMUTABLE */;
     }
 
     /// Turn the given object into a mutable shared object that everyone
@@ -37,9 +37,9 @@ module sui::transfer {
     spec share_object {
         pragma opaque;
         aborts_if [abstract] sui::prover::owned(obj);
-        modifies [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] exists<sui::prover::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes).status == 2 /* SHARED */;
+        modifies [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] exists<sui::object::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes).status == 2 /* SHARED */;
     }
 
     native fun transfer_internal<T: key>(obj: T, recipient: address);
@@ -47,10 +47,10 @@ module sui::transfer {
     spec transfer_internal {
         pragma opaque;
         aborts_if [abstract] false;
-        modifies [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] exists<sui::prover::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes).owner == recipient;
-        ensures [abstract] global<sui::prover::Ownership>(sui::object::id(obj).bytes).status == 1 /* OWNED */;
+        modifies [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] exists<sui::object::Ownership>(sui::object::id(obj).bytes);
+        ensures [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes).owner == recipient;
+        ensures [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes).status == 1 /* OWNED */;
     }
 
     // Cost calibration functions

--- a/crates/sui-framework/sources/transfer.move
+++ b/crates/sui-framework/sources/transfer.move
@@ -21,7 +21,10 @@ module sui::transfer {
 
     spec freeze_object {
         pragma opaque;
-        aborts_if [abstract] sui::prover::owned(obj);
+        // never aborts as it requires object by-value and:
+        // - it's OK to freeze whether object is fresh or owned
+        // - shared or immutable object cannot be passed by value
+        aborts_if [abstract] false;
         modifies [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes);
         ensures [abstract] exists<sui::object::Ownership>(sui::object::id(obj).bytes);
         ensures [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes).status == 3 /* IMMUTABLE */;
@@ -46,6 +49,9 @@ module sui::transfer {
 
     spec transfer_internal {
         pragma opaque;
+        // never aborts as it requires object by-value and:
+        // - it's OK to transfer whether object is fresh or already owned
+        // - shared or immutable object cannot be passed by value
         aborts_if [abstract] false;
         modifies [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes);
         ensures [abstract] exists<sui::object::Ownership>(sui::object::id(obj).bytes);

--- a/crates/sui-framework/sources/transfer.move
+++ b/crates/sui-framework/sources/transfer.move
@@ -3,6 +3,9 @@
 
 module sui::transfer {
 
+    use sui::object;
+    use sui::prover;
+
     /// Shared an object that was previously created. Shared objects must currently
     /// be constructed in the transaction they are created.
     const ESharedNonNewObject: u64 = 0;
@@ -25,9 +28,9 @@ module sui::transfer {
         // - it's OK to freeze whether object is fresh or owned
         // - shared or immutable object cannot be passed by value
         aborts_if [abstract] false;
-        modifies [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] exists<sui::object::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes).status == 3 /* IMMUTABLE */;
+        modifies [abstract] global<object::Ownership>(object::id(obj).bytes);
+        ensures [abstract] exists<object::Ownership>(object::id(obj).bytes);
+        ensures [abstract] global<object::Ownership>(object::id(obj).bytes).status == prover::IMMUTABLE;
     }
 
     /// Turn the given object into a mutable shared object that everyone
@@ -40,9 +43,9 @@ module sui::transfer {
     spec share_object {
         pragma opaque;
         aborts_if [abstract] sui::prover::owned(obj);
-        modifies [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] exists<sui::object::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes).status == 2 /* SHARED */;
+        modifies [abstract] global<object::Ownership>(object::id(obj).bytes);
+        ensures [abstract] exists<object::Ownership>(object::id(obj).bytes);
+        ensures [abstract] global<object::Ownership>(object::id(obj).bytes).status == prover::SHARED;
     }
 
     native fun transfer_internal<T: key>(obj: T, recipient: address);
@@ -53,10 +56,10 @@ module sui::transfer {
         // - it's OK to transfer whether object is fresh or already owned
         // - shared or immutable object cannot be passed by value
         aborts_if [abstract] false;
-        modifies [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] exists<sui::object::Ownership>(sui::object::id(obj).bytes);
-        ensures [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes).owner == recipient;
-        ensures [abstract] global<sui::object::Ownership>(sui::object::id(obj).bytes).status == 1 /* OWNED */;
+        modifies [abstract] global<object::Ownership>(object::id(obj).bytes);
+        ensures [abstract] exists<object::Ownership>(object::id(obj).bytes);
+        ensures [abstract] global<object::Ownership>(object::id(obj).bytes).owner == recipient;
+        ensures [abstract] global<object::Ownership>(object::id(obj).bytes).status == prover::OWNED;
     }
 
     // Cost calibration functions

--- a/crates/sui-framework/sources/tx_context.move
+++ b/crates/sui-framework/sources/tx_context.move
@@ -61,6 +61,13 @@ module sui::tx_context {
     /// Native function for deriving an ID via hash(tx_hash || ids_created)
     native fun derive_id(tx_hash: vector<u8>, ids_created: u64): address;
 
+    spec derive_id {
+        pragma opaque;
+        // this function never aborts
+        aborts_if [abstract] false;
+        // TODO: specify actual function behavior
+    }
+
     // ==== test-only functions ====
 
     #[test_only]

--- a/crates/sui-framework/sources/types.move
+++ b/crates/sui-framework/sources/types.move
@@ -8,4 +8,11 @@ module sui::types {
     /// Tests if the argument type is a one-time witness, that is a type with only one instantiation
     /// across the entire code base.
     public native fun is_one_time_witness<T: drop>(_: &T): bool;
+
+    spec is_one_time_witness {
+        pragma opaque;
+        // TODO: stub to be replaced by actual abort conditions if any
+        aborts_if [abstract] true;
+        // TODO: specify actual function behavior
+    }
 }

--- a/crates/sui-framework/tests/prover_tests.move
+++ b/crates/sui-framework/tests/prover_tests.move
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::prover_tests {
+    use sui::object::UID;
+
+    struct Obj has key, store {
+        id: UID
+    }
+
+    // ====================================================================
+    // Object ownership
+    // ====================================================================
+
+    public fun simple_transfer(o: Obj, recipient: address) {
+        sui::transfer::transfer(o, recipient);
+    }
+
+    spec simple_transfer {
+        ensures sui::prover::owned_by(o, recipient);
+        aborts_if false;
+    }
+
+    public fun simple_share(o: Obj) {
+        sui::transfer::share_object(o)
+    }
+
+    spec simple_share {
+        ensures sui::prover::shared(o);
+        aborts_if sui::prover::owned(o);
+    }
+
+    public fun simple_freeze(o: Obj) {
+        sui::transfer::freeze_object(o)
+    }
+
+    spec simple_freeze {
+        ensures sui::prover::immutable(o);
+        aborts_if sui::prover::owned(o);
+    }
+
+    // ====================================================================
+    // Dynamic fields
+    // ====================================================================
+
+    public fun simple_field_add(o: &mut Obj, n1: u64, v1: u8, n2: u8, v2: u64) {
+        sui::dynamic_field::add(&mut o.id, n1, v1);
+        sui::dynamic_field::add(&mut o.id, n2, v2);
+    }
+
+    spec simple_field_add {
+        aborts_if sui::prover::has_field(o, n1);
+        aborts_if sui::prover::has_field(o, n2);
+        ensures sui::prover::has_field(o, n1);
+        ensures sui::prover::has_field(o, n2);
+        ensures sui::prover::num_fields<Obj,u64>(o) == old(sui::prover::num_fields<Obj,u64>(o)) + 1;
+        ensures sui::prover::num_fields<Obj,u8>(o) == old(sui::prover::num_fields<Obj,u8>(o)) + 1;
+    }
+
+    public fun simple_field_remove(o: &mut Obj, n1: u64, n2: u8) {
+        sui::dynamic_field::remove<u64,u8>(&mut o.id, n1);
+        sui::dynamic_field::remove<u8,u64>(&mut o.id, n2);
+    }
+
+    spec simple_field_remove {
+        aborts_if !sui::prover::has_field(o, n1);
+        aborts_if !sui::prover::has_field(o, n2);
+        ensures !sui::prover::has_field(o, n1);
+        ensures !sui::prover::has_field(o, n2);
+        ensures sui::prover::num_fields<Obj,u64>(o) == old(sui::prover::num_fields<Obj,u64>(o)) - 1;
+        ensures sui::prover::num_fields<Obj,u8>(o) == old(sui::prover::num_fields<Obj,u8>(o)) - 1;
+    }
+}

--- a/crates/sui-framework/tests/prover_tests.move
+++ b/crates/sui-framework/tests/prover_tests.move
@@ -39,6 +39,16 @@ module sui::prover_tests {
         aborts_if sui::prover::owned(o);
     }
 
+    public fun simple_delete(o: Obj) {
+        let Obj { id } = o;
+        sui::object::delete(id);
+    }
+
+    spec simple_delete {
+        aborts_if false;
+        ensures !sui::prover::owned(o) && !sui::prover::shared(o) && !sui::prover::immutable(o);
+    }
+
     // ====================================================================
     // Dynamic fields
     // ====================================================================

--- a/crates/sui-framework/tests/prover_tests.move
+++ b/crates/sui-framework/tests/prover_tests.move
@@ -36,7 +36,7 @@ module sui::prover_tests {
 
     spec simple_freeze {
         ensures sui::prover::immutable(o);
-        aborts_if sui::prover::owned(o);
+        aborts_if false;
     }
 
     public fun simple_delete(o: Obj) {

--- a/crates/sui/src/sui_move/prove.rs
+++ b/crates/sui/src/sui_move/prove.rs
@@ -68,6 +68,10 @@ impl Prove {
                             sui_framework_address_concat_string("::dynamic_field"),
                             "dynamic_field_instances".to_string(),
                         ),
+                        (
+                            sui_framework_address_concat_string("::prover"),
+                            "prover_instances".to_string(),
+                        ),
                     ],
                 });
         }

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -14,6 +14,10 @@ procedure {:inline 1} $2_address_from_u256(num: int) returns (res: int);
 // ==================================================================================
 // Native transfer
 
+const INVALID_ADDR: int;
+axiom INVALID_ADDR == -1;
+
+
 function {:inline} ownership_update<T>(m: $Memory T, id: int, v: T): $Memory T {
     $Memory(domain#$Memory(m)[id := true], contents#$Memory(m)[id := v])
 }
@@ -26,13 +30,11 @@ function {:inline} ownership_update<T>(m: $Memory T, id: int, v: T): $Memory T {
 // ----------------------------------------------------------------------------------
 // Native transfer implementation for object type `{{instance.suffix}}`
 
-
-
 procedure {:inline 1} $2_transfer_transfer_internal{{S}}(obj: {{T}}, recipient: int) {
     var id: int;
     var v: $2_prover_Ownership;
     id := $bytes#$2_object_ID($2_object_$id{{S}}(obj));
-    v := $2_prover_Ownership($1_option_spec_some'address'(recipient), 1);
+    v := $2_prover_Ownership(recipient, 1);
     $2_prover_Ownership_$memory := ownership_update($2_prover_Ownership_$memory, id, v);
 }
 
@@ -45,7 +47,7 @@ procedure {:inline 1} $2_transfer_share_object{{S}}(obj: {{T}}) {
     }
 
     id := $bytes#$2_object_ID($2_object_$id{{S}}(obj));
-    v := $2_prover_Ownership($1_option_Option'address'(EmptyVec()), 2);
+    v := $2_prover_Ownership(INVALID_ADDR, 2);
     $2_prover_Ownership_$memory := ownership_update($2_prover_Ownership_$memory, id, v);
 }
 
@@ -58,7 +60,7 @@ procedure {:inline 1} $2_transfer_freeze_object{{S}}(obj: {{T}}) {
     }
 
     id := $bytes#$2_object_ID($2_object_$id{{S}}(obj));
-    v := $2_prover_Ownership($1_option_Option'address'(EmptyVec()), 3);
+    v := $2_prover_Ownership(INVALID_ADDR, 3);
     $2_prover_Ownership_$memory := ownership_update($2_prover_Ownership_$memory, id, v);
 }
 

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -132,7 +132,10 @@ procedure {:inline 1} $2_types_is_one_time_witness{{S}}(_: {{T}}) returns (res: 
 // ==================================================================================
 // Native dynamic_field
 
+procedure {:inline 1} $2_dynamic_field_has_child_object(parent: int, id: int) returns (res: bool);
+
 {%- for instance in dynamic_field_instances %}
+
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
 {%- set T = instance.name -%}
 

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -130,36 +130,6 @@ procedure {:inline 1} $2_types_is_one_time_witness{{S}}(_: {{T}}) returns (res: 
 // ==================================================================================
 // Native dynamic_field
 
-procedure {:inline 1} $2_dynamic_field_has_child_object(parent: int, id: int) returns (res: bool);
-
-{%- for instance_0 in dynamic_field_instances %}
-{%- for instance_1 in dynamic_field_instances %}
-{%- set S = "'" ~ instance_0.suffix ~ "'" -%}
-{%- set T = instance_0.name -%}
-{%- set K = "'" ~ instance_0.suffix ~ "_" ~ instance_1.suffix ~ "'" -%}
-
-// ----------------------------------------------------------------------------------
-// Native dynamic field implementation for object type `{{instance_0.suffix}}_{{instance_1.suffix}}
-// This may be suboptimal as this template will be expanded for all combinations of concrete types
-// but handling it probelry would require non-trivial changes to prelude generation code in the core Move repo
-
-procedure {:inline 1} $2_dynamic_field_add{{K}}(parent: $Mutation $2_object_UID, name: {{T}}, value: {{T}}) returns (res: $Mutation $2_object_UID) {
-    var id: int;
-    var v: $2_prover_DynamicFields{{S}};
-    id := $bytes#$2_object_ID($id#$2_object_UID($Dereference(parent)));
-    if ($2_prover_uid_has_field{{S}}($2_prover_DynamicFields{{S}}_$memory, id, name)) {
-        call $ExecFailureAbort();
-        return;
-    }
-    v := $2_prover_DynamicFields{{S}}(ExtendVec($names#$2_prover_DynamicFields{{S}}($ResourceValue($2_prover_DynamicFields{{S}}_$memory, id)), name));
-    $2_prover_DynamicFields{{S}}_$memory := ownership_update($2_prover_DynamicFields{{S}}_$memory, id, v);
-    res := parent;
-}
-
-{%- endfor %}
-{%- endfor %}
-
-
 {%- for instance in dynamic_field_instances %}
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
 {%- set T = instance.name -%}

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -12,61 +12,6 @@ procedure {:inline 1} $2_address_to_u256(addr: int) returns (res: int);
 procedure {:inline 1} $2_address_from_u256(num: int) returns (res: int);
 
 // ==================================================================================
-// Native transfer
-
-const INVALID_ADDR: int;
-axiom INVALID_ADDR == -1;
-
-
-function {:inline} ownership_update<T>(m: $Memory T, id: int, v: T): $Memory T {
-    $Memory(domain#$Memory(m)[id := true], contents#$Memory(m)[id := v])
-}
-
-{%- for instance in transfer_instances %}
-
-{%- set S = "'" ~ instance.suffix ~ "'" -%}
-{%- set T = instance.name -%}
-
-// ----------------------------------------------------------------------------------
-// Native transfer implementation for object type `{{instance.suffix}}`
-
-procedure {:inline 1} $2_transfer_transfer_internal{{S}}(obj: {{T}}, recipient: int) {
-    var id: int;
-    var v: $2_prover_Ownership;
-    id := $bytes#$2_object_ID($2_object_$id{{S}}(obj));
-    v := $2_prover_Ownership(recipient, 1);
-    $2_prover_Ownership_$memory := ownership_update($2_prover_Ownership_$memory, id, v);
-}
-
-procedure {:inline 1} $2_transfer_share_object{{S}}(obj: {{T}}) {
-    var id: int;
-    var v: $2_prover_Ownership;
-    if ($2_prover_owned{{S}}($2_prover_Ownership_$memory, obj)) {
-        call $ExecFailureAbort();
-        return;
-    }
-
-    id := $bytes#$2_object_ID($2_object_$id{{S}}(obj));
-    v := $2_prover_Ownership(INVALID_ADDR, 2);
-    $2_prover_Ownership_$memory := ownership_update($2_prover_Ownership_$memory, id, v);
-}
-
-procedure {:inline 1} $2_transfer_freeze_object{{S}}(obj: {{T}}) {
-    var id: int;
-    var v: $2_prover_Ownership;
-    if ($2_prover_owned{{S}}($2_prover_Ownership_$memory, obj)) {
-        call $ExecFailureAbort();
-        return;
-    }
-
-    id := $bytes#$2_object_ID($2_object_$id{{S}}(obj));
-    v := $2_prover_Ownership(INVALID_ADDR, 3);
-    $2_prover_Ownership_$memory := ownership_update($2_prover_Ownership_$memory, id, v);
-}
-
-{%- endfor %}
-
-// ==================================================================================
 // Native object
 
 

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -102,6 +102,26 @@ procedure {:inline 1} $2_dynamic_field_has_child_object_with_ty{{S}}(parent: int
 {%- endfor %}
 
 // ==================================================================================
+// Native prover
+
+
+{%- for instance in prover_instances %}
+
+{%- set S = "'" ~ instance.suffix ~ "'" -%}
+{%- set T = instance.name -%}
+
+// ----------------------------------------------------------------------------------
+// Native Sui prover implementation for object type `{{instance.suffix}}`
+
+function $2_prover_vec_remove{{S}}(v: Vec ({{T}}), elem_idx: int): Vec ({{T}}) {
+    RemoveAtVec(v, elem_idx)
+}
+procedure {:inline 1} $2_types_is_one_time_witness{{S}}(_: {{T}}) returns (res: bool);
+
+{%- endfor %}
+
+
+// ==================================================================================
 // Reads and writes to dynamic fields (skeletons)
 
 function GetDynField<T, V>(o: T, addr: int): V;

--- a/crates/sui/src/sui_move/sui-natives.bpl
+++ b/crates/sui/src/sui_move/sui-natives.bpl
@@ -116,7 +116,6 @@ procedure {:inline 1} $2_dynamic_field_has_child_object_with_ty{{S}}(parent: int
 function $2_prover_vec_remove{{S}}(v: Vec ({{T}}), elem_idx: int): Vec ({{T}}) {
     RemoveAtVec(v, elem_idx)
 }
-procedure {:inline 1} $2_types_is_one_time_witness{{S}}(_: {{T}}) returns (res: bool);
 
 {%- endfor %}
 


### PR DESCRIPTION
This PR adds support for Sui's storage model to the Move Prover. As we found out after a long period of trial-and-error investigation, we can model a large part of Sui storage in Move itself. Consequently, the key components of the model are defined in the prover.move file (Move side) and, though less so, in the sui-natives.bpl file (Boogie modeling language side).

Please note that this is a partial solution to modeling Sui storage model. At this point we are focusing on proving absence of aborts or presence of aborts of only expected types and for now we only support a subset of operations related to manipulating Sui storage.

For example, we do not yet fully specify all native functions but in order to avoid missing any aborts we mark them all as aborting and will model them appropriately after hitting an abort triggered by a given native function.