### PR TITLE
[fix] shutdown narwhal when using external consensus

### DIFF
--- a/narwhal/consensus/src/tests/dag_tests.rs
+++ b/narwhal/consensus/src/tests/dag_tests.rs
@@ -3,13 +3,14 @@
 
 use super::{Dag, ValidatorDagError};
 use crate::metrics::ConsensusMetrics;
+use crate::NUM_SHUTDOWN_RECEIVERS;
 use dag::node_dag::NodeDagError;
 use fastcrypto::hash::Hash;
 use indexmap::IndexMap;
 use prometheus::Registry;
 use std::{collections::BTreeSet, sync::Arc};
 use test_utils::{make_optimal_certificates, CommitteeFixture};
-use types::Certificate;
+use types::{Certificate, PreSubscribedBroadcastSender};
 
 #[tokio::test]
 async fn inner_dag_insert_one() {
@@ -24,11 +25,12 @@ async fn inner_dag_insert_one() {
         .collect::<BTreeSet<_>>();
     let (mut certificates, _next_parents) =
         make_optimal_certificates(&committee, 1..=4, &genesis, &keys);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
     // set up a Dag
     let (tx_cert, rx_cert) = test_utils::test_channel!(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    Dag::new(&committee, rx_cert, metrics);
+    Dag::new(&committee, rx_cert, metrics, tx_shutdown.subscribe());
 
     // Feed the certificates to the Dag
     while let Some(certificate) = certificates.pop_front() {
@@ -51,8 +53,14 @@ async fn test_dag_read_notify() {
     let certs = certificates.clone().into_iter().map(|c| (c.digest(), c));
     // set up a Dag
     let (_tx_cert, rx_cert) = test_utils::test_channel!(1);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let arc = Arc::new(Dag::new(&committee, rx_cert, metrics));
+    let arc = Arc::new(Dag::new(
+        &committee,
+        rx_cert,
+        metrics,
+        tx_shutdown.subscribe(),
+    ));
     let cloned = arc.clone();
     let handle = tokio::spawn(async move {
         let _ = &arc;
@@ -85,7 +93,9 @@ async fn test_dag_new_has_genesis_and_its_not_live() {
     // set up a Dag
     let (_tx_cert, rx_cert) = test_utils::test_channel!(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_, dag) = Dag::new(&committee, rx_cert, metrics);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+
+    let (_, dag) = Dag::new(&committee, rx_cert, metrics, tx_shutdown.subscribe());
 
     for certificate in genesis.clone() {
         assert!(dag.contains(certificate).await);
@@ -135,7 +145,9 @@ async fn test_dag_compresses_empty_blocks() {
     // set up a Dag
     let (_tx_cert, rx_cert) = test_utils::test_channel!(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_, dag) = Dag::new(&committee, rx_cert, metrics);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+
+    let (_, dag) = Dag::new(&committee, rx_cert, metrics, tx_shutdown.subscribe());
 
     // insert one round of empty certificates
     let (mut certificates, next_parents) =
@@ -201,7 +213,9 @@ async fn test_dag_rounds_after_compression() {
     // set up a Dag
     let (_tx_cert, rx_cert) = test_utils::test_channel!(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_, dag) = Dag::new(&committee, rx_cert, metrics);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+
+    let (_, dag) = Dag::new(&committee, rx_cert, metrics, tx_shutdown.subscribe());
 
     // insert one round of empty certificates
     let (mut certificates, next_parents) =
@@ -250,7 +264,9 @@ async fn dag_mutation_failures() {
     // set up a Dag
     let (_tx_cert, rx_cert) = test_utils::test_channel!(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+
+    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics, tx_shutdown.subscribe());
     let mut certs_to_insert = certificates.clone();
     let mut certs_to_insert_in_reverse = certs_to_insert.clone();
     let mut certs_to_remove_before_insert = certs_to_insert.clone();
@@ -314,11 +330,12 @@ async fn dag_insert_one_and_rounds_node_read() {
         .collect::<BTreeSet<_>>();
     let (certificates, _next_parents) =
         make_optimal_certificates(&committee, 1..=4, &genesis, &keys);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
     // set up a Dag
     let (_tx_cert, rx_cert) = test_utils::test_channel!(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics);
+    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics, tx_shutdown.subscribe());
     let mut certs_to_insert = certificates.clone();
 
     // Feed the certificates to the Dag
@@ -361,11 +378,12 @@ async fn dag_insert_and_remove_reads() {
         .collect::<BTreeSet<_>>();
     let (mut certificates, _next_parents) =
         make_optimal_certificates(&committee, 1..=4, &genesis, &keys);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
     // set up a Dag
     let (_tx_cert, rx_cert) = test_utils::test_channel!(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics);
+    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics, tx_shutdown.subscribe());
 
     // Feed the certificates to the Dag
     while let Some(certificate) = certificates.pop_front() {

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -216,7 +216,12 @@ impl PrimaryNodeInner {
         let (dag, network_model) = if !internal_consensus {
             debug!("Consensus is disabled: the primary will run w/o Bullshark");
             let consensus_metrics = Arc::new(ConsensusMetrics::new(registry));
-            let (handle, dag) = Dag::new(&committee.load(), rx_new_certificates, consensus_metrics);
+            let (handle, dag) = Dag::new(
+                &committee.load(),
+                rx_new_certificates,
+                consensus_metrics,
+                tx_shutdown.subscribe(),
+            );
 
             handles.push(handle);
 

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -583,6 +583,7 @@ impl Primary {
                 dag,
                 committee.clone(),
                 endpoint_metrics,
+                tx_shutdown.subscribe(),
             );
 
             handles.extend(vec![block_synchronizer_handle, consensus_api_handle]);

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -75,7 +75,7 @@ pub mod primary_tests;
 pub const CHANNEL_CAPACITY: usize = 1_000;
 
 /// The number of shutdown receivers to create on startup. We need one per component loop.
-pub const NUM_SHUTDOWN_RECEIVERS: u64 = 25;
+pub const NUM_SHUTDOWN_RECEIVERS: u64 = 26;
 
 /// Maximum duration to fetch certificates from local storage.
 const FETCH_CERTIFICATES_MAX_HANDLER_TIME: Duration = Duration::from_secs(10);

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -101,7 +101,13 @@ async fn get_network_peers_from_admin_server() {
         rx_consensus_round_updates,
         /* dag */
         Some(Arc::new(
-            Dag::new(&committee, rx_new_certificates, consensus_metrics).1,
+            Dag::new(
+                &committee,
+                rx_new_certificates,
+                consensus_metrics,
+                tx_shutdown.subscribe(),
+            )
+            .1,
         )),
         NetworkModel::Asynchronous,
         &mut tx_shutdown,
@@ -217,7 +223,13 @@ async fn get_network_peers_from_admin_server() {
         rx_consensus_round_updates,
         /* dag */
         Some(Arc::new(
-            Dag::new(&committee, rx_new_certificates_2, consensus_metrics).1,
+            Dag::new(
+                &committee,
+                rx_new_certificates_2,
+                consensus_metrics,
+                tx_shutdown.subscribe(),
+            )
+            .1,
         )),
         NetworkModel::Asynchronous,
         &mut tx_shutdown_2,

--- a/narwhal/primary/tests/integration_tests_proposer_api.rs
+++ b/narwhal/primary/tests/integration_tests_proposer_api.rs
@@ -115,7 +115,13 @@ async fn test_rounds_errors() {
         rx_consensus_round_updates,
         /* external_consensus */
         Some(Arc::new(
-            Dag::new(&no_name_committee, rx_new_certificates, consensus_metrics).1,
+            Dag::new(
+                &no_name_committee,
+                rx_new_certificates,
+                consensus_metrics,
+                tx_shutdown.subscribe(),
+            )
+            .1,
         )),
         NetworkModel::Asynchronous,
         &mut tx_shutdown,
@@ -183,7 +189,15 @@ async fn test_rounds_return_successful_response() {
 
     // AND setup the DAG
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let dag = Arc::new(Dag::new(&committee, rx_new_certificates, consensus_metrics).1);
+    let dag = Arc::new(
+        Dag::new(
+            &committee,
+            rx_new_certificates,
+            consensus_metrics,
+            tx_shutdown.subscribe(),
+        )
+        .1,
+    );
 
     Primary::spawn(
         name.clone(),
@@ -272,7 +286,17 @@ async fn test_node_read_causal_signed_certificates() {
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let (tx_new_certificates, rx_new_certificates) =
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
-    let dag = Arc::new(Dag::new(&committee, rx_new_certificates, consensus_metrics).1);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+
+    let dag = Arc::new(
+        Dag::new(
+            &committee,
+            rx_new_certificates,
+            consensus_metrics,
+            tx_shutdown.subscribe(),
+        )
+        .1,
+    );
 
     // No need to populate genesis in the Dag
     let genesis_certs = Certificate::genesis(&committee);
@@ -327,7 +351,6 @@ async fn test_node_read_causal_signed_certificates() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
-    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
     let primary_1_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -393,7 +416,13 @@ async fn test_node_read_causal_signed_certificates() {
         rx_consensus_round_updates_2,
         /* external_consensus */
         Some(Arc::new(
-            Dag::new(&committee, rx_new_certificates_2, consensus_metrics_2).1,
+            Dag::new(
+                &committee,
+                rx_new_certificates_2,
+                consensus_metrics_2,
+                tx_shutdown.subscribe(),
+            )
+            .1,
         )),
         NetworkModel::Asynchronous,
         &mut tx_shutdown_2,

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -126,7 +126,13 @@ async fn test_get_collections() {
         rx_consensus_round_updates,
         /* dag */
         Some(Arc::new(
-            Dag::new(&committee, rx_new_certificates, consensus_metrics).1,
+            Dag::new(
+                &committee,
+                rx_new_certificates,
+                consensus_metrics,
+                tx_shutdown.subscribe(),
+            )
+            .1,
         )),
         NetworkModel::Asynchronous,
         &mut tx_shutdown,
@@ -227,8 +233,7 @@ async fn test_get_collections() {
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
-// #[cfg_attr(windows, ignore)]
-#[ignore]
+#[cfg_attr(windows, ignore)]
 async fn test_remove_collections() {
     telemetry_subscribers::init_for_testing();
 
@@ -257,8 +262,18 @@ async fn test_remove_collections() {
     // Make the Dag
     let (tx_new_certificates, rx_new_certificates) =
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let dag = Arc::new(Dag::new(&committee, rx_new_certificates, consensus_metrics).1);
+    let dag = Arc::new(
+        Dag::new(
+            &committee,
+            rx_new_certificates,
+            consensus_metrics,
+            tx_shutdown.subscribe(),
+        )
+        .1,
+    );
     // No need to populate genesis in the Dag
 
     // Generate headers
@@ -305,8 +320,6 @@ async fn test_remove_collections() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
-
-    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
     Primary::spawn(
         name.clone(),
@@ -482,7 +495,17 @@ async fn test_read_causal_signed_certificates() {
     let (tx_new_certificates, rx_new_certificates) =
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let dag = Arc::new(Dag::new(&committee, rx_new_certificates, consensus_metrics).1);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+
+    let dag = Arc::new(
+        Dag::new(
+            &committee,
+            rx_new_certificates,
+            consensus_metrics,
+            tx_shutdown.subscribe(),
+        )
+        .1,
+    );
 
     // No need to  genesis in the Dag
     let genesis_certs = Certificate::genesis(&committee);
@@ -537,8 +560,6 @@ async fn test_read_causal_signed_certificates() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
-
-    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
     let primary_1_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -605,7 +626,13 @@ async fn test_read_causal_signed_certificates() {
         rx_consensus_round_updates_2,
         /* external_consensus */
         Some(Arc::new(
-            Dag::new(&committee, rx_new_certificates_2, consensus_metrics_2).1,
+            Dag::new(
+                &committee,
+                rx_new_certificates_2,
+                consensus_metrics_2,
+                tx_shutdown_2.subscribe(),
+            )
+            .1,
         )),
         NetworkModel::Asynchronous,
         &mut tx_shutdown_2,
@@ -697,8 +724,18 @@ async fn test_read_causal_unsigned_certificates() {
     // Make the Dag
     let (tx_new_certificates, rx_new_certificates) =
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let dag = Arc::new(Dag::new(&committee, rx_new_certificates, consensus_metrics).1);
+    let dag = Arc::new(
+        Dag::new(
+            &committee,
+            rx_new_certificates,
+            consensus_metrics,
+            tx_shutdown.subscribe(),
+        )
+        .1,
+    );
 
     // No need to genesis in the Dag
     let genesis_certs = Certificate::genesis(&committee);
@@ -758,8 +795,6 @@ async fn test_read_causal_unsigned_certificates() {
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
 
-    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
-
     // Spawn Primary 1 that we will be interacting with.
     Primary::spawn(
         name_1.clone(),
@@ -811,7 +846,13 @@ async fn test_read_causal_unsigned_certificates() {
         rx_consensus_round_updates_2,
         /* external_consensus */
         Some(Arc::new(
-            Dag::new(&committee, rx_new_certificates_2, consensus_metrics_2).1,
+            Dag::new(
+                &committee,
+                rx_new_certificates_2,
+                consensus_metrics_2,
+                tx_shutdown_2.subscribe(),
+            )
+            .1,
         )),
         NetworkModel::Asynchronous,
         &mut tx_shutdown_2,
@@ -980,7 +1021,13 @@ async fn test_get_collections_with_missing_certificates() {
         rx_consensus_round_updates,
         /* external_consensus */
         Some(Arc::new(
-            Dag::new(&committee, rx_new_certificates_1, consensus_metrics).1,
+            Dag::new(
+                &committee,
+                rx_new_certificates_1,
+                consensus_metrics,
+                tx_shutdown.subscribe(),
+            )
+            .1,
         )),
         NetworkModel::Asynchronous,
         &mut tx_shutdown,

--- a/narwhal/test-utils/src/cluster.rs
+++ b/narwhal/test-utils/src/cluster.rs
@@ -721,7 +721,11 @@ impl AuthorityDetails {
             panic!("External consensus is disabled, won't create a proposer client");
         }
 
-        let config = mysten_network::config::Config::new();
+        let config = mysten_network::config::Config {
+            connect_timeout: Some(Duration::from_secs(10)),
+            request_timeout: Some(Duration::from_secs(10)),
+            ..Default::default()
+        };
         let channel = config
             .connect_lazy(&internal.primary.parameters.consensus_api_grpc.socket_addr)
             .unwrap();

--- a/narwhal/types/src/pre_subscribed_broadcast.rs
+++ b/narwhal/types/src/pre_subscribed_broadcast.rs
@@ -15,6 +15,7 @@ pub struct PreSubscribedBroadcastSender {
     receivers: Vec<ConditionalBroadcastReceiver>,
 }
 
+#[derive(Debug)]
 pub struct ConditionalBroadcastReceiver {
     pub receiver: broadcast::Receiver<()>,
 }

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -296,7 +296,13 @@ async fn get_network_peers_from_admin_server() {
         rx_consensus_round_updates,
         /* dag */
         Some(Arc::new(
-            Dag::new(&committee, rx_new_certificates, consensus_metrics).1,
+            Dag::new(
+                &committee,
+                rx_new_certificates,
+                consensus_metrics,
+                tx_shutdown.subscribe(),
+            )
+            .1,
         )),
         NetworkModel::Asynchronous,
         &mut tx_shutdown,
@@ -412,7 +418,13 @@ async fn get_network_peers_from_admin_server() {
         rx_consensus_round_updates,
         /* dag */
         Some(Arc::new(
-            Dag::new(&committee, rx_new_certificates_2, consensus_metrics).1,
+            Dag::new(
+                &committee,
+                rx_new_certificates_2,
+                consensus_metrics,
+                tx_shutdown.subscribe(),
+            )
+            .1,
         )),
         NetworkModel::Asynchronous,
         &mut tx_shutdown_2,


### PR DESCRIPTION
The PR is fixing the Narwhal shutdown when using an external consensus. This will allow the current nightly integration tests pass. When running as `cargo nextest run -E 'kind(test) and package(narwhal-primary)' --run-ignored ignored-only` with some decreased latency they do pass:

<img width="1050" alt="Screenshot 2023-01-26 at 20 25 49" src="https://user-images.githubusercontent.com/17335598/214943474-3d02be3b-13df-406c-91d1-8b288be816e1.png">
