### PR TITLE
Adjust epoch frequency

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -81,7 +81,11 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
             .submit_to_consensus(&transaction, epoch_store)
             .await?;
         if let Some(checkpoints_per_epoch) = self.checkpoints_per_epoch {
-            if checkpoint_seq != 0 && checkpoint_seq % checkpoints_per_epoch == 0 {
+            let epoch = epoch_store.epoch();
+            if checkpoint_seq != 0
+                && ((epoch == 0 && checkpoint_seq % 28800 == 0)
+                    || (epoch > 0 && checkpoint_seq % checkpoints_per_epoch == 0))
+            {
                 self.sender.close_epoch(epoch_store)?;
             }
         }


### PR DESCRIPTION
For the first epoch, we hard code the length to be 28800; for the second and beyond, we use the config frequency.