### PR TITLE
ignore rpc errors when collecting validator responses

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -295,6 +295,8 @@ struct ProcessTransactionState {
     // Tally of stake for good vs bad responses.
     good_stake: StakeUnit,
     bad_stake: StakeUnit,
+    // bad stake from SuiError:RpcError
+    bad_stake_rpc_error: StakeUnit,
     // If there are conflicting transactions, we note them down and may attempt to retry
     conflicting_tx_digests:
         BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
@@ -1315,8 +1317,8 @@ where
                         if state.certificate.is_some() {
                             return Ok(ReduceOutput::End(state));
                         }
-
-                        if state.bad_stake > validity {
+                        // TODO: have a more generic handling of non-retryable errors
+                        if state.bad_stake - state.bad_stake_rpc_error > validity {
                             self.metrics
                                 .num_signatures
                                 .observe(state.signatures.len() as f64);
@@ -1334,13 +1336,13 @@ where
             .await
             // The reduction above shouldn't return error
             .unwrap();
-
         debug!(
             ?tx_digest,
             num_errors = state.errors.iter().map(|e| e.1.len()).sum::<usize>(),
             num_unique_errors = state.errors.len(),
             good_stake = state.good_stake,
             bad_stake = state.bad_stake,
+            bad_stake_rpc_error = state.bad_stake_rpc_error,
             num_signatures = state.signatures.len(),
             has_certificate = state.certificate.is_some(),
             "Received signatures response from validators handle_transaction"
@@ -1380,6 +1382,10 @@ where
             .process_tx_errors
             .with_label_values(&[&concise_name.to_string(), err.as_ref()])
             .inc();
+
+        if let SuiError::RpcError(..) = &err {
+            state.bad_stake_rpc_error += weight;
+        }
 
         if let SuiError::ObjectLockConflict {
             obj_ref,
@@ -1589,6 +1595,7 @@ where
             // The map here allows us to count the stake for each unique effect.
             effects_map: EffectsStakeMap,
             bad_stake: StakeUnit,
+            bad_stake_rpc_error: StakeUnit,
             errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
         }
 
@@ -1643,9 +1650,12 @@ where
                                 let concise_name = name.concise();
                                 debug!(?tx_digest, name=?name.concise(), weight, "Failed to get signed effects from validator handle_certificate: {:?}", err);
                                 self.metrics.process_cert_errors.with_label_values(&[&concise_name.to_string(), err.as_ref()]).inc();
+                                if let SuiError::RpcError(..) = &err {
+                                    state.bad_stake_rpc_error += weight;
+                                }
                                 state.errors.push((err, vec![name], weight));
                                 state.bad_stake += weight;
-                                if state.bad_stake > validity {
+                                if state.bad_stake - state.bad_stake_rpc_error > validity {
                                     return Ok(ReduceOutput::End(state));
                                 }
                             }

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -321,6 +321,10 @@ impl HandleTransactionTestAuthorityClient {
     pub fn reset_tx_info_response(&mut self) {
         self.tx_info_resp_to_return = Err(SuiError::Unknown("".to_string()));
     }
+
+    pub fn set_tx_info_response_error(&mut self, resp: SuiError) {
+        self.tx_info_resp_to_return = Err(resp);
+    }
 }
 
 impl Default for HandleTransactionTestAuthorityClient {

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -211,15 +211,15 @@ impl Committee {
         }
     }
 
+    /// 2f+1
     pub fn quorum_threshold(&self) -> StakeUnit {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (2 N + 3) / 3 = 2f + 1 + (2k + 2)/3 = 2f + 1 + k = N - f
         2 * self.total_votes / 3 + 1
     }
 
+    /// f+1
     pub fn validity_threshold(&self) -> StakeUnit {
-        // If N = 3f + 1 + k (0 <= k < 3)
-        // then (N + 2) / 3 = f + 1 + k/3 = f + 1
         validity_threshold(self.total_votes)
     }
 


### PR DESCRIPTION
1. Today when we collect validator sigs, if there are >= f+1 errors, we stop ad return
2. We consider a transaction non-retryable if >= f+1 errors are non-retryable. This is because the system should tolerate f byzantine validators. 
3. When the network has a non-zero offline validators that are unreachable, some bad transactions with non retryable error (e.g. GasBudgeTooLow) will be mistakenly treated as retryable. Imagine among 40 validators, 1 returns RpcError and 13 returns GasBudgeTooLow.
4. In this change, we do not count rpc-errors in authority aggregator when checking bad stake validity, hence ignoring offline validators.

To generalize the problem, these off-line validators could be byzantine in various ways and sending other retryable errors such as `ValidatorHaltedAtEpochBoundary` all the time, so a more robust solution is to expand the "ignore list" to all non-retryable errors. A more advanced design involves keeping track of validator responsiveness in authority aggregator, and avoid validators that are byzantine in a time decaying manner.