### PR TITLE
source validation: use expect-test for local vs on-chain checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,6 +2506,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "expect-test"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4661aca38d826eb7c72fe128e4238220616de4c0cc00db7bfc38e2e1364dd3"
+dependencies = [
+ "dissimilar",
+ "once_cell",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9080,6 +9090,7 @@ name = "sui-source-validation"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "expect-test",
  "futures",
  "move-binary-format",
  "move-bytecode-utils",
@@ -11053,6 +11064,7 @@ dependencies = [
  "error-code",
  "ethnum",
  "event-listener",
+ "expect-test",
  "eyre",
  "fail 0.4.0",
  "fail 0.5.1",

--- a/crates/sui-source-validation/Cargo.toml
+++ b/crates/sui-source-validation/Cargo.toml
@@ -30,6 +30,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 
+expect-test = "1.4.0"
 rand = "0.8.5"
 tempfile = "3.3.0"
 tokio = { version = "1.20.1", features = ["macros", "test-util"] }

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use expect_test::expect;
 use move_core_types::account_address::AccountAddress;
+use std::collections::HashMap;
 use std::io::Write;
 use std::{fs, io, path::Path};
 use std::{path::PathBuf, str};
@@ -14,7 +16,7 @@ use sui_types::{
 use test_utils::network::TestClusterBuilder;
 use test_utils::transaction::publish_package_with_wallet;
 
-use crate::{BytecodeSourceVerifier, SourceMode, SourceVerificationError};
+use crate::{BytecodeSourceVerifier, SourceMode};
 
 #[tokio::test]
 async fn successful_verification() -> anyhow::Result<()> {
@@ -139,12 +141,14 @@ async fn fail_verification_bad_address() -> anyhow::Result<()> {
     let client = context.get_client().await?;
     let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
 
-    assert!(matches!(
-        verifier
+    let expected = expect!["On-chain address cannot be zero"];
+    expected.assert_eq(
+        &verifier
             .verify_package_root_and_deps(&a_pkg.package, AccountAddress::ZERO)
-            .await,
-        Err(SourceVerificationError::ZeroOnChainAddresSpecifiedFailure),
-    ),);
+            .await
+            .unwrap_err()
+            .to_string(),
+    );
 
     Ok(())
 }
@@ -165,16 +169,18 @@ async fn fail_to_verify_unpublished_root() -> anyhow::Result<()> {
 
     // Trying to verify the root package, which hasn't been published -- this is going to fail
     // because there is no on-chain package to verify against.
-    assert!(matches!(
-        verifier
+    let expected = expect!["Invalid module b with error: Can't verify unpublished source"];
+    expected.assert_eq(
+        &verifier
             .verify_package(
                 &b_pkg.package,
                 /* verify_deps */ false,
-                SourceMode::Verify
+                SourceMode::Verify,
             )
-            .await,
-        Err(SourceVerificationError::InvalidModuleFailure { .. }),
-    ));
+            .await
+            .unwrap_err()
+            .to_string(),
+    );
 
     Ok(())
 }
@@ -240,10 +246,12 @@ async fn rpc_call_failed_during_verify() -> anyhow::Result<()> {
 async fn package_not_found() -> anyhow::Result<()> {
     let mut cluster = TestClusterBuilder::new().build().await?;
     let context = &mut cluster.wallet;
+    let mut stable_addrs = HashMap::new();
 
     let a_pkg = {
         let fixtures = tempfile::tempdir()?;
         let b_id = SuiAddress::random_for_testing_only();
+        stable_addrs.insert(b_id, "<b_id>");
         copy_package(&fixtures, "b", [("b", b_id)]).await?;
         let a_src = copy_package(&fixtures, "a", [("a", SuiAddress::ZERO), ("b", b_id)]).await?;
         compile_package(a_src)
@@ -252,26 +260,34 @@ async fn package_not_found() -> anyhow::Result<()> {
     let client = context.get_client().await?;
     let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
 
-    assert!(matches!(
-        verifier.verify_package_deps(&a_pkg.package).await,
-        Err(SourceVerificationError::SuiObjectRefFailure(_)),
-    ),);
+    let Err(err) = verifier.verify_package_deps(&a_pkg.package).await else {
+        panic!("Expected verification to fail");
+    };
 
-    assert!(matches!(
-        // Subst address here doesnt matter
-        verifier
-            .verify_package_root_and_deps(&a_pkg.package, AccountAddress::random())
-            .await,
-        Err(SourceVerificationError::SuiObjectRefFailure(_)),
-    ),);
+    let expected = expect!["Dependency object does not exist or was deleted: ObjectNotFound { object_id: 0x<b_id>, version: None }"];
+    expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
 
-    assert!(matches!(
-        // Subst address here doesnt matter
-        verifier
-            .verify_package_root(&a_pkg.package, AccountAddress::random())
-            .await,
-        Err(SourceVerificationError::SuiObjectRefFailure(_)),
-    ),);
+    let Err(err) = verifier.verify_package_root_and_deps(
+	&a_pkg.package,
+	/* Subst address here doesnt matter */ AccountAddress::random(),
+    ).await else {
+	panic!("Expected verification to fail");
+    };
+
+    let expected = expect!["Dependency object does not exist or was deleted: ObjectNotFound { object_id: 0x<b_id>, version: None }"];
+    expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
+
+    let package_root = AccountAddress::random();
+    stable_addrs.insert(SuiAddress::from(package_root), "<package_root>");
+    let Err(err) = verifier.verify_package_root(
+	&a_pkg.package,
+	package_root,
+    ).await else {
+	panic!("Expected verification to fail");
+    };
+
+    let expected = expect!["Dependency object does not exist or was deleted: ObjectNotFound { object_id: 0x<package_root>, version: None }"];
+    expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
 
     Ok(())
 }
@@ -291,13 +307,14 @@ async fn dependency_is_an_object() -> anyhow::Result<()> {
     let client = context.get_client().await?;
     let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
 
-    assert!(matches!(
-        verifier.verify_package_deps(&a_pkg.package).await,
-        Err(SourceVerificationError::ObjectFoundWhenPackageExpected(
-            SUI_SYSTEM_STATE_OBJECT_ID,
-            _,
-        )),
-    ),);
+    let expected = expect!["Dependency ID contains a Sui object, not a Move package: 0x0000000000000000000000000000000000000005"];
+    expected.assert_eq(
+        &verifier
+            .verify_package_deps(&a_pkg.package)
+            .await
+            .unwrap_err()
+            .to_string(),
+    );
 
     Ok(())
 }
@@ -329,12 +346,8 @@ async fn module_not_found_on_chain() -> anyhow::Result<()> {
         panic!("Expected verification to fail");
     };
 
-    let SourceVerificationError::OnChainDependencyNotFound { package, module } = err else {
-        panic!("Expected OnChainDependencyNotFound, got: {:?}", err);
-    };
-
-    assert_eq!(package, "b".into());
-    assert_eq!(module, "c".into());
+    let expected = expect!["On-chain version of dependency b::c was not found."];
+    expected.assert_eq(&err.to_string());
 
     Ok(())
 }
@@ -344,6 +357,7 @@ async fn module_not_found_locally() -> anyhow::Result<()> {
     let mut cluster = TestClusterBuilder::new().build().await?;
     let sender = cluster.get_address_0();
     let context = &mut cluster.wallet;
+    let mut stable_addrs = HashMap::new();
 
     let b_ref = {
         let fixtures = tempfile::tempdir()?;
@@ -354,6 +368,7 @@ async fn module_not_found_locally() -> anyhow::Result<()> {
     let a_pkg = {
         let fixtures = tempfile::tempdir()?;
         let b_id = b_ref.0.into();
+        stable_addrs.insert(b_id, "b_id");
         let b_src = copy_package(&fixtures, "b", [("b", b_id)]).await?;
         let a_src = copy_package(&fixtures, "a", [("a", SuiAddress::ZERO), ("b", b_id)]).await?;
         tokio::fs::remove_file(b_src.join("sources").join("d.move")).await?;
@@ -367,12 +382,8 @@ async fn module_not_found_locally() -> anyhow::Result<()> {
         panic!("Expected verification to fail");
     };
 
-    let SourceVerificationError::LocalDependencyNotFound { address, module } = err else {
-        panic!("Expected LocalDependencyNotFound, got: {:?}", err);
-    };
-
-    assert_eq!(address, b_ref.0.into());
-    assert_eq!(module.as_ref(), "d");
+    let expected = expect!["Local version of dependency b_id::d was not found."];
+    expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
 
     Ok(())
 }
@@ -382,6 +393,7 @@ async fn module_bytecode_mismatch() -> anyhow::Result<()> {
     let mut cluster = TestClusterBuilder::new().build().await?;
     let sender = cluster.get_address_0();
     let context = &mut cluster.wallet;
+    let mut stable_addrs = HashMap::new();
 
     let b_ref = {
         let fixtures = tempfile::tempdir()?;
@@ -400,6 +412,7 @@ async fn module_bytecode_mismatch() -> anyhow::Result<()> {
     let (a_pkg, a_ref) = {
         let fixtures = tempfile::tempdir()?;
         let b_id = b_ref.0.into();
+        stable_addrs.insert(b_id, "<b_id>");
         copy_package(&fixtures, "b", [("b", b_id)]).await?;
         let a_src = copy_package(&fixtures, "a", [("a", SuiAddress::ZERO), ("b", b_id)]).await?;
 
@@ -414,6 +427,7 @@ async fn module_bytecode_mismatch() -> anyhow::Result<()> {
         (compiled, publish_package(context, sender, a_src).await)
     };
     let a_addr: SuiAddress = a_ref.0.into();
+    stable_addrs.insert(a_addr, "<a_addr>");
 
     let client = context.get_client().await?;
     let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
@@ -422,25 +436,15 @@ async fn module_bytecode_mismatch() -> anyhow::Result<()> {
         panic!("Expected verification to fail");
     };
 
-    let SourceVerificationError::ModuleBytecodeMismatch { address, package, module } = err else {
-        panic!("Expected ModuleBytecodeMismatch, got: {:?}", err);
-    };
-
-    assert_eq!(address, b_ref.0.into());
-    assert_eq!(package, "b".into());
-    assert_eq!(module, "c".into());
+    let expected = expect!["Local dependency did not match its on-chain version at <b_id>::b::c"];
+    expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
 
     let Err(err) = verifier.verify_package_root(&a_pkg.package, a_addr.into()).await else {
         panic!("Expected verification to fail");
     };
 
-    let SourceVerificationError::ModuleBytecodeMismatch { address, package, module } = err else {
-        panic!("Expected ModuleBytecodeMismatch, got: {:?}", err);
-    };
-
-    assert_eq!(address, a_addr.into());
-    assert_eq!(package, "a".into());
-    assert_eq!(module, "a".into());
+    let expected = expect!["Local dependency did not match its on-chain version at <a_addr>::a::a"];
+    expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
 
     Ok(())
 }
@@ -448,6 +452,13 @@ async fn module_bytecode_mismatch() -> anyhow::Result<()> {
 /// Compile the package at absolute path `package`.
 fn compile_package(package: impl AsRef<Path>) -> CompiledPackage {
     sui_framework::build_move_package(package.as_ref(), BuildConfig::default()).unwrap()
+}
+
+fn sanitize_id(mut message: String, m: &HashMap<SuiAddress, &str>) -> String {
+    for (addr, label) in m {
+        message = message.replace(format!("{addr}").strip_prefix("0x").unwrap(), label);
+    }
+    message
 }
 
 /// Compile and publish package at absolute path `package` to chain.

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -192,6 +192,7 @@ encode_unicode-dff4ba8e3ae991db = { package = "encode_unicode", version = "1" }
 endian-type = { version = "0.1", default-features = false }
 ethnum = { version = "1", default-features = false }
 event-listener = { version = "2", default-features = false }
+expect-test = { version = "1", default-features = false }
 eyre = { version = "0.6" }
 fail-9fbad63c4bcf4a8f = { package = "fail", version = "0.4", default-features = false }
 fail-d8f496e17d97b5cb = { package = "fail", version = "0.5", default-features = false }
@@ -856,6 +857,7 @@ endian-type = { version = "0.1", default-features = false }
 enum_dispatch = { version = "0.3", default-features = false }
 ethnum = { version = "1", default-features = false }
 event-listener = { version = "2", default-features = false }
+expect-test = { version = "1", default-features = false }
 eyre = { version = "0.6" }
 fail-9fbad63c4bcf4a8f = { package = "fail", version = "0.4", default-features = false }
 fail-d8f496e17d97b5cb = { package = "fail", version = "0.5", default-features = false }


### PR DESCRIPTION
This updates `sui-source-validation` to use rust [expect-test](https://docs.rs/expect-test/latest/expect_test/). `expect-test` lets you inline expected test values as strings or typed data, and automatically updates test values in line in the source files with `UPDATE_EXPECT=1` (analogous to snapshot tests where expected values are stored in separate files e.g., `UB=1`). It is similar to testing frameworks in other languages, e.g., [inline-snapshots in Jest](https://jestjs.io/docs/snapshot-testing#inline-snapshots)

The main motivation comes from working on https://github.com/MystenLabs/sui/pull/7898 up the stack. There, we want to aggregate multiple errors in one error. This means that all tests that assert on the type of error would need to change, and I also found it troublesome to assert on equality of vector or set of errors (e.g., either I need to implement all kinds of traits for this to work, and it trickles into some types defined in the `move` repo, or some other wrangling). 

With `expect-test`, the output test value (which is ultimately a string representing a warning for this tool) does not need to change even though the underlying error type becomes wrapped in a vector or set (great). Also, when testing a vector or collection of errors, we only need to rely on `Display` to test and snapshot the expected value, sidestepping the need for comparators on containers.

We always have the option to use plain assertions in tests, or case out on typed Rust values if that is important, so we don't _need_ to use `expect-test` everywhere. In this case, I find it easy and helpful, since these tests should ultimately catch a user-facing error, and we can now review the message for accuracy. See inline comments for more details.