### PR TITLE
indexer: add transaction stats for peak TPS

### DIFF
--- a/crates/sui-indexer/migrations/2023-01-26-234605_transaction_stats/down.sql
+++ b/crates/sui-indexer/migrations/2023-01-26-234605_transaction_stats/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE transaction_stats;

--- a/crates/sui-indexer/migrations/2023-01-26-234605_transaction_stats/up.sql
+++ b/crates/sui-indexer/migrations/2023-01-26-234605_transaction_stats/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE transaction_stats (
+    id BIGSERIAL PRIMARY KEY,
+    computation_time TIMESTAMP NOT NULL,
+    start_txn_time TIMESTAMP NOT NULL,
+    end_txn_time TIMESTAMP NOT NULL,
+    tps REAL NOT NULL
+);
+
+CREATE INDEX transaction_stats_computation_time ON transaction_stats (computation_time);
+CREATE INDEX transaction_stats_start_txn_time ON transaction_stats (start_txn_time);
+CREATE INDEX transaction_stats_end_txn_time ON transaction_stats (end_txn_time);

--- a/crates/sui-indexer/src/errors.rs
+++ b/crates/sui-indexer/src/errors.rs
@@ -35,8 +35,14 @@ pub enum IndexerError {
     #[error("Indexer failed to initialize fullnode RPC client with error: `{0}`")]
     RpcClientInitError(String),
 
+    #[error("Indexer failed to convert timestamp to NaiveDateTime.")]
+    TimestampOverflow,
+
     #[error("Indexer failed to parse transaction digest read from DB with error: `{0}`")]
     TransactionDigestParsingError(String),
+
+    #[error("Indexer failed to find transaction time, which should not happen.")]
+    TransactionTimeNotAvailable,
 }
 
 impl IndexerError {
@@ -55,6 +61,8 @@ impl IndexerError {
             IndexerError::PgConnectionPoolInitError(_) => "PgConnectionPoolInitError".into(),
             IndexerError::RpcClientInitError(_) => "RpcClientInitError".into(),
             IndexerError::PgPoolConnectionError(_) => "PgPoolConnectionError".into(),
+            IndexerError::TransactionTimeNotAvailable => "TransactionTimeNotAvailable".into(),
+            IndexerError::TimestampOverflow => "TimestampOverflow".into(),
         }
     }
 }

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -325,3 +325,28 @@ impl IndexerPackageProcessorMetrics {
         }
     }
 }
+
+#[derive(Clone, Debug)]
+pub struct IndexerTransactionStatsProcessorMetrics {
+    pub total_transaction_stats_processed: IntCounter,
+    pub total_transaction_stats_error: IntCounter,
+}
+
+impl IndexerTransactionStatsProcessorMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            total_transaction_stats_processed: register_int_counter_with_registry!(
+                "total_transaction_stats_processed",
+                "Total number of transaction stats processed",
+                registry,
+            )
+            .unwrap(),
+            total_transaction_stats_error: register_int_counter_with_registry!(
+                "total_transaction_stats_error",
+                "Total number of transaction stats error",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}

--- a/crates/sui-indexer/src/models/mod.rs
+++ b/crates/sui-indexer/src/models/mod.rs
@@ -12,6 +12,7 @@ pub mod objects;
 pub mod package_logs;
 pub mod packages;
 pub mod transaction_logs;
+pub mod transaction_stats;
 pub mod transactions;
 // TODO: remove below after wave 2
 pub mod move_event_logs;

--- a/crates/sui-indexer/src/models/transaction_stats.rs
+++ b/crates/sui-indexer/src/models/transaction_stats.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::transaction_stats;
+use crate::schema::transaction_stats::dsl::*;
+use crate::PgPoolConnection;
+
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+use diesel::result::Error;
+
+#[derive(Queryable, Debug)]
+#[diesel(primary_key(id))]
+pub struct TransactionStats {
+    pub id: i64,
+    pub computation_time: NaiveDateTime,
+    pub start_txn_time: NaiveDateTime,
+    pub end_txn_time: NaiveDateTime,
+    pub tps: f32,
+}
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = transaction_stats)]
+pub struct NewTransactionStats {
+    pub computation_time: NaiveDateTime,
+    pub start_txn_time: NaiveDateTime,
+    pub end_txn_time: NaiveDateTime,
+    pub tps: f32,
+}
+
+pub fn commit_transaction_stats(
+    pg_pool_conn: &mut PgPoolConnection,
+    new_tx_stats_vec: Vec<NewTransactionStats>,
+) -> Result<usize, IndexerError> {
+    let tx_stats_commit_result: Result<usize, Error> = pg_pool_conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|conn| {
+            diesel::insert_into(transaction_stats::table)
+                .values(&new_tx_stats_vec)
+                .on_conflict(id)
+                .do_nothing()
+                .execute(conn)
+        });
+
+    tx_stats_commit_result.map_err(|e| {
+        IndexerError::PostgresWriteError(format!(
+            "Failed writing transaction stats to Postgres DB with transaction stats {:?} and error: {:?}",
+            new_tx_stats_vec, e
+        ))
+    })
+}

--- a/crates/sui-indexer/src/processors/mod.rs
+++ b/crates/sui-indexer/src/processors/mod.rs
@@ -5,3 +5,4 @@ pub mod address_processor;
 pub mod object_processor;
 pub mod package_processor;
 pub mod processor_orchestrator;
+pub mod transaction_stats_processor;

--- a/crates/sui-indexer/src/processors/transaction_stats_processor.rs
+++ b/crates/sui-indexer/src/processors/transaction_stats_processor.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::Registry;
+use std::sync::Arc;
+use tracing::info;
+
+use sui_indexer::errors::IndexerError;
+use sui_indexer::metrics::IndexerTransactionStatsProcessorMetrics;
+use sui_indexer::models::transaction_stats::{commit_transaction_stats, NewTransactionStats};
+use sui_indexer::models::transactions::{read_last_transaction, read_transactions_since};
+use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
+
+const TRANSACTION_STATS_COMPUTATION_WINDOW_IN_SECONDS: i64 = 5;
+
+pub struct TransactionStatsProcessor {
+    pg_connection_pool: Arc<PgConnectionPool>,
+    pub transaction_stats_processor_metrics: IndexerTransactionStatsProcessorMetrics,
+}
+
+impl TransactionStatsProcessor {
+    pub fn new(
+        pg_connection_pool: Arc<PgConnectionPool>,
+        prometheus_registry: &Registry,
+    ) -> TransactionStatsProcessor {
+        let transaction_stats_processor_metrics =
+            IndexerTransactionStatsProcessorMetrics::new(prometheus_registry);
+        Self {
+            pg_connection_pool,
+            transaction_stats_processor_metrics,
+        }
+    }
+
+    pub async fn start(&self) -> Result<(), IndexerError> {
+        info!("Indexer transaction stats processor started...");
+        let mut pg_pool_conn = get_pg_pool_connection(self.pg_connection_pool.clone())?;
+
+        loop {
+            let mut last_txn_opt = read_last_transaction(&mut pg_pool_conn)?;
+            while last_txn_opt.is_none() {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                last_txn_opt = read_last_transaction(&mut pg_pool_conn)?;
+            }
+            // unwrap is safe here because we know last_txn_opt is not None
+            let last_txn = last_txn_opt.unwrap();
+            let end_timestamp = last_txn
+                .transaction_time
+                .ok_or(IndexerError::TransactionTimeNotAvailable)?;
+            let since = end_timestamp
+                .checked_sub_signed(chrono::Duration::seconds(
+                    TRANSACTION_STATS_COMPUTATION_WINDOW_IN_SECONDS,
+                ))
+                .ok_or(IndexerError::TimestampOverflow)?;
+            let transactions = read_transactions_since(&mut pg_pool_conn, since)?;
+            let tps = (transactions.len() as f32)
+                / (TRANSACTION_STATS_COMPUTATION_WINDOW_IN_SECONDS as f32);
+            let stats = NewTransactionStats {
+                computation_time: chrono::NaiveDateTime::from_timestamp_millis(
+                    chrono::Utc::now().timestamp_millis(),
+                )
+                .ok_or(IndexerError::TimestampOverflow)?,
+                start_txn_time: since,
+                end_txn_time: end_timestamp,
+                tps,
+            };
+            commit_transaction_stats(&mut pg_pool_conn, vec![stats])?;
+            self.transaction_stats_processor_metrics
+                .total_transaction_stats_processed
+                .inc();
+            tokio::time::sleep(std::time::Duration::from_secs(
+                TRANSACTION_STATS_COMPUTATION_WINDOW_IN_SECONDS as u64,
+            ))
+            .await;
+        }
+    }
+}

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -162,6 +162,16 @@ diesel::table! {
 }
 
 diesel::table! {
+    transaction_stats (id) {
+        id -> Int8,
+        computation_time -> Timestamp,
+        start_txn_time -> Timestamp,
+        end_txn_time -> Timestamp,
+        tps -> Float4,
+    }
+}
+
+diesel::table! {
     transactions (id) {
         id -> Int8,
         transaction_digest -> Varchar,
@@ -204,5 +214,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     publish_event_logs,
     publish_events,
     transaction_logs,
+    transaction_stats,
     transactions,
 );


### PR DESCRIPTION
Per requests from product team, this PR adds TPS calculation to indexer end, which will unblock the peak TPS feature on Explorer for wave 2.
<img width="560" alt="Screen Shot 2023-01-26 at 5 58 42 PM" src="https://user-images.githubusercontent.com/106119108/214984299-156702b3-a994-4324-b915-e52a42139e76.png">

tested with local validator and saw the txn stats can be populated properly
