### PR TITLE
Explorer show complete event data

### DIFF
--- a/apps/explorer/src/components/events/eventDisplay.tsx
+++ b/apps/explorer/src/components/events/eventDisplay.tsx
@@ -116,9 +116,12 @@ export function newObjectEventDisplay(event: NewObjectEvent): EventDisplayData {
             title: 'New Object',
             content: [
                 contentLine('Module', packMod, true),
+                contentLine('Object Type', event.objectType),
+                objectContent('Object ID', event.objectId),
                 [
                     addressContent('', event.sender),
                     addressContent('', getOwnerStr(event.recipient)),
+
                 ],
             ],
         },

--- a/apps/explorer/src/components/events/eventDisplay.tsx
+++ b/apps/explorer/src/components/events/eventDisplay.tsx
@@ -91,10 +91,12 @@ function contentLine(
 }
 
 export function moveEventDisplay(event: MoveEvent): EventDisplayData {
+    const packMod = `${event.packageId}::${event.transactionModule}`;
     return {
         top: {
             title: 'Move Event',
             content: [
+                contentLine('Module', packMod, true),
                 contentLine('Type', event.type, true),
                 addressContent('Sender', event.sender as string),
                 contentLine('BCS', event.bcs, true),
@@ -118,10 +120,10 @@ export function newObjectEventDisplay(event: NewObjectEvent): EventDisplayData {
                 contentLine('Module', packMod, true),
                 contentLine('Object Type', event.objectType),
                 objectContent('Object ID', event.objectId),
+                contentLine('Version', event.version.toString()),
                 [
                     addressContent('', event.sender),
                     addressContent('', getOwnerStr(event.recipient)),
-
                 ],
             ],
         },
@@ -131,10 +133,12 @@ export function newObjectEventDisplay(event: NewObjectEvent): EventDisplayData {
 export function transferObjectEventDisplay(
     event: TransferObjectEvent
 ): EventDisplayData {
+    const packMod = `${event.packageId}::${event.transactionModule}`;
     return {
         top: {
             title: 'Transfer Object',
             content: [
+                contentLine('Module', packMod, true),
                 contentLine('Object Type', event.objectType, true),
                 objectContent('Object ID', event.objectId),
                 contentLine('Version', event.version.toString()),
@@ -150,10 +154,12 @@ export function transferObjectEventDisplay(
 export function mutateObjectEventDisplay(
     event: MutateObjectEvent
 ): EventDisplayData {
+    const packMod = `${event.packageId}::${event.transactionModule}`;
     return {
         top: {
             title: 'Mutate Object',
             content: [
+                contentLine('Module', packMod, true),
                 contentLine('Object Type', event.objectType, true),
                 objectContent('Object ID', event.objectId),
                 contentLine('Version', event.version.toString()),


### PR DESCRIPTION
More coverage for the explorer transaction events section 

<img width="897" alt="Screenshot 2023-01-27 at 10 03 39 AM" src="https://user-images.githubusercontent.com/8676844/215120414-043491db-ea0e-4c05-8dae-03ba6bf167fd.png">
