### PR TITLE
[RWLocks] Temporary add #[serde(skip)] for SharedObject::mutable

### DIFF
--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -357,7 +357,6 @@ ObjectArg:
               TYPENAME: ObjectID
           - initial_shared_version:
               TYPENAME: SequenceNumber
-          - mutable: BOOL
 ObjectDigest:
   NEWTYPESTRUCT: BYTES
 ObjectFormatOptions:

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -86,8 +86,14 @@ pub enum ObjectArg {
     SharedObject {
         id: ObjectID,
         initial_shared_version: SequenceNumber,
+        // Temporary fix until SDK will be aware of mutable flag
+        #[serde(skip, default = "bool_true")]
         mutable: bool,
     },
+}
+
+fn bool_true() -> bool {
+    true
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -4,8 +4,7 @@
 use futures::{stream, StreamExt};
 use sui_core::authority_client::AuthorityAPI;
 use sui_types::messages::{
-    CallArg, EntryArgumentError, EntryArgumentErrorKind, ExecutionFailureStatus, ExecutionStatus,
-    ObjectArg, ObjectInfoRequest, ObjectInfoRequestKind,
+    CallArg, ExecutionStatus, ObjectArg, ObjectInfoRequest, ObjectInfoRequestKind,
 };
 use test_utils::authority::get_client;
 use test_utils::transaction::{
@@ -87,7 +86,8 @@ async fn call_shared_object_contract() {
     );
     let effects = submit_single_owner_transaction(transaction, configs.validator_set()).await;
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
-    let counter_creation_transaction = effects.transaction_digest;
+    // todo(RWLock) uncomment when serialization of mutable field is fixed
+    // let counter_creation_transaction = effects.transaction_digest;
     let ((counter_id, counter_initial_shared_version, _), _) = effects.created[0];
     let counter_object_arg = ObjectArg::SharedObject {
         id: counter_id,
@@ -120,8 +120,9 @@ async fn call_shared_object_contract() {
         // Only gas object transaction and counter creation are dependencies
         // Note that this assert would fail for second transaction
         // if they send counter_object_arg instead of counter_object_arg_imm
-        assert_eq!(effects.dependencies.len(), 2);
-        assert!(effects.dependencies.contains(&counter_creation_transaction));
+        // todo(RWLock) uncomment when serialization of mutable field is fixed
+        // assert_eq!(effects.dependencies.len(), 2);
+        // assert!(effects.dependencies.contains(&counter_creation_transaction));
     }
 
     // Make a transaction to increment the counter.
@@ -135,16 +136,19 @@ async fn call_shared_object_contract() {
     let effects = submit_shared_object_transaction(transaction, configs.validator_set())
         .await
         .unwrap();
-    let increment_transaction = effects.transaction_digest;
+    // todo(RWLock) uncomment when serialization of mutable field is fixed
+    // let increment_transaction = effects.transaction_digest;
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
     // Again - only gas object transaction and counter creation are dependencies
     // Previously executed assert_value transaction(s) are not a dependency because they took immutable reference to shared object
-    assert_eq!(effects.dependencies.len(), 2);
-    assert!(effects.dependencies.contains(&counter_creation_transaction));
+    // todo(RWLock) uncomment when serialization of mutable field is fixed
+    // assert_eq!(effects.dependencies.len(), 2);
+    // assert!(effects.dependencies.contains(&counter_creation_transaction));
 
     // assert_value can take both mutable and immutable references
     // it is allowed to pass mutable shared object arg to move call taking immutable reference
-    let mut assert_value_mut_transaction = None;
+    // todo(RWLock) uncomment when serialization of mutable field is fixed
+    // let mut assert_value_mut_transaction = None;
     for imm in [true, false] {
         // Ensure the value of the counter is `1`.
         let transaction = move_transaction(
@@ -166,36 +170,39 @@ async fn call_shared_object_contract() {
             .unwrap();
         assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
         // Gas object transaction and increment transaction are dependencies
-        assert_eq!(effects.dependencies.len(), 2);
-        assert!(effects.dependencies.contains(&increment_transaction));
-        assert_value_mut_transaction = Some(effects.transaction_digest);
+        // todo(RWLock) uncomment when serialization of mutable field is fixed
+        // assert_eq!(effects.dependencies.len(), 2);
+        // assert!(effects.dependencies.contains(&increment_transaction));
+        // assert_value_mut_transaction = Some(effects.transaction_digest);
     }
 
-    let assert_value_mut_transaction = assert_value_mut_transaction.unwrap();
+    // todo(RWLock) uncomment when serialization of mutable field is fixed
+    // let assert_value_mut_transaction = assert_value_mut_transaction.unwrap();
 
     // And last check - attempt to send increment transaction with immutable reference
-    let transaction = move_transaction(
-        gas_objects.pop().unwrap(),
-        "counter",
-        "increment",
-        package_id,
-        vec![CallArg::Object(counter_object_arg_imm)],
-    );
-    let effects = submit_shared_object_transaction(transaction, configs.validator_set())
-        .await
-        .unwrap();
-    // Transaction fails
-    assert!(matches!(
-        effects.status,
-        ExecutionStatus::Failure {
-            error: ExecutionFailureStatus::EntryArgumentError(EntryArgumentError {
-                kind: EntryArgumentErrorKind::ObjectMutabilityMismatch,
-                ..
-            })
-        }
-    ));
-    assert_eq!(effects.dependencies.len(), 2);
-    assert!(effects.dependencies.contains(&assert_value_mut_transaction));
+    // todo(RWLock) uncomment when serialization of mutable field is fixed
+    // let transaction = move_transaction(
+    //     gas_objects.pop().unwrap(),
+    //     "counter",
+    //     "increment",
+    //     package_id,
+    //     vec![CallArg::Object(counter_object_arg_imm)],
+    // );
+    // let effects = submit_shared_object_transaction(transaction, configs.validator_set())
+    //     .await
+    //     .unwrap();
+    // // Transaction fails
+    // assert!(matches!(
+    //     effects.status,
+    //     ExecutionStatus::Failure {
+    //         error: ExecutionFailureStatus::EntryArgumentError(EntryArgumentError {
+    //             kind: EntryArgumentErrorKind::ObjectMutabilityMismatch,
+    //             ..
+    //         })
+    //     }
+    // ));
+    // assert_eq!(effects.dependencies.len(), 2);
+    // assert!(effects.dependencies.contains(&assert_value_mut_transaction));
 }
 
 /// Same test as `call_shared_object_contract` but the clients submits many times the same


### PR DESCRIPTION
We support default for SharedObject::mutable on the JsonRPC, but default does not work with BCS.

Temporary remove this flag to unblock SDK incompatibility on the BCS level.