### PR TITLE
[Narwhal] more cleanups in DAG

### DIFF
--- a/narwhal/consensus/benches/process_certificates.rs
+++ b/narwhal/consensus/benches/process_certificates.rs
@@ -44,7 +44,7 @@ pub fn process_certificates(c: &mut Criterion) {
         let store = make_consensus_store(&store_path);
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-        let mut state = ConsensusState::new(Certificate::genesis(&committee), metrics.clone());
+        let mut state = ConsensusState::new(metrics.clone());
 
         let data_size: usize = certificates
             .iter()

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -11,7 +11,7 @@ use crypto::PublicKey;
 use fastcrypto::traits::EncodeDecodeBase64;
 use std::{collections::BTreeSet, sync::Arc};
 use tokio::time::Instant;
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 use types::{Certificate, CertificateDigest, CommittedSubDag, ConsensusStore, Round, StoreResult};
 
 #[cfg(test)]

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -276,7 +276,7 @@ impl Bullshark {
                     }
                 }
             } else {
-                error!(
+                trace!(
                     "Round not present in Dag store: {:?} when looking for parents of {:?}",
                     round - 1,
                     certificate

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -325,15 +325,6 @@ where
                                 tracing::info!("Committed {} -> {:?}", certificate.header, digest);
                             }
 
-                            // Update DAG size metric periodically to limit computation cost.
-                            // TODO: this should be triggered on collection when library support for
-                            // closure metrics is available.
-                            if i % 1_000 == 0 {
-                                self.metrics
-                                    .dag_size_bytes
-                                    .set((mysten_util_mem::malloc_size(&self.state.dag) + std::mem::size_of::<Dag>()) as i64);
-                            }
-
                             commited_certificates.push(certificate.clone());
                         }
 

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -46,23 +46,12 @@ pub struct ConsensusState {
 }
 
 impl ConsensusState {
-    pub fn new(genesis: Vec<Certificate>, metrics: Arc<ConsensusMetrics>) -> Self {
-        let genesis = genesis
-            .into_iter()
-            .map(|x| (x.origin(), (x.digest(), x)))
-            .collect::<HashMap<_, _>>();
-
+    pub fn new(metrics: Arc<ConsensusMetrics>) -> Self {
         Self {
             last_committed_round: 0,
-            last_committed: genesis
-                .iter()
-                .map(|(x, (_, y))| (x.clone(), y.round()))
-                .collect(),
+            last_committed: Default::default(),
             latest_sub_dag_index: 0,
-            dag: [(0, genesis)]
-                .iter()
-                .cloned()
-                .collect::<BTreeMap<_, HashMap<_, _>>>(),
+            dag: Default::default(),
             metrics,
         }
     }

--- a/narwhal/consensus/src/metrics.rs
+++ b/narwhal/consensus/src/metrics.rs
@@ -27,8 +27,6 @@ pub struct ConsensusMetrics {
     /// The number of certificates from consensus that were restored and sent to the executor
     /// following a node restart
     pub recovered_consensus_output: IntCounter,
-    /// The approximate size in memory (including heap allocations) of the Dag.
-    pub dag_size_bytes: IntGauge,
     /// The latency between two successful commit rounds
     pub commit_rounds_latency: Histogram,
     /// The number of certificates committed per commit round
@@ -80,11 +78,6 @@ impl ConsensusMetrics {
             recovered_consensus_output: register_int_counter_with_registry!(
                 "recovered_consensus_output", 
                 "The number of certificates from consensus that were restored and sent to the executor following a node restart",
-                registry
-            ).unwrap(),
-            dag_size_bytes: register_int_gauge_with_registry!(
-                "dag_size_bytes",
-                "The approximate size in memory (including heap allocations) of the dag",
                 registry
             ).unwrap(),
             commit_rounds_latency: register_histogram_with_registry!(

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -66,7 +66,6 @@ async fn commit_one() {
         tx_output,
         bullshark,
         metrics,
-        gc_depth,
     );
     tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 
@@ -132,7 +131,6 @@ async fn dead_node() {
         tx_output,
         bullshark,
         metrics,
-        gc_depth,
     );
     tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 
@@ -253,7 +251,6 @@ async fn not_enough_support() {
         tx_output,
         bullshark,
         metrics,
-        gc_depth,
     );
     tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 
@@ -344,7 +341,6 @@ async fn missing_leader() {
         tx_output,
         bullshark,
         metrics,
-        gc_depth,
     );
     tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 
@@ -416,7 +412,6 @@ async fn committed_round_after_restart() {
             tx_output,
             bullshark,
             metrics.clone(),
-            gc_depth,
         );
 
         // When `input_round` is 2 * r + 1, r > 1, the previous commit round would be 2 * (r - 1),
@@ -497,7 +492,6 @@ async fn restart_with_new_committee() {
             tx_output,
             bullshark,
             metrics.clone(),
-            gc_depth,
         );
         tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -79,7 +79,6 @@ async fn test_consensus_recovery_with_bullshark() {
         tx_output,
         bullshark,
         metrics.clone(),
-        gc_depth,
     );
 
     // WHEN we feed all certificates to the consensus.
@@ -169,7 +168,6 @@ async fn test_consensus_recovery_with_bullshark() {
         tx_output,
         bullshark,
         metrics.clone(),
-        gc_depth,
     );
 
     // WHEN we send same certificates but up to round 3 (inclusive)
@@ -237,7 +235,6 @@ async fn test_consensus_recovery_with_bullshark() {
         tx_output,
         bullshark,
         metrics.clone(),
-        gc_depth,
     );
 
     // WHEN send the certificates of round >= 5 to trigger a leader election for round 4

--- a/narwhal/consensus/src/tests/tusk_tests.rs
+++ b/narwhal/consensus/src/tests/tusk_tests.rs
@@ -59,7 +59,6 @@ async fn commit_one() {
         tx_output,
         tusk,
         metrics,
-        gc_depth,
     );
     tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 
@@ -125,7 +124,6 @@ async fn dead_node() {
         tx_output,
         tusk,
         metrics,
-        gc_depth,
     );
     tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 
@@ -245,7 +243,6 @@ async fn not_enough_support() {
         tx_output,
         tusk,
         metrics,
-        gc_depth,
     );
     tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 
@@ -334,7 +331,6 @@ async fn missing_leader() {
         tx_output,
         tusk,
         metrics,
-        gc_depth,
     );
     tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 
@@ -397,7 +393,6 @@ async fn restart_with_new_committee() {
             tx_output,
             tusk,
             metrics.clone(),
-            gc_depth,
         );
         tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -197,7 +197,7 @@ mod tests {
 
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-        let mut state = ConsensusState::new(Certificate::genesis(&committee), metrics);
+        let mut state = ConsensusState::new(metrics);
         let mut tusk = Tusk::new(committee, store, gc_depth);
         for certificate in certificates {
             tusk.process_certificate(&mut state, certificate).unwrap();
@@ -234,14 +234,14 @@ mod tests {
         // TODO: evidence that this test fails when `failure_probability` parameter >= 1/3
         let (certificates, _next_parents) =
             test_utils::make_certificates(&committee, 1..=rounds, &genesis, &keys, 0.333);
-        let arc_committee = Arc::new(ArcSwap::from_pointee(committee.clone()));
+        let arc_committee = Arc::new(ArcSwap::from_pointee(committee));
 
         let store_path = test_utils::temp_dir();
         let store = make_consensus_store(&store_path);
 
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-        let mut state = ConsensusState::new(Certificate::genesis(&committee), metrics);
+        let mut state = ConsensusState::new(metrics);
         let mut tusk = Tusk::new((**arc_committee.load()).clone(), store, gc_depth);
 
         for certificate in certificates {

--- a/narwhal/consensus/src/utils.rs
+++ b/narwhal/consensus/src/utils.rs
@@ -80,12 +80,12 @@ pub fn order_dag(
             };
 
             // We skip the certificate if we (1) already processed it or (2) we reached a round that we already
-            // committed for this authority.
+            // committed or will never commit for this authority.
             let mut skip = already_ordered.contains(&digest);
             skip |= state
                 .last_committed
                 .get(&certificate.origin())
-                .map_or_else(|| false, |r| r == &certificate.round());
+                .map_or_else(|| false, |r| &certificate.round() <= r);
             if !skip {
                 buffer.push(certificate);
                 already_ordered.insert(digest);

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -75,7 +75,6 @@ async fn test_recovery() {
         tx_output,
         bullshark,
         metrics,
-        gc_depth,
     );
     tokio::spawn(async move { while rx_primary.recv().await.is_some() {} });
 

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -337,7 +337,6 @@ impl PrimaryNodeInner {
             tx_sequence,
             ordering_engine,
             consensus_metrics.clone(),
-            parameters.gc_depth,
         );
 
         // Spawn the client executing the transactions. It can also synchronize with the


### PR DESCRIPTION
When testing Sui + Narwhal with simulated crashes, there were many error logs about missing round in the DAG. These messages are actually benign, because a certificate may have no parent in the DAG because all parents have been committed. Similar to the case of missing a single parent in DAG in the same function, the log severity of missing a round in DAG should be `trace`. There is a panic that makes sure during DAG traversal, there is a path between leaders, so real issues will still be caught.

I also considered not dropping committed certificates unless it is past GC depth, and turn the error logs into panics. But it seems that would be a larger change.

Also, include a few more clean ups in DAG:
- Not require genesis info when creating ConsensusState, because round 0 is what committed rounds initialized to be, so no genesis certificate  will be in the consensus output.
- Drop all committed certificates. It seems we only drop children of committed certificates and I don't see of utilities of keeping certificates at the last committed rounds of each origin.