### PR TITLE
[wallet-ext] Add default stale time + enable more automatic refetching

### DIFF
--- a/apps/wallet/src/ui/app/helpers/queryClient.ts
+++ b/apps/wallet/src/ui/app/helpers/queryClient.ts
@@ -8,9 +8,9 @@ export const queryClient = new QueryClient({
         queries: {
             // Only retry once by default:
             retry: 1,
-            // TODO: Rather than disabling all automatic refetching, we should find sane defaults here:
-            refetchOnMount: false,
-            refetchOnWindowFocus: false,
+            // Default stale time to 30 seconds, which seems like a sensible tradeoff between network requests and stale data.
+            staleTime: 30 * 1000,
+            // Disable automatic interval fetching
             refetchInterval: 0,
             refetchIntervalInBackground: false,
         },

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -279,7 +279,7 @@ function StakingCard() {
                     txDigest = getTransactionDigest(response);
                 }
 
-                //  invalidate the react query for 0x5 and validator
+                // Invalidate the react query for 0x5 and validator
                 Promise.all([
                     queryClient.invalidateQueries({
                         queryKey: ['object', normalizeSuiAddress(STATE_OBJECT)],

--- a/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
+++ b/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
@@ -7,22 +7,15 @@ import { useRpc } from '_hooks';
 
 import type { ValidatorMetaData, DelegatedStake } from '@mysten/sui.js';
 
-const STAKE_DELEGATOR_STALE_TIME = 5 * 1000;
-
 export function useGetDelegatedStake(
     address: string
 ): UseQueryResult<DelegatedStake[], Error> {
     const rpc = useRpc();
-    return useQuery(
-        ['validator', address],
-        () => rpc.getDelegatedStake(address),
-        {
-            staleTime: STAKE_DELEGATOR_STALE_TIME,
-        }
+    return useQuery(['validator', address], () =>
+        rpc.getDelegatedStake(address)
     );
 }
 
-// maybe be cached for a long time
 export function useGetValidatorMetaData(): UseQueryResult<
     ValidatorMetaData[],
     Error


### PR DESCRIPTION
This adds a default 30 second stale time to all wallet requests, which should provide a good tradeoff between network request volume and serving stale data. I re-enabled some of the automatic refetching that happens, which should keep data a little more fresh when navigating around. In the one case where we explicitly set stale time, I removed it to fall back into the 30 second default. In my testing this didn't harm the user experience at all.