### PR TITLE
[explorer] Fix gas budget display

### DIFF
--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -429,6 +429,8 @@ function TransactionView({
 
     const txError = getExecutionStatusError(transaction);
 
+    const gasPrice = transaction.certificate.data.gasPrice || 1;
+
     return (
         <div className={clsx(styles.txdetailsbg)}>
             <div className="mt-5 mb-10">
@@ -546,7 +548,7 @@ function TransactionView({
                                     <GasAmount
                                         amount={
                                             transaction.certificate.data
-                                                .gasBudget
+                                                .gasBudget * gasPrice
                                         }
                                     />
                                 </DescriptionItem>

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -555,6 +555,9 @@ function TransactionView({
 
                                 {gasFeesExpanded && (
                                     <>
+                                        <DescriptionItem title="Gas Price">
+                                            <GasAmount amount={gasPrice} />
+                                        </DescriptionItem>
                                         <DescriptionItem title="Computation Fee">
                                             <GasAmount
                                                 amount={


### PR DESCRIPTION
Gas budget is displayed as MIST but is in gas units, so the display is currently incorrect. This updates to use the gas price when we display the budget.