### PR TITLE
[core] Refactor TransactionInfoResponse

### DIFF
--- a/apps/explorer/tests/search.spec.ts
+++ b/apps/explorer/tests/search.spec.ts
@@ -32,7 +32,7 @@ test('can search for transaction', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
 
-    const txid = tx.certificate.transactionDigest;
+    const txid = tx.effects.effects.transactionDigest;
     await page.goto('/');
     await search(page, txid);
     await expect(page).toHaveURL(`/transaction/${txid}`);

--- a/apps/explorer/tests/transaction.spec.ts
+++ b/apps/explorer/tests/transaction.spec.ts
@@ -7,7 +7,7 @@ import { faucet, mint } from './utils/localnet';
 test('displays the transaction timestamp', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
-    const txid = tx.certificate.transactionDigest;
+    const txid = tx.effects.effects.transactionDigest;
     await page.goto(`/transaction/${txid}`);
     await expect(
         page.getByTestId('transaction-timestamp').locator('div').nth(1)
@@ -17,7 +17,7 @@ test('displays the transaction timestamp', async ({ page }) => {
 test('displays gas breakdown', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
-    const txid = tx.certificate.transactionDigest;
+    const txid = tx.effects.effects.transactionDigest;
     await page.goto(`/transaction/${txid}`);
     await expect(page.getByTestId('gas-breakdown')).toBeVisible();
 });

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -476,9 +476,7 @@ impl AuthorityState {
         &self,
         transaction: VerifiedTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
-        let transaction_digest = *transaction.digest();
-
+    ) -> Result<VerifiedSignedTransaction, SuiError> {
         let (_gas_status, input_objects) = transaction_input_checker::check_transaction_input(
             &self.database,
             &transaction.data().intent_message.value,
@@ -515,12 +513,10 @@ impl AuthorityState {
         // The call to self.set_transaction_lock checks the lock is not conflicting,
         // and returns ConflictingTransaction error in case there is a lock on a different
         // existing transaction.
-        self.set_transaction_lock(&owned_objects, signed_transaction, epoch_store)
+        self.set_transaction_lock(&owned_objects, signed_transaction.clone(), epoch_store)
             .await?;
 
-        // Return the signed Transaction or maybe a cert.
-        self.make_transaction_info(&transaction_digest, epoch_store)
-            .await
+        Ok(signed_transaction)
     }
 
     /// Initiate a new transaction.
@@ -528,25 +524,18 @@ impl AuthorityState {
         &self,
         transaction: VerifiedTransaction,
     ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
-        let transaction_digest = *transaction.digest();
+        let epoch_store = self.epoch_store();
+
+        let tx_digest = *transaction.digest();
         debug!(
-            "handle_transaction. Tx data: {:?}",
+            "handle_transaction with transaction data: {:?}",
             &transaction.data().intent_message.value
         );
-
-        let epoch_store = self.epoch_store();
         // Ensure an idempotent answer. This is checked before the system_tx check so that
         // a validator is able to return the signed system tx if it was already signed locally.
-        if epoch_store
-            .get_signed_transaction(&transaction_digest)?
-            .is_some()
-        {
-            self.metrics.tx_already_processed.inc();
-            return self
-                .make_transaction_info(&transaction_digest, &epoch_store)
-                .await;
+        if let Some(response) = self.make_transaction_info(&tx_digest, &epoch_store)? {
+            return Ok(response);
         }
-
         // CRITICAL! Validators should never sign an external system transaction.
         fp_ensure!(
             !transaction.is_system_tx(),
@@ -567,16 +556,16 @@ impl AuthorityState {
             return Err(SuiError::ValidatorHaltedAtEpochEnd);
         }
 
-        let response = self
+        let signed = self
             .handle_transaction_impl(transaction, &epoch_store)
             .await;
-        match response {
-            Ok(r) => Ok(r),
-            // If we see an error, it is possible that a certificate has already been processed.
+        match signed {
+            Ok(s) => Ok(VerifiedTransactionInfoResponse::Signed(s)),
+            // It happens frequently that while we are checking the validity of the transaction, it
+            // has just been executed.
             // In that case, we could still return Ok to avoid showing confusing errors.
             Err(err) => self
-                .get_tx_info_already_executed(&transaction_digest, &epoch_store)
-                .await?
+                .make_transaction_info(&tx_digest, &epoch_store)?
                 .ok_or(err),
         }
     }
@@ -1160,19 +1149,6 @@ impl AuthorityState {
         self.database.effects_exists(digest)
     }
 
-    pub async fn get_tx_info_already_executed(
-        &self,
-        digest: &TransactionDigest,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<Option<VerifiedTransactionInfoResponse>> {
-        if self.database.effects_exists(digest)? {
-            debug!("Transaction {digest:?} already executed");
-            Ok(Some(self.make_transaction_info(digest, epoch_store).await?))
-        } else {
-            Ok(None)
-        }
-    }
-
     #[instrument(level = "debug", skip_all, err)]
     fn index_tx(
         &self,
@@ -1428,8 +1404,10 @@ impl AuthorityState {
         &self,
         request: TransactionInfoRequest,
     ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
-        self.make_transaction_info(&request.transaction_digest, &self.epoch_store())
-            .await
+        self.make_transaction_info(&request.transaction_digest, &self.epoch_store())?
+            .ok_or(SuiError::TransactionNotFound {
+                digest: request.transaction_digest,
+            })
     }
 
     pub async fn handle_object_info_request(
@@ -2321,19 +2299,33 @@ impl AuthorityState {
     }
 
     /// Make an information response for a transaction
-    pub async fn make_transaction_info(
+    pub fn make_transaction_info(
         &self,
         transaction_digest: &TransactionDigest,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
-        Ok(VerifiedTransactionInfoResponse {
-            signed_transaction: epoch_store.get_signed_transaction(transaction_digest)?,
-            certified_transaction: self
+    ) -> Result<Option<VerifiedTransactionInfoResponse>, SuiError> {
+        if let Some(effects) =
+            self.get_signed_effects_and_maybe_resign(epoch_store.epoch(), transaction_digest)?
+        {
+            if let Some(cert) = self
                 .database
-                .get_certified_transaction(transaction_digest)?,
-            signed_effects: self
-                .get_signed_effects_and_maybe_resign(epoch_store.epoch(), transaction_digest)?,
-        })
+                .get_certified_transaction(transaction_digest)?
+            {
+                return Ok(Some(VerifiedTransactionInfoResponse::Executed(
+                    cert, effects,
+                )));
+            }
+            // The read of effects and read of cert are not atomic. It's possible that we reverted
+            // the transaction (during epoch change) in between the above two reads, and we end up
+            // having effects but not certs. In this case, we just fall through.
+            debug!(tx_digest=?transaction_digest, "Signed effects exist but no certificate");
+        }
+        if let Some(signed) = epoch_store.get_signed_transaction(transaction_digest)? {
+            self.metrics.tx_already_processed.inc();
+            Ok(Some(VerifiedTransactionInfoResponse::Signed(signed)))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Get the signed effects of the given transaction. If the effects was signed in a previous

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -23,7 +23,6 @@ use sui_network::{
     default_mysten_network_config, DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_REQUEST_TIMEOUT_SEC,
 };
 use sui_types::crypto::{AuthorityPublicKeyBytes, AuthoritySignInfo};
-use sui_types::message_envelope::Message;
 use sui_types::object::{Object, ObjectFormatOptions, ObjectRead};
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::{
@@ -49,7 +48,6 @@ use tokio::time::{sleep, timeout};
 
 use crate::authority::{AuthorityState, AuthorityStore};
 use crate::epoch::committee_store::CommitteeStore;
-use tap::TapFallible;
 
 pub const DEFAULT_RETRIES: usize = 4;
 
@@ -209,8 +207,12 @@ impl EffectsStakeMap {
         effects: SignedTransactionEffects,
         weight: StakeUnit,
         committee: &Committee,
-    ) -> Result<bool, EffectsCertError> {
+    ) -> bool {
         let epoch = effects.epoch();
+        if epoch != committee.epoch {
+            return false;
+        }
+
         let digest = *effects.digest();
         let (effects, sig) = effects.into_data_and_sig();
         let entry = self
@@ -225,34 +227,27 @@ impl EffectsStakeMap {
         entry.signatures.push(sig);
 
         if entry.stake < committee.quorum_threshold() {
-            return Ok(false);
+            return false;
         }
-        let cte = CertifiedTransactionEffects::new(
+        let result = CertifiedTransactionEffects::new(
             entry.effects.clone(),
             entry.signatures.clone(),
             committee,
         )
-        .tap_err(|err| {
-            error!(
-                "A quorum of effects are available but failed to form a certificate: {:?}",
-                err
-            );
-        })
-        .map_err(|e| EffectsCertError {
-            error: e,
-            effect_digest: entry.effects.digest(),
-            authorities: entry.signatures.iter().map(|s| s.authority).collect(),
-            total_stake: entry.stake,
-        })?
-        .verify(committee)
-        .map_err(|e| EffectsCertError {
-            error: e,
-            effect_digest: entry.effects.digest(),
-            authorities: entry.signatures.iter().map(|s| s.authority).collect(),
-            total_stake: entry.stake,
-        })?;
-        self.effects_cert = Some(cte);
-        Ok(true)
+        .and_then(|c| c.verify(committee));
+        match result {
+            Err(err) => {
+                error!(
+                    "A quorum of effects are available but failed to form a certificate: {:?}",
+                    err
+                );
+                false
+            }
+            Ok(c) => {
+                self.effects_cert = Some(c);
+                true
+            }
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -1284,59 +1279,25 @@ where
                 |mut state, name, weight, result| {
                     Box::pin(async move {
                         match result {
-                            Ok(VerifiedTransactionInfoResponse {
-                                certified_transaction: Some(inner_certificate),
-                                signed_effects: Some(inner_effects),
-                                ..
-                            }) => {
-                                if let Err(err) = self.handle_response_with_certified_transaction(&mut state, name, weight, tx_digest, inner_certificate, inner_effects.into_inner()) {
-                                    // The error means we fail to verify a TransactionEffectsCertificate
-                                    // with a quorum. This shouldn't happen in theory but when it does,
-                                    // we exit
-                                    state.errors.push((err.error, err.authorities, err.total_stake));
-                                    return Ok(ReduceOutput::End(state));
-                                }
-                            }
-                            // If we get back a signed transaction, then we aggregate the
-                            // new signature and check whether we have enough to form
-                            // a certificate.
-                            Ok(VerifiedTransactionInfoResponse {
-                                signed_transaction: Some(inner_signed_transaction),
-                                ..
-                            }) => {
-                                self.handle_response_with_signed_transaction(&mut state, name, weight, tx_digest, inner_signed_transaction, transaction_ref, threshold);
-                            }
+                            Ok(response) => match response {
+                                VerifiedTransactionInfoResponse::Signed(signed) => self
+                                    .handle_response_with_signed_transaction(
+                                        &mut state, signed, name, weight,
+                                    ),
+                                VerifiedTransactionInfoResponse::Executed(cert, effects) => self
+                                    .handle_response_with_certified_transaction(
+                                        &mut state, cert, effects, name, weight,
+                                    ),
+                            },
                             Err(err) => {
-                                self.handle_response_with_err(&mut state, name, weight, tx_digest, err);
-                            }
-                            // In case we don't get an error but also don't get a valid value:
-                            // the response contains either signed transaction or transaction certificate.
-                            // This should only happen on byzantine validators.
-                            Ok(rep) => {
-                                let error_msg = format!(
-                                    "Validator returned unexpected response for handle_transaction. has_signed_tx: {}, has_tx_cert: {}, has_signed_effects: {}",
-                                    rep.signed_transaction.is_some(),
-                                    rep.certified_transaction.is_some(),
-                                    rep.signed_effects.is_some(),
+                                self.handle_response_with_err(
+                                    &mut state, name, weight, tx_digest, err,
                                 );
-                                error!(?tx_digest, name=?name.concise(), error_msg);
-
-                                state.errors.push((
-                                    SuiError::ByzantineAuthoritySuspicion {
-                                        authority: name,
-                                        reason: error_msg,
-                                    },
-                                    vec![name],
-                                    weight,
-                                ));
-                                state.bad_stake += weight; // This is the bad stake counter
                             }
                         };
 
-                        // When we have good stake, we end the processing:
-                        // we either have a certificate or have trouble in forming
-                        // a cert, which shouldn't happen.
-                        if state.good_stake >= threshold {
+                        // If we have a certificate, then finish.
+                        if state.certificate.is_some() {
                             return Ok(ReduceOutput::End(state));
                         }
 
@@ -1349,12 +1310,7 @@ where
                             return Ok(ReduceOutput::End(state));
                         }
 
-                        // If we have a certificate, then finish, otherwise continue.
-                        if state.certificate.is_some() {
-                            Ok(ReduceOutput::End(state))
-                        } else {
-                            Ok(ReduceOutput::Continue(state))
-                        }
+                        Ok(ReduceOutput::Continue(state))
                     })
                 },
                 // A long timeout before we hear back from a quorum
@@ -1429,13 +1385,11 @@ where
     fn handle_response_with_signed_transaction(
         &self,
         state: &mut ProcessTransactionState,
+        signed_transaction: VerifiedSignedTransaction,
         name: AuthorityName,
         weight: StakeUnit,
-        tx_digest: &TransactionDigest,
-        signed_transaction: VerifiedSignedTransaction,
-        transaction_ref: &VerifiedTransaction,
-        threshold: StakeUnit,
     ) {
+        let tx_digest = *signed_transaction.digest();
         // If the signed transaction's epoch is older, then the validator is falling behind.
         // If it's newer then we need a reconfig. Either way, we return a transient error.
         if signed_transaction.epoch() != self.committee.epoch {
@@ -1457,13 +1411,16 @@ where
             ));
             state.bad_stake += weight;
         } else {
-            let tx_digest = *signed_transaction.digest();
             debug!(?tx_digest, name=?name.concise(), weight, "Received signed transaction from validator handle_transaction");
-            state
-                .signatures
-                .push(signed_transaction.into_inner().into_data_and_sig().1);
+            state.signatures.push(
+                signed_transaction
+                    .clone()
+                    .into_inner()
+                    .into_data_and_sig()
+                    .1,
+            );
             state.good_stake += weight;
-            if state.good_stake >= threshold {
+            if state.good_stake >= self.committee.quorum_threshold() {
                 self.metrics
                     .num_signatures
                     .observe(state.signatures.len() as f64);
@@ -1471,10 +1428,11 @@ where
                 self.metrics.num_bad_stake.observe(state.bad_stake as f64);
 
                 let ct = CertifiedTransaction::new(
-                    transaction_ref.data().clone(),
+                    signed_transaction.into_message(),
                     state.signatures.clone(),
                     &self.committee,
                 )
+                // TODO: We don't need to verify again.
                 .and_then(|ct| ct.verify(&self.committee));
                 match ct {
                     Ok(ct) => {
@@ -1496,12 +1454,12 @@ where
     fn handle_response_with_certified_transaction(
         &self,
         state: &mut ProcessTransactionState,
+        certificate: VerifiedCertificate,
+        signed_effects: VerifiedSignedTransactionEffects,
         name: AuthorityName,
         weight: StakeUnit,
-        tx_digest: &TransactionDigest,
-        certificate: VerifiedCertificate,
-        signed_effects: SignedTransactionEffects,
-    ) -> Result<(), EffectsCertError> {
+    ) {
+        let tx_digest = certificate.digest();
         // If we get a certificate in the same epoch, then we use it.
         // A certificate in a past epoch does not guarantee finality
         // and validators may reject to process it.
@@ -1522,15 +1480,15 @@ where
             // form a CertifiedTransactionEffects which requires all sigs
             // in the same epoch, this is not necessary but not a big deal
             // anyways.
-            // TODO: we may return a CertifiedTransactionEffects directly here
+            // TODO: Return effects cert directly.
             if state
                 .effects_map
-                .add(signed_effects, weight, &self.committee)?
+                .add(signed_effects.into_inner(), weight, &self.committee)
             {
                 debug!(
-                    ?tx_digest,
-                    "Got quorum for effects for certs that are from previous epochs handle_transaction"
-                );
+                ?tx_digest,
+                "Got quorum for effects for certs that are from previous epochs handle_transaction"
+            );
                 state.certificate = Some(certificate);
             }
         } else {
@@ -1555,7 +1513,6 @@ where
             ));
             state.bad_stake += weight;
         }
-        Ok(())
     }
 
     /// Check if we have some signed TransactionEffects but not a quorum
@@ -1653,22 +1610,12 @@ where
                                     "Validator handled certificate successfully",
                                 );
                                 // Note: here we aggregate votes by the hash of the effects structure
-                                match state.effects_map.add(signed_effects.into_inner(), weight, &self.committee) {
-                                    Err(err) => {
-                                        // The error means we fail to verify a TransactionEffectsCertificate
-                                        // with a quorum. This shouldn't happen in theory but when it does,
-                                        // we exit
-                                        state.errors.push((err.error, err.authorities, err.total_stake));
-                                        return Ok(ReduceOutput::End(state));
-                                    }
-                                    Ok(true) => {
+                                if state.effects_map.add(signed_effects.into_inner(), weight, &self.committee) {
                                         debug!(
                                             ?tx_digest,
                                             "Got quorum for validators handle_certificate."
                                         );
                                         return Ok(ReduceOutput::End(state));
-                                    }
-                                    _ => ()
                                 }
                             }
                             Err(err) => {
@@ -1760,44 +1707,6 @@ where
         Ok(ObjectRead::NotExists(object_id))
     }
 
-    /// This function tries to fetch CertifiedTransaction from any validators.
-    /// Returns Error if certificate cannot be found in any validators.
-    pub async fn handle_cert_info_request(
-        &self,
-        digest: &TransactionDigest,
-        timeout_total: Option<Duration>,
-    ) -> SuiResult<VerifiedTransactionInfoResponse> {
-        self.quorum_once_with_timeout(
-            None,
-            None,
-            |_authority, client| {
-                Box::pin(async move {
-                    let resp = client
-                        .handle_transaction_info_request((*digest).into())
-                        .await?;
-
-                    if let VerifiedTransactionInfoResponse {
-                        certified_transaction: Some(_),
-                        signed_effects: Some(_),
-                        ..
-                    } = &resp
-                    {
-                        Ok(resp)
-                    } else {
-                        // TODO change this error to TransactionCertificateNotFound
-                        // handle_transaction_info_request returns success even if it doesn't have
-                        // any data.
-                        Err(SuiError::TransactionNotFound { digest: *digest })
-                    }
-                })
-            },
-            self.timeouts.serial_authority_request_timeout,
-            timeout_total,
-            "handle_cert_info_request".to_string(),
-        )
-        .await
-    }
-
     /// This function tries to get SignedTransaction OR CertifiedTransaction from
     /// an given list of validators who are supposed to know about it.
     pub async fn handle_transaction_info_request_from_some_validators(
@@ -1806,38 +1715,17 @@ where
         // authorities known to have the transaction info we are requesting.
         validators: &BTreeSet<AuthorityName>,
         timeout_total: Option<Duration>,
-    ) -> SuiResult<(
-        Option<VerifiedSignedTransaction>,
-        Option<VerifiedCertificate>,
-    )> {
+    ) -> SuiResult<VerifiedTransactionInfoResponse> {
         self.quorum_once_with_timeout(
             None,
             Some(validators),
-            |authority, client| {
+            |_authority, client| {
                 Box::pin(async move {
-                    let response = client
+                    client
                         .handle_transaction_info_request(TransactionInfoRequest {
                             transaction_digest: *tx_digest,
                         })
-                        .await?;
-                    if let Some(certified_transaction) = response.certified_transaction {
-                        return Ok((None, Some(certified_transaction)));
-                    }
-
-                    if let Some(signed_transaction) = response.signed_transaction {
-                        return Ok((Some(signed_transaction), None));
-                    }
-
-                    // This validator could not give the transaction info, but it is supposed to know about the transaction.
-                    // This could also happen on epoch change boundary.
-                    warn!(?tx_digest, name=?authority.concise(), "Validator failed to give info about a transaction, it's either byzantine or just went through an epoch change");
-                    Err(SuiError::ByzantineAuthoritySuspicion {
-                        authority,
-                        reason: format!(
-                            "Validator claimed to know about tx {:?} but did not return it when queried",
-                            tx_digest,
-                        )
-                    })
+                        .await
                 })
             },
             Duration::from_secs(2),

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -255,7 +255,7 @@ impl ValidatorService {
         let tx_digest = transaction.digest();
 
         // Enable Trace Propagation across spans/processes using tx_digest
-        let span = tracing::error_span!("validator_state_process_tx", ?tx_digest);
+        let span = error_span!("validator_state_process_tx", ?tx_digest);
 
         let info = state
             .handle_transaction(transaction)

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -60,7 +60,7 @@ impl AuthorityAPI for LocalAuthorityClient {
                 error: "Mock error after handle_transaction".to_owned(),
             });
         }
-        result.map(|r| r.into())
+        result.map(|v| v.into())
     }
 
     async fn handle_certificate(
@@ -224,7 +224,7 @@ impl AuthorityAPI for MockAuthorityApi {
     /// Handle Object information requests for this account.
     async fn handle_transaction_info_request(
         &self,
-        _request: TransactionInfoRequest,
+        request: TransactionInfoRequest,
     ) -> Result<TransactionInfoResponse, SuiError> {
         let count = {
             let mut count = self.count.lock().unwrap();
@@ -237,12 +237,9 @@ impl AuthorityAPI for MockAuthorityApi {
             tokio::time::sleep(self.delay).await;
         }
 
-        let res = TransactionInfoResponse {
-            signed_transaction: None,
-            certified_transaction: None,
-            signed_effects: None,
-        };
-        Ok(res)
+        Err(SuiError::TransactionNotFound {
+            digest: request.transaction_digest,
+        })
     }
 
     async fn handle_checkpoint(
@@ -262,7 +259,7 @@ impl AuthorityAPI for MockAuthorityApi {
 
 #[derive(Clone)]
 pub struct HandleTransactionTestAuthorityClient {
-    pub tx_info_resp_to_return: TransactionInfoResponse,
+    pub tx_info_resp_to_return: SuiResult<TransactionInfoResponse>,
 }
 
 #[async_trait]
@@ -271,7 +268,7 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
         &self,
         _transaction: Transaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
-        Ok(self.tx_info_resp_to_return.clone())
+        self.tx_info_resp_to_return.clone()
     }
 
     async fn handle_certificate(
@@ -313,16 +310,16 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
 impl HandleTransactionTestAuthorityClient {
     pub fn new() -> Self {
         Self {
-            tx_info_resp_to_return: TransactionInfoResponse {
-                signed_transaction: None,
-                certified_transaction: None,
-                signed_effects: None,
-            },
+            tx_info_resp_to_return: Err(SuiError::Unknown("".to_string())),
         }
     }
 
     pub fn set_tx_info_response(&mut self, resp: TransactionInfoResponse) {
-        self.tx_info_resp_to_return = resp;
+        self.tx_info_resp_to_return = Ok(resp);
+    }
+
+    pub fn reset_tx_info_response(&mut self) {
+        self.tx_info_resp_to_return = Err(SuiError::Unknown("".to_string()));
     }
 }
 

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -192,7 +192,7 @@ where
                 } = response;
                 if !wait_for_local_execution {
                     return Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
-                        tx_cert.into(),
+                        Some(tx_cert.into()),
                         effects_cert.into(),
                         false,
                     ))));
@@ -206,12 +206,12 @@ where
                 .await
                 {
                     Ok(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
-                        tx_cert.into(),
+                        Some(tx_cert.into()),
                         effects_cert.into(),
                         true,
                     )))),
                     Err(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
-                        tx_cert.into(),
+                        Some(tx_cert.into()),
                         effects_cert.into(),
                         false,
                     )))),

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -29,7 +29,8 @@ use sui_types::committee::Committee;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    QuorumDriverResponse, VerifiedCertificate, VerifiedCertifiedTransactionEffects,
+    FinalizedEffects, QuorumDriverResponse, VerifiedCertificate,
+    VerifiedCertifiedTransactionEffects,
 };
 use sui_types::quorum_driver_types::{
     QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResult,
@@ -193,7 +194,7 @@ where
                 if !wait_for_local_execution {
                     return Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         Some(tx_cert.into()),
-                        effects_cert.into(),
+                        FinalizedEffects::new_from_effects_cert(effects_cert.into()),
                         false,
                     ))));
                 }
@@ -207,12 +208,12 @@ where
                 {
                     Ok(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         Some(tx_cert.into()),
-                        effects_cert.into(),
+                        FinalizedEffects::new_from_effects_cert(effects_cert.into()),
                         true,
                     )))),
                     Err(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         Some(tx_cert.into()),
-                        effects_cert.into(),
+                        FinalizedEffects::new_from_effects_cert(effects_cert.into()),
                         false,
                     )))),
                 }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -301,7 +301,10 @@ async fn execute_transaction_with_fault_configs(
         get_local_client(&mut authorities, *index).fault_config = *config;
     }
 
-    authorities.process_certificate(cert.into()).await.is_ok()
+    authorities
+        .process_certificate(cert.into_cert_for_testing().into())
+        .await
+        .is_ok()
 }
 
 /// The intent of this is to test whether client side timeouts
@@ -331,7 +334,7 @@ async fn test_quorum_map_and_reduce_timeout() {
     let tx = create_object_move_transaction(addr1, &key1, addr1, 100, pkg.id(), gas_ref_1);
     let certified_tx = authorities.process_transaction(tx.clone()).await;
     assert!(certified_tx.is_ok());
-    let certificate = certified_tx.unwrap();
+    let certificate = certified_tx.unwrap().into_cert_for_testing();
     // Send request with a very small timeout to trigger timeout error
     authorities.timeouts.pre_quorum_timeout = Duration::from_nanos(0);
     authorities.timeouts.post_quorum_timeout = Duration::from_nanos(0);
@@ -1002,7 +1005,11 @@ async fn test_handle_transaction_response() {
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx, 0);
     // Validators now gives valid signed tx and we get TxCert
     let mut agg = get_agg(authorities.clone(), clients.clone(), 0);
-    let cert_epoch_0 = agg.process_transaction(tx.clone()).await.unwrap();
+    let cert_epoch_0 = agg
+        .process_transaction(tx.clone())
+        .await
+        .unwrap()
+        .into_cert_for_testing();
 
     // Case 2
     // Validators return signed-tx with epoch 0, client expects 1
@@ -1060,7 +1067,11 @@ async fn test_handle_transaction_response() {
         .insert_new_committee(&committee_1)
         .unwrap();
     agg.committee = committee_1.clone();
-    let cert_epoch_1 = agg.process_transaction(tx.clone()).await.unwrap();
+    let cert_epoch_1 = agg
+        .process_transaction(tx.clone())
+        .await
+        .unwrap()
+        .into_cert_for_testing();
 
     // Case 5
     // Validators return tx-cert with epoch 0, client expects 1

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -63,7 +63,7 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
 
     let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
-    let effects = response.into_data();
+    let effects = response.1.into_data();
     assert!(effects.status.is_ok());
     assert_eq!((effects.created.len(), effects.mutated.len()), (N, N + 1),);
     assert!(effects
@@ -127,7 +127,7 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
 
     let tx = to_sender_signed_transaction(data, &sender_key);
 
-    let response = send_and_confirm_transaction(&authority_state, tx).await?;
+    let response = send_and_confirm_transaction(&authority_state, tx).await?.1;
     let effects = response.into_data();
     assert!(effects.status.is_err());
     assert_eq!((effects.created.len(), effects.mutated.len()), (0, N + 1));

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -76,7 +76,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
             .handle_transaction(transaction.clone())
             .await
             .unwrap();
-        let vote = response.signed_transaction.unwrap();
+        let vote = response.into_signed_for_testing();
         let certificate = CertifiedTransaction::new(
             transaction.into_message(),
             vec![vote.auth_sig().clone()],

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -1942,7 +1942,8 @@ pub async fn build_and_try_publish_test_package(
         transaction.clone().into_inner(),
         send_and_confirm_transaction(authority, transaction)
             .await
-            .unwrap(),
+            .unwrap()
+            .1,
     )
 }
 

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -456,7 +456,9 @@ async fn execute_pay_sui(
     }));
     let data = TransactionData::new(kind, sender, gas_object_ref, gas_budget, 1);
     let tx = to_sender_signed_transaction(data, &sender_key);
-    let txn_result = send_and_confirm_transaction(&authority_state, tx).await;
+    let txn_result = send_and_confirm_transaction(&authority_state, tx)
+        .await
+        .map(|(_, effects)| effects);
 
     PaySuiTransactionExecutionResult {
         authority_state,
@@ -504,7 +506,9 @@ async fn execute_pay_all_sui(
     }));
     let data = TransactionData::new(kind, sender, gas_object_ref, gas_budget, 1);
     let tx = to_sender_signed_transaction(data, &sender_key);
-    let txn_result = send_and_confirm_transaction(&authority_state, tx).await;
+    let txn_result = send_and_confirm_transaction(&authority_state, tx)
+        .await
+        .map(|(_, effects)| effects);
     PaySuiTransactionExecutionResult {
         authority_state,
         txn_result,

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -413,7 +413,9 @@ pub struct SuiTBlsSignRandomnessObjectResponse {
 #[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub struct SuiExecuteTransactionResponse {
-    pub certificate: SuiCertifiedTransaction,
+    // If this transaction was already finalized previously, there is no guarantee that a
+    // certificate is still available.
+    pub certificate: Option<SuiCertifiedTransaction>,
     pub effects: SuiCertifiedTransactionEffects,
     // If the transaction is confirmed to be executed locally
     // before this response.
@@ -428,7 +430,10 @@ impl SuiExecuteTransactionResponse {
         Ok(match resp {
             ExecuteTransactionResponse::EffectsCert(cert) => {
                 let (certificate, effects, is_executed_locally) = *cert;
-                let certificate: SuiCertifiedTransaction = certificate.try_into()?;
+                let certificate: Option<SuiCertifiedTransaction> = match certificate {
+                    Some(c) => Some(c.try_into()?),
+                    None => None,
+                };
                 let effects: SuiCertifiedTransactionEffects =
                     SuiCertifiedTransactionEffects::try_from(effects, resolver)?;
                 SuiExecuteTransactionResponse {

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -43,11 +43,12 @@ use sui_types::event::{EventEnvelope, EventType};
 use sui_types::filter::{EventFilter, TransactionFilter};
 use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
+use sui_types::message_envelope::Message;
 use sui_types::messages::{
-    CallArg, CertifiedTransaction, CertifiedTransactionEffects, ExecuteTransactionResponse,
-    ExecutionStatus, GenesisObject, InputObjectKind, MoveModulePublish, ObjectArg, Pay, PayAllSui,
-    PaySui, SingleTransactionKind, TransactionData, TransactionEffects, TransactionKind,
-    VerifiedCertificate,
+    CallArg, CertifiedTransaction, EffectsFinalityInfo, ExecuteTransactionResponse,
+    ExecutionStatus, FinalizedEffects, GenesisObject, InputObjectKind, MoveModulePublish,
+    ObjectArg, Pay, PayAllSui, PaySui, SingleTransactionKind, TransactionData, TransactionEffects,
+    TransactionKind, VerifiedCertificate,
 };
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::move_package::{disassemble_modules, MovePackage};
@@ -402,7 +403,7 @@ pub enum SuiTBlsSignObjectCommitmentType {
     /// Check that the object is committed by the consensus.
     ConsensusCommitted,
     /// Check that the object is committed using the effects certificate.
-    FastPathCommitted(SuiCertifiedTransactionEffects),
+    FastPathCommitted(SuiFinalizedEffects),
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -416,7 +417,7 @@ pub struct SuiExecuteTransactionResponse {
     // If this transaction was already finalized previously, there is no guarantee that a
     // certificate is still available.
     pub certificate: Option<SuiCertifiedTransaction>,
-    pub effects: SuiCertifiedTransactionEffects,
+    pub effects: SuiFinalizedEffects,
     // If the transaction is confirmed to be executed locally
     // before this response.
     pub confirmed_local_execution: bool,
@@ -434,8 +435,8 @@ impl SuiExecuteTransactionResponse {
                     Some(c) => Some(c.try_into()?),
                     None => None,
                 };
-                let effects: SuiCertifiedTransactionEffects =
-                    SuiCertifiedTransactionEffects::try_from(effects, resolver)?;
+                let effects: SuiFinalizedEffects =
+                    SuiFinalizedEffects::try_from(effects, resolver)?;
                 SuiExecuteTransactionResponse {
                     certificate,
                     effects,
@@ -1833,17 +1834,35 @@ impl TryFrom<VerifiedCertificate> for SuiCertifiedTransaction {
     }
 }
 
-/// The certified Transaction Effects which has signatures from >= 2/3 of validators
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename = "CertifiedTransactionEffects", rename_all = "camelCase")]
-pub struct SuiCertifiedTransactionEffects {
-    pub transaction_effects_digest: TransactionEffectsDigest,
-    pub effects: SuiTransactionEffects,
-    /// authority signature information signed by the quorum of the validators.
-    pub auth_sign_info: SuiAuthorityStrongQuorumSignInfo,
+#[serde(rename = "EffectsFinalityInfo", rename_all = "camelCase")]
+pub enum SuiEffectsFinalityInfo {
+    Certified(SuiAuthorityStrongQuorumSignInfo),
+    Checkpointed(EpochId, CheckpointSequenceNumber),
 }
 
-impl Display for SuiCertifiedTransactionEffects {
+impl From<EffectsFinalityInfo> for SuiEffectsFinalityInfo {
+    fn from(info: EffectsFinalityInfo) -> Self {
+        match info {
+            EffectsFinalityInfo::Certified(cert) => {
+                Self::Certified(SuiAuthorityStrongQuorumSignInfo::from(&cert))
+            }
+            EffectsFinalityInfo::Checkpointed(epoch, checkpoint) => {
+                Self::Checkpointed(epoch, checkpoint)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename = "FinalizedEffects", rename_all = "camelCase")]
+pub struct SuiFinalizedEffects {
+    pub transaction_effects_digest: TransactionEffectsDigest,
+    pub effects: SuiTransactionEffects,
+    pub finality_info: SuiEffectsFinalityInfo,
+}
+
+impl Display for SuiFinalizedEffects {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut writer = String::new();
         writeln!(
@@ -1852,30 +1871,34 @@ impl Display for SuiCertifiedTransactionEffects {
             self.transaction_effects_digest
         )?;
         writeln!(writer, "Transaction Effects: {:?}", self.effects)?;
-        writeln!(
-            writer,
-            "Signed Authorities Bitmap: {:?}",
-            self.auth_sign_info.signers_map
-        )?;
+        match &self.finality_info {
+            SuiEffectsFinalityInfo::Certified(cert) => {
+                writeln!(writer, "Signed Authorities Bitmap: {:?}", cert.signers_map)?;
+            }
+            SuiEffectsFinalityInfo::Checkpointed(epoch, checkpoint) => {
+                writeln!(
+                    writer,
+                    "Finalized at epoch {:?}, checkpoint {:?}",
+                    epoch, checkpoint
+                )?;
+            }
+        }
+
         write!(f, "{}", writer)
     }
 }
 
-impl SuiCertifiedTransactionEffects {
+impl SuiFinalizedEffects {
     fn try_from(
-        cert: CertifiedTransactionEffects,
+        effects: FinalizedEffects,
         resolver: &impl GetModule,
     ) -> Result<Self, anyhow::Error> {
-        let digest = *cert.digest();
-        let (effects, auth_sign_info) = cert.into_data_and_sig();
+        let digest = effects.effects.digest();
         // We should always have a signature here.
-        if auth_sign_info.signature.sig.is_none() {
-            return Err(anyhow::anyhow!("No quorum signature."));
-        }
         Ok(Self {
             transaction_effects_digest: digest,
-            effects: SuiTransactionEffects::try_from(effects, resolver)?,
-            auth_sign_info: SuiAuthorityStrongQuorumSignInfo::from(&auth_sign_info),
+            effects: SuiTransactionEffects::try_from(effects.effects, resolver)?,
+            finality_info: effects.finality_info.into(),
         })
     }
 }

--- a/crates/sui-json-rpc/src/threshold_bls_api.rs
+++ b/crates/sui-json-rpc/src/threshold_bls_api.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::SuiTBlsSignObjectCommitmentType::{ConsensusCommitted, FastPathCommitted};
 use sui_json_rpc_types::{
-    SuiCertifiedTransactionEffects, SuiTBlsSignObjectCommitmentType,
+    SuiEffectsFinalityInfo, SuiFinalizedEffects, SuiTBlsSignObjectCommitmentType,
     SuiTBlsSignRandomnessObjectResponse,
 };
 use sui_open_rpc::Module;
@@ -63,44 +63,53 @@ impl ThresholdBlsApi {
         Ok(())
     }
 
-    async fn verify_effects_cert(
+    async fn verify_finalized_effects(
         &self,
         object_id: ObjectID,
-        effects_cert: &SuiCertifiedTransactionEffects,
+        finalized_effects: &SuiFinalizedEffects,
     ) -> Result<(), Error> {
-        if effects_cert.auth_sign_info.epoch != self.state.epoch() {
-            Err(anyhow!(
-                "Old effects certificate, check instead if committed by consensus"
-            ))?
+        match &finalized_effects.finality_info {
+            SuiEffectsFinalityInfo::Certified(cert) => {
+                let epoch_store = self.state.epoch_store();
+                if cert.epoch != epoch_store.epoch() {
+                    Err(anyhow!(
+                        "Old effects certificate, check instead if committed by consensus"
+                    ))?
+                }
+                // Check the certificate.
+                let _committee = epoch_store.committee();
+
+                // TODO: convert SuiTransactionEffects to TransactionEffects before the next line.
+                // effects_cert
+                //     .auth_sign_info
+                //     .verify(&effects_cert.effects, &committee)
+                //     .map_err(|e| anyhow!(e))?;
+
+                // Check that the object is indeed in the effects.
+                finalized_effects
+                    .effects
+                    .created
+                    .iter()
+                    .chain(finalized_effects.effects.mutated.iter())
+                    .find(|owned_obj_ref| owned_obj_ref.reference.object_id == object_id)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "Object was not created/mutated in the provided effects certificate"
+                        )
+                    })?;
+
+                // Check that the object is indeed a Randomness object.
+                let _obj = self.get_randomness_object(object_id).await?;
+                Ok(())
+            }
+            SuiEffectsFinalityInfo::Checkpointed(_epoch, _checkpoint) => {
+                // TODO: Properly verify this.
+                Err(SuiError::UnsupportedFeatureError {
+                    error: "Checkpointed effects not supported yet".to_string(),
+                }
+                .into())
+            }
         }
-        // Check the certificate.
-        let _committee = self
-            .state
-            .committee_store()
-            .get_committee(&self.state.epoch())?
-            .ok_or_else(|| Error::InternalError(anyhow!("Committee not available")))?;
-
-        // TODO: convert SuiTransactionEffects to TransactionEffects before the next line.
-        // effects_cert
-        //     .auth_sign_info
-        //     .verify(&effects_cert.effects, &committee)
-        //     .map_err(|e| anyhow!(e))?;
-
-        // Check that the object is indeed in the effects.
-        effects_cert
-            .effects
-            .created
-            .iter()
-            .chain(effects_cert.effects.mutated.iter())
-            .find(|owned_obj_ref| owned_obj_ref.reference.object_id == object_id)
-            .ok_or_else(|| {
-                anyhow!("Object was not created/mutated in the provided effects certificate")
-            })?;
-
-        // Check that the object is indeed a Randomness object.
-        let _obj = self.get_randomness_object(object_id).await?;
-
-        Ok(())
     }
 }
 
@@ -117,8 +126,9 @@ impl ThresholdBlsApiServer for ThresholdBlsApi {
     ) -> RpcResult<SuiTBlsSignRandomnessObjectResponse> {
         match commitment_type {
             ConsensusCommitted => self.verify_object_alive_and_committed(object_id).await?,
-            FastPathCommitted(effects_cert) => {
-                self.verify_effects_cert(object_id, &effects_cert).await?
+            FastPathCommitted(finalized_effects) => {
+                self.verify_finalized_effects(object_id, &finalized_effects)
+                    .await?
             }
         };
         // Construct the message to be signed, as done in the Move code of the Randomness object.

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5298,13 +5298,19 @@
       "SuiExecuteTransactionResponse": {
         "type": "object",
         "required": [
-          "certificate",
           "confirmed_local_execution",
           "effects"
         ],
         "properties": {
           "certificate": {
-            "$ref": "#/components/schemas/CertifiedTransaction"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CertifiedTransaction"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "confirmed_local_execution": {
             "type": "boolean"

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2953,31 +2953,6 @@
           }
         }
       },
-      "CertifiedTransactionEffects": {
-        "description": "The certified Transaction Effects which has signatures from >= 2/3 of validators",
-        "type": "object",
-        "required": [
-          "authSignInfo",
-          "effects",
-          "transactionEffectsDigest"
-        ],
-        "properties": {
-          "authSignInfo": {
-            "description": "authority signature information signed by the quorum of the validators.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SuiAuthorityStrongQuorumSignInfo"
-              }
-            ]
-          },
-          "effects": {
-            "$ref": "#/components/schemas/TransactionEffects"
-          },
-          "transactionEffectsDigest": {
-            "$ref": "#/components/schemas/TransactionEffectsDigest"
-          }
-        }
-      },
       "CheckpointContents": {
         "description": "CheckpointContents are the transactions included in an upcoming checkpoint. They must have already been causally ordered. Since the causal order algorithm is the same among validators, we expect all honest validators to come up with the same order for each checkpoint content.",
         "type": "object",
@@ -3347,6 +3322,48 @@
       },
       "Ed25519SuiSignature": {
         "$ref": "#/components/schemas/Base64"
+      },
+      "EffectsFinalityInfo": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "certified"
+            ],
+            "properties": {
+              "certified": {
+                "$ref": "#/components/schemas/SuiAuthorityStrongQuorumSignInfo"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "checkpointed"
+            ],
+            "properties": {
+              "checkpointed": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "Entry_for_SuiAddress_and_VecSet_for_SuiAddress": {
         "description": "Rust version of the Move sui::vec_map::Entry type",
@@ -4222,6 +4239,25 @@
             }
           }
         ]
+      },
+      "FinalizedEffects": {
+        "type": "object",
+        "required": [
+          "effects",
+          "finalityInfo",
+          "transactionEffectsDigest"
+        ],
+        "properties": {
+          "effects": {
+            "$ref": "#/components/schemas/TransactionEffects"
+          },
+          "finalityInfo": {
+            "$ref": "#/components/schemas/EffectsFinalityInfo"
+          },
+          "transactionEffectsDigest": {
+            "$ref": "#/components/schemas/TransactionEffectsDigest"
+          }
+        }
       },
       "GasCostSummary": {
         "type": "object",
@@ -5316,7 +5352,7 @@
             "type": "boolean"
           },
           "effects": {
-            "$ref": "#/components/schemas/CertifiedTransactionEffects"
+            "$ref": "#/components/schemas/FinalizedEffects"
           }
         }
       },
@@ -5877,7 +5913,7 @@
             ],
             "properties": {
               "FastPathCommitted": {
-                "$ref": "#/components/schemas/CertifiedTransactionEffects"
+                "$ref": "#/components/schemas/FinalizedEffects"
               }
             },
             "additionalProperties": false

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -35,6 +35,14 @@ pub struct Envelope<T: Message, S> {
 }
 
 impl<T: Message, S> Envelope<T, S> {
+    pub fn new_from_data_and_sig(data: T, sig: S) -> Self {
+        Self {
+            digest: Default::default(),
+            data,
+            auth_signature: sig,
+        }
+    }
+
     pub fn data(&self) -> &T {
         &self.data
     }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2427,7 +2427,7 @@ pub type IsTransactionExecutedLocally = bool;
 pub enum ExecuteTransactionResponse {
     EffectsCert(
         Box<(
-            CertifiedTransaction,
+            Option<CertifiedTransaction>,
             CertifiedTransactionEffects,
             IsTransactionExecutedLocally,
         )>,

--- a/crates/sui/tests/checkpoint_tests.rs
+++ b/crates/sui/tests/checkpoint_tests.rs
@@ -40,7 +40,11 @@ async fn basic_checkpoints_integration_test() {
         AuthAggMetrics::new(&registry),
     )
     .unwrap();
-    let cert = net.process_transaction(tx.clone()).await.unwrap();
+    let cert = net
+        .process_transaction(tx.clone())
+        .await
+        .unwrap()
+        .into_cert_for_testing();
     let _effects = net
         .process_certificate(cert.clone().into_inner())
         .await

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -423,7 +423,8 @@ async fn test_full_node_cold_sync() -> Result<(), anyhow::Error> {
             transaction_digest: digest,
         })
         .await?;
-    assert!(info.signed_effects.is_some());
+    // Check that it has been executed.
+    info.into_executed_for_testing();
 
     Ok(())
 }

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -955,7 +955,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
         effects_cert: certified_txn_effects,
     } = rx.recv().await.unwrap().unwrap();
     let (ct, cte, is_executed_locally) = *res;
-    assert_eq!(*ct.digest(), digest);
+    assert_eq!(*ct.unwrap().digest(), digest);
     assert_eq!(*certified_txn.digest(), digest);
     assert_eq!(*cte.digest(), *certified_txn_effects.digest());
     assert!(is_executed_locally);
@@ -980,7 +980,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
         effects_cert: certified_txn_effects,
     } = rx.recv().await.unwrap().unwrap();
     let (ct, cte, is_executed_locally) = *res;
-    assert_eq!(*ct.digest(), digest);
+    assert_eq!(*ct.unwrap().digest(), digest);
     assert_eq!(*certified_txn.digest(), digest);
     assert_eq!(*cte.digest(), *certified_txn_effects.digest());
     assert!(!is_executed_locally);
@@ -1037,11 +1037,11 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
             .unwrap();
 
         let SuiExecuteTransactionResponse {
-            certificate,
-            effects: _,
+            certificate: _,
+            effects,
             confirmed_local_execution,
         } = response;
-        assert_eq!(&certificate.transaction_digest, tx_digest);
+        assert_eq!(&effects.effects.transaction_digest, tx_digest);
         assert!(confirmed_local_execution);
     }
     Ok(())
@@ -1077,11 +1077,11 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
         .unwrap();
 
     let SuiExecuteTransactionResponse {
-        certificate,
-        effects: _,
+        certificate: _,
+        effects,
         confirmed_local_execution,
     } = response;
-    assert_eq!(&certificate.transaction_digest, tx_digest);
+    assert_eq!(&effects.effects.transaction_digest, tx_digest);
     assert!(confirmed_local_execution);
 
     let _response: SuiTransactionResponse = jsonrpc_client
@@ -1102,11 +1102,11 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
         .unwrap();
 
     let SuiExecuteTransactionResponse {
-        certificate,
-        effects: _,
+        certificate: _,
+        effects,
         confirmed_local_execution,
     } = response;
-    assert_eq!(&certificate.transaction_digest, tx_digest);
+    assert_eq!(&effects.effects.transaction_digest, tx_digest);
     assert!(!confirmed_local_execution);
 
     Ok(())

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -25,6 +25,7 @@ use sui_types::base_types::{ObjectRef, SequenceNumber};
 use sui_types::crypto::{get_key_pair, SuiKeyPair};
 use sui_types::event::BalanceChangeType;
 use sui_types::event::Event;
+use sui_types::message_envelope::Message;
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
     QuorumDriverResponse,
@@ -957,7 +958,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let (ct, cte, is_executed_locally) = *res;
     assert_eq!(*ct.unwrap().digest(), digest);
     assert_eq!(*certified_txn.digest(), digest);
-    assert_eq!(*cte.digest(), *certified_txn_effects.digest());
+    assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(is_executed_locally);
     // verify that the node has sequenced and executed the txn
     node.state().get_transaction(digest).await
@@ -982,7 +983,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let (ct, cte, is_executed_locally) = *res;
     assert_eq!(*ct.unwrap().digest(), digest);
     assert_eq!(*certified_txn.digest(), digest);
-    assert_eq!(*cte.digest(), *certified_txn_effects.digest());
+    assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(!is_executed_locally);
     wait_for_tx(digest, node.state().clone()).await;
     node.state().get_transaction(digest).await

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -146,7 +146,11 @@ async fn reconfig_with_revert_end_to_end_test() {
         AuthAggMetrics::new(&registry),
     )
     .unwrap();
-    let cert = net.process_transaction(tx.clone()).await.unwrap();
+    let cert = net
+        .process_transaction(tx.clone())
+        .await
+        .unwrap()
+        .into_cert_for_testing();
     let effects1 = net
         .process_certificate(cert.clone().into_inner())
         .await
@@ -162,7 +166,11 @@ async fn reconfig_with_revert_end_to_end_test() {
         &keypair,
         None,
     );
-    let cert = net.process_transaction(tx.clone()).await.unwrap();
+    let cert = net
+        .process_transaction(tx.clone())
+        .await
+        .unwrap()
+        .into_cert_for_testing();
 
     // Close epoch on 3 (2f+1) validators.
     let mut reverting_authority_idx = None;
@@ -237,7 +245,7 @@ async fn reconfig_with_revert_end_to_end_test() {
                     .unwrap();
                 assert_eq!(2, object.version().value());
                 // Due to race conditions, it's possible that tx2 went in
-                // before 2f+1 validators sent EndOfPublish messges and close
+                // before 2f+1 validators sent EndOfPublish messages and close
                 // the curtain of epoch 0. So, we are asserting that
                 // the object version is either 1 or 2, but needs to be
                 // consistent in all validators.
@@ -321,7 +329,11 @@ async fn test_validator_resign_effects() {
         AuthAggMetrics::new(&registry),
     )
     .unwrap();
-    let cert = net.process_transaction(tx.clone()).await.unwrap();
+    let cert = net
+        .process_transaction(tx.clone())
+        .await
+        .unwrap()
+        .into_cert_for_testing();
     let effects0 = net
         .process_certificate(cert.clone().into_inner())
         .await

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -7,7 +7,7 @@ use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_macros::sim_test;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::messages::{
-    CertifiedTransaction, ExecuteTransactionRequest, ExecuteTransactionRequestType,
+    CertifiedTransactionEffects, ExecuteTransactionRequest, ExecuteTransactionRequestType,
     ExecuteTransactionResponse, TransactionData, VerifiedTransaction,
 };
 use sui_types::object::generate_test_gas_objects_with_owner;
@@ -206,7 +206,7 @@ async fn test_tx_across_epoch_boundaries() {
     let (sender, keypair) = get_key_pair::<AccountKeyPair>();
     let gas_objects = generate_test_gas_objects_with_owner(1, sender);
     let (result_tx, mut result_rx) =
-        tokio::sync::mpsc::channel::<CertifiedTransaction>(total_tx_cnt);
+        tokio::sync::mpsc::channel::<CertifiedTransactionEffects>(total_tx_cnt);
 
     let (config, mut gas_objects) = test_authority_configs_with_objects(gas_objects);
     let authorities = spawn_test_authorities([], &config).await;
@@ -247,8 +247,8 @@ async fn test_tx_across_epoch_boundaries() {
                 {
                     Ok(ExecuteTransactionResponse::EffectsCert(res)) => {
                         info!(?tx_digest, "tx result: ok");
-                        let (tx_cert, _, _) = *res;
-                        result_tx.send(tx_cert).await.unwrap();
+                        let (_, effects_cert, _) = *res;
+                        result_tx.send(effects_cert).await.unwrap();
                     }
                     Err(QuorumDriverError::TimeoutBeforeFinality) => {
                         info!(?tx_digest, "tx result: timeout and will retry")
@@ -277,7 +277,7 @@ async fn test_tx_across_epoch_boundaries() {
     // The transaction must finalize in epoch 1
     let start = std::time::Instant::now();
     match tokio::time::timeout(tokio::time::Duration::from_secs(15), result_rx.recv()).await {
-        Ok(Some(tx_cert)) if tx_cert.auth_sig().epoch == 1 => (),
+        Ok(Some(effects_cert)) if effects_cert.epoch() == 1 => (),
         other => panic!("unexpected error: {:?}", other),
     }
     info!("test completed in {:?}", start.elapsed());

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -7,8 +7,8 @@ use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_macros::sim_test;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::messages::{
-    CertifiedTransactionEffects, ExecuteTransactionRequest, ExecuteTransactionRequestType,
-    ExecuteTransactionResponse, TransactionData, VerifiedTransaction,
+    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
+    FinalizedEffects, TransactionData, VerifiedTransaction,
 };
 use sui_types::object::generate_test_gas_objects_with_owner;
 use sui_types::quorum_driver_types::QuorumDriverError;
@@ -205,8 +205,7 @@ async fn test_tx_across_epoch_boundaries() {
     let total_tx_cnt = 1;
     let (sender, keypair) = get_key_pair::<AccountKeyPair>();
     let gas_objects = generate_test_gas_objects_with_owner(1, sender);
-    let (result_tx, mut result_rx) =
-        tokio::sync::mpsc::channel::<CertifiedTransactionEffects>(total_tx_cnt);
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel::<FinalizedEffects>(total_tx_cnt);
 
     let (config, mut gas_objects) = test_authority_configs_with_objects(gas_objects);
     let authorities = spawn_test_authorities([], &config).await;

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -238,7 +238,7 @@ export const SuiExecuteTransactionResponse = union([
     }),
   }),
   object({
-    certificate: CertifiedTransaction,
+    certificate: optional(CertifiedTransaction),
     effects: SuiCertifiedTransactionEffects,
     confirmed_local_execution: boolean(),
   }),


### PR DESCRIPTION
This PR makes two major refactoring:
1. TransactionInfoResponse is now an enum instead of struct. Previously we have 3 optional fields; now we have two enum cases, one for signed, and one for executed. We need both cert and effects in the executed case today since the client needs it, but down the road we should get rid of the cert.
2. Merged the return value of handle_transaction and handle_transaction_info.