### PR TITLE
Enable e2e test against devent and testnet branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ jobs:
         uses: "./.github/actions/diffs"
         id: diff
 
+  # Run e2e test against localnet built on the main branch
   localnet:
     name: Localnet
     needs: diff
@@ -64,4 +65,52 @@ jobs:
         with:
           name: playwright-report-wallet
           path: apps/wallet/playwright-report/
+          retention-days: 30
+
+  # Run e2e test against localnet built on the devnet branch for backward compatibility check
+  local_devnet_branch:
+    name: Local Network Built on devnet branch
+    needs: diff
+    if: needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isWallet == 'true'
+    runs-on: ubuntu-ghcloud
+    steps:
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+        with:
+          ref: devnet
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
+        with:
+          version: 7
+      - run: cargo build --bin sui-test-validator --bin sui --profile dev
+      - name: Install Nodejs
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3
+        with:
+          node-version: "18"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright Browsers
+        run: pnpm explorer playwright install --with-deps chromium
+
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+        with:
+          clean: false
+
+      # - name: Run TS SDK e2e tests
+      #   if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
+      #   run: pnpm dlx concurrently --kill-others --success command-1 'RUST_LOG="consensus=off"  target/debug/sui-test-validator' 'pnpm sdk test:e2e'
+
+      - name: Set env
+        run: echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG="consensus=off "$(echo $PWD/target/debug/sui-test-validator))" >> $GITHUB_ENV
+
+      - name: Run Explorer e2e tests
+        if: ${{ needs.diff.outputs.isExplorer == 'true' }}
+        run: pnpm explorer playwright test
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report-explorer
+          path: apps/explorer/playwright-report/
           retention-days: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,7 @@ jobs:
     if: needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'
     runs-on: ubuntu-ghcloud
     steps:
+      # checkout the devnet branch
       - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
         with:
           ref: devnet
@@ -84,6 +85,12 @@ jobs:
         with:
           version: 7
       - run: cargo build --bin sui-test-validator --bin sui --profile dev
+
+      # checkout the current branch
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+        with:
+          clean: false
+
       - name: Install Nodejs
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3
         with:
@@ -94,16 +101,12 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm explorer playwright install --with-deps chromium
 
-      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
-        with:
-          clean: false
-
       - name: Set env
         run: echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG=\"consensus=off\" $(echo $PWD/target/debug/sui-test-validator))" >> $GITHUB_ENV
 
-      # - name: Run TS SDK e2e tests
-      #   if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
-      #   run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
+      - name: Run TS SDK e2e tests
+        if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
+        run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
 
       - name: Run Explorer e2e tests
         if: ${{ needs.diff.outputs.isExplorer == 'true' }}
@@ -126,6 +129,7 @@ jobs:
     if: needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'
     runs-on: ubuntu-ghcloud
     steps:
+      # checkout the testnet branch
       - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
         with:
           ref: testnet
@@ -135,6 +139,12 @@ jobs:
         with:
           version: 7
       - run: cargo build --bin sui-test-validator --bin sui --profile dev
+
+      # checkout the current branch
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+        with:
+          clean: false
+
       - name: Install Nodejs
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3
         with:
@@ -145,16 +155,12 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm explorer playwright install --with-deps chromium
 
-      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
-        with:
-          clean: false
-
       - name: Set env
         run: echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG="consensus=off "$(echo $PWD/target/debug/sui-test-validator))" >> $GITHUB_ENV
 
-      # - name: Run TS SDK e2e tests
-      #   if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
-      #   run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
+      - name: Run TS SDK e2e tests
+        if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
+        run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
 
       - name: Run Explorer e2e tests
         if: ${{ needs.diff.outputs.isExplorer == 'true' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,7 +71,8 @@ jobs:
   local_devnet_branch:
     name: Local Network Built on devnet branch
     needs: diff
-    if: needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isWallet == 'true'
+    # TODO: add wallet e2e to the `if` condition when available
+    if: needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'
     runs-on: ubuntu-ghcloud
     steps:
       - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
@@ -97,16 +98,69 @@ jobs:
         with:
           clean: false
 
+      - name: Set env
+        run: echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG=\"consensus=off\" $(echo $PWD/target/debug/sui-test-validator))" >> $GITHUB_ENV
+
       # - name: Run TS SDK e2e tests
       #   if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
-      #   run: pnpm dlx concurrently --kill-others --success command-1 'RUST_LOG="consensus=off"  target/debug/sui-test-validator' 'pnpm sdk test:e2e'
-
-      - name: Set env
-        run: echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG="consensus=off "$(echo $PWD/target/debug/sui-test-validator))" >> $GITHUB_ENV
+      #   run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
 
       - name: Run Explorer e2e tests
         if: ${{ needs.diff.outputs.isExplorer == 'true' }}
         run: pnpm explorer playwright test
+
+      # TODO: add wallet e2e when available
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report-explorer
+          path: apps/explorer/playwright-report/
+          retention-days: 30
+
+  # Run e2e test against localnet built on the Testnet branch for backward compatibility check
+  local_testnet_branch:
+    name: Local Network Built on testnet branch
+    needs: diff
+    # TODO: add wallet e2e to the `if` condition when available
+    if: needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'
+    runs-on: ubuntu-ghcloud
+    steps:
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+        with:
+          ref: testnet
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
+        with:
+          version: 7
+      - run: cargo build --bin sui-test-validator --bin sui --profile dev
+      - name: Install Nodejs
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3
+        with:
+          node-version: "18"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright Browsers
+        run: pnpm explorer playwright install --with-deps chromium
+
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+        with:
+          clean: false
+
+      - name: Set env
+        run: echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG="consensus=off "$(echo $PWD/target/debug/sui-test-validator))" >> $GITHUB_ENV
+
+      # - name: Run TS SDK e2e tests
+      #   if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
+      #   run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
+
+      - name: Run Explorer e2e tests
+        if: ${{ needs.diff.outputs.isExplorer == 'true' }}
+        run: pnpm explorer playwright test
+
+      # TODO: add wallet e2e when available
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,9 +4,10 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     outputs:
-      isWallet: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), 'sui-wallet')) || steps.diff.outputs.isRust }}
-      isExplorer: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), 'sui-explorer')) || steps.diff.outputs.isRust }}
-      isTypescriptSDK: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), '@mysten/sui.js')) || steps.diff.outputs.isRust }}
+      isWallet: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), 'sui-wallet')) }}
+      isExplorer: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), 'sui-explorer')) }}
+      isTypescriptSDK: ${{ (steps.turbo.outputs.packages && contains(fromJson(steps.turbo.outputs.packages), '@mysten/sui.js')) }}
+      isRust: ${{ steps.diff.outputs.isRust }}
     steps:
       - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
       - name: Detect Changes (turbo)
@@ -20,7 +21,7 @@ jobs:
   localnet:
     name: Localnet
     needs: diff
-    if: needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isWallet == 'true'
+    if: needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true'
     runs-on: ubuntu-ghcloud
     steps:
       - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
@@ -41,11 +42,12 @@ jobs:
         run: pnpm explorer playwright install --with-deps chromium
 
       - name: Run TS SDK e2e tests
-        if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
+        if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isRust == 'true'}}
         run: pnpm dlx concurrently --kill-others --success command-1 'RUST_LOG="consensus=off" cargo run --bin sui-test-validator' 'pnpm sdk test:e2e'
 
       - name: Run Explorer e2e tests
-        if: ${{ needs.diff.outputs.isExplorer == 'true' }}
+        # need to run Explorer e2e when its upstream(TS SDK and Rust) or itself is changed
+        if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isRust == 'true'}}
         run: pnpm explorer playwright test
       - uses: actions/upload-artifact@v3
         if: always()
@@ -55,10 +57,11 @@ jobs:
           retention-days: 30
 
       - name: Build Wallet
-        if: ${{ needs.diff.outputs.isWallet == 'true' }}
+        # need to run Wallet e2e when its upstream(TS SDK and Rust) or itself is changed
+        if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
         run: pnpm wallet build
       - name: Run Wallet e2e tests
-        if: ${{ needs.diff.outputs.isWallet == 'true' }}
+        if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm wallet playwright test
       - uses: actions/upload-artifact@v3
         if: always()
@@ -109,7 +112,7 @@ jobs:
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
 
       - name: Run Explorer e2e tests
-        if: ${{ needs.diff.outputs.isExplorer == 'true' }}
+        if: ${{ needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
         run: pnpm explorer playwright test
 
       # TODO: add wallet e2e when available
@@ -163,7 +166,7 @@ jobs:
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
 
       - name: Run Explorer e2e tests
-        if: ${{ needs.diff.outputs.isExplorer == 'true' }}
+        if: ${{ needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
         run: pnpm explorer playwright test
 
       # TODO: add wallet e2e when available

--- a/apps/explorer/playwright.config.ts
+++ b/apps/explorer/playwright.config.ts
@@ -105,6 +105,7 @@ const config: PlaywrightTestConfig = {
         // Localnet:
         {
             command:
+                process.env.E2E_RUN_LOCAL_NET_CMD ??
                 'RUST_LOG="consensus=off" cargo run --bin sui-test-validator',
             port: 9123,
             timeout: 120 * 1000,

--- a/apps/explorer/playwright.config.ts
+++ b/apps/explorer/playwright.config.ts
@@ -106,7 +106,7 @@ const config: PlaywrightTestConfig = {
         {
             command:
                 process.env.E2E_RUN_LOCAL_NET_CMD ??
-                '../../target/debug/sui-test-validator',
+                'RUST_LOG="consensus=off" cargo run --bin sui-test-validator',
             port: 9123,
             timeout: 120 * 1000,
             reuseExistingServer: !process.env.CI,

--- a/apps/explorer/playwright.config.ts
+++ b/apps/explorer/playwright.config.ts
@@ -106,7 +106,7 @@ const config: PlaywrightTestConfig = {
         {
             command:
                 process.env.E2E_RUN_LOCAL_NET_CMD ??
-                'RUST_LOG="consensus=off" cargo run --bin sui-test-validator',
+                '../../target/debug/sui-test-validator',
             port: 9123,
             timeout: 120 * 1000,
             reuseExistingServer: !process.env.CI,

--- a/apps/explorer/tests/objects.spec.ts
+++ b/apps/explorer/tests/objects.spec.ts
@@ -3,13 +3,14 @@
 
 import { test, expect } from '@playwright/test';
 
+import { getCreatedObjects } from '@mysten/sui.js';
 import { faucet, mint } from './utils/localnet';
 
 test('can be reached through URL', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
 
-    const { objectId } = tx.effects.effects.created![0].reference;
+    const { objectId } = getCreatedObjects(tx)![0].reference;
     await page.goto(`/object/${objectId}`);
     await expect(page.getByRole('heading', { name: objectId })).toBeVisible();
 });
@@ -19,7 +20,7 @@ test.describe('Owned Objects', () => {
         const address = await faucet();
         const tx = await mint(address);
 
-        const [nft] = tx.effects.effects.created!;
+        const [nft] = getCreatedObjects(tx)!;
         await page.goto(`/address/0x${address}`);
 
         // Find a reference to the NFT:

--- a/apps/explorer/tests/search.spec.ts
+++ b/apps/explorer/tests/search.spec.ts
@@ -4,6 +4,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
 import { faucet, mint } from './utils/localnet';
+import { getCreatedObjects, getTransactionDigest } from '@mysten/sui.js';
 
 async function search(page: Page, text: string) {
     const searchbar = page.getByRole('combobox');
@@ -23,7 +24,7 @@ test('can search for objects', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
 
-    const { objectId } = tx.effects.effects.created![0].reference;
+    const { objectId } = getCreatedObjects(tx)![0].reference;
     await page.goto('/');
     await search(page, objectId);
     await expect(page).toHaveURL(`/object/${objectId}`);
@@ -33,7 +34,7 @@ test('can search for transaction', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
 
-    const txid = tx.effects.effects.transactionDigest;
+    const txid = getTransactionDigest(tx);
     await page.goto('/');
     await search(page, txid);
     await expect(page).toHaveURL(`/transaction/${txid}`);

--- a/apps/explorer/tests/transaction.spec.ts
+++ b/apps/explorer/tests/transaction.spec.ts
@@ -3,11 +3,12 @@
 import { expect, test } from '@playwright/test';
 
 import { faucet, mint } from './utils/localnet';
+import { getTransactionDigest } from '@mysten/sui.js';
 
 test('displays the transaction timestamp', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
-    const txid = tx.effects.effects.transactionDigest;
+    const txid = getTransactionDigest(tx);
     await page.goto(`/transaction/${txid}`);
     await expect(
         page.getByTestId('transaction-timestamp').locator('div').nth(1)
@@ -17,7 +18,7 @@ test('displays the transaction timestamp', async ({ page }) => {
 test('displays gas breakdown', async ({ page }) => {
     const address = await faucet();
     const tx = await mint(address);
-    const txid = tx.effects.effects.transactionDigest;
+    const txid = getTransactionDigest(tx);
     await page.goto(`/transaction/${txid}`);
     await expect(page.getByTestId('gas-breakdown')).toBeVisible();
 });

--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -46,10 +46,14 @@ export async function mint(address: string) {
     });
 
     if (!('certificate' in tx)) {
-        throw new Error('Missing certificate');
+        throw new Error(
+            `Missing certificate in txn ${JSON.stringify(tx, null, 2)}`
+        );
     }
     if (!('effects' in tx)) {
-        throw new Error('Missing effects');
+        throw new Error(
+            `Missing effects in txn ${JSON.stringify(tx, null, 2)}`
+        );
     }
 
     return tx;

--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -9,6 +9,8 @@ import {
     RawSigner,
     LocalTxnDataSerializer,
     type Keypair,
+    SuiExecuteTransactionResponse,
+    assert,
 } from '@mysten/sui.js';
 
 const addressToKeypair = new Map<string, Keypair>();
@@ -45,17 +47,7 @@ export async function mint(address: string) {
         gasBudget: 30000,
     });
 
-    if (!('certificate' in tx)) {
-        throw new Error(
-            `Missing certificate in txn ${JSON.stringify(tx, null, 2)}`
-        );
-    }
-    if (!('effects' in tx)) {
-        throw new Error(
-            `Missing effects in txn ${JSON.stringify(tx, null, 2)}`
-        );
-    }
-
+    assert(tx, SuiExecuteTransactionResponse);
     return tx;
 }
 

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -377,8 +377,8 @@ export function getTransactionDigest(
   if ('transactionDigest' in tx) {
     return tx.transactionDigest;
   }
-  const ctxn = getCertifiedTransaction(tx)!;
-  return ctxn.transactionDigest;
+  const effects = getTransactionEffects(tx)!;
+  return effects.transactionDigest;
 }
 
 export function getTransactionSignature(tx: CertifiedTransaction): string {

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -306,7 +306,8 @@ export const MoveValidatorsFieldsClass = object({
 export const MoveSuiSystemObjectFields = object({
   chain_id: optional(number()),
   epoch: string(),
-  epoch_start_timestamp_ms: string(),
+  // TODO(cleanup): remove optional after TestNet Wave 2(0.22.0)
+  epoch_start_timestamp_ms: optional(string()),
   safe_mode: boolean(),
   id: object({
     id: string(),

--- a/sdk/typescript/test/e2e/checkpoint.test.ts
+++ b/sdk/typescript/test/e2e/checkpoint.test.ts
@@ -6,9 +6,14 @@ import { setup, TestToolbox } from './utils/setup';
 
 describe('Checkpoints Reading API', () => {
   let toolbox: TestToolbox;
+  let shouldSkip: boolean;
 
   beforeAll(async () => {
     toolbox = await setup();
+    // TODO(cleanup): remove this after TestNet Wave 2(0.22.0) or backward compatibility
+    // is supported
+    const version = await toolbox.provider.getRpcApiVersion()!;
+    shouldSkip = version?.major === 0 && version?.minor < 23;
   });
 
   it('Get latest checkpoint sequence number', async () => {
@@ -28,6 +33,9 @@ describe('Checkpoints Reading API', () => {
   });
 
   it('get checkpoint summary by digest', async () => {
+    if (shouldSkip) {
+      return;
+    }
     const checkpoint_resp = await toolbox.provider.getCheckpointSummary(1);
     const digest = checkpoint_resp.previous_digest;
     expect(digest).not.toBeNull();
@@ -41,11 +49,17 @@ describe('Checkpoints Reading API', () => {
   });
 
   it('get checkpoint contents', async () => {
+    if (shouldSkip) {
+      return;
+    }
     const resp = await toolbox.provider.getCheckpointContents(0);
     expect(resp.transactions.length).greaterThan(0);
   });
 
   it('get checkpoint contents by digest', async () => {
+    if (shouldSkip) {
+      return;
+    }
     const checkpoint_resp = await toolbox.provider.getCheckpointSummary(0);
     const digest = checkpoint_resp.content_digest;
     const resp = await toolbox.provider.getCheckpointContentsByDigest(digest);

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -65,6 +65,7 @@ export function getProvider(providerType: ProviderType): JsonRpcProvider {
 }
 
 export async function setup(providerType: ProviderType = 'rpc') {
+  console.error('My branch!!!!');
   const keypair = Ed25519Keypair.generate();
   const address = keypair.getPublicKey().toSuiAddress();
   const provider = getProvider(providerType);

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -65,7 +65,6 @@ export function getProvider(providerType: ProviderType): JsonRpcProvider {
 }
 
 export async function setup(providerType: ProviderType = 'rpc') {
-  console.error('My branch!!!!');
   const keypair = Ed25519Keypair.generate();
   const address = keypair.getPublicKey().toSuiAddress();
   const provider = getProvider(providerType);


### PR DESCRIPTION
- Added CI workflow to verify that the TypeScript/Explorer/Rust changes are compatible with TestNet and DevNet branch
- Edited the existing localnet e2e tests for Explorer and wallet: previously we only run Explorer/Wallet test when there is a rust change or an Explorer/Wallet change, now the test will also run when there's a TypeScript change(since TS change can also break Explorer).
- Fixed some backward incompatibility on the SDK and Explorer side with the testnet branch
