### PR TITLE
Add mark on addresses command response

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -764,7 +764,7 @@ impl SuiClientCommands {
             }
 
             SuiClientCommands::Addresses => {
-                SuiClientCommandResult::Addresses(context.config.keystore.addresses())
+                SuiClientCommandResult::Addresses(context.config.keystore.addresses(), context.active_address().ok())
             }
 
             SuiClientCommands::Objects { address } => {
@@ -1255,10 +1255,14 @@ impl Display for SuiClientCommandResult {
             SuiClientCommandResult::PayAllSui(cert, effects) => {
                 write!(writer, "{}", write_cert_and_effects(cert, effects)?)?;
             }
-            SuiClientCommandResult::Addresses(addresses) => {
+            SuiClientCommandResult::Addresses(addresses, active_address) => {
                 writeln!(writer, "Showing {} results.", addresses.len())?;
                 for address in addresses {
-                    writeln!(writer, "{}", address)?;
+                    if active_address.is_some() && active_address.unwrap() == *address {
+                        writeln!(writer, "{} <=", address)?;
+                    } else {
+                        writeln!(writer, "{}", address)?;
+                    }
                 }
             }
             SuiClientCommandResult::Objects(object_refs) => {
@@ -1552,7 +1556,7 @@ pub enum SuiClientCommandResult {
     Pay(SuiCertifiedTransaction, SuiTransactionEffects),
     PaySui(SuiCertifiedTransaction, SuiTransactionEffects),
     PayAllSui(SuiCertifiedTransaction, SuiTransactionEffects),
-    Addresses(Vec<SuiAddress>),
+    Addresses(Vec<SuiAddress>, Option<SuiAddress>),
     Objects(Vec<SuiObjectInfo>),
     DynamicFieldQuery(DynamicFieldPage),
     SyncClientState,

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -763,9 +763,10 @@ impl SuiClientCommands {
                 SuiClientCommandResult::PayAllSui(cert, effects)
             }
 
-            SuiClientCommands::Addresses => {
-                SuiClientCommandResult::Addresses(context.config.keystore.addresses(), context.active_address().ok())
-            }
+            SuiClientCommands::Addresses => SuiClientCommandResult::Addresses(
+                context.config.keystore.addresses(),
+                context.active_address().ok(),
+            ),
 
             SuiClientCommands::Objects { address } => {
                 let address = address.unwrap_or(context.active_address()?);

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1258,7 +1258,7 @@ impl Display for SuiClientCommandResult {
             SuiClientCommandResult::Addresses(addresses, active_address) => {
                 writeln!(writer, "Showing {} results.", addresses.len())?;
                 for address in addresses {
-                    if active_address.is_some() && active_address.unwrap() == *address {
+                    if *active_address == Some(*address) {
                         writeln!(writer, "{} <=", address)?;
                     } else {
                         writeln!(writer, "{}", address)?;

--- a/crates/sui/src/console.rs
+++ b/crates/sui/src/console.rs
@@ -126,7 +126,7 @@ async fn handle_command(
     // TODO: Completion data are keyed by strings, are there ways to make it more error proof?
     if let Ok(mut cache) = completion_cache.write() {
         match result {
-            SuiClientCommandResult::Addresses(ref addresses) => {
+            SuiClientCommandResult::Addresses(ref addresses, _) => {
                 let addresses = addresses
                     .iter()
                     .map(|addr| format!("{addr}"))


### PR DESCRIPTION
`sui client addresses` returns several addresses, but it is impossible to recognize which address is activated before trying `sui client active-address`.

This change adds a simple mark on the active address of the response.