### PR TITLE
Remove events from effects

### DIFF
--- a/.changeset/thirty-wolves-taste.md
+++ b/.changeset/thirty-wolves-taste.md
@@ -1,0 +1,6 @@
+---
+"@mysten/wallet-adapter-unsafe-burner": minor
+"@mysten/sui.js": minor
+---
+
+Removed events from transaction effects, TransactionEvents will now be provided in the TransactionResponse, along side TransactionEffects.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8630,6 +8630,7 @@ dependencies = [
  "sui-json-rpc-types",
  "sui-keys",
  "sui-node",
+ "sui-sdk",
  "sui-types",
  "tap",
  "telemetry-subscribers",

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -327,7 +327,7 @@ function TransactionView({
     );
 
     const txKindData = formatByTransactionKind(txKindName, txnDetails, sender);
-    const txEventData = transaction.effects.events?.map(eventToDisplay);
+    const txEventData = transaction.events?.map(eventToDisplay);
 
     let eventTitles: [string, string][] = [];
     const txEventDisplay = txEventData?.map((ed, index) => {

--- a/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
@@ -11,21 +11,26 @@ import { Text } from '_src/ui/app/shared/text';
 import { IconTooltip } from '_src/ui/app/shared/tooltip';
 import { useSystemState } from '_src/ui/app/staking/useSystemState';
 
-import type { TransactionEffects, MoveEvent } from '@mysten/sui.js';
+import type {
+    TransactionEffects,
+    MoveEvent,
+    TransactionEvents,
+} from '@mysten/sui.js';
 
 type StakeTxnCardProps = {
     txnEffects: TransactionEffects;
+    events: TransactionEvents;
 };
 
 const REQUEST_DELEGATION_EVENT = '0x2::validator_set::DelegationRequestEvent';
 
 // TODO: moveEvents is will be changing
 // For Staked Transaction use moveEvent Field to get the validator address, delegation amount, epoch
-export function StakeTxnCard({ txnEffects }: StakeTxnCardProps) {
+export function StakeTxnCard({ txnEffects, events }: StakeTxnCardProps) {
     const stakingData = useMemo(() => {
-        if (!txnEffects?.events) return null;
+        if (!events) return null;
 
-        const event = txnEffects.events.find(
+        const event = events.find(
             (event) =>
                 'moveEvent' in event &&
                 event.moveEvent.type === REQUEST_DELEGATION_EVENT
@@ -33,7 +38,7 @@ export function StakeTxnCard({ txnEffects }: StakeTxnCardProps) {
         if (!event) return null;
         const { moveEvent } = event as { moveEvent: MoveEvent };
         return moveEvent;
-    }, [txnEffects.events]);
+    }, [events]);
 
     const { data: system } = useSystemState();
 

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -39,7 +39,7 @@ type ReceiptCardProps = {
 };
 
 function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
-    const { effects } = txn;
+    const { effects, events } = txn;
     const timestamp = txn.timestamp_ms || txn.timestampMs;
     const executionStatus = getExecutionStatusType(txn);
     const error = useMemo(() => getExecutionStatusError(txn), [txn]);
@@ -58,8 +58,8 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
 
         return transferId
             ? transferId
-            : getTxnEffectsEventID(effects, activeAddress)[0];
-    }, [activeAddress, transaction, effects]);
+            : getTxnEffectsEventID(effects, events, activeAddress)[0];
+    }, [transaction, effects, events, activeAddress]);
 
     const gasTotal = getTotalGasUsed(txn);
 
@@ -112,7 +112,7 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
 
                 {isStakeTxn ? (
                     moveCallLabel === 'Staked' ? (
-                        <StakeTxnCard txnEffects={effects} />
+                        <StakeTxnCard txnEffects={effects} events={events} />
                     ) : (
                         <UnStakeTxnCard
                             txn={txn}

--- a/apps/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-    getExecutionStatusType,
-    getTransactionKindName,
-    getMoveCallTransaction,
     getExecutionStatusError,
-    getTransferObjectTransaction,
-    SUI_TYPE_ARG,
+    getExecutionStatusType,
+    getMoveCallTransaction,
+    getTransactionDigest,
+    getTransactionKindName,
     getTransactions,
     getTransactionSender,
-    getTransactionDigest,
+    getTransferObjectTransaction,
+    SUI_TYPE_ARG,
 } from '@mysten/sui.js';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
@@ -21,22 +21,23 @@ import { TxnImage } from './TxnImage';
 import { CoinBalance } from '_app/shared/coin-balance';
 import { DateCard } from '_app/shared/date-card';
 import { Text } from '_app/shared/text';
-import { notEmpty, checkStakingTxn } from '_helpers';
-import { useGetTxnRecipientAddress, useGetTransferAmount } from '_hooks';
+import { checkStakingTxn, notEmpty } from '_helpers';
+import { useGetTransferAmount, useGetTxnRecipientAddress } from '_hooks';
 
 import type {
-    SuiTransactionResponse,
     SuiAddress,
-    TransactionEffects,
     SuiEvent,
+    SuiTransactionResponse,
+    TransactionEffects,
+    TransactionEvents,
 } from '@mysten/sui.js';
 
 export const getTxnEffectsEventID = (
     txEffects: TransactionEffects,
+    events: TransactionEvents,
     address: string
 ): string[] => {
-    const events = txEffects?.events || [];
-    const objectIDs = events
+    return events
         ?.map((event: SuiEvent) => {
             const data = Object.values(event).find(
                 (itm) => itm?.recipient?.AddressOwner === address
@@ -44,7 +45,6 @@ export const getTxnEffectsEventID = (
             return data?.objectId;
         })
         .filter(notEmpty);
-    return objectIDs;
 };
 
 export function TransactionCard({
@@ -63,8 +63,8 @@ export function TransactionCard({
             getTransferObjectTransaction(transaction)?.objectRef?.objectId;
         return transferId
             ? transferId
-            : getTxnEffectsEventID(txn.effects, address)[0];
-    }, [address, transaction, txn.effects]);
+            : getTxnEffectsEventID(txn.effects, txn.events, address)[0];
+    }, [address, transaction, txn.effects, txn.events]);
 
     const transfer = useGetTransferAmount({
         txn,

--- a/apps/wallet/src/ui/app/helpers/getAmount.ts
+++ b/apps/wallet/src/ui/app/helpers/getAmount.ts
@@ -13,14 +13,15 @@ import {
 import type {
     SuiTransactionKind,
     TransactionEffects,
+    TransactionEvents,
     SuiEvent,
 } from '@mysten/sui.js';
 
 const getCoinType = (
     txEffects: TransactionEffects,
+    events: TransactionEvents,
     address: string
 ): string | null => {
-    const events = txEffects?.events || [];
     const coinType = events
         ?.map((event: SuiEvent) => {
             const data = Object.values(event).find(
@@ -40,7 +41,8 @@ type FormattedBalance = {
 
 export function getAmount(
     txnData: SuiTransactionKind,
-    txnEffect: TransactionEffects
+    txnEffect: TransactionEffects,
+    events: TransactionEvents
 ): FormattedBalance | null {
     const txKindName = getTransactionKindName(txnData);
     if (txKindName === 'TransferObject') {
@@ -62,7 +64,8 @@ export function getAmount(
                       recipientAddress: txn.recipient,
                       amount: txn?.amount,
                       coinType:
-                          txnEffect && getCoinType(txnEffect, txn.recipient),
+                          txnEffect &&
+                          getCoinType(txnEffect, events, txn.recipient),
                   },
               ]
             : null;
@@ -76,7 +79,7 @@ export function getAmount(
             const coinType =
                 txKindName === 'PaySui'
                     ? SUI_TYPE_ARG
-                    : getCoinType(txnEffect, recipient);
+                    : getCoinType(txnEffect, events, recipient);
             return {
                 ...acc,
                 [recipient]: {

--- a/apps/wallet/src/ui/app/helpers/getEventsSummary.ts
+++ b/apps/wallet/src/ui/app/helpers/getEventsSummary.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { TransactionEffects } from '@mysten/sui.js';
+import type { TransactionEvents } from '@mysten/sui.js';
 
 export type CoinsMetaProps = {
     amount: number;
@@ -15,10 +15,9 @@ export type TxnMetaResponse = {
 };
 
 export function getEventsSummary(
-    txEffects: TransactionEffects,
+    events: TransactionEvents,
     address: string
 ): TxnMetaResponse {
-    const events = txEffects?.events || [];
     const coinsMeta = {} as { [coinType: string]: CoinsMetaProps };
     const objectIDs: string[] = [];
 

--- a/apps/wallet/src/ui/app/hooks/useGetTransferAmount.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetTransferAmount.ts
@@ -15,12 +15,12 @@ export function useGetTransferAmount({
     txn: SuiTransactionResponse;
     activeAddress: SuiAddress;
 }) {
-    const { effects } = txn;
-    const { coins } = getEventsSummary(effects, activeAddress);
+    const { effects, events } = txn;
+    const { coins } = getEventsSummary(events, activeAddress);
 
     const suiTransfer = useMemo(() => {
         const txdetails = getTransactions(txn)[0];
-        return getAmount(txdetails, effects)?.map(
+        return getAmount(txdetails, effects, events)?.map(
             ({ amount, coinType, recipientAddress }) => {
                 return {
                     amount: amount || 0,
@@ -29,7 +29,7 @@ export function useGetTransferAmount({
                 };
             }
         );
-    }, [txn, effects]);
+    }, [txn, effects, events]);
 
     const transferAmount = useMemo(() => {
         return suiTransfer?.length

--- a/apps/wallet/src/ui/app/hooks/useGetTxnRecipientAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetTxnRecipientAddress.ts
@@ -17,15 +17,15 @@ type Props = {
 };
 
 export function useGetTxnRecipientAddress({ txn, address }: Props) {
-    const { effects } = txn;
+    const { events } = txn;
 
     const eventsSummary = useMemo(() => {
-        const { coins } = getEventsSummary(effects, address);
+        const { coins } = getEventsSummary(events, address);
         return coins;
-    }, [effects, address]);
+    }, [events, address]);
 
     const [transaction] = getTransactions(txn);
-    const amountByRecipient = getAmount(transaction, txn.effects);
+    const amountByRecipient = getAmount(transaction, txn.effects, events);
 
     const recipientAddress = useMemo(() => {
         const transferObjectRecipientAddress =

--- a/apps/wallet/src/ui/app/hooks/useTransactionSummary.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionSummary.ts
@@ -29,10 +29,11 @@ export function useTransactionSummary({
     const { data } = useTransactionDryRun(txData, addressForTransaction);
 
     const eventsSummary = useMemo(
-        () => (data ? getEventsSummary(data, addressForTransaction) : null),
+        () =>
+            data ? getEventsSummary(data.events, addressForTransaction) : null,
         [data, addressForTransaction]
     );
-    const txGasEstimation = data && getTotalGasUsed(data);
+    const txGasEstimation = data && getTotalGasUsed(data.effects);
 
     return [eventsSummary, txGasEstimation || null];
 }

--- a/apps/wallet/src/ui/app/pages/home/tokens/CoinActivityCard.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/CoinActivityCard.tsx
@@ -24,7 +24,7 @@ export function CoinActivitiesCard({ coinType }: { coinType: string }) {
     const txnByCoinType = useMemo(() => {
         if (!txns || !activeAddress) return null;
         return txns?.filter((txn) => {
-            const { coins } = getEventsSummary(txn.effects, activeAddress);
+            const { coins } = getEventsSummary(txn.events, activeAddress);
             // find txn with coinType from eventsSummary
             return !!coins.find(
                 ({ coinType: summaryCoinType }) => summaryCoinType === coinType

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -3,6 +3,7 @@
 
 import {
     Coin as CoinAPI,
+    getEvents,
     getTransactionEffects,
     SUI_SYSTEM_STATE_OBJECT_ID,
 } from '@mysten/sui.js';
@@ -187,12 +188,13 @@ export class Coin {
             });
 
             const effects = getTransactionEffects(result);
+            const events = getEvents(result);
 
-            if (!effects || !effects.events) {
+            if (!effects || !events) {
                 throw new Error('Missing effects or events');
             }
 
-            const changeEvent = effects.events.find((event) => {
+            const changeEvent = events.find((event) => {
                 if ('coinBalanceChange' in event) {
                     return event.coinBalanceChange.amount === Number(amount);
                 }

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -4,6 +4,7 @@
 import {
     fromB64,
     getCertifiedTransaction,
+    getEvents,
     getTransactionEffects,
     LocalTxnDataSerializer,
     type SignedTransaction,
@@ -190,6 +191,7 @@ export const respondToTransactionRequest = createAsyncThunk<
                     txResult = {
                         certificate: getCertifiedTransaction(response)!,
                         effects: getTransactionEffects(response)!,
+                        events: getEvents(response)!,
                         timestamp_ms: null,
                         parsed_data: null,
                     };

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -1000,7 +1000,7 @@ fn test_pay_success_without_delete() {
     let mut ctx = TxContext::with_sender_for_testing_only(&sender);
 
     assert!(pay(&mut store, coin_objects, recipients, amounts, &mut ctx).is_ok());
-    let (store, _events) = store.into_inner();
+    let store = store.into_inner();
 
     assert!(store.deleted.is_empty());
     assert_eq!(store.created().len(), 2);
@@ -1037,7 +1037,7 @@ fn test_pay_success_delete_one() {
     let mut ctx = TxContext::random_for_testing_only();
 
     assert!(pay(&mut store, coin_objects, recipients, amounts, &mut ctx).is_ok());
-    let (store, _events) = store.into_inner();
+    let store = store.into_inner();
 
     assert_eq!(store.deleted.len(), 1);
     assert!(store.deleted.contains_key(&input_coin_id1));
@@ -1073,7 +1073,7 @@ fn test_pay_success_delete_all() {
     let mut ctx = TxContext::with_sender_for_testing_only(&sender);
 
     assert!(pay(&mut store, coin_objects, recipients, amounts, &mut ctx).is_ok());
-    let (store, _events) = store.into_inner();
+    let store = store.into_inner();
 
     assert_eq!(store.deleted.len(), 2);
     assert!(store.deleted.contains_key(&input_coin_id1));
@@ -1108,7 +1108,7 @@ fn test_pay_sui_success_one_input_coin() {
     );
     let mut ctx = TxContext::with_sender_for_testing_only(&sender);
     assert!(pay_sui(&mut store, &mut coin_objects, recipients, amounts, &mut ctx).is_ok());
-    let (store, _events) = store.into_inner();
+    let store = store.into_inner();
 
     assert!(store.deleted.is_empty());
     assert_eq!(store.written.len(), 3);
@@ -1147,7 +1147,7 @@ fn test_pay_sui_success_multiple_input_coins() {
     );
     let mut ctx = TxContext::with_sender_for_testing_only(&sender);
     assert!(pay_sui(&mut store, &mut coin_objects, recipients, amounts, &mut ctx).is_ok());
-    let (store, _events) = store.into_inner();
+    let store = store.into_inner();
 
     assert_eq!(store.deleted.len(), 2);
     assert!(store.deleted.contains_key(&input_coin_id2));
@@ -1186,7 +1186,7 @@ fn test_pay_all_sui_success_multiple_input_coins() {
         input_objects_from_objects(coin_objects.clone()),
     );
     assert!(pay_all_sui(sender, &mut store, &mut coin_objects, recipient).is_ok());
-    let (store, _events) = store.into_inner();
+    let store = store.into_inner();
 
     assert_eq!(store.deleted.len(), 2);
     assert!(store.deleted.contains_key(&input_coin_id2));

--- a/crates/sui-cluster-test/src/test_case/call_contract_test.rs
+++ b/crates/sui-cluster-test/src/test_case/call_contract_test.rs
@@ -71,7 +71,7 @@ impl TestCaseImpl for CallContractTest {
             .object_id;
 
         // Examine effects
-        let events = &response.effects.events;
+        let events = &response.events.data;
         assert_eq!(
             events.len(),
             3,

--- a/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
@@ -89,7 +89,7 @@ impl NativeTransferTest {
         obj_to_transfer_id: ObjectID,
         method: &str,
     ) {
-        let events = &mut response.effects.events;
+        let events = &mut response.events.data;
         assert_eq!(
             events.len(),
             3,

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -58,6 +58,7 @@ pub struct Genesis {
     checkpoint_contents: CheckpointContents,
     transaction: Transaction,
     effects: TransactionEffects,
+    events: TransactionEvents,
     objects: Vec<Object>,
 }
 
@@ -67,6 +68,7 @@ pub struct GenesisTuple(
     pub CheckpointContents,
     pub Transaction,
     pub TransactionEffects,
+    pub TransactionEvents,
     pub Vec<Object>,
 );
 
@@ -106,6 +108,9 @@ impl Genesis {
 
     pub fn effects(&self) -> &TransactionEffects {
         &self.effects
+    }
+    pub fn events(&self) -> &TransactionEvents {
+        &self.events
     }
 
     pub fn checkpoint(&self) -> VerifiedCheckpoint {
@@ -215,19 +220,21 @@ impl Serialize for Genesis {
         use serde::ser::Error;
 
         #[derive(Serialize)]
-        struct RawGeneis<'a> {
+        struct RawGenesis<'a> {
             checkpoint: &'a CertifiedCheckpointSummary,
             checkpoint_contents: &'a CheckpointContents,
             transaction: &'a Transaction,
             effects: &'a TransactionEffects,
+            events: &'a TransactionEvents,
             objects: &'a [Object],
         }
 
-        let raw_genesis = RawGeneis {
+        let raw_genesis = RawGenesis {
             checkpoint: &self.checkpoint,
             checkpoint_contents: &self.checkpoint_contents,
             transaction: &self.transaction,
             effects: &self.effects,
+            events: &self.events,
             objects: &self.objects,
         };
 
@@ -250,11 +257,12 @@ impl<'de> Deserialize<'de> for Genesis {
         use serde::de::Error;
 
         #[derive(Deserialize)]
-        struct RawGeneis {
+        struct RawGenesis {
             checkpoint: CertifiedCheckpointSummary,
             checkpoint_contents: CheckpointContents,
             transaction: Transaction,
             effects: TransactionEffects,
+            events: TransactionEvents,
             objects: Vec<Object>,
         }
 
@@ -266,11 +274,12 @@ impl<'de> Deserialize<'de> for Genesis {
             data
         };
 
-        let RawGeneis {
+        let RawGenesis {
             checkpoint,
             checkpoint_contents,
             transaction,
             effects,
+            events,
             objects,
         } = bcs::from_bytes(&bytes).map_err(|e| Error::custom(e.to_string()))?;
 
@@ -279,6 +288,7 @@ impl<'de> Deserialize<'de> for Genesis {
             checkpoint_contents,
             transaction,
             effects,
+            events,
             objects,
         })
     }
@@ -404,8 +414,14 @@ impl Builder {
     }
 
     pub fn add_validator_signature(mut self, keypair: &AuthorityKeyPair) -> Self {
-        let GenesisTuple(checkpoint, _checkpoint_contents, _transaction, _effects, _objects) =
-            self.build_unsigned_genesis_checkpoint();
+        let GenesisTuple(
+            checkpoint,
+            _checkpoint_contents,
+            _transaction,
+            _effects,
+            _events,
+            _objects,
+        ) = self.build_unsigned_genesis_checkpoint();
 
         let name = keypair.public().into();
         assert!(
@@ -462,7 +478,7 @@ impl Builder {
     }
 
     pub fn build(mut self) -> Genesis {
-        let GenesisTuple(checkpoint, checkpoint_contents, transaction, effects, objects) =
+        let GenesisTuple(checkpoint, checkpoint_contents, transaction, effects, events, objects) =
             self.build_unsigned_genesis_checkpoint();
 
         let committee = Self::committee(&objects);
@@ -494,6 +510,7 @@ impl Builder {
             checkpoint_contents,
             transaction,
             effects,
+            events,
             objects,
         };
 
@@ -704,7 +721,7 @@ fn build_unsigned_genesis_data(
         parameters.initial_sui_custody_account_address,
     );
 
-    let (genesis_transaction, genesis_effects, objects) =
+    let (genesis_transaction, genesis_effects, genesis_events, objects) =
         create_genesis_transaction(objects, &protocol_config, &epoch_data);
     let (checkpoint, checkpoint_contents) =
         create_genesis_checkpoint(parameters, &genesis_transaction, &genesis_effects);
@@ -714,6 +731,7 @@ fn build_unsigned_genesis_data(
         checkpoint_contents,
         genesis_transaction,
         genesis_effects,
+        genesis_events,
         objects,
     )
 }
@@ -747,7 +765,12 @@ fn create_genesis_transaction(
     objects: Vec<Object>,
     protocol_config: &ProtocolConfig,
     epoch_data: &EpochData,
-) -> (Transaction, TransactionEffects, Vec<Object>) {
+) -> (
+    Transaction,
+    TransactionEffects,
+    TransactionEvents,
+    Vec<Object>,
+) {
     let genesis_transaction = {
         let genesis_objects = objects
             .into_iter()
@@ -775,7 +798,7 @@ fn create_genesis_transaction(
     };
 
     // execute txn to effects
-    let (effects, objects) = {
+    let (effects, events, objects) = {
         let mut store = sui_types::in_memory_storage::InMemoryStorage::new(Vec::new());
         let temporary_store = TemporaryStore::new(
             &mut store,
@@ -825,10 +848,10 @@ fn create_genesis_transaction(
                 o
             })
             .collect();
-        (effects, objects)
+        (effects, inner_temp_store.events, objects)
     };
 
-    (genesis_transaction, effects, objects)
+    (genesis_transaction, effects, events, objects)
 }
 
 fn create_genesis_objects(
@@ -939,12 +962,9 @@ fn process_package(
         protocol_config,
     )?;
 
-    let (
-        InnerTemporaryStore {
-            written, deleted, ..
-        },
-        _events,
-    ) = temporary_store.into_inner();
+    let InnerTemporaryStore {
+        written, deleted, ..
+    } = temporary_store.into_inner();
 
     store.finish(written, deleted);
 
@@ -1038,12 +1058,9 @@ pub fn generate_genesis_system_object(
         &protocol_config,
     )?;
 
-    let (
-        InnerTemporaryStore {
-            written, deleted, ..
-        },
-        _events,
-    ) = temporary_store.into_inner();
+    let InnerTemporaryStore {
+        written, deleted, ..
+    } = temporary_store.into_inner();
 
     store.finish(written, deleted);
 

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -31,9 +31,9 @@ use sui_types::gas::SuiGasStatus;
 use sui_types::in_memory_storage::InMemoryStorage;
 use sui_types::intent::{Intent, IntentMessage, IntentScope};
 use sui_types::message_envelope::Message;
-use sui_types::messages::InputObjects;
 use sui_types::messages::Transaction;
 use sui_types::messages::{CallArg, TransactionEffects};
+use sui_types::messages::{InputObjects, TransactionEvents};
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary, VerifiedCheckpoint,
 };

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 use std::sync::Arc;
 use sui_storage::mutex_table::{LockGuard, MutexTable};
 use sui_types::accumulator::Accumulator;
+use sui_types::digests::TransactionEventsDigest;
 use sui_types::error::UserInputError;
 use sui_types::message_envelope::Message;
 use sui_types::object::Owner;
@@ -131,6 +132,12 @@ impl AuthorityStore {
                 .unwrap();
             // We don't insert the effects to executed_effects yet because the genesis tx hasn't but will be executed.
             // This is important for fullnodes to be able to generate indexing data right now.
+
+            store
+                .perpetual_tables
+                .events
+                .insert(&genesis.events().digest(), genesis.events())
+                .unwrap();
         }
 
         Ok(store)
@@ -153,6 +160,18 @@ impl AuthorityStore {
             .effects
             .contains_key(effects_digest)
             .map_err(|e| e.into())
+    }
+
+    pub(crate) fn get_events(
+        &self,
+        event_digest: &TransactionEventsDigest,
+    ) -> SuiResult<TransactionEvents> {
+        self.perpetual_tables
+            .events
+            .get(event_digest)?
+            .ok_or(SuiError::TransactionEventsNotFound {
+                digest: *event_digest,
+            })
     }
 
     pub fn multi_get_effects<'a>(
@@ -632,6 +651,7 @@ impl AuthorityStore {
             mutable_inputs: active_inputs,
             written,
             deleted,
+            events,
         } = inner_temporary_store;
         trace!(written =? written.values().map(|((obj_id, ver, _), _, _)| (obj_id, ver)).collect::<Vec<_>>(),
                "batch_update_objects: temp store written");
@@ -677,6 +697,9 @@ impl AuthorityStore {
                 (ObjectKey::from(obj_ref), new_object)
             }),
         )?;
+
+        write_batch =
+            write_batch.insert_batch(&self.perpetual_tables.events, [(events.digest(), events)])?;
 
         let new_locks_to_init: Vec<_> = written
             .iter()

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use sui_storage::default_db_options;
 use sui_types::accumulator::Accumulator;
 use sui_types::base_types::SequenceNumber;
+use sui_types::digests::TransactionEventsDigest;
 use sui_types::storage::ObjectStore;
 use typed_store::metrics::SamplingInterval;
 use typed_store::rocks::{DBMap, DBOptions, MetricConf, ReadWriteOptions};
@@ -71,6 +72,11 @@ pub struct AuthorityPerpetualTables {
     /// to be executed, we wait for them to appear in this table. When we revert transactions, we remove them from both
     /// tables.
     pub(crate) executed_effects: DBMap<TransactionDigest, TransactionEffectsDigest>,
+
+    // Currently this is needed in the validator for returning events during process certificates.
+    // We could potentially remove this if we decided not to provide events in the execution path.
+    // TODO: Figure out what to do with this table in the long run. Also we need a pruning policy for this table.
+    pub(crate) events: DBMap<TransactionEventsDigest, TransactionEvents>,
 
     /// When transaction is executed via checkpoint executor, we store association here
     pub(crate) executed_transactions_to_checkpoint:

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -223,7 +223,7 @@ struct ProcessCertificateState {
 #[derive(Debug)]
 pub enum ProcessTransactionResult {
     Certified(VerifiedCertificate),
-    Executed(VerifiedCertifiedTransactionEffects),
+    Executed(VerifiedCertifiedTransactionEffects, TransactionEvents),
 }
 
 impl ProcessTransactionResult {
@@ -1010,13 +1010,13 @@ where
                 debug!(?tx_digest, name=?name.concise(), weight, "Received signed transaction from validator handle_transaction");
                 self.handle_transaction_response_with_signed(state, signed)
             }
-            Ok(VerifiedTransactionInfoResponse::ExecutedWithCert(cert, effects)) => {
+            Ok(VerifiedTransactionInfoResponse::ExecutedWithCert(cert, effects, events)) => {
                 debug!(?tx_digest, name=?name.concise(), weight, "Received prev certificate and effects from validator handle_transaction");
-                self.handle_transaction_response_with_executed(state, Some(cert), effects)
+                self.handle_transaction_response_with_executed(state, Some(cert), effects, events)
             }
-            Ok(VerifiedTransactionInfoResponse::ExecutedWithoutCert(_, effects)) => {
+            Ok(VerifiedTransactionInfoResponse::ExecutedWithoutCert(_, effects, events)) => {
                 debug!(?tx_digest, name=?name.concise(), weight, "Received prev effects from validator handle_transaction");
-                self.handle_transaction_response_with_executed(state, None, effects)
+                self.handle_transaction_response_with_executed(state, None, effects, events)
             }
             Err(err) => {
                 self.record_conflicting_transaction_if_any(state, name, weight, &err);
@@ -1070,6 +1070,7 @@ where
         state: &mut ProcessTransactionState,
         certificate: Option<VerifiedCertificate>,
         signed_effects: VerifiedSignedTransactionEffects,
+        events: TransactionEvents,
     ) -> SuiResult<Option<ProcessTransactionResult>> {
         match certificate {
             Some(certificate) if certificate.epoch() == self.committee.epoch => {
@@ -1091,6 +1092,7 @@ where
                             CertifiedTransactionEffects::new_from_data_and_sig(effects, cert_sig);
                         Ok(Some(ProcessTransactionResult::Executed(
                             ct.verify(&self.committee)?,
+                            events,
                         )))
                     }
                 }
@@ -1133,7 +1135,10 @@ where
     pub async fn process_certificate(
         &self,
         certificate: CertifiedTransaction,
-    ) -> Result<VerifiedCertifiedTransactionEffects, QuorumExecuteCertificateError> {
+    ) -> Result<
+        (VerifiedCertifiedTransactionEffects, TransactionEvents),
+        QuorumExecuteCertificateError,
+    > {
         let state = ProcessCertificateState {
             effects_map: MultiStakeAggregator::new(Arc::new(self.committee.clone())),
             bad_stake: 0,
@@ -1216,9 +1221,12 @@ where
         state: &mut ProcessCertificateState,
         response: SuiResult<VerifiedHandleCertificateResponse>,
         name: AuthorityName,
-    ) -> SuiResult<Option<VerifiedCertifiedTransactionEffects>> {
+    ) -> SuiResult<Option<(VerifiedCertifiedTransactionEffects, TransactionEvents)>> {
         match response {
-            Ok(VerifiedHandleCertificateResponse { signed_effects }) => {
+            Ok(VerifiedHandleCertificateResponse {
+                signed_effects,
+                events,
+            }) => {
                 debug!(
                     ?tx_digest,
                     name = ?name.concise(),
@@ -1240,7 +1248,7 @@ where
                         );
                         ct.verify(&self.committee).map(|ct| {
                             debug!(?tx_digest, "Got quorum for validators handle_certificate.");
-                            Some(ct)
+                            Some((ct, events))
                         })
                     }
                 }
@@ -1259,7 +1267,7 @@ where
             .await?;
         let cert = match result {
             ProcessTransactionResult::Certified(cert) => cert,
-            ProcessTransactionResult::Executed(effects) => {
+            ProcessTransactionResult::Executed(effects, _) => {
                 return Ok(effects);
             }
         };
@@ -1269,7 +1277,7 @@ where
             .instrument(tracing::debug_span!("process_cert"))
             .await?;
 
-        Ok(response)
+        Ok(response.0)
     }
 
     /// This function tries to get SignedTransaction OR CertifiedTransaction from

--- a/crates/sui-core/src/event_handler.rs
+++ b/crates/sui-core/src/event_handler.rs
@@ -12,6 +12,7 @@ use sui_json_rpc_types::SuiMoveStruct;
 use sui_storage::event_store::{EventStore, EventStoreType};
 use sui_types::base_types::TransactionDigest;
 use sui_types::filter::EventFilter;
+use sui_types::messages::TransactionEvents;
 use sui_types::{
     error::{SuiError, SuiResult},
     event::{Event, EventEnvelope},
@@ -59,12 +60,13 @@ impl EventHandler {
     pub async fn process_events(
         &self,
         effects: &TransactionEffects,
+        events: &TransactionEvents,
         timestamp_ms: u64,
         seq_num: u64,
         module_cache: &SyncModuleCache<ResolverWrapper<AuthorityStore>>,
     ) -> SuiResult {
-        let res: Result<Vec<_>, _> = effects
-            .events
+        let res: Result<Vec<_>, _> = events
+            .data
             .iter()
             .enumerate()
             .map(|(event_num, e)| {

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -65,7 +65,7 @@ async fn test_quorum_driver_submit_transaction() {
     // Test submit_transaction
     let qd_clone = quorum_driver_handler.clone();
     let handle = tokio::task::spawn(async move {
-        let (tx, QuorumDriverResponse { effects_cert }) = qd_clone
+        let (tx, QuorumDriverResponse { effects_cert, .. }) = qd_clone
             .subscribe_to_effects()
             .recv()
             .await
@@ -95,7 +95,7 @@ async fn test_quorum_driver_submit_transaction_no_ticket() {
     );
     let qd_clone = quorum_driver_handler.clone();
     let handle = tokio::task::spawn(async move {
-        let (tx, QuorumDriverResponse { effects_cert }) = qd_clone
+        let (tx, QuorumDriverResponse { effects_cert, .. }) = qd_clone
             .subscribe_to_effects()
             .recv()
             .await
@@ -115,7 +115,7 @@ async fn verify_ticket_response<'a>(
     ticket: Registration<'a, TransactionDigest, QuorumDriverResult>,
     tx_digest: &TransactionDigest,
 ) {
-    let QuorumDriverResponse { effects_cert } = ticket.await.unwrap();
+    let QuorumDriverResponse { effects_cert, .. } = ticket.await.unwrap();
     assert_eq!(&effects_cert.data().transaction_digest, tx_digest);
 }
 
@@ -137,7 +137,7 @@ async fn test_quorum_driver_with_given_notify_read() {
 
     let qd_clone = quorum_driver_handler.clone();
     let handle = tokio::task::spawn(async move {
-        let (tx, QuorumDriverResponse { effects_cert }) = qd_clone
+        let (tx, QuorumDriverResponse { effects_cert, .. }) = qd_clone
             .subscribe_to_effects()
             .recv()
             .await
@@ -309,7 +309,7 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
         .unwrap();
 
     // Aggregator gets three good responses and execution succeeds.
-    let QuorumDriverResponse { effects_cert } = res;
+    let QuorumDriverResponse { effects_cert, .. } = res;
     assert_eq!(effects_cert.transaction_digest, tx2_digest);
 
     // Case 4 - object is locked by 2 txes with weight 2 and 1 respectivefully. Then try to execute the third txn
@@ -370,7 +370,7 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
         .await
         .unwrap();
 
-    let QuorumDriverResponse { effects_cert } = res;
+    let QuorumDriverResponse { effects_cert, .. } = res;
     assert_eq!(effects_cert.transaction_digest, tx_digest);
 
     // Case 7 - three validators lock the object, by different txes

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -229,7 +229,7 @@ impl<C> SafeClient<C> {
                         .verify(&committee)?,
                 ))
             }
-            TransactionStatus::Executed(cert_opt, effects) => {
+            TransactionStatus::Executed(cert_opt, effects, events) => {
                 let signed_effects = self.check_signed_effects(digest, effects, None)?;
                 match cert_opt {
                     Some(cert) => {
@@ -241,11 +241,13 @@ impl<C> SafeClient<C> {
                             )
                             .verify(&committee)?,
                             signed_effects,
+                            events,
                         ))
                     }
                     None => Ok(VerifiedTransactionInfoResponse::ExecutedWithoutCert(
                         transaction,
                         signed_effects,
+                        events,
                     )),
                 }
             }
@@ -309,6 +311,7 @@ where
     ) -> SuiResult<VerifiedHandleCertificateResponse> {
         Ok(VerifiedHandleCertificateResponse {
             signed_effects: self.check_signed_effects(digest, response.signed_effects, None)?,
+            events: response.events,
         })
     }
 

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use sui_types::base_types::TransactionDigest;
 use sui_types::committee::Committee;
 use sui_types::committee::EpochId;
-use sui_types::digests::TransactionEffectsDigest;
-use sui_types::messages::TransactionEffects;
+use sui_types::digests::{TransactionEffectsDigest, TransactionEventsDigest};
 use sui_types::messages::VerifiedTransaction;
+use sui_types::messages::{TransactionEffects, TransactionEvents};
 use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::messages_checkpoint::CheckpointContentsDigest;
 use sui_types::messages_checkpoint::CheckpointDigest;
@@ -103,6 +103,13 @@ impl ReadStore for RocksDbStore {
         digest: &TransactionEffectsDigest,
     ) -> Result<Option<TransactionEffects>, Self::Error> {
         self.authority_store.perpetual_tables.effects.get(digest)
+    }
+
+    fn get_transaction_events(
+        &self,
+        digest: &TransactionEventsDigest,
+    ) -> Result<Option<TransactionEvents>, Self::Error> {
+        self.authority_store.perpetual_tables.events.get(digest)
     }
 }
 

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -210,10 +210,11 @@ where
             Err(err) => Err(err),
             Ok(response) => {
                 good_response_metrics.inc();
-                let QuorumDriverResponse { effects_cert } = response;
+                let QuorumDriverResponse { effects_cert, .. } = response;
                 if !wait_for_local_execution {
                     return Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         FinalizedEffects::new_from_effects_cert(effects_cert.into()),
+                        response.events,
                         false,
                     ))));
                 }
@@ -232,10 +233,12 @@ where
                 {
                     Ok(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         FinalizedEffects::new_from_effects_cert(effects_cert.into()),
+                        response.events,
                         true,
                     )))),
                     Err(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         FinalizedEffects::new_from_effects_cert(effects_cert.into()),
+                        response.events,
                         false,
                     )))),
                 }
@@ -340,7 +343,7 @@ where
     ) {
         loop {
             match effects_receiver.recv().await {
-                Ok(Ok((transaction, QuorumDriverResponse { effects_cert }))) => {
+                Ok(Ok((transaction, QuorumDriverResponse { effects_cert, .. }))) => {
                     let executable_tx = VerifiedExecutableTransaction::new_from_quorum_execution(
                         transaction,
                         effects_cert.executed_epoch,

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -209,7 +209,7 @@ where
                 }
                 tx_data = Some(data);
             }
-            Ok(VerifiedTransactionInfoResponse::ExecutedWithCert(cert, _)) => {
+            Ok(VerifiedTransactionInfoResponse::ExecutedWithCert(cert, _, _)) => {
                 return cert.into_inner();
             }
             _ => {}
@@ -721,6 +721,7 @@ async fn test_handle_transaction_response() {
         status: TransactionStatus::Executed(
             Some(cert_epoch_0.auth_sig().clone()),
             sign_tx_effects(effects, 0, *name_0, key_0),
+            TransactionEvents { data: vec![] },
         ),
     };
     clients
@@ -914,6 +915,7 @@ fn set_tx_info_response_with_cert_and_effects<'a>(
             status: TransactionStatus::Executed(
                 Some(cert.auth_sig().clone()),
                 SignedTransactionEffects::new(epoch, effects.clone(), key, *name),
+                TransactionEvents { data: vec![] },
             ),
         };
         clients.get_mut(name).unwrap().set_tx_info_response(resp);

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -230,7 +230,7 @@ async fn test_dry_run_transaction() {
         )
         .await
         .unwrap();
-    assert_eq!(response.status, SuiExecutionStatus::Success);
+    assert_eq!(response.effects.status, SuiExecutionStatus::Success);
 
     // Make sure that objects are not mutated after dry run.
     let gas_object_version = fullnode
@@ -257,7 +257,9 @@ async fn test_dev_inspect_object_by_bytes() {
         init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
 
     // test normal call
-    let DevInspectResults { effects, results } = call_dev_inspect(
+    let DevInspectResults {
+        effects, results, ..
+    } = call_dev_inspect(
         &fullnode,
         &sender,
         &object_basics.0,
@@ -324,7 +326,9 @@ async fn test_dev_inspect_object_by_bytes() {
     assert_eq!(actual_gas_used, dev_inspect_gas_summary);
 
     // use the created object directly, via its bytes
-    let DevInspectResults { effects, results } = call_dev_inspect(
+    let DevInspectResults {
+        effects, results, ..
+    } = call_dev_inspect(
         &fullnode,
         &sender,
         &object_basics.0,
@@ -428,7 +432,9 @@ async fn test_dev_inspect_unowned_object() {
     assert_eq!(created_object.owner, Owner::AddressOwner(bob));
 
     // alice uses the object with dev inspect, despite not being the owner
-    let DevInspectResults { effects, results } = call_dev_inspect(
+    let DevInspectResults {
+        effects, results, ..
+    } = call_dev_inspect(
         &fullnode,
         &alice,
         &object_basics.0,
@@ -529,7 +535,9 @@ async fn test_dev_inspect_dynamic_field() {
     assert!(matches!(results, Err(e) if e.contains("kind: CircularObjectOwnership")));
 
     // add a dynamic field to an object
-    let DevInspectResults { effects, results } = call_dev_inspect(
+    let DevInspectResults {
+        effects, results, ..
+    } = call_dev_inspect(
         &fullnode,
         &sender,
         &object_basics.0,

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -614,7 +614,13 @@ async fn execute_transfer_with_price(
     let response = if run_confirm {
         send_and_confirm_transaction(&authority_state, tx)
             .await
-            .map(|(cert, effects)| TransactionStatus::Executed(Some(cert.into_sig()), effects))
+            .map(|(cert, effects)| {
+                TransactionStatus::Executed(
+                    Some(cert.into_sig()),
+                    effects,
+                    TransactionEvents::default(),
+                )
+            })
     } else {
         authority_state
             .handle_transaction(tx)

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -327,12 +327,17 @@ async fn test_object_owning_another_object() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
-    assert_eq!(effects.events.len(), 2);
-    assert_eq!(effects.events[0].event_type(), EventType::CoinBalanceChange);
-    assert_eq!(effects.events[1].event_type(), EventType::NewObject);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event_type(), EventType::CoinBalanceChange);
+    assert_eq!(events[1].event_type(), EventType::NewObject);
     let parent = effects.created[0].0;
-    assert_eq!(effects.events[1].object_id(), Some(parent.0));
+    assert_eq!(events[1].object_id(), Some(parent.0));
 
     // Create a child.
     let effects = call_move(
@@ -348,10 +353,15 @@ async fn test_object_owning_another_object() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
-    assert_eq!(effects.events.len(), 2);
-    assert_eq!(effects.events[0].event_type(), EventType::CoinBalanceChange);
-    assert_eq!(effects.events[1].event_type(), EventType::NewObject);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event_type(), EventType::CoinBalanceChange);
+    assert_eq!(events[1].event_type(), EventType::NewObject);
     let child = effects.created[0].0;
 
     // Mutate the child directly should work fine.
@@ -443,10 +453,15 @@ async fn test_object_owning_another_object() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
-    assert_eq!(effects.events.len(), 2);
-    assert_eq!(effects.events[0].event_type(), EventType::CoinBalanceChange);
-    assert_eq!(effects.events[1].event_type(), EventType::NewObject);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event_type(), EventType::CoinBalanceChange);
+    assert_eq!(events[1].event_type(), EventType::NewObject);
     let new_parent = effects.created[0].0;
 
     // Transfer the child to the new_parent.
@@ -466,29 +481,30 @@ async fn test_object_owning_another_object() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
-    assert_eq!(effects.events.len(), 7);
+    assert_eq!(events.len(), 7);
     // TODO: figure out why an extra event is emitted.
-    // assert_eq!(effects.events.len(), 6);
-    let num_transfers = effects
-        .events
+    // assert_eq!(events.len(), 6);
+    let num_transfers = events
         .iter()
         .filter(|e| matches!(e.event_type(), EventType::TransferObject { .. }))
         .count();
     assert_eq!(num_transfers, 1);
-    let num_created = effects
-        .events
+    let num_created = events
         .iter()
         .filter(|e| matches!(e.event_type(), EventType::NewObject { .. }))
         .count();
     assert_eq!(num_created, 1);
-    let child_event = effects
-        .events
+    let child_event = events
         .iter()
         .find(|e| e.object_id() == Some(child.0))
         .unwrap();
-    let num_deleted = effects
-        .events
+    let num_deleted = events
         .iter()
         .filter(|e| matches!(e.event_type(), EventType::DeleteObject { .. }))
         .count();
@@ -561,11 +577,16 @@ async fn test_create_then_delete_parent_child() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
     // Creates 3 objects, the parent, a field, and the child
     assert_eq!(effects.created.len(), 3);
     // Creates 4 events, gas charge, child, parent and wrapped object
-    assert_eq!(effects.events.len(), 4);
+    assert_eq!(events.len(), 4);
     let parent = effects
         .created
         .iter()
@@ -590,7 +611,7 @@ async fn test_create_then_delete_parent_child() {
     assert!(effects.status.is_ok());
     // Check that both objects were deleted.
     assert_eq!(effects.deleted.len(), 3);
-    assert_eq!(effects.events.len(), 4);
+    assert_eq!(events.len(), 4);
 }
 
 #[tokio::test]
@@ -618,6 +639,11 @@ async fn test_create_then_delete_parent_child_wrap() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
     // Modifies the gas object
     assert_eq!(effects.mutated.len(), 1);
@@ -625,7 +651,7 @@ async fn test_create_then_delete_parent_child_wrap() {
     assert_eq!(effects.created.len(), 2);
     // not wrapped as it wasn't first created
     assert_eq!(effects.wrapped.len(), 0);
-    assert_eq!(effects.events.len(), 3);
+    assert_eq!(events.len(), 3);
 
     let gas_ref = effects.mutated[0].0;
 
@@ -657,6 +683,11 @@ async fn test_create_then_delete_parent_child_wrap() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
 
     // The parent and field are considered deleted, the child doesn't count because it wasn't
@@ -664,7 +695,7 @@ async fn test_create_then_delete_parent_child_wrap() {
     assert_eq!(effects.deleted.len(), 2);
     // The child was never created so it is not unwrapped.
     assert_eq!(effects.unwrapped_then_deleted.len(), 0);
-    assert_eq!(effects.events.len(), 3);
+    assert_eq!(events.len(), 3);
 
     assert_eq!(
         effects
@@ -705,12 +736,17 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
-    assert_eq!(effects.events.len(), 2);
-    assert_eq!(effects.events[0].event_type(), EventType::CoinBalanceChange);
-    assert_eq!(effects.events[1].event_type(), EventType::NewObject);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event_type(), EventType::CoinBalanceChange);
+    assert_eq!(events[1].event_type(), EventType::NewObject);
     let parent = effects.created[0].0;
-    assert_eq!(effects.events[1].object_id(), Some(parent.0));
+    assert_eq!(events[1].object_id(), Some(parent.0));
 
     // Create a child.
     let effects = call_move(
@@ -726,10 +762,15 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
-    assert_eq!(effects.events.len(), 2);
-    assert_eq!(effects.events[0].event_type(), EventType::CoinBalanceChange);
-    assert_eq!(effects.events[1].event_type(), EventType::NewObject);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event_type(), EventType::CoinBalanceChange);
+    assert_eq!(events[1].event_type(), EventType::NewObject);
     let child = effects.created[0].0;
 
     // Add the child to the parent.
@@ -747,12 +788,17 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
     assert_eq!(effects.created.len(), 1);
     assert_eq!(effects.wrapped.len(), 1);
-    // assert_eq!(effects.events.len(), 4);
+    // assert_eq!(events.len(), 4);
     // TODO: figure out why an extra event is being emitted here.
-    assert_eq!(effects.events.len(), 5);
+    assert_eq!(events.len(), 5);
 
     // Delete the parent and child altogether.
     let effects = call_move(
@@ -768,12 +814,17 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     )
     .await
     .unwrap();
+    let events = if let Some(digest) = &effects.events_digest {
+        authority.database.get_events(digest).unwrap().data
+    } else {
+        vec![]
+    };
     assert!(effects.status.is_ok());
     // Check that parent object was deleted.
     assert_eq!(effects.deleted.len(), 2);
     // Check that child object was unwrapped and deleted.
     assert_eq!(effects.unwrapped_then_deleted.len(), 1);
-    assert_eq!(effects.events.len(), 4);
+    assert_eq!(events.len(), 4);
 }
 
 #[tokio::test]

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -210,7 +210,7 @@ async fn create_txes(
         package_id,
         /* arguments */ Vec::default(),
     );
-    let effects =
+    let (effects, _) =
         submit_single_owner_transaction(transaction.clone(), &configs.validator_set()).await;
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
     let ((counter_id, counter_initial_shared_version, _), _) = effects.created[0];
@@ -275,11 +275,13 @@ async fn run_actual_costs(
             submit_shared_object_transaction(tx, &configs.validator_set())
                 .await
                 .unwrap()
+                .0
                 .gas_cost_summary()
                 .clone()
         } else {
             submit_single_owner_transaction(tx, &configs.validator_set())
                 .await
+                .0
                 .gas_cost_summary()
                 .clone()
         };

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -29,6 +29,7 @@ rocksdb = "0.20.1"
 tempfile = "3.3.0"
 
 sui = { path = "../sui" }
+sui-sdk = { path = "../sui-sdk" }
 sui-node = { path = "../sui-node" }
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }
 sui-types = { path = "../sui-types" }

--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -8,7 +8,7 @@ use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::RpcModule;
 use sui_json_rpc::api::{WriteApiClient, WriteApiServer};
 use sui_json_rpc::SuiRpcModule;
-use sui_json_rpc_types::{DevInspectResults, SuiTransactionEffects, SuiTransactionResponse};
+use sui_json_rpc_types::{DevInspectResults, DryRunTransactionResponse, SuiTransactionResponse};
 use sui_open_rpc::Module;
 use sui_types::base_types::{EpochId, SuiAddress};
 use sui_types::messages::ExecuteTransactionRequestType;
@@ -70,7 +70,7 @@ impl WriteApiServer for WriteApi {
             .await
     }
 
-    async fn dry_run_transaction(&self, tx_bytes: Base64) -> RpcResult<SuiTransactionEffects> {
+    async fn dry_run_transaction(&self, tx_bytes: Base64) -> RpcResult<DryRunTransactionResponse> {
         self.fullnode.dry_run_transaction(tx_bytes).await
     }
 }

--- a/crates/sui-indexer/src/handlers/event_handler.rs
+++ b/crates/sui-indexer/src/handlers/event_handler.rs
@@ -98,7 +98,7 @@ impl EventHandler {
                 .map(|txn_resp| IndexerEventEnvelope {
                     transaction_digest: txn_resp.effects.transaction_digest,
                     timestamp: txn_resp.timestamp_ms,
-                    events: txn_resp.effects.events,
+                    events: txn_resp.events.data,
                     next_cursor: None,
                 })
                 .collect();

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -246,6 +246,8 @@ impl TryInto<SuiTransactionResponse> for Transaction {
                 .transaction_time
                 .map(|time| time.timestamp_millis() as u64),
             checkpoint: Some(self.checkpoint_sequence_number as u64),
+            // TODO: Indexer need to persist event properly.
+            events: Default::default(),
         })
     }
 }

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -23,7 +23,6 @@ use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{StructTag, TypeTag};
 use move_core_types::value::{MoveStruct, MoveStructLayout, MoveValue};
 use schemars::JsonSchema;
-use serde::ser::Error;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -37,6 +36,7 @@ use sui_types::base_types::{
 use sui_types::coin::CoinMetadata;
 use sui_types::committee::EpochId;
 use sui_types::crypto::SuiAuthorityStrongQuorumSignInfo;
+use sui_types::digests::TransactionEventsDigest;
 use sui_types::dynamic_field::DynamicFieldInfo;
 use sui_types::error::{ExecutionError, SuiError, UserInputError, UserInputResult};
 use sui_types::event::{BalanceChangeType, Event, EventID};
@@ -47,7 +47,7 @@ use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
     CallArg, EffectsFinalityInfo, ExecutionStatus, GenesisObject, InputObjectKind,
     MoveModulePublish, ObjectArg, Pay, PayAllSui, PaySui, SenderSignedData, SingleTransactionKind,
-    TransactionData, TransactionEffects, TransactionKind,
+    TransactionData, TransactionEffects, TransactionEvents, TransactionKind,
 };
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointDigest, CheckpointSequenceNumber, CheckpointSummary,
@@ -353,6 +353,7 @@ pub enum MoveFunctionArgType {
 pub struct SuiTransactionResponse {
     pub transaction: SuiTransaction,
     pub effects: SuiTransactionEffects,
+    pub events: SuiTransactionEvents,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timestamp_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -362,46 +363,7 @@ pub struct SuiTransactionResponse {
     pub checkpoint: Option<CheckpointSequenceNumber>,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
-pub enum SuiParsedTransactionResponse {
-    Publish(SuiParsedPublishResponse),
-    MergeCoin(SuiParsedMergeCoinResponse),
-    SplitCoin(SuiParsedSplitCoinResponse),
-}
-
-impl SuiParsedTransactionResponse {
-    pub fn to_publish_response(self) -> Result<SuiParsedPublishResponse, SuiError> {
-        match self {
-            SuiParsedTransactionResponse::Publish(resp) => Ok(resp),
-            _ => Err(SuiError::UnexpectedMessage),
-        }
-    }
-
-    pub fn to_merge_coin_response(self) -> Result<SuiParsedMergeCoinResponse, SuiError> {
-        match self {
-            SuiParsedTransactionResponse::MergeCoin(resp) => Ok(resp),
-            _ => Err(SuiError::UnexpectedMessage),
-        }
-    }
-
-    pub fn to_split_coin_response(self) -> Result<SuiParsedSplitCoinResponse, SuiError> {
-        match self {
-            SuiParsedTransactionResponse::SplitCoin(resp) => Ok(resp),
-            _ => Err(SuiError::UnexpectedMessage),
-        }
-    }
-}
-
-impl Display for SuiParsedTransactionResponse {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            SuiParsedTransactionResponse::Publish(r) => r.fmt(f),
-            SuiParsedTransactionResponse::MergeCoin(r) => r.fmt(f),
-            SuiParsedTransactionResponse::SplitCoin(r) => r.fmt(f),
-        }
-    }
-}
-
+#[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub enum SuiTBlsSignObjectCommitmentType {
     /// Check that the object is committed by the consensus.
@@ -452,62 +414,6 @@ impl TryFrom<Object> for SuiCoinMetadata {
             description,
             icon_url,
         })
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct SuiParsedSplitCoinResponse {
-    /// The updated original coin object after split
-    pub updated_coin: SuiParsedObject,
-    /// All the newly created coin objects generated from the split
-    pub new_coins: Vec<SuiParsedObject>,
-    /// The updated gas payment object after deducting payment
-    pub updated_gas: SuiParsedObject,
-}
-
-impl Display for SuiParsedSplitCoinResponse {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut writer = String::new();
-        writeln!(writer, "{}", "----- Split Coin Results ----".bold())?;
-
-        let coin = GasCoin::try_from(&self.updated_coin).map_err(fmt::Error::custom)?;
-        writeln!(writer, "Updated Coin : {}", coin)?;
-        let mut new_coin_text = Vec::new();
-        for coin in &self.new_coins {
-            let coin = GasCoin::try_from(coin).map_err(fmt::Error::custom)?;
-            new_coin_text.push(format!("{coin}"))
-        }
-        writeln!(
-            writer,
-            "New Coins : {}",
-            new_coin_text.join(",\n            ")
-        )?;
-        let gas_coin = GasCoin::try_from(&self.updated_gas).map_err(fmt::Error::custom)?;
-        writeln!(writer, "Updated Gas : {}", gas_coin)?;
-        write!(f, "{}", writer)
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct SuiParsedMergeCoinResponse {
-    /// The updated original coin object after merge
-    pub updated_coin: SuiParsedObject,
-    /// The updated gas payment object after deducting payment
-    pub updated_gas: SuiParsedObject,
-}
-
-impl Display for SuiParsedMergeCoinResponse {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut writer = String::new();
-        writeln!(writer, "{}", "----- Merge Coin Results ----".bold())?;
-
-        let coin = GasCoin::try_from(&self.updated_coin).map_err(fmt::Error::custom)?;
-        writeln!(writer, "Updated Coin : {}", coin)?;
-        let gas_coin = GasCoin::try_from(&self.updated_gas).map_err(fmt::Error::custom)?;
-        writeln!(writer, "Updated Gas : {}", gas_coin)?;
-        write!(f, "{}", writer)
     }
 }
 
@@ -969,45 +875,6 @@ impl TryFrom<&SuiMoveStruct> for GasCoin {
         Err(SuiError::TypeError {
             error: format!("Struct is not a gas coin: {move_struct:?}"),
         })
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct SuiParsedPublishResponse {
-    /// The newly published package object reference.
-    pub package: SuiObjectRef,
-    /// List of Move objects created as part of running the module initializers in the package
-    pub created_objects: Vec<SuiParsedObject>,
-    /// The updated gas payment object after deducting payment
-    pub updated_gas: SuiParsedObject,
-}
-
-impl Display for SuiParsedPublishResponse {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut writer = String::new();
-        writeln!(writer, "{}", "----- Publish Results ----".bold())?;
-        writeln!(
-            writer,
-            "{}",
-            format!(
-                "The newly published package object ID: {:?}\n",
-                self.package.object_id
-            )
-            .bold()
-        )?;
-        if !self.created_objects.is_empty() {
-            writeln!(
-                writer,
-                "List of objects created by running module initializers:"
-            )?;
-            for obj in &self.created_objects {
-                writeln!(writer, "{}\n", obj)?;
-            }
-        }
-        let gas_coin = GasCoin::try_from(&self.updated_gas).map_err(fmt::Error::custom)?;
-        writeln!(writer, "Updated Gas : {}", gas_coin)?;
-        write!(f, "{}", writer)
     }
 }
 
@@ -1886,42 +1753,42 @@ impl Display for SuiFinalizedEffects {
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "TransactionEffects", rename_all = "camelCase")]
 pub struct SuiTransactionEffects {
-    // The status of the execution
+    /// The status of the execution
     pub status: SuiExecutionStatus,
     /// The epoch when this transaction was executed.
     pub executed_epoch: EpochId,
     pub gas_used: SuiGasCostSummary,
-    // The object references of the shared objects used in this transaction. Empty if no shared objects were used.
+    /// The object references of the shared objects used in this transaction. Empty if no shared objects were used.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub shared_objects: Vec<SuiObjectRef>,
-    // The transaction digest
+    /// The transaction digest
     pub transaction_digest: TransactionDigest,
-    // ObjectRef and owner of new objects created.
+    /// ObjectRef and owner of new objects created.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub created: Vec<OwnedObjectRef>,
-    // ObjectRef and owner of mutated objects, including gas object.
+    /// ObjectRef and owner of mutated objects, including gas object.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mutated: Vec<OwnedObjectRef>,
-    // ObjectRef and owner of objects that are unwrapped in this transaction.
-    // Unwrapped objects are objects that were wrapped into other objects in the past,
-    // and just got extracted out.
+    /// ObjectRef and owner of objects that are unwrapped in this transaction.
+    /// Unwrapped objects are objects that were wrapped into other objects in the past,
+    /// and just got extracted out.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub unwrapped: Vec<OwnedObjectRef>,
-    // Object Refs of objects now deleted (the old refs).
+    /// Object Refs of objects now deleted (the old refs).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deleted: Vec<SuiObjectRef>,
     /// Object refs of objects previously wrapped in other objects but now deleted.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub unwrapped_then_deleted: Vec<SuiObjectRef>,
-    // Object refs of objects now wrapped in other objects.
+    /// Object refs of objects now wrapped in other objects.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub wrapped: Vec<SuiObjectRef>,
-    // The updated gas object reference. Have a dedicated field for convenient access.
-    // It's also included in mutated.
+    /// The updated gas object reference. Have a dedicated field for convenient access.
+    /// It's also included in mutated.
     pub gas_object: OwnedObjectRef,
-    /// The events emitted during execution. Note that only successful transactions emit events
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub events: Vec<SuiEvent>,
+    /// The digest of the events emitted during execution,
+    /// can be None if the transaction does not emmit any event.
+    pub events_digest: Option<TransactionEventsDigest>,
     /// The set of transaction digests this transaction depends on.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<TransactionDigest>,
@@ -1932,12 +1799,11 @@ impl SuiTransactionEffects {
     pub fn mutated_excluding_gas(&self) -> impl Iterator<Item = &OwnedObjectRef> {
         self.mutated.iter().filter(|o| *o != &self.gas_object)
     }
+}
 
-    pub fn try_from(
-        effect: TransactionEffects,
-        resolver: &impl GetModule,
-    ) -> Result<Self, anyhow::Error> {
-        Ok(Self {
+impl From<TransactionEffects> for SuiTransactionEffects {
+    fn from(effect: TransactionEffects) -> Self {
+        Self {
             status: effect.status.into(),
             executed_epoch: effect.executed_epoch,
             gas_used: effect.gas_used.into(),
@@ -1953,13 +1819,9 @@ impl SuiTransactionEffects {
                 owner: effect.gas_object.1,
                 reference: effect.gas_object.0.into(),
             },
-            events: effect
-                .events
-                .into_iter()
-                .map(|event| SuiEvent::try_from(event, resolver))
-                .collect::<Result<_, _>>()?,
+            events_digest: effect.events_digest,
             dependencies: effect.dependencies,
-        })
+        }
     }
 }
 
@@ -2013,6 +1875,33 @@ impl Display for SuiTransactionEffects {
     }
 }
 
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunTransactionResponse {
+    pub effects: SuiTransactionEffects,
+    pub events: SuiTransactionEvents,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename = "TransactionEffects", transparent)]
+pub struct SuiTransactionEvents {
+    pub data: Vec<SuiEvent>,
+}
+
+impl SuiTransactionEvents {
+    pub fn try_from(
+        events: TransactionEvents,
+        resolver: &impl GetModule,
+    ) -> Result<Self, anyhow::Error> {
+        Ok(Self {
+            data: events
+                .data
+                .into_iter()
+                .map(|event| SuiEvent::try_from(event, resolver))
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
 /// The response from processing a dev inspect transaction
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "DevInspectResults", rename_all = "camelCase")]
@@ -2021,6 +1910,8 @@ pub struct DevInspectResults {
     /// Note however, that not all dev-inspect transactions are actually usable as transactions so
     /// it might not be possible actually generate these effects from a normal transaction.
     pub effects: SuiTransactionEffects,
+    /// Events that likely would be generated if the transaction is actually run.
+    pub events: SuiTransactionEvents,
     /// Execution results (including return values) from executing the transactions
     /// Currently contains only return values from Move calls
     pub results: Result<Vec<(usize, SuiExecutionResult)>, String>,
@@ -2046,10 +1937,10 @@ type ExecutionResult = (
 impl DevInspectResults {
     pub fn new(
         effects: TransactionEffects,
+        events: TransactionEvents,
         return_values: Result<Vec<(usize, ExecutionResult)>, ExecutionError>,
         resolver: &impl GetModule,
     ) -> Result<Self, anyhow::Error> {
-        let effects = SuiTransactionEffects::try_from(effects, resolver)?;
         let results = match return_values {
             Err(e) => Err(format!("{}", e)),
             Ok(srvs) => Ok(srvs
@@ -2072,7 +1963,11 @@ impl DevInspectResults {
                 })
                 .collect()),
         };
-        Ok(Self { effects, results })
+        Ok(Self {
+            effects: effects.into(),
+            events: SuiTransactionEvents::try_from(events, resolver)?,
+            results,
+        })
     }
 }
 

--- a/crates/sui-json-rpc/src/api/write.rs
+++ b/crates/sui-json-rpc/src/api/write.rs
@@ -4,7 +4,7 @@
 use fastcrypto::encoding::Base64;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
-use sui_json_rpc_types::{DevInspectResults, SuiTransactionEffects, SuiTransactionResponse};
+use sui_json_rpc_types::{DevInspectResults, DryRunTransactionResponse, SuiTransactionResponse};
 
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{EpochId, SuiAddress};
@@ -75,5 +75,5 @@ pub trait WriteApi {
     /// Return transaction execution effects including the gas cost summary,
     /// while the effects are not committed to the chain.
     #[method(name = "dryRunTransaction")]
-    async fn dry_run_transaction(&self, tx_bytes: Base64) -> RpcResult<SuiTransactionEffects>;
+    async fn dry_run_transaction(&self, tx_bytes: Base64) -> RpcResult<DryRunTransactionResponse>;
 }

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -21,6 +21,7 @@ use sui_types::coin::{Coin, CoinMetadata, LockedCoin, TreasuryCap};
 use sui_types::error::SuiError;
 use sui_types::event::Event;
 use sui_types::gas_coin::GAS;
+use sui_types::messages::TransactionEvents;
 use sui_types::object::Object;
 use sui_types::parse_sui_struct_tag;
 
@@ -123,13 +124,18 @@ impl CoinReadApi {
         object_struct_tag: StructTag,
     ) -> Result<Object, Error> {
         let publish_txn_digest = self.get_object(package_id).await?.previous_transaction;
-        let (_, effects) = self
+        let (_, effect) = self
             .state
             .get_executed_transaction_and_effects(publish_txn_digest)
             .await?;
 
-        let object_id = effects
-            .events
+        let events = if let Some(digests) = effect.events_digest {
+            self.state.get_transaction_events(digests).await?
+        } else {
+            TransactionEvents::default()
+        };
+
+        let object_id = events.data
             .into_iter()
             .find_map(|e| {
                 if let Event::NewObject { object_type, .. } = &e {

--- a/crates/sui-json-rpc/src/event_api.rs
+++ b/crates/sui-json-rpc/src/event_api.rs
@@ -81,7 +81,7 @@ impl EventReadApiServer for EventReadApi {
         // Retrieve 1 extra item for next cursor
         let mut data = self
             .state
-            .get_events(query, cursor, limit + 1, descending)
+            .query_events(query, cursor, limit + 1, descending)
             .await?;
         let next_cursor = data.get(limit).map(|(id, _)| id.clone());
         data.truncate(limit);

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -84,13 +84,13 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
 
     let SuiTransactionResponse { effects, .. } = tx_response;
     assert_eq!(
-        dryrun_response.transaction_digest,
+        dryrun_response.effects.transaction_digest,
         effects.transaction_digest
     );
     Ok(())
 }
 
-#[sim_test]
+#[tokio::test]
 async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();
@@ -134,10 +134,14 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
         .await?;
 
     let SuiTransactionResponse { effects, .. } = tx_response;
+    let events = http_client
+        .get_transaction(effects.transaction_digest)
+        .await?
+        .events;
     assert_eq!(SuiExecutionStatus::Success, effects.status);
 
-    let package_id = effects
-        .events
+    let package_id = events
+        .data
         .iter()
         .find_map(|e| {
             if let SuiEvent::Publish { package_id, .. } = e {
@@ -172,15 +176,17 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
         .submit_transaction(
             tx_bytes,
             signatures,
-            ExecuteTransactionRequestType::WaitForEffectsCert,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
 
-    let SuiTransactionResponse { effects, .. } = tx_response;
+    let SuiTransactionResponse {
+        effects, events, ..
+    } = tx_response;
     assert_eq!(SuiExecutionStatus::Success, effects.status);
 
-    let randomness_object_id = effects
-        .events
+    let randomness_object_id = events
+        .data
         .iter()
         .find_map(|e| {
             if let SuiEvent::NewObject { object_id, .. } = e {
@@ -427,10 +433,10 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiTransactionResponse { effects, .. } = tx_response;
+    let SuiTransactionResponse { events, .. } = tx_response;
 
-    let package_id = effects
-        .events
+    let package_id = events
+        .data
         .iter()
         .find_map(|e| {
             if let SuiEvent::Publish { package_id, .. } = e {
@@ -485,10 +491,10 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiTransactionResponse { effects, .. } = tx_response;
+    let SuiTransactionResponse { events, .. } = tx_response;
 
-    let package_id = effects
-        .events
+    let package_id = events
+        .data
         .iter()
         .find_map(|e| {
             if let SuiEvent::Publish { package_id, .. } = e {
@@ -505,8 +511,8 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
 
     assert_eq!(0, result.value);
 
-    let treasury_cap = effects
-        .events
+    let treasury_cap = events
+        .data
         .iter()
         .find_map(|e| {
             if let SuiEvent::NewObject {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -222,10 +222,10 @@
         }
       ],
       "result": {
-        "name": "SuiTransactionEffects",
+        "name": "DryRunTransactionResponse",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionEffects"
+          "$ref": "#/components/schemas/DryRunTransactionResponse"
         }
       }
     },
@@ -276,11 +276,11 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AABbVIthbaY7DOB9gW6J73uaOCF3tEIruqJ/fmJeoxmqChhIZm/+0ika4ko/gXc1OgUiDXZcqcQho2gIPxj+Ry85AgAAAAAAAAAgT4LxyFh7mNZMAL+0bDhDvYv2zPp8ZahhOGmM0f3Kw9yb8aISQfje080kjakG+4RnDnP26ac8d18JyptUgwmaUFV9xCqu/uuMFU193EVriuqjEyx0A1MdyY6D9uGY0tfRAgAAAAAAAAAge6kd3H5xfPcIyTcGDwQEhzbsM/sXRtmZpeWM1cZ37YCb8aISQfje080kjakG+4RnDnP26ac8d18JyptUgwmaUAEAAAAAAAAA6AMAAAAAAAAA"
+              "value": "AABVfcQqrv7rjBVNfdxFa4rqoxMsdANTHcmOg/bhmNLX0XupHdx+cXz3CMk3Bg8EBIc27DP7F0bZmaXljNXGd+2AAgAAAAAAAAAgzMqpegLMOpgEFnDhYJ23FOmFjJbp5GmFXxzzv9+X6GVPuIgKC69cF+3DB1mtlwVnAyS6rhgBhRo36LTApC3mdU+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNH9ysPcAgAAAAAAAAAg6NjHzoY/MT2j29kqg+8m0Si4j+Zr8m4ODQnNr3J9HYRPuIgKC69cF+3DB1mtlwVnAyS6rhgBhRo36LTApC3mdQEAAAAAAAAA6AMAAAAAAAAA"
             },
             {
               "name": "signature",
-              "value": "AAr/5ofSykcV/hoagNkoZpEZWj39H8IqfCWQtI2AT2h/pmxutp5HLVQZ5afowYxRjhBnkbUY+uqHRI++yAFGagCPzAHpyxY0YA6/WHSGiJpFTzhYtad9cNxpF+agpzFFbg=="
+              "value": "AH6XTo1HVHf4m92sObAgdmoNTFLiCFSzj7eOJobK8KjO3xa0NIv6WEOBVcC19elqJ+OmstR38vGS8P6j+eG4Aw5tqSk/XTlS5stFH/W02Kxeyb0TWYjhlUjBKhMcXPgTNg=="
             },
             {
               "name": "request_type",
@@ -295,29 +295,29 @@
                   "transactions": [
                     {
                       "TransferObject": {
-                        "recipient": "0x5b548b616da63b0ce07d816e89ef7b9a382177b4422bbaa27f7e625ea319aa0a",
+                        "recipient": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc98e83f6e198d2d7d1",
                         "objectRef": {
-                          "objectId": "0x1848666ffed2291ae24a3f8177353a05220d765ca9c421a368083f18fe472f39",
+                          "objectId": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80",
                           "version": 2,
-                          "digest": "6MP1w4WAxmKG85kRuPYqFDYXdW7JbartrLnPrm6L8tfm"
+                          "digest": "EnRQXe1hDGAJCFyF2ds2GmPHdvf9V6yxf24LisEsDkYt"
                         }
                       }
                     }
                   ],
-                  "sender": "0x9bf1a21241f8ded3cd248da906fb84670e73f6e9a73c775f09ca9b5483099a50",
+                  "sender": "0x4fb8880a0baf5c17edc30759ad9705670324baae1801851a37e8b4c0a42de675",
                   "gasData": {
                     "payment": {
-                      "objectId": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc98e83f6e198d2d7d1",
+                      "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
                       "version": 2,
-                      "digest": "9KiiSPVAMRLw8dhc1gq9SngDDhBZG5JfHXw9CyshyLkP"
+                      "digest": "GfwJqw63FK6AVQnKKkQprvrk3cVLziMBqhMfNkDuCHj9"
                     },
-                    "owner": "0x9bf1a21241f8ded3cd248da906fb84670e73f6e9a73c775f09ca9b5483099a50",
+                    "owner": "0x4fb8880a0baf5c17edc30759ad9705670324baae1801851a37e8b4c0a42de675",
                     "price": 1,
                     "budget": 1000
                   }
                 },
                 "txSignatures": [
-                  "AAr/5ofSykcV/hoagNkoZpEZWj39H8IqfCWQtI2AT2h/pmxutp5HLVQZ5afowYxRjhBnkbUY+uqHRI++yAFGagCPzAHpyxY0YA6/WHSGiJpFTzhYtad9cNxpF+agpzFFbg=="
+                  "AH6XTo1HVHf4m92sObAgdmoNTFLiCFSzj7eOJobK8KjO3xa0NIv6WEOBVcC19elqJ+OmstR38vGS8P6j+eG4Aw5tqSk/XTlS5stFH/W02Kxeyb0TWYjhlUjBKhMcXPgTNg=="
                 ]
               },
               "effects": {
@@ -330,55 +330,56 @@
                   "storageCost": 100,
                   "storageRebate": 10
                 },
-                "transactionDigest": "GfwJqw63FK6AVQnKKkQprvrk3cVLziMBqhMfNkDuCHj9",
+                "transactionDigest": "Cv7n2YaM7Am1ssZGu4khsFkcKHnpgVhwFCSs4kLjrtLW",
                 "mutated": [
                   {
                     "owner": {
-                      "AddressOwner": "0x9bf1a21241f8ded3cd248da906fb84670e73f6e9a73c775f09ca9b5483099a50"
+                      "AddressOwner": "0x4fb8880a0baf5c17edc30759ad9705670324baae1801851a37e8b4c0a42de675"
                     },
                     "reference": {
-                      "objectId": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc98e83f6e198d2d7d1",
+                      "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
                       "version": 2,
-                      "digest": "9KiiSPVAMRLw8dhc1gq9SngDDhBZG5JfHXw9CyshyLkP"
+                      "digest": "GfwJqw63FK6AVQnKKkQprvrk3cVLziMBqhMfNkDuCHj9"
                     }
                   },
                   {
                     "owner": {
-                      "AddressOwner": "0x5b548b616da63b0ce07d816e89ef7b9a382177b4422bbaa27f7e625ea319aa0a"
+                      "AddressOwner": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc98e83f6e198d2d7d1"
                     },
                     "reference": {
-                      "objectId": "0x1848666ffed2291ae24a3f8177353a05220d765ca9c421a368083f18fe472f39",
+                      "objectId": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80",
                       "version": 2,
-                      "digest": "6MP1w4WAxmKG85kRuPYqFDYXdW7JbartrLnPrm6L8tfm"
+                      "digest": "EnRQXe1hDGAJCFyF2ds2GmPHdvf9V6yxf24LisEsDkYt"
                     }
                   }
                 ],
                 "gasObject": {
                   "owner": {
-                    "ObjectOwner": "0x9bf1a21241f8ded3cd248da906fb84670e73f6e9a73c775f09ca9b5483099a50"
+                    "ObjectOwner": "0x4fb8880a0baf5c17edc30759ad9705670324baae1801851a37e8b4c0a42de675"
                   },
                   "reference": {
-                    "objectId": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc98e83f6e198d2d7d1",
+                    "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
                     "version": 2,
-                    "digest": "9KiiSPVAMRLw8dhc1gq9SngDDhBZG5JfHXw9CyshyLkP"
+                    "digest": "GfwJqw63FK6AVQnKKkQprvrk3cVLziMBqhMfNkDuCHj9"
                   }
                 },
-                "events": [
-                  {
-                    "transferObject": {
-                      "packageId": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                      "transactionModule": "native",
-                      "sender": "0x9bf1a21241f8ded3cd248da906fb84670e73f6e9a73c775f09ca9b5483099a50",
-                      "recipient": {
-                        "AddressOwner": "0x5b548b616da63b0ce07d816e89ef7b9a382177b4422bbaa27f7e625ea319aa0a"
-                      },
-                      "objectType": "0x2::example::Object",
-                      "objectId": "0x1848666ffed2291ae24a3f8177353a05220d765ca9c421a368083f18fe472f39",
-                      "version": 2
-                    }
-                  }
-                ]
+                "eventsDigest": "B3xLC8EbyvTxy5pgiwTNUzHLa6kS7uwD6sZdErKB8F8f"
               },
+              "events": [
+                {
+                  "transferObject": {
+                    "packageId": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    "transactionModule": "native",
+                    "sender": "0x4fb8880a0baf5c17edc30759ad9705670324baae1801851a37e8b4c0a42de675",
+                    "recipient": {
+                      "AddressOwner": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc98e83f6e198d2d7d1"
+                    },
+                    "objectType": "0x2::example::Object",
+                    "objectId": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80",
+                    "version": 2
+                  }
+                }
+              ],
               "checkpoint": null
             }
           }
@@ -571,9 +572,9 @@
             "value": {
               "epoch": 5000,
               "sequenceNumber": 1000,
-              "digest": "88sbZ6JronTqbQUL25HUPouw9wJJRiSKtUjry81YgPDS",
+              "digest": "3NynUFNC8xctjvGVBmGEDLNkAjSQpiygktDQhxhTBi8W",
               "networkTotalTransactions": 792385,
-              "previousDigest": "3yndxsmJNXFrRAUnuqKT6aekThhqmSDJ46opD7UjtL9N",
+              "previousDigest": "76gyHCk7FRrGACRqXM7Ybj5uJLtAzgEMJ5P9CeEzxZSG",
               "epochRollingGasCostSummary": {
                 "computation_cost": 0,
                 "storage_cost": 0,
@@ -582,7 +583,7 @@
               "timestampMs": 1676911928,
               "endOfEpochData": null,
               "transactions": [
-                "BhbWpBeESxuRWvmvLMyb2JNUuFa6j4aG1T4WUiPgKAHm"
+                "6kerMphN4S5QTfd9TAhwMiFq1q9c2YwfpheBfWm85vUq"
               ]
             }
           }
@@ -983,13 +984,13 @@
             {
               "name": "query",
               "value": {
-                "Transaction": "9Tvs1pGrMbNv7kkr1PoKLsWamyQpaFz5UWbL2AQ1ezk2"
+                "Transaction": "7PsBHpUW6yfGNov2WrbVafLjgT9nYziQ3gVDbRq6zTbF"
               }
             },
             {
               "name": "cursor",
               "value": {
-                "txDigest": "9Tvs1pGrMbNv7kkr1PoKLsWamyQpaFz5UWbL2AQ1ezk2",
+                "txDigest": "7PsBHpUW6yfGNov2WrbVafLjgT9nYziQ3gVDbRq6zTbF",
                 "eventSeq": 10
               }
             },
@@ -1008,21 +1009,21 @@
               "data": [
                 {
                   "timestamp": 0,
-                  "txDigest": "JUYYqipgFGhPNRTdjtWCXAHaMBcEP7ayxHxmDnD2T1R",
+                  "txDigest": "HzTi7BC8QyKBMEbcLMUF7H219B1LXC1EaE7hhCCQArJa",
                   "id": {
-                    "txDigest": "JUYYqipgFGhPNRTdjtWCXAHaMBcEP7ayxHxmDnD2T1R",
+                    "txDigest": "HzTi7BC8QyKBMEbcLMUF7H219B1LXC1EaE7hhCCQArJa",
                     "eventSeq": 0
                   },
                   "event": {
                     "transferObject": {
                       "packageId": "0x0000000000000000000000000000000000000000000000000000000000000002",
                       "transactionModule": "native",
-                      "sender": "0xcb48bf478c14ef34f447cc36adc0095f6b3765a96a157f8db7f34dbe728797b3",
+                      "sender": "0x07579d9f6ba8ea13152dbcdac21159552dfbe58a18b3648e440a692e72767239",
                       "recipient": {
-                        "AddressOwner": "0xf1de0eae420a2e4ae1bb772ab2dd5d5a7dfa949c0ef06908e7a54900f279be4c"
+                        "AddressOwner": "0x6a101e9a3af5c8070112f808648b36efbf8dee8a1a82de46d9504e96a1108a17"
                       },
                       "objectType": "0x2::example::Object",
-                      "objectId": "0x6a101e9a3af5c8070112f808648b36efbf8dee8a1a82de46d9504e96a1108a17",
+                      "objectId": "0x8ef76f56c399633a2eb310bca9124e5f2f38ce739eaacbb6600688804e078448",
                       "version": 2
                     }
                   }
@@ -1650,22 +1651,23 @@
                     "digest": "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi"
                   }
                 },
-                "events": [
-                  {
-                    "transferObject": {
-                      "packageId": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                      "transactionModule": "native",
-                      "sender": "0xf6f0ade7cd7d4c2ca2c1ad25115b06135dd146bd595eb56e4a30e1cd1aad862c",
-                      "recipient": {
-                        "AddressOwner": "0x64bb73a1ed58b2c18b0cbf377792e206e6b80d4d5eea64e2e70563b1589026c4"
-                      },
-                      "objectType": "0x2::example::Object",
-                      "objectId": "0xe37f941a451ef8209a0fbfbf1b549b2bb26b8eaee08895146df27bc3cf2610c1",
-                      "version": 2
-                    }
-                  }
-                ]
+                "eventsDigest": "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2"
               },
+              "events": [
+                {
+                  "transferObject": {
+                    "packageId": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    "transactionModule": "native",
+                    "sender": "0xf6f0ade7cd7d4c2ca2c1ad25115b06135dd146bd595eb56e4a30e1cd1aad862c",
+                    "recipient": {
+                      "AddressOwner": "0x64bb73a1ed58b2c18b0cbf377792e206e6b80d4d5eea64e2e70563b1589026c4"
+                    },
+                    "objectType": "0x2::example::Object",
+                    "objectId": "0xe37f941a451ef8209a0fbfbf1b549b2bb26b8eaee08895146df27bc3cf2610c1",
+                    "version": 2
+                  }
+                }
+              ],
               "checkpoint": null
             }
           }
@@ -1727,12 +1729,12 @@
             {
               "name": "query",
               "value": {
-                "InputObject": "0xfc00ffcda00afc5ea9e39cb2f232525cdceea35a433a7b0f50e8dfb2e21ba497"
+                "InputObject": "0xc54ab30a3d9adc07c1429c4d6bbecaf9457c9af77a91f631760853934d383634"
               }
             },
             {
               "name": "cursor",
-              "value": "EH9P6ZppBPmi2H5wpDZP7ybMLhLnVW6ZKgCZcNjDnncj"
+              "value": "DiemdKPLqS6GKyWoJqnqm18m3KmHTW2a516RfvZ6ETSX"
             },
             {
               "name": "limit",
@@ -1747,11 +1749,11 @@
             "name": "Result",
             "value": {
               "data": [
-                "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2",
                 "8QrPa4x9iNG5r2zQfmeH8pJoVjjtq9AGzp8rp2fxi8Sk",
-                "3nek86HEjXZ7K3EtrAcBG4wMrCS21gqr8BqwwC6M6P7F"
+                "3nek86HEjXZ7K3EtrAcBG4wMrCS21gqr8BqwwC6M6P7F",
+                "AvLgYFSEW12Ac2uBFYcbznKdBj9CowNrpBuHMq53f8mu"
               ],
-              "nextCursor": "AvLgYFSEW12Ac2uBFYcbznKdBj9CowNrpBuHMq53f8mu"
+              "nextCursor": "HxidAfFfyr4kXSiWeVq1J6Tk526YUVDoSUY5PSnS4tEJ"
             }
           }
         }
@@ -2535,12 +2537,12 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AAAEFnDhYJ23FOmFjJbp5GmFXxzzv9+X6GWxDABG4pPAjOwPQHg9msS/SrtNf4IGR/2F0ZGD3ufH/5VWl/4rcEyVAgAAAAAAAAAgXLq9w2zxufLshIGibKfYEWlVl5QCi48C5DAqVZXYiJo7gTKqACtsiGty0eYJF8Cbyj8iU8jqsqc8xrRKhddEK0CjhG6SmLddtyXB7jAnt4PqaJ4aOOtHbG78RO21zT3+AgAAAAAAAAAgMvS/bD6KxC7vE4XgFAPkmkspatyyLqJ9PJLkziJWrGQ7gTKqACtsiGty0eYJF8Cbyj8iU8jqsqc8xrRKhddEKwEAAAAAAAAA6AMAAAAAAAAA"
+              "value": "AAAy9L9sPorELu8TheAUA+SaSylq3LIuon08kuTOIlasZFy6vcNs8bny7ISBomyn2BFpVZeUAouPAuQwKlWV2IiaAgAAAAAAAAAgLEOAXQ1vVAKnrQ2lvexUnHzeoGvEodM5oiUh7qkzuInTBWxU38/Wzpg7ga1fbxcalrZhjj8rLo7egQ86U3GPP2fG0xxslw5WfwPvZ9gRpPhDZluN4/KC+kiz4BA7qbvtAgAAAAAAAAAgagYVO5/EhuEB8OnicDrIZm0GrsxN3355JqNhlwxlpbHTBWxU38/Wzpg7ga1fbxcalrZhjj8rLo7egQ86U3GPPwEAAAAAAAAA6AMAAAAAAAAA"
             },
             {
               "name": "signatures",
               "value": [
-                "AOnbe8dwcE329ge0soWHT+e/VSQkEaUTxS/vwW/uJ+Yeaon+u3lQDUdKM+EzTB5u54bk9nlO8TDUm7FpfdTq9Qq3vgOHjFO7cZ6EOYXvUhLPEKgiiTaG+mi4TA+ThLEVrw=="
+                "ANz1nc//IojONTcCQoBBkZPEoxhksBhL7jqy/JOSIMX9DPjIcAAEOJceXRDhHWGf1sxYS2QXeO/fVrJACZ7VFASRFyzRWy5Z5Iom1zB2m6Vx2RU7g7aQu+hOm3dBh5doKQ=="
               ]
             },
             {
@@ -2556,29 +2558,29 @@
                   "transactions": [
                     {
                       "TransferObject": {
-                        "recipient": "0x041670e1609db714e9858c96e9e469855f1cf3bfdf97e865b10c0046e293c08c",
+                        "recipient": "0x32f4bf6c3e8ac42eef1385e01403e49a4b296adcb22ea27d3c92e4ce2256ac64",
                         "objectRef": {
-                          "objectId": "0xec0f40783d9ac4bf4abb4d7f820647fd85d19183dee7c7ff955697fe2b704c95",
+                          "objectId": "0x5cbabdc36cf1b9f2ec8481a26ca7d81169559794028b8f02e4302a5595d8889a",
                           "version": 2,
-                          "digest": "7EyfTiUYik55JWka5aGUkSFMCQeLzGnUM7wT8AYMh71b"
+                          "digest": "3yndxsmJNXFrRAUnuqKT6aekThhqmSDJ46opD7UjtL9N"
                         }
                       }
                     }
                   ],
-                  "sender": "0x3b8132aa002b6c886b72d1e60917c09bca3f2253c8eab2a73cc6b44a85d7442b",
+                  "sender": "0xd3056c54dfcfd6ce983b81ad5f6f171a96b6618e3f2b2e8ede810f3a53718f3f",
                   "gasData": {
                     "payment": {
-                      "objectId": "0x40a3846e9298b75db725c1ee3027b783ea689e1a38eb476c6efc44edb5cd3dfe",
+                      "objectId": "0x67c6d31c6c970e567f03ef67d811a4f843665b8de3f282fa48b3e0103ba9bbed",
                       "version": 2,
-                      "digest": "4RuqnEzNdF4nKWjW1MhnKQ1E6sijZvSM5dUNgiPmjme3"
+                      "digest": "88sbZ6JronTqbQUL25HUPouw9wJJRiSKtUjry81YgPDS"
                     },
-                    "owner": "0x3b8132aa002b6c886b72d1e60917c09bca3f2253c8eab2a73cc6b44a85d7442b",
+                    "owner": "0xd3056c54dfcfd6ce983b81ad5f6f171a96b6618e3f2b2e8ede810f3a53718f3f",
                     "price": 1,
                     "budget": 1000
                   }
                 },
                 "txSignatures": [
-                  "AOnbe8dwcE329ge0soWHT+e/VSQkEaUTxS/vwW/uJ+Yeaon+u3lQDUdKM+EzTB5u54bk9nlO8TDUm7FpfdTq9Qq3vgOHjFO7cZ6EOYXvUhLPEKgiiTaG+mi4TA+ThLEVrw=="
+                  "ANz1nc//IojONTcCQoBBkZPEoxhksBhL7jqy/JOSIMX9DPjIcAAEOJceXRDhHWGf1sxYS2QXeO/fVrJACZ7VFASRFyzRWy5Z5Iom1zB2m6Vx2RU7g7aQu+hOm3dBh5doKQ=="
                 ]
               },
               "effects": {
@@ -2591,55 +2593,56 @@
                   "storageCost": 100,
                   "storageRebate": 10
                 },
-                "transactionDigest": "7z6qPvSvB629YJdVvCxF4nG35Lm1CQeFeU9GSMMc6wFr",
+                "transactionDigest": "BhbWpBeESxuRWvmvLMyb2JNUuFa6j4aG1T4WUiPgKAHm",
                 "mutated": [
                   {
                     "owner": {
-                      "AddressOwner": "0x3b8132aa002b6c886b72d1e60917c09bca3f2253c8eab2a73cc6b44a85d7442b"
+                      "AddressOwner": "0xd3056c54dfcfd6ce983b81ad5f6f171a96b6618e3f2b2e8ede810f3a53718f3f"
                     },
                     "reference": {
-                      "objectId": "0x40a3846e9298b75db725c1ee3027b783ea689e1a38eb476c6efc44edb5cd3dfe",
+                      "objectId": "0x67c6d31c6c970e567f03ef67d811a4f843665b8de3f282fa48b3e0103ba9bbed",
                       "version": 2,
-                      "digest": "4RuqnEzNdF4nKWjW1MhnKQ1E6sijZvSM5dUNgiPmjme3"
+                      "digest": "88sbZ6JronTqbQUL25HUPouw9wJJRiSKtUjry81YgPDS"
                     }
                   },
                   {
                     "owner": {
-                      "AddressOwner": "0x041670e1609db714e9858c96e9e469855f1cf3bfdf97e865b10c0046e293c08c"
+                      "AddressOwner": "0x32f4bf6c3e8ac42eef1385e01403e49a4b296adcb22ea27d3c92e4ce2256ac64"
                     },
                     "reference": {
-                      "objectId": "0xec0f40783d9ac4bf4abb4d7f820647fd85d19183dee7c7ff955697fe2b704c95",
+                      "objectId": "0x5cbabdc36cf1b9f2ec8481a26ca7d81169559794028b8f02e4302a5595d8889a",
                       "version": 2,
-                      "digest": "7EyfTiUYik55JWka5aGUkSFMCQeLzGnUM7wT8AYMh71b"
+                      "digest": "3yndxsmJNXFrRAUnuqKT6aekThhqmSDJ46opD7UjtL9N"
                     }
                   }
                 ],
                 "gasObject": {
                   "owner": {
-                    "ObjectOwner": "0x3b8132aa002b6c886b72d1e60917c09bca3f2253c8eab2a73cc6b44a85d7442b"
+                    "ObjectOwner": "0xd3056c54dfcfd6ce983b81ad5f6f171a96b6618e3f2b2e8ede810f3a53718f3f"
                   },
                   "reference": {
-                    "objectId": "0x40a3846e9298b75db725c1ee3027b783ea689e1a38eb476c6efc44edb5cd3dfe",
+                    "objectId": "0x67c6d31c6c970e567f03ef67d811a4f843665b8de3f282fa48b3e0103ba9bbed",
                     "version": 2,
-                    "digest": "4RuqnEzNdF4nKWjW1MhnKQ1E6sijZvSM5dUNgiPmjme3"
+                    "digest": "88sbZ6JronTqbQUL25HUPouw9wJJRiSKtUjry81YgPDS"
                   }
                 },
-                "events": [
-                  {
-                    "transferObject": {
-                      "packageId": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                      "transactionModule": "native",
-                      "sender": "0x3b8132aa002b6c886b72d1e60917c09bca3f2253c8eab2a73cc6b44a85d7442b",
-                      "recipient": {
-                        "AddressOwner": "0x041670e1609db714e9858c96e9e469855f1cf3bfdf97e865b10c0046e293c08c"
-                      },
-                      "objectType": "0x2::example::Object",
-                      "objectId": "0xec0f40783d9ac4bf4abb4d7f820647fd85d19183dee7c7ff955697fe2b704c95",
-                      "version": 2
-                    }
-                  }
-                ]
+                "eventsDigest": "GdfET1avZReDftpJNB8LSuHJ2cKUheSbEaLMzuPVXHsM"
               },
+              "events": [
+                {
+                  "transferObject": {
+                    "packageId": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    "transactionModule": "native",
+                    "sender": "0xd3056c54dfcfd6ce983b81ad5f6f171a96b6618e3f2b2e8ede810f3a53718f3f",
+                    "recipient": {
+                      "AddressOwner": "0x32f4bf6c3e8ac42eef1385e01403e49a4b296adcb22ea27d3c92e4ce2256ac64"
+                    },
+                    "objectType": "0x2::example::Object",
+                    "objectId": "0x5cbabdc36cf1b9f2ec8481a26ca7d81169559794028b8f02e4302a5595d8889a",
+                    "version": 2
+                  }
+                }
+              ],
               "checkpoint": null
             }
           }
@@ -3392,6 +3395,7 @@
         "type": "object",
         "required": [
           "effects",
+          "events",
           "results"
         ],
         "properties": {
@@ -3403,6 +3407,13 @@
               }
             ]
           },
+          "events": {
+            "description": "Events that likely would be generated if the transaction is actually run.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Event"
+            }
+          },
           "results": {
             "description": "Execution results (including return values) from executing the transactions Currently contains only return values from Move calls",
             "allOf": [
@@ -3410,6 +3421,24 @@
                 "$ref": "#/components/schemas/Result_of_Array_of_Tuple_of_uint_and_SuiExecutionResult_or_String"
               }
             ]
+          }
+        }
+      },
+      "DryRunTransactionResponse": {
+        "type": "object",
+        "required": [
+          "effects",
+          "events"
+        ],
+        "properties": {
+          "effects": {
+            "$ref": "#/components/schemas/TransactionEffects"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Event"
+            }
           }
         }
       },
@@ -6155,6 +6184,7 @@
         "type": "object",
         "required": [
           "effects",
+          "events",
           "transaction"
         ],
         "properties": {
@@ -6175,6 +6205,12 @@
           },
           "effects": {
             "$ref": "#/components/schemas/TransactionEffects"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Event"
+            }
           },
           "timestampMs": {
             "type": [
@@ -6345,12 +6381,14 @@
         ],
         "properties": {
           "created": {
+            "description": "ObjectRef and owner of new objects created.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/OwnedObjectRef"
             }
           },
           "deleted": {
+            "description": "Object Refs of objects now deleted (the old refs).",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectRef"
@@ -6363,12 +6401,16 @@
               "$ref": "#/components/schemas/TransactionDigest"
             }
           },
-          "events": {
-            "description": "The events emitted during execution. Note that only successful transactions emit events",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Event"
-            }
+          "eventsDigest": {
+            "description": "The digest of the events emitted during execution, can be None if the transaction does not emmit any event.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TransactionEventsDigest"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "executedEpoch": {
             "description": "The epoch when this transaction was executed.",
@@ -6377,30 +6419,48 @@
             "minimum": 0.0
           },
           "gasObject": {
-            "$ref": "#/components/schemas/OwnedObjectRef"
+            "description": "The updated gas object reference. Have a dedicated field for convenient access. It's also included in mutated.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OwnedObjectRef"
+              }
+            ]
           },
           "gasUsed": {
             "$ref": "#/components/schemas/GasCostSummary"
           },
           "mutated": {
+            "description": "ObjectRef and owner of mutated objects, including gas object.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/OwnedObjectRef"
             }
           },
           "sharedObjects": {
+            "description": "The object references of the shared objects used in this transaction. Empty if no shared objects were used.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectRef"
             }
           },
           "status": {
-            "$ref": "#/components/schemas/ExecutionStatus"
+            "description": "The status of the execution",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExecutionStatus"
+              }
+            ]
           },
           "transactionDigest": {
-            "$ref": "#/components/schemas/TransactionDigest"
+            "description": "The transaction digest",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionDigest"
+              }
+            ]
           },
           "unwrapped": {
+            "description": "ObjectRef and owner of objects that are unwrapped in this transaction. Unwrapped objects are objects that were wrapped into other objects in the past, and just got extracted out.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/OwnedObjectRef"
@@ -6414,6 +6474,7 @@
             }
           },
           "wrapped": {
+            "description": "Object refs of objects now wrapped in other objects.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ObjectRef"
@@ -6422,6 +6483,9 @@
         }
       },
       "TransactionEffectsDigest": {
+        "$ref": "#/components/schemas/Sha3Digest"
+      },
+      "TransactionEventsDigest": {
         "$ref": "#/components/schemas/Sha3Digest"
       },
       "TransactionKind": {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -19,14 +19,15 @@ use sui_json_rpc_types::{
     RPCTransactionRequestParams, SuiData, SuiEvent, SuiEventEnvelope, SuiExecutionStatus,
     SuiGasCostSummary, SuiObject, SuiObjectInfo, SuiObjectRead, SuiObjectRef, SuiParsedData,
     SuiPastObjectRead, SuiRawData, SuiRawMoveObject, SuiTransaction, SuiTransactionData,
-    SuiTransactionEffects, SuiTransactionResponse, TransactionBytes, TransactionsPage,
-    TransferObjectParams,
+    SuiTransactionEffects, SuiTransactionEvents, SuiTransactionResponse, TransactionBytes,
+    TransactionsPage, TransferObjectParams,
 };
 use sui_open_rpc::ExamplePairing;
 use sui_types::base_types::{
     ObjectDigest, ObjectID, ObjectType, SequenceNumber, SuiAddress, TransactionDigest,
 };
 use sui_types::crypto::{get_key_pair_from_rng, AccountKeyPair};
+use sui_types::digests::TransactionEventsDigest;
 use sui_types::event::EventID;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
@@ -480,8 +481,11 @@ impl RpcExampleProvider {
                     owner: Owner::ObjectOwner(signer),
                     reference: SuiObjectRef::from(gas_ref),
                 },
-                events: vec![sui_event],
+                events_digest: Some(TransactionEventsDigest::new(self.rng.gen())),
                 dependencies: vec![],
+            },
+            events: SuiTransactionEvents {
+                data: vec![sui_event],
             },
             timestamp_ms: None,
             transaction: SuiTransaction {

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -271,7 +271,7 @@ pub async fn metadata(
         })?;
     let dry_run = context.client.read_api().dry_run_transaction(data).await?;
 
-    let budget = dry_run.gas_used.computation_cost + dry_run.gas_used.storage_cost;
+    let budget = dry_run.effects.gas_used.computation_cost + dry_run.effects.gas_used.storage_cost;
 
     Ok(ConstructionMetadataResponse {
         metadata: ConstructionMetadata {

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -334,7 +334,7 @@ impl TryFrom<SuiTransactionResponse> for Operations {
 
         // Extract coin change operations from events
         let coin_change_operations = Self::get_balance_operation_from_events(
-            &response.effects.events,
+            &response.events.data,
             status,
             accounted_balances,
         );

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sui_json_rpc::api::GovernanceReadApiClient;
 use sui_json_rpc_types::{
-    Balance, Checkpoint, CheckpointId, Coin, CoinPage, DynamicFieldPage, EventPage,
-    GetObjectDataResponse, GetPastObjectDataResponse, GetRawObjectDataResponse, SuiCoinMetadata,
-    SuiEventEnvelope, SuiEventFilter, SuiMoveNormalizedModule, SuiObjectInfo,
-    SuiTransactionEffects, SuiTransactionResponse, TransactionsPage,
+    Balance, Checkpoint, CheckpointId, Coin, CoinPage, DryRunTransactionResponse, DynamicFieldPage,
+    EventPage, GetObjectDataResponse, GetPastObjectDataResponse, GetRawObjectDataResponse,
+    SuiCoinMetadata, SuiEventEnvelope, SuiEventFilter, SuiMoveNormalizedModule, SuiObjectInfo,
+    SuiTransactionResponse, TransactionsPage,
 };
 use sui_types::balance::Supply;
 use sui_types::base_types::{
@@ -202,7 +202,7 @@ impl ReadApi {
     pub async fn dry_run_transaction(
         &self,
         tx: TransactionData,
-    ) -> SuiRpcResult<SuiTransactionEffects> {
+    ) -> SuiRpcResult<DryRunTransactionResponse> {
         Ok(self
             .api
             .http

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -26,7 +26,6 @@ use sui_json_rpc_types::{GetRawObjectDataResponse, SuiObjectInfo};
 use sui_transaction_builder::{DataReader, TransactionBuilder};
 pub use sui_types as types;
 use sui_types::base_types::{ObjectID, SuiAddress};
-
 pub mod apis;
 pub mod error;
 pub const SUI_COIN_TYPE: &str = "0x2::sui::SUI";

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -323,7 +323,7 @@ pub async fn get_transaction(tx_digest: TransactionDigest, genesis: PathBuf) -> 
                 r.2.as_ref()
                     .map(|ok_result| match &ok_result.status {
                         TransactionStatus::Signed(_) => None,
-                        TransactionStatus::Executed(_, effects) => Some(effects.digest()),
+                        TransactionStatus::Executed(_, effects, _) => Some(effects.digest()),
                     })
                     .ok();
             (key, r)
@@ -332,7 +332,9 @@ pub async fn get_transaction(tx_digest: TransactionDigest, genesis: PathBuf) -> 
         .group_by(|(_, r)| {
             r.2.as_ref().map(|ok_result| match &ok_result.status {
                 TransactionStatus::Signed(_) => None,
-                TransactionStatus::Executed(_, effects) => Some((effects.data(), effects.digest())),
+                TransactionStatus::Executed(_, effects, _) => {
+                    Some((effects.data(), effects.digest()))
+                }
             })
         });
     let mut s = String::new();

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -594,7 +594,6 @@ impl<'a> SuiTestAdapter<'a> {
             inner,
             TransactionEffects {
                 status,
-                events,
                 created,
                 mutated,
                 unwrapped,
@@ -662,7 +661,7 @@ impl<'a> SuiTestAdapter<'a> {
                 created: created_ids,
                 written: written_ids,
                 deleted: deleted_ids,
-                events,
+                events: inner.events.data,
             }),
             ExecutionStatus::Failure { error, .. } => {
                 Err(anyhow::anyhow!(self.stabilize_str(format!(

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1463,6 +1463,7 @@ mod bcs_signable {
 
     impl BcsSignable for crate::messages::CommitteeInfoResponse {}
     impl BcsSignable for crate::messages::TransactionEffects {}
+    impl BcsSignable for crate::messages::TransactionEvents {}
     impl BcsSignable for crate::messages::TransactionData {}
     impl BcsSignable for crate::messages::SenderSignedData {}
     impl BcsSignable for crate::object::Object {}

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -468,6 +468,30 @@ impl fmt::UpperHex for TransactionEffectsDigest {
     }
 }
 
+#[serde_as]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, JsonSchema)]
+pub struct TransactionEventsDigest(Sha3Digest);
+
+impl TransactionEventsDigest {
+    pub const ZERO: Self = Self(Sha3Digest::ZERO);
+
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(Sha3Digest::new(digest))
+    }
+
+    pub fn random() -> Self {
+        Self(Sha3Digest::random())
+    }
+}
+
+impl fmt::Debug for TransactionEventsDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TransactionEventsDigest")
+            .field(&self.0)
+            .finish()
+    }
+}
+
 // Each object has a unique digest
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema)]
 pub struct ObjectDigest(Sha3Digest);

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -43,6 +43,7 @@ macro_rules! fp_ensure {
         }
     };
 }
+use crate::digests::TransactionEventsDigest;
 pub(crate) use fp_ensure;
 
 #[macro_export]
@@ -283,6 +284,8 @@ pub enum SuiError {
     },
     #[error("{TRANSACTION_NOT_FOUND_MSG_PREFIX} [{:?}].", digest)]
     TransactionNotFound { digest: TransactionDigest },
+    #[error("Could not find the referenced transaction events [{digest:?}].")]
+    TransactionEventsNotFound { digest: TransactionEventsDigest },
     #[error(
         "Attempt to move to `Executed` state an transaction that has already been executed: {:?}.",
         digest

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -8,6 +8,7 @@ use crate::crypto::{
     sha3_hash, AuthoritySignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo,
     Ed25519SuiSignature, EmptySignInfo, Signature, Signer, SuiSignatureInner, ToFromBytes,
 };
+use crate::digests::TransactionEventsDigest;
 use crate::gas::GasCostSummary;
 use crate::intent::{Intent, IntentMessage, IntentScope};
 use crate::message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope};
@@ -1687,7 +1688,11 @@ pub type SignedTransaction = Envelope<SenderSignedData, AuthoritySignInfo>;
 pub type VerifiedSignedTransaction = VerifiedEnvelope<SenderSignedData, AuthoritySignInfo>;
 
 pub type CertifiedTransaction = Envelope<SenderSignedData, AuthorityStrongQuorumSignInfo>;
-pub type TxCertAndSignedEffects = (CertifiedTransaction, SignedTransactionEffects);
+pub type TxCertAndSignedEffects = (
+    CertifiedTransaction,
+    SignedTransactionEffects,
+    TransactionEvents,
+);
 
 pub type VerifiedCertificate = VerifiedEnvelope<SenderSignedData, AuthorityStrongQuorumSignInfo>;
 pub type TrustedCertificate = TrustedEnvelope<SenderSignedData, AuthorityStrongQuorumSignInfo>;
@@ -1796,6 +1801,7 @@ pub enum TransactionStatus {
     Executed(
         Option<AuthorityStrongQuorumSignInfo>,
         SignedTransactionEffects,
+        TransactionEvents,
     ),
 }
 
@@ -1809,7 +1815,7 @@ impl TransactionStatus {
 
     pub fn into_effects_for_testing(self) -> SignedTransactionEffects {
         match self {
-            Self::Executed(_, e) => e,
+            Self::Executed(_, e, _) => e,
             _ => unreachable!("Incorrect response type"),
         }
     }
@@ -1822,11 +1828,12 @@ impl PartialEq for TransactionStatus {
                 Self::Signed(s2) => s1.epoch == s2.epoch,
                 _ => false,
             },
-            Self::Executed(c1, e1) => match other {
-                Self::Executed(c2, e2) => {
+            Self::Executed(c1, e1, ev1) => match other {
+                Self::Executed(c2, e2, ev2) => {
                     c1.as_ref().map(|a| a.epoch) == c2.as_ref().map(|a| a.epoch)
                         && e1.epoch() == e2.epoch()
                         && e1.digest() == e2.digest()
+                        && ev1.digest() == ev2.digest()
                 }
                 _ => false,
             },
@@ -1847,16 +1854,24 @@ pub struct TransactionInfoResponse {
 #[derive(Clone, Debug)]
 pub enum VerifiedTransactionInfoResponse {
     Signed(VerifiedSignedTransaction),
-    ExecutedWithCert(VerifiedCertificate, VerifiedSignedTransactionEffects),
-    ExecutedWithoutCert(VerifiedTransaction, VerifiedSignedTransactionEffects),
+    ExecutedWithCert(
+        VerifiedCertificate,
+        VerifiedSignedTransactionEffects,
+        TransactionEvents,
+    ),
+    ExecutedWithoutCert(
+        VerifiedTransaction,
+        VerifiedSignedTransactionEffects,
+        TransactionEvents,
+    ),
 }
 
 impl VerifiedTransactionInfoResponse {
     pub fn is_executed(&self) -> bool {
         match self {
             VerifiedTransactionInfoResponse::Signed(_) => false,
-            VerifiedTransactionInfoResponse::ExecutedWithCert(_, _)
-            | VerifiedTransactionInfoResponse::ExecutedWithoutCert(_, _) => true,
+            VerifiedTransactionInfoResponse::ExecutedWithCert(_, _, _)
+            | VerifiedTransactionInfoResponse::ExecutedWithoutCert(_, _, _) => true,
         }
     }
 }
@@ -1865,11 +1880,13 @@ impl VerifiedTransactionInfoResponse {
 pub struct HandleCertificateResponse {
     pub signed_effects: SignedTransactionEffects,
     // TODO: Add a case for finalized transaction.
+    pub events: TransactionEvents,
 }
 
 #[derive(Clone, Debug)]
 pub struct VerifiedHandleCertificateResponse {
     pub signed_effects: VerifiedSignedTransactionEffects,
+    pub events: TransactionEvents,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
@@ -2471,8 +2488,9 @@ pub struct TransactionEffects {
     /// The updated gas object reference. Have a dedicated field for convenient access.
     /// It's also included in mutated.
     pub gas_object: (ObjectRef, Owner),
-    /// The events emitted during execution. Note that only successful transactions emit events
-    pub events: Vec<Event>,
+    /// The digest of the events emitted during execution,
+    /// can be None if the transaction does not emmit any event.
+    pub events_digest: Option<TransactionEventsDigest>,
     /// The set of transaction digests this transaction depends on.
     pub dependencies: Vec<TransactionDigest>,
 }
@@ -2536,9 +2554,19 @@ impl TransactionEffects {
             unwrapped_object_count: self.unwrapped.len(),
             deleted_object_count: self.deleted.len(),
             wrapped_object_count: self.wrapped.len(),
-            event_count: self.events.len(),
             dependency_count: self.dependencies.len(),
         }
+    }
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Default)]
+pub struct TransactionEvents {
+    pub data: Vec<Event>,
+}
+
+impl TransactionEvents {
+    pub fn digest(&self) -> TransactionEventsDigest {
+        TransactionEventsDigest::new(sha3_hash(self))
     }
 }
 
@@ -2616,7 +2644,7 @@ impl Default for TransactionEffects {
                 random_object_ref(),
                 Owner::AddressOwner(SuiAddress::default()),
             ),
-            events: Vec::new(),
+            events_digest: None,
             dependencies: Vec::new(),
         }
     }
@@ -2634,7 +2662,6 @@ pub struct TransactionEffectsDebugSummary {
     pub unwrapped_object_count: usize,
     pub deleted_object_count: usize,
     pub wrapped_object_count: usize,
-    pub event_count: usize,
     pub dependency_count: usize,
     // TODO: Add deleted_and_unwrapped_object_count and event digest.
 }
@@ -3065,7 +3092,13 @@ pub type IsTransactionExecutedLocally = bool;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ExecuteTransactionResponse {
-    EffectsCert(Box<(FinalizedEffects, IsTransactionExecutedLocally)>),
+    EffectsCert(
+        Box<(
+            FinalizedEffects,
+            TransactionEvents,
+            IsTransactionExecutedLocally,
+        )>,
+    ),
 }
 
 #[derive(Clone, Debug)]
@@ -3076,6 +3109,7 @@ pub struct QuorumDriverRequest {
 #[derive(Debug, Clone)]
 pub struct QuorumDriverResponse {
     pub effects_cert: VerifiedCertifiedTransactionEffects,
+    pub events: TransactionEvents,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -17,6 +17,7 @@ use tracing::trace;
 use crate::coin::Coin;
 use crate::committee::EpochId;
 use crate::event::BalanceChangeType;
+use crate::messages::TransactionEvents;
 use crate::storage::{ObjectStore, SingleTxContext};
 use crate::sui_system_state::{get_sui_system_state, SuiSystemState};
 use crate::{
@@ -43,6 +44,7 @@ pub struct InnerTemporaryStore {
     pub mutable_inputs: Vec<ObjectRef>,
     pub written: BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
     pub deleted: BTreeMap<ObjectID, (SequenceNumber, DeleteKind)>,
+    pub events: TransactionEvents,
 }
 
 impl InnerTemporaryStore {
@@ -169,7 +171,7 @@ impl<S> TemporaryStore<S> {
     }
 
     /// Break up the structure and return its internal stores (objects, active_inputs, written, deleted)
-    pub fn into_inner(self) -> (InnerTemporaryStore, Vec<Event>) {
+    pub fn into_inner(self) -> InnerTemporaryStore {
         #[cfg(debug_assertions)]
         {
             self.check_invariants();
@@ -272,13 +274,13 @@ impl<S> TemporaryStore<S> {
         // Combine object events with move events.
         events.extend(self.events);
 
-        let store = InnerTemporaryStore {
+        InnerTemporaryStore {
             objects: self.input_objects,
             mutable_inputs: self.mutable_input_refs,
             written,
             deleted,
-        };
-        (store, events)
+            events: TransactionEvents { data: events },
+        }
     }
 
     fn create_written_events(
@@ -553,7 +555,7 @@ impl<S> TemporaryStore<S> {
             modified_at_versions.push((*id, *version));
         });
 
-        let (inner, events) = self.into_inner();
+        let inner = self.into_inner();
 
         // In the case of special transactions that don't require a gas object,
         // we don't really care about the effects to gas, just use the input for it.
@@ -608,7 +610,11 @@ impl<S> TemporaryStore<S> {
             unwrapped_then_deleted,
             wrapped,
             gas_object: updated_gas_object_info,
-            events,
+            events_digest: if inner.events.data.is_empty() {
+                None
+            } else {
+                Some(inner.events.digest())
+            },
             dependencies: transaction_dependencies,
         };
         (inner, effects)

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -113,7 +113,7 @@ async fn reconfig_with_revert_end_to_end_test() {
         .await
         .unwrap()
         .into_cert_for_testing();
-    let effects1 = net
+    let (effects1, _) = net
         .process_certificate(cert.clone().into_inner())
         .await
         .unwrap();
@@ -297,7 +297,7 @@ async fn test_validator_resign_effects() {
         .await
         .unwrap()
         .into_cert_for_testing();
-    let effects0 = net
+    let (effects0, _) = net
         .process_certificate(cert.clone().into_inner())
         .await
         .unwrap();
@@ -307,7 +307,7 @@ async fn test_validator_resign_effects() {
     trigger_reconfiguration(&authorities).await;
     // Manually reconfigure the aggregator.
     net.committee.epoch = 1;
-    let effects1 = net.process_certificate(cert.into_inner()).await.unwrap();
+    let (effects1, _) = net.process_certificate(cert.into_inner()).await.unwrap();
     // Ensure that we are able to form a new effects cert in the new epoch.
     assert_eq!(effects1.epoch(), 1);
     assert_eq!(effects0.into_message(), effects1.into_message());

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -89,7 +89,7 @@ async fn call_shared_object_contract() {
         package_id,
         /* arguments */ Vec::default(),
     );
-    let effects = submit_single_owner_transaction(transaction, &configs.validator_set()).await;
+    let (effects, _) = submit_single_owner_transaction(transaction, &configs.validator_set()).await;
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
     let counter_creation_transaction = effects.transaction_digest;
     let ((counter_id, counter_initial_shared_version, _), _) = effects.created[0];
@@ -117,7 +117,7 @@ async fn call_shared_object_contract() {
                 CallArg::Pure(0u64.to_le_bytes().to_vec()),
             ],
         );
-        let effects = submit_shared_object_transaction(transaction, &configs.validator_set())
+        let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
             .await
             .unwrap();
         assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
@@ -136,7 +136,7 @@ async fn call_shared_object_contract() {
         package_id,
         vec![CallArg::Object(counter_object_arg)],
     );
-    let effects = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
         .await
         .unwrap();
     let increment_transaction = effects.transaction_digest;
@@ -165,7 +165,7 @@ async fn call_shared_object_contract() {
                 CallArg::Pure(1u64.to_le_bytes().to_vec()),
             ],
         );
-        let effects = submit_shared_object_transaction(transaction, &configs.validator_set())
+        let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
             .await
             .unwrap();
         assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
@@ -185,7 +185,7 @@ async fn call_shared_object_contract() {
         package_id,
         vec![CallArg::Object(counter_object_arg_imm)],
     );
-    let effects = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
         .await
         .unwrap();
     // Transaction fails
@@ -234,7 +234,7 @@ async fn access_clock_object_test() {
     let start = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
-    let effects = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, events) = submit_shared_object_transaction(transaction, &configs.validator_set())
         .await
         .unwrap();
     let finish = SystemTime::now()
@@ -242,8 +242,8 @@ async fn access_clock_object_test() {
         .unwrap();
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
 
-    assert_eq!(2, effects.events.len());
-    let event = effects.events.get(1).unwrap();
+    assert_eq!(2, events.data.len());
+    let event = events.data.get(1).unwrap();
     let Event::MoveEvent { contents, .. } = event else { panic!("Expected move event, got {:?}", event) };
 
     use serde::{Deserialize, Serialize};
@@ -306,7 +306,7 @@ async fn shared_object_flood() {
         package_id,
         /* arguments */ Vec::default(),
     );
-    let effects = submit_single_owner_transaction(transaction, &configs.validator_set()).await;
+    let (effects, _) = submit_single_owner_transaction(transaction, &configs.validator_set()).await;
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
     let ((counter_id, counter_initial_shared_version, _), _) = effects.created[0];
     let counter_object_arg = ObjectArg::SharedObject {
@@ -326,7 +326,7 @@ async fn shared_object_flood() {
             CallArg::Pure(0u64.to_le_bytes().to_vec()),
         ],
     );
-    let effects = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
         .await
         .unwrap();
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
@@ -339,7 +339,7 @@ async fn shared_object_flood() {
         package_id,
         vec![CallArg::Object(counter_object_arg)],
     );
-    let effects = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
         .await
         .unwrap();
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
@@ -355,7 +355,7 @@ async fn shared_object_flood() {
             CallArg::Pure(1u64.to_le_bytes().to_vec()),
         ],
     );
-    let effects = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
         .await
         .unwrap();
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
@@ -394,7 +394,7 @@ async fn shared_object_sync() {
             ) > 0
         });
 
-    let effects = submit_single_owner_transaction(
+    let (effects, _) = submit_single_owner_transaction(
         create_counter_transaction.clone(),
         //&configs.validator_set()[1..],
         &slow_validators,
@@ -440,7 +440,7 @@ async fn shared_object_sync() {
     );
 
     // Let's submit the transaction to the original set of validators.
-    let effects = submit_shared_object_transaction(
+    let (effects, _) = submit_shared_object_transaction(
         increment_counter_transaction.clone(),
         &configs.validator_set()[1..],
     )
@@ -450,7 +450,7 @@ async fn shared_object_sync() {
 
     // Submit transactions to the out-of-date authority.
     // It will succeed because we share owned object certificates through narwhal
-    let effects = submit_shared_object_transaction(
+    let (effects, _) = submit_shared_object_transaction(
         increment_counter_transaction,
         &configs.validator_set()[0..1],
     )
@@ -485,7 +485,7 @@ async fn replay_shared_object_transaction() {
 
     let mut version = None;
     for _ in 0..2 {
-        let effects = submit_single_owner_transaction(
+        let (effects, _) = submit_single_owner_transaction(
             create_counter_transaction.clone(),
             &configs.validator_set(),
         )

--- a/crates/sui/tests/shared_objects_version_tests.rs
+++ b/crates/sui/tests/shared_objects_version_tests.rs
@@ -10,6 +10,7 @@ use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber};
 use sui_types::error::SuiResult;
 use sui_types::messages::{
     CallArg, ExecutionFailureStatus, ExecutionStatus, ObjectArg, TransactionEffects,
+    TransactionEvents,
 };
 use sui_types::object::{generate_test_gas_objects, Object, Owner, OBJECT_START_VERSION};
 use sui_types::SUI_FRAMEWORK_ADDRESS;
@@ -146,7 +147,7 @@ impl TestEnvironment {
         &mut self,
         function: &'static str,
         arguments: Vec<CallArg>,
-    ) -> TransactionEffects {
+    ) -> (TransactionEffects, TransactionEvents) {
         submit_single_owner_transaction(
             move_transaction(
                 self.gas_objects.pop().unwrap(),
@@ -164,7 +165,7 @@ impl TestEnvironment {
         &mut self,
         function: &'static str,
         arguments: Vec<CallArg>,
-    ) -> SuiResult<TransactionEffects> {
+    ) -> SuiResult<(TransactionEffects, TransactionEvents)> {
         submit_shared_object_transaction(
             move_transaction(
                 self.gas_objects.pop().unwrap(),
@@ -179,7 +180,7 @@ impl TestEnvironment {
     }
 
     async fn create_counter(&mut self) -> (ObjectRef, Owner) {
-        let fx = self.owned_move_call("create_counter", vec![]).await;
+        let (fx, _) = self.owned_move_call("create_counter", vec![]).await;
         assert!(fx.status.is_ok());
 
         *fx.created
@@ -189,7 +190,7 @@ impl TestEnvironment {
     }
 
     async fn create_shared_counter(&mut self) -> (ObjectRef, Owner) {
-        let fx = self.owned_move_call("create_shared_counter", vec![]).await;
+        let (fx, _) = self.owned_move_call("create_shared_counter", vec![]).await;
         assert!(fx.status.is_ok());
 
         *fx.created
@@ -202,7 +203,7 @@ impl TestEnvironment {
         &mut self,
         counter: ObjectRef,
     ) -> Result<(ObjectRef, Owner), ExecutionFailureStatus> {
-        let fx = self
+        let (fx, _) = self
             .owned_move_call(
                 "share_counter",
                 vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(counter))],
@@ -221,7 +222,7 @@ impl TestEnvironment {
     }
 
     async fn increment_owned_counter(&mut self, counter: ObjectRef) -> (ObjectRef, Owner) {
-        let fx = self
+        let (fx, _) = self
             .owned_move_call(
                 "increment_counter",
                 vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(counter))],
@@ -241,7 +242,7 @@ impl TestEnvironment {
         counter: ObjectID,
         initial_shared_version: SequenceNumber,
     ) -> SuiResult<(ObjectRef, Owner)> {
-        let fx = self
+        let (fx, _) = self
             .shared_move_call(
                 "increment_counter",
                 vec![CallArg::Object(ObjectArg::SharedObject {

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -72,7 +72,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
 
     let ExecuteTransactionResponse::EffectsCert(result) = res;
-    let (_, executed_locally) = *result;
+    let (_, _, executed_locally) = *result;
     assert!(executed_locally);
 
     assert!(node
@@ -250,7 +250,7 @@ async fn test_tx_across_epoch_boundaries() {
                 {
                     Ok(ExecuteTransactionResponse::EffectsCert(res)) => {
                         info!(?tx_digest, "tx result: ok");
-                        let (effects_cert, _) = *res;
+                        let (effects_cert, _, _) = *res;
                         result_tx.send(effects_cert).await.unwrap();
                     }
                     Err(QuorumDriverError::TimeoutBeforeFinality) => {

--- a/dapps/frenemies/src/network/queries/scorecard-history.ts
+++ b/dapps/frenemies/src/network/queries/scorecard-history.ts
@@ -30,7 +30,7 @@ export function useScorecardHistory(scorecardId?: string | null) {
       );
 
       return txs
-        .reduce((acc: any[], tx) => acc.concat(tx.effects.events || []), [])
+        .reduce((acc: any[], tx) => acc.concat(tx.events || []), [])
         .filter(
           (evt) => "moveEvent" in evt && evt.moveEvent.type == SCORECARD_UPDATED
         )

--- a/dapps/frenemies/src/utils/coins.ts
+++ b/dapps/frenemies/src/utils/coins.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  CoinStruct,
+  CoinStruct, getEvents,
   getTransactionEffects,
   SUI_TYPE_ARG,
 } from "@mysten/sui.js";
@@ -71,13 +71,13 @@ export function useManageCoin() {
       },
     });
 
-    const effects = getTransactionEffects(result);
+    const events = getEvents(result);
 
-    if (!effects || !effects.events) {
+    if (!events) {
       throw new Error("Missing effects or events");
     }
 
-    const changeEvent = effects.events.find((event) => {
+    const changeEvent = events.find((event) => {
       if ("coinBalanceChange" in event) {
         return event.coinBalanceChange.amount === Number(amount);
       }

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -34,7 +34,6 @@ import {
   PaginatedEvents,
   FaucetResponse,
   Order,
-  TransactionEffects,
   DevInspectResults,
   CoinMetadata,
   isValidTransactionDigest,
@@ -57,6 +56,7 @@ import {
   Checkpoint,
   CheckPointContentsDigest,
   CommitteeInfo,
+  DryRunTransactionResponse,
 } from '../types';
 import { DynamicFieldName, DynamicFieldPage } from '../types/dynamic_fields';
 import {
@@ -844,12 +844,14 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async dryRunTransaction(txBytes: Uint8Array): Promise<TransactionEffects> {
+  async dryRunTransaction(
+    txBytes: Uint8Array,
+  ): Promise<DryRunTransactionResponse> {
     try {
       const resp = await this.client.requestWithType(
         'sui_dryRunTransaction',
         [toB64(txBytes)],
-        TransactionEffects,
+        DryRunTransactionResponse,
         this.options.skipDataValidation,
       );
       return resp;

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -31,7 +31,6 @@ import {
   RpcApiVersion,
   FaucetResponse,
   Order,
-  TransactionEffects,
   CoinMetadata,
   DevInspectResults,
   SuiSystemState,
@@ -46,6 +45,7 @@ import {
   CheckPointContentsDigest,
   Checkpoint,
   CommitteeInfo,
+  DryRunTransactionResponse,
 } from '../types';
 
 import { DynamicFieldName, DynamicFieldPage } from '../types/dynamic_fields';
@@ -342,7 +342,9 @@ export abstract class Provider {
    * gas budget and the transaction effects
    * @param txBytes
    */
-  abstract dryRunTransaction(txBytes: Uint8Array): Promise<TransactionEffects>;
+  abstract dryRunTransaction(
+    txBytes: Uint8Array,
+  ): Promise<DryRunTransactionResponse>;
 
   /**
    * Return the list of dynamic field objects owned by an object

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -31,7 +31,6 @@ import {
   RpcApiVersion,
   FaucetResponse,
   Order,
-  TransactionEffects,
   CoinMetadata,
   DevInspectResults,
   SuiSystemState,
@@ -46,6 +45,7 @@ import {
   CheckPointContentsDigest,
   CommitteeInfo,
   Checkpoint,
+  DryRunTransactionResponse,
 } from '../types';
 import { Provider } from './provider';
 
@@ -199,7 +199,7 @@ export class VoidProvider extends Provider {
     throw this.newError('devInspectTransaction');
   }
 
-  dryRunTransaction(_txBytes: Uint8Array): Promise<TransactionEffects> {
+  dryRunTransaction(_txBytes: Uint8Array): Promise<DryRunTransactionResponse> {
     throw this.newError('dryRunTransaction');
   }
 

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -15,9 +15,9 @@ import {
   getTotalGasUsedUpperBound,
   SuiAddress,
   SuiExecuteTransactionResponse,
-  TransactionEffects,
   DevInspectResults,
   bcsForVersion,
+  DryRunTransactionResponse,
 } from '../types';
 import { IntentScope, messageWithIntent } from '../utils/intent';
 import { Signer } from './signer';
@@ -198,7 +198,7 @@ export abstract class SignerWithProvider implements Signer {
    */
   async dryRunTransaction(
     tx: SignableTransaction | string | Uint8Array,
-  ): Promise<TransactionEffects> {
+  ): Promise<DryRunTransactionResponse> {
     const address = await this.getAddress();
     let dryRunTxBytes: Uint8Array;
     if (typeof tx === 'string') {

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -20,6 +20,9 @@ export type TransactionDigest = Infer<typeof TransactionDigest>;
 export const TransactionEffectsDigest = string();
 export type TransactionEffectsDigest = Infer<typeof TransactionEffectsDigest>;
 
+export const TransactionEventDigest = string();
+export type TransactionEventDigest = Infer<typeof TransactionEventDigest>;
+
 export const ObjectId = string();
 export type ObjectId = Infer<typeof ObjectId>;
 

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -9,7 +9,7 @@ import {
   LocalTxnDataSerializer,
   RawSigner,
   Connection,
-  devnetConnection,
+  devnetConnection, getEvents,
 } from "@mysten/sui.js";
 import {
   WalletAdapter,
@@ -76,6 +76,7 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
       return {
         certificate: getCertifiedTransaction(response)!,
         effects: getTransactionEffects(response)!,
+        events: getEvents(response)!,
         timestamp_ms: null,
         parsed_data: null,
       };


### PR DESCRIPTION
This PR removes events from TransactionEffects, replacing it with a `EventsSummary`, which contain the event count and an optional event digest.

I am including the `TransactionEvents` in `TransactionResponse`, `DryRunTransactionResponse` and `DevInspectResponse` to minimise disruption to the apps.

In order to return `TransactionEvents` in execute_transaction, `process_certificates` now returns the events as well as the effects.

I have also fixed errors in typescript SDK, explorer, wallet and frenemies due to the scheme changes.