### PR TITLE
fix wrong rewards on changeEpoch transaction

### DIFF
--- a/apps/wallet/src/ui/app/helpers/getEventsSummary.ts
+++ b/apps/wallet/src/ui/app/helpers/getEventsSummary.ts
@@ -33,16 +33,19 @@ export function getEventsSummary(
             event?.coinBalanceChange?.transactionModule !== 'gas'
         ) {
             const { coinBalanceChange } = event;
-            const { coinType, amount, owner } = coinBalanceChange;
+            const { coinType, amount, owner, sender } = coinBalanceChange;
             const { AddressOwner } = owner as { AddressOwner: string };
 
-            coinsMeta[`${AddressOwner}${coinType}`] = {
-                amount:
-                    (coinsMeta[`${AddressOwner}${coinType}`]?.amount || 0) +
-                    amount,
-                coinType: coinType,
-                receiverAddress: AddressOwner,
-            };
+            // ChangeEpoch txn includes coinBalanceChange event for other addresses
+            if (AddressOwner === address || address === sender) {
+                coinsMeta[`${AddressOwner}${coinType}`] = {
+                    amount:
+                        (coinsMeta[`${AddressOwner}${coinType}`]?.amount || 0) +
+                        amount,
+                    coinType: coinType,
+                    receiverAddress: AddressOwner,
+                };
+            }
         }
 
         // return objectIDs of the transfer objects


### PR DESCRIPTION
- ChangeEpoch transaction includes rewards for other addresses. This only aggregates `coinBalanceChange` related to the current address.

Before 
<img width="455" alt="Screenshot 2023-01-30 at 3 12 19 AM" src="https://user-images.githubusercontent.com/8676844/215423700-a3e495ce-af24-4877-9bd8-633c78fcd209.png">

After
<img width="447" alt="Screenshot 2023-01-30 at 3 14 31 AM" src="https://user-images.githubusercontent.com/8676844/215423719-a6a79db4-70b1-4934-99b0-d17c66c11958.png">
