### PR TITLE
docs - sui documentation updates link fix

### DIFF
--- a/doc/src/learn/index.md
+++ b/doc/src/learn/index.md
@@ -22,7 +22,7 @@ Check for the latest release of Sui, including Release Notes, on the [Sui Releas
 
 ### Doc updates
 
-We list changes and updates to the documentation in the [Sui documentation updates](../learn/sui-doc-updates.md) topic.
+We list changes and updates to the documentation in the [Sui documentation updates](../doc-updates/index.md) topic.
 
 See the [docs-related commit history](https://github.com/MystenLabs/sui/commits/main/doc/src) in the Sui repo.
 


### PR DESCRIPTION
Updates the hyperlink in the [page](https://docs.sui.io/learn#doc-updates) for "Sui Doc Updates" section