### PR TITLE
[narwhal] introduce certificate submit position in metrics

### DIFF
--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -2,6 +2,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+extern crate core;
+
 pub mod authority;
 pub mod authority_aggregator;
 pub mod authority_client;


### PR DESCRIPTION
Introducing on the metrics the authority's position when this is submitting a transaction to consensus. That will allow us to confirm case where a transaction needs to get re-submitted from other authorities in order to get sequenced.