### PR TITLE
wallet-ext: wait for a transaction to be indexed

### DIFF
--- a/apps/wallet/.eslintrc.js
+++ b/apps/wallet/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
         '@typescript-eslint/unified-signatures': 'error',
         '@typescript-eslint/parameter-properties': 'error',
         'no-console': ['warn'],
+        '@typescript-eslint/no-non-null-assertion': 'off',
     },
     overrides: [
         {
@@ -60,7 +61,6 @@ module.exports = {
             rules: {
                 // Allow any casting in tests:
                 '@typescript-eslint/no-explicit-any': 'off',
-                '@typescript-eslint/no-non-null-assertion': 'off',
             },
         },
     ],

--- a/apps/wallet/src/ui/app/hooks/useRecentTransactions.ts
+++ b/apps/wallet/src/ui/app/hooks/useRecentTransactions.ts
@@ -20,6 +20,9 @@ import {
     type SuiEvent,
     type ExecutionStatusType,
     type TransactionKindName,
+    type SuiTransactionResponse,
+    type SuiAddress,
+    type JsonRpcProvider,
 } from '@mysten/sui.js';
 import { useQuery } from '@tanstack/react-query';
 
@@ -71,6 +74,119 @@ const getTxnEffectsEventID = (
     return objectIDs;
 };
 
+async function processTransactionEffects(
+    transactions: SuiTransactionResponse[],
+    address: SuiAddress,
+    rpc: JsonRpcProvider
+) {
+    const txResults = transactions.map((txEff) => {
+        const digest = getTransactionDigest(txEff.certificate);
+
+        const txns = getTransactions(txEff.certificate);
+
+        // TODO handle batch transactions
+        if (txns.length > 1) {
+            return null;
+        }
+
+        const txn = txns[0];
+        const txKind = getTransactionKindName(txn);
+        const txTransferObject = getTransferObjectTransaction(txn);
+        const amountByRecipient = getAmount(txn, txEff.effects);
+        const sender = getTransactionSender(txEff.certificate);
+        const amount = amountByRecipient && amountByRecipient[0]?.amount;
+        //TODO: Support multiple recipients
+        const recipientObj =
+            amountByRecipient &&
+            amountByRecipient?.filter(
+                ({ recipientAddress }) => recipientAddress !== sender
+            );
+
+        const recipient = recipientObj && recipientObj[0]?.recipientAddress;
+
+        const moveCallTxn = getMoveCallTransaction(txn);
+        const metaDataObjectId = getTxnEffectsEventID(txEff.effects, address);
+
+        const { coins: eventsSummary } = getEventsSummary(
+            txEff.effects,
+            address
+        );
+        const amountTransfers = eventsSummary.reduce(
+            (acc, { amount }) => acc + amount,
+            0
+        );
+
+        return {
+            txId: digest,
+            status: getExecutionStatusType(txEff),
+            txGas: getTotalGasUsed(txEff),
+            kind: txKind,
+            callFunctionName: moveCallTxnName(moveCallTxn?.function),
+            from: sender,
+            isSender: sender === address,
+            error: getExecutionStatusError(txEff),
+            timestampMs: txEff.timestamp_ms,
+            ...(recipient && { to: recipient }),
+            ...((amount || amountTransfers) && {
+                amount: Math.abs(amount || amountTransfers),
+            }),
+            ...((txTransferObject?.objectRef?.objectId ||
+                metaDataObjectId.length > 0) && {
+                objectId: txTransferObject?.objectRef?.objectId
+                    ? [txTransferObject?.objectRef?.objectId]
+                    : [...metaDataObjectId],
+            }),
+        };
+    });
+
+    const objectIds = txResults.map((itm) => itm?.objectId).filter(notEmpty);
+    const objectIDs = [...new Set(objectIds.flat())];
+    const getObjectBatch = await rpc.getObjectBatch(objectIDs);
+    const txObjects = getObjectBatch.filter(
+        ({ status }) => status === 'Exists'
+    );
+
+    const txnResp = txResults.map((itm) => {
+        const txnObjects =
+            txObjects && itm?.objectId && Array.isArray(txObjects)
+                ? txObjects
+                      .filter(({ status }) => status === 'Exists')
+                      .find((obj) => itm.objectId?.includes(getObjectId(obj)))
+                : null;
+
+        const { details } = txnObjects || {};
+
+        const coinType =
+            txnObjects &&
+            is(details, SuiObject) &&
+            Coin.getCoinTypeArg(txnObjects);
+
+        const fields =
+            txnObjects && is(details, SuiObject)
+                ? getObjectFields(txnObjects)
+                : null;
+
+        return {
+            ...itm,
+            coinType,
+            coinSymbol: coinType && Coin.getCoinSymbol(coinType),
+            ...(fields &&
+                fields.url && {
+                    description:
+                        typeof fields.description === 'string' &&
+                        fields.description,
+                    name: typeof fields.name === 'string' && fields.name,
+                    url: fields.url,
+                }),
+            ...(fields && {
+                balance: fields.balance,
+            }),
+        };
+    });
+
+    return txnResp as TxResultByAddress;
+}
+
 // TODO: This is not an ideal hook, and was ported from redux quickly in order to fix
 // performance issues in the wallet.
 export function useRecentTransactions() {
@@ -96,126 +212,7 @@ export function useRecentTransactions() {
                 deduplicate(transactions)
             );
 
-            const txResults = txEffs.map((txEff) => {
-                const digest = transactions.filter(
-                    (transactionId) =>
-                        transactionId ===
-                        getTransactionDigest(txEff.certificate)
-                )[0];
-
-                const txns = getTransactions(txEff.certificate);
-
-                // TODO handle batch transactions
-                if (txns.length > 1) {
-                    return null;
-                }
-
-                const txn = txns[0];
-                const txKind = getTransactionKindName(txn);
-                const txTransferObject = getTransferObjectTransaction(txn);
-                const amountByRecipient = getAmount(txn, txEff.effects);
-                const sender = getTransactionSender(txEff.certificate);
-                const amount =
-                    amountByRecipient && amountByRecipient[0]?.amount;
-                //TODO: Support multiple recipients
-                const recipientObj =
-                    amountByRecipient &&
-                    amountByRecipient?.filter(
-                        ({ recipientAddress }) => recipientAddress !== sender
-                    );
-
-                const recipient =
-                    recipientObj && recipientObj[0]?.recipientAddress;
-
-                const moveCallTxn = getMoveCallTransaction(txn);
-                const metaDataObjectId = getTxnEffectsEventID(
-                    txEff.effects,
-                    address
-                );
-
-                const { coins: eventsSummary } = getEventsSummary(
-                    txEff.effects,
-                    address
-                );
-                const amountTransfers = eventsSummary.reduce(
-                    (acc, { amount }) => acc + amount,
-                    0
-                );
-
-                return {
-                    txId: digest,
-                    status: getExecutionStatusType(txEff),
-                    txGas: getTotalGasUsed(txEff),
-                    kind: txKind,
-                    callFunctionName: moveCallTxnName(moveCallTxn?.function),
-                    from: sender,
-                    isSender: sender === address,
-                    error: getExecutionStatusError(txEff),
-                    timestampMs: txEff.timestamp_ms,
-                    ...(recipient && { to: recipient }),
-                    ...((amount || amountTransfers) && {
-                        amount: Math.abs(amount || amountTransfers),
-                    }),
-                    ...((txTransferObject?.objectRef?.objectId ||
-                        metaDataObjectId.length > 0) && {
-                        objectId: txTransferObject?.objectRef?.objectId
-                            ? [txTransferObject?.objectRef?.objectId]
-                            : [...metaDataObjectId],
-                    }),
-                };
-            });
-
-            const objectIds = txResults
-                .map((itm) => itm?.objectId)
-                .filter(notEmpty);
-            const objectIDs = [...new Set(objectIds.flat())];
-            const getObjectBatch = await rpc.getObjectBatch(objectIDs);
-            const txObjects = getObjectBatch.filter(
-                ({ status }) => status === 'Exists'
-            );
-
-            const txnResp = txResults.map((itm) => {
-                const txnObjects =
-                    txObjects && itm?.objectId && Array.isArray(txObjects)
-                        ? txObjects
-                              .filter(({ status }) => status === 'Exists')
-                              .find((obj) =>
-                                  itm.objectId?.includes(getObjectId(obj))
-                              )
-                        : null;
-
-                const { details } = txnObjects || {};
-
-                const coinType =
-                    txnObjects &&
-                    is(details, SuiObject) &&
-                    Coin.getCoinTypeArg(txnObjects);
-
-                const fields =
-                    txnObjects && is(details, SuiObject)
-                        ? getObjectFields(txnObjects)
-                        : null;
-
-                return {
-                    ...itm,
-                    coinType,
-                    coinSymbol: coinType && Coin.getCoinSymbol(coinType),
-                    ...(fields &&
-                        fields.url && {
-                            description:
-                                typeof fields.description === 'string' &&
-                                fields.description,
-                            name:
-                                typeof fields.name === 'string' && fields.name,
-                            url: fields.url,
-                        }),
-                    ...(fields && {
-                        balance: fields.balance,
-                    }),
-                };
-            });
-
-            return txnResp as TxResultByAddress;
+            return processTransactionEffects(txEffs, address, rpc);
         },
         {
             enabled: !!address,
@@ -223,4 +220,29 @@ export function useRecentTransactions() {
             staleTime: 10 * 1000,
         }
     );
+}
+
+export function useRecentTransaction(transactionDigest: string | null) {
+    const rpc = useRpc();
+    const userAddress = useAppSelector((state) => state.account.address);
+    return useQuery({
+        queryKey: [
+            'recent transaction',
+            'get transaction with effects',
+            transactionDigest,
+        ],
+        queryFn: async () => {
+            const transactionResponse = await rpc.getTransactionWithEffects(
+                transactionDigest!
+            );
+            const processedTransactions = await processTransactionEffects(
+                [transactionResponse],
+                userAddress!,
+                rpc
+            );
+            return processedTransactions?.[0] || null;
+        },
+        enabled: !!transactionDigest?.length && !!userAddress,
+        retry: 10,
+    });
 }

--- a/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import { useMemo, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Navigate, useSearchParams, useNavigate } from 'react-router-dom';
 
 import { SuiIcons } from '_components/icon';
 import Loading from '_components/loading';
 import Overlay from '_components/overlay';
 import ReceiptCard from '_components/receipt-card';
-import { useRecentTransactions } from '_src/ui/app/hooks/useRecentTransactions';
+import { useRecentTransaction } from '_src/ui/app/hooks/useRecentTransactions';
 
 import st from './ReceiptPage.module.scss';
 
@@ -21,11 +21,7 @@ function ReceiptPage() {
 
     const transferType = searchParams.get('transfer') as 'nft' | 'coin';
 
-    const { data, isLoading } = useRecentTransactions();
-
-    const txnItem = useMemo(() => {
-        return data?.find((txn) => txn.txId === txDigest);
-    }, [data, txDigest]);
+    const { data: txnItem, isLoading } = useRecentTransaction(txDigest);
 
     //TODO: redo the CTA links
     const ctaLinks = transferType === 'nft' ? '/nfts' : '/';
@@ -36,7 +32,7 @@ function ReceiptPage() {
         navigate(linkTo);
     }, [linkTo, navigate]);
 
-    if ((!txDigest && !txnItem) || (!isLoading && !data?.length)) {
+    if (!txDigest || (!isLoading && !txnItem)) {
         return <Navigate to={linkTo} replace={true} />;
     }
 


### PR DESCRIPTION
* eslint turn null assertion check off
* fix displaying empty receipt page after staking
  * after staking it seems the transaction takes about 30s to be indexed in order to avoid showing an empty page, now we retry 10 times to fetch the transaction and only after that we redirect to the activity page
  * this is a quick fix to address the issue we should follow up with a better approach

before


https://user-images.githubusercontent.com/10210143/215489617-eb8b1d71-b548-43df-8293-c01c1736d31a.mov

after


https://user-images.githubusercontent.com/10210143/215489660-e5248568-9833-4756-b008-e23c9cd979fb.mov



related to APPS-433