### PR TITLE
wallet-ext: dapp status centered relatively to screen

### DIFF
--- a/apps/wallet/src/ui/app/components/logo/index.tsx
+++ b/apps/wallet/src/ui/app/components/logo/index.tsx
@@ -25,7 +25,7 @@ const Logo = ({ networkName }: LogoProps) => {
             <div className={cl('flex flex-col', { 'mb-2': !!networkName })}>
                 <Icon icon={SuiIcons.SuiLogoTxt} />
                 {networkName && (
-                    <div className="-mt-2 ml-0.5">
+                    <div className="-mt-2 ml-0.5 whitespace-nowrap">
                         <Text variant="subtitleSmallExtra">
                             {networkNames[networkName]}
                         </Text>

--- a/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayout.module.scss
+++ b/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayout.module.scss
@@ -16,9 +16,9 @@
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
-    padding: 0 15px;
-    justify-content: space-between;
+    padding: 0 12px;
     min-height: 52px;
+    gap: 20px;
 
     &.center {
         justify-content: center;
@@ -53,4 +53,25 @@
 .with-nav {
     padding: 25px sizing.$main-sides-space;
     @include utils.main-extra-space-for-nav;
+}
+
+.dapp-status-container {
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+}
+
+.logo-container,
+.menu-container {
+    display: flex;
+    flex: 1 0;
+    align-items: center;
+}
+
+.logo-container {
+    justify-content: flex-start;
+}
+
+.menu-container {
+    justify-content: flex-end;
 }

--- a/apps/wallet/src/ui/app/shared/page-main-layout/index.tsx
+++ b/apps/wallet/src/ui/app/shared/page-main-layout/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { useAppSelector } from '../../hooks';
@@ -11,8 +12,6 @@ import { ErrorBoundary } from '_components/error-boundary';
 import Logo from '_components/logo';
 import { MenuButton, MenuContent } from '_components/menu';
 import Navigation from '_components/navigation';
-
-import type { ReactNode } from 'react';
 
 import st from './PageMainLayout.module.scss';
 
@@ -34,6 +33,17 @@ export default function PageMainLayout({
     className,
 }: PageMainLayoutProps) {
     const networkName = useAppSelector(({ app: { apiEnv } }) => apiEnv);
+    const [logoWidth, setLogoWidth] = useState<number>();
+    const logoRef = useRef<HTMLAnchorElement>(null);
+    useEffect(() => {
+        const observer = new ResizeObserver(([entry]) => {
+            setLogoWidth(entry?.borderBoxSize[0]?.inlineSize);
+        });
+        if (logoRef.current) {
+            observer.observe(logoRef.current);
+        }
+        return () => observer.disconnect();
+    }, []);
     return (
         <div className={st.container}>
             <div
@@ -42,12 +52,30 @@ export default function PageMainLayout({
                         centerLogo && !topNavMenuEnabled && !dappStatusEnabled,
                 })}
             >
-                <Link to="/tokens" className="no-underline text-gray-90">
-                    <Logo networkName={networkName} />
-                </Link>
-                {dappStatusEnabled ? <DappStatus /> : null}
+                <div
+                    className={st.logoContainer}
+                    style={{ flexBasis: logoWidth }}
+                >
+                    <Link
+                        ref={logoRef}
+                        to="/tokens"
+                        className="no-underline text-gray-90"
+                    >
+                        <Logo networkName={networkName} />
+                    </Link>
+                </div>
+                {dappStatusEnabled ? (
+                    <div className={st.dappStatusContainer}>
+                        <DappStatus />
+                    </div>
+                ) : null}
                 {topNavMenuEnabled ? (
-                    <MenuButton className={st.menuButton} />
+                    <div
+                        className={st.menuContainer}
+                        style={{ flexBasis: logoWidth }}
+                    >
+                        <MenuButton className={st.menuButton} />
+                    </div>
                 ) : null}
             </div>
             <div className={st.content}>


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="364" alt="Screenshot 2023-01-30 at 21 51 29" src="https://user-images.githubusercontent.com/10210143/215604892-8d62e143-dc9f-4e70-9acf-20ff8a683b6e.png"> | <img width="359" alt="Screenshot 2023-02-05 at 12 58 39" src="https://user-images.githubusercontent.com/10210143/216846065-cedf1a29-4415-4524-a58e-e4c4474b3e03.png"> |
| 
<img width="364" alt="Screenshot 2023-01-30 at 21 51 56" src="https://user-images.githubusercontent.com/10210143/215605056-be9fd3cb-41b5-4473-a161-db8320cdb029.png"> | <img width="359" alt="Screenshot 2023-02-05 at 12 58 28" src="https://user-images.githubusercontent.com/10210143/216846090-8605f110-0244-4329-86af-553ffea5e1e2.png"> |

This should address [this comment](https://github.com/MystenLabs/sui/pull/7606#issuecomment-1401361805)

