### PR TITLE
[programmable transactions] Added type declarations

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -333,6 +333,9 @@ fn execution_loop<
             SingleTransactionKind::ConsensusCommitPrologue(prologue) => {
                 setup_consensus_commit(prologue, temporary_store, tx_ctx, move_vm, gas_status)?
             }
+            SingleTransactionKind::ProgrammableTransaction(_) => {
+                unreachable!("programmable transactions are not yet supported")
+            }
         };
     }
     Ok(results)

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -18,8 +18,9 @@ use sui_types::{
         AuthoritySignature, KeypairTraits, Signature,
     },
     messages::{
-        CallArg, EntryArgumentErrorKind, EntryTypeArgumentErrorKind, ExecutionFailureStatus,
-        ExecutionStatus, ObjectArg, ObjectInfoRequestKind, SingleTransactionKind, TransactionKind,
+        Argument, CallArg, Command, EntryArgumentErrorKind, EntryTypeArgumentErrorKind,
+        ExecutionFailureStatus, ExecutionStatus, ObjectArg, ObjectInfoRequestKind,
+        SingleTransactionKind, TransactionKind,
     },
     object::{Data, Owner},
     storage::DeleteKind,
@@ -89,6 +90,8 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<MoveTypeLayout>(&samples)?;
     tracer.trace_type::<base_types::SuiAddress>(&samples)?;
     tracer.trace_type::<DeleteKind>(&samples)?;
+    tracer.trace_type::<Argument>(&samples)?;
+    tracer.trace_type::<Command>(&samples)?;
 
     tracer.registry()
 }

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -82,7 +82,8 @@ pub(crate) async fn check_dev_inspect_input(
             SingleTransactionKind::Publish(_)
             | SingleTransactionKind::ChangeEpoch(_)
             | SingleTransactionKind::Genesis(_)
-            | SingleTransactionKind::ConsensusCommitPrologue(_) => {
+            | SingleTransactionKind::ConsensusCommitPrologue(_)
+            | SingleTransactionKind::ProgrammableTransaction(_) => {
                 anyhow::bail!("Transaction kind {} is not supported in dev-inspect", k)
             }
         }

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -12,6 +12,21 @@ AccountAddress:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 20
+Argument:
+  ENUM:
+    0:
+      GasCoin: UNIT
+    1:
+      Input:
+        NEWTYPE: U16
+    2:
+      Result:
+        NEWTYPE: U16
+    3:
+      NestedResult:
+        TUPLE:
+          - U16
+          - U16
 AuthorityPublicKeyBytes:
   NEWTYPESTRUCT: BYTES
 BLS12381Signature:
@@ -48,6 +63,34 @@ CircularObjectOwnership:
   STRUCT:
     - object:
         TYPENAME: ObjectID
+Command:
+  ENUM:
+    0:
+      MoveCall:
+        NEWTYPE:
+          TYPENAME: ProgrammableMoveCall
+    1:
+      TransferObjects:
+        TUPLE:
+          - SEQ:
+              TYPENAME: Argument
+          - TYPENAME: Argument
+    2:
+      SplitCoin:
+        TUPLE:
+          - TYPENAME: Argument
+          - TYPENAME: Argument
+    3:
+      MergeCoins:
+        TUPLE:
+          - TYPENAME: Argument
+          - SEQ:
+              TYPENAME: Argument
+    4:
+      Publish:
+        NEWTYPE:
+          SEQ:
+            SEQ: U8
 ConsensusCommitPrologue:
   STRUCT:
     - checkpoint_start_timestamp_ms: U64
@@ -427,6 +470,28 @@ PaySui:
           TYPENAME: SuiAddress
     - amounts:
         SEQ: U64
+ProgrammableMoveCall:
+  STRUCT:
+    - package:
+        TYPENAME: ObjectID
+    - module:
+        TYPENAME: Identifier
+    - function:
+        TYPENAME: Identifier
+    - type_arguments:
+        SEQ:
+          TYPENAME: TypeTag
+    - arguments:
+        SEQ:
+          TYPENAME: Argument
+ProgrammableTransaction:
+  STRUCT:
+    - inputs:
+        SEQ:
+          TYPENAME: CallArg
+    - commands:
+        SEQ:
+          TYPENAME: Command
 ProtocolVersion:
   NEWTYPESTRUCT: U64
 SequenceNumber:
@@ -475,6 +540,10 @@ SingleTransactionKind:
       ConsensusCommitPrologue:
         NEWTYPE:
           TYPENAME: ConsensusCommitPrologue
+    10:
+      ProgrammableTransaction:
+        NEWTYPE:
+          TYPENAME: ProgrammableTransaction
 StructTag:
   STRUCT:
     - address:

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1779,6 +1779,9 @@ impl TryFrom<SingleTransactionKind> for SuiTransactionKind {
                     checkpoint_start_timestamp_ms: p.checkpoint_start_timestamp_ms,
                 })
             }
+            SingleTransactionKind::ProgrammableTransaction(_) => {
+                anyhow::bail!("programmable transactions are not yet supported")
+            }
         })
     }
 }


### PR DESCRIPTION
- Added type/struct declarations
- Added some basic checks/infrastructure

Nothing here is final. I'm just trying to break things up a bit so they will be easier to land and change in time. I'm not exactly sure how best to block the transaction kind outside of tests without a CFG check. If anyone has suggestions let me know :)

(built on #7791) 

EDIT: I also am sticking with the 2D approach as I think it will make things a bit easier when dealing with `entry` functions that take a vector of objects as inputs. I can write up a bit more about this if/when we want to discuss it. 