### PR TITLE
move: resolve function names in ID leak verifier errors

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -681,6 +681,10 @@ impl ExecutionError {
         &self.inner.kind
     }
 
+    pub fn source(&self) -> &Option<BoxError> {
+        &self.inner.source
+    }
+
     pub fn to_execution_status(&self) -> ExecutionFailureStatus {
         self.kind().clone()
     }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-25:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function call.") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function call. Found in _::m::foo") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
@@ -2,8 +2,8 @@ processed 2 tasks
 
 task 0 'publish'. lines 4-25:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct.") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::m::foo") } }
 
 task 1 'publish'. lines 27-48:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function call.") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function call. Found in _::m::foo") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_call_with_borrow_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_call_with_borrow_field.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-34:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function call.") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function call. Found in _::m::bad") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-19:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function return.") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function return. Found in _::m::foo") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-19:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct.") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::m::foo") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.exp
@@ -2,8 +2,8 @@ processed 2 tasks
 
 task 0 'publish'. lines 4-36:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct.") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::test::test") } }
 
 task 1 'publish'. lines 38-60:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct.") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::m::foo") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-20:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a vector.") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a vector. Found in _::m::foo") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/transmute.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/transmute.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-28:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct.") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::m::transmute") } }


### PR DESCRIPTION
Follow up of https://github.com/MystenLabs/sui/pull/7495#issuecomment-1402275901. This restores location info in error message that got removed in the `id leak` pass in https://github.com/MystenLabs/sui/pull/7495. 

This PR improves a bit on the state of affairs by reporting the function too, which we didn't have previously for this pass (only module). I got to this solution by looking at what other verifier passes do (e.g., [`global_access_modifier`](https://github.com/MystenLabs/sui/blob/0f4a79155640e5dd1d94da406eb1cccf96f553f5/crates/sui-verifier/src/global_storage_access_verifier.rs#L108-L113)). Echoing what @tnowacki said for priorities on better error reporting, ideally we want to:

- look at linters as a long term solution to subsume some of the checks here (and report high-fidelity location info)
- improve sui verifier errors (i.e., not use strings, for protocol stability)
- actually improve sui verifier location info (e.g., line / col and other info I imagine)

but these are all longer term efforts, so for now this current style of error reporting in verifier passes is a cheap win.