### PR TITLE
Remove events from effects after hard-coded epoch

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -133,7 +133,7 @@ pub(crate) const MAX_TX_RECOVERY_RETRY: u32 = 3;
 pub(crate) const MAX_PER_OBJECT_EXECUTION_QUEUE_LENGTH: usize = 1000;
 
 // The epoch at which we start removing events from effects
-const REMOVE_EFFECTS_EPOCH: u64 = 0;
+const REMOVE_EFFECTS_EPOCH: u64 = 7;
 
 type CertTxGuard<'a> = DBTxGuard<
     'a,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1052,7 +1052,7 @@ impl AuthorityState {
 
         let effects_with_events = effects.clone();
 
-        if epoch_store.epoch() >= REMOVE_EFFECTS_EPOCH {
+        if epoch_store.epoch() >= REMOVE_EFFECTS_EPOCH && certificate.is_change_epoch_tx() {
             // remove all events (except some events required by rosetta) from effects -
             // fullnode will still
             // index them, but they will not be transmitted over state sync.

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -101,7 +101,16 @@ pub struct AuthorityPerEpochStore {
     pending_consensus_certificates: Mutex<HashSet<TransactionDigest>>,
     /// A write-ahead/recovery log used to ensure we finish fully processing certs after errors or
     /// crashes.
-    wal: Arc<DBWriteAheadLog<TrustedCertificate, (InnerTemporaryStore, SignedTransactionEffects)>>,
+    wal: Arc<
+        DBWriteAheadLog<
+            TrustedCertificate,
+            (
+                InnerTemporaryStore,
+                SignedTransactionEffects, // effects without events
+                TransactionEffects,       // effects with original events (for indexing)
+            ),
+        >,
+    >,
 
     /// The moment when the current epoch started locally on this validator. Note that this
     /// value could be skewed if the node crashed and restarted in the middle of the epoch. That's
@@ -324,8 +333,16 @@ impl AuthorityPerEpochStore {
 
     pub fn wal(
         &self,
-    ) -> &Arc<DBWriteAheadLog<TrustedCertificate, (InnerTemporaryStore, SignedTransactionEffects)>>
-    {
+    ) -> &Arc<
+        DBWriteAheadLog<
+            TrustedCertificate,
+            (
+                InnerTemporaryStore,
+                SignedTransactionEffects,
+                TransactionEffects,
+            ),
+        >,
+    > {
         &self.wal
     }
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1067,6 +1067,10 @@ impl<S> Envelope<SenderSignedData, S> {
     pub fn is_system_tx(&self) -> bool {
         self.data().intent_message.value.kind.is_system_tx()
     }
+
+    pub fn is_change_epoch_tx(&self) -> bool {
+        self.data().intent_message.value.kind.is_change_epoch_tx()
+    }
 }
 
 /// A transaction that is signed by a sender but not yet by an authority.


### PR DESCRIPTION
Short term hack after discussion with @lxfind to hopefully remove events from effects entirely, but without effecting indexing on fullnode.

@gegaowp / @patrickkuo can you please confirm this won't impact indexing?