### PR TITLE
[RPC][TypeScript SDK] Fix gas selection by taking gas price into consideration

### DIFF
--- a/.changeset/old-timers-heal.md
+++ b/.changeset/old-timers-heal.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Fix gas selection logic to take gas price into account

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
-    bcsForVersion,
+  bcsForVersion,
   deserializeTransactionBytesToTransactionData,
   LocalTxnDataSerializer,
   MoveCallTransaction,
@@ -57,11 +57,10 @@ describe('Transaction Serialization and deserialization', () => {
       )) as UnserializedSignableTransaction;
     expect(deserialized.kind).toEqual('moveCall');
 
-    const deserializedTxnData =
-      deserializeTransactionBytesToTransactionData(
-        bcsForVersion(await toolbox.provider.getRpcApiVersion()),
-        localTxnBytes,
-      );
+    const deserializedTxnData = deserializeTransactionBytesToTransactionData(
+      bcsForVersion(await toolbox.provider.getRpcApiVersion()),
+      localTxnBytes
+    );
     const reserialized = await localSerializer.serializeTransactionData(
       deserializedTxnData
     );
@@ -71,6 +70,7 @@ describe('Transaction Serialization and deserialization', () => {
         ...deserialized.data,
         gasBudget: Number(deserialized.data.gasBudget!.toString(10)),
         gasPayment: '0x' + deserialized.data.gasPayment,
+        gasPrice: Number(deserialized.data.gasPrice!.toString(10)),
       };
       return normalized;
     }
@@ -112,7 +112,6 @@ describe('Transaction Serialization and deserialization', () => {
       arguments: [coins[0].objectId],
       gasBudget: DEFAULT_GAS_BUDGET,
     };
-
     await serializeAndDeserialize(moveCall);
   });
 


### PR DESCRIPTION
Previously the gas selection algorithm selects coins with amount greater than the gas budget since the gas price had always been 1. We now have variant gas price, and therefore this PR changes the threshold to be `gas budget * gas price`.