### PR TITLE
[reconfig] Add more logging

### DIFF
--- a/crates/sui-core/src/authority/authority_notify_read.rs
+++ b/crates/sui-core/src/authority/authority_notify_read.rs
@@ -5,7 +5,8 @@ use crate::authority::authority_store::EffectsStore;
 use crate::authority::AuthorityStore;
 use async_trait::async_trait;
 use either::Either;
-use futures::future::join_all;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use parking_lot::Mutex;
 use parking_lot::MutexGuard;
 use std::collections::hash_map::DefaultHasher;
@@ -22,6 +23,8 @@ use sui_types::base_types::TransactionDigest;
 use sui_types::error::SuiResult;
 use sui_types::messages::VerifiedSignedTransactionEffects;
 use tokio::sync::oneshot;
+use tokio::time::Instant;
+use tracing::debug;
 
 #[async_trait]
 pub trait EffectsNotifyRead: Send + Sync + 'static {
@@ -182,20 +185,35 @@ impl EffectsNotifyRead for Arc<AuthorityStore> {
         &self,
         digests: Vec<TransactionDigest>,
     ) -> SuiResult<Vec<VerifiedSignedTransactionEffects>> {
+        let timer = Instant::now();
         // We need to register waiters _before_ reading from the database to avoid race conditions
         let registrations = self.effects_notify_read.register_all(digests.clone());
         let effects = EffectsStore::get_effects(self, digests.iter())?;
         // Zipping together registrations and effects ensures returned order is the same as order of digests
-        let results = effects
+        let mut results: FuturesUnordered<_> = effects
             .into_iter()
             .zip(registrations.into_iter())
             .map(|(e, r)| match e {
                 // Note that Some() clause also drops registration that is already fulfilled
                 Some(ready) => Either::Left(futures::future::ready(ready)),
                 None => Either::Right(r),
-            });
-
-        Ok(join_all(results).await)
+            })
+            .collect();
+        let mut effects_map = HashMap::new();
+        let mut last_finished = None;
+        while let Some(finished) = results.next().await {
+            last_finished = Some(finished.transaction_digest);
+            effects_map.insert(finished.transaction_digest, finished);
+        }
+        debug!(duration=?timer.elapsed(), ?last_finished, "Finished notify_read_effects");
+        Ok(digests
+            .iter()
+            .map(|d| {
+                effects_map
+                    .remove(d)
+                    .expect("Every effect must have been added after each task finishes above")
+            })
+            .collect())
     }
 
     fn get_effects(
@@ -209,6 +227,7 @@ impl EffectsNotifyRead for Arc<AuthorityStore> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::future::join_all;
 
     #[tokio::test]
     pub async fn test_notify_read() {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -696,6 +696,10 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
+    pub fn pending_consensus_certificates_count(&self) -> usize {
+        self.pending_consensus_certificates.lock().len()
+    }
+
     pub fn pending_consensus_certificates_empty(&self) -> bool {
         self.pending_consensus_certificates.lock().is_empty()
     }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -419,22 +419,25 @@ impl ConsensusAdapter {
         epoch_store
             .remove_pending_consensus_transaction(&transaction.key())
             .expect("Storage error when removing consensus transaction");
-        let send_end_of_publish =
-            if let ConsensusTransactionKind::UserTransaction(_cert) = &transaction.kind {
-                let reconfig_guard = epoch_store.get_reconfig_state_read_lock_guard();
-                // If we are in RejectUserCerts state and we just drained the list we need to
-                // send EndOfPublish to signal other validators that we are not submitting more certificates to the epoch.
-                // Note that there could be a race condition here where we enter this check in RejectAllCerts state.
-                // In that case we don't need to send EndOfPublish because condition to enter
-                // RejectAllCerts is when 2f+1 other validators already sequenced their EndOfPublish message.
-                if reconfig_guard.is_reject_user_certs() {
-                    epoch_store.pending_consensus_certificates_empty() // send end of epoch if empty
-                } else {
-                    false
-                }
+        let send_end_of_publish = if let ConsensusTransactionKind::UserTransaction(_cert) =
+            &transaction.kind
+        {
+            let reconfig_guard = epoch_store.get_reconfig_state_read_lock_guard();
+            // If we are in RejectUserCerts state and we just drained the list we need to
+            // send EndOfPublish to signal other validators that we are not submitting more certificates to the epoch.
+            // Note that there could be a race condition here where we enter this check in RejectAllCerts state.
+            // In that case we don't need to send EndOfPublish because condition to enter
+            // RejectAllCerts is when 2f+1 other validators already sequenced their EndOfPublish message.
+            if reconfig_guard.is_reject_user_certs() {
+                let pending_count = epoch_store.pending_consensus_certificates_count();
+                debug!(epoch=?epoch_store.epoch(), ?pending_count, "Deciding whether to send EndOfPublish");
+                pending_count == 0 // send end of epoch if empty
             } else {
                 false
-            };
+            }
+        } else {
+            false
+        };
         if send_end_of_publish {
             // sending message outside of any locks scope
             if let Err(err) = self.submit(
@@ -477,7 +480,9 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
     fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
         let send_end_of_publish = {
             let reconfig_guard = epoch_store.get_reconfig_state_write_lock_guard();
-            let send_end_of_publish = epoch_store.pending_consensus_certificates_empty();
+            let pending_count = epoch_store.pending_consensus_certificates_count();
+            debug!(epoch=?epoch_store.epoch(), ?pending_count, "Trying to close epoch");
+            let send_end_of_publish = pending_count == 0;
             epoch_store.close_user_certs(reconfig_guard);
             send_end_of_publish
         };


### PR DESCRIPTION
This PR adds more logging related to reconfig.
One major change is to be able to log the longest task while waiting for effects to be available. This will provide useful information when we want to debug the delay between when we want to create checkpoint and when it's finally created.