### PR TITLE
[test] Use BuildConfig::new_for_testing in tests

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -306,7 +306,7 @@ async fn execute_transaction_with_fault_configs(
 /// execution on its side
 #[sim_test(config = "constant_latency_ms(1)")]
 async fn test_quorum_map_and_reduce_timeout() {
-    let build_config = BuildConfig::default();
+    let build_config = BuildConfig::new_for_testing();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("src/unit_tests/data/object_basics");
     let modules = sui_framework::build_move_package(&path, build_config)

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3244,7 +3244,7 @@ pub async fn init_state_with_ids_and_object_basics<
     // add object_basics package object to genesis, since lots of test use it
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("src/unit_tests/data/object_basics");
-    let modules: Vec<_> = BuildConfig::default()
+    let modules: Vec<_> = BuildConfig::new_for_testing()
         .build(path)
         .unwrap()
         .get_modules()
@@ -3276,7 +3276,7 @@ pub async fn init_state_with_ids_and_object_basics_with_fullnode<
     // add object_basics package object to genesis, since lots of test use it
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("src/unit_tests/data/object_basics");
-    let modules: Vec<_> = BuildConfig::default()
+    let modules: Vec<_> = BuildConfig::new_for_testing()
         .build(path)
         .unwrap()
         .get_modules()

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -1896,7 +1896,7 @@ async fn test_entry_point_string_vec_error() {
 #[tokio::test]
 #[cfg_attr(msim, ignore)]
 async fn test_object_no_id_error() {
-    let mut build_config = BuildConfig::default();
+    let mut build_config = BuildConfig::new_for_testing();
     build_config.config.test_mode = true;
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     // in this package object struct (NotObject) is defined incorrectly and publishing should
@@ -1919,7 +1919,7 @@ pub async fn build_and_try_publish_test_package(
     gas_budget: u64,
     with_unpublished_deps: bool,
 ) -> (Transaction, SignedTransactionEffects) {
-    let build_config = BuildConfig::default();
+    let build_config = BuildConfig::new_for_testing();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("src/unit_tests/data/");
     path.push(test_dir);

--- a/crates/sui-framework-build/src/unit_tests/build_tests.rs
+++ b/crates/sui-framework-build/src/unit_tests/build_tests.rs
@@ -13,7 +13,7 @@ fn generate_struct_layouts() {
         .unwrap()
         .to_path_buf();
     path.push("sui-framework");
-    let pkg = BuildConfig::default().build(path).unwrap();
+    let pkg = BuildConfig::new_for_testing().build(path).unwrap();
     let registry = pkg.generate_struct_layouts();
     // check for a couple of types that aren't likely to go away
     assert!(registry.contains_key("0000000000000000000000000000000000000001::string::String"));

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -173,7 +173,7 @@ mod tests {
         get_sui_framework();
         get_move_stdlib();
         let path = PathBuf::from(DEFAULT_FRAMEWORK_PATH);
-        BuildConfig::default().build(path.clone()).unwrap();
+        BuildConfig::new_for_testing().build(path.clone()).unwrap();
         check_move_unit_tests(&path);
     }
 
@@ -194,7 +194,7 @@ mod tests {
             let path = Path::new(env!("CARGO_MANIFEST_DIR"))
                 .join("../../sui_programmability/examples")
                 .join(example);
-            BuildConfig::default().build(path.clone()).unwrap();
+            BuildConfig::new_for_testing().build(path.clone()).unwrap();
             check_move_unit_tests(&path);
         }
     }
@@ -204,7 +204,7 @@ mod tests {
     fn run_book_examples_move_unit_tests() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../doc/book/examples");
 
-        BuildConfig::default().build(path.clone()).unwrap();
+        BuildConfig::new_for_testing().build(path.clone()).unwrap();
         check_move_unit_tests(&path);
     }
 

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -115,7 +115,7 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
     ////////////////////////////////////////////////////////////////////////
     // Publish the basic randomness example
 
-    let compiled_modules = BuildConfig::default()
+    let compiled_modules = BuildConfig::new_for_testing()
         .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?
         .get_package_base64(false);
     let transaction_bytes: TransactionBytes = http_client
@@ -249,7 +249,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let objects = http_client.get_objects_owned_by_address(*address).await?;
     let gas = objects.first().unwrap();
 
-    let compiled_modules = BuildConfig::default()
+    let compiled_modules = BuildConfig::new_for_testing()
         .build(Path::new("../../sui_programmability/examples/fungible_tokens").to_path_buf())?
         .get_package_base64(/* with_unpublished_deps */ false);
 
@@ -466,7 +466,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let gas = objects.first().unwrap();
 
     // Publish test coin package
-    let compiled_modules = BuildConfig::default()
+    let compiled_modules = BuildConfig::new_for_testing()
         .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?
         .get_package_base64(/* with_unpublished_deps */ false);
 

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -401,7 +401,10 @@ fn test_basic_args_linter_pure_args_good() {
 fn test_basic_args_linter_top_level() {
     let path =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../../sui_programmability/examples/nfts");
-    let compiled_modules = BuildConfig::default().build(path).unwrap().into_modules();
+    let compiled_modules = BuildConfig::new_for_testing()
+        .build(path)
+        .unwrap()
+        .into_modules();
     let example_package =
         Object::new_package(compiled_modules, TransactionDigest::genesis()).unwrap();
     let example_package = example_package.data.try_as_package().unwrap();
@@ -518,7 +521,10 @@ fn test_basic_args_linter_top_level() {
     // Test with vecu8 as address
     let path =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../../sui_programmability/examples/basics");
-    let compiled_modules = BuildConfig::default().build(path).unwrap().into_modules();
+    let compiled_modules = BuildConfig::new_for_testing()
+        .build(path)
+        .unwrap()
+        .into_modules();
     let example_package =
         Object::new_package(compiled_modules, TransactionDigest::genesis()).unwrap();
     let framework_pkg = example_package.data.try_as_package().unwrap();
@@ -614,7 +620,10 @@ fn test_basic_args_linter_top_level() {
     // Test with object vector  args
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../sui-core/src/unit_tests/data/entry_point_vector");
-    let compiled_modules = BuildConfig::default().build(path).unwrap().into_modules();
+    let compiled_modules = BuildConfig::new_for_testing()
+        .build(path)
+        .unwrap()
+        .into_modules();
     let example_package =
         Object::new_package(compiled_modules, TransactionDigest::genesis()).unwrap();
     let example_package = example_package.data.try_as_package().unwrap();

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -90,7 +90,7 @@ async fn test_publish_and_move_call() {
     let sender = get_random_address(&network.accounts, vec![]);
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../sui_programmability/examples/fungible_tokens");
-    let package = sui_framework::build_move_package(&path, BuildConfig::default()).unwrap();
+    let package = sui_framework::build_move_package(&path, BuildConfig::new_for_testing()).unwrap();
     let compiled_module = package
         .get_modules()
         .map(|m| {

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -447,7 +447,7 @@ async fn module_bytecode_mismatch() -> anyhow::Result<()> {
 
 /// Compile the package at absolute path `package`.
 fn compile_package(package: impl AsRef<Path>) -> CompiledPackage {
-    sui_framework::build_move_package(package.as_ref(), BuildConfig::default()).unwrap()
+    sui_framework::build_move_package(package.as_ref(), BuildConfig::new_for_testing()).unwrap()
 }
 
 /// Compile and publish package at absolute path `package` to chain.

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -315,7 +315,7 @@ pub fn make_publish_basics_transaction(gas_object: ObjectRef) -> VerifiedTransac
     let (sender, keypair) = deterministic_random_account_key();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("../../sui_programmability/examples/basics");
-    let build_config = BuildConfig::default();
+    let build_config = BuildConfig::new_for_testing();
     let all_module_bytes = sui_framework::build_move_package(&path, build_config)
         .unwrap()
         .get_package_bytes(/* with_unpublished_deps */ false);


### PR DESCRIPTION
Use this new test variant of `BuildConfig` where possible, to avoid filesystem races in tests.

## Test Plan

```
$ cargo nextest run
```