### PR TITLE
[Examples] Minor update to color_object.move

### DIFF
--- a/sui_programmability/examples/objects_tutorial/sources/color_object.move
+++ b/sui_programmability/examples/objects_tutorial/sources/color_object.move
@@ -77,7 +77,6 @@ module tutorial::color_objectTests {
     use sui::test_scenario;
     use tutorial::color_object::{Self, ColorObject};
     use sui::object;
-    use sui::transfer;
     use sui::tx_context;
 
     // == Tests covered in Chapter 1 ==
@@ -188,7 +187,7 @@ module tutorial::color_objectTests {
         test_scenario::next_tx(scenario, owner);
         {
             let object = test_scenario::take_from_sender<ColorObject>(scenario);
-            transfer::transfer(object, recipient);
+            color_object::transfer(object, recipient);
         };
         // Check that owner no longer owns the object.
         test_scenario::next_tx(scenario, owner);


### PR DESCRIPTION
Remove the unnecessary import of `sui::transfer` and use the newly defined `color_object::transfer`.