### PR TITLE
[Narwhal] Add a `min_header_delay` parameter

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -25,6 +25,7 @@ validator_configs:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
         max_header_delay: 100ms
+        min_header_delay: 100ms
         gc_depth: 50
         sync_retry_delay: 5000ms
         sync_retry_nodes: 3
@@ -92,6 +93,7 @@ validator_configs:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
         max_header_delay: 100ms
+        min_header_delay: 100ms
         gc_depth: 50
         sync_retry_delay: 5000ms
         sync_retry_nodes: 3
@@ -159,6 +161,7 @@ validator_configs:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
         max_header_delay: 100ms
+        min_header_delay: 100ms
         gc_depth: 50
         sync_retry_delay: 5000ms
         sync_retry_nodes: 3
@@ -226,6 +229,7 @@ validator_configs:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
         max_header_delay: 100ms
+        min_header_delay: 100ms
         gc_depth: 50
         sync_retry_delay: 5000ms
         sync_retry_nodes: 3
@@ -293,6 +297,7 @@ validator_configs:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
         max_header_delay: 100ms
+        min_header_delay: 100ms
         gc_depth: 50
         sync_retry_delay: 5000ms
         sync_retry_nodes: 3
@@ -360,6 +365,7 @@ validator_configs:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
         max_header_delay: 100ms
+        min_header_delay: 100ms
         gc_depth: 50
         sync_retry_delay: 5000ms
         sync_retry_nodes: 3
@@ -427,6 +433,7 @@ validator_configs:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
         max_header_delay: 100ms
+        min_header_delay: 100ms
         gc_depth: 50
         sync_retry_delay: 5000ms
         sync_retry_nodes: 3

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -33,6 +33,7 @@ pub fn test_and_configure_authority_configs(committee_size: usize) -> NetworkCon
         // Narwhal parameters may result in tests taking >60 seconds.
         parameters.header_num_of_batches_threshold = 1;
         parameters.max_header_delay = Duration::from_millis(200);
+        parameters.min_header_delay = Duration::from_millis(200);
         parameters.batch_size = 1;
         parameters.max_batch_delay = Duration::from_millis(200);
     }
@@ -54,6 +55,7 @@ pub fn test_authority_configs_with_objects(objects: Vec<Object>) -> (NetworkConf
         // Narwhal parameters may result in tests taking >60 seconds.
         parameters.header_num_of_batches_threshold = 1;
         parameters.max_header_delay = Duration::from_millis(200);
+        parameters.min_header_delay = Duration::from_millis(200);
         parameters.batch_size = 1;
         parameters.max_batch_delay = Duration::from_millis(200);
     }

--- a/narwhal/benchmark/README.md
+++ b/narwhal/benchmark/README.md
@@ -39,7 +39,8 @@ The nodes parameters determine the configuration for the primaries and workers:
 node_params = {
     'header_num_of_batches_threshold': 32,
     'max_header_num_of_batches': 1000,
-    'max_header_delay': '100ms',
+    'max_header_delay': '2000ms',
+    'min_header_delay': '1000ms',
     'gc_depth': 50,
     'sync_retry_delay': '10000ms',
     'sync_retry_nodes': 3,
@@ -65,7 +66,8 @@ They are defined as follows:
 
 - `header_num_of_batches_threshold`: The minimum number of batches that will trigger a new header creation
 - `max_header_num_of_batches`: The maximum number of batch digests included in a header.
-- `max_header_delay`: The maximum delay that the primary waits between generating two headers, even if the header did not reach `header_num_of_batches_threshold`. Denominated in milliseconds (ms).
+- `max_header_delay`: The maximum delay that the primary waits between generating two headers, even if the header does not reach `header_num_of_batches_threshold` or contain leader in parents. Denominated in milliseconds (ms).
+- `min_header_delay`: The delay that the primary waits between generating two headers, even if `header_num_of_batches_threshold` is not reached. Denominated in ms.
 - `gc_depth`: The depth of the garbage collection. Denominated in number of rounds.
 - `sync_retry_delay`: The delay after which the synchronizer retries to send sync requests. Denominated in ms.
 - `sync_retry_nodes`: How many nodes to sync when re-trying to send sync-request. These nodes are picked at random from the committee.

--- a/narwhal/config/tests/config_tests.rs
+++ b/narwhal/config/tests/config_tests.rs
@@ -174,7 +174,6 @@ fn parameters_import_snapshot_matches() {
     let input = r#"{
          "header_num_of_batches_threshold": 32,
          "max_header_num_of_batches": 1000,
-         "max_header_delay": "100ms",
          "gc_depth": 50,
          "sync_retry_delay": "5s",
          "sync_retry_nodes": 3,

--- a/narwhal/config/tests/snapshots/config_tests__parameters.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters.snap
@@ -6,6 +6,7 @@ expression: parameters
   "header_num_of_batches_threshold": 32,
   "max_header_num_of_batches": 1000,
   "max_header_delay": "100ms",
+  "min_header_delay": "100ms",
   "gc_depth": 50,
   "sync_retry_delay": "5000ms",
   "sync_retry_nodes": 3,

--- a/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
@@ -5,7 +5,8 @@ expression: params
 {
   "header_num_of_batches_threshold": 32,
   "max_header_num_of_batches": 1000,
-  "max_header_delay": "100ms",
+  "max_header_delay": "2000ms",
+  "min_header_delay": "1800ms",
   "gc_depth": 50,
   "sync_retry_delay": "5000ms",
   "sync_retry_nodes": 3,

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -505,6 +505,7 @@ impl Primary {
             parameters.header_num_of_batches_threshold,
             parameters.max_header_num_of_batches,
             parameters.max_header_delay,
+            parameters.min_header_delay,
             None,
             network_model,
             tx_shutdown.subscribe(),

--- a/narwhal/primary/src/tests/proposer_tests.rs
+++ b/narwhal/primary/src/tests/proposer_tests.rs
@@ -36,6 +36,7 @@ async fn propose_empty() {
         /* header_num_of_batches_threshold */ 32,
         /* max_header_num_of_batches */ 100,
         /* max_header_delay */ Duration::from_millis(20),
+        /* min_header_delay */ Duration::from_millis(20),
         None,
         NetworkModel::PartiallySynchronous,
         tx_shutdown.subscribe(),
@@ -84,6 +85,8 @@ async fn propose_payload_and_repropose_after_n_seconds() {
         /* header_num_of_batches_threshold */ 1,
         /* max_header_num_of_batches */ max_num_of_batches,
         /* max_header_delay */
+        Duration::from_millis(1_000_000), // Ensure it is not triggered.
+        /* min_header_delay */
         Duration::from_millis(1_000_000), // Ensure it is not triggered.
         Some(header_resend_delay),
         NetworkModel::PartiallySynchronous,
@@ -206,6 +209,8 @@ async fn equivocation_protection() {
         /* max_header_num_of_batches */ 10,
         /* max_header_delay */
         Duration::from_millis(1_000_000), // Ensure it is not triggered.
+        /* min_header_delay */
+        Duration::from_millis(1_000_000), // Ensure it is not triggered.
         None,
         NetworkModel::PartiallySynchronous,
         tx_shutdown.subscribe(),
@@ -275,6 +280,8 @@ async fn equivocation_protection() {
         /* header_num_of_batches_threshold */ 1,
         /* max_header_num_of_batches */ 10,
         /* max_header_delay */
+        Duration::from_millis(1_000_000), // Ensure it is not triggered.
+        /* min_header_delay */
         Duration::from_millis(1_000_000), // Ensure it is not triggered.
         None,
         NetworkModel::PartiallySynchronous,


### PR DESCRIPTION
Currently we are trying to use the header batches threshold to determine the speed of generating headers, which depends on the rate of batch creations, which in turn depends on the write rate. Instead, adding a new `min_header_delay` parameter, which allows proposing headers before reaching batch threshold, would make the header propose latency more predictable especially under lower TPS.

For now, the `min_header_delay` is set to 1.8s, only slightly below `max_header_delay`, to separate behavior change from this PR. We will run experiments on different values. One possibility as @arun-koshy proposed is to set `min_header_delay` to 1s and `max_header_delay` to 5s.

Also, ensure leader only needs to wait for parent stakes and nothing else.