### PR TITLE
[inc147] Fix retry loop on making checkpoints

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -428,7 +428,7 @@ impl CheckpointBuilder {
 
     async fn run(mut self) {
         info!("Starting CheckpointBuilder");
-        loop {
+        'main: loop {
             // Check whether an exit signal has been received, if so we break the loop.
             // This gives us a chance to exit, in case checkpoint making keeps failing.
             match self.exit.has_changed() {
@@ -445,7 +445,7 @@ impl CheckpointBuilder {
                     error!("Error while making checkpoint, will retry in 1s: {:?}", e);
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     self.metrics.checkpoint_errors.inc();
-                    continue;
+                    continue 'main;
                 }
             }
             debug!("Waiting for more checkpoints from consensus after processing {last_processed_height:?}");


### PR DESCRIPTION
Fix the logic to retry checkpoints what a validator has failed to create due to an error. The bug was that the `continue` statement was continuing the `for` iterator, rather than restarting the iteration at the start of the `loop`. Identified with @akichidis .