### PR TITLE
keytool: Make keytool sign take tx_bytes

### DIFF
--- a/crates/sui-types/src/intent.rs
+++ b/crates/sui-types/src/intent.rs
@@ -1,24 +1,54 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use eyre::eyre;
+use fastcrypto::encoding::decode_bytes_hex;
 use serde::{Deserialize, Serialize};
 use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
+use std::str::FromStr;
 
 #[cfg(test)]
 #[path = "unit_tests/intent_tests.rs"]
 mod intent_tests;
 
+/// The version here is to distinguish between signing different versions of the struct
+/// or enum. Serialized output between two different versions of the same struct/enum
+/// might accidentally (or maliciously on purpose) match.
 #[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug, Hash)]
 #[repr(u8)]
 pub enum IntentVersion {
     V0 = 0,
 }
 
+impl TryFrom<u8> for IntentVersion {
+    type Error = eyre::Report;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::V0),
+            _ => Err(eyre!("Invalid IntentVersion")),
+        }
+    }
+}
+
+/// This enums specifies the application ID. Two intents in two different applications
+/// (i.e., Narwhal, Sui, Ethereum etc) should never collide, so that even when a signing
+/// key is reused, nobody can take a signature designated for app_1 and present it as a
+/// valid signature for an (any) intent in app_2.
 #[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug, Hash)]
 #[repr(u8)]
 pub enum AppId {
     Sui = 0,
+}
+
+impl TryFrom<u8> for AppId {
+    type Error = eyre::Report;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Sui),
+            _ => Err(eyre!("Invalid AppId")),
+        }
+    }
 }
 
 impl Default for AppId {
@@ -26,24 +56,53 @@ impl Default for AppId {
         Self::Sui
     }
 }
-pub trait SecureIntent: Serialize + private::SealedIntent {}
 
 #[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug, Hash)]
 #[repr(u8)]
 pub enum IntentScope {
     TransactionData = 0,
     TransactionEffects = 1,
-    // deleted
-    // AuthorityBatch = 2,
-    CheckpointSummary = 3,
-    PersonalMessage = 4,
+    CheckpointSummary = 2,
+    PersonalMessage = 3,
 }
 
+impl TryFrom<u8> for IntentScope {
+    type Error = eyre::Report;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::TransactionData),
+            1 => Ok(Self::TransactionEffects),
+            2 => Ok(Self::CheckpointSummary),
+            3 => Ok(Self::PersonalMessage),
+            _ => Err(eyre!("Invalid IntentScope")),
+        }
+    }
+}
+/// An intent is a compact struct serves as the domain separator for a message that a signature commits to.
+/// It consists of three parts: [enum IntentScope] (what the type of the message is), [enum IntentVersion], [enum AppId] (what application that the signature refers to).
+/// It is used to construct [struct IntentMessage] that what a signature commits to.
+///
+/// The serialization of an Intent is a 3-byte array where each field is represented by a byte.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Hash)]
 pub struct Intent {
     pub scope: IntentScope,
     pub version: IntentVersion,
     pub app_id: AppId,
+}
+
+impl FromStr for Intent {
+    type Err = eyre::Report;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s: Vec<u8> = decode_bytes_hex(s).map_err(|_| eyre!("Invalid Intent"))?;
+        if s.len() != 3 {
+            return Err(eyre!("Invalid Intent"));
+        }
+        Ok(Self {
+            scope: s[0].try_into()?,
+            version: s[1].try_into()?,
+            app_id: s[2].try_into()?,
+        })
+    }
 }
 
 impl Intent {
@@ -68,6 +127,14 @@ impl Default for Intent {
     }
 }
 
+/// Intent Message is a wrapper around a message with its intent. The message can
+/// be any type that implements [trait Serialize]. *ALL* signatures in Sui must commits
+/// to the intent message, not the message itself. This guarantees any intent
+/// message signed in the system cannot collide with another since they are domain
+/// separated by intent.
+///
+/// The serialization of an IntentMessage is compact: it only appends three bytes
+/// to the message itself.
 #[derive(Debug, PartialEq, Eq, Serialize, Clone, Hash, Deserialize)]
 pub struct IntentMessage<T> {
     pub intent: Intent,
@@ -80,11 +147,13 @@ impl<T> IntentMessage<T> {
     }
 }
 
-// --- PersonalMessage intent ---
+/// A person message that wraps around a byte array.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct PersonalMessage {
     pub message: Vec<u8>,
 }
+
+pub trait SecureIntent: Serialize + private::SealedIntent {}
 
 pub(crate) mod private {
     use super::IntentMessage;


### PR DESCRIPTION
https://github.com/MystenLabs/sui/issues/7585
https://github.com/MystenLabs/sui/issues/7933

Also added more description to all keytool commands.

Test:
No passed intent uses default:
```
target/debug/sui keytool sign --address 0x183ee5473ffecfc959d0c547a6198b94e3c2c971 --data AAUBJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEykfPeOqVvjFzPykn9reCYsWIDgQEQJwAAAAAAACG2Cqmoyxicy+IEYdv60iAv3vVbJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEAAAAAAAAA6AMAAAAAAAA=
Signer address: 0x183ee5473ffecfc959d0c547a6198b94e3c2c971
Raw tx_bytes to execute: AAUBJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEykfPeOqVvjFzPykn9reCYsWIDgQEQJwAAAAAAACG2Cqmoyxicy+IEYdv60iAv3vVbJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEAAAAAAAAA6AMAAAAAAAA=
Intent: Intent { scope: TransactionData, version: V0, app_id: Sui }
Intent message to sign: "AAAAAAUBJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEykfPeOqVvjFzPykn9reCYsWIDgQEQJwAAAAAAACG2Cqmoyxicy+IEYdv60iAv3vVbJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEAAAAAAAAA6AMAAAAAAAA="
Serialized signature (`flag || sig || pk` in Base64): "ACmYa480pal2uM89WbuwXBZSdp039JdRrWQlLnqJiM1mcHPHFgowmc8TvwygUFjIQRx0Z7Jhf60hr73Vs5paKgCoeXc+5rQMhfoio/a8o4a+JNvOiAf0zfFkx2u0qtuVnA=="
```

Pass in intent as hex works: 
```
target/debug/sui keytool sign --address 0x183ee5473ffecfc959d0c547a6198b94e3c2c971 --data AAUBJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEykfPeOqVvjFzPykn9reCYsWIDgQEQJwAAAAAAACG2Cqmoyxicy+IEYdv60iAv3vVbJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEAAAAAAAAA6AMAAAAAAAA= --intent 010000
Signer address: 0x183ee5473ffecfc959d0c547a6198b94e3c2c971
Raw tx_bytes to execute: AAUBJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEykfPeOqVvjFzPykn9reCYsWIDgQEQJwAAAAAAACG2Cqmoyxicy+IEYdv60iAv3vVbJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEAAAAAAAAA6AMAAAAAAAA=
Intent: Intent { scope: TransactionEffects, version: V0, app_id: Sui }
Intent message to sign: "AQAAAAUBJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEykfPeOqVvjFzPykn9reCYsWIDgQEQJwAAAAAAACG2Cqmoyxicy+IEYdv60iAv3vVbJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEAAAAAAAAA6AMAAAAAAAA="
Serialized signature (`flag || sig || pk` in Base64): "AOhgzSIDTjVYzSM2bLSB1eRoJ5FS3NGxP4VnqzjndexsV1ntrgfpbwwCG3MV4YaftW3oZN5DzgNYMkaNqvTeaweoeXc+5rQMhfoio/a8o4a+JNvOiAf0zfFkx2u0qtuVnA=="
```
Invalid data shows better error: 

```
target/debug/sui keytool sign --address 0x183ee5473ffecfc959d0c547a6198b94e3c2c971 --data AAUBJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEykfPeOqVvjFzPykn9reCYsWIDgQEQJwAAAAAAACG2Cqmoyxicy+IEYdv60iAv3vVbJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEAAAAAAAAA6AMAAAAAAAA
Signer address: 0x183ee5473ffecfc959d0c547a6198b94e3c2c971
Raw tx_bytes to execute: AAUBJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEykfPeOqVvjFzPykn9reCYsWIDgQEQJwAAAAAAACG2Cqmoyxicy+IEYdv60iAv3vVbJGVmt0B7OkTdye3kkgee3MiGJucAAAAAAAAAACCKlXcHDNqFIL1TuGQiJV7+CaO7V4A85cMKz9ILXOz7PAEAAAAAAAAA6AMAAAAAAAA
Intent: Intent { scope: TransactionData, version: V0, app_id: Sui }
Cannot deserialize data as TransactionData invalid Base64 encoding

Location:
    /Users/joy/.cargo/git/checkouts/fastcrypto-52df1bab54ce57e6/235211d/fastcrypto/src/encoding.rs:104:53
```