### PR TITLE
[rpc] Add finalized effects

### DIFF
--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -29,7 +29,8 @@ use sui_types::committee::Committee;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    QuorumDriverResponse, VerifiedCertificate, VerifiedCertifiedTransactionEffects,
+    FinalizedEffects, QuorumDriverResponse, VerifiedCertificate,
+    VerifiedCertifiedTransactionEffects,
 };
 use sui_types::quorum_driver_types::{
     QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResult,
@@ -193,7 +194,7 @@ where
                 if !wait_for_local_execution {
                     return Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         Some(tx_cert.into()),
-                        effects_cert.into(),
+                        FinalizedEffects::new_from_effects_cert(effects_cert.into()),
                         false,
                     ))));
                 }
@@ -207,12 +208,12 @@ where
                 {
                     Ok(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         Some(tx_cert.into()),
-                        effects_cert.into(),
+                        FinalizedEffects::new_from_effects_cert(effects_cert.into()),
                         true,
                     )))),
                     Err(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         Some(tx_cert.into()),
-                        effects_cert.into(),
+                        FinalizedEffects::new_from_effects_cert(effects_cert.into()),
                         false,
                     )))),
                 }

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -43,11 +43,12 @@ use sui_types::event::{EventEnvelope, EventType};
 use sui_types::filter::{EventFilter, TransactionFilter};
 use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
+use sui_types::message_envelope::Message;
 use sui_types::messages::{
-    CallArg, CertifiedTransaction, CertifiedTransactionEffects, ExecuteTransactionResponse,
-    ExecutionStatus, GenesisObject, InputObjectKind, MoveModulePublish, ObjectArg, Pay, PayAllSui,
-    PaySui, SingleTransactionKind, TransactionData, TransactionEffects, TransactionKind,
-    VerifiedCertificate,
+    CallArg, CertifiedTransaction, EffectsFinalityInfo, ExecuteTransactionResponse,
+    ExecutionStatus, FinalizedEffects, GenesisObject, InputObjectKind, MoveModulePublish,
+    ObjectArg, Pay, PayAllSui, PaySui, SingleTransactionKind, TransactionData, TransactionEffects,
+    TransactionKind, VerifiedCertificate,
 };
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::move_package::{disassemble_modules, MovePackage};
@@ -402,7 +403,7 @@ pub enum SuiTBlsSignObjectCommitmentType {
     /// Check that the object is committed by the consensus.
     ConsensusCommitted,
     /// Check that the object is committed using the effects certificate.
-    FastPathCommitted(SuiCertifiedTransactionEffects),
+    FastPathCommitted(SuiFinalizedEffects),
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -416,7 +417,7 @@ pub struct SuiExecuteTransactionResponse {
     // If this transaction was already finalized previously, there is no guarantee that a
     // certificate is still available.
     pub certificate: Option<SuiCertifiedTransaction>,
-    pub effects: SuiCertifiedTransactionEffects,
+    pub effects: SuiFinalizedEffects,
     // If the transaction is confirmed to be executed locally
     // before this response.
     pub confirmed_local_execution: bool,
@@ -434,8 +435,8 @@ impl SuiExecuteTransactionResponse {
                     Some(c) => Some(c.try_into()?),
                     None => None,
                 };
-                let effects: SuiCertifiedTransactionEffects =
-                    SuiCertifiedTransactionEffects::try_from(effects, resolver)?;
+                let effects: SuiFinalizedEffects =
+                    SuiFinalizedEffects::try_from(effects, resolver)?;
                 SuiExecuteTransactionResponse {
                     certificate,
                     effects,
@@ -1833,17 +1834,35 @@ impl TryFrom<VerifiedCertificate> for SuiCertifiedTransaction {
     }
 }
 
-/// The certified Transaction Effects which has signatures from >= 2/3 of validators
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename = "CertifiedTransactionEffects", rename_all = "camelCase")]
-pub struct SuiCertifiedTransactionEffects {
-    pub transaction_effects_digest: TransactionEffectsDigest,
-    pub effects: SuiTransactionEffects,
-    /// authority signature information signed by the quorum of the validators.
-    pub auth_sign_info: SuiAuthorityStrongQuorumSignInfo,
+#[serde(rename = "EffectsFinalityInfo", rename_all = "camelCase")]
+pub enum SuiEffectsFinalityInfo {
+    Certified(SuiAuthorityStrongQuorumSignInfo),
+    Checkpointed(EpochId, CheckpointSequenceNumber),
 }
 
-impl Display for SuiCertifiedTransactionEffects {
+impl From<EffectsFinalityInfo> for SuiEffectsFinalityInfo {
+    fn from(info: EffectsFinalityInfo) -> Self {
+        match info {
+            EffectsFinalityInfo::Certified(cert) => {
+                Self::Certified(SuiAuthorityStrongQuorumSignInfo::from(&cert))
+            }
+            EffectsFinalityInfo::Checkpointed(epoch, checkpoint) => {
+                Self::Checkpointed(epoch, checkpoint)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename = "FinalizedEffects", rename_all = "camelCase")]
+pub struct SuiFinalizedEffects {
+    pub transaction_effects_digest: TransactionEffectsDigest,
+    pub effects: SuiTransactionEffects,
+    pub finality_info: SuiEffectsFinalityInfo,
+}
+
+impl Display for SuiFinalizedEffects {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut writer = String::new();
         writeln!(
@@ -1852,30 +1871,34 @@ impl Display for SuiCertifiedTransactionEffects {
             self.transaction_effects_digest
         )?;
         writeln!(writer, "Transaction Effects: {:?}", self.effects)?;
-        writeln!(
-            writer,
-            "Signed Authorities Bitmap: {:?}",
-            self.auth_sign_info.signers_map
-        )?;
+        match &self.finality_info {
+            SuiEffectsFinalityInfo::Certified(cert) => {
+                writeln!(writer, "Signed Authorities Bitmap: {:?}", cert.signers_map)?;
+            }
+            SuiEffectsFinalityInfo::Checkpointed(epoch, checkpoint) => {
+                writeln!(
+                    writer,
+                    "Finalized at epoch {:?}, checkpoint {:?}",
+                    epoch, checkpoint
+                )?;
+            }
+        }
+
         write!(f, "{}", writer)
     }
 }
 
-impl SuiCertifiedTransactionEffects {
+impl SuiFinalizedEffects {
     fn try_from(
-        cert: CertifiedTransactionEffects,
+        effects: FinalizedEffects,
         resolver: &impl GetModule,
     ) -> Result<Self, anyhow::Error> {
-        let digest = *cert.digest();
-        let (effects, auth_sign_info) = cert.into_data_and_sig();
+        let digest = effects.effects.digest();
         // We should always have a signature here.
-        if auth_sign_info.signature.sig.is_none() {
-            return Err(anyhow::anyhow!("No quorum signature."));
-        }
         Ok(Self {
             transaction_effects_digest: digest,
-            effects: SuiTransactionEffects::try_from(effects, resolver)?,
-            auth_sign_info: SuiAuthorityStrongQuorumSignInfo::from(&auth_sign_info),
+            effects: SuiTransactionEffects::try_from(effects.effects, resolver)?,
+            finality_info: effects.finality_info.into(),
         })
     }
 }

--- a/crates/sui-json-rpc/src/threshold_bls_api.rs
+++ b/crates/sui-json-rpc/src/threshold_bls_api.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::SuiTBlsSignObjectCommitmentType::{ConsensusCommitted, FastPathCommitted};
 use sui_json_rpc_types::{
-    SuiCertifiedTransactionEffects, SuiTBlsSignObjectCommitmentType,
+    SuiEffectsFinalityInfo, SuiFinalizedEffects, SuiTBlsSignObjectCommitmentType,
     SuiTBlsSignRandomnessObjectResponse,
 };
 use sui_open_rpc::Module;
@@ -63,44 +63,53 @@ impl ThresholdBlsApi {
         Ok(())
     }
 
-    async fn verify_effects_cert(
+    async fn verify_finalized_effects(
         &self,
         object_id: ObjectID,
-        effects_cert: &SuiCertifiedTransactionEffects,
+        finalized_effects: &SuiFinalizedEffects,
     ) -> Result<(), Error> {
-        if effects_cert.auth_sign_info.epoch != self.state.epoch() {
-            Err(anyhow!(
-                "Old effects certificate, check instead if committed by consensus"
-            ))?
+        match &finalized_effects.finality_info {
+            SuiEffectsFinalityInfo::Certified(cert) => {
+                let epoch_store = self.state.epoch_store();
+                if cert.epoch != epoch_store.epoch() {
+                    Err(anyhow!(
+                        "Old effects certificate, check instead if committed by consensus"
+                    ))?
+                }
+                // Check the certificate.
+                let _committee = epoch_store.committee();
+
+                // TODO: convert SuiTransactionEffects to TransactionEffects before the next line.
+                // effects_cert
+                //     .auth_sign_info
+                //     .verify(&effects_cert.effects, &committee)
+                //     .map_err(|e| anyhow!(e))?;
+
+                // Check that the object is indeed in the effects.
+                finalized_effects
+                    .effects
+                    .created
+                    .iter()
+                    .chain(finalized_effects.effects.mutated.iter())
+                    .find(|owned_obj_ref| owned_obj_ref.reference.object_id == object_id)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "Object was not created/mutated in the provided effects certificate"
+                        )
+                    })?;
+
+                // Check that the object is indeed a Randomness object.
+                let _obj = self.get_randomness_object(object_id).await?;
+                Ok(())
+            }
+            SuiEffectsFinalityInfo::Checkpointed(_epoch, _checkpoint) => {
+                // TODO: Properly verify this.
+                Err(SuiError::UnsupportedFeatureError {
+                    error: "Checkpointed effects not supported yet".to_string(),
+                }
+                .into())
+            }
         }
-        // Check the certificate.
-        let _committee = self
-            .state
-            .committee_store()
-            .get_committee(&self.state.epoch())?
-            .ok_or_else(|| Error::InternalError(anyhow!("Committee not available")))?;
-
-        // TODO: convert SuiTransactionEffects to TransactionEffects before the next line.
-        // effects_cert
-        //     .auth_sign_info
-        //     .verify(&effects_cert.effects, &committee)
-        //     .map_err(|e| anyhow!(e))?;
-
-        // Check that the object is indeed in the effects.
-        effects_cert
-            .effects
-            .created
-            .iter()
-            .chain(effects_cert.effects.mutated.iter())
-            .find(|owned_obj_ref| owned_obj_ref.reference.object_id == object_id)
-            .ok_or_else(|| {
-                anyhow!("Object was not created/mutated in the provided effects certificate")
-            })?;
-
-        // Check that the object is indeed a Randomness object.
-        let _obj = self.get_randomness_object(object_id).await?;
-
-        Ok(())
     }
 }
 
@@ -117,8 +126,9 @@ impl ThresholdBlsApiServer for ThresholdBlsApi {
     ) -> RpcResult<SuiTBlsSignRandomnessObjectResponse> {
         match commitment_type {
             ConsensusCommitted => self.verify_object_alive_and_committed(object_id).await?,
-            FastPathCommitted(effects_cert) => {
-                self.verify_effects_cert(object_id, &effects_cert).await?
+            FastPathCommitted(finalized_effects) => {
+                self.verify_finalized_effects(object_id, &finalized_effects)
+                    .await?
             }
         };
         // Construct the message to be signed, as done in the Move code of the Randomness object.

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2953,31 +2953,6 @@
           }
         }
       },
-      "CertifiedTransactionEffects": {
-        "description": "The certified Transaction Effects which has signatures from >= 2/3 of validators",
-        "type": "object",
-        "required": [
-          "authSignInfo",
-          "effects",
-          "transactionEffectsDigest"
-        ],
-        "properties": {
-          "authSignInfo": {
-            "description": "authority signature information signed by the quorum of the validators.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SuiAuthorityStrongQuorumSignInfo"
-              }
-            ]
-          },
-          "effects": {
-            "$ref": "#/components/schemas/TransactionEffects"
-          },
-          "transactionEffectsDigest": {
-            "$ref": "#/components/schemas/TransactionEffectsDigest"
-          }
-        }
-      },
       "CheckpointContents": {
         "description": "CheckpointContents are the transactions included in an upcoming checkpoint. They must have already been causally ordered. Since the causal order algorithm is the same among validators, we expect all honest validators to come up with the same order for each checkpoint content.",
         "type": "object",
@@ -3347,6 +3322,48 @@
       },
       "Ed25519SuiSignature": {
         "$ref": "#/components/schemas/Base64"
+      },
+      "EffectsFinalityInfo": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "certified"
+            ],
+            "properties": {
+              "certified": {
+                "$ref": "#/components/schemas/SuiAuthorityStrongQuorumSignInfo"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "checkpointed"
+            ],
+            "properties": {
+              "checkpointed": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "Entry_for_SuiAddress_and_VecSet_for_SuiAddress": {
         "description": "Rust version of the Move sui::vec_map::Entry type",
@@ -4222,6 +4239,25 @@
             }
           }
         ]
+      },
+      "FinalizedEffects": {
+        "type": "object",
+        "required": [
+          "effects",
+          "finalityInfo",
+          "transactionEffectsDigest"
+        ],
+        "properties": {
+          "effects": {
+            "$ref": "#/components/schemas/TransactionEffects"
+          },
+          "finalityInfo": {
+            "$ref": "#/components/schemas/EffectsFinalityInfo"
+          },
+          "transactionEffectsDigest": {
+            "$ref": "#/components/schemas/TransactionEffectsDigest"
+          }
+        }
       },
       "GasCostSummary": {
         "type": "object",
@@ -5316,7 +5352,7 @@
             "type": "boolean"
           },
           "effects": {
-            "$ref": "#/components/schemas/CertifiedTransactionEffects"
+            "$ref": "#/components/schemas/FinalizedEffects"
           }
         }
       },
@@ -5877,7 +5913,7 @@
             ],
             "properties": {
               "FastPathCommitted": {
-                "$ref": "#/components/schemas/CertifiedTransactionEffects"
+                "$ref": "#/components/schemas/FinalizedEffects"
               }
             },
             "additionalProperties": false

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -35,6 +35,14 @@ pub struct Envelope<T: Message, S> {
 }
 
 impl<T: Message, S> Envelope<T, S> {
+    pub fn new_from_data_and_sig(data: T, sig: S) -> Self {
+        Self {
+            digest: Default::default(),
+            data,
+            auth_signature: sig,
+        }
+    }
+
     pub fn data(&self) -> &T {
         &self.data
     }

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -25,6 +25,7 @@ use sui_types::base_types::{ObjectRef, SequenceNumber};
 use sui_types::crypto::{get_key_pair, SuiKeyPair};
 use sui_types::event::BalanceChangeType;
 use sui_types::event::Event;
+use sui_types::message_envelope::Message;
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
     QuorumDriverResponse,
@@ -957,7 +958,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let (ct, cte, is_executed_locally) = *res;
     assert_eq!(*ct.unwrap().digest(), digest);
     assert_eq!(*certified_txn.digest(), digest);
-    assert_eq!(*cte.digest(), *certified_txn_effects.digest());
+    assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(is_executed_locally);
     // verify that the node has sequenced and executed the txn
     node.state().get_transaction(digest).await
@@ -982,7 +983,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let (ct, cte, is_executed_locally) = *res;
     assert_eq!(*ct.unwrap().digest(), digest);
     assert_eq!(*certified_txn.digest(), digest);
-    assert_eq!(*cte.digest(), *certified_txn_effects.digest());
+    assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(!is_executed_locally);
     wait_for_tx(digest, node.state().clone()).await;
     node.state().get_transaction(digest).await

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -7,8 +7,8 @@ use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_macros::sim_test;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::messages::{
-    CertifiedTransactionEffects, ExecuteTransactionRequest, ExecuteTransactionRequestType,
-    ExecuteTransactionResponse, TransactionData, VerifiedTransaction,
+    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
+    FinalizedEffects, TransactionData, VerifiedTransaction,
 };
 use sui_types::object::generate_test_gas_objects_with_owner;
 use sui_types::quorum_driver_types::QuorumDriverError;
@@ -205,8 +205,7 @@ async fn test_tx_across_epoch_boundaries() {
     let total_tx_cnt = 1;
     let (sender, keypair) = get_key_pair::<AccountKeyPair>();
     let gas_objects = generate_test_gas_objects_with_owner(1, sender);
-    let (result_tx, mut result_rx) =
-        tokio::sync::mpsc::channel::<CertifiedTransactionEffects>(total_tx_cnt);
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel::<FinalizedEffects>(total_tx_cnt);
 
     let (config, mut gas_objects) = test_authority_configs_with_objects(gas_objects);
     let authorities = spawn_test_authorities([], &config).await;


### PR DESCRIPTION
This PR adds the concept of finalized effects, to replace effects certificate.
There are two different cases for a finalized effects, one is effects certificate, and one is effects that were finalized in a specific checkpoint.
This PR only touches the RPC interface to update it first. Latter we will make validators to actually return it.