### PR TITLE
[reconfiguration] Time based reconfiguration trigger

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::node::{
-    default_checkpoints_per_epoch, default_end_of_epoch_broadcast_channel_capacity,
+    default_end_of_epoch_broadcast_channel_capacity, default_epoch_duration_ms,
     AuthorityKeyPairWithPath, KeyPairWithPath,
 };
 use crate::{
@@ -47,7 +47,7 @@ pub struct ConfigBuilder<R = OsRng> {
     additional_objects: Vec<Object>,
     with_swarm: bool,
     validator_ip_sel: ValidatorIpSelection,
-    checkpoints_per_epoch: Option<u64>,
+    epoch_duration_ms: u64,
 }
 
 impl ConfigBuilder {
@@ -67,7 +67,7 @@ impl ConfigBuilder {
             } else {
                 ValidatorIpSelection::Localhost
             },
-            checkpoints_per_epoch: default_checkpoints_per_epoch(),
+            epoch_duration_ms: default_epoch_duration_ms(),
         }
     }
 }
@@ -108,8 +108,8 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
-    pub fn with_checkpoints_per_epoch(mut self, ckpts: u64) -> Self {
-        self.checkpoints_per_epoch = Some(ckpts);
+    pub fn with_epoch_duration(mut self, epoch_duration_ms: u64) -> Self {
+        self.epoch_duration_ms = epoch_duration_ms;
         self
     }
 
@@ -123,7 +123,7 @@ impl<R> ConfigBuilder<R> {
             additional_objects: self.additional_objects,
             with_swarm: self.with_swarm,
             validator_ip_sel: self.validator_ip_sel,
-            checkpoints_per_epoch: self.checkpoints_per_epoch,
+            epoch_duration_ms: self.epoch_duration_ms,
         }
     }
 }
@@ -367,7 +367,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     json_rpc_address: utils::available_local_socket_address(),
                     consensus_config: Some(consensus_config),
                     enable_event_processing: false,
-                    checkpoints_per_epoch: self.checkpoints_per_epoch,
+                    epoch_duration_ms: self.epoch_duration_ms,
                     genesis: crate::node::Genesis::new(genesis.clone()),
                     grpc_load_shed: initial_accounts_config.grpc_load_shed,
                     grpc_concurrency_limit: initial_accounts_config.grpc_concurrency_limit,

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -60,13 +60,12 @@ pub struct NodeConfig {
     #[serde(default)]
     pub enable_event_processing: bool,
 
-    /// Number of checkpoints per epoch.
-    /// Some means reconfiguration is enabled.
-    /// None means reconfiguration is disabled.
+    // TODO: It will be removed down the road.
+    /// Epoch duration in ms.
+    /// u64::MAX means reconfiguration is disabled
     /// Exposing this in config to allow easier testing with shorter epoch.
-    /// TODO: It will be removed down the road.
-    #[serde(default = "default_checkpoints_per_epoch")]
-    pub checkpoints_per_epoch: Option<u64>,
+    #[serde(default = "default_epoch_duration_ms")]
+    pub epoch_duration_ms: u64,
 
     #[serde(default)]
     pub grpc_load_shed: Option<bool>,
@@ -135,9 +134,9 @@ pub fn default_concurrency_limit() -> Option<usize> {
     Some(DEFAULT_GRPC_CONCURRENCY_LIMIT)
 }
 
-pub fn default_checkpoints_per_epoch() -> Option<u64> {
-    // Currently a checkpoint is ~3 seconds, 3000 checkpoints is 9000s, which is about 2.5 hours.
-    Some(3000)
+pub fn default_epoch_duration_ms() -> u64 {
+    // 24 Hrs
+    24 * 60 * 60 * 1000
 }
 
 pub fn default_end_of_epoch_broadcast_channel_capacity() -> usize {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -3,7 +3,7 @@
 
 use crate::node::AuthorityStorePruningConfig;
 use crate::node::{
-    default_checkpoints_per_epoch, default_end_of_epoch_broadcast_channel_capacity,
+    default_end_of_epoch_broadcast_channel_capacity, default_epoch_duration_ms,
     AuthorityKeyPairWithPath, KeyPairWithPath,
 };
 use crate::p2p::{P2pConfig, SeedPeer};
@@ -232,7 +232,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             json_rpc_address,
             consensus_config: None,
             enable_event_processing: self.enable_event_store,
-            checkpoints_per_epoch: default_checkpoints_per_epoch(),
+            epoch_duration_ms: default_epoch_duration_ms(),
             genesis: validator_config.genesis.clone(),
             grpc_load_shed: None,
             grpc_concurrency_limit: None,

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -53,7 +53,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    checkpoints-per-epoch: 3000
+    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -120,7 +120,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    checkpoints-per-epoch: 3000
+    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -187,7 +187,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    checkpoints-per-epoch: 3000
+    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -254,7 +254,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    checkpoints-per-epoch: 3000
+    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -321,7 +321,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    checkpoints-per-epoch: 3000
+    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -388,7 +388,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    checkpoints-per-epoch: 3000
+    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -455,7 +455,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    checkpoints-per-epoch: 3000
+    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -170,7 +170,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
     );
 
     authority_state
-        .reconfigure(second_committee.committee().clone())
+        .reconfigure(second_committee.committee().clone(), 0)
         .await
         .unwrap();
 

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -480,6 +480,10 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
     fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
         let send_end_of_publish = {
             let reconfig_guard = epoch_store.get_reconfig_state_write_lock_guard();
+            if !reconfig_guard.should_accept_user_certs() {
+                // Allow caller to call this method multiple times
+                return;
+            }
             let pending_count = epoch_store.pending_consensus_certificates_count();
             debug!(epoch=?epoch_store.epoch(), ?pending_count, "Trying to close epoch");
             let send_end_of_publish = pending_count == 0;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2398,6 +2398,7 @@ async fn test_authority_persist() {
             &epoch_store_path,
             None,
             EpochMetrics::new(&registry),
+            Some(Default::default()),
         );
 
         let checkpoint_store_path = dir.join(format!("DB_{:?}", ObjectID::random()));
@@ -3921,6 +3922,7 @@ async fn test_tallying_rule_score_updates() {
         &epoch_store_path,
         None,
         metrics.clone(),
+        Some(Default::default()),
     );
 
     let get_stored_seq_num_and_counter = |auth_name: &AuthorityName| {

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -27,7 +27,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_count: usize,
     fullnode_rpc_addr: Option<SocketAddr>,
     with_event_store: bool,
-    checkpoints_per_epoch: Option<u64>,
+    epoch_duration_ms: Option<u64>,
 }
 
 impl SwarmBuilder {
@@ -41,7 +41,7 @@ impl SwarmBuilder {
             fullnode_count: 0,
             fullnode_rpc_addr: None,
             with_event_store: false,
-            checkpoints_per_epoch: None,
+            epoch_duration_ms: None,
         }
     }
 }
@@ -56,7 +56,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_count: self.fullnode_count,
             fullnode_rpc_addr: self.fullnode_rpc_addr,
             with_event_store: false,
-            checkpoints_per_epoch: None,
+            epoch_duration_ms: None,
         }
     }
 
@@ -98,8 +98,8 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    pub fn with_checkpoints_per_epoch(mut self, ckpts: u64) -> Self {
-        self.checkpoints_per_epoch = Some(ckpts);
+    pub fn with_epoch_duration_ms(mut self, epoch_duration_ms: u64) -> Self {
+        self.epoch_duration_ms = Some(epoch_duration_ms);
         self
     }
 }
@@ -119,8 +119,8 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             config_builder = config_builder.initial_accounts_config(initial_accounts_config);
         }
 
-        if let Some(checkpoints_per_epoch) = self.checkpoints_per_epoch {
-            config_builder = config_builder.with_checkpoints_per_epoch(checkpoints_per_epoch);
+        if let Some(epoch_duration_ms) = self.epoch_duration_ms {
+            config_builder = config_builder.with_epoch_duration(epoch_duration_ms);
         }
 
         let network_config = config_builder

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -76,7 +76,7 @@ async fn advance_epoch_tx_test_impl(
         .create_advance_epoch_tx_cert(
             &states[0].epoch_store_for_testing(),
             &GasCostSummary::new(0, 0, 0),
-            0,
+            0, // epoch_start_timestamp_ms
             Duration::from_secs(15),
             certifier,
         )
@@ -92,7 +92,7 @@ async fn advance_epoch_tx_test_impl(
                 .create_advance_epoch_tx_cert(
                     &state.epoch_store_for_testing(),
                     &GasCostSummary::new(0, 0, 0),
-                    0,
+                    0,                         // epoch_start_timestamp_ms
                     Duration::from_secs(1000), // A very very long time
                     certifier,
                 )
@@ -269,7 +269,7 @@ async fn test_passive_reconfig() {
     telemetry_subscribers::init_for_testing();
 
     let test_cluster = TestClusterBuilder::new()
-        .with_checkpoints_per_epoch(10)
+        .with_epoch_duration_ms(1000)
         .build()
         .await
         .unwrap();

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -172,7 +172,7 @@ pub struct TestClusterBuilder {
     num_validators: Option<usize>,
     fullnode_rpc_port: Option<u16>,
     enable_fullnode_events: bool,
-    checkpoints_per_epoch: Option<u64>,
+    epoch_duration_ms: Option<u64>,
 }
 
 impl TestClusterBuilder {
@@ -182,7 +182,7 @@ impl TestClusterBuilder {
             fullnode_rpc_port: None,
             num_validators: None,
             enable_fullnode_events: false,
-            checkpoints_per_epoch: None,
+            epoch_duration_ms: None,
         }
     }
 
@@ -206,8 +206,8 @@ impl TestClusterBuilder {
         self
     }
 
-    pub fn with_checkpoints_per_epoch(mut self, ckpts: u64) -> Self {
-        self.checkpoints_per_epoch = Some(ckpts);
+    pub fn with_epoch_duration_ms(mut self, epoch_duration_ms: u64) -> Self {
+        self.epoch_duration_ms = Some(epoch_duration_ms);
         self
     }
 
@@ -269,8 +269,8 @@ impl TestClusterBuilder {
             builder = builder.initial_accounts_config(genesis_config);
         }
 
-        if let Some(checkpoints_per_epoch) = self.checkpoints_per_epoch {
-            builder = builder.with_checkpoints_per_epoch(checkpoints_per_epoch);
+        if let Some(epoch_duration_ms) = self.epoch_duration_ms {
+            builder = builder.with_epoch_duration_ms(epoch_duration_ms);
         }
 
         let mut swarm = builder.build();


### PR DESCRIPTION
Instead of using number of checkpoints as a trigger for reconfiguration, we use a time based trigger - when more than configured duration has passed since epoch started we trigger reconfiguration.