### PR TITLE
Audit all epoch store loads in AuthorityState

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -451,17 +451,12 @@ pub struct AuthorityState {
 ///
 /// Repeating valid commands should produce no changes and return no error.
 impl AuthorityState {
-    pub fn is_validator(&self) -> bool {
-        self.epoch_store().committee().authority_exists(&self.name)
+    pub fn is_validator(&self, epoch_store: &AuthorityPerEpochStore) -> bool {
+        epoch_store.committee().authority_exists(&self.name)
     }
 
-    pub fn is_fullnode(&self) -> bool {
-        !self.is_validator()
-    }
-
-    // TODO: Audit all callsites to make sure it's safe.
-    pub fn epoch(&self) -> EpochId {
-        self.epoch_store().epoch()
+    pub fn is_fullnode(&self, epoch_store: &AuthorityPerEpochStore) -> bool {
+        !self.is_validator(epoch_store)
     }
 
     pub fn committee_store(&self) -> &Arc<CommitteeStore> {
@@ -526,7 +521,7 @@ impl AuthorityState {
         &self,
         transaction: VerifiedTransaction,
     ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
-        let epoch_store = self.epoch_store();
+        let epoch_store = self.load_epoch_store_one_call_per_task();
 
         let tx_digest = *transaction.digest();
         debug!(
@@ -589,7 +584,7 @@ impl AuthorityState {
         effects: &VerifiedCertifiedTransactionEffects,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
-        assert!(self.is_fullnode());
+        assert!(self.is_fullnode(epoch_store));
         let _metrics_guard = self
             .metrics
             .execute_certificate_with_effects_latency
@@ -1052,7 +1047,8 @@ impl AuthorityState {
         transaction: TransactionData,
         transaction_digest: TransactionDigest,
     ) -> Result<SuiTransactionEffects, anyhow::Error> {
-        if !self.is_fullnode() {
+        let epoch_store = self.load_epoch_store_one_call_per_task();
+        if !self.is_fullnode(&epoch_store) {
             return Err(anyhow!("dry-exec is only support on fullnodes"));
         }
 
@@ -1078,7 +1074,7 @@ impl AuthorityState {
                 &self.move_vm,
                 &self._native_functions,
                 gas_status,
-                self.epoch(),
+                epoch_store.epoch(),
             );
         SuiTransactionEffects::try_from(effects, self.module_cache.as_ref())
     }
@@ -1091,7 +1087,8 @@ impl AuthorityState {
         gas_price: u64,
         epoch: EpochId,
     ) -> Result<DevInspectResults, anyhow::Error> {
-        if !self.is_fullnode() {
+        let epoch_store = self.load_epoch_store_one_call_per_task();
+        if !self.is_fullnode(&epoch_store) {
             return Err(anyhow!("dev-inspect is only supported on fullnodes"));
         }
 
@@ -1406,17 +1403,20 @@ impl AuthorityState {
         &self,
         request: TransactionInfoRequest,
     ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
-        self.make_transaction_info(&request.transaction_digest, &self.epoch_store())?
-            .ok_or(SuiError::TransactionNotFound {
-                digest: request.transaction_digest,
-            })
+        self.make_transaction_info(
+            &request.transaction_digest,
+            &self.load_epoch_store_one_call_per_task(),
+        )?
+        .ok_or(SuiError::TransactionNotFound {
+            digest: request.transaction_digest,
+        })
     }
 
     pub async fn handle_object_info_request(
         &self,
         request: ObjectInfoRequest,
     ) -> Result<VerifiedObjectInfoResponse, SuiError> {
-        let epoch_store = self.epoch_store();
+        let epoch_store = self.load_epoch_store_one_call_per_task();
         let ref_and_digest = match request.request_kind {
             ObjectInfoRequestKind::PastObjectInfo(seq)
             | ObjectInfoRequestKind::PastObjectInfoDebug(seq, _) => {
@@ -1625,7 +1625,7 @@ impl AuthorityState {
         // Process tx recovery log first, so that checkpoint recovery (below)
         // doesn't observe partially-committed txes.
         state
-            .process_tx_recovery_log(None, &state.epoch_store())
+            .process_tx_recovery_log(None, &state.load_epoch_store_one_call_per_task())
             .await
             .expect("Could not fully process recovery log at startup!");
 
@@ -1832,29 +1832,22 @@ impl AuthorityState {
         self.database.clone()
     }
 
-    // TODO: Deprecate this once we replace all calls with load_epoch_store.
-    pub fn epoch_store(&self) -> Guard<Arc<AuthorityPerEpochStore>> {
+    pub fn current_epoch_for_testing(&self) -> EpochId {
+        self.epoch_store_for_testing().epoch()
+    }
+
+    /// Load the current epoch store. This can change during reconfiguration. To ensure that
+    /// we never end up accessing different epoch stores in a single task, we need to make sure
+    /// that this is called once per task. Each call needs to be carefully audited to ensure it is
+    /// the case. This also means we should minimize the number of call-sites. Only call it when
+    /// there is no way to obtain it from somewhere else.
+    pub fn load_epoch_store_one_call_per_task(&self) -> Guard<Arc<AuthorityPerEpochStore>> {
         self.epoch_store.load()
     }
 
     // Load the epoch store, should be used in tests only.
     pub fn epoch_store_for_testing(&self) -> Guard<Arc<AuthorityPerEpochStore>> {
-        self.epoch_store()
-    }
-
-    pub fn load_epoch_store(
-        &self,
-        intended_epoch: EpochId,
-    ) -> SuiResult<Guard<Arc<AuthorityPerEpochStore>>> {
-        let store = self.epoch_store();
-        fp_ensure!(
-            store.epoch() == intended_epoch,
-            SuiError::StoreAccessEpochMismatch {
-                store_epoch: store.epoch(),
-                intended_epoch,
-            }
-        );
-        Ok(store)
+        self.load_epoch_store_one_call_per_task()
     }
 
     pub fn clone_committee_for_testing(&self) -> Committee {
@@ -2596,7 +2589,7 @@ impl AuthorityState {
     /// This function is called at the very end of the epoch.
     /// This step is required before updating new epoch in the db and calling reopen_epoch_db.
     async fn revert_uncommitted_epoch_transactions(&self) -> SuiResult {
-        let epoch_store = self.epoch_store();
+        let epoch_store = self.load_epoch_store_one_call_per_task();
         {
             let state = epoch_store.get_reconfig_state_write_lock_guard();
             if state.should_accept_user_certs() {
@@ -2641,7 +2634,7 @@ impl AuthorityState {
         let epoch_start_configuration = EpochStartConfiguration {
             epoch_start_timestamp_ms,
         };
-        let epoch_tables = self.epoch_store().new_at_next_epoch(
+        let epoch_tables = self.load_epoch_store_one_call_per_task().new_at_next_epoch(
             self.name,
             new_committee,
             epoch_start_configuration,

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -276,6 +276,8 @@ impl ValidatorService {
         request: tonic::Request<CertifiedTransaction>,
         metrics: Arc<ValidatorServiceMetrics>,
     ) -> Result<tonic::Response<HandleCertificateResponse>, tonic::Status> {
+        let epoch_store = state.load_epoch_store_one_call_per_task();
+
         let certificate = request.into_inner();
         let shared_object_tx = certificate.contains_shared_object();
 
@@ -286,8 +288,6 @@ impl ValidatorService {
                 .handle_certificate_non_consensus_latency
                 .start_timer()
         };
-
-        let epoch_store = state.load_epoch_store_one_call_per_task();
 
         // 1) Check if cert already executed
         let tx_digest = *certificate.digest();

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -287,7 +287,7 @@ impl ValidatorService {
                 .start_timer()
         };
 
-        let epoch_store = state.epoch_store();
+        let epoch_store = state.load_epoch_store_one_call_per_task();
 
         // 1) Check if cert already executed
         let tx_digest = *certificate.digest();
@@ -300,7 +300,7 @@ impl ValidatorService {
         }
 
         // 2) Validate if cert can be executed, and verify the cert.
-        if state.is_fullnode() {
+        if state.is_fullnode(&epoch_store) {
             return Err(tonic::Status::unimplemented(format!(
                 "Cannot execute certificate without effects on fullnode! {:?}",
                 certificate.digest()

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -170,17 +170,19 @@ pub async fn test_checkpoint_executor_cross_epoch() {
         num_to_sync_per_epoch as u64,
     );
 
-    authority_state
-        .reconfigure(second_committee.committee().clone(), 0)
+    let new_epoch_store = authority_state
+        .reconfigure(
+            &authority_state.epoch_store_for_testing(),
+            second_committee.committee().clone(),
+            0,
+        )
         .await
         .unwrap();
 
     // checkpoint execution should resume starting at checkpoints
     // of next epoch
     timeout(Duration::from_secs(5), async {
-        executor
-            .run_epoch(authority_state.epoch_store_for_testing().clone())
-            .await;
+        executor.run_epoch(new_epoch_store).await;
     })
     .await
     .unwrap();

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -45,7 +45,7 @@ pub async fn test_checkpoint_executor_crash_recovery() {
         &committee,
     );
 
-    let epoch_store = state.epoch_store().clone();
+    let epoch_store = state.epoch_store_for_testing().clone();
     let executor_handle =
         spawn_monitored_task!(async move { executor.run_epoch(epoch_store).await });
     tokio::time::sleep(Duration::from_secs(5)).await;
@@ -78,7 +78,7 @@ pub async fn test_checkpoint_executor_crash_recovery() {
         state.transaction_manager().clone(),
     );
 
-    let epoch_store = state.epoch_store().clone();
+    let epoch_store = state.epoch_store_for_testing().clone();
     let executor_handle =
         spawn_monitored_task!(async move { executor.run_epoch(epoch_store).await });
     tokio::time::sleep(Duration::from_secs(5)).await;
@@ -155,7 +155,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
     // Ensure executor reaches end of epoch in a timely manner
     timeout(Duration::from_secs(5), async {
         executor
-            .run_epoch(authority_state.epoch_store().clone())
+            .run_epoch(authority_state.epoch_store_for_testing().clone())
             .await;
     })
     .await
@@ -179,7 +179,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
     // of next epoch
     timeout(Duration::from_secs(5), async {
         executor
-            .run_epoch(authority_state.epoch_store().clone())
+            .run_epoch(authority_state.epoch_store_for_testing().clone())
             .await;
     })
     .await
@@ -249,7 +249,7 @@ pub async fn test_reconfig_crash_recovery() {
 
     timeout(Duration::from_secs(1), async {
         executor
-            .run_epoch(authority_state.epoch_store().clone())
+            .run_epoch(authority_state.epoch_store_for_testing().clone())
             .await;
     })
     .await
@@ -278,7 +278,7 @@ pub async fn test_reconfig_crash_recovery() {
 
     timeout(Duration::from_millis(200), async {
         executor
-            .run_epoch(authority_state.epoch_store().clone())
+            .run_epoch(authority_state.epoch_store_for_testing().clone())
             .await;
     })
     .await

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1252,7 +1252,7 @@ mod tests {
         for digest in all_digests {
             let signature = Signature::Ed25519SuiSignature(Default::default());
             state
-                .epoch_store()
+                .epoch_store_for_testing()
                 .test_insert_user_signature(digest, &signature);
         }
 

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -185,7 +185,7 @@ mod tests {
 
         let metrics = SuiTxValidatorMetrics::new(&Default::default());
         let validator = SuiTxValidator::new(
-            state.epoch_store_for_testing(),
+            state.epoch_store_for_testing().clone(),
             state.transaction_manager().clone(),
             metrics,
         );

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -185,7 +185,7 @@ mod tests {
 
         let metrics = SuiTxValidatorMetrics::new(&Default::default());
         let validator = SuiTxValidator::new(
-            state.epoch_store().clone(),
+            state.epoch_store_for_testing(),
             state.transaction_manager().clone(),
             metrics,
         );

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -66,7 +66,7 @@ pub async fn execution_process(
             return;
         };
 
-        let epoch_store = authority.epoch_store();
+        let epoch_store = authority.load_epoch_store_one_call_per_task();
 
         let digest = *certificate.digest();
         debug!(?digest, "Pending certificate execution activated.");

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -66,6 +66,7 @@ pub async fn execution_process(
             return;
         };
 
+        // TODO: Ideally execution_driver should own a copy of epoch store and recreate each epoch.
         let epoch_store = authority.load_epoch_store_one_call_per_task();
 
         let digest = *certificate.digest();

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -145,7 +145,7 @@ impl LocalAuthorityClient {
         // Check existing effects before verifying the cert to allow querying certs finalized
         // from previous epochs.
         let tx_digest = *certificate.digest();
-        let epoch_store = state.epoch_store();
+        let epoch_store = state.epoch_store_for_testing();
         let signed_effects =
             match state.get_signed_effects_and_maybe_resign(epoch_store.epoch(), &tx_digest) {
                 Ok(Some(effects)) => effects,

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -273,7 +273,7 @@ where
                 tx_cert,
                 effects_cert,
                 // TODO: Check whether it's safe to call epoch_store here.
-                &validator_state.epoch_store(),
+                &validator_state.load_epoch_store_one_call_per_task(),
             ),
         )
         .instrument(error_span!("transaction_orchestrator", ?tx_digest))

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -249,6 +249,8 @@ where
         effects_cert: &VerifiedCertifiedTransactionEffects,
         metrics: &TransactionOrchestratorMetrics,
     ) -> SuiResult {
+        let epoch_store = validator_state.load_epoch_store_one_call_per_task();
+
         // TODO: attempt a finalized tx at most once per request.
         // Every WaitForLocalExecution request will be attempted to execute twice,
         // one from the subscriber queue, one from the proactive execution before
@@ -272,8 +274,7 @@ where
             validator_state.fullnode_execute_certificate_with_effects(
                 tx_cert,
                 effects_cert,
-                // TODO: Check whether it's safe to call epoch_store here.
-                &validator_state.load_epoch_store_one_call_per_task(),
+                &epoch_store,
             ),
         )
         .instrument(error_span!("transaction_orchestrator", ?tx_digest))

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -713,7 +713,7 @@ async fn test_dev_inspect_uses_unbound_object() {
     }));
 
     let result = fullnode
-        .dev_inspect_transaction(sender, kind, 1, fullnode.epoch())
+        .dev_inspect_transaction(sender, kind, 1, fullnode.current_epoch_for_testing())
         .await;
     let Err(err) = result else { panic!() };
     assert!(err
@@ -3711,7 +3711,7 @@ pub async fn call_dev_inspect(
         arguments,
     }));
     authority
-        .dev_inspect_transaction(*sender, kind, 1, authority.epoch())
+        .dev_inspect_transaction(*sender, kind, 1, authority.current_epoch_for_testing())
         .await
 }
 

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -173,7 +173,7 @@ impl RpcReadApiServer for ReadApi {
             .tap_err(|err| debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err))?;
 
         let mut signers = Vec::new();
-        let epoch_store = self.state.epoch_store();
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
         for authority_index in cert.auth_sig().signers_map.iter() {
             let authority = epoch_store
                 .committee()

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -166,6 +166,8 @@ impl RpcReadApiServer for ReadApi {
         &self,
         digest: TransactionDigest,
     ) -> RpcResult<SuiTransactionAuthSignersResponse> {
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+
         let (cert, _effects) = self
             .state
             .get_transaction(digest)
@@ -173,7 +175,6 @@ impl RpcReadApiServer for ReadApi {
             .tap_err(|err| debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err))?;
 
         let mut signers = Vec::new();
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
         for authority_index in cert.auth_sig().signers_map.iter() {
             let authority = epoch_store
                 .committee()

--- a/crates/sui/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/sui/tests/onsite_reconfig_observer_tests.rs
@@ -43,7 +43,7 @@ async fn test_onsite_reconfig_observer_basic() {
     info!("Shutting down epoch 0");
     for handle in &authorities {
         handle
-            .with_async(|node| async { node.close_epoch().await.unwrap() })
+            .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
             .await;
     }
     // Wait for all nodes to reach the next epoch.

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -181,7 +181,7 @@ async fn reconfig_with_revert_end_to_end_test() {
                 if position_submit_certificate(&net.committee, &node.state().name, tx.digest())
                     < (authorities.len() - 1)
                 {
-                    node.close_epoch().await.unwrap();
+                    node.close_epoch_for_testing().await.unwrap();
                 } else {
                     // remember the authority that wouild submit it to consensus last.
                     reverting_authority_idx = Some(i);
@@ -221,7 +221,7 @@ async fn reconfig_with_revert_end_to_end_test() {
         .map(|handle| {
             handle.with_async(|node| async {
                 loop {
-                    if node.state().epoch() == 1 {
+                    if node.state().current_epoch_for_testing() == 1 {
                         break;
                     }
                     tokio::time::sleep(Duration::from_secs(5)).await;
@@ -358,7 +358,7 @@ async fn trigger_reconfiguration(authorities: &[SuiNodeHandle]) {
     // Close epoch on 3 (2f+1) validators.
     for handle in authorities.iter().skip(1) {
         handle
-            .with_async(|node| async { node.close_epoch().await.unwrap() })
+            .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
             .await;
     }
     info!("close_epoch complete after {:?}", start.elapsed());

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -175,7 +175,7 @@ async fn test_transaction_orchestrator_reconfig() {
 
     for handle in &authorities {
         handle
-            .with_async(|node| async { node.close_epoch().await.unwrap() })
+            .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
             .await;
     }
 
@@ -224,7 +224,7 @@ async fn test_tx_across_epoch_boundaries() {
     // to make sure QD does not get quorum until reconfig
     for handle in authorities.iter().take(2) {
         handle
-            .with_async(|node| async { node.close_epoch().await.unwrap() })
+            .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
             .await;
     }
 
@@ -262,7 +262,7 @@ async fn test_tx_across_epoch_boundaries() {
     // Ask the remaining 2 validators to close epoch
     for handle in authorities.iter().skip(2) {
         handle
-            .with_async(|node| async { node.close_epoch().await.unwrap() })
+            .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
             .await;
     }
 

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -344,7 +344,7 @@ pub async fn wait_for_nodes_transition_to_epoch<'a>(
         .map(|handle| {
             handle.with_async(|node| async move {
                 let mut rx = node.subscribe_to_epoch_change();
-                let epoch = node.current_epoch();
+                let epoch = node.current_epoch_for_testing();
                 if epoch != expected_epoch {
                     let committee = rx.recv().await.unwrap();
                     assert_eq!(committee.epoch, expected_epoch);


### PR DESCRIPTION
Remove all unintended epoch store loads from the state.
Rename the function name to make it obvious that we should be careful when calling it.