### PR TITLE
Separate unwrapped_then_deleted objects in TransactionEffects

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1130,22 +1130,15 @@ impl AuthorityState {
 
         let mut deleted_owners = vec![];
         let mut deleted_dynamic_fields = vec![];
-        for ((id, _, _), kind) in effects.all_deleted() {
-            match kind {
-                DeleteKind::Normal | DeleteKind::UnwrapThenDelete => {
-                    let Some(old_version) = modified_at_version.get(id) else{
-                        error!("Error processing object owner index for tx [{:?}], cannot find modified at version for deleted object [{id}].", effects.transaction_digest);
-                        continue;
-                    };
-                    match self.get_owner_at_version(id, *old_version)? {
-                        Owner::AddressOwner(addr) => deleted_owners.push((addr, *id)),
-                        Owner::ObjectOwner(object_id) => {
-                            deleted_dynamic_fields.push((ObjectID::from(object_id), *id))
-                        }
-                        _ => {}
-                    }
+        for (id, _, _) in &effects.deleted {
+            let old_version = modified_at_version.get(id).unwrap();
+
+            match self.get_owner_at_version(id, *old_version)? {
+                Owner::AddressOwner(addr) => deleted_owners.push((addr, *id)),
+                Owner::ObjectOwner(object_id) => {
+                    deleted_dynamic_fields.push((ObjectID::from(object_id), *id))
                 }
-                DeleteKind::Wrap => {}
+                _ => {}
             }
         }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1130,17 +1130,22 @@ impl AuthorityState {
 
         let mut deleted_owners = vec![];
         let mut deleted_dynamic_fields = vec![];
-        for (id, _, _) in &effects.deleted {
-            let Some(old_version) = modified_at_version.get(id) else{
-                error!("Error processing object owner index for tx [{:?}], cannot find modified at version for deleted object [{id}].", effects.transaction_digest);
-                continue;
-            };
-            match self.get_owner_at_version(id, *old_version)? {
-                Owner::AddressOwner(addr) => deleted_owners.push((addr, *id)),
-                Owner::ObjectOwner(object_id) => {
-                    deleted_dynamic_fields.push((ObjectID::from(object_id), *id))
+        for ((id, _, _), kind) in effects.all_deleted() {
+            match kind {
+                DeleteKind::Normal | DeleteKind::UnwrapThenDelete => {
+                    let Some(old_version) = modified_at_version.get(id) else{
+                        error!("Error processing object owner index for tx [{:?}], cannot find modified at version for deleted object [{id}].", effects.transaction_digest);
+                        continue;
+                    };
+                    match self.get_owner_at_version(id, *old_version)? {
+                        Owner::AddressOwner(addr) => deleted_owners.push((addr, *id)),
+                        Owner::ObjectOwner(object_id) => {
+                            deleted_dynamic_fields.push((ObjectID::from(object_id), *id))
+                        }
+                        _ => {}
+                    }
                 }
-                _ => {}
+                DeleteKind::Wrap => {}
             }
         }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1028,6 +1028,7 @@ impl AuthorityStore {
             .chain(effects.unwrapped.iter())
             .map(|(r, _)| r)
             .chain(effects.deleted.iter())
+            .chain(effects.unwrapped_then_deleted.iter())
             .chain(effects.wrapped.iter());
         write_batch = write_batch.delete_batch(&self.perpetual_tables.parent_sync, all_new_refs)?;
 

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -120,12 +120,6 @@ pub fn create_fake_cert_and_effect_digest<'a>(
 pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
     TransactionEffects {
         transaction_digest: *tx.digest(),
-        created: Vec::new(),
-        mutated: Vec::new(),
-        unwrapped: Vec::new(),
-        deleted: Vec::new(),
-        unwrapped_then_deleted: Vec::new(),
-        wrapped: Vec::new(),
         gas_object: (
             random_object_ref(),
             Owner::AddressOwner(tx.data().intent_message.value.sender()),

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -120,6 +120,12 @@ pub fn create_fake_cert_and_effect_digest<'a>(
 pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
     TransactionEffects {
         transaction_digest: *tx.digest(),
+        created: Vec::new(),
+        mutated: Vec::new(),
+        unwrapped: Vec::new(),
+        deleted: Vec::new(),
+        unwrapped_then_deleted: Vec::new(),
+        wrapped: Vec::new(),
         gas_object: (
             random_object_ref(),
             Owner::AddressOwner(tx.data().intent_message.value.sender()),

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -372,6 +372,7 @@ async fn test_dev_inspect_object_by_bytes() {
     assert!(effects.created.is_empty());
     assert_eq!(effects.mutated.len(), 2);
     assert!(effects.deleted.is_empty());
+    assert!(effects.unwrapped_then_deleted.is_empty());
 
     // compare the bytes
     let updated_object = validator

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1967,6 +1967,9 @@ pub struct SuiTransactionEffects {
     // Object Refs of objects now deleted (the old refs).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deleted: Vec<SuiObjectRef>,
+    /// Object refs of objects previously wrapped in other objects but now deleted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unwrapped_then_deleted: Vec<SuiObjectRef>,
     // Object refs of objects now wrapped in other objects.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub wrapped: Vec<SuiObjectRef>,
@@ -2001,6 +2004,7 @@ impl SuiTransactionEffects {
             mutated: to_owned_ref(effect.mutated),
             unwrapped: to_owned_ref(effect.unwrapped),
             deleted: to_sui_object_ref(effect.deleted),
+            unwrapped_then_deleted: to_sui_object_ref(effect.unwrapped_then_deleted),
             wrapped: to_sui_object_ref(effect.wrapped),
             gas_object: OwnedObjectRef {
                 owner: effect.gas_object.1,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6592,6 +6592,13 @@
               "$ref": "#/components/schemas/OwnedObjectRef"
             }
           },
+          "unwrappedThenDeleted": {
+            "description": "Object refs of objects previously wrapped in other objects but now deleted.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectRef"
+            }
+          },
           "wrapped": {
             "type": "array",
             "items": {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -500,6 +500,7 @@ impl RpcExampleProvider {
                 ],
                 unwrapped: vec![],
                 deleted: vec![],
+                unwrapped_then_deleted: vec![],
                 wrapped: vec![],
                 gas_object: OwnedObjectRef {
                     owner: Owner::ObjectOwner(signer),

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2401,6 +2401,8 @@ pub struct TransactionEffects {
     /// Object Refs of objects now deleted (the old refs).
     pub deleted: Vec<ObjectRef>,
     /// Object refs of objects now wrapped in other objects.
+    pub unwrapped_then_deleted: Vec<ObjectRef>,
+    /// Object refs of objects now wrapped in other objects.
     pub wrapped: Vec<ObjectRef>,
     /// The updated gas object reference. Have a dedicated field for convenient access.
     /// It's also included in mutated.
@@ -2426,6 +2428,21 @@ impl TransactionEffects {
                     .iter()
                     .map(|(r, o)| (r, o, WriteKind::Unwrap)),
             )
+    }
+
+    /// Return an iterator that iterates through all deleted objects, including deleted,
+    /// unwrapped_then_deleted, and wrapped objects. In other words, all objects that
+    /// do not exist in the object state after this transaction.
+    pub fn all_deleted(&self) -> impl Iterator<Item = (&ObjectRef, DeleteKind)> + Clone {
+        self.deleted
+            .iter()
+            .map(|r| (r, DeleteKind::Normal))
+            .chain(
+                self.unwrapped_then_deleted
+                    .iter()
+                    .map(|r| (r, DeleteKind::UnwrapThenDelete)),
+            )
+            .chain(self.wrapped.iter().map(|r| (r, DeleteKind::Wrap)))
     }
 
     pub fn execution_digests(&self) -> ExecutionDigests {
@@ -2552,6 +2569,7 @@ impl Default for TransactionEffects {
             mutated: Vec::new(),
             unwrapped: Vec::new(),
             deleted: Vec::new(),
+            unwrapped_then_deleted: Vec::new(),
             wrapped: Vec::new(),
             gas_object: (
                 random_object_ref(),

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2400,7 +2400,7 @@ pub struct TransactionEffects {
     pub unwrapped: Vec<(ObjectRef, Owner)>,
     /// Object Refs of objects now deleted (the old refs).
     pub deleted: Vec<ObjectRef>,
-    /// Object refs of objects now wrapped in other objects.
+    /// Object refs of objects previously wrapped in other objects but now deleted.
     pub unwrapped_then_deleted: Vec<ObjectRef>,
     /// Object refs of objects now wrapped in other objects.
     pub wrapped: Vec<ObjectRef>,

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -544,11 +544,17 @@ impl<S> TemporaryStore<S> {
 
         let mut deleted = vec![];
         let mut wrapped = vec![];
+        let mut unwrapped_then_deleted = vec![];
         for (id, (version, kind)) in &inner.deleted {
             match kind {
-                DeleteKind::Normal | DeleteKind::UnwrapThenDelete => {
+                DeleteKind::Normal => {
                     deleted.push((*id, *version, ObjectDigest::OBJECT_DIGEST_DELETED))
                 }
+                DeleteKind::UnwrapThenDelete => unwrapped_then_deleted.push((
+                    *id,
+                    *version,
+                    ObjectDigest::OBJECT_DIGEST_DELETED,
+                )),
                 DeleteKind::Wrap => {
                     wrapped.push((*id, *version, ObjectDigest::OBJECT_DIGEST_WRAPPED))
                 }
@@ -566,6 +572,7 @@ impl<S> TemporaryStore<S> {
             mutated,
             unwrapped,
             deleted,
+            unwrapped_then_deleted,
             wrapped,
             gas_object: updated_gas_object_info,
             events,

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -201,6 +201,8 @@ export const TransactionEffects = object({
   unwrapped: optional(array(OwnedObjectRef)),
   /** Object Refs of objects now deleted (the old refs) */
   deleted: optional(array(SuiObjectRef)),
+  /** Object Refs of objects now deleted (the old refs) */
+  unwrapped_then_deleted: optional(array(SuiObjectRef)),
   /** Object refs of objects now wrapped in other objects */
   wrapped: optional(array(SuiObjectRef)),
   /**


### PR DESCRIPTION
This will allow us to properly account for `wrap`/`unwrap` when generating live object set from transaction effects