### PR TITLE
Add support for new Sui Dapp

### DIFF
--- a/apps/wallet/apps/dapps.json
+++ b/apps/wallet/apps/dapps.json
@@ -14,6 +14,13 @@
         "tags": ["NFT"]
     },
     {
+        "name": "Sui Name Service"
+        "description": "Your .sui domain & profile!",
+        "link": "https://sns.domains",
+        "icon": "https://sns.domains/logo/logo.png",
+        "tags": ["Infra"],
+    },
+    {
         "name": "Sui Name Service (SuiNS)",
         "description": "Find your .sui name!",
         "link": "https://suins.io/",


### PR DESCRIPTION
The Sui Name Service is one of the most popular applications in the Sui eco-system with more than 230,000 registrations in just the past 3 weeks. This pull requests adds them to the repo.