### PR TITLE
Add tokio dep to mysten-metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5102,6 +5102,7 @@ dependencies = [
  "prometheus-closure-metric",
  "scopeguard",
  "tap",
+ "tokio",
  "tracing",
  "uuid",
  "workspace-hack",

--- a/crates/mysten-metrics/Cargo.toml
+++ b/crates/mysten-metrics/Cargo.toml
@@ -13,6 +13,7 @@ scopeguard = "1"
 prometheus = "0.13"
 once_cell = "1"
 tap = "1.0"
+tokio.workspace = true
 dashmap = "5.4.0"
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"]}
 parking_lot = "0.12.1"

--- a/narwhal/crypto/src/lib.rs
+++ b/narwhal/crypto/src/lib.rs
@@ -9,7 +9,7 @@
 )]
 
 use fastcrypto::{
-    ed25519,
+    bls12381, ed25519,
     hash::{Blake2b256, HashFunction},
 };
 

--- a/narwhal/crypto/src/lib.rs
+++ b/narwhal/crypto/src/lib.rs
@@ -9,7 +9,7 @@
 )]
 
 use fastcrypto::{
-    bls12381, ed25519,
+    ed25519,
     hash::{Blake2b256, HashFunction},
 };
 


### PR DESCRIPTION
Revision 57d89e53093272f625ca8fe5e5b08819f32dffd3 removed the tokio dependency from Mysten-metrics, but this seems to [have broken](https://github.com/MystenLabs/sui/actions/runs/4071082946/jobs/7012546629) the build.