### PR TITLE
wallet-ext: fix alert error for stake actions

### DIFF
--- a/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
@@ -135,7 +135,7 @@ function StakeForm({
                 </Card>
                 <ErrorMessage name="amount" component="div">
                     {(msg) => (
-                        <div className="mt-2 flex flex-col flex-nowrap">
+                        <div className="mt-2 flex flex-col flex-nowrap self-stretch">
                             <Alert mode="warning" className="text-body">
                                 {msg}
                             </Alert>
@@ -144,9 +144,11 @@ function StakeForm({
                 </ErrorMessage>
 
                 {submitError ? (
-                    <div className="mt-2 flex flex-col flex-nowrap">
+                    <div className="mt-2 flex flex-col flex-nowrap self-stretch">
                         <Alert mode="warning">
-                            <strong>Stake failed</strong>
+                            <div>
+                                <strong>Stake failed</strong>
+                            </div>
                             <small>{submitError}</small>
                         </Alert>
                     </div>

--- a/apps/wallet/src/ui/app/staking/stake/UnstakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/UnstakeForm.tsx
@@ -134,7 +134,7 @@ export function UnStakeForm({
             </Card>
             <ErrorMessage name="amount" component="div">
                 {(msg) => (
-                    <div className="mt-2 flex flex-col flex-nowrap">
+                    <div className="mt-2 flex flex-col flex-nowrap self-stretch">
                         <Alert mode="warning" className="text-body">
                             {msg}
                         </Alert>
@@ -143,10 +143,9 @@ export function UnStakeForm({
             </ErrorMessage>
 
             {submitError ? (
-                <div className="mt-2 flex flex-col flex-nowrap">
+                <div className="mt-2 flex flex-col flex-nowrap self-stretch">
                     <Alert mode="warning">
                         <strong>Unstake failed</strong>
-
                         <div>
                             <small>{submitError}</small>
                         </div>


### PR DESCRIPTION
* quick fix to split the error title and the message to different lines and make the component stretch to match the width of the view


| before | after |
| - | - |
| <img width="388" alt="Screenshot 2023-02-02 at 13 46 50" src="https://user-images.githubusercontent.com/10210143/216341850-1391ccfe-c172-4963-b7ce-c3e304435fe4.png"> | <img width="388" alt="Screenshot 2023-02-02 at 13 46 31" src="https://user-images.githubusercontent.com/10210143/216341943-72655b0c-6d0b-4215-8e8e-d2af8063de12.png"> |
| <img width="388" alt="Screenshot 2023-02-02 at 13 49 29" src="https://user-images.githubusercontent.com/10210143/216342700-cc1ef74e-9694-40d4-bcdf-2602f6d3b2f3.png"> | <img width="388" alt="Screenshot 2023-02-02 at 13 39 25" src="https://user-images.githubusercontent.com/10210143/216342779-896d72e1-623d-443b-a714-3ceab8817626.png"> |

