### PR TITLE
[move][sui-verifier] Flip ID Leak rules

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive_object.move
@@ -23,8 +23,8 @@ struct Counter has key, store {
     count: u64,
 }
 
-fun new(id: UID): Counter {
-    Counter { id, count: 0 }
+fun new(ctx: &mut TxContext): Counter {
+    Counter { id: object::new(ctx), count: 0 }
 }
 
 fun count(counter: &Counter): u64 {
@@ -49,9 +49,9 @@ entry fun t0(ctx: &mut TxContext) {
 
 entry fun t1(obj: &mut Obj, ctx: &mut TxContext) {
     let id = &mut obj.id;
-    add(id, 0, new(object::new(ctx)));
-    add(id, b"", new(object::new(ctx)));
-    add(id, false, new(object::new(ctx)));
+    add(id, 0, new(ctx));
+    add(id, b"", new(ctx));
+    add(id, false, new(ctx));
 }
 
 entry fun t2(obj: &Obj) {

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/transfer_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/transfer_object.move
@@ -23,8 +23,8 @@ struct Counter has key, store {
     count: u64,
 }
 
-fun new(id: UID): Counter {
-    Counter { id, count: 0 }
+fun new(ctx: &mut TxContext): Counter {
+    Counter { id: object::new(ctx), count: 0 }
 }
 
 fun count(counter: &Counter): u64 {
@@ -48,7 +48,7 @@ entry fun create(ctx: &mut TxContext) {
 }
 
 entry fun add_counter(obj: &mut Obj, ctx: &mut TxContext) {
-    add(&mut obj.id, 0, new(object::new(ctx)))
+    add(&mut obj.id, 0, new(ctx))
 }
 
 entry fun obj_bump(obj: &mut Obj) {

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.exp
@@ -1,0 +1,41 @@
+processed 10 tasks
+
+init:
+A: object(100)
+
+task 1 'publish'. lines 10-84:
+created: object(105)
+written: object(104)
+
+task 2 'run'. lines 86-86:
+created: object(107)
+written: object(106)
+
+task 3 'run'. lines 88-88:
+created: object(109)
+written: object(107), object(108)
+
+task 4 'run'. lines 90-90:
+written: object(107), object(109), object(110)
+
+task 5 'run'. lines 92-92:
+created: object(112)
+written: object(111)
+deleted: object(107)
+
+task 6 'view-object'. lines 94-94:
+Owner: Object ID: ( fake(107) )
+Version: 4
+Contents: sui::dynamic_field::Field<u64, a::m::Counter> {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}, name: 0u64, value: a::m::Counter {id: sui::object::UID {id: sui::object::ID {bytes: _}}, count: 1u64}}
+
+task 7 'run'. lines 96-96:
+written: object(112), object(113)
+
+task 8 'run'. lines 98-98:
+written: object(114)
+deleted: object(112)
+
+task 9 'view-object'. lines 100-100:
+Owner: Object ID: ( fake(107) )
+Version: 4
+Contents: sui::dynamic_field::Field<u64, a::m::Counter> {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}, name: 0u64, value: a::m::Counter {id: sui::object::UID {id: sui::object::ID {bytes: _}}, count: 1u64}}

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.move
@@ -1,0 +1,100 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// similar to dynamic_object_field_tests but over multiple transactions,
+// as this uses a different code path
+// test remove with the wrong value type
+
+//# init --addresses a=0x0 --accounts A
+
+//# publish
+module a::m {
+
+use sui::dynamic_field::{add, exists_, borrow, borrow_mut};
+use sui::object::{Self, UID};
+use sui::tx_context::{sender, TxContext};
+
+struct Wrapper has key {
+    id: UID,
+    old: UID,
+}
+
+struct Obj has key, store {
+    id: UID,
+}
+
+struct Counter has key, store {
+    id: UID,
+    count: u64,
+}
+
+fun new(ctx: &mut TxContext): Counter {
+    Counter { id: object::new(ctx), count: 0 }
+}
+
+fun count(counter: &Counter): u64 {
+    counter.count
+}
+
+fun bump(counter: &mut Counter): &mut Counter {
+    counter.count = counter.count + 1;
+    counter
+}
+
+fun destroy(counter: Counter): u64 {
+    let Counter { id, count } = counter;
+    object::delete(id);
+    count
+}
+
+entry fun t0(ctx: &mut TxContext) {
+    let id = object::new(ctx);
+    sui::transfer::transfer(Obj { id }, sender(ctx))
+}
+
+entry fun t1(obj: &mut Obj, ctx: &mut TxContext) {
+    let id = &mut obj.id;
+    add(id, 0, new(ctx));
+}
+
+entry fun t2(obj: &mut Obj) {
+    let id = &mut obj.id;
+    bump(borrow_mut(id, 0));
+}
+
+entry fun t3(obj: Obj, ctx: &mut TxContext) {
+    let Obj { id } = obj;
+    assert!(count(borrow(&id, 0)) == 1, 0);
+    let wrapper = Wrapper { id: object::new(ctx), old: id };
+    sui::transfer::transfer(wrapper, sender(ctx))
+}
+
+entry fun t4(wrapper: &mut Wrapper) {
+    assert!(!exists_<u64>(&mut wrapper.id, 0), 0);
+    assert!(count(borrow(&wrapper.old, 0)) == 1, 0);
+}
+
+entry fun t5(wrapper: Wrapper) {
+    let Wrapper { id, old } = wrapper;
+    object::delete(id);
+    object::delete(old);
+    // does not delete counter
+}
+
+}
+
+//# run a::m::t0 --sender A
+
+//# run a::m::t1 --sender A --args object(107)
+
+//# run a::m::t2 --sender A --args object(107)
+
+//# run a::m::t3 --sender A --args object(107)
+
+//# view-object 109
+
+//# run a::m::t4 --sender A --args object(112)
+
+//# run a::m::t5 --sender A --args object(112)
+
+//# view-object 109

--- a/crates/sui-framework-test/src/lib.rs
+++ b/crates/sui-framework-test/src/lib.rs
@@ -61,7 +61,7 @@ mod test {
 
         // build tests first to enable Sui-specific test code verification
         build_move_package(path, config)
-            .unwrap_or_else(|_| panic!("Building tests at {}", path.display()));
+            .unwrap_or_else(|e| panic!("Building tests at {}.\nWith error {e}", path.display()));
 
         assert_eq!(
             run_move_unit_tests(path, move_config, None, false).unwrap(),

--- a/crates/sui-framework/tests/dynamic_object_field_tests.move
+++ b/crates/sui-framework/tests/dynamic_object_field_tests.move
@@ -30,16 +30,16 @@ module sui::dynamic_object_field_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let id = ts::new_object(&mut scenario);
-        let uid1 = ts::new_object(&mut scenario);
-        let id1 = object::uid_to_inner(&uid1);
-        let uid2 = ts::new_object(&mut scenario);
-        let id2 = object::uid_to_inner(&uid2);
-        let uid3 = ts::new_object(&mut scenario);
-        let id3 = object::uid_to_inner(&uid3);
+        let counter1 = new(&mut scenario);
+        let id1 = object::id(&counter1);
+        let counter2 = new(&mut scenario);
+        let id2 = object::id(&counter2);
+        let counter3 = new(&mut scenario);
+        let id3 = object::id(&counter3);
         // add fields
-        add(&mut id, 0, new(uid1));
-        add(&mut id, b"", new(uid2));
-        add(&mut id, false, new(uid3));
+        add(&mut id, 0, counter1);
+        add(&mut id, b"", counter2);
+        add(&mut id, false, counter3);
         // check they exist
         assert!(exists_(&id, 0), 0);
         assert!(exists_(&id, b""), 0);
@@ -78,8 +78,8 @@ module sui::dynamic_object_field_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let id = ts::new_object(&mut scenario);
-        add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
-        add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
+        add<u64, Counter>(&mut id, 0, new(&mut scenario));
+        add<u64, Counter>(&mut id, 0, new(&mut scenario));
         abort 42
     }
 
@@ -89,7 +89,7 @@ module sui::dynamic_object_field_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let id = ts::new_object(&mut scenario);
-        add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
+        add<u64, Counter>(&mut id, 0, new(&mut scenario));
         add<u64, Fake>(&mut id, 0, Fake { id: ts::new_object(&mut scenario) });
         abort 42
     }
@@ -110,7 +110,7 @@ module sui::dynamic_object_field_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let id = ts::new_object(&mut scenario);
-        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        add(&mut id, 0, new(&mut scenario));
         borrow<u64, Fake>(&mut id, 0);
         abort 42
     }
@@ -131,7 +131,7 @@ module sui::dynamic_object_field_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let id = ts::new_object(&mut scenario);
-        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        add(&mut id, 0, new(&mut scenario));
         borrow_mut<u64, Fake>(&mut id, 0);
         abort 42
     }
@@ -152,7 +152,7 @@ module sui::dynamic_object_field_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let id = ts::new_object(&mut scenario);
-        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        add(&mut id, 0, new(&mut scenario));
         let Fake { id } = remove<u64, Fake>(&mut id, 0);
         object::delete(id);
         abort 42
@@ -164,7 +164,7 @@ module sui::dynamic_object_field_tests {
         let scenario = ts::begin(sender);
         let id = ts::new_object(&mut scenario);
         assert!(!exists_<u64>(&id, 0), 0);
-        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        add(&mut id, 0, new(&mut scenario));
         assert!(exists_<u64>(&id, 0), 0);
         assert!(!exists_<u8>(&id, 0), 0);
         ts::end(scenario);
@@ -178,7 +178,7 @@ module sui::dynamic_object_field_tests {
         let id = ts::new_object(&mut scenario);
         assert!(!exists_with_type<u64, Counter>(&id, 0), 0);
         assert!(!exists_with_type<u64, Fake>(&id, 0), 0);
-        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        add(&mut id, 0, new(&mut scenario));
         assert!(exists_with_type<u64, Counter>(&id, 0), 0);
         assert!(!exists_with_type<u8, Counter>(&id, 0), 0);
         assert!(!exists_with_type<u8, Fake>(&id, 0), 0);
@@ -192,7 +192,7 @@ module sui::dynamic_object_field_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let id = ts::new_object(&mut scenario);
-        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        add(&mut id, 0, new(&mut scenario));
         assert!(exists_<u64>(&mut id, 0), 0);
         ts::end(scenario);
         object::delete(id);
@@ -205,7 +205,7 @@ module sui::dynamic_object_field_tests {
         let scenario = ts::begin(sender);
         let id1 = ts::new_object(&mut scenario);
         let id2 = ts::new_object(&mut scenario);
-        add(&mut id1, 0, new(ts::new_object(&mut scenario)));
+        add(&mut id1, 0, new(&mut scenario));
         assert!(exists_<u64>(&mut id1, 0), 0);
         assert!(!exists_<u64>(&mut id2, 0), 0);
         bump(borrow_mut(&mut id1, 0));
@@ -220,8 +220,8 @@ module sui::dynamic_object_field_tests {
         object::delete(id2);
     }
 
-    fun new(id: UID): Counter {
-        Counter { id, count: 0 }
+    fun new(scenario: &mut ts::Scenario): Counter {
+        Counter { id: ts::new_object(scenario), count: 0 }
     }
 
     fun count(counter: &Counter): u64 {

--- a/crates/sui-framework/tests/object_bag_tests.move
+++ b/crates/sui-framework/tests/object_bag_tests.move
@@ -32,13 +32,13 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let bag = object_bag::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
-        let id1 = object::uid_to_inner(&uid1);
-        let uid2 = ts::new_object(&mut scenario);
-        let id2 = object::uid_to_inner(&uid2);
+        let counter1 = new(&mut scenario);
+        let id1 = object::id(&counter1);
+        let counter2 = new(&mut scenario);
+        let id2 = object::id(&counter2);
         // add fields
-        add(&mut bag, b"hello", new(uid1));
-        add(&mut bag, 1, new(uid2));
+        add(&mut bag, b"hello", counter1);
+        add(&mut bag, 1, counter2);
         // check they exist
         assert!(contains(&bag, b"hello"), 0);
         assert!(contains(&bag, 1), 0);
@@ -72,10 +72,8 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let bag = object_bag::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
-        let uid2 = ts::new_object(&mut scenario);
-        add(&mut bag, b"hello", new(uid1));
-        add(&mut bag, b"hello", new(uid2));
+        add(&mut bag, b"hello", new(&mut scenario));
+        add(&mut bag, b"hello", new(&mut scenario));
         abort 42
     }
 
@@ -115,8 +113,8 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let bag = object_bag::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
-        add(&mut bag, 0, new(uid1));
+        let counter = new(&mut scenario);
+        add(&mut bag, 0, counter);
         object_bag::destroy_empty(bag);
         ts::end(scenario);
     }
@@ -126,9 +124,9 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let bag = object_bag::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
+        let counter = new(&mut scenario);
         assert!(!contains(&mut bag, 0), 0);
-        add(&mut bag, 0, new(uid1));
+        add(&mut bag, 0, counter);
         assert!(contains(&mut bag, 0), 0);
         assert!(!contains(&mut bag, 1), 0);
         ts::end(scenario);
@@ -141,10 +139,10 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let bag = object_bag::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
+        let counter = new(&mut scenario);
         assert!(!contains_with_type<u64, Counter>(&mut bag, 0), 0);
         assert!(!contains_with_type<u64, Fake>(&mut bag, 0), 0);
-        add(&mut bag, 0, new(uid1));
+        add(&mut bag, 0, counter);
         assert!(contains_with_type<u64, Counter>(&bag, 0), 0);
         assert!(!contains_with_type<u8, Counter>(&bag, 0), 0);
         assert!(!contains_with_type<u8, Fake>(&bag, 0), 0);
@@ -158,14 +156,14 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let bag = object_bag::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
-        let uid2 = ts::new_object(&mut scenario);
+        let counter1 = new(&mut scenario);
+        let counter2 = new(&mut scenario);
         assert!(object_bag::is_empty(&bag), 0);
         assert!(object_bag::length(&bag) == 0, 0);
-        add(&mut bag, 0, new(uid1));
+        add(&mut bag, 0, counter1);
         assert!(!object_bag::is_empty(&bag), 0);
         assert!(object_bag::length(&bag) == 1, 0);
-        add(&mut bag, 1, new(uid2));
+        add(&mut bag, 1, counter2);
         assert!(!object_bag::is_empty(&bag), 0);
         assert!(object_bag::length(&bag) == 2, 0);
         ts::end(scenario);
@@ -181,7 +179,7 @@ module sui::object_bag_tests {
         let scenario = ts::begin(sender);
         let bag1 = object_bag::new(ts::ctx(&mut scenario));
         let bag2 = object_bag::new(ts::ctx(&mut scenario));
-        add(&mut bag1, 0, new(ts::new_object(&mut scenario)));
+        add(&mut bag1, 0, new(&mut scenario));
         assert!(contains(&bag1, 0), 0);
         assert!(!contains(&bag2, 0), 0);
         bump(borrow_mut(&mut bag1, 0));
@@ -197,8 +195,8 @@ module sui::object_bag_tests {
         object_bag::destroy_empty(bag2);
     }
 
-    fun new(id: UID): Counter {
-        Counter { id, count: 0 }
+    fun new(scenario: &mut ts::Scenario): Counter {
+        Counter { id: ts::new_object(scenario), count: 0 }
     }
 
     fun count(counter: &Counter): u64 {

--- a/crates/sui-framework/tests/object_table_tests.move
+++ b/crates/sui-framework/tests/object_table_tests.move
@@ -18,13 +18,13 @@ module sui::object_table_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let table = object_table::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
-        let id1 = object::uid_to_inner(&uid1);
-        let uid2 = ts::new_object(&mut scenario);
-        let id2 = object::uid_to_inner(&uid2);
+        let counter1 = new(&mut scenario);
+        let id1 = object::id(&counter1);
+        let counter2 = new(&mut scenario);
+        let id2 = object::id(&counter2);
         // add fields
-        add(&mut table, b"hello", new(uid1));
-        add(&mut table, b"goodbye", new(uid2));
+        add(&mut table, b"hello", counter1);
+        add(&mut table, b"goodbye", counter2);
         // check they exist
         assert!(contains(&table, b"hello"), 0);
         assert!(contains(&table, b"goodbye"), 0);
@@ -56,10 +56,8 @@ module sui::object_table_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let table = object_table::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
-        let uid2 = ts::new_object(&mut scenario);
-        add(&mut table, b"hello", new(uid1));
-        add(&mut table, b"hello", new(uid2));
+        add(&mut table, b"hello", new(&mut scenario));
+        add(&mut table, b"hello", new(&mut scenario));
         abort 42
     }
 
@@ -99,8 +97,7 @@ module sui::object_table_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let table = object_table::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
-        add(&mut table, 0, new(uid1));
+        add(&mut table, 0, new(&mut scenario));
         object_table::destroy_empty(table);
         ts::end(scenario);
     }
@@ -110,9 +107,8 @@ module sui::object_table_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let table = object_table::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
         assert!(!contains(&mut table, 0), 0);
-        add(&mut table, 0, new(uid1));
+        add(&mut table, 0, new(&mut scenario));
         assert!(contains(&mut table, 0), 0);
         assert!(!contains(&mut table, 1), 0);
         ts::end(scenario);
@@ -125,14 +121,12 @@ module sui::object_table_tests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
         let table = object_table::new(ts::ctx(&mut scenario));
-        let uid1 = ts::new_object(&mut scenario);
-        let uid2 = ts::new_object(&mut scenario);
         assert!(object_table::is_empty(&table), 0);
         assert!(object_table::length(&table) == 0, 0);
-        add(&mut table, 0, new(uid1));
+        add(&mut table, 0, new(&mut scenario));
         assert!(!object_table::is_empty(&table), 0);
         assert!(object_table::length(&table) == 1, 0);
-        add(&mut table, 1, new(uid2));
+        add(&mut table, 1, new(&mut scenario));
         assert!(!object_table::is_empty(&table), 0);
         assert!(object_table::length(&table) == 2, 0);
         ts::end(scenario);
@@ -148,7 +142,7 @@ module sui::object_table_tests {
         let scenario = ts::begin(sender);
         let table1 = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
         let table2 = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
-        add(&mut table1, 0, new(ts::new_object(&mut scenario)));
+        add(&mut table1, 0, new(&mut scenario));
         assert!(contains(&table1, 0), 0);
         assert!(!contains(&table2, 0), 0);
         bump(borrow_mut(&mut table1, 0));
@@ -164,8 +158,8 @@ module sui::object_table_tests {
         object_table::destroy_empty(table2);
     }
 
-    fun new(id: UID): Counter {
-        Counter { id, count: 0 }
+    fun new(scenario: &mut ts::Scenario): Counter {
+        Counter { id: ts::new_object(scenario), count: 0 }
     }
 
     fun count(counter: &Counter): u64 {

--- a/crates/sui-types/src/id.rs
+++ b/crates/sui-types/src/id.rs
@@ -11,7 +11,8 @@ use move_core_types::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub const OBJECT_MODULE_NAME: &IdentStr = ident_str!("object");
+pub const OBJECT_MODULE_NAME_STR: &str = "object";
+pub const OBJECT_MODULE_NAME: &IdentStr = ident_str!(OBJECT_MODULE_NAME_STR);
 pub const UID_STRUCT_NAME: &IdentStr = ident_str!("UID");
 pub const ID_STRUCT_NAME: &IdentStr = ident_str!("ID");
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
-task 0 'publish'. lines 4-25:
-Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function call. Found in _::m::foo"), command: Some(0) } }
+task 0 'publish'. lines 4-26:
+created: object(104)
+written: object(103)

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.mvir
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //# publish
+// allowed since no object is being created with the UID
 module 0x0.m {
     import 0x2.object;
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
-task 0 'publish'. lines 4-25:
+task 0 'publish'. lines 4-26:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::m::foo"), command: Some(0) } }
 
-task 1 'publish'. lines 27-48:
+task 1 'publish'. lines 28-50:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function call. Found in _::m::foo"), command: Some(0) } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
@@ -2,8 +2,8 @@ processed 2 tasks
 
 task 0 'publish'. lines 4-26:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::m::foo"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid object creation in _::m::foo. Object created without a newly created UID. The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object Found in _::m::foo"), command: Some(0) } }
 
 task 1 'publish'. lines 28-50:
-Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function call. Found in _::m::foo"), command: Some(0) } }
+created: object(105)
+written: object(104)

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.mvir
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //# publish
+// not allowed since Foo is not packed with a fresh UID
 module 0x0.m {
     import 0x2.object;
 
@@ -25,6 +26,7 @@ module 0x0.m {
 }
 
 //# publish
+// allowed since no packing occurs
 module 0x0.m {
     import 0x2.object;
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/loop.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/loop.exp
@@ -1,0 +1,5 @@
+processed 1 task
+
+task 0 'publish'. lines 4-34:
+created: object(104)
+written: object(103)

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/loop.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/loop.mvir
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# publish
+// allowed, even though a bit pointless
+module 0x0.m {
+    import 0x2.object;
+    import 0x2.tx_context;
+    import 0x2.transfer;
+
+    struct Obj has key {
+        id: object.UID,
+    }
+
+    public entry transmute(ctx: &mut tx_context.TxContext) {
+        let id: object.UID;
+        let obj: Self.Obj;
+        let i: u64;
+        label l0:
+        i = 0;
+        id = object.new(copy(ctx));
+        label loop_start:
+            jump_if (copy(i) > 10) loop_end;
+            object.delete(move(id));
+            id = object.new(copy(ctx));
+            i = move(i) + 1;
+            jump loop_start;
+        label loop_end:
+        obj = Obj { id: move(id) };
+        transfer.transfer<Self.Obj>(move(obj), tx_context.sender(freeze(copy(ctx))));
+        return;
+    }
+
+}

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_call_with_borrow_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_call_with_borrow_field.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-34:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function call. Found in _::m::bad"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid object creation in _::m::new. Object created without a newly created UID. The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object Found in _::m::new"), command: Some(0) } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_call_with_borrow_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_call_with_borrow_field.mvir
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //# publish
-// no allowed, leaking through call
+// no allowed, the call tries to make a new UID
 module 0x0.m {
     import 0x2.object;
     import 0x2.transfer;

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
-task 0 'publish'. lines 4-19:
-Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leaked through function return. Found in _::m::foo"), command: Some(0) } }
+task 0 'publish'. lines 4-20:
+created: object(104)
+written: object(103)

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.mvir
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //# publish
+// allowed, no object is being made with the UID
 module 0x0.m {
     import 0x2.object;
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
-task 0 'publish'. lines 4-19:
+task 0 'publish'. lines 4-20:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::m::foo"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid object creation in _::m::foo. Object created without a newly created UID. The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object Found in _::m::foo"), command: Some(0) } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.mvir
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //# publish
+// not allowed, a new object is being made with the UID
 module 0x0.m {
     import 0x2.object;
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
-task 0 'publish'. lines 4-36:
+task 0 'publish'. lines 4-37:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::test::test"), command: Some(0) } }
 
-task 1 'publish'. lines 38-60:
+task 1 'publish'. lines 39-62:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::m::foo"), command: Some(0) } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.exp
@@ -2,8 +2,8 @@ processed 2 tasks
 
 task 0 'publish'. lines 4-37:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::test::test"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid object creation in _::test::test. Object created without a newly created UID. The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object Found in _::test::test"), command: Some(0) } }
 
 task 1 'publish'. lines 39-62:
-Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::m::foo"), command: Some(0) } }
+created: object(105)
+written: object(104)

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.mvir
@@ -46,8 +46,8 @@ module 0x0.m {
     }
 
     struct Bar {
-        v: u64,
         id: object.UID,
+        v: u64,
     }
 
     foo(f: Self.Foo) {
@@ -55,7 +55,7 @@ module 0x0.m {
         let b: Self.Bar;
         label l0:
         Foo { id } = move(f);
-        b = Bar { v: 0, id: move(id) };
+        b = Bar { id: move(id), v: 0 };
         abort 0;
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.mvir
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //# publish
+// not allowed since C is not packed with a fresh UID
 module 0x0.test {
     import 0x2.object;
     import 0x2.transfer;
@@ -36,6 +37,7 @@ module 0x0.test {
 }
 
 //# publish
+// allowed since Bar does not have key
 module 0x0.m {
     import 0x2.object;
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-21:
-Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a vector. Found in _::m::foo"), command: Some(0) } }
+created: object(104)
+written: object(103)

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
-task 0 'publish'. lines 4-20:
+task 0 'publish'. lines 4-21:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a vector. Found in _::m::foo"), command: Some(0) } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.mvir
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //# publish
+// allowed, anything can be done with a UID after unpacking, as long as it isn't repacked
 module 0x0.m {
     import 0x2.object;
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/transmute.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/transmute.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-28:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID is leaked into a struct. Found in _::m::transmute"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid object creation in _::m::transmute. Object created without a newly created UID. The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object Found in _::m::transmute"), command: Some(0) } }

--- a/crates/sui-verifier/src/id_leak_verifier.rs
+++ b/crates/sui-verifier/src/id_leak_verifier.rs
@@ -23,26 +23,51 @@ use move_binary_format::{
 use move_bytecode_verifier::absint::{
     AbstractDomain, AbstractInterpreter, JoinResult, TransferFunctions,
 };
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 use std::collections::BTreeMap;
 use sui_types::{
     error::ExecutionError, id::OBJECT_MODULE_NAME, messages::ExecutionFailureStatus,
-    SUI_FRAMEWORK_ADDRESS,
+    sui_system_state::SUI_SYSTEM_MODULE_NAME, SUI_FRAMEWORK_ADDRESS,
 };
 
-use crate::verification_failure;
+use crate::{verification_failure, TEST_SCENARIO_MODULE_NAME};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum AbstractValue {
-    ID,
-    NonID,
+    Fresh,
+    Other,
 }
+
+type FunctionIdent<'a> = (&'a AccountAddress, &'a IdentStr, &'a IdentStr);
+const OBJECT_NEW: FunctionIdent = (
+    &SUI_FRAMEWORK_ADDRESS,
+    OBJECT_MODULE_NAME,
+    ident_str!("new"),
+);
+const OBJECT_NEW_UID_FROM_HASH: FunctionIdent = (
+    &SUI_FRAMEWORK_ADDRESS,
+    OBJECT_MODULE_NAME,
+    ident_str!("new_uid_from_hash"),
+);
+const TS_NEW_OBJECT: FunctionIdent = (
+    &SUI_FRAMEWORK_ADDRESS,
+    ident_str!(TEST_SCENARIO_MODULE_NAME),
+    ident_str!("new_object"),
+);
+const SUI_SYSTEM_CREATE: FunctionIdent = (
+    &SUI_FRAMEWORK_ADDRESS,
+    SUI_SYSTEM_MODULE_NAME,
+    ident_str!("create"),
+);
+const FRESH_ID_FUNCTIONS: &[FunctionIdent] = &[OBJECT_NEW, OBJECT_NEW_UID_FROM_HASH, TS_NEW_OBJECT];
+const FUNCTIONS_TO_SKIP: &[FunctionIdent] = &[SUI_SYSTEM_CREATE];
 
 impl AbstractValue {
     pub fn join(&self, value: &AbstractValue) -> AbstractValue {
         if self == value {
             *value
         } else {
-            AbstractValue::ID
+            AbstractValue::Other
         }
     }
 }
@@ -63,6 +88,13 @@ fn verify_id_leak(module: &CompiledModule) -> Result<(), ExecutionError> {
             FunctionView::function(module, FunctionDefinitionIndex(index as u16), code, handle);
         let initial_state = AbstractState::new(&func_view);
         let mut verifier = IDLeakAnalysis::new(&binary_view, &func_view);
+        let function_to_verify = verifier.cur_function();
+        if FUNCTIONS_TO_SKIP
+            .iter()
+            .any(|to_skip| function_to_verify == *to_skip)
+        {
+            continue;
+        }
         verifier
             .analyze_function(initial_state, &func_view)
             .map_err(|err| {
@@ -98,7 +130,7 @@ impl AbstractState {
         for param_idx in 0..function_view.parameters().len() {
             state
                 .locals
-                .insert(param_idx as LocalIndex, AbstractValue::NonID);
+                .insert(param_idx as LocalIndex, AbstractValue::Other);
         }
 
         state
@@ -110,7 +142,7 @@ impl AbstractDomain for AbstractState {
     fn join(&mut self, state: &AbstractState) -> JoinResult {
         let mut changed = false;
         for (local, value) in &state.locals {
-            let old_value = *self.locals.get(local).unwrap_or(&AbstractValue::NonID);
+            let old_value = *self.locals.get(local).unwrap_or(&AbstractValue::Other);
             changed |= *value != old_value;
             self.locals.insert(*local, value.join(&old_value));
         }
@@ -135,6 +167,28 @@ impl<'a> IDLeakAnalysis<'a> {
             function_view,
             stack: vec![],
         }
+    }
+
+    fn stack_popn(&mut self, n: usize) {
+        let new_len = self.stack.len() - n;
+        self.stack.drain(new_len..);
+    }
+
+    fn resolve_function(&self, function_handle: &FunctionHandle) -> FunctionIdent<'a> {
+        let m = self.binary_view.module_handle_at(function_handle.module);
+        let address = self.binary_view.address_identifier_at(m.address);
+        let module = self.binary_view.identifier_at(m.name);
+        let function = self.binary_view.identifier_at(function_handle.name);
+        (address, module, function)
+    }
+
+    fn cur_function(&self) -> FunctionIdent<'a> {
+        let fdef = self
+            .binary_view
+            .function_def_at(self.function_view.index().unwrap())
+            .unwrap();
+        let handle = self.binary_view.function_handle_at(fdef.function);
+        self.resolve_function(handle)
     }
 }
 
@@ -168,52 +222,32 @@ impl<'a> TransferFunctions for IDLeakAnalysis<'a> {
 
 impl<'a> AbstractInterpreter for IDLeakAnalysis<'a> {}
 
-/// Certain Sui Framework functions can safely take a `ID` by value
-fn is_call_safe_to_leak(verifier: &IDLeakAnalysis, function_handle: &FunctionHandle) -> bool {
-    let m = verifier
-        .binary_view
-        .module_handle_at(function_handle.module);
-    let is_framework =
-        verifier.binary_view.address_identifier_at(m.address) == &SUI_FRAMEWORK_ADDRESS;
-    if !is_framework {
-        return false;
-    }
-
-    // sui::object::delete
-    (verifier.binary_view.identifier_at(m.name) == OBJECT_MODULE_NAME
-        && verifier
-            .binary_view
-            .identifier_at(function_handle.name)
-            .as_str()
-            == "delete") ||
-    // sui::transfer::delete_child_object
-    (verifier.binary_view.identifier_at(m.name).as_str() == "transfer"
-            && verifier
-                .binary_view
-                .identifier_at(function_handle.name)
-                .as_str()
-                == "delete_child_object")
-}
-
 fn call(
     verifier: &mut IDLeakAnalysis,
     function_handle: &FunctionHandle,
 ) -> Result<(), ExecutionError> {
-    let guaranteed_safe = is_call_safe_to_leak(verifier, function_handle);
     let parameters = verifier
         .binary_view
         .signature_at(function_handle.parameters);
-    for _ in 0..parameters.len() {
-        if verifier.stack.pop().unwrap() == AbstractValue::ID && !guaranteed_safe {
-            return Err(verification_failure(
-                "ID leaked through function call.".to_string(),
-            ));
-        }
-    }
+    verifier.stack_popn(parameters.len());
 
     let return_ = verifier.binary_view.signature_at(function_handle.return_);
-    for _ in 0..return_.0.len() {
-        verifier.stack.push(AbstractValue::NonID);
+    let function = verifier.resolve_function(function_handle);
+    if FRESH_ID_FUNCTIONS
+        .iter()
+        .any(|makes_fresh| function == *makes_fresh)
+    {
+        if return_.0.len() != 1 {
+            debug_assert!(false, "{:?} should have a single return value", function);
+            return Err(ExecutionError::from_kind(
+                ExecutionFailureStatus::InvariantViolation,
+            ));
+        }
+        verifier.stack.push(AbstractValue::Fresh);
+    } else {
+        verifier
+            .stack
+            .extend(vec![AbstractValue::Other; return_.0.len()]);
     }
     Ok(())
 }
@@ -229,35 +263,35 @@ fn pack(
     verifier: &mut IDLeakAnalysis,
     struct_def: &StructDefinition,
 ) -> Result<(), ExecutionError> {
-    for _ in 0..num_fields(struct_def) {
-        let value = verifier.stack.pop().unwrap();
-        if value == AbstractValue::ID {
-            return Err(verification_failure(
-                "ID is leaked into a struct.".to_string(),
-            ));
+    // When unpacking, an object whose struct type has key ability must have the first field as
+    // "id". That fields must come from one of the functions that creates a new UID.
+    let handle = verifier
+        .binary_view
+        .struct_handle_at(struct_def.struct_handle);
+    let num_fields = num_fields(struct_def);
+    verifier.stack_popn(num_fields - 1);
+    let last_value = verifier.stack.pop().unwrap();
+    if handle.abilities.has_key() {
+        if last_value != AbstractValue::Fresh {
+            let (cur_package, cur_module, cur_function) = verifier.cur_function();
+            let msg = format!(
+                "Invalid object creation in {cur_package}::{cur_module}::{cur_function}. \
+                Object created without a newly created UID. \
+                The UID must come directly from sui::{}::{}.",
+                OBJECT_NEW.1, OBJECT_NEW.2,
+            );
+            return Err(verification_failure(msg));
         }
     }
-    verifier.stack.push(AbstractValue::NonID);
+    verifier.stack.push(AbstractValue::Other);
     Ok(())
 }
 
 fn unpack(verifier: &mut IDLeakAnalysis, struct_def: &StructDefinition) {
-    // When unpacking, fields of the struct will be pushed to the stack in order.
-    // An object whose struct type has key ability must have the first field as "id",
-    // representing the ID field of the object. It's the focus of our tracking.
-    // The struct_with_key_verifier verifies that the first field must be the id field.
     verifier.stack.pop().unwrap();
-    let handle = verifier
-        .binary_view
-        .struct_handle_at(struct_def.struct_handle);
-    verifier.stack.push(if handle.abilities.has_key() {
-        AbstractValue::ID
-    } else {
-        AbstractValue::NonID
-    });
-    for _ in 1..num_fields(struct_def) {
-        verifier.stack.push(AbstractValue::NonID);
-    }
+    verifier
+        .stack
+        .extend(vec![AbstractValue::Other; num_fields(struct_def)]);
 }
 
 fn execute_inner(
@@ -271,9 +305,9 @@ fn execute_inner(
         Bytecode::Pop => {
             verifier.stack.pop().unwrap();
         }
-        Bytecode::CopyLoc(local) => {
-            let value = state.locals.get(local).unwrap();
-            verifier.stack.push(*value);
+        Bytecode::CopyLoc(_local) => {
+            // cannot copy a UID
+            verifier.stack.push(AbstractValue::Other);
         }
         Bytecode::MoveLoc(local) => {
             let value = state.locals.remove(local).unwrap();
@@ -299,7 +333,7 @@ fn execute_inner(
         | Bytecode::VecLen(_)
         | Bytecode::VecPopBack(_) => {
             verifier.stack.pop().unwrap();
-            verifier.stack.push(AbstractValue::NonID);
+            verifier.stack.push(AbstractValue::Other);
         }
 
         // These bytecodes don't operate on any value.
@@ -329,26 +363,23 @@ fn execute_inner(
         | Bytecode::VecMutBorrow(_) => {
             verifier.stack.pop().unwrap();
             verifier.stack.pop().unwrap();
-            verifier.stack.push(AbstractValue::NonID);
+            verifier.stack.push(AbstractValue::Other);
         }
         Bytecode::WriteRef => {
-            // Top of stack is the reference, and the second element is the value.
             verifier.stack.pop().unwrap();
-            if verifier.stack.pop().unwrap() == AbstractValue::ID {
-                return Err(verification_failure("ID is leaked to a reference.".to_string()));
-            }
+            verifier.stack.pop().unwrap();
         }
 
         // These bytecodes produce references, and hence cannot be ID.
         Bytecode::MutBorrowLoc(_)
-        | Bytecode::ImmBorrowLoc(_) => verifier.stack.push(AbstractValue::NonID),
+        | Bytecode::ImmBorrowLoc(_) => verifier.stack.push(AbstractValue::Other),
 
         | Bytecode::MutBorrowField(_)
         | Bytecode::MutBorrowFieldGeneric(_)
         | Bytecode::ImmBorrowField(_)
         | Bytecode::ImmBorrowFieldGeneric(_) => {
             verifier.stack.pop().unwrap();
-            verifier.stack.push(AbstractValue::NonID);
+            verifier.stack.push(AbstractValue::Other);
         }
 
         // These bytecodes are not allowed, and will be
@@ -377,11 +408,7 @@ fn execute_inner(
         }
 
         Bytecode::Ret => {
-            for _ in 0..verifier.function_view.return_().len() {
-                if verifier.stack.pop().unwrap() == AbstractValue::ID {
-		    return Err(verification_failure("ID leaked through function return.".to_string()));
-                }
-            }
+            verifier.stack_popn(verifier.function_view.return_().len())
         }
 
         Bytecode::BrTrue(_) | Bytecode::BrFalse(_) | Bytecode::Abort => {
@@ -390,7 +417,7 @@ fn execute_inner(
 
         // These bytecodes produce constants, and hence cannot be ID.
         Bytecode::LdTrue | Bytecode::LdFalse | Bytecode::LdU8(_) | Bytecode::LdU16(_)| Bytecode::LdU32(_)  | Bytecode::LdU64(_) | Bytecode::LdU128(_)| Bytecode::LdU256(_)  | Bytecode::LdConst(_) => {
-            verifier.stack.push(AbstractValue::NonID);
+            verifier.stack.push(AbstractValue::Other);
         }
 
         Bytecode::Pack(idx) => {
@@ -413,27 +440,18 @@ fn execute_inner(
         }
 
         Bytecode::VecPack(_, num) => {
-            for _ in 0..*num {
-                if verifier.stack.pop().unwrap() == AbstractValue::ID {
-		    return Err(verification_failure("ID is leaked into a vector.".to_string()));
-                }
-            }
-            verifier.stack.push(AbstractValue::NonID);
+            verifier.stack_popn(*num as usize);
+            verifier.stack.push(AbstractValue::Other);
         }
 
         Bytecode::VecPushBack(_) => {
-            if verifier.stack.pop().unwrap() == AbstractValue::ID {
-		return Err(verification_failure("ID is leaked into a vector.".to_string()));
-            }
+            verifier.stack.pop().unwrap();
             verifier.stack.pop().unwrap();
         }
 
         Bytecode::VecUnpack(_, num) => {
             verifier.stack.pop().unwrap();
-
-            for _ in 0..*num {
-                verifier.stack.push(AbstractValue::NonID);
-            }
+            verifier.stack.extend(vec![AbstractValue::Other; *num as usize])
         }
 
         Bytecode::VecSwap(_) => {

--- a/crates/sui-verifier/src/id_leak_verifier.rs
+++ b/crates/sui-verifier/src/id_leak_verifier.rs
@@ -280,18 +280,16 @@ fn pack(
     let num_fields = num_fields(struct_def);
     verifier.stack_popn(num_fields - 1);
     let last_value = verifier.stack.pop().unwrap();
-    if handle.abilities.has_key() {
-        if last_value != AbstractValue::Fresh {
-            let (cur_package, cur_module, cur_function) = verifier.cur_function();
-            let msg = format!(
-                "Invalid object creation in {cur_package}::{cur_module}::{cur_function}. \
+    if handle.abilities.has_key() && last_value != AbstractValue::Fresh {
+        let (cur_package, cur_module, cur_function) = verifier.cur_function();
+        let msg = format!(
+            "Invalid object creation in {cur_package}::{cur_module}::{cur_function}. \
                 Object created without a newly created UID. \
                 The UID must come directly from sui::{}::{}. \
                 Or for tests, it can come from sui::{}::{}",
-                OBJECT_NEW.1, OBJECT_NEW.2, TS_NEW_OBJECT.1, TS_NEW_OBJECT.2,
-            );
-            return Err(verification_failure(msg));
-        }
+            OBJECT_NEW.1, OBJECT_NEW.2, TS_NEW_OBJECT.1, TS_NEW_OBJECT.2,
+        );
+        return Err(verification_failure(msg));
     }
     verifier.stack.push(AbstractValue::Other);
     Ok(())

--- a/crates/sui-verifier/src/lib.rs
+++ b/crates/sui-verifier/src/lib.rs
@@ -23,6 +23,7 @@ use sui_types::{
 };
 
 pub const INIT_FN_NAME: &IdentStr = ident_str!("init");
+pub const TEST_SCENARIO_MODULE_NAME: &str = "test_scenario";
 
 fn verification_failure(error: String) -> ExecutionError {
     ExecutionError::new_with_source(ExecutionErrorKind::SuiMoveVerificationError, error)

--- a/crates/sui-verifier/src/private_generics.rs
+++ b/crates/sui-verifier/src/private_generics.rs
@@ -13,9 +13,8 @@ use move_binary_format::{
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 use sui_types::{error::ExecutionError, SUI_FRAMEWORK_ADDRESS};
 
-use crate::{format_signature_token, verification_failure};
+use crate::{format_signature_token, verification_failure, TEST_SCENARIO_MODULE_NAME};
 
-const TEST_SCENARIO_MODULE_NAME: &str = "test_scenario";
 pub const TRANSFER_MODULE: &IdentStr = ident_str!("transfer");
 pub const EVENT_MODULE: &IdentStr = ident_str!("event");
 pub const TRANSFER_FUNCTIONS: &[&IdentStr] = &[

--- a/sui_programmability/examples/nfts/sources/auction.move
+++ b/sui_programmability/examples/nfts/sources/auction.move
@@ -17,13 +17,13 @@
 ///  - The auction starts with the owner sending an item to be sold along with
 ///    its own address to the auctioneer who creates and initializes an
 ///    auction.
-///  - Bidders send their bid to the auctioneer. 
+///  - Bidders send their bid to the auctioneer.
 ///    A bid consists of the funds offered for the item and the bidder's address.
 ///  - The auctioneer periodically inspects the bids:
-///    - (inspected bid > current best bid (initially there is no bid)): 
+///    - (inspected bid > current best bid (initially there is no bid)):
 ///      The auctioneer updates the auction with the current bid
 ///      and the funds of the previous highest bid are sent back to their owner.
-///    - (inspected bid <= current best bid): 
+///    - (inspected bid <= current best bid):
 ///      The auctioneer sents the inspected bid's funds back to the new bidder,
 ///      and the auction remains unchanged.
 ///  - The auctioneer eventually ends the auction:
@@ -65,10 +65,12 @@ module nfts::auction {
     /// moment. This is executed by the owner of the asset to be
     /// auctioned.
     public fun create_auction<T: key + store>(
-        to_sell: T, id: UID, auctioneer: address, ctx: &mut TxContext
-    ) {
-        let auction = auction_lib::create_auction(id, to_sell, ctx);
+        to_sell: T, auctioneer: address, ctx: &mut TxContext
+    ): ID {
+        let auction = auction_lib::create_auction(to_sell, ctx);
+        let id = object::id(&auction);
         auction_lib::transfer(auction, auctioneer);
+        id
     }
 
     /// Creates a bid a and send it to the auctioneer along with the

--- a/sui_programmability/examples/nfts/sources/auction_lib.move
+++ b/sui_programmability/examples/nfts/sources/auction_lib.move
@@ -47,13 +47,13 @@ module nfts::auction_lib {
     /// Creates an auction. This is executed by the owner of the asset to be
     /// auctioned.
     public(friend) fun create_auction<T: key + store>(
-        id: UID, to_sell: T, ctx: &mut TxContext
+        to_sell: T, ctx: &mut TxContext
     ): Auction<T> {
         // A question one might asked is how do we know that to_sell
         // is owned by the caller of this entry function and the
         // answer is that it's checked by the runtime.
         Auction<T> {
-            id,
+            id: object::new(ctx),
             to_sell: option::some(to_sell),
             owner: tx_context::sender(ctx),
             bid_data: option::none(),

--- a/sui_programmability/examples/nfts/sources/shared_auction.move
+++ b/sui_programmability/examples/nfts/sources/shared_auction.move
@@ -27,7 +27,6 @@
 
 module nfts::shared_auction {
     use sui::coin::{Self, Coin};
-    use sui::object;
     use sui::sui::SUI;
     use sui::tx_context::{Self, TxContext};
 
@@ -43,7 +42,7 @@ module nfts::shared_auction {
     /// Creates an auction. This is executed by the owner of the asset
     /// to be auctioned.
     public entry fun create_auction<T: key + store >(to_sell: T, ctx: &mut TxContext) {
-        let auction = auction_lib::create_auction(object::new(ctx), to_sell, ctx);
+        let auction = auction_lib::create_auction(to_sell, ctx);
         auction_lib::share_object(auction);
     }
 

--- a/sui_programmability/examples/nfts/tests/auction_tests.move
+++ b/sui_programmability/examples/nfts/tests/auction_tests.move
@@ -58,16 +58,8 @@ module nfts::auction_tests {
             id: object::new(ctx),
             value: 42,
         };
-        // generate unique auction ID (it would be more natural to
-        // generate one in crate_auction and return it, but we cannot
-        // do this at the moment)
-        let id = object::new(ctx);
-        // we need to dereference (copy) right here rather wherever
-        // auction_id is used - otherwise id would still be considered
-        // borrowed and could not be passed argument to a function
-        // consuming it
-        let auction_id = object::uid_to_inner(&id);
-        auction::create_auction(to_sell, id, auctioneer, ctx);
+        // create the auction
+        let auction_id = auction::create_auction(to_sell, auctioneer, ctx);
 
         // a transaction by the first bidder to create and put a bid
         test_scenario::next_tx(scenario, bidder1);


### PR DESCRIPTION
- Instead of checking leaks at unpack, we check them at pack.
- The rule for this is that the `id` field of an object must come from a set of approved functions, ostensibly just `object::new`
- This is quite the breaking change, but opens up the door for more complicated dynamic field behavior, since you can keep the UID around after the object is unpacked.
  - This might complciate efforts to track wrapped objects?