### PR TITLE
[checkpoints] Use strong(2f+1) quorum for checkpoints.

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -22,7 +22,7 @@ use sui_types::base_types::{ExecutionDigests, TransactionDigest};
 use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::crypto::{
     AuthorityKeyPair, AuthorityPublicKeyBytes, AuthoritySignInfo, AuthoritySignature,
-    AuthorityWeakQuorumSignInfo, SuiAuthoritySignature, ToFromBytes,
+    AuthorityStrongQuorumSignInfo, SuiAuthoritySignature, ToFromBytes,
 };
 use sui_types::gas::SuiGasStatus;
 use sui_types::in_memory_storage::InMemoryStorage;
@@ -464,7 +464,7 @@ impl Builder {
 
             CertifiedCheckpointSummary {
                 summary: checkpoint,
-                auth_signature: AuthorityWeakQuorumSignInfo::new_from_auth_sign_infos(
+                auth_signature: AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(
                     signatures, &committee,
                 )
                 .unwrap(),

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -28,7 +28,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_types::base_types::{EpochId, TransactionDigest};
-use sui_types::crypto::{AuthoritySignInfo, AuthorityWeakQuorumSignInfo};
+use sui_types::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
 use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::gas::GasCostSummary;
@@ -393,7 +393,7 @@ pub struct CheckpointSignatureAggregator {
     next_index: u64,
     summary: CheckpointSummary,
     digest: CheckpointDigest,
-    signatures: StakeAggregator<AuthoritySignInfo, false>,
+    signatures: StakeAggregator<AuthoritySignInfo, true>,
 }
 
 impl CheckpointBuilder {
@@ -906,7 +906,7 @@ impl CheckpointSignatureAggregator {
     pub fn try_aggregate(
         &mut self,
         data: CheckpointSignatureMessage,
-    ) -> Result<AuthorityWeakQuorumSignInfo, ()> {
+    ) -> Result<AuthorityStrongQuorumSignInfo, ()> {
         let their_digest = data.summary.summary.digest();
         let author = data.summary.auth_signature.authority;
         let signature = data.summary.auth_signature;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3917,8 +3917,8 @@ async fn test_tallying_rule_score_updates() {
             .unwrap()
     };
 
-    // Only include auth_0 and auth_1 in this certified checkpoint.
-    let ckpt_1 = mock_certified_checkpoint(authorities[0..2].iter(), committee.clone(), 1);
+    // Only include auth_[0..3] in this certified checkpoint.
+    let ckpt_1 = mock_certified_checkpoint(authorities[0..3].iter(), committee.clone(), 1);
 
     assert!(epoch_store
         .record_certified_checkpoint_signatures(&ckpt_1)
@@ -3932,7 +3932,10 @@ async fn test_tallying_rule_score_updates() {
         get_stored_seq_num_and_counter(&auth_1_name),
         Some((Some(1), 1))
     );
-    assert_eq!(get_stored_seq_num_and_counter(&auth_2_name), None);
+    assert_eq!(
+        get_stored_seq_num_and_counter(&auth_2_name),
+        Some((Some(1), 1))
+    );
     assert_eq!(get_stored_seq_num_and_counter(&auth_3_name), None);
 
     // Only include auth_1, auth_2 and auth_3 in this certified checkpoint.
@@ -3952,7 +3955,7 @@ async fn test_tallying_rule_score_updates() {
     );
     assert_eq!(
         get_stored_seq_num_and_counter(&auth_2_name),
-        Some((Some(2), 1))
+        Some((Some(2), 2))
     );
     assert_eq!(
         get_stored_seq_num_and_counter(&auth_3_name),
@@ -3976,7 +3979,7 @@ async fn test_tallying_rule_score_updates() {
     );
     assert_eq!(
         get_stored_seq_num_and_counter(&auth_2_name),
-        Some((Some(2), 1))
+        Some((Some(2), 2))
     );
     assert_eq!(
         get_stored_seq_num_and_counter(&auth_3_name),
@@ -3996,6 +3999,6 @@ async fn test_tallying_rule_score_updates() {
     };
     assert_eq!(get_auth_score_metric(&auth_0_name), 1);
     assert_eq!(get_auth_score_metric(&auth_1_name), 2);
-    assert_eq!(get_auth_score_metric(&auth_2_name), 1);
+    assert_eq!(get_auth_score_metric(&auth_2_name), 2);
     assert_eq!(get_auth_score_metric(&auth_3_name), 1);
 }

--- a/crates/sui-network/src/state_sync/test_utils.rs
+++ b/crates/sui-network/src/state_sync/test_utils.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::{
     base_types::AuthorityName,
     committee::{Committee, EpochId, StakeUnit},
     crypto::{
         AuthorityKeyPair, AuthorityPublicKeyBytes, AuthoritySignInfo, AuthoritySignature,
-        AuthorityWeakQuorumSignInfo, KeypairTraits, SuiAuthoritySignature,
+        KeypairTraits, SuiAuthoritySignature,
     },
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointDigest, CheckpointSequenceNumber,
@@ -84,7 +85,7 @@ impl CommitteeFixture {
 
         let checkpoint = CertifiedCheckpointSummary {
             summary: checkpoint,
-            auth_signature: AuthorityWeakQuorumSignInfo::new_from_auth_sign_infos(
+            auth_signature: AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(
                 signatures,
                 self.committee(),
             )

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::base_types::ExecutionDigests;
 use crate::committee::{EpochId, StakeUnit};
 use crate::crypto::{
-    AuthoritySignInfo, AuthoritySignInfoTrait, AuthorityWeakQuorumSignInfo, Signature,
+    AuthoritySignInfo, AuthoritySignInfoTrait, AuthorityStrongQuorumSignInfo, Signature,
 };
 use crate::error::SuiResult;
 use crate::gas::GasCostSummary;
@@ -249,7 +249,7 @@ impl SignedCheckpointSummary {
 // or other authenticated data structures to support light
 // clients and more efficient sync protocols.
 
-pub type CertifiedCheckpointSummary = CheckpointSummaryEnvelope<AuthorityWeakQuorumSignInfo>;
+pub type CertifiedCheckpointSummary = CheckpointSummaryEnvelope<AuthorityStrongQuorumSignInfo>;
 
 impl CertifiedCheckpointSummary {
     /// Aggregate many checkpoint signatures to form a checkpoint certificate.
@@ -270,7 +270,7 @@ impl CertifiedCheckpointSummary {
 
         let certified_checkpoint = CertifiedCheckpointSummary {
             summary: signed_checkpoints[0].summary.clone(),
-            auth_signature: AuthorityWeakQuorumSignInfo::new_from_auth_sign_infos(
+            auth_signature: AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(
                 signed_checkpoints
                     .into_iter()
                     .map(|v| v.auth_signature)


### PR DESCRIPTION
We previously had a weak(f+1) quorum for certified checkpoint because this is sufficient in terms on minimal safety.

However, after recent accident we had a discussion(thanks @bmwill for kicking it off) that having 2f+1 for certifying checkpoints makes more sense as it avoids forks in case of possible non-deterministic execution bug, those greatly reducing potential 'blast radius' of such bugs