### PR TITLE
[Testnet] Wait for input type deps for txns from Narwhal / RPC.

### DIFF
--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -119,17 +119,15 @@ impl TransactionManager {
             let _tx_lock = epoch_store.acquire_tx_lock(&digest);
 
             // if effects indicate a success then we need to add and wait for argument packages,
-            // otherwise we can skip
-            let mut skip_adding_type_arg_deps = true; // default to not adding these temporarily to
-                                                      // unbrick validators
-            let mut inputs = cert.data().intent_message.value.input_objects()?;
-
+            // otherwise we can skip. default to not adding these to unbrick catch up.
+            let mut skip_adding_type_arg_deps = digest_to_effects.is_some();
             if let Some(digest_to_effects) = &digest_to_effects {
                 if let Some(effect) = digest_to_effects.get(cert.digest()) {
                     skip_adding_type_arg_deps = effect.status.is_err();
                 }
             }
 
+            let mut inputs = cert.data().intent_message.value.input_objects()?;
             if !skip_adding_type_arg_deps {
                 inputs.extend(cert.data().intent_message.value.type_argument_packages());
             }


### PR DESCRIPTION
Since all validators are supposed to have the patch to reject signing transactions when input type is not found, txns from Narwhal / RPC should and can wait for input types to become available.