### PR TITLE
wallet-ext: fix stake validation issues

### DIFF
--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -216,11 +216,11 @@ export class Coin {
         gasFee: bigint
     ) {
         const totalAmount = amount + gasFee;
-
+        const gasBudget = Coin.computeGasBudgetForPay(coins, totalAmount);
         const inputCoins =
             CoinAPI.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
                 coins,
-                totalAmount
+                totalAmount + BigInt(gasBudget)
             );
 
         const address = await signer.getAddress();
@@ -234,7 +234,7 @@ export class Coin {
             recipients: [address, address],
             // TODO: Update SDK to accept bigint
             amounts: [Number(amount), Number(gasFee)],
-            gasBudget: Coin.computeGasBudgetForPay(coins, totalAmount),
+            gasBudget,
         });
 
         const effects = getTransactionEffects(result);

--- a/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
-import { ErrorMessage, Field, Form, useFormikContext } from 'formik';
-import { useRef, memo, useCallback } from 'react';
+import { Field, Form, useFormikContext } from 'formik';
+import { memo, useCallback, useEffect } from 'react';
 
 import Loading from '../../components/loading';
 import { useGasBudgetInMist } from '../../hooks/useGasBudgetInMist';
 import { Card } from '_app/shared/card';
 import { Text } from '_app/shared/text';
-import Alert from '_components/alert';
 import NumberInput from '_components/number-input';
 import { useFormatCoin } from '_hooks';
 import {
@@ -22,32 +21,25 @@ import type { FormValues } from './StakingCard';
 const HIDE_MAX = true;
 
 export type StakeFromProps = {
-    submitError: string | null;
     coinBalance: bigint;
     coinType: string;
     epoch: string;
-    onClearSubmitError: () => void;
 };
 
-function StakeForm({
-    submitError,
-    coinBalance,
-    coinType,
-    onClearSubmitError,
-    epoch,
-}: StakeFromProps) {
+function StakeForm({ coinBalance, coinType, epoch }: StakeFromProps) {
     const { setFieldValue } = useFormikContext<FormValues>();
 
-    const onClearRef = useRef(onClearSubmitError);
-    onClearRef.current = onClearSubmitError;
     const { gasBudget: gasBudgetInMist, isLoading } = useGasBudgetInMist(
         DEFAULT_GAS_BUDGET_FOR_PAY * 4 + DEFAULT_GAS_BUDGET_FOR_STAKE
     );
     const [gasBudgetEstimation] = useFormatCoin(gasBudgetInMist, SUI_TYPE_ARG);
 
-    const totalAvailableBalance =
+    let totalAvailableBalance =
         coinBalance -
         BigInt(coinType === SUI_TYPE_ARG ? gasBudgetInMist || 0 : 0);
+    if (totalAvailableBalance < 0) {
+        totalAvailableBalance = 0n;
+    }
 
     const [maxToken, symbol, queryResult] = useFormatCoin(
         totalAvailableBalance,
@@ -58,6 +50,12 @@ function StakeForm({
         if (!maxToken) return;
         setFieldValue('amount', maxToken);
     }, [maxToken, setFieldValue]);
+    useEffect(() => {
+        setFieldValue(
+            'gasBudget',
+            isLoading ? '' : (gasBudgetInMist || 0).toString()
+        );
+    }, [setFieldValue, gasBudgetInMist, isLoading]);
 
     return (
         <Form
@@ -133,24 +131,6 @@ function StakeForm({
                         </Text>
                     </div>
                 </Card>
-                <ErrorMessage name="amount" component="div">
-                    {(msg) => (
-                        <div className="mt-2 flex flex-col flex-nowrap">
-                            <Alert mode="warning" className="text-body">
-                                {msg}
-                            </Alert>
-                        </div>
-                    )}
-                </ErrorMessage>
-
-                {submitError ? (
-                    <div className="mt-2 flex flex-col flex-nowrap">
-                        <Alert mode="warning">
-                            <strong>Stake failed</strong>
-                            <small>{submitError}</small>
-                        </Alert>
-                    </div>
-                ) : null}
             </Loading>
         </Form>
     );

--- a/apps/wallet/src/ui/app/staking/stake/UnstakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/UnstakeForm.tsx
@@ -2,52 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
-import { ErrorMessage, Form, useFormikContext } from 'formik';
-import { useEffect, useRef } from 'react';
+import { Form, useFormikContext } from 'formik';
+import { useEffect } from 'react';
 
 import LoadingIndicator from '../../components/loading/LoadingIndicator';
 import { useGasBudgetInMist } from '../../hooks/useGasBudgetInMist';
 import { Card } from '_app/shared/card';
 import { Text } from '_app/shared/text';
-import Alert from '_components/alert';
 import { useFormatCoin } from '_hooks';
 import { DEFAULT_GAS_BUDGET_FOR_STAKE } from '_redux/slices/sui-objects/Coin';
 
 import type { FormValues } from './StakingCard';
 
 export type StakeFromProps = {
-    submitError: string | null;
     coinBalance: bigint;
     coinType: string;
     stakingReward?: number;
-    onClearSubmitError: () => void;
 };
 
 export function UnStakeForm({
-    submitError,
     coinBalance,
     coinType,
-    onClearSubmitError,
     stakingReward,
 }: StakeFromProps) {
-    const { setFieldValue, setTouched } = useFormikContext<FormValues>();
-
-    const onClearRef = useRef(onClearSubmitError);
-    onClearRef.current = onClearSubmitError;
-
+    const { setFieldValue } = useFormikContext<FormValues>();
     const { gasBudget, isLoading } = useGasBudgetInMist(
         DEFAULT_GAS_BUDGET_FOR_STAKE
     );
     const [gasBudgetFormatted, symbol] = useFormatCoin(gasBudget, SUI_TYPE_ARG);
-
     const [rewards, rewardSymbol] = useFormatCoin(stakingReward, SUI_TYPE_ARG);
-
     const [tokenBalance] = useFormatCoin(coinBalance, coinType);
-
     useEffect(() => {
-        onClearRef.current();
-        setFieldValue('amount', tokenBalance);
-    }, [setFieldValue, setTouched, tokenBalance]);
+        setFieldValue(
+            'gasBudget',
+            isLoading ? '' : (gasBudget || 0).toString(),
+            true
+        );
+    }, [setFieldValue, gasBudget, isLoading]);
 
     return (
         <Form
@@ -132,27 +123,6 @@ export function UnStakeForm({
                     </div>
                 </div>
             </Card>
-            <ErrorMessage name="amount" component="div">
-                {(msg) => (
-                    <div className="mt-2 flex flex-col flex-nowrap">
-                        <Alert mode="warning" className="text-body">
-                            {msg}
-                        </Alert>
-                    </div>
-                )}
-            </ErrorMessage>
-
-            {submitError ? (
-                <div className="mt-2 flex flex-col flex-nowrap">
-                    <Alert mode="warning">
-                        <strong>Unstake failed</strong>
-
-                        <div>
-                            <small>{submitError}</small>
-                        </div>
-                    </Alert>
-                </div>
-            ) : null}
         </Form>
     );
 }

--- a/apps/wallet/src/ui/app/staking/stake/validation.ts
+++ b/apps/wallet/src/ui/app/staking/stake/validation.ts
@@ -2,59 +2,103 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BigNumber from 'bignumber.js';
-import * as Yup from 'yup';
+import { mixed, object } from 'yup';
 
 import { formatBalance } from '../../hooks/useFormatCoin';
 
 export function createValidationSchema(
     coinBalance: bigint,
     coinSymbol: string,
-    decimals: number
+    decimals: number,
+    isUnstake: boolean
 ) {
-    return Yup.object({
-        // NOTE: This is an intentional subset of the token validaiton:
-        amount: Yup.mixed()
+    return object({
+        // NOTE: This is an intentional subset of the token validation:
+        amount: isUnstake
+            ? mixed()
+            : mixed()
+                  .transform((_, original) => {
+                      return new BigNumber(original);
+                  })
+                  .test('required', `\${path} is a required field`, (value) => {
+                      return !!value;
+                  })
+                  .test(
+                      'valid',
+                      'The value provided is not valid.',
+                      (value?: BigNumber) => {
+                          if (!value || value.isNaN() || !value.isFinite()) {
+                              return false;
+                          }
+                          return true;
+                      }
+                  )
+                  .test(
+                      'min',
+                      `\${path} must be greater than 0 ${coinSymbol}`,
+                      (amount?: BigNumber) => (amount ? amount.gt(0) : false)
+                  )
+                  .test('max', (amount: BigNumber | undefined, ctx) => {
+                      const gasBudget = ctx.parent.gasBudget || 0n;
+                      const availableBalance = coinBalance - gasBudget;
+                      if (availableBalance < 0) {
+                          return ctx.createError({
+                              message: 'Insufficient funds',
+                          });
+                      }
+                      const enoughBalance = amount
+                          ? amount
+                                .shiftedBy(decimals)
+                                .lte(availableBalance.toString())
+                          : false;
+                      if (enoughBalance) {
+                          return true;
+                      }
+                      return ctx.createError({
+                          message: `\${path} must be less than ${formatBalance(
+                              availableBalance,
+                              decimals
+                          )} ${coinSymbol}`,
+                      });
+                  })
+                  .test(
+                      'max-decimals',
+                      `The value exceeds the maximum decimals (${decimals}).`,
+                      (amount?: BigNumber) => {
+                          return amount
+                              ? amount.shiftedBy(decimals).isInteger()
+                              : false;
+                      }
+                  )
+                  .label('Amount'),
+        gasBudget: mixed()
             .transform((_, original) => {
-                return new BigNumber(original);
+                try {
+                    return BigInt(original);
+                } catch (e) {
+                    return null;
+                }
             })
-            .test('required', `\${path} is a required field`, (value) => {
+            // we calculate/load the gas budget on component mount and set the for field to the result
+            // here we return an empty message to avoid showing an error but set the form invalid
+            .test('required', '', (value) => {
                 return !!value;
             })
-            .test(
-                'valid',
-                'The value provided is not valid.',
-                (value?: BigNumber) => {
-                    if (!value || value.isNaN() || !value.isFinite()) {
-                        return false;
-                    }
+            .test('gasBudget', (gasBudget, ctx) => {
+                //NOTE: no need to include the amount because budget is included in the max check of the amount
+                // this check is mainly for the unstake form
+                if (coinBalance > gasBudget || !gasBudget) {
                     return true;
                 }
-            )
-            .test(
-                'min',
-                `\${path} must be greater than 0 ${coinSymbol}`,
-                (amount?: BigNumber) => (amount ? amount.gt(0) : false)
-            )
-            .test(
-                'max',
-                `\${path} must be less than ${formatBalance(
-                    coinBalance,
-                    decimals
-                )} ${coinSymbol}`,
-                (amount?: BigNumber) =>
-                    amount
-                        ? amount.shiftedBy(decimals).lte(coinBalance.toString())
-                        : false
-            )
-            .test(
-                'max-decimals',
-                `The value exceeds the maximum decimals (${decimals}).`,
-                (amount?: BigNumber) => {
-                    return amount
-                        ? amount.shiftedBy(decimals).isInteger()
-                        : false;
-                }
-            )
-            .label('Amount'),
+                return ctx.createError({
+                    message: `Insufficient SUI balance (${formatBalance(
+                        coinBalance,
+                        decimals
+                    )}) to cover for the gas fee (${formatBalance(
+                        gasBudget,
+                        decimals
+                    )})`,
+                });
+            }),
     });
 }


### PR DESCRIPTION
* stake coin manage transaction include gas budget to input coins
  * input coins are used for gas as well so we need to include enough coins for that as well
* move submit errors to toasts
  

https://user-images.githubusercontent.com/10210143/216430113-bf68c18c-6a8e-4c7e-865d-6f9d54d9be1a.mov


* fix showing negative available amount to stake

before

https://user-images.githubusercontent.com/10210143/216440077-d30c6c51-9f79-454e-bdc8-13f05d06c2b4.mov


after

https://user-images.githubusercontent.com/10210143/216430329-92724d3e-482f-40a1-bae4-cff01c2423d4.mov


* fix gas budget validation when unstaking

before


https://user-images.githubusercontent.com/10210143/216439679-f1df11c9-fc35-424c-8228-1f9ebf5ae798.mov

after


https://user-images.githubusercontent.com/10210143/216439731-160d40ce-23c7-431d-9cac-f4a196849564.mov


