### PR TITLE
[3/x][checkpoint] Checkpoint Prologue transaction and Move function

### DIFF
--- a/.changeset/honest-ads-boil.md
+++ b/.changeset/honest-ads-boil.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Support for deserializing new ConsensusCommitPrologue system transaction

--- a/crates/sui-adapter-transactional-tests/tests/checkpoint/clock.exp
+++ b/crates/sui-adapter-transactional-tests/tests/checkpoint/clock.exp
@@ -1,0 +1,17 @@
+processed 5 tasks
+
+task 1 'consensus-commit-prologue'. lines 6-6:
+written: object(102)
+
+task 2 'view-object'. lines 8-8:
+Owner: Shared
+Version: 2
+Contents: sui::clock::Clock {id: sui::object::UID {id: sui::object::ID {bytes: fake(102)}}, timestamp_ms: 43u64}
+
+task 3 'consensus-commit-prologue'. lines 10-10:
+written: object(102)
+
+task 4 'view-object'. lines 12-12:
+Owner: Shared
+Version: 3
+Contents: sui::clock::Clock {id: sui::object::UID {id: sui::object::ID {bytes: fake(102)}}, timestamp_ms: 45u64}

--- a/crates/sui-adapter-transactional-tests/tests/checkpoint/clock.move
+++ b/crates/sui-adapter-transactional-tests/tests/checkpoint/clock.move
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init
+
+//# consensus-commit-prologue --timestamp-ms 43
+
+//# view-object 102
+
+//# consensus-commit-prologue --timestamp-ms 45
+
+//# view-object 102

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -23,11 +23,15 @@ use sui_types::id::UID;
 use sui_types::messages::ExecutionFailureStatus;
 #[cfg(test)]
 use sui_types::messages::InputObjects;
-use sui_types::messages::{GenesisTransaction, ObjectArg, Pay, PayAllSui, PaySui, TransactionKind};
+use sui_types::messages::{
+    ConsensusCommitPrologue, GenesisTransaction, ObjectArg, Pay, PayAllSui, PaySui, TransactionKind,
+};
 use sui_types::object::{Data, MoveObject, Owner};
 use sui_types::storage::SingleTxContext;
 use sui_types::storage::{ChildObjectResolver, DeleteKind, ParentSync, WriteKind};
-use sui_types::sui_system_state::ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME;
+use sui_types::sui_system_state::{
+    ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME, CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME,
+};
 #[cfg(test)]
 use sui_types::temporary_store;
 use sui_types::temporary_store::InnerTemporaryStore;
@@ -44,7 +48,8 @@ use sui_types::{
     SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use sui_types::{
-    MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+    MOVE_STDLIB_OBJECT_ID, SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION,
+    SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 
 use sui_types::temporary_store::TemporaryStore;
@@ -325,6 +330,9 @@ fn execution_loop<
                     }
                 }
             }
+            SingleTransactionKind::ConsensusCommitPrologue(prologue) => {
+                setup_consensus_commit(prologue, temporary_store, tx_ctx, move_vm, gas_status)?
+            }
         };
     }
     Ok(results)
@@ -389,6 +397,38 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
             tx_ctx,
         )?;
     }
+    Ok(())
+}
+
+/// Perform metadata updates in preparation for the transactions in the upcoming checkpoint:
+///
+/// - Set the timestamp for the `Clock` shared object from the timestamp in the header from
+///   consensus.
+fn setup_consensus_commit<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
+    prologue: ConsensusCommitPrologue,
+    temporary_store: &mut TemporaryStore<S>,
+    tx_ctx: &mut TxContext,
+    move_vm: &Arc<MoveVM>,
+    gas_status: &mut SuiGasStatus,
+) -> Result<(), ExecutionError> {
+    adapter::execute::<execution_mode::Normal, _, _>(
+        move_vm,
+        temporary_store,
+        ModuleId::new(SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_MODULE_NAME.to_owned()),
+        &CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME.to_owned(),
+        vec![],
+        vec![
+            CallArg::Object(ObjectArg::SharedObject {
+                id: SUI_CLOCK_OBJECT_ID,
+                initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
+                mutable: true,
+            }),
+            CallArg::Pure(bcs::to_bytes(&prologue.checkpoint_start_timestamp_ms).unwrap()),
+        ],
+        gas_status.create_move_gas_status(),
+        tx_ctx,
+    )?;
+
     Ok(())
 }
 

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -80,7 +80,8 @@ pub(crate) async fn check_dev_inspect_input(
             | SingleTransactionKind::PayAllSui(_) => (),
             SingleTransactionKind::Publish(_)
             | SingleTransactionKind::ChangeEpoch(_)
-            | SingleTransactionKind::Genesis(_) => {
+            | SingleTransactionKind::Genesis(_)
+            | SingleTransactionKind::ConsensusCommitPrologue(_) => {
                 anyhow::bail!("Transaction kind {} is not supported in dev-inspect", k)
             }
         }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2627,6 +2627,36 @@ async fn test_idempotent_reversed_confirmation() {
 }
 
 #[tokio::test]
+async fn test_refusal_to_sign_consensus_commit_prologue() {
+    // The system should refuse to handle sender-signed system transactions
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_object_id = ObjectID::random();
+    let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
+    let authority_state = init_state_with_objects(vec![gas_object.clone()]).await;
+
+    let gas_ref = gas_object.compute_object_reference();
+    let tx_data = TransactionData::new_with_dummy_gas_price(
+        TransactionKind::Single(SingleTransactionKind::ConsensusCommitPrologue(
+            ConsensusCommitPrologue {
+                checkpoint_start_timestamp_ms: 42,
+            },
+        )),
+        sender,
+        gas_ref,
+        MAX_GAS,
+    );
+
+    // Sender is able to sign it.
+    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
+
+    // But the authority should refuse to handle it.
+    assert!(matches!(
+        authority_state.handle_transaction(transaction).await,
+        Err(SuiError::InvalidSystemTransaction),
+    ));
+}
+
+#[tokio::test]
 async fn test_genesis_sui_system_state_object() {
     // This test verifies that we can read the genesis SuiSystemState object.
     // And its Move layout matches the definition in Rust (so that we can deserialize it).

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -48,6 +48,9 @@ CircularObjectOwnership:
   STRUCT:
     - object:
         TYPENAME: ObjectID
+ConsensusCommitPrologue:
+  STRUCT:
+    - checkpoint_start_timestamp_ms: U64
 Data:
   ENUM:
     0:
@@ -480,6 +483,10 @@ SingleTransactionKind:
       Genesis:
         NEWTYPE:
           TYPENAME: GenesisTransaction
+    9:
+      ConsensusCommitPrologue:
+        NEWTYPE:
+          TYPENAME: ConsensusCommitPrologue
 StructTag:
   STRUCT:
     - address:

--- a/crates/sui-framework/docs/clock.md
+++ b/crates/sui-framework/docs/clock.md
@@ -10,6 +10,7 @@ shared object that is created at 0x6 during genesis.
 -  [Resource `Clock`](#0x2_clock_Clock)
 -  [Function `timestamp_ms`](#0x2_clock_timestamp_ms)
 -  [Function `create`](#0x2_clock_create)
+-  [Function `set_timestamp`](#0x2_clock_set_timestamp)
 
 
 <pre><code><b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
@@ -113,6 +114,32 @@ called exactly once, during genesis.
         // call.
         timestamp_ms: 0,
     })
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_clock_set_timestamp"></a>
+
+## Function `set_timestamp`
+
+Set the Clock's timestamp -- this function should only be called by
+<code>sui::system_state::consensus_commit_prologue</code>.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="clock.md#0x2_clock_set_timestamp">set_timestamp</a>(<a href="clock.md#0x2_clock">clock</a>: &<b>mut</b> <a href="clock.md#0x2_clock_Clock">clock::Clock</a>, timestamp_ms: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="clock.md#0x2_clock_set_timestamp">set_timestamp</a>(<a href="clock.md#0x2_clock">clock</a>: &<b>mut</b> <a href="clock.md#0x2_clock_Clock">Clock</a>, timestamp_ms: u64) {
+    <a href="clock.md#0x2_clock">clock</a>.timestamp_ms = timestamp_ms
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -28,6 +28,7 @@
 -  [Function `undo_report_validator`](#0x2_sui_system_undo_report_validator)
 -  [Function `advance_epoch`](#0x2_sui_system_advance_epoch)
 -  [Function `advance_epoch_safe_mode`](#0x2_sui_system_advance_epoch_safe_mode)
+-  [Function `consensus_commit_prologue`](#0x2_sui_system_consensus_commit_prologue)
 -  [Function `epoch`](#0x2_sui_system_epoch)
 -  [Function `epoch_start_timestamp_ms`](#0x2_sui_system_epoch_start_timestamp_ms)
 -  [Function `validator_delegate_amount`](#0x2_sui_system_validator_delegate_amount)
@@ -40,6 +41,7 @@
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="clock.md#0x2_clock">0x2::clock</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
 <b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
@@ -1188,6 +1190,37 @@ version
     self.epoch = new_epoch;
     self.protocol_version = next_protocol_version;
     self.safe_mode = <b>true</b>;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_consensus_commit_prologue"></a>
+
+## Function `consensus_commit_prologue`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_consensus_commit_prologue">consensus_commit_prologue</a>(<a href="clock.md#0x2_clock">clock</a>: &<b>mut</b> <a href="clock.md#0x2_clock_Clock">clock::Clock</a>, timestamp_ms: u64, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_consensus_commit_prologue">consensus_commit_prologue</a>(
+    <a href="clock.md#0x2_clock">clock</a>: &<b>mut</b> Clock,
+    timestamp_ms: u64,
+    ctx: &TxContext,
+) {
+    // Validator will make a special system call <b>with</b> sender set <b>as</b> 0x0.
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, 0);
+
+    <a href="clock.md#0x2_clock_set_timestamp">clock::set_timestamp</a>(<a href="clock.md#0x2_clock">clock</a>, timestamp_ms);
 }
 </code></pre>
 

--- a/crates/sui-framework/sources/clock.move
+++ b/crates/sui-framework/sources/clock.move
@@ -8,6 +8,7 @@ module sui::clock {
     use sui::transfer;
 
     friend sui::genesis;
+    friend sui::sui_system;
 
     /// Singleton shared object that exposes time to Move calls.  This
     /// object is found at address 0x6, and can only be read (accessed
@@ -42,6 +43,12 @@ module sui::clock {
             // call.
             timestamp_ms: 0,
         })
+    }
+
+    /// Set the Clock's timestamp -- this function should only be called by
+    /// `sui::system_state::consensus_commit_prologue`.
+    public(friend) fun set_timestamp(clock: &mut Clock, timestamp_ms: u64) {
+        clock.timestamp_ms = timestamp_ms
     }
 
     #[test_only]

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -3,6 +3,7 @@
 
 module sui::sui_system {
     use sui::balance::{Self, Balance, Supply};
+    use sui::clock::{Self, Clock};
     use sui::coin::{Self, Coin};
     use sui::staking_pool::{Delegation, StakedSui};
     use sui::object::{Self, UID};
@@ -569,6 +570,17 @@ module sui::sui_system {
         self.epoch = new_epoch;
         self.protocol_version = next_protocol_version;
         self.safe_mode = true;
+    }
+
+    public entry fun consensus_commit_prologue(
+        clock: &mut Clock,
+        timestamp_ms: u64,
+        ctx: &TxContext,
+    ) {
+        // Validator will make a special system call with sender set as 0x0.
+        assert!(tx_context::sender(ctx) == @0x0, 0);
+
+        clock::set_timestamp(clock, timestamp_ms);
     }
 
     /// Return the current epoch number. Useful for applications that need a coarse-grained concept of time,

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1592,6 +1592,11 @@ pub struct SuiGenesisTransaction {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SuiConsensusCommitPrologue {
+    pub checkpoint_start_timestamp_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "TransactionKind")]
 pub enum SuiTransactionKind {
     /// Initiate an object transfer between addresses
@@ -1614,6 +1619,9 @@ pub enum SuiTransactionKind {
     ChangeEpoch(SuiChangeEpoch),
     /// A system transaction used for initializing the initial state of the chain.
     Genesis(SuiGenesisTransaction),
+    /// A system transaction marking the start of a series of transactions scheduled as part of a
+    /// checkpoint
+    ConsensusCommitPrologue(SuiConsensusCommitPrologue),
     // .. more transaction types go here
 }
 
@@ -1692,13 +1700,19 @@ impl Display for SuiTransactionKind {
                 write!(writer, "Type Arguments : {:?}", c.type_arguments)?;
             }
             Self::ChangeEpoch(e) => {
-                writeln!(writer, "Transaction Kind: Epoch Change")?;
-                writeln!(writer, "New epoch ID: {}", e.epoch)?;
-                writeln!(writer, "Storage gas reward: {}", e.storage_charge)?;
-                writeln!(writer, "Computation gas reward: {}", e.computation_charge)?;
+                writeln!(writer, "Transaction Kind : Epoch Change")?;
+                writeln!(writer, "New epoch ID : {}", e.epoch)?;
+                writeln!(writer, "Storage gas reward : {}", e.storage_charge)?;
+                writeln!(writer, "Computation gas reward : {}", e.computation_charge)?;
+                writeln!(writer, "Storage rebate : {}", e.storage_rebate)?;
+                writeln!(writer, "Timestamp : {}", e.epoch_start_timestamp_ms)?;
             }
             Self::Genesis(_) => {
-                writeln!(writer, "Transaction Kind: Genesis Transaction")?;
+                writeln!(writer, "Transaction Kind : Genesis Transaction")?;
+            }
+            Self::ConsensusCommitPrologue(p) => {
+                writeln!(writer, "Transaction Kind : Consensus Commit Prologue")?;
+                writeln!(writer, "Timestamp : {}", p.checkpoint_start_timestamp_ms)?;
             }
         }
         write!(f, "{}", writer)
@@ -1753,10 +1767,17 @@ impl TryFrom<SingleTransactionKind> for SuiTransactionKind {
                 epoch: e.epoch,
                 storage_charge: e.storage_charge,
                 computation_charge: e.computation_charge,
+                storage_rebate: e.storage_rebate,
+                epoch_start_timestamp_ms: e.epoch_start_timestamp_ms,
             }),
             SingleTransactionKind::Genesis(g) => Self::Genesis(SuiGenesisTransaction {
                 objects: g.objects.iter().map(GenesisObject::id).collect(),
             }),
+            SingleTransactionKind::ConsensusCommitPrologue(p) => {
+                Self::ConsensusCommitPrologue(SuiConsensusCommitPrologue {
+                    checkpoint_start_timestamp_ms: p.checkpoint_start_timestamp_ms,
+                })
+            }
         })
     }
 }
@@ -1778,7 +1799,8 @@ pub struct SuiChangeEpoch {
     pub epoch: EpochId,
     pub storage_charge: u64,
     pub computation_charge: u64,
-    // TODO: add storage rebate here
+    pub storage_rebate: u64,
+    pub epoch_start_timestamp_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5234,7 +5234,9 @@
         "required": [
           "computation_charge",
           "epoch",
-          "storage_charge"
+          "epoch_start_timestamp_ms",
+          "storage_charge",
+          "storage_rebate"
         ],
         "properties": {
           "computation_charge": {
@@ -5247,7 +5249,17 @@
             "format": "uint64",
             "minimum": 0.0
           },
+          "epoch_start_timestamp_ms": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
           "storage_charge": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "storage_rebate": {
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
@@ -5298,6 +5310,19 @@
           "symbol": {
             "description": "Symbol for the token",
             "type": "string"
+          }
+        }
+      },
+      "SuiConsensusCommitPrologue": {
+        "type": "object",
+        "required": [
+          "checkpoint_start_timestamp_ms"
+        ],
+        "properties": {
+          "checkpoint_start_timestamp_ms": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         }
       },
@@ -6302,6 +6327,19 @@
             "properties": {
               "Genesis": {
                 "$ref": "#/components/schemas/SuiGenesisTransaction"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A system transaction marking the start of a series of transactions scheduled as part of a checkpoint",
+            "type": "object",
+            "required": [
+              "ConsensusCommitPrologue"
+            ],
+            "properties": {
+              "ConsensusCommitPrologue": {
+                "$ref": "#/components/schemas/SuiConsensusCommitPrologue"
               }
             },
             "additionalProperties": false

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -388,6 +388,7 @@ pub enum OperationType {
     MoveCall,
     EpochChange,
     Genesis,
+    ConsensusCommitPrologue,
 }
 
 impl From<&SuiTransactionKind> for OperationType {
@@ -402,6 +403,9 @@ impl From<&SuiTransactionKind> for OperationType {
             SuiTransactionKind::TransferSui(_) => OperationType::TransferSUI,
             SuiTransactionKind::ChangeEpoch(_) => OperationType::EpochChange,
             SuiTransactionKind::Genesis(_) => OperationType::Genesis,
+            SuiTransactionKind::ConsensusCommitPrologue(_) => {
+                OperationType::ConsensusCommitPrologue
+            }
         }
     }
 }

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -52,11 +52,19 @@ pub struct TransferObjectCommand {
 }
 
 #[derive(Debug, clap::Parser)]
+pub struct ConsensusCommitPrologueCommand {
+    #[clap(long = "timestamp-ms")]
+    pub timestamp_ms: u64,
+}
+
+#[derive(Debug, clap::Parser)]
 pub enum SuiSubcommand {
     #[clap(name = "view-object")]
     ViewObject(ViewObjectCommand),
     #[clap(name = "transfer-object")]
     TransferObject(TransferObjectCommand),
+    #[clap(name = "consensus-commit-prologue")]
+    ConsensusCommitPrologue(ConsensusCommitPrologueCommand),
 }
 
 #[derive(Debug)]

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -22,6 +22,8 @@ const SUI_SYSTEM_STATE_STRUCT_NAME: &IdentStr = ident_str!("SuiSystemState");
 pub const SUI_SYSTEM_MODULE_NAME: &IdentStr = ident_str!("sui_system");
 pub const ADVANCE_EPOCH_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch");
 pub const ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch_safe_mode");
+pub const CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME: &IdentStr =
+    ident_str!("consensus_commit_prologue");
 
 /// Rust version of the Move sui::sui_system::SystemParameters type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -754,6 +754,30 @@ fn test_change_epoch_transaction() {
 }
 
 #[test]
+fn test_consensus_commit_prologue_transaction() {
+    let tx = VerifiedTransaction::new_consensus_commit_prologue(42);
+    assert!(tx.contains_shared_object());
+    assert_eq!(
+        tx.shared_input_objects().next().unwrap(),
+        SharedInputObject {
+            id: SUI_CLOCK_OBJECT_ID,
+            initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
+            mutable: true,
+        },
+    );
+    assert!(tx.is_system_tx());
+    assert_eq!(
+        tx.data()
+            .intent_message
+            .value
+            .input_objects()
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn test_move_input_objects() {
     let package = ObjectID::random();
     let p1 = ObjectID::random();

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -44,8 +44,16 @@ export const SuiChangeEpoch = object({
   epoch: EpochId,
   storage_charge: number(),
   computation_charge: number(),
+  // TODO: Make non-optional after v0.26.0 lands everywhere
+  storage_rebate: optional(number()),
+  epoch_start_timestamp_ms: optional(number()),
 });
 export type SuiChangeEpoch = Infer<typeof SuiChangeEpoch>;
+
+export const SuiConsensusCommitPrologue = object({
+  checkpoint_start_timestamp_ms: number(),
+});
+export type SuiConsensusCommitPrologue = Infer<typeof SuiConsensusCommitPrologue>;
 
 export const Pay = object({
   coins: array(SuiObjectRef),
@@ -92,6 +100,7 @@ export type TransactionKindName =
   | 'Call'
   | 'TransferSui'
   | 'ChangeEpoch'
+  | 'ConsensusCommitPrologue'
   | 'Pay'
   | 'PaySui'
   | 'PayAllSui'
@@ -103,6 +112,7 @@ export const SuiTransactionKind = union([
   object({ Call: MoveCall }),
   object({ TransferSui: SuiTransferSui }),
   object({ ChangeEpoch: SuiChangeEpoch }),
+  object({ ConsensusCommitPrologue: SuiConsensusCommitPrologue }),
   object({ Pay: Pay }),
   object({ PaySui: PaySui }),
   object({ PayAllSui: PayAllSui }),
@@ -461,6 +471,12 @@ export function getChangeEpochTransaction(
   data: SuiTransactionKind,
 ): SuiChangeEpoch | undefined {
   return 'ChangeEpoch' in data ? data.ChangeEpoch : undefined;
+}
+
+export function getConsensusCommitPrologueTransaction(
+  data: SuiTransactionKind
+): SuiConsensusCommitPrologue | undefined {
+  return 'ConsensusCommitPrologue' in data ? data.ConsensusCommitPrologue : undefined;
 }
 
 export function getTransactions(

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -53,7 +53,9 @@ export type SuiChangeEpoch = Infer<typeof SuiChangeEpoch>;
 export const SuiConsensusCommitPrologue = object({
   checkpoint_start_timestamp_ms: number(),
 });
-export type SuiConsensusCommitPrologue = Infer<typeof SuiConsensusCommitPrologue>;
+export type SuiConsensusCommitPrologue = Infer<
+  typeof SuiConsensusCommitPrologue
+>;
 
 export const Pay = object({
   coins: array(SuiObjectRef),
@@ -474,9 +476,11 @@ export function getChangeEpochTransaction(
 }
 
 export function getConsensusCommitPrologueTransaction(
-  data: SuiTransactionKind
+  data: SuiTransactionKind,
 ): SuiConsensusCommitPrologue | undefined {
-  return 'ConsensusCommitPrologue' in data ? data.ConsensusCommitPrologue : undefined;
+  return 'ConsensusCommitPrologue' in data
+    ? data.ConsensusCommitPrologue
+    : undefined;
 }
 
 export function getTransactions(


### PR DESCRIPTION
Adds a system transaction that calls `checkpoint_prologue` -- a new move function in `sui::sui_system`.  This function does work at the beginning of each checkpoint (similar to the job of `advance_epoch`), which initially includes updating the clock, but may later be extended to support delegation.

Does not introduce the mechanism for injecting the `CheckpointPrologue` transaction at the start of each checkpoint.

Relaxes the previously added entry-point verifier to allow functions in `sui::sui_system` to accept mutable Clock parameters.

## Test Plan

Test checking details of system transaction:

```
$ cargo nextest run -- test_checkpoint_prologue_transaction
```

Test checking that the transaction will not be signed if provided from an external source:

```
$ cargo nextest run -- test_refusal_to_sign_checkpoint_prologue
```

Test that the checkpoint_prologue updates the clock:

```
$ cargo nextest run -- checkpoint/clock.move
```

## Stack

- #7922 
- #8054 