### PR TITLE
wallet-ext: fix copy account in tokens view

### DIFF
--- a/apps/wallet/src/ui/app/components/AccountSelector.tsx
+++ b/apps/wallet/src/ui/app/components/AccountSelector.tsx
@@ -20,7 +20,7 @@ export function AccountSelector() {
     const activeAddress = useActiveAddress();
     const multiAccountsEnabled = useFeature(FEATURES.WALLET_MULTI_ACCOUNTS).on;
     const activeAddressShort = useMiddleEllipsis(activeAddress);
-    const copyToAddress = useCopyToClipboard(activeAddressShort, {
+    const copyToAddress = useCopyToClipboard(activeAddress || '', {
         copySuccessMessage: 'Address copied',
     });
     const backgroundClient = useBackgroundClient();


### PR DESCRIPTION
* copy was using the short address with the ellipsis in the middle