### PR TITLE
wallet-ext: receipt view retry fetching transactions

### DIFF
--- a/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
@@ -28,12 +28,9 @@ function ReceiptPage() {
     const { data, isLoading, isError } = useQuery(
         ['transactions-by-id', transactionId],
         async () => {
-            if (!transactionId) {
-                return null;
-            }
-            return rpc.getTransactionWithEffects(transactionId);
+            return rpc.getTransactionWithEffects(transactionId!);
         },
-        { enabled: !!transactionId }
+        { enabled: !!transactionId, retry: 8 }
     );
 
     // return route or default to transactions


### PR DESCRIPTION
* this is in order to mitigate the issue where we can not read/get the transaction from the api right after it was executed