### PR TITLE
Add MultiStakeAggregator

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -74,6 +74,7 @@ pub struct ExecutionIndicesWithHash {
 }
 
 pub struct AuthorityPerEpochStore {
+    // TODO: Make this Arc<Committee> for more efficient pass-around.
     committee: Committee,
     tables: AuthorityEpochTables,
 
@@ -276,7 +277,7 @@ impl AuthorityPerEpochStore {
         let epoch_id = committee.epoch;
         let tables = AuthorityEpochTables::open(epoch_id, parent_path, db_options.clone());
         let end_of_publish =
-            StakeAggregator::from_iter(committee.clone(), tables.end_of_publish.iter());
+            StakeAggregator::from_iter(Arc::new(committee.clone()), tables.end_of_publish.iter());
         let reconfig_state = tables
             .load_reconfig_state()
             .expect("Load reconfig state at initialization cannot fail");

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -16,7 +16,6 @@ use move_core_types::value::MoveStructLayout;
 use mysten_metrics::monitored_future;
 use mysten_network::config::Config;
 use std::convert::AsRef;
-use std::fmt::Display;
 use sui_config::genesis::Genesis;
 use sui_config::NetworkConfig;
 use sui_network::{
@@ -48,6 +47,7 @@ use tokio::time::{sleep, timeout};
 
 use crate::authority::{AuthorityState, AuthorityStore};
 use crate::epoch::committee_store::CommitteeStore;
+use crate::stake_aggregator::MultiStakeAggregator;
 
 pub const DEFAULT_RETRIES: usize = 4;
 
@@ -170,95 +170,6 @@ impl AuthAggMetrics {
     }
 }
 
-#[derive(Debug)]
-struct EffectsStakeInfo {
-    stake: StakeUnit,
-    effects: TransactionEffects,
-    signatures: Vec<AuthoritySignInfo>,
-}
-
-#[derive(Default)]
-struct EffectsStakeMap {
-    effects_map: HashMap<(EpochId, TransactionEffectsDigest), EffectsStakeInfo>,
-    effects_cert: Option<VerifiedCertifiedTransactionEffects>,
-}
-
-#[derive(Error, Debug)]
-struct EffectsCertError {
-    error: SuiError,
-    effect_digest: TransactionEffectsDigest,
-    authorities: Vec<AuthorityName>,
-    total_stake: StakeUnit,
-}
-
-impl Display for EffectsCertError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "effect_digest: {:?}, error: {:?}, authorities: {:?}, total_stake: {:?}",
-            self.effect_digest, self.error, self.authorities, self.total_stake,
-        )
-    }
-}
-
-impl EffectsStakeMap {
-    pub fn add(
-        &mut self,
-        effects: SignedTransactionEffects,
-        weight: StakeUnit,
-        committee: &Committee,
-    ) -> bool {
-        let epoch = effects.epoch();
-        if epoch != committee.epoch {
-            return false;
-        }
-
-        let digest = *effects.digest();
-        let (effects, sig) = effects.into_data_and_sig();
-        let entry = self
-            .effects_map
-            .entry((epoch, digest))
-            .or_insert(EffectsStakeInfo {
-                stake: 0,
-                effects,
-                signatures: vec![],
-            });
-        entry.stake += weight;
-        entry.signatures.push(sig);
-
-        if entry.stake < committee.quorum_threshold() {
-            return false;
-        }
-        let result = CertifiedTransactionEffects::new(
-            entry.effects.clone(),
-            entry.signatures.clone(),
-            committee,
-        )
-        .and_then(|c| c.verify(committee));
-        match result {
-            Err(err) => {
-                error!(
-                    "A quorum of effects are available but failed to form a certificate: {:?}",
-                    err
-                );
-                false
-            }
-            Ok(c) => {
-                self.effects_cert = Some(c);
-                true
-            }
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        self.effects_map.len()
-    }
-
-    pub fn get_cert(&self) -> Option<VerifiedCertifiedTransactionEffects> {
-        self.effects_cert.clone()
-    }
-}
-
 #[derive(Error, Debug)]
 #[error(
     "Failed to execute certificate on a quorum of validators. Validator errors: {:?}",
@@ -283,13 +194,13 @@ pub struct QuorumSignTransactionError {
         BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
 }
 
-#[derive(Default)]
 struct ProcessTransactionState {
     // The list of signatures gathered at any point
     signatures: Vec<AuthoritySignInfo>,
     // A certificate if we manage to make or find one
     certificate: Option<VerifiedCertificate>,
-    effects_map: EffectsStakeMap,
+    effects_map:
+        MultiStakeAggregator<(EpochId, TransactionEffectsDigest), TransactionEffects, true>,
     // The list of errors gathered at any point
     errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
     // Tally of stake for good vs bad responses.
@@ -1280,7 +1191,16 @@ where
             transaction.data().intent_message.value
         );
 
-        let state = ProcessTransactionState::default();
+        let committee = Arc::new(self.committee.clone());
+        let state = ProcessTransactionState {
+            signatures: vec![],
+            certificate: None,
+            effects_map: MultiStakeAggregator::new(committee.clone()),
+            errors: vec![],
+            good_stake: 0,
+            bad_stake: 0,
+            conflicting_tx_digests: Default::default(),
+        };
 
         let transaction_ref = &transaction;
         let mut state = self
@@ -1359,7 +1279,7 @@ where
             conflicting_tx_digests: state.conflicting_tx_digests,
         })?;
 
-        if let Some(effects_cert) = state.effects_map.effects_cert {
+        if let Some(effects_cert) = state.effects_map.get_message_cert() {
             Ok(ProcessTransactionResult::Executed(cert, effects_cert))
         } else {
             Ok(ProcessTransactionResult::Certified(cert))
@@ -1501,15 +1421,13 @@ where
             // form a CertifiedTransactionEffects which requires all sigs
             // in the same epoch, this is not necessary but not a big deal
             // anyways.
-            // TODO: Return effects cert directly.
-            if state
-                .effects_map
-                .add(signed_effects.into_inner(), weight, &self.committee)
-            {
+            let key = (signed_effects.epoch(), *signed_effects.digest());
+            let (effects, sig) = signed_effects.into_inner().into_data_and_sig();
+            if state.effects_map.add(key, &effects, sig) {
                 debug!(
-                ?tx_digest,
-                "Got quorum for effects for certs that are from previous epochs handle_transaction"
-            );
+                    ?tx_digest,
+                    "Got quorum for effects for certs that are from previous epochs handle_transaction"
+                );
                 state.certificate = Some(certificate);
             }
         } else {
@@ -1541,25 +1459,13 @@ where
         tx_digest: &TransactionDigest,
         mut state: ProcessTransactionState,
     ) -> ProcessTransactionState {
-        if state.certificate.is_none() && !state.effects_map.effects_map.is_empty() {
+        if state.certificate.is_none() && state.effects_map.unique_key_count() > 0 {
             warn!(
                 ?tx_digest,
-                "Received signed Effects but not with a quorum {:?}", state.effects_map.effects_map
+                "Received signed Effects but not with a quorum {:?}", state.effects_map
             );
-            let non_quorum_effects = state
-                .effects_map
-                .effects_map
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        *k,
-                        (
-                            v.signatures.iter().map(|s| s.authority).collect::<Vec<_>>(),
-                            v.stake,
-                        ),
-                    )
-                })
-                .collect::<BTreeMap<_, _>>();
+            let non_quorum_effects = state.effects_map.get_all_unique_values();
+
             let mut involved_validators = Vec::new();
             let mut total_stake = 0;
             for (validators, stake) in non_quorum_effects.values() {
@@ -1582,17 +1488,21 @@ where
         &self,
         certificate: CertifiedTransaction,
     ) -> Result<VerifiedCertifiedTransactionEffects, QuorumExecuteCertificateError> {
-        #[derive(Default)]
         struct ProcessCertificateState {
             // Different authorities could return different effects.  We want at least one effect to come
             // from 2f+1 authorities, which meets quorum and can be considered the approved effect.
             // The map here allows us to count the stake for each unique effect.
-            effects_map: EffectsStakeMap,
+            effects_map:
+                MultiStakeAggregator<(EpochId, TransactionEffectsDigest), TransactionEffects, true>,
             bad_stake: StakeUnit,
             errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
         }
 
-        let state = ProcessCertificateState::default();
+        let state = ProcessCertificateState {
+            effects_map: MultiStakeAggregator::new(Arc::new(self.committee.clone())),
+            bad_stake: 0,
+            errors: vec![],
+        };
 
         let tx_digest = *certificate.digest();
         let timeout_after_quorum = self.timeouts.post_quorum_timeout;
@@ -1630,13 +1540,14 @@ where
                                     name = ?name.concise(),
                                     "Validator handled certificate successfully",
                                 );
+                                let signed_effects = signed_effects.into_inner();
                                 // Note: here we aggregate votes by the hash of the effects structure
-                                if state.effects_map.add(signed_effects.into_inner(), weight, &self.committee) {
-                                        debug!(
-                                            ?tx_digest,
-                                            "Got quorum for validators handle_certificate."
-                                        );
-                                        return Ok(ReduceOutput::End(state));
+                                if state.effects_map.add((signed_effects.epoch(), *signed_effects.digest()), signed_effects.data(), signed_effects.auth_sig().clone()) {
+                                    debug!(
+                                        ?tx_digest,
+                                        "Got quorum for validators handle_certificate."
+                                    );
+                                    return Ok(ReduceOutput::End(state));
                                 }
                             }
                             Err(err) => {
@@ -1662,16 +1573,16 @@ where
 
         debug!(
             ?tx_digest,
-            num_unique_effects = state.effects_map.len(),
+            num_unique_effects = state.effects_map.unique_key_count(),
             bad_stake = state.bad_stake,
             "Received effects responses from validators"
         );
 
         // Check that one effects structure has more than 2f votes,
         // and return it.
-        if let Some(cert) = state.effects_map.get_cert() {
+        if let Some(effects_cert) = state.effects_map.get_message_cert() {
             debug!(?tx_digest, "Found an effect with good stake over threshold");
-            return Ok(cert);
+            return Ok(effects_cert);
         }
 
         // If none has, fail.

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -841,7 +841,9 @@ impl CheckpointAggregator {
                     next_index: 0,
                     digest: summary.digest(),
                     summary,
-                    signatures: StakeAggregator::new(self.epoch_store.committee().clone()),
+                    signatures: StakeAggregator::new(Arc::new(
+                        self.epoch_store.committee().clone(),
+                    )),
                 });
                 self.current.as_mut().unwrap()
             };

--- a/crates/sui-core/src/stake_aggregator.rs
+++ b/crates/sui-core/src/stake_aggregator.rs
@@ -2,20 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
+use std::sync::Arc;
 use sui_types::base_types::AuthorityName;
 use sui_types::committee::{Committee, StakeUnit};
 use sui_types::crypto::{AuthorityQuorumSignInfo, AuthoritySignInfo};
 use sui_types::error::SuiError;
+use sui_types::message_envelope::{Envelope, Message, VerifiedEnvelope};
 
-pub struct StakeAggregator<V, const STRENGTH: bool> {
-    data: HashMap<AuthorityName, V>,
+#[derive(Debug)]
+pub struct StakeAggregator<S, const STRENGTH: bool> {
+    data: HashMap<AuthorityName, S>,
     total_votes: StakeUnit,
-    committee: Committee,
+    committee: Arc<Committee>,
 }
 
-impl<V: Clone, const STRENGTH: bool> StakeAggregator<V, STRENGTH> {
-    pub fn new(committee: Committee) -> Self {
+/// StakeAggregator is a utility data structure that allows us to aggregate a list of validator
+/// signatures over time. A committee is used to determine whether we have reached sufficient
+/// quorum (defined based on `STRENGTH`). The generic implementation does not require `S` to be
+/// an actual signature, but just an indication that a specific validator has voted. A specialized
+/// implementation for `AuthoritySignInfo` is followed below.
+impl<S: Clone, const STRENGTH: bool> StakeAggregator<S, STRENGTH> {
+    pub fn new(committee: Arc<Committee>) -> Self {
         Self {
             data: Default::default(),
             total_votes: Default::default(),
@@ -23,13 +32,13 @@ impl<V: Clone, const STRENGTH: bool> StakeAggregator<V, STRENGTH> {
         }
     }
 
-    pub fn from_iter<I: Iterator<Item = (AuthorityName, V)>>(
-        committee: Committee,
+    pub fn from_iter<I: Iterator<Item = (AuthorityName, S)>>(
+        committee: Arc<Committee>,
         data: I,
     ) -> Self {
         let mut this = Self::new(committee);
-        for (authority, v) in data {
-            this.insert_generic(authority, v);
+        for (authority, s) in data {
+            this.insert_generic(authority, s);
         }
         this
     }
@@ -37,16 +46,16 @@ impl<V: Clone, const STRENGTH: bool> StakeAggregator<V, STRENGTH> {
     /// A generic version of inserting arbitrary type of V (e.g. void type).
     /// If V is AuthoritySignInfo, the `insert` function should be used instead since it does extra
     /// checks and aggregations in the end.
-    pub fn insert_generic(&mut self, authority: AuthorityName, v: V) -> InsertResult<V, ()> {
+    pub fn insert_generic(&mut self, authority: AuthorityName, s: S) -> InsertResult<S, ()> {
         match self.data.entry(authority) {
             Entry::Occupied(oc) => {
                 return InsertResult::RepeatingEntry {
                     previous: oc.get().clone(),
-                    new: v,
+                    new: s,
                 };
             }
             Entry::Vacant(va) => {
-                va.insert(v);
+                va.insert(s);
             }
         }
         let votes = self.committee.weight(&authority);
@@ -119,5 +128,94 @@ pub enum InsertResult<V, CertT> {
 impl<V, CertT> InsertResult<V, CertT> {
     pub fn is_quorum_reached(&self) -> bool {
         matches!(self, Self::QuorumReached(..))
+    }
+}
+
+/// MultiStakeAggregator is a utility data structure that tracks the stake accumulation of
+/// potentially multiple different values (usually due to byzantine/corrupted responses). Each
+/// value is tracked using a StakeAggregator and determine whether it has reached a quorum.
+/// Once quorum is reached, the `cert` field will be set. This also means there will be only one
+/// cert in the end, if any.
+/// A specialized implementation is also provided for `Message` value type, so that we could create
+/// `Envelope` directly.
+#[derive(Debug)]
+pub struct MultiStakeAggregator<K, V, const STRENGTH: bool> {
+    committee: Arc<Committee>,
+    stake_maps: HashMap<K, (V, StakeAggregator<AuthoritySignInfo, STRENGTH>)>,
+    cert: Option<(V, AuthorityQuorumSignInfo<STRENGTH>)>,
+}
+
+impl<K, V, const STRENGTH: bool> MultiStakeAggregator<K, V, STRENGTH> {
+    pub fn new(committee: Arc<Committee>) -> Self {
+        Self {
+            committee,
+            stake_maps: Default::default(),
+            cert: None,
+        }
+    }
+
+    pub fn unique_key_count(&self) -> usize {
+        self.stake_maps.len()
+    }
+
+    pub fn get_certificate(&self) -> &Option<(V, AuthorityQuorumSignInfo<STRENGTH>)> {
+        &self.cert
+    }
+}
+
+impl<K, V, const STRENGTH: bool> MultiStakeAggregator<K, V, STRENGTH>
+where
+    K: Hash + Eq,
+    V: Clone,
+{
+    pub fn add(&mut self, k: K, v: &V, sig: AuthoritySignInfo) -> bool {
+        let entry = self
+            .stake_maps
+            .entry(k)
+            .or_insert((v.clone(), StakeAggregator::new(self.committee.clone())));
+        match entry.1.insert(sig) {
+            InsertResult::QuorumReached(cert) => {
+                self.cert = Some((v.clone(), cert));
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl<K, V, const STRENGTH: bool> MultiStakeAggregator<K, V, STRENGTH>
+where
+    K: Clone + Ord,
+{
+    pub fn get_all_unique_values(&self) -> BTreeMap<K, (Vec<AuthorityName>, StakeUnit)> {
+        self.stake_maps
+            .iter()
+            .map(|(k, (_, s))| {
+                (
+                    k.clone(),
+                    (
+                        s.data.iter().map(|(name, _)| *name).collect(),
+                        s.total_votes,
+                    ),
+                )
+            })
+            .collect()
+    }
+}
+
+impl<K, V, const STRENGTH: bool> MultiStakeAggregator<K, V, STRENGTH>
+where
+    V: Message + Clone,
+{
+    pub fn get_message_cert(
+        &self,
+    ) -> Option<VerifiedEnvelope<V, AuthorityQuorumSignInfo<STRENGTH>>> {
+        self.get_certificate().as_ref().map(|(message, sig)| {
+            // No verification is necessary since we constructed the signatures properly.
+            VerifiedEnvelope::new_unchecked(Envelope::new_from_data_and_sig(
+                message.clone(),
+                sig.clone(),
+            ))
+        })
     }
 }


### PR DESCRIPTION
Adds a utility data structure on top of StakeAggregator that allows us track multiple variants of values and their stake situation. Use it in authority aggregator.