### PR TITLE
[core] Support finalized transaction in handle_certificate

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -276,7 +276,7 @@ impl AuthorityPerEpochStore {
         let epoch_id = committee.epoch;
         let tables = AuthorityEpochTables::open(epoch_id, parent_path, db_options.clone());
         let end_of_publish =
-            StakeAggregator::from_iter(committee.clone(), tables.end_of_publish.iter());
+            StakeAggregator::from_iter(Arc::new(committee.clone()), tables.end_of_publish.iter());
         let reconfig_state = tables
             .load_reconfig_state()
             .expect("Load reconfig state at initialization cannot fail");

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -143,11 +143,12 @@ impl AuthorityStore {
     pub(crate) fn get_signed_effects(
         &self,
         transaction_digest: &TransactionDigest,
-    ) -> SuiResult<Option<TrustedSignedTransactionEffects>> {
+    ) -> SuiResult<Option<VerifiedSignedTransactionEffects>> {
         Ok(self
             .perpetual_tables
             .executed_effects
-            .get(transaction_digest)?)
+            .get(transaction_digest)?
+            .map(|e| e.into()))
     }
 
     /// Returns the TransactionEffects if we have an effects structure for this transaction digest
@@ -218,6 +219,16 @@ impl AuthorityStore {
             .executed_transactions_to_checkpoint
             .get(digest)?
             .map(|(epoch, _)| epoch))
+    }
+
+    pub fn get_transaction_checkpoint_info(
+        &self,
+        digest: &TransactionDigest,
+    ) -> SuiResult<Option<(EpochId, CheckpointSequenceNumber)>> {
+        Ok(self
+            .perpetual_tables
+            .executed_transactions_to_checkpoint
+            .get(digest)?)
     }
 
     /// Returns true if there are no objects in the database

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -841,7 +841,9 @@ impl CheckpointAggregator {
                     next_index: 0,
                     digest: summary.digest(),
                     summary,
-                    signatures: StakeAggregator::new(self.epoch_store.committee().clone()),
+                    signatures: StakeAggregator::new(Arc::new(
+                        self.epoch_store.committee().clone(),
+                    )),
                 });
                 self.current.as_mut().unwrap()
             };

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -356,7 +356,7 @@ where
         &self,
         certificate: VerifiedCertificate,
     ) -> Result<QuorumDriverResponse, QuorumDriverInternalError> {
-        let effects = self
+        let finalized_effects = self
             .validators
             .load()
             .process_certificate(certificate.clone().into_inner())
@@ -365,7 +365,7 @@ where
             .map_err(QuorumDriverInternalError::CertificateError)?;
         let response = QuorumDriverResponse {
             tx_cert: certificate,
-            effects_cert: effects,
+            finalized_effects,
         };
 
         Ok(response)
@@ -694,7 +694,7 @@ where
                     );
                     let response = QuorumDriverResponse {
                         tx_cert,
-                        effects_cert,
+                        finalized_effects: effects_cert.into_inner().into(),
                     };
                     quorum_driver.notify(&tx_digest, &Ok(response), old_retry_times + 1);
                     return;
@@ -717,12 +717,12 @@ where
         let response = match quorum_driver.process_certificate(tx_cert.clone()).await {
             Ok(QuorumDriverResponse {
                 tx_cert,
-                effects_cert,
+                finalized_effects,
             }) => {
                 debug!(?tx_digest, "Certificate processing succeeded");
                 QuorumDriverResponse {
                     tx_cert,
-                    effects_cert,
+                    finalized_effects,
                 }
             }
             // Note: non retryable failure when processing a cert

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -412,9 +412,16 @@ where
         digest: &TransactionDigest,
         response: HandleCertificateResponse,
     ) -> SuiResult<VerifiedHandleCertificateResponse> {
-        Ok(VerifiedHandleCertificateResponse {
-            signed_effects: self.check_signed_effects(digest, response.signed_effects, None)?,
-        })
+        match response {
+            HandleCertificateResponse::Executed(signed_effects) => {
+                Ok(VerifiedHandleCertificateResponse::Executed(
+                    self.check_signed_effects(digest, signed_effects, None)?,
+                ))
+            }
+            HandleCertificateResponse::Finalized(epoch, checkpoint, effects) => Ok(
+                VerifiedHandleCertificateResponse::Finalized(epoch, checkpoint, effects),
+            ),
+        }
     }
 
     /// Execute a certificate.

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -232,8 +232,7 @@ where
         .handle_certificate(cert.clone())
         .await
         .unwrap()
-        .signed_effects
-        .into_message()
+        .into_effects()
 }
 
 pub async fn do_cert_configurable<A>(authority: &A, cert: &CertifiedTransaction)

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -953,12 +953,12 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let ExecuteTransactionResponse::EffectsCert(res) = res;
     let QuorumDriverResponse {
         tx_cert: certified_txn,
-        effects_cert: certified_txn_effects,
+        finalized_effects,
     } = rx.recv().await.unwrap().unwrap();
     let (ct, cte, is_executed_locally) = *res;
     assert_eq!(*ct.unwrap().digest(), digest);
     assert_eq!(*certified_txn.digest(), digest);
-    assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
+    assert_eq!(cte.effects.digest(), finalized_effects.effects.digest());
     assert!(is_executed_locally);
     // verify that the node has sequenced and executed the txn
     node.state().get_transaction(digest).await
@@ -978,12 +978,12 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let ExecuteTransactionResponse::EffectsCert(res) = res;
     let QuorumDriverResponse {
         tx_cert: certified_txn,
-        effects_cert: certified_txn_effects,
+        finalized_effects,
     } = rx.recv().await.unwrap().unwrap();
     let (ct, cte, is_executed_locally) = *res;
     assert_eq!(*ct.unwrap().digest(), digest);
     assert_eq!(*certified_txn.digest(), digest);
-    assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
+    assert_eq!(cte.effects.digest(), finalized_effects.effects.digest());
     assert!(!is_executed_locally);
     wait_for_tx(digest, node.state().clone()).await;
     node.state().get_transaction(digest).await

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -487,7 +487,7 @@ pub async fn submit_shared_object_transaction_with_committee(
 pub fn get_unique_effects(replies: Vec<HandleCertificateResponse>) -> TransactionEffects {
     let mut all_effects = HashMap::new();
     for reply in replies {
-        let effects = reply.signed_effects.into_data();
+        let effects = reply.into_effects();
         all_effects.insert(effects.digest(), effects);
     }
     assert_eq!(all_effects.len(), 1);


### PR DESCRIPTION
Allow authority handle_certificate path to return information about transactions that were finalized in previous checkpoints. Authority aggregator can then act upon such information properly.