### PR TITLE
[wallet-ext] - reverse default sort order

### DIFF
--- a/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
@@ -21,7 +21,7 @@ export function SelectValidatorCard() {
         null
     );
     const [sortKey, setSortKey] = useState<'name' | 'apy'>('apy');
-    const [sortAscending, setSortAscending] = useState(false);
+    const [sortAscending, setSortAscending] = useState(true);
 
     const { data, isLoading, isError } = useGetObject(STATE_OBJECT);
 


### PR DESCRIPTION
- reverse default sort order for validators. validators are now sorted by APY in ascending order by default