### PR TITLE
swap remove instead of remove the max element in priority queue

### DIFF
--- a/crates/sui-framework/docs/priority_queue.md
+++ b/crates/sui-framework/docs/priority_queue.md
@@ -16,6 +16,7 @@ Priority queue implemented using a max heap.
 -  [Function `create_entries`](#0x2_priority_queue_create_entries)
 -  [Function `restore_heap_recursive`](#0x2_priority_queue_restore_heap_recursive)
 -  [Function `max_heapify_recursive`](#0x2_priority_queue_max_heapify_recursive)
+-  [Function `priorities`](#0x2_priority_queue_priorities)
 
 
 <pre><code><b>use</b> <a href="">0x1::vector</a>;
@@ -27,6 +28,11 @@ Priority queue implemented using a max heap.
 
 ## Struct `PriorityQueue`
 
+Struct representing a priority queue. The <code>entries</code> vector represents a max
+heap structure, where entries[0] is the root, entries[1] and entries[2] are the
+left child and right child of the root, etc. More generally, the children of
+entries[i] are at at i * 2 + 1 and i * 2 + 2. The max heap should have the invariant
+that the parent node's priority is always higher than its child nodes' priorities.
 
 
 <pre><code><b>struct</b> <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T: drop&gt; <b>has</b> drop, store
@@ -102,7 +108,7 @@ For when heap is empty and there's no data to pop.
 
 ## Function `new`
 
-Create a new priority queue from the entries.
+Create a new priority queue from the input entry vectors.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_new">new</a>&lt;T: drop&gt;(entries: <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">priority_queue::Entry</a>&lt;T&gt;&gt;): <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">priority_queue::PriorityQueue</a>&lt;T&gt;
@@ -117,6 +123,7 @@ Create a new priority queue from the entries.
 <pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_new">new</a>&lt;T: drop&gt;(entries: <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a>&lt;T&gt;&gt;) : <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt; {
     <b>let</b> len = <a href="_length">vector::length</a>(&entries);
     <b>let</b> i = len / 2;
+    // Max heapify from the first node that is a parent (node at len / 2).
     <b>while</b> (i &gt; 0) {
         i = i - 1;
         <a href="priority_queue.md#0x2_priority_queue_max_heapify_recursive">max_heapify_recursive</a>(&<b>mut</b> entries, len, i);
@@ -148,7 +155,10 @@ Pop the entry with the highest priority value.
 <pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_pop_max">pop_max</a>&lt;T: drop&gt;(pq: &<b>mut</b> <a href="priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt;) : (u64, T) {
     <b>let</b> len = <a href="_length">vector::length</a>(&pq.entries);
     <b>assert</b>!(len &gt; 0, <a href="priority_queue.md#0x2_priority_queue_EPopFromEmptyHeap">EPopFromEmptyHeap</a>);
-    <b>let</b> <a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a> { priority, value } = <a href="_remove">vector::remove</a>(&<b>mut</b> pq.entries, 0);
+    // Swap the max element <b>with</b> the last element in the entries and remove the max element.
+    <b>let</b> <a href="priority_queue.md#0x2_priority_queue_Entry">Entry</a> { priority, value } = <a href="_swap_remove">vector::swap_remove</a>(&<b>mut</b> pq.entries, 0);
+    // Now the max heap property <b>has</b> been violated at the root node, but nowhere <b>else</b>
+    // so we call max heapify on the root node.
     <a href="priority_queue.md#0x2_priority_queue_max_heapify_recursive">max_heapify_recursive</a>(&<b>mut</b> pq.entries, len - 1, 0);
     (priority, value)
 }
@@ -293,6 +303,11 @@ Insert a new entry into the queue.
 
 ## Function `max_heapify_recursive`
 
+Max heapify the subtree whose root is at index <code>i</code>. That means after this function
+finishes, the subtree should have the property that the parent node has higher priority
+than both child nodes.
+This function assumes that all the other nodes in the subtree (nodes other than the root)
+do satisfy the max heap property.
 
 
 <pre><code><b>fun</b> <a href="priority_queue.md#0x2_priority_queue_max_heapify_recursive">max_heapify_recursive</a>&lt;T: drop&gt;(v: &<b>mut</b> <a href="">vector</a>&lt;<a href="priority_queue.md#0x2_priority_queue_Entry">priority_queue::Entry</a>&lt;T&gt;&gt;, len: u64, i: u64)
@@ -312,14 +327,20 @@ Insert a new entry into the queue.
     <b>let</b> left = i * 2 + 1;
     <b>let</b> right = left + 1;
     <b>let</b> max = i;
+    // Find the node <b>with</b> highest priority among node `i` and its two children.
     <b>if</b> (left &lt; len && <a href="_borrow">vector::borrow</a>(v, left).priority&gt; <a href="_borrow">vector::borrow</a>(v, max).priority) {
         max = left;
     };
     <b>if</b> (right &lt; len && <a href="_borrow">vector::borrow</a>(v, right).priority &gt; <a href="_borrow">vector::borrow</a>(v, max).priority) {
         max = right;
     };
+    // If the parent node (node `i`) doesn't have the highest priority, we swap the parent <b>with</b> the
+    // max priority node.
     <b>if</b> (max != i) {
         <a href="_swap">vector::swap</a>(v, max, i);
+        // After the swap, we have restored the property at node `i` but now the max heap property
+        // may be violated at node `max` since this node now <b>has</b> a new value. So we need <b>to</b> now
+        // max heapify the subtree rooted at node `max`.
         <a href="priority_queue.md#0x2_priority_queue_max_heapify_recursive">max_heapify_recursive</a>(v, len, max);
     }
 }
@@ -335,6 +356,36 @@ Insert a new entry into the queue.
 
 
 <pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_priority_queue_priorities"></a>
+
+## Function `priorities`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_priorities">priorities</a>&lt;T: drop&gt;(pq: &<a href="priority_queue.md#0x2_priority_queue_PriorityQueue">priority_queue::PriorityQueue</a>&lt;T&gt;): <a href="">vector</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="priority_queue.md#0x2_priority_queue_priorities">priorities</a>&lt;T: drop&gt;(pq: &<a href="priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt;): <a href="">vector</a>&lt;u64&gt; {
+    <b>let</b> res = <a href="">vector</a>[];
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; <a href="_length">vector::length</a>(&pq.entries)) {
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, <a href="_borrow">vector::borrow</a>(&pq.entries, i).priority);
+        i = i +1;
+    };
+    res
+}
 </code></pre>
 
 

--- a/crates/sui-framework/sources/priority_queue.move
+++ b/crates/sui-framework/sources/priority_queue.move
@@ -8,6 +8,11 @@ module sui::priority_queue {
     /// For when heap is empty and there's no data to pop.
     const EPopFromEmptyHeap: u64 = 0;
 
+    /// Struct representing a priority queue. The `entries` vector represents a max
+    /// heap structure, where entries[0] is the root, entries[1] and entries[2] are the
+    /// left child and right child of the root, etc. More generally, the children of
+    /// entries[i] are at at i * 2 + 1 and i * 2 + 2. The max heap should have the invariant
+    /// that the parent node's priority is always higher than its child nodes' priorities.
     struct PriorityQueue<T: drop> has store, drop {
         entries: vector<Entry<T>>,
     }
@@ -17,10 +22,11 @@ module sui::priority_queue {
         value: T,
     }
 
-    /// Create a new priority queue from the entries.
+    /// Create a new priority queue from the input entry vectors.
     public fun new<T: drop>(entries: vector<Entry<T>>) : PriorityQueue<T> {
         let len = vector::length(&entries);
         let i = len / 2;
+        // Max heapify from the first node that is a parent (node at len / 2).
         while (i > 0) {
             i = i - 1;
             max_heapify_recursive(&mut entries, len, i);
@@ -32,7 +38,10 @@ module sui::priority_queue {
     public fun pop_max<T: drop>(pq: &mut PriorityQueue<T>) : (u64, T) {
         let len = vector::length(&pq.entries);
         assert!(len > 0, EPopFromEmptyHeap);
-        let Entry { priority, value } = vector::remove(&mut pq.entries, 0);
+        // Swap the max element with the last element in the entries and remove the max element.
+        let Entry { priority, value } = vector::swap_remove(&mut pq.entries, 0);
+        // Now the max heap property has been violated at the root node, but nowhere else
+        // so we call max heapify on the root node.
         max_heapify_recursive(&mut pq.entries, len - 1, 0);
         (priority, value)
     }
@@ -81,6 +90,11 @@ module sui::priority_queue {
         pragma opaque;
     }
 
+    /// Max heapify the subtree whose root is at index `i`. That means after this function
+    /// finishes, the subtree should have the property that the parent node has higher priority
+    /// than both child nodes.
+    /// This function assumes that all the other nodes in the subtree (nodes other than the root)
+    /// do satisfy the max heap property.
     fun max_heapify_recursive<T: drop>(v: &mut vector<Entry<T>>, len: u64, i: u64) {
         if (len == 0) {
             return
@@ -89,20 +103,36 @@ module sui::priority_queue {
         let left = i * 2 + 1;
         let right = left + 1;
         let max = i;
+        // Find the node with highest priority among node `i` and its two children.
         if (left < len && vector::borrow(v, left).priority> vector::borrow(v, max).priority) {
             max = left;
         };
         if (right < len && vector::borrow(v, right).priority > vector::borrow(v, max).priority) {
             max = right;
         };
+        // If the parent node (node `i`) doesn't have the highest priority, we swap the parent with the
+        // max priority node.
         if (max != i) {
             vector::swap(v, max, i);
+            // After the swap, we have restored the property at node `i` but now the max heap property
+            // may be violated at node `max` since this node now has a new value. So we need to now
+            // max heapify the subtree rooted at node `max`.
             max_heapify_recursive(v, len, max);
         }
     }
 
     spec max_heapify_recursive {
         pragma opaque;
+    }
+
+    public fun priorities<T: drop>(pq: &PriorityQueue<T>): vector<u64> {
+        let res = vector[];
+        let i = 0;
+        while (i < vector::length(&pq.entries)) {
+            vector::push_back(&mut res, vector::borrow(&pq.entries, i).priority);
+            i = i +1;
+        };
+        res
     }
 
     #[test]
@@ -126,6 +156,27 @@ module sui::priority_queue {
         check_pop_max(&mut h, 3, 20);
         check_pop_max(&mut h, 2, 40);
         check_pop_max(&mut h, 1, 30);
+    }
+
+    #[test]
+    fun test_swap_remove_edge_case() {
+        // This test would fail if `remove` is used incorrectly instead of `swap_remove` in `pop_max`.
+        // It's hard to characterize exactly under what condition this bug is triggered but roughly
+        // it happens when the entire tree vector is shifted left by one because of the incorrect usage
+        // of `remove`, and the resulting new root and its two children appear to satisfy the heap invariant
+        // so we stop max-heapifying there, while the rest of the tree is all messed up because of the shift.
+        let priorities = vector[8, 7, 3, 6, 2, 1, 0, 5, 4];
+        let values = vector[0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let h = new(create_entries(priorities, values));
+        check_pop_max(&mut h, 8, 0);
+        check_pop_max(&mut h, 7, 0);
+        check_pop_max(&mut h, 6, 0);
+        check_pop_max(&mut h, 5, 0);
+        check_pop_max(&mut h, 4, 0);
+        check_pop_max(&mut h, 3, 0);
+        check_pop_max(&mut h, 2, 0);
+        check_pop_max(&mut h, 1, 0);
+        check_pop_max(&mut h, 0, 0);
     }
 
     #[test_only]


### PR DESCRIPTION
In our priority queue implementation, we should swap_remove the max element instead of directly removing it. Directly removing the element will cause the order of the rest of the max heap to be messed up and violate the property.