### PR TITLE
Enqueue single-writer txns after batch verification

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -545,7 +545,11 @@ impl SuiNode {
                     committee.clone(),
                     SharedWorkerCache::from(worker_cache),
                     consensus_handler,
-                    SuiTxValidator::new(epoch_store, sui_tx_validator_metrics.clone()),
+                    SuiTxValidator::new(
+                        epoch_store,
+                        state.transaction_manager().clone(),
+                        sui_tx_validator_metrics.clone(),
+                    ),
                 )
                 .await;
         } else {


### PR DESCRIPTION
I think this simplest / most-obviously-correct thing here is to leave the consensus_handler machinery in place exactly as-is, and don't write to `pending_certificates` in this path. This is just an optimization to give the validator a head start on executing single writer txns.