### PR TITLE
[4/x][signing] Don't sign mutable access to the Clock

### DIFF
--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -17,6 +17,7 @@ use sui_types::{
     },
     object::{Object, Owner},
 };
+use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION};
 use tracing::instrument;
 
 async fn get_gas_status(
@@ -342,6 +343,15 @@ fn check_one_object(
                     return Err(SuiError::NotSharedObjectError);
                 }
             };
+        }
+        InputObjectKind::SharedMoveObject {
+            id: SUI_CLOCK_OBJECT_ID,
+            initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
+            mutable: true,
+        } => {
+            // Only system transactions (which don't perform input checks) can accept the Clock
+            // object as a mutable parameter.
+            return Err(SuiError::ImmutableParameterExpectedError);
         }
         InputObjectKind::SharedMoveObject {
             initial_shared_version: input_initial_shared_version,

--- a/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
+++ b/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
@@ -3,6 +3,7 @@
 
 /// Test CTURD object basics (create, transfer, update, read, delete)
 module examples::object_basics {
+    use sui::clock::Clock;
     use sui::dynamic_object_field as ofield;
     use sui::event;
     use sui::object::{Self, UID, ID};
@@ -107,4 +108,6 @@ module examples::object_basics {
     }
 
     public entry fun generic_test<T>() {}
+
+    public entry fun use_clock(_clock: &Clock) {}
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -229,6 +229,8 @@ pub enum SuiError {
     TransferImmutableError,
     #[error("Wrong initial version given for shared object")]
     SharedObjectStartingVersionMismatch,
+    #[error("Mutable parameter provided, immutable parameter expected.")]
+    ImmutableParameterExpectedError,
 
     // Errors related to batches
     #[error("The range specified is invalid.")]


### PR DESCRIPTION
User transactions that request mutable access (requiring a write lock) to the singleton `Clock` at address `0x6` will not be signed by honest validators.

This prevents those transactions from (intentionally or otherwise) bottlenecking throughput on transactions that reference the `Clock` by taking an exclusive lock on it.

## Test Plan

New unit tests in `authority_tests`:

```
$ cargo nextest run -- test_invalid_mutable_clock_parameter
$ cargo nextest run -- test_valid_immutable_clock_parameter
```

## Stack

- #7922 
- #8054 
- #8055 