### PR TITLE
[epoch] Call consensus_adapter submit_recovered only on cold start

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -85,7 +85,6 @@ impl AuthorityServer {
         let consensus_adapter = ConsensusAdapter::new(
             consensus_client,
             state.name,
-            &state.epoch_store_for_testing(),
             ConsensusAdapterMetrics::new_test(),
         );
 

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -120,12 +120,8 @@ async fn submit_transaction_to_consensus_adapter() {
         }
     }
     // Make a new consensus adapter instance.
-    let adapter = ConsensusAdapter::new(
-        Box::new(SubmitDirectly(state.clone())),
-        state.name,
-        &state.epoch_store_for_testing(),
-        metrics,
-    );
+    let adapter =
+        ConsensusAdapter::new(Box::new(SubmitDirectly(state.clone())), state.name, metrics);
 
     // Submit the transaction and ensure the adapter reports success to the caller. Note
     // that consensus may drop some transactions (so we may need to resubmit them).


### PR DESCRIPTION
submit_recovered only needs to be called at node cold start. ConsensusAdapter is re-created at each epoch, but we don't need to call submit_recovered each time. This cleans up some dependencies.