### PR TITLE
[move] Rewrite uses of borrow_mut for dynamic fields natively

### DIFF
--- a/crates/sui-framework/docs/dynamic_field.md
+++ b/crates/sui-framework/docs/dynamic_field.md
@@ -214,15 +214,10 @@ type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
     <a href="object.md#0x2_object">object</a>: &<b>mut</b> UID,
     name: Name,
-): &<b>mut</b> Value {
-    <b>let</b> object_addr = <a href="object.md#0x2_object_uid_to_address">object::uid_to_address</a>(<a href="object.md#0x2_object">object</a>);
-    <b>let</b> <a href="">hash</a> = <a href="dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
-    <b>let</b> field = <a href="dynamic_field.md#0x2_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;<a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(<a href="object.md#0x2_object">object</a>, <a href="">hash</a>);
-    &<b>mut</b> field.value
-}
+): &<b>mut</b> Value;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/dynamic_field.md
+++ b/crates/sui-framework/docs/dynamic_field.md
@@ -16,6 +16,7 @@ building block for core collection types
 -  [Function `add`](#0x2_dynamic_field_add)
 -  [Function `borrow`](#0x2_dynamic_field_borrow)
 -  [Function `borrow_mut`](#0x2_dynamic_field_borrow_mut)
+-  [Function `borrow_mut_native`](#0x2_dynamic_field_borrow_mut_native)
 -  [Function `remove`](#0x2_dynamic_field_remove)
 -  [Function `exists_`](#0x2_dynamic_field_exists_)
 -  [Function `exists_with_type`](#0x2_dynamic_field_exists_with_type)
@@ -214,7 +215,34 @@ type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
+    <a href="object.md#0x2_object">object</a>: &<b>mut</b> UID,
+    name: Name,
+): &<b>mut</b> Value {
+    <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut_native">borrow_mut_native</a>&lt;Name,Value,<a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name,Value&gt;&gt;(<a href="object.md#0x2_object">object</a>, name)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_dynamic_field_borrow_mut_native"></a>
+
+## Function `borrow_mut_native`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut_native">borrow_mut_native</a>&lt;Name: <b>copy</b>, drop, store, Value: store, <a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>: key&gt;(<a href="object.md#0x2_object">object</a>: &<b>mut</b> <a href="object.md#0x2_object_UID">object::UID</a>, name: Name): &<b>mut</b> Value
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut_native">borrow_mut_native</a>&lt;Name: <b>copy</b> + drop + store, Value: store, <a href="dynamic_field.md#0x2_dynamic_field_Field">Field</a>: key&gt;(
     <a href="object.md#0x2_object">object</a>: &<b>mut</b> UID,
     name: Name,
 ): &<b>mut</b> Value;

--- a/crates/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/sources/dynamic_field.move
@@ -74,7 +74,14 @@ public fun borrow<Name: copy + drop + store, Value: store>(
 /// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
 /// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
 /// type.
-public native fun borrow_mut<Name: copy + drop + store, Value: store>(
+public fun borrow_mut<Name: copy + drop + store, Value: store>(
+    object: &mut UID,
+    name: Name,
+): &mut Value {
+    borrow_mut_native<Name,Value,Field<Name,Value>>(object, name)
+}
+
+public native fun borrow_mut_native<Name: copy + drop + store, Value: store, Field: key>(
     object: &mut UID,
     name: Name,
 ): &mut Value;

--- a/crates/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/sources/dynamic_field.move
@@ -74,15 +74,10 @@ public fun borrow<Name: copy + drop + store, Value: store>(
 /// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
 /// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
 /// type.
-public fun borrow_mut<Name: copy + drop + store, Value: store>(
+public native fun borrow_mut<Name: copy + drop + store, Value: store>(
     object: &mut UID,
     name: Name,
-): &mut Value {
-    let object_addr = object::uid_to_address(object);
-    let hash = hash_type_and_key(object_addr, name);
-    let field = borrow_child_object_mut<Field<Name, Value>>(object, hash);
-    &mut field.value
-}
+): &mut Value;
 
 /// Removes the `object`s dynamic field with the name specified by `name: Name` and returns the
 /// bound value.

--- a/crates/sui-framework/src/natives/mod.rs
+++ b/crates/sui-framework/src/natives/mod.rs
@@ -62,8 +62,8 @@ pub fn all_natives(
         ),
         (
             "dynamic_field",
-            "borrow_mut",
-            make_native!(dynamic_field::borrow_mut),
+            "borrow_mut_native",
+            make_native!(dynamic_field::borrow_mut_native),
         ),
         (
             "dynamic_field",

--- a/crates/sui-framework/src/natives/mod.rs
+++ b/crates/sui-framework/src/natives/mod.rs
@@ -62,6 +62,11 @@ pub fn all_natives(
         ),
         (
             "dynamic_field",
+            "borrow_mut",
+            make_native!(dynamic_field::borrow_mut),
+        ),
+        (
+            "dynamic_field",
             "borrow_child_object",
             make_native!(dynamic_field::borrow_child_object),
         ),


### PR DESCRIPTION
The motivation for this rewrite is to enable the Move Prover to properly analyze `borrow_mut`-like functions in the `dynamic_field` module which is currently blocked by the `Field` type being exposed in the body of the `borrow_mut`-like functions but not available in the prover due to the Sui storage model being expressed as opaque specs. Despite this, the prover relies on this type being available during borrow analysis (and injecting writebacks for mutable references) which causes compilation errors (the type use is injected by borrow analysis but its definition is not available).

This PR is a draft currently provided for illustration purposes and relies on a change to core Move exposing `TypeTag` to `Type` conversion in the native context that is not yet available.