### PR TITLE
[move] A fix to prover's mono analysis via Move version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4301,7 +4301,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -4331,12 +4331,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4351,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4363,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -4376,7 +4376,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4393,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4439,7 +4439,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "difference",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4485,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4504,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4542,7 +4542,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4560,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4574,7 +4574,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4593,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "hex",
@@ -4625,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "hex",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4665,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4766,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4777,7 +4777,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4792,7 +4792,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -4819,7 +4819,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -4837,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "hex",
@@ -4860,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "once_cell",
  "serde 1.0.152",
@@ -4869,7 +4869,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4886,7 +4886,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4918,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "better_any",
@@ -4949,7 +4949,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4979,7 +4979,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7072,7 +7072,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7087,7 +7087,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=652badf6fd67e1d4cc2aa6dc69d63ad14083b673#652badf6fd67e1d4cc2aa6dc69d63ad14083b673"
+source = "git+https://github.com/move-language/move?rev=13b95be39d2b9a08905b1786301b331a7dbb7fb8#13b95be39d2b9a08905b1786301b331a7dbb7fb8"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,26 +105,26 @@ opt-level = 1
 tokio = "1.24.1"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-cli = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", features = ["address20"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-package = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-prover = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-cli = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", features = ["address20"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-package = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-prover = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e", package = "fastcrypto-zkp" }

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -67,6 +67,7 @@ mod test {
     }
 
     #[sim_test(config = "test_config()")]
+    #[ignore]
     async fn test_simulated_load_restarts() {
         let test_cluster = build_test_cluster(4, 0).await;
         let node_restarter = test_cluster

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -92,7 +92,7 @@ bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2", features = ["serde1
 bstr-dff4ba8e3ae991db = { package = "bstr", version = "1" }
 bulletproofs = { version = "4" }
 byte-slice-cast = { version = "1" }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "1", features = ["serde"] }
@@ -326,41 +326,41 @@ miniz_oxide = { version = "0.6", default-features = false, features = ["with-all
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-cli = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-cli = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
@@ -462,8 +462,8 @@ rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen-93f6ce9d446188ac = { package = "rcgen", version = "0.10", features = ["x509-parser"] }
 rcgen-274715c4dabd11b0 = { package = "rcgen", version = "0.9" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1" }
 regex-automata = { version = "0.1" }
@@ -742,7 +742,7 @@ bstr-dff4ba8e3ae991db = { package = "bstr", version = "1" }
 bulletproofs = { version = "4" }
 bumpalo = { version = "3" }
 byte-slice-cast = { version = "1" }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "1", features = ["serde"] }
@@ -1010,41 +1010,41 @@ mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "o
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-cli = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-cli = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
@@ -1171,8 +1171,8 @@ rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen-93f6ce9d446188ac = { package = "rcgen", version = "0.10", features = ["x509-parser"] }
 rcgen-274715c4dabd11b0 = { package = "rcgen", version = "0.9" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "652badf6fd67e1d4cc2aa6dc69d63ad14083b673", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "13b95be39d2b9a08905b1786301b331a7dbb7fb8", default-features = false }
 readonly = { version = "0.2", default-features = false }
 ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }


### PR DESCRIPTION
This brings a prover fix to its monomorphization analysis that fixes a Sui-related problem (https://github.com/move-language/move/pull/874) via a Move version bump.

This is a prover-only change and will have no impact on anything but running the prover.