### PR TITLE
[jsonrpc] - set max_request_body_size to 2GB

### DIFF
--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -112,6 +112,7 @@ impl JsonRpcServerBuilder {
             .layer(metrics_layer);
 
         let server = ServerBuilder::default()
+            .max_response_body_size(2 << 30)
             .max_connections(max_connection)
             .set_host_filtering(AllowHosts::Any)
             .set_middleware(middleware)

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -84,6 +84,8 @@ impl SuiClientBuilder {
         let ws = if let Some(url) = self.ws_url {
             Some(
                 WsClientBuilder::default()
+                    .max_request_body_size(2 << 30)
+                    .max_concurrent_requests(self.max_concurrent_requests)
                     .set_headers(headers.clone())
                     .request_timeout(self.request_timeout)
                     .build(url)
@@ -94,9 +96,10 @@ impl SuiClientBuilder {
         };
 
         let http = HttpClientBuilder::default()
+            .max_request_body_size(2 << 30)
+            .max_concurrent_requests(self.max_concurrent_requests)
             .set_headers(headers.clone())
             .request_timeout(self.request_timeout)
-            .max_concurrent_requests(self.max_concurrent_requests)
             .build(http)?;
 
         let info = Self::get_server_info(&http, &ws).await?;


### PR DESCRIPTION
we patched this in testnet but forgot to cherrypick back to the main and devnet