### PR TITLE
indexer: Adding new fields to checkpoint table

### DIFF
--- a/crates/sui-indexer/migrations/2023-01-16-233119_checkpoint/up.sql
+++ b/crates/sui-indexer/migrations/2023-01-16-233119_checkpoint/up.sql
@@ -8,10 +8,14 @@ CREATE TABLE checkpoints (
     total_storage_cost BIGINT NOT NULL,
     total_storage_rebate BIGINT NOT NULL,
     total_transactions BIGINT NOT NULL,
+    total_transactions_current_epoch BIGINT NOT NULL,
+    total_transactions_from_genesis BIGINT NOT NULL,
     previous_digest VARCHAR(255),
     next_epoch_committee TEXT,
     -- number of milliseconds from the Unix epoch
     timestamp_ms BIGINT NOT NULL,
+    timestamp_ms_str TIMESTAMP NOT NULL,
+    checkpoint_tps REAL NOT NULL,
     UNIQUE(sequence_number) 
 );
 

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -4,14 +4,15 @@
 use prometheus::Registry;
 use std::sync::Arc;
 use sui_sdk::SuiClient;
-use tracing::info;
+use tracing::{error, info};
 
 use sui_indexer::errors::IndexerError;
 use sui_indexer::metrics::IndexerCheckpointHandlerMetrics;
 use sui_indexer::models::checkpoint_logs::{commit_checkpoint_log, read_checkpoint_log};
-use sui_indexer::models::checkpoints::commit_checkpoint;
+use sui_indexer::models::checkpoints::{
+    commit_checkpoint, create_checkpoint, read_previous_checkpoint, Checkpoint,
+};
 use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
-
 pub struct CheckpointHandler {
     rpc_client: SuiClient,
     pg_connection_pool: Arc<PgConnectionPool>,
@@ -37,6 +38,18 @@ impl CheckpointHandler {
 
         let checkpoint_log = read_checkpoint_log(&mut pg_pool_conn)?;
         let mut next_cursor_sequence_number = checkpoint_log.next_cursor_sequence_number;
+        let mut previous_checkpoint_commit = Checkpoint::default();
+
+        if next_cursor_sequence_number != 0 {
+            let temp_checkpoint =
+                read_previous_checkpoint(&mut pg_pool_conn, next_cursor_sequence_number - 1);
+            match temp_checkpoint {
+                Ok(checkpoint) => previous_checkpoint_commit = checkpoint,
+                Err(err) => {
+                    error!("{}", err)
+                }
+            }
+        }
 
         loop {
             self.checkpoint_handler_metrics
@@ -62,12 +75,14 @@ impl CheckpointHandler {
                 .total_checkpoint_received
                 .inc();
             // unwrap here is safe because we checked for error above
-            commit_checkpoint(&mut pg_pool_conn, checkpoint.unwrap())?;
+            let new_checkpoint = create_checkpoint(checkpoint.unwrap(), previous_checkpoint_commit);
+            commit_checkpoint(&mut pg_pool_conn, new_checkpoint.clone())?;
             info!("Checkpoint {} committed", next_cursor_sequence_number);
             self.checkpoint_handler_metrics
                 .total_checkpoint_processed
                 .inc();
 
+            previous_checkpoint_commit = Checkpoint::from(new_checkpoint.clone());
             next_cursor_sequence_number += 1;
             commit_checkpoint_log(&mut pg_pool_conn, next_cursor_sequence_number)?;
         }

--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -1,13 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::errors::IndexerError;
 use crate::schema::checkpoints;
 use crate::schema::checkpoints::dsl::{checkpoints as checkpoints_table, sequence_number};
 // use crate::utils::log_errors_to_pg;
+use crate::errors::IndexerError;
 use crate::PgPoolConnection;
 
+use chrono::NaiveDateTime;
 use diesel::prelude::*;
+use diesel::result::Error;
 
 use sui_types::messages_checkpoint::CheckpointSummary;
 
@@ -21,9 +23,35 @@ pub struct Checkpoint {
     pub total_storage_cost: i64,
     pub total_storage_rebate: i64,
     pub total_transactions: i64,
+    pub total_transactions_current_epoch: i64,
+    pub total_transactions_from_genesis: i64,
     pub previous_digest: Option<String>,
     pub next_epoch_committee: Option<String>,
     pub timestamp_ms: i64,
+    pub timestamp_ms_str: NaiveDateTime,
+    pub checkpoint_tps: f32,
+}
+
+impl Default for Checkpoint {
+    fn default() -> Checkpoint {
+        Checkpoint {
+            sequence_number: 0,
+            content_digest: String::from(""),
+            epoch: 0,
+            total_gas_cost: 0,
+            total_computation_cost: 0,
+            total_storage_cost: 0,
+            total_storage_rebate: 0,
+            total_transactions: 0,
+            total_transactions_current_epoch: 0,
+            total_transactions_from_genesis: 0,
+            previous_digest: None,
+            next_epoch_committee: None,
+            timestamp_ms: 0,
+            timestamp_ms_str: NaiveDateTime::from_timestamp_millis(0).unwrap(),
+            checkpoint_tps: 0.0,
+        }
+    }
 }
 
 #[derive(Debug, Insertable, Clone)]
@@ -37,15 +65,41 @@ pub struct NewCheckpoint {
     pub total_storage_cost: i64,
     pub total_storage_rebate: i64,
     pub total_transactions: i64,
+    pub total_transactions_current_epoch: i64,
+    pub total_transactions_from_genesis: i64,
     pub previous_digest: Option<String>,
     pub next_epoch_committee: Option<String>,
     pub timestamp_ms: i64,
+    pub timestamp_ms_str: NaiveDateTime,
+    pub checkpoint_tps: f32,
 }
 
-pub fn commit_checkpoint(
-    pg_pool_conn: &mut PgPoolConnection,
+impl From<NewCheckpoint> for Checkpoint {
+    fn from(new_checkpoint: NewCheckpoint) -> Self {
+        Checkpoint {
+            sequence_number: new_checkpoint.sequence_number,
+            content_digest: new_checkpoint.content_digest,
+            epoch: new_checkpoint.epoch,
+            total_gas_cost: new_checkpoint.total_gas_cost,
+            total_computation_cost: new_checkpoint.total_computation_cost,
+            total_storage_cost: new_checkpoint.total_storage_cost,
+            total_storage_rebate: new_checkpoint.total_storage_rebate,
+            total_transactions: new_checkpoint.total_transactions,
+            total_transactions_current_epoch: new_checkpoint.total_transactions_current_epoch,
+            total_transactions_from_genesis: new_checkpoint.total_transactions_from_genesis,
+            previous_digest: new_checkpoint.previous_digest,
+            next_epoch_committee: new_checkpoint.next_epoch_committee,
+            timestamp_ms: new_checkpoint.timestamp_ms,
+            timestamp_ms_str: new_checkpoint.timestamp_ms_str,
+            checkpoint_tps: new_checkpoint.checkpoint_tps,
+        }
+    }
+}
+
+pub fn create_checkpoint(
     checkpoint_summary: CheckpointSummary,
-) -> Result<usize, IndexerError> {
+    previous_checkpoint_commit: Checkpoint,
+) -> NewCheckpoint {
     let total_gas_cost = checkpoint_summary
         .epoch_rolling_gas_cost_summary
         .computation_cost
@@ -59,7 +113,31 @@ pub fn commit_checkpoint(
         serde_json::to_string(&c).expect("Failed to serialize next_epoch_committee to JSON")
     });
 
-    let checkpoint = NewCheckpoint {
+    // Unsure how to calculate TPS for first item
+    let mut tps = 0.0;
+    let mut checkpoint_transaction_count = checkpoint_summary.network_total_transactions as i64;
+    let mut current_epoch_transaction_count = checkpoint_summary.network_total_transactions as i64;
+
+    if checkpoint_summary.sequence_number != 0 {
+        tps = (checkpoint_summary.network_total_transactions as f32
+            - previous_checkpoint_commit.total_transactions_from_genesis as f32)
+            / ((checkpoint_summary.timestamp_ms - previous_checkpoint_commit.timestamp_ms as u64)
+                as f32
+                / 1000.0) as f32;
+
+        checkpoint_transaction_count = checkpoint_summary.network_total_transactions as i64
+            - previous_checkpoint_commit.total_transactions_from_genesis;
+
+        current_epoch_transaction_count =
+            if previous_checkpoint_commit.next_epoch_committee.is_none() {
+                previous_checkpoint_commit.total_transactions_current_epoch
+                    + checkpoint_transaction_count
+            } else {
+                checkpoint_transaction_count
+            };
+    }
+
+    NewCheckpoint {
         sequence_number: checkpoint_summary.sequence_number as i64,
         content_digest: checkpoint_summary.content_digest.base58_encode(),
         epoch: checkpoint_summary.epoch as i64,
@@ -73,14 +151,48 @@ pub fn commit_checkpoint(
         total_storage_rebate: checkpoint_summary
             .epoch_rolling_gas_cost_summary
             .storage_rebate as i64,
-        total_transactions: checkpoint_summary.network_total_transactions as i64,
+        total_transactions: checkpoint_transaction_count,
+        total_transactions_from_genesis: checkpoint_summary.network_total_transactions as i64,
+        total_transactions_current_epoch: current_epoch_transaction_count,
         previous_digest: checkpoint_summary
             .previous_digest
             .map(|d| d.base58_encode()),
         next_epoch_committee: next_committee_json,
         timestamp_ms: checkpoint_summary.timestamp_ms as i64,
-    };
+        timestamp_ms_str: NaiveDateTime::from_timestamp_millis(
+            checkpoint_summary.timestamp_ms as i64,
+        )
+        .unwrap(),
+        checkpoint_tps: tps,
+    }
+}
+
+pub fn commit_checkpoint(
+    pg_pool_conn: &mut PgPoolConnection,
+    checkpoint: NewCheckpoint,
+) -> Result<usize, IndexerError> {
     commit_checkpoint_impl(pg_pool_conn, checkpoint)
+}
+
+pub fn read_previous_checkpoint(
+    pg_pool_conn: &mut PgPoolConnection,
+    currency_checkpoint_sequence_number: i64,
+) -> Result<Checkpoint, IndexerError> {
+    let checkpoint_read_result: Result<Checkpoint, Error> = pg_pool_conn
+        .build_transaction()
+        .read_only()
+        .run::<_, Error, _>(|conn| {
+            checkpoints_table
+                .filter(sequence_number.eq(currency_checkpoint_sequence_number - 1))
+                .limit(1)
+                .first::<Checkpoint>(conn)
+        });
+    checkpoint_read_result.map_err(|e| {
+        IndexerError::PostgresReadError(format!(
+            "Failed reading previous checkpoint in PostgresDB with error {:?}",
+            e
+        ))
+    })
 }
 
 fn commit_checkpoint_impl(

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -33,9 +33,13 @@ diesel::table! {
         total_storage_cost -> Int8,
         total_storage_rebate -> Int8,
         total_transactions -> Int8,
+        total_transactions_current_epoch -> Int8,
+        total_transactions_from_genesis -> Int8,
         previous_digest -> Nullable<Varchar>,
         next_epoch_committee -> Nullable<Text>,
         timestamp_ms -> Int8,
+        timestamp_ms_str -> Timestamp,
+        checkpoint_tps -> Float4,
     }
 }
 


### PR DESCRIPTION
Fields requested in SUI-1520

Transaction Counts reset properly after epoch change:
<img width="1489" alt="image" src="https://user-images.githubusercontent.com/123408603/217350687-1ebfdc5a-d27e-4c3e-9e05-f48545be4542.png">

Testing Done:

1. Started indexer from a clean db
2. Stopped and restarted indexer to ensure it picks up from the last checkpoint correctly
3. Checked that the math for the transactions are correct for a new epoch

Second image showing columns: 
![image](https://user-images.githubusercontent.com/123408603/218757954-822e7e5e-d55c-4128-babe-c944c97b6eee.png)
