### PR TITLE
crypto: Sign over intent for all authority messages

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -28,6 +28,7 @@ use sui_types::crypto::{
 use sui_types::epoch_data::EpochData;
 use sui_types::gas::SuiGasStatus;
 use sui_types::in_memory_storage::InMemoryStorage;
+use sui_types::intent::{Intent, IntentMessage, IntentScope};
 use sui_types::message_envelope::Message;
 use sui_types::messages::{CallArg, TransactionEffects};
 use sui_types::messages::{CertifiedTransaction, Transaction};
@@ -388,7 +389,11 @@ impl Builder {
             "provided keypair does not correspond to a validator in the validator set"
         );
         let checkpoint_signature = {
-            let signature = AuthoritySignature::new(&checkpoint, checkpoint.epoch, keypair);
+            let intent_msg = IntentMessage::new(
+                Intent::default().with_scope(IntentScope::CheckpointSummary),
+                checkpoint.clone(),
+            );
+            let signature = AuthoritySignature::new_secure(&intent_msg, &checkpoint.epoch, keypair);
             AuthoritySignInfo {
                 epoch: checkpoint.epoch,
                 authority: name,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -31,6 +31,8 @@ use std::{collections::HashMap, pin::Pin};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_types::crypto::AuthoritySignInfo;
 use sui_types::error::UserInputError;
+use sui_types::intent::Intent;
+use sui_types::intent::IntentScope;
 use sui_types::message_envelope::Message;
 use sui_types::parse_sui_struct_tag;
 use tap::TapFallible;
@@ -2462,6 +2464,7 @@ impl AuthorityState {
             Some(AuthoritySignInfo::new(
                 epoch_store.epoch(),
                 effects,
+                Intent::default().with_scope(IntentScope::TransactionEffects),
                 self.name,
                 &*self.secret,
             ))

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -21,6 +21,7 @@ use sui_types::crypto::{
     NetworkKeyPair, SuiKeyPair,
 };
 use sui_types::crypto::{AuthorityKeyPair, Signer};
+use sui_types::intent::{Intent, IntentScope};
 use sui_types::messages::{TransactionData, VerifiedTransaction, DUMMY_GAS_PRICE};
 use sui_types::utils::create_fake_transaction;
 use sui_types::utils::to_sender_signed_transaction;
@@ -105,7 +106,13 @@ pub fn create_fake_cert_and_effect_digest<'a>(
         transaction.data().clone(),
         signers
             .map(|(name, signer)| {
-                AuthoritySignInfo::new(committee.epoch, transaction.data(), *name, signer)
+                AuthoritySignInfo::new(
+                    committee.epoch,
+                    transaction.data(),
+                    Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+                    *name,
+                    signer,
+                )
             })
             .collect(),
         committee,

--- a/crates/sui-network/src/state_sync/test_utils.rs
+++ b/crates/sui-network/src/state_sync/test_utils.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
+use sui_types::intent::{Intent, IntentMessage, IntentScope};
 use sui_types::{
     base_types::AuthorityName,
     committee::{Committee, EpochId, ProtocolVersion, StakeUnit},
@@ -76,7 +77,11 @@ impl CommitteeFixture {
             .validators
             .iter()
             .map(|(name, (key, _))| {
-                let signature = AuthoritySignature::new(&checkpoint, checkpoint.epoch, key);
+                let intent_msg = IntentMessage::new(
+                    Intent::default().with_scope(IntentScope::CheckpointSummary),
+                    checkpoint.clone(),
+                );
+                let signature = AuthoritySignature::new_secure(&intent_msg, &checkpoint.epoch, key);
                 AuthoritySignInfo {
                     epoch: checkpoint.epoch,
                     authority: *name,

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -31,7 +31,7 @@ use strum::EnumString;
 use crate::base_types::{AuthorityName, ObjectID, SuiAddress};
 use crate::committee::{Committee, EpochId, StakeUnit};
 use crate::error::{SuiError, SuiResult};
-use crate::intent::IntentMessage;
+use crate::intent::{Intent, IntentMessage};
 use crate::sui_serde::{Readable, SuiBitmap};
 use fastcrypto::encoding::{Base64, Encoding, Hex};
 use fastcrypto::hash::{HashFunction, Sha3_256};
@@ -434,90 +434,52 @@ impl FromStr for AuthorityPublicKeyBytes {
 //
 
 pub trait SuiAuthoritySignature {
-    fn new<T>(value: &T, epoch_id: EpochId, secret: &dyn Signer<Self>) -> Self
-    where
-        T: Signable<Vec<u8>>;
-
-    fn verify<T>(
-        &self,
-        value: &T,
-        epoch_id: EpochId,
-        author: AuthorityPublicKeyBytes,
-    ) -> Result<(), SuiError>
-    where
-        T: Signable<Vec<u8>>;
-
     fn verify_secure<T>(
         &self,
         value: &IntentMessage<T>,
+        epoch_id: EpochId,
         author: AuthorityPublicKeyBytes,
     ) -> Result<(), SuiError>
     where
         T: Serialize;
 
-    fn new_secure<T>(value: &IntentMessage<T>, secret: &dyn Signer<Self>) -> Self
+    fn new_secure<T>(
+        value: &IntentMessage<T>,
+        epoch_id: &EpochId,
+        secret: &dyn Signer<Self>,
+    ) -> Self
     where
         T: Serialize;
 }
 
 impl SuiAuthoritySignature for AuthoritySignature {
-    fn new<T>(value: &T, epoch_id: EpochId, secret: &dyn Signer<Self>) -> Self
-    where
-        T: Signable<Vec<u8>>,
-    {
-        let mut message = Vec::new();
-        value.write(&mut message);
-        epoch_id.write(&mut message);
-        Signer::sign(secret, &message)
-    }
-
-    fn verify<T>(
-        &self,
-        value: &T,
-        epoch_id: EpochId,
-        author: AuthorityPublicKeyBytes,
-    ) -> Result<(), SuiError>
-    where
-        T: Signable<Vec<u8>>,
-    {
-        // is this a cryptographically valid public Key?
-        let public_key = AuthorityPublicKey::try_from(author).map_err(|_| {
-            SuiError::KeyConversionError(
-                "Failed to serialize public key bytes to valid public key".to_string(),
-            )
-        })?;
-        // serialize the message (see BCS serialization for determinism)
-        let mut message = Vec::new();
-        value.write(&mut message);
-        epoch_id.write(&mut message);
-
-        // perform cryptographic signature check
-        public_key
-            .verify(&message, self)
-            .map_err(|error| SuiError::InvalidSignature {
-                error: error.to_string(),
-            })
-    }
-
-    fn new_secure<T>(value: &IntentMessage<T>, secret: &dyn Signer<Self>) -> Self
+    fn new_secure<T>(value: &IntentMessage<T>, epoch: &EpochId, secret: &dyn Signer<Self>) -> Self
     where
         T: Serialize,
     {
-        Signer::sign(
-            secret,
-            &bcs::to_bytes(&value).expect("Message serialization should not fail"),
-        )
+        let mut message = Vec::new();
+        let intent_msg_bytes =
+            bcs::to_bytes(&value).expect("Message serialization should not fail");
+        message.extend(intent_msg_bytes);
+        epoch.write(&mut message);
+        secret.sign(&message)
     }
 
     fn verify_secure<T>(
         &self,
         value: &IntentMessage<T>,
+        epoch: EpochId,
         author: AuthorityPublicKeyBytes,
     ) -> Result<(), SuiError>
     where
         T: Serialize,
     {
-        let message = bcs::to_bytes(&value).expect("Message serialization should not fail");
+        let mut message = Vec::new();
+        let intent_msg_bytes =
+            bcs::to_bytes(&value).expect("Message serialization should not fail");
+        message.extend(intent_msg_bytes);
+        epoch.write(&mut message);
+
         let public_key = AuthorityPublicKey::try_from(author).map_err(|_| {
             SuiError::KeyConversionError(
                 "Failed to serialize public key bytes to valid public key".to_string(),
@@ -1083,7 +1045,12 @@ impl<S: SuiSignatureInner + Sized> SuiSignature for S {
 /// TODO: We could also add the aggregated signature as another impl of the trait.
 ///       This will make CertifiedTransaction also an instance of the same struct.
 pub trait AuthoritySignInfoTrait: private::SealedAuthoritySignInfoTrait {
-    fn verify<T: Signable<Vec<u8>>>(&self, data: &T, committee: &Committee) -> SuiResult;
+    fn verify_secure<T: Serialize>(
+        &self,
+        data: &T,
+        intent: Intent,
+        committee: &Committee,
+    ) -> SuiResult;
 
     fn add_to_verification_obligation(
         &self,
@@ -1096,7 +1063,12 @@ pub trait AuthoritySignInfoTrait: private::SealedAuthoritySignInfoTrait {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EmptySignInfo {}
 impl AuthoritySignInfoTrait for EmptySignInfo {
-    fn verify<T: Signable<Vec<u8>>>(&self, _data: &T, _committee: &Committee) -> SuiResult {
+    fn verify_secure<T: Serialize>(
+        &self,
+        _data: &T,
+        _intent: Intent,
+        _committee: &Committee,
+    ) -> SuiResult {
         Ok(())
     }
 
@@ -1110,23 +1082,6 @@ impl AuthoritySignInfoTrait for EmptySignInfo {
     }
 }
 
-pub fn add_to_verification_obligation_and_verify<S, T>(
-    sig: &S,
-    data: &T,
-    committee: &Committee,
-    epoch_id: EpochId,
-) -> SuiResult
-where
-    S: AuthoritySignInfoTrait,
-    T: Signable<Vec<u8>>,
-{
-    let mut obligation = VerificationObligation::default();
-    let idx = obligation.add_message(data, epoch_id);
-    sig.add_to_verification_obligation(committee, &mut obligation, idx)?;
-    obligation.verify_all()?;
-    Ok(())
-}
-
 #[derive(Clone, Debug, Eq, Serialize, Deserialize)]
 pub struct AuthoritySignInfo {
     pub epoch: EpochId,
@@ -1134,8 +1089,17 @@ pub struct AuthoritySignInfo {
     pub signature: AuthoritySignature,
 }
 impl AuthoritySignInfoTrait for AuthoritySignInfo {
-    fn verify<T: Signable<Vec<u8>>>(&self, data: &T, committee: &Committee) -> SuiResult<()> {
-        add_to_verification_obligation_and_verify(self, data, committee, self.epoch)
+    fn verify_secure<T: Serialize>(
+        &self,
+        data: &T,
+        intent: Intent,
+        committee: &Committee,
+    ) -> SuiResult<()> {
+        let mut obligation = VerificationObligation::default();
+        let idx = obligation.add_message(data, self.epoch, intent);
+        self.add_to_verification_obligation(committee, &mut obligation, idx)?;
+        obligation.verify_all()?;
+        Ok(())
     }
 
     fn add_to_verification_obligation(
@@ -1182,16 +1146,21 @@ impl AuthoritySignInfo {
     pub fn new<T>(
         epoch: EpochId,
         value: &T,
+        intent: Intent,
         name: AuthorityName,
         secret: &dyn Signer<AuthoritySignature>,
     ) -> Self
     where
-        T: Signable<Vec<u8>>,
+        T: Serialize,
     {
         Self {
             epoch,
             authority: name,
-            signature: AuthoritySignature::new(value, epoch, secret),
+            signature: AuthoritySignature::new_secure(
+                &IntentMessage::new(intent, value),
+                &epoch,
+                secret,
+            ),
         }
     }
 }
@@ -1291,8 +1260,17 @@ static_assertions::assert_not_impl_any!(AuthorityWeakQuorumSignInfo: Hash, Eq, P
 impl<const STRONG_THRESHOLD: bool> AuthoritySignInfoTrait
     for AuthorityQuorumSignInfo<STRONG_THRESHOLD>
 {
-    fn verify<T: Signable<Vec<u8>>>(&self, data: &T, committee: &Committee) -> SuiResult<()> {
-        add_to_verification_obligation_and_verify(self, data, committee, self.epoch)
+    fn verify_secure<T: Serialize>(
+        &self,
+        data: &T,
+        intent: Intent,
+        committee: &Committee,
+    ) -> SuiResult {
+        let mut obligation = VerificationObligation::default();
+        let idx = obligation.add_message(data, self.epoch, intent);
+        self.add_to_verification_obligation(committee, &mut obligation, idx)?;
+        obligation.verify_all()?;
+        Ok(())
     }
 
     fn add_to_verification_obligation(
@@ -1560,14 +1538,16 @@ impl VerificationObligation {
 
     /// Add a new message to the list of messages to be verified.
     /// Returns the index of the message.
-    pub fn add_message<T>(&mut self, message_value: &T, epoch: EpochId) -> usize
+    pub fn add_message<T>(&mut self, message_value: &T, epoch: EpochId, intent: Intent) -> usize
     where
-        T: Signable<Vec<u8>>,
+        T: Serialize,
     {
         let mut message = Vec::new();
-        message_value.write(&mut message);
+        let intent_msg = IntentMessage::new(intent, message_value);
+        let intent_msg_bytes =
+            bcs::to_bytes(&intent_msg).expect("Message serialization should not fail");
+        message.extend(intent_msg_bytes);
         epoch.write(&mut message);
-
         self.signatures.push(AggregateAuthoritySignature::default());
         self.public_keys.push(Vec::new());
         self.messages.push(message);
@@ -1607,7 +1587,6 @@ impl VerificationObligation {
         .map_err(|error| SuiError::InvalidSignature {
             error: format!("{error}"),
         })?;
-
         Ok(())
     }
 }
@@ -1615,7 +1594,7 @@ impl VerificationObligation {
 pub mod bcs_signable_test {
     use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Clone, Serialize, Deserialize)]
     pub struct Foo(pub String);
 
     #[cfg(test)]
@@ -1630,9 +1609,15 @@ pub mod bcs_signable_test {
     where
         T: super::bcs_signable::BcsSignable,
     {
+        use crate::intent::{Intent, IntentScope};
+
         let mut obligation = VerificationObligation::default();
         // Add the obligation of the authority signature verifications.
-        let idx = obligation.add_message(value, 0);
+        let idx = obligation.add_message(
+            value,
+            0,
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+        );
         (obligation, idx)
     }
 }

--- a/crates/sui-types/src/intent.rs
+++ b/crates/sui-types/src/intent.rs
@@ -41,6 +41,7 @@ pub enum AppId {
     Sui = 0,
 }
 
+// TODO(joyqvq): Use num_derive
 impl TryFrom<u8> for AppId {
     type Error = eyre::Report;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
@@ -64,6 +65,10 @@ pub enum IntentScope {
     TransactionEffects = 1,
     CheckpointSummary = 2,
     PersonalMessage = 3,
+    SenderSignedTransaction = 4,
+    ProofOfPossession = 5,
+    TransactionEffectsDigest = 6,
+    ExecutionDigests = 7,
 }
 
 impl TryFrom<u8> for IntentScope {
@@ -74,6 +79,10 @@ impl TryFrom<u8> for IntentScope {
             1 => Ok(Self::TransactionEffects),
             2 => Ok(Self::CheckpointSummary),
             3 => Ok(Self::PersonalMessage),
+            4 => Ok(Self::SenderSignedTransaction),
+            5 => Ok(Self::ProofOfPossession),
+            6 => Ok(Self::TransactionEffectsDigest),
+            7 => Ok(Self::ExecutionDigests),
             _ => Err(eyre!("Invalid IntentScope")),
         }
     }

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -6,9 +6,10 @@ use crate::certificate_proof::CertificateProof;
 use crate::committee::{Committee, EpochId};
 use crate::crypto::{
     AuthorityQuorumSignInfo, AuthoritySignInfo, AuthoritySignInfoTrait, AuthoritySignature,
-    AuthorityStrongQuorumSignInfo, EmptySignInfo, Signable, Signer,
+    AuthorityStrongQuorumSignInfo, EmptySignInfo, Signer,
 };
 use crate::error::SuiResult;
+use crate::intent::{Intent, IntentScope};
 use crate::messages_checkpoint::CheckpointSequenceNumber;
 use once_cell::sync::OnceCell;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -17,6 +18,7 @@ use std::ops::{Deref, DerefMut};
 
 pub trait Message {
     type DigestType: Clone + Debug;
+    const SCOPE: IntentScope;
 
     fn digest(&self) -> Self::DigestType;
 
@@ -112,7 +114,7 @@ impl<T: Message> Envelope<T, EmptySignInfo> {
 
 impl<T> Envelope<T, AuthoritySignInfo>
 where
-    T: Message + Signable<Vec<u8>>,
+    T: Message + Serialize,
 {
     pub fn new(
         epoch: EpochId,
@@ -120,7 +122,13 @@ where
         secret: &dyn Signer<AuthoritySignature>,
         authority: AuthorityName,
     ) -> Self {
-        let auth_signature = AuthoritySignInfo::new(epoch, &data, authority, secret);
+        let auth_signature = AuthoritySignInfo::new(
+            epoch,
+            &data,
+            Intent::default().with_scope(T::SCOPE),
+            authority,
+            secret,
+        );
         Self {
             digest: OnceCell::new(),
             data,
@@ -134,7 +142,11 @@ where
 
     pub fn verify_signature(&self, committee: &Committee) -> SuiResult {
         self.data.verify()?;
-        self.auth_signature.verify(self.data(), committee)
+        self.auth_signature.verify_secure(
+            self.data(),
+            Intent::default().with_scope(T::SCOPE),
+            committee,
+        )
     }
 
     pub fn verify(
@@ -150,7 +162,7 @@ where
 
 impl<T, const S: bool> Envelope<T, AuthorityQuorumSignInfo<S>>
 where
-    T: Message + Signable<Vec<u8>>,
+    T: Message + Serialize,
 {
     pub fn new(
         data: T,
@@ -176,7 +188,11 @@ where
     // and make sure they all call verify to avoid repeated verifications.
     pub fn verify_signature(&self, committee: &Committee) -> SuiResult {
         self.data.verify()?;
-        self.auth_signature.verify(self.data(), committee)
+        self.auth_signature.verify_secure(
+            self.data(),
+            Intent::default().with_scope(T::SCOPE),
+            committee,
+        )
     }
 
     pub fn verify(

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -9,7 +9,7 @@ use crate::crypto::{
     Ed25519SuiSignature, EmptySignInfo, Signature, Signer, SuiSignatureInner, ToFromBytes,
 };
 use crate::gas::GasCostSummary;
-use crate::intent::{Intent, IntentMessage};
+use crate::intent::{Intent, IntentMessage, IntentScope};
 use crate::message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope};
 use crate::messages_checkpoint::{
     CheckpointSequenceNumber, CheckpointSignatureMessage, CheckpointTimestamp,
@@ -1462,6 +1462,7 @@ impl SenderSignedData {
 
 impl Message for SenderSignedData {
     type DigestType = TransactionDigest;
+    const SCOPE: IntentScope = IntentScope::SenderSignedTransaction;
 
     fn digest(&self) -> Self::DigestType {
         TransactionDigest::new(sha3_hash(&self.intent_message.value))
@@ -2529,6 +2530,7 @@ impl TransactionEffects {
 
 impl Message for TransactionEffectsDigest {
     type DigestType = TransactionEffectsDigest;
+    const SCOPE: IntentScope = IntentScope::TransactionEffectsDigest;
 
     fn digest(&self) -> Self::DigestType {
         *self
@@ -2541,6 +2543,7 @@ impl Message for TransactionEffectsDigest {
 
 impl Message for ExecutionDigests {
     type DigestType = TransactionDigest;
+    const SCOPE: IntentScope = IntentScope::ExecutionDigests;
 
     fn digest(&self) -> Self::DigestType {
         self.transaction
@@ -2553,6 +2556,7 @@ impl Message for ExecutionDigests {
 
 impl Message for TransactionEffects {
     type DigestType = TransactionEffectsDigest;
+    const SCOPE: IntentScope = IntentScope::TransactionEffects;
 
     fn digest(&self) -> Self::DigestType {
         TransactionEffectsDigest::new(sha3_hash(self))

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -15,6 +15,7 @@ use crate::crypto::{
     get_key_pair, get_key_pair_from_bytes, AccountKeyPair, AuthorityKeyPair, AuthoritySignature,
     Signature, SuiAuthoritySignature, SuiSignature,
 };
+use crate::intent::{Intent, IntentMessage};
 use crate::{gas_coin::GasCoin, object::Object, SUI_FRAMEWORK_ADDRESS};
 use sui_protocol_config::ProtocolConfig;
 
@@ -302,7 +303,11 @@ fn test_transaction_digest_serde_human_readable() {
 #[test]
 fn test_authority_signature_serde_not_human_readable() {
     let (_, key): (_, AuthorityKeyPair) = get_key_pair();
-    let sig = AuthoritySignature::new(&Foo("some data".to_string()), 0, &key);
+    let sig = AuthoritySignature::new_secure(
+        &IntentMessage::new(Intent::default(), Foo("some data".to_string())),
+        &0,
+        &key,
+    );
     let serialized = bincode::serialize(&sig).unwrap();
     let bcs_serialized = bcs::to_bytes(&sig).unwrap();
 
@@ -314,7 +319,11 @@ fn test_authority_signature_serde_not_human_readable() {
 #[test]
 fn test_authority_signature_serde_human_readable() {
     let (_, key): (_, AuthorityKeyPair) = get_key_pair();
-    let sig = AuthoritySignature::new(&Foo("some data".to_string()), 0, &key);
+    let sig = AuthoritySignature::new_secure(
+        &IntentMessage::new(Intent::default(), Foo("some data".to_string())),
+        &0,
+        &key,
+    );
     let serialized = serde_json::to_string(&sig).unwrap();
     assert_eq!(format!("\"{}\"", sig.encode_base64()), serialized);
     let deserialized: AuthoritySignature = serde_json::from_str(&serialized).unwrap();

--- a/crates/sui-types/src/unit_tests/intent_tests.rs
+++ b/crates/sui-types/src/unit_tests/intent_tests.rs
@@ -96,7 +96,7 @@ fn test_authority_signature_intent() {
     assert_eq!(&intent_bcs[3..], signed_data_bcs);
 
     // Let's ensure we can sign and verify intents.
-    let s = AuthoritySignature::new_secure(&tx1.data().intent_message, &kp);
-    let verification = s.verify_secure(&tx1.data().intent_message, kp.public().into());
+    let s = AuthoritySignature::new_secure(&tx1.data().intent_message, &0, &kp);
+    let verification = s.verify_secure(&tx1.data().intent_message, 0, kp.public().into());
     assert!(verification.is_ok())
 }

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -18,6 +18,7 @@ use crate::crypto::Secp256k1SuiSignature;
 use crate::crypto::SuiKeyPair;
 use crate::crypto::SuiSignature;
 use crate::crypto::SuiSignatureInner;
+use crate::crypto::VerificationObligation;
 use crate::crypto::{
     get_key_pair, AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes,
     AuthoritySignInfoTrait, SuiAuthoritySignature,
@@ -180,7 +181,13 @@ fn test_new_with_signatures() {
     for _ in 0..5 {
         let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
         let name = AuthorityPublicKeyBytes::from(sec.public());
-        signatures.push(AuthoritySignInfo::new(0, &message, name, &sec));
+        signatures.push(AuthoritySignInfo::new(
+            0,
+            &message,
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+            name,
+            &sec,
+        ));
         authorities.insert(name, 1);
     }
     let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
@@ -226,6 +233,7 @@ fn test_handle_reject_malicious_signature() {
             signatures.push(AuthoritySignInfo::new(
                 0,
                 &Foo("some data".to_string()),
+                Intent::default().with_scope(IntentScope::SenderSignedTransaction),
                 name,
                 &sec,
             ))
@@ -237,7 +245,11 @@ fn test_handle_reject_malicious_signature() {
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
     {
         let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
-        let sig = AuthoritySignature::new(&message, committee.epoch, &sec);
+        let sig = AuthoritySignature::new_secure(
+            &IntentMessage::new(Intent::default(), message.clone()),
+            &committee.epoch,
+            &sec,
+        );
         quorum.signature.add_signature(sig).unwrap();
     }
     let (mut obligation, idx) = get_obligation_input(&message);
@@ -250,40 +262,45 @@ fn test_handle_reject_malicious_signature() {
 #[test]
 fn test_auth_sig_commit_to_wrong_epoch_id_fail() {
     let message: Foo = Foo("some data".to_string());
-    let mut signatures: Vec<AuthoritySignInfo> = Vec::new();
-    let mut authorities: BTreeMap<AuthorityPublicKeyBytes, u64> = BTreeMap::new();
-
-    for _ in 0..5 {
-        let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
-        let name = AuthorityPublicKeyBytes::from(sec.public());
-        authorities.insert(name, 1);
-        signatures.push(AuthoritySignInfo::new(
-            1,
-            &Foo("some data".to_string()),
-            name,
-            &sec,
-        ));
-    }
-    // committee set up with epoch 1
-    let committee = Committee::new(1, ProtocolVersion::MIN, authorities.clone()).unwrap();
-    let mut quorum =
-        AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
-    {
-        let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
-        // signature commits to epoch 0
-        let sig = AuthoritySignature::new(&message, 1, &sec);
-        quorum.signature.add_signature(sig).unwrap();
-    }
-    let (mut obligation, idx) = get_obligation_input(&message);
-    assert!(quorum
-        .add_to_verification_obligation(&committee, &mut obligation, idx)
-        .is_ok());
-    assert_eq!(
-        obligation.verify_all(),
-        Err(SuiError::InvalidSignature {
-            error: "General cryptographic error".to_string()
-        })
+    let mut obligation = VerificationObligation::default();
+    let idx = obligation.add_message(
+        &message,
+        0, // Obligation added with correct epoch id.
+        Intent::default().with_scope(IntentScope::SenderSignedTransaction),
     );
+    let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
+
+    // Auth signtaure commits to epoch 0 verifies ok.
+    let sig = AuthoritySignature::new_secure(
+        &IntentMessage::new(
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+            message.clone(),
+        ),
+        &0,
+        &sec,
+    );
+    let res = obligation.add_signature_and_public_key(&sig, sec.public(), idx);
+    assert!(res.is_ok());
+    assert!(obligation.verify_all().is_ok());
+
+    // Auth signtaure commits to epoch 1 fails to verify.
+    let mut obligation = VerificationObligation::default();
+    let idx1 = obligation.add_message(
+        &message,
+        0, // Obligation added with correct epoch id.
+        Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+    );
+    let sig1 = AuthoritySignature::new_secure(
+        &IntentMessage::new(
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+            message.clone(),
+        ),
+        &1,
+        &sec,
+    );
+    let res = obligation.add_signature_and_public_key(&sig1, sec.public(), idx1);
+    assert!(res.is_ok());
+    assert!(obligation.verify_all().is_err());
 }
 
 #[test]
@@ -298,6 +315,7 @@ fn test_bitmap_out_of_range() {
         signatures.push(AuthoritySignInfo::new(
             0,
             &Foo("some data".to_string()),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
             name,
             &sec,
         ));
@@ -329,6 +347,7 @@ fn test_reject_extra_public_key() {
         signatures.push(AuthoritySignInfo::new(
             0,
             &Foo("some data".to_string()),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
             name,
             &sec,
         ));
@@ -368,6 +387,7 @@ fn test_reject_reuse_signatures() {
         signatures.push(AuthoritySignInfo::new(
             0,
             &Foo("some data".to_string()),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
             name,
             &sec,
         ));
@@ -403,6 +423,7 @@ fn test_empty_bitmap() {
         signatures.push(AuthoritySignInfo::new(
             0,
             &Foo("some data".to_string()),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
             name,
             &sec,
         ));
@@ -603,11 +624,19 @@ fn test_user_signature_committed_in_signed_transactions() {
     let committee = Committee::new(0, ProtocolVersion::MIN, authorities.clone()).unwrap();
     assert!(signed_tx_a
         .auth_sig()
-        .verify(transaction_a.data(), &committee)
+        .verify_secure(
+            transaction_a.data(),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+            &committee
+        )
         .is_ok());
     assert!(signed_tx_a
         .auth_sig()
-        .verify(transaction_b.data(), &committee)
+        .verify_secure(
+            transaction_b.data(),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+            &committee
+        )
         .is_err());
 
     // Test hash non-equality
@@ -922,7 +951,11 @@ fn verify_sender_signature_correctly_with_flag() {
     // authority accepts signs tx after verification
     assert!(signed_tx
         .auth_sig()
-        .verify(transaction.data(), &committee)
+        .verify_secure(
+            transaction.data(),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+            &committee
+        )
         .is_ok());
 
     let transaction_1 =
@@ -947,12 +980,20 @@ fn verify_sender_signature_correctly_with_flag() {
     // signature verified
     assert!(signed_tx_1
         .auth_sig()
-        .verify(transaction_1.data(), &committee)
+        .verify_secure(
+            transaction_1.data(),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+            &committee
+        )
         .is_ok());
 
     assert!(signed_tx_1
         .auth_sig()
-        .verify(transaction.data(), &committee)
+        .verify_secure(
+            transaction.data(),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+            &committee
+        )
         .is_err());
 
     // create transaction with r1 signer
@@ -972,7 +1013,11 @@ fn verify_sender_signature_correctly_with_flag() {
     );
     assert!(signed_tx_3
         .auth_sig()
-        .verify(tx_32.data(), &committee)
+        .verify_secure(
+            tx_32.data(),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+            &committee
+        )
         .is_ok());
 }
 


### PR DESCRIPTION
- authority sig now commits to its intent scope in addition to the message for:
    - sender signed transaction
    - transaction effect
    - checkpoint summary

- IntentScope is defined as an associated constant [trait Message] (implemented for all three above).

not included in this pr: 
- proof of possession (since it involves a bigger change involving updating move)
- narwhal signing headers (the keypair usage looks a bit different, want to do some refactoring there)