### PR TITLE
[sui-rosetta] - default data directory to /data, and override fullnode's db dir

### DIFF
--- a/.github/scripts/rosetta/start_rosetta.sh
+++ b/.github/scripts/rosetta/start_rosetta.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 echo "Start Rosetta online server"
-sui-rosetta start-online-server --data_path ./data &
+sui-rosetta start-online-server --data-path ./data &
 
 echo "Start Rosetta offline server"
 sui-rosetta start-offline-server &

--- a/.github/scripts/rosetta/start_rosetta.sh
+++ b/.github/scripts/rosetta/start_rosetta.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 echo "Start Rosetta online server"
-sui-rosetta start-online-server &
+sui-rosetta start-online-server --data_path ./data &
 
 echo "Start Rosetta offline server"
 sui-rosetta start-offline-server &

--- a/crates/sui-rosetta/docker/sui-rosetta-devnet/docker-compose.yaml
+++ b/crates/sui-rosetta/docker/sui-rosetta-devnet/docker-compose.yaml
@@ -1,33 +1,21 @@
 ---
 version: "3.9"
 services:
-  sui-full-node:
-    image: mysten/sui-rosetta-devnet
-    ports:
-      - "9000:9000"
-    expose:
-      - "9000"
-    working_dir: /sui/devnet
-    command:
-      - /bin/bash
-      - -c
-      - |
-        /usr/local/bin/sui-node --config-path fullnode.yaml
-    stdin_open: true
-    tty: true
   rosetta-online:
     image: mysten/sui-rosetta-devnet
     ports:
       - "9002:9002"
     expose:
       - "9002"
+    volumes:
+      - data:/data:rw
     working_dir: /sui/devnet
     command:
       - /bin/bash
       - -c
       - |
         /usr/local/bin/sui-rosetta generate-rosetta-cli-config --env devnet &
-        /usr/local/bin/sui-rosetta start-online-remote-server --env devnet --full-node-url http://sui-full-node:9000
+        /usr/local/bin/sui-rosetta start-online-server --env devnet --node-config fullnode.yaml
     stdin_open: true
     tty: true
   rosetta-offline:
@@ -44,4 +32,5 @@ services:
         /usr/local/bin/sui-rosetta start-offline-server --env devnet
     stdin_open: true
     tty: true
-
+volumes:
+  data:


### PR DESCRIPTION
CB is having issue restoring from snapshots, possibly due to data directory configuration issues, this PR defaults the data directory to /data and also override embedded sui node's database directory to /data/sui_db