### PR TITLE
[TypeScript SDK] Refactor Coin class to use CoinStruct instead of ObjectData

### DIFF
--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -43,7 +43,7 @@ export async function mint(address: string) {
             'An example NFT.',
             'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
         ],
-        gasPayment: gasPayment.objectId,
+        gasPayment: gasPayment.coinObjectId,
         gasBudget: 30000,
     });
 

--- a/sdk/typescript/src/framework/framework.ts
+++ b/sdk/typescript/src/framework/framework.ts
@@ -103,8 +103,7 @@ export class Coin {
   ): CoinStruct[] {
     return Coin.sortByBalance(
       coins.filter(
-        (c) =>
-          !exclude.includes(c.coinObjectId) && c.balance >= amount,
+        (c) => !exclude.includes(c.coinObjectId) && c.balance >= amount,
       ),
     );
   }
@@ -186,11 +185,7 @@ export class Coin {
    */
   static sortByBalance(coins: CoinStruct[]): CoinStruct[] {
     return [...coins].sort((a, b) =>
-      a.balance < b.balance
-        ? -1
-        : a.balance > b.balance
-        ? 1
-        : 0,
+      a.balance < b.balance ? -1 : a.balance > b.balance ? 1 : 0,
     );
   }
 

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -58,6 +58,7 @@ import {
   CheckpointDigest,
   CheckPointContentsDigest,
   CommitteeInfo,
+  CoinStruct,
 } from '../types';
 import { DynamicFieldPage } from '../types/dynamic_fields';
 import {
@@ -428,9 +429,9 @@ export class JsonRpcProvider extends Provider {
 
   async getGasObjectsOwnedByAddress(
     address: SuiAddress,
-  ): Promise<SuiObjectInfo[]> {
-    const objects = await this.getObjectsOwnedByAddress(address);
-    return objects.filter((obj: SuiObjectInfo) => Coin.isSUI(obj));
+  ): Promise<CoinStruct[]> {
+    const objects = await this.getCoins(address);
+    return objects.data;
   }
 
   /**
@@ -457,15 +458,13 @@ export class JsonRpcProvider extends Provider {
     amount: bigint,
     typeArg: string = SUI_TYPE_ARG,
     exclude: ObjectId[] = [],
-  ): Promise<GetObjectDataResponse[]> {
-    const coinsStruct = await this.getCoins(address, typeArg);
-    const coinIds = coinsStruct.data.map((c) => c.coinObjectId);
-    const coins = await this.getObjectBatch(coinIds);
+  ): Promise<CoinStruct[]> {
+    const coins = await this.getCoins(address, typeArg);
     return (await Coin.selectCoinsWithBalanceGreaterThanOrEqual(
-      coins,
+      coins.data,
       amount,
       exclude,
-    )) as GetObjectDataResponse[];
+    )) as CoinStruct[];
   }
 
   async selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
@@ -473,15 +472,13 @@ export class JsonRpcProvider extends Provider {
     amount: bigint,
     typeArg: string = SUI_TYPE_ARG,
     exclude: ObjectId[] = [],
-  ): Promise<GetObjectDataResponse[]> {
-    const coinsStruct = await this.getCoins(address, typeArg);
-    const coinIds = coinsStruct.data.map((c) => c.coinObjectId);
-    const coins = await this.getObjectBatch(coinIds);
+  ): Promise<CoinStruct[]> {
+    const coins = await this.getCoins(address, typeArg);
     return (await Coin.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
-      coins,
+      coins.data,
       amount,
       exclude,
-    )) as GetObjectDataResponse[];
+    )) as CoinStruct[];
   }
 
   async getObjectsOwnedByObject(objectId: ObjectId): Promise<SuiObjectInfo[]> {

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -46,6 +46,7 @@ import {
   CheckpointDigest,
   CheckPointContentsDigest,
   CommitteeInfo,
+  CoinStruct,
 } from '../types';
 
 import { DynamicFieldPage } from '../types/dynamic_fields';
@@ -147,7 +148,7 @@ export abstract class Provider {
    */
   abstract getGasObjectsOwnedByAddress(
     _address: string,
-  ): Promise<SuiObjectInfo[]>;
+  ): Promise<CoinStruct[]>;
 
   /**
    * @deprecated The method should not be used
@@ -170,7 +171,7 @@ export abstract class Provider {
     amount: bigint,
     typeArg: string,
     exclude: ObjectId[],
-  ): Promise<GetObjectDataResponse[]>;
+  ): Promise<CoinStruct[]>;
 
   /**
    * Convenience method for select a minimal set of coin objects that has a balance greater than
@@ -187,7 +188,7 @@ export abstract class Provider {
     amount: bigint,
     typeArg: string,
     exclude: ObjectId[],
-  ): Promise<GetObjectDataResponse[]>;
+  ): Promise<CoinStruct[]>;
 
   /**
    * Get details about an object

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -146,9 +146,7 @@ export abstract class Provider {
   /**
    * Convenience method for getting all gas objects(SUI Tokens) owned by an address
    */
-  abstract getGasObjectsOwnedByAddress(
-    _address: string,
-  ): Promise<CoinStruct[]>;
+  abstract getGasObjectsOwnedByAddress(_address: string): Promise<CoinStruct[]>;
 
   /**
    * @deprecated The method should not be used

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -131,9 +131,7 @@ export class VoidProvider extends Provider {
     throw this.newError('getObjectsOwnedByAddress');
   }
 
-  async getGasObjectsOwnedByAddress(
-    _address: string,
-  ): Promise<CoinStruct[]> {
+  async getGasObjectsOwnedByAddress(_address: string): Promise<CoinStruct[]> {
     throw this.newError('getGasObjectsOwnedByAddress');
   }
 

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -47,6 +47,7 @@ import {
   CheckpointDigest,
   CheckPointContentsDigest,
   CommitteeInfo,
+  CoinStruct,
 } from '../types';
 import { Provider } from './provider';
 
@@ -132,7 +133,7 @@ export class VoidProvider extends Provider {
 
   async getGasObjectsOwnedByAddress(
     _address: string,
-  ): Promise<SuiObjectInfo[]> {
+  ): Promise<CoinStruct[]> {
     throw this.newError('getGasObjectsOwnedByAddress');
   }
 
@@ -151,7 +152,7 @@ export class VoidProvider extends Provider {
     _amount: bigint,
     _typeArg: string,
     _exclude: ObjectId[] = [],
-  ): Promise<GetObjectDataResponse[]> {
+  ): Promise<CoinStruct[]> {
     throw this.newError('selectCoinsWithBalanceGreaterThanOrEqual');
   }
 
@@ -160,7 +161,7 @@ export class VoidProvider extends Provider {
     _amount: bigint,
     _typeArg: string,
     _exclude: ObjectId[],
-  ): Promise<GetObjectDataResponse[]> {
+  ): Promise<CoinStruct[]> {
     throw this.newError('selectCoinSetWithCombinedBalanceGreaterThanOrEqual');
   }
 

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -287,7 +287,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
       exclude.concat(await this.extractObjectIds(txn)),
     );
 
-    return coins.length > 0 ? Coin.getID(coins[0]) : undefined;
+    return coins.length > 0 ? coins[0].coinObjectId : undefined;
   }
 
   /**

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -4,12 +4,11 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
   Coin,
-  getObjectId,
+  CoinStruct,
   LocalTxnDataSerializer,
   normalizeSuiObjectId,
   ObjectId,
   RawSigner,
-  SuiObjectInfo,
   SUI_TYPE_ARG,
 } from '../../src';
 
@@ -21,7 +20,7 @@ describe('Coin related API', () => {
   let toolbox: TestToolbox;
   let signer: RawSigner;
   let coinToSplit: ObjectId;
-  let coinsAfterSplit: SuiObjectInfo[];
+  let coinsAfterSplit: CoinStruct[];
 
   beforeAll(async () => {
     toolbox = await setup();
@@ -33,13 +32,13 @@ describe('Coin related API', () => {
     const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
       toolbox.address(),
     );
-    coinToSplit = coins[0].objectId;
+    coinToSplit = coins[0].coinObjectId;
     // split coins into desired amount
     await signer.splitCoin({
       coinObjectId: coinToSplit,
       splitAmounts: SPLIT_AMOUNTS.map((s) => Number(s)),
       gasBudget: DEFAULT_GAS_BUDGET,
-      gasPayment: coins[1].objectId,
+      gasPayment: coins[1].coinObjectId,
     });
     coinsAfterSplit = await toolbox.provider.getGasObjectsOwnedByAddress(
       toolbox.address(),
@@ -52,7 +51,6 @@ describe('Coin related API', () => {
       toolbox.address(),
     );
     coins.forEach((c) => {
-      expect(Coin.isCoin(c)).toBeTruthy();
       expect(Coin.isSUI(c)).toBeTruthy();
     });
   });
@@ -67,7 +65,7 @@ describe('Coin related API', () => {
     const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
       toolbox.address(),
     );
-    const coinTypeArg: string = Coin.getCoinTypeArg(coins[0])!;
+    const coinTypeArg: string = coins[0].coinType;
     expect(Coin.getCoinStructTag(coinTypeArg)).toStrictEqual(exampleStructTag);
   });
 
@@ -80,7 +78,7 @@ describe('Coin related API', () => {
             BigInt(a),
           );
         expect(coins.length).toEqual(coinsAfterSplit.length - i);
-        const balances = coins.map((c) => Coin.getBalance(c)!);
+        const balances = coins.map((c) => c.balance);
         // verify that the balances are in ascending order
         expect(balances).toStrictEqual(balances.sort());
         // verify that balances are all greater than or equal to the provided amount
@@ -95,7 +93,7 @@ describe('Coin related API', () => {
         toolbox.address(),
         BigInt(1),
       );
-    expect(coins.find((c) => getObjectId(c) === coinToSplit)).toBeDefined();
+    expect(coins.find((c) => c.coinObjectId === coinToSplit)).toBeDefined();
 
     const coinsWithExclude =
       await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
@@ -105,7 +103,7 @@ describe('Coin related API', () => {
         [coinToSplit],
       );
     expect(
-      coinsWithExclude.find((c) => getObjectId(c) === coinToSplit),
+      coinsWithExclude.find((c) => c.coinObjectId === coinToSplit),
     ).toBeUndefined();
   });
 
@@ -117,7 +115,7 @@ describe('Coin related API', () => {
             toolbox.address(),
             BigInt(a),
           );
-        const balances = coins.map((c) => Coin.getBalance(c)!);
+        const balances = coins.map((c) => BigInt(c.balance));
         expect(balances).toStrictEqual([SPLIT_AMOUNTS[i]]);
       }),
     );
@@ -127,14 +125,14 @@ describe('Coin related API', () => {
         toolbox.address(),
         BigInt(1),
       );
-    const largestBalance = Coin.getBalance(allCoins[allCoins.length - 1])!;
+    const largestBalance = BigInt(allCoins[allCoins.length - 1].balance);
 
     const coins =
       await toolbox.provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
         toolbox.address(),
         largestBalance + SPLIT_AMOUNTS[0],
       );
-    const balances = coins.map((c) => Coin.getBalance(c)!);
+    const balances = coins.map((c) => BigInt(c.balance));
     expect(balances).toStrictEqual([SPLIT_AMOUNTS[0], largestBalance]);
   });
 });

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -47,10 +47,10 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
         );
 
       const splitTxn = await signer.splitCoin({
-        coinObjectId: getObjectId(coins[0]),
+        coinObjectId: coins[0].coinObjectId,
         splitAmounts: [2000, 2000, 2000],
         gasBudget: gasBudget,
-        gasPayment: getObjectId(coins[1]),
+        gasPayment: coins[1].coinObjectId,
       });
       const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
         getObjectId(c),
@@ -80,7 +80,7 @@ describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
         module: 'serializer_tests',
         function: 'return_struct',
         typeArguments: ['0x2::coin::Coin<0x2::sui::SUI>'],
-        arguments: [coins[0].objectId],
+        arguments: [coins[0].coinObjectId],
         gasBudget: DEFAULT_GAS_BUDGET,
       };
 

--- a/sdk/typescript/test/e2e/event-subscription.test.ts
+++ b/sdk/typescript/test/e2e/event-subscription.test.ts
@@ -34,7 +34,7 @@ describe('Event Subscription API', () => {
     );
 
     await signer.payAllSui({
-      inputCoins: inputCoins.map((o) => o.objectId),
+      inputCoins: inputCoins.map((o) => o.coinObjectId),
       recipient: DEFAULT_RECIPIENT,
       gasBudget: DEFAULT_GAS_BUDGET,
     });

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -84,7 +84,7 @@ async function addDelegation(signer: RawSigner) {
 
   return await signer.signAndExecuteTransaction(
     await SuiSystemStateUtil.newRequestAddDelegationTxn(
-      [coins[0].objectId],
+      [coins[0].coinObjectId],
       BigInt(DEFAULT_STAKED_AMOUNT),
       validators[0].sui_address,
       DEFAULT_GAS_BUDGET,

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -3,7 +3,6 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
-  Coin,
   getCreatedObjects,
   getExecutionStatusType,
   LocalTxnDataSerializer,
@@ -73,7 +72,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
         toolbox.address(),
       );
-      const coinIDs = coins.map((coin) => Coin.getID(coin));
+      const coinIDs = coins.map((coin) => coin.coinObjectId);
       const txn = await signer.executeMoveCall({
         packageObjectId: SUI_FRAMEWORK_ADDRESS,
         module: 'pay',

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -26,7 +26,7 @@ describe('Object Reading API', () => {
     expect(gasObjects.length).to.greaterThan(0);
     const objectInfos = await Promise.all(
       gasObjects.map((gasObject) =>
-        toolbox.provider.getObject(gasObject['objectId']),
+        toolbox.provider.getObject(gasObject.coinObjectId),
       ),
     );
     objectInfos.forEach((objectInfo) =>

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -45,7 +45,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       await validateTransaction(signer, {
         kind: 'splitCoin',
         data: {
-          coinObjectId: coins[0].objectId,
+          coinObjectId: coins[0].coinObjectId,
           splitAmounts: [DEFAULT_GAS_BUDGET * 2],
           gasBudget: DEFAULT_GAS_BUDGET,
         },
@@ -59,8 +59,8 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       await validateTransaction(signer, {
         kind: 'mergeCoin',
         data: {
-          primaryCoin: coins[0].objectId,
-          coinToMerge: coins[1].objectId,
+          primaryCoin: coins[0].coinObjectId,
+          coinToMerge: coins[1].coinObjectId,
           gasBudget: DEFAULT_GAS_BUDGET,
         },
       });
@@ -83,7 +83,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
             'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
           ],
           gasBudget: DEFAULT_GAS_BUDGET,
-          gasPayment: coins[0].objectId,
+          gasPayment: coins[0].coinObjectId,
         },
       });
     });
@@ -108,11 +108,11 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
           typeArguments: [],
           arguments: [
             SUI_SYSTEM_STATE_OBJECT_ID,
-            coins[2].objectId,
+            coins[2].coinObjectId,
             validator_address,
           ],
           gasBudget: DEFAULT_GAS_BUDGET,
-          gasPayment: coins[3].objectId,
+          gasPayment: coins[3].coinObjectId,
         },
       });
     });
@@ -124,7 +124,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       await validateTransaction(signer, {
         kind: 'transferSui',
         data: {
-          suiObjectId: coins[0].objectId,
+          suiObjectId: coins[0].coinObjectId,
           gasBudget: DEFAULT_GAS_BUDGET,
           recipient: DEFAULT_RECIPIENT,
           amount: 100,
@@ -139,10 +139,10 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       await validateTransaction(signer, {
         kind: 'transferObject',
         data: {
-          objectId: coins[0].objectId,
+          objectId: coins[0].coinObjectId,
           gasBudget: DEFAULT_GAS_BUDGET,
           recipient: DEFAULT_RECIPIENT,
-          gasPayment: coins[1].objectId,
+          gasPayment: coins[1].coinObjectId,
         },
       });
     });
@@ -156,10 +156,10 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
 
       // get some new coins with small amount
       const splitTxn = await signer.splitCoin({
-        coinObjectId: getObjectId(coins[0]),
+        coinObjectId: coins[0].coinObjectId,
         splitAmounts: [1, 2, 3],
         gasBudget: DEFAULT_GAS_BUDGET,
-        gasPayment: getObjectId(coins[1]),
+        gasPayment: coins[1].coinObjectId,
       });
       const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
         getObjectId(c),
@@ -173,7 +173,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
           gasBudget: DEFAULT_GAS_BUDGET,
           recipients: [DEFAULT_RECIPIENT, DEFAULT_RECIPIENT_2],
           amounts: [4, 2],
-          gasPayment: getObjectId(coins[2]),
+          gasPayment: coins[2].coinObjectId,
         },
       });
     });
@@ -187,10 +187,10 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
         );
 
       const splitTxn = await signer.splitCoin({
-        coinObjectId: getObjectId(coins[0]),
+        coinObjectId: coins[0].coinObjectId,
         splitAmounts: [2000, 2000, 2000],
         gasBudget: gasBudget,
-        gasPayment: getObjectId(coins[1]),
+        gasPayment: coins[1].coinObjectId,
       });
       const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
         getObjectId(c),
@@ -216,10 +216,10 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
         );
 
       const splitTxn = await signer.splitCoin({
-        coinObjectId: getObjectId(coins[0]),
+        coinObjectId: coins[0].coinObjectId,
         splitAmounts: [2000, 2000, 2000],
         gasBudget: gasBudget,
-        gasPayment: getObjectId(coins[1]),
+        gasPayment: coins[1].coinObjectId,
       });
       const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
         getObjectId(c),

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -95,7 +95,7 @@ describe('Transaction Serialization and deserialization', () => {
         'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
       ],
       gasBudget: DEFAULT_GAS_BUDGET,
-      gasPayment: coins[0].objectId,
+      gasPayment: coins[0].coinObjectId,
     };
 
     const deserialized = await serializeAndDeserialize(moveCall);
@@ -111,7 +111,7 @@ describe('Transaction Serialization and deserialization', () => {
       module: 'serializer_tests',
       function: 'list',
       typeArguments: ['0x2::coin::Coin<0x2::sui::SUI>', '0x2::sui::SUI'],
-      arguments: [coins[0].objectId],
+      arguments: [coins[0].coinObjectId],
       gasBudget: DEFAULT_GAS_BUDGET,
     };
     await serializeAndDeserialize(moveCall);
@@ -134,11 +134,11 @@ describe('Transaction Serialization and deserialization', () => {
       typeArguments: [],
       arguments: [
         SUI_SYSTEM_STATE_OBJECT_ID,
-        coins[2].objectId,
+        coins[2].coinObjectId,
         validator_address,
       ],
       gasBudget: DEFAULT_GAS_BUDGET,
-      gasPayment: coins[3].objectId,
+      gasPayment: coins[3].coinObjectId,
     };
 
     const deserialized = await serializeAndDeserialize(moveCall);
@@ -164,7 +164,7 @@ describe('Transaction Serialization and deserialization', () => {
         'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
       ],
       gasBudget: DEFAULT_GAS_BUDGET,
-      gasPayment: coins[0].objectId,
+      gasPayment: coins[0].coinObjectId,
     } as MoveCallTransaction;
     const serArgsExpected = await new CallArgSerializer(
       toolbox.provider,
@@ -185,7 +185,7 @@ describe('Transaction Serialization and deserialization', () => {
         'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
       ],
       gasBudget: DEFAULT_GAS_BUDGET,
-      gasPayment: coins[0].objectId,
+      gasPayment: coins[0].coinObjectId,
     } as MoveCallTransaction;
     const serArgs = await new CallArgSerializer(
       toolbox.provider,


### PR DESCRIPTION
 - This PR modifies getGasObjectsOwnedByAddress, selectCoinsWithBalanceGreaterThanOrEqual and selectCoinSetWithCombinedBalanceGreaterThanOrEqual method to use getCoins() instead of getObjectsOwnedByAddress(). 
 - This also changes the return Promise to be Promise<CoinStruct> instead of Promise<GetObjectDataResponse>.
 - The reason behind the change is that there is no need to get huge responses with all the objects of an address and then filter them out to get the coins. With CoinRead Api methods we get smaller responses with just the required objects. Moreover it makes more sense to return a CoinStruct when requesting coins instead of getting the whole GetObjectDataResponse.

I have currently modified the TypeScript SDK. There are changes that need to be made in explorer and wallet in order for this to work correctly. If you find value in this PR I can further work on making explorer and wallet work with the new changes. 