### PR TITLE
fallback to broken nft image links

### DIFF
--- a/apps/wallet/src/ui/app/components/nft-display/NftImage.tsx
+++ b/apps/wallet/src/ui/app/components/nft-display/NftImage.tsx
@@ -68,9 +68,7 @@ export function NftImage({
         'w-full h-full object-cover',
         animateHover && 'group-hover:scale-110 duration-500 ease-ease-out-cubic'
     );
-    const imgSrc = src
-        ? src.replace(/^ipfs:\/\//, 'https://ipfs.io/ipfs/')
-        : '';
+
     return (
         <div
             className={nftImageStyles({
@@ -99,7 +97,7 @@ export function NftImage({
             ) : (
                 <img
                     className={imgCls}
-                    src={imgSrc}
+                    src={src?.replace(/^ipfs:\/\//, 'https://ipfs.io/ipfs/')}
                     alt={name || 'NFT'}
                     title={title}
                     onError={() => setError(true)}

--- a/apps/wallet/src/ui/app/components/nft-display/NftImage.tsx
+++ b/apps/wallet/src/ui/app/components/nft-display/NftImage.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Image32 } from '@mysten/icons';
 import { cva } from 'class-variance-authority';
 import cl from 'classnames';
-
-import Icon, { SuiIcons } from '../icon';
+import { useState } from 'react';
 
 import type { VariantProps } from 'class-variance-authority';
 
@@ -27,6 +27,10 @@ const nftImageStyles = cva('overflow-hidden', {
             md: 'w-36 h-36',
             lg: 'w-44 h-44',
         },
+        backgroundColor: {
+            'gray-40': 'bg-gray-40',
+            'placeholder-gradient-01': 'bg-placeholderGradient01',
+        },
     },
     compoundVariants: [
         {
@@ -37,6 +41,7 @@ const nftImageStyles = cva('overflow-hidden', {
     ],
     defaultVariants: {
         borderRadius: 'md',
+        backgroundColor: 'placeholder-gradient-01',
     },
 });
 
@@ -56,36 +61,49 @@ export function NftImage({
     animateHover,
     borderRadius,
     size,
+    backgroundColor,
 }: NftImageProps) {
+    const [error, setError] = useState(false);
     const imgCls = cl(
         'w-full h-full object-cover',
         animateHover && 'group-hover:scale-110 duration-500 ease-ease-out-cubic'
     );
+    const imgSrc = src
+        ? src.replace(/^ipfs:\/\//, 'https://ipfs.io/ipfs/')
+        : '';
     return (
-        <div className={nftImageStyles({ animateHover, borderRadius, size })}>
-            {src ? (
-                <img
-                    className={imgCls}
-                    src={src.replace(/^ipfs:\/\//, 'https://ipfs.io/ipfs/')}
-                    alt={name || 'NFT'}
-                    title={title}
-                />
-            ) : (
+        <div
+            className={nftImageStyles({
+                animateHover,
+                borderRadius,
+                size,
+                backgroundColor,
+            })}
+        >
+            {error ? (
                 <div
                     className={cl(
                         imgCls,
                         'flex flex-col flex-nowrap items-center justify-center',
-                        'select-none uppercase text-steel-dark bg-placeholderGradient01 gap-2'
+                        'select-none uppercase text-steel-dark gap-2'
                     )}
                     title={title}
                 >
-                    <Icon className="text-xl" icon={SuiIcons.NftTypeImage} />
+                    <Image32 className="text-steel text-3xl" />
                     {showLabel ? (
                         <span className="text-captionSmall font-medium">
                             No media
                         </span>
                     ) : null}
                 </div>
+            ) : (
+                <img
+                    className={imgCls}
+                    src={imgSrc}
+                    alt={name || 'NFT'}
+                    title={title}
+                    onError={() => setError(true)}
+                />
             )}
         </div>
     );

--- a/apps/wallet/src/ui/app/components/nft-display/NftImage.tsx
+++ b/apps/wallet/src/ui/app/components/nft-display/NftImage.tsx
@@ -68,7 +68,9 @@ export function NftImage({
         'w-full h-full object-cover',
         animateHover && 'group-hover:scale-110 duration-500 ease-ease-out-cubic'
     );
-
+    const imgSrc = src
+        ? src.replace(/^ipfs:\/\//, 'https://ipfs.io/ipfs/')
+        : '';
     return (
         <div
             className={nftImageStyles({
@@ -97,7 +99,7 @@ export function NftImage({
             ) : (
                 <img
                     className={imgCls}
-                    src={src?.replace(/^ipfs:\/\//, 'https://ipfs.io/ipfs/')}
+                    src={imgSrc}
                     alt={name || 'NFT'}
                     title={title}
                     onError={() => setError(true)}

--- a/apps/wallet/src/ui/app/components/transactions-card/TxnIcon.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/TxnIcon.tsx
@@ -59,7 +59,7 @@ export function TxnIcon({ txnFailed, variant }: TxnItemIconProps) {
     return (
         <div
             className={cl([
-                txnFailed ? 'bg-issue-light' : 'bg-gray-45',
+                txnFailed ? 'bg-issue-light' : 'bg-gray-40',
                 'w-7.5 h-7.5 flex justify-center items-center rounded-2lg',
             ])}
         >

--- a/apps/wallet/src/ui/app/components/transactions-card/TxnImage.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/TxnImage.tsx
@@ -23,6 +23,7 @@ export function TxnImage({ id, label }: { id: string; label?: string }) {
                     size="xs"
                     name={nftMeta.name}
                     src={nftMeta.url}
+                    backgroundColor="gray-40"
                 />
 
                 <div className="flex flex-col gap-1 justify-center break-all w-56">


### PR DESCRIPTION
- Added a fallback icon for broken NFT images
- Update the background icon color on the activities feed.

<img width="411" alt="Screenshot 2023-02-08 at 7 39 27 AM" src="https://user-images.githubusercontent.com/8676844/217533676-5fa24ea3-39f4-44fe-aacb-15885dfd504e.png">
<img width="394" alt="Screenshot 2023-02-08 at 7 39 44 AM" src="https://user-images.githubusercontent.com/8676844/217533703-7530608e-5984-401c-b5eb-6d597dea5198.png">
