### PR TITLE
add shared object locking costs

### DIFF
--- a/crates/sui-protocol-constants/src/lib.rs
+++ b/crates/sui-protocol-constants/src/lib.rs
@@ -93,6 +93,14 @@ pub const OBJ_ACCESS_COST_DELETE_PER_BYTE: u64 = 40;
 // entire object, just consulting an ID -> tx digest map
 pub const OBJ_ACCESS_COST_VERIFY_PER_BYTE: u64 = 200;
 
+/// Per object cost to lock shared objects in mutable mode
+/// TODO: change from 0 cost once we decide what's reasonable
+pub const SHARED_OBJ_LOCK_COST_MUTABLE: u64 = 0;
+
+/// Per object cost to lock shared objects in immutable mode
+/// TODO: change from 0 cost once we decide what's reasonable
+pub const SHARED_OBJ_LOCK_COST_IMMUTABLE: u64 = 0;
+
 /// === Storage gas costs ===
 
 /// Per-byte cost of storing an object in the Sui global object store. Some of this cost may be refundable if the object is later freed

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -346,16 +346,9 @@ impl SingleTransactionKind {
     /// Returns a tuple of (# mutable, # immutable) shared input objects
     /// Currently used to charge for the RW Locks
     pub fn shared_input_objects_counts(&self) -> (usize, usize) {
-        let (mut mutable_count, mut immutable_count) = (0, 0);
-
-        for s in self.shared_input_objects() {
-            if s.mutable {
-                mutable_count += 1;
-            } else {
-                immutable_count += 1;
-            }
-        }
-        (mutable_count, immutable_count)
+        let (mutable, immutable): (Vec<_>, Vec<_>) =
+            self.shared_input_objects().partition(|s| s.mutable);
+        (mutable.len(), immutable.len())
     }
 
     pub fn shared_input_objects(&self) -> impl Iterator<Item = SharedInputObject> + '_ {


### PR DESCRIPTION
Add costs for read and write shared object locks.
Currently they're set to 0.
@andll will give feedback on reasonable values.

Todo:
1. Figure out reasonable nonzero costs
2. Add tests