### PR TITLE
Fix of a terrible leaderboard overflow

### DIFF
--- a/sui_programmability/examples/frenemies/sources/leaderboard.move
+++ b/sui_programmability/examples/frenemies/sources/leaderboard.move
@@ -171,7 +171,7 @@ module frenemies::leaderboard {
     // - if there is such an entry, new_score.score > v[_].score. this is because we only call `score_insertion_sort` when the player's score increases
     fun score_insertion_sort(v: &mut vector<Score>, new_score: Score) {
         let len = vector::length(v);
-        let at_capacity = len == LEADERBOARD_SIZE;
+        let at_capacity = len == LEADERBOARD_SIZE || len > LEADERBOARD_SIZE;
         let new_high_score = len == 0 || gt(&new_score, vector::borrow(v, len - 1));
         if (!new_high_score) {
             if (!at_capacity) {

--- a/sui_programmability/examples/frenemies/sources/leaderboard.move
+++ b/sui_programmability/examples/frenemies/sources/leaderboard.move
@@ -197,7 +197,8 @@ module frenemies::leaderboard {
             };
         };
         // new top score!
-        vector::insert(v, new_score, 0)
+        vector::insert(v, new_score, 0);
+        vector::pop_back(v)
     }
 
     fun gt(s1: &Score, s2: &Score): bool {


### PR DESCRIPTION
As we know most of frenemies update transactions started to fail at some point. Saying "MoveObjectTooBig { object_size: 256012, max_object_size: 256000 }"

I've got a hypothesis that
when there already were 2000 in score vector. New top score suddenly came. So, nothing was popped in while loop. 

The last line was triggered.
 vector::insert(v, new_score, 0) just added a new 2001 element and then everything went wrong.

The assertion at_capacity no longer held. Where at_capacity = len == LEADERBOARD_SIZE;

So each time new score was added. 
Because of 
if (!at_capacity) {                vector::push_back(v,new_score)
 };
Soon it resulted in a terrible overflow.