### PR TITLE
remove unsed Move type in events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,7 +1346,7 @@ checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -305,7 +305,7 @@ fn execute_internal<
         .map_err(|e| convert_vm_error(e, vm, state_view))?;
     let user_events = user_events
         .into_iter()
-        .map(|(_ty, tag, value)| {
+        .map(|(tag, value)| {
             let layout = session.get_type_layout(&TypeTag::Struct(Box::new(tag.clone())))?;
             let bytes = value.simple_serialize(&layout).unwrap();
             Ok((tag, bytes))

--- a/crates/sui-framework/src/natives/event.rs
+++ b/crates/sui-framework/src/natives/event.rs
@@ -36,6 +36,6 @@ pub fn emit(
     };
 
     let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
-    obj_runtime.emit_event(ty, *tag, event)?;
+    obj_runtime.emit_event(*tag, event)?;
     Ok(NativeResult::ok(cost, smallvec![]))
 }

--- a/crates/sui-framework/src/natives/object_runtime/mod.rs
+++ b/crates/sui-framework/src/natives/object_runtime/mod.rs
@@ -59,7 +59,7 @@ pub(crate) struct TestInventories {
 pub struct RuntimeResults {
     pub writes: LinkedHashMap<ObjectID, (WriteKind, Owner, Type, StructTag, Value)>,
     pub deletions: LinkedHashMap<ObjectID, DeleteKind>,
-    pub user_events: Vec<(Type, StructTag, Value)>,
+    pub user_events: Vec<(StructTag, Value)>,
     // loaded child objects and their versions
     pub loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
 }
@@ -74,7 +74,7 @@ pub(crate) struct ObjectRuntimeState {
     // transfers to a new owner (shared, immutable, object, or account address)
     // TODO these struct tags can be removed if type_to_type_tag was exposed in the session
     transfers: LinkedHashMap<ObjectID, (Owner, Type, StructTag, Value)>,
-    events: Vec<(Type, StructTag, Value)>,
+    events: Vec<(StructTag, Value)>,
 }
 
 #[derive(Tid)]
@@ -207,7 +207,7 @@ impl<'a> ObjectRuntime<'a> {
         Ok(transfer_result)
     }
 
-    pub fn emit_event(&mut self, ty: Type, tag: StructTag, event: Value) -> PartialVMResult<()> {
+    pub fn emit_event(&mut self, tag: StructTag, event: Value) -> PartialVMResult<()> {
         if self.state.events.len() == (MAX_NUM_EVENT_EMIT as usize) {
             return Err(PartialVMError::new(StatusCode::MEMORY_LIMIT_EXCEEDED)
                 .with_message(format!(
@@ -217,7 +217,7 @@ impl<'a> ObjectRuntime<'a> {
                     VMMemoryLimitExceededSubStatusCode::EVENT_COUNT_LIMIT_EXCEEDED as u64,
                 ));
         }
-        self.state.events.push((ty, tag, event));
+        self.state.events.push((tag, event));
         Ok(())
     }
 


### PR DESCRIPTION
This removes unused Move Type in user events. Which should reduce the resource footprint.