### PR TITLE
Handle frenemies dead round update calling cheaters

### DIFF
--- a/sui_programmability/examples/new-frenemies/sources/frenemies.move
+++ b/sui_programmability/examples/new-frenemies/sources/frenemies.move
@@ -82,7 +82,9 @@ module frenemies::frenemies {
         let old_name = sui::bcs::peel_vec_u8(&mut name_bcs);
         string::utf8(old_name)
     }
-
+    
+    const ECheatedDuringDownTime: u64 = 1337;
+    
     public entry fun migrate(old_scorecard: &old_frenemies::frenemies::Scorecard, migration: &mut Migration, ctx: &mut TxContext) {
         let old_assignment = old_frenemies::frenemies::assignment(old_scorecard);
         let assignment = assignment::new_for_testing(
@@ -97,6 +99,9 @@ module frenemies::frenemies {
         let name = registry::name_for_testing(old_name);
 
         let score = old_frenemies::frenemies::score(old_scorecard);
+        let old_epoch = old_frenemies::frenemies::epoch(old_scorecard);
+        assert!( old_epoch < 23, ECheatedDuringDownTime);
+
         let epoch = tx_context::epoch(ctx);
         let participation = old_frenemies::frenemies::participation(old_scorecard);
 


### PR DESCRIPTION
[Update 2: A curious thing. Probably
let at_capacity = len == LEADERBOARD_SIZE this strict equality which broke after the moment of overflow. Kept pushing new values instead of replacing. Which was 100% impossible due to overflow. So this line kind of protected against replacement during down time. And cheating!. Please, correct if it's wrong as well:)
]

[Update now I realize I was super wrong and looking through those dead time update transactions. All were just zero score change. Which did not trigger the leaderboard update at all. 
Just do not read further it's all wrong. There were no cheaters. But I'll save it for the history. ]

There is a very peculiar issue with the migration. Really weird one. 

Look at the transactions. https://explorer.sui.io/object/0x7c901b42a5ffcd22e057e66e42b7c25002b44f4e An account cheated by calling update via RPC during frenemies downtime. 73 scores a huge advantage! They could do it probably because their name string is shorter or equal to replaced. So, it didn't cause overflow.

Sorry, I'm from the phone and did not test it. But, the issue seems to be real and dangerous and needs to be fixed. Probably you would not do it so radically like I did, just stopping the person from getting any more scores. 

Perhaps you would just prefer to subtract the unfair advantage, gained during dead round, which might be huge. It might be life or death situation where someone gets pushed out of 2000 by a cheater.