### PR TITLE
Increase concurrent checkpoint execution to 200

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -239,7 +239,7 @@ impl ConsensusConfig {
 pub struct CheckpointExecutorConfig {
     /// Upper bound on the number of checkpoints that can be concurrently executed
     ///
-    /// If unspecified, this will default to `100`
+    /// If unspecified, this will default to `200`
     #[serde(default = "default_checkpoint_execution_max_concurrency")]
     pub checkpoint_execution_max_concurrency: usize,
 
@@ -253,7 +253,7 @@ pub struct CheckpointExecutorConfig {
 }
 
 fn default_checkpoint_execution_max_concurrency() -> usize {
-    100
+    200
 }
 
 fn default_local_execution_timeout_sec() -> u64 {

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -69,7 +69,7 @@ validator_configs:
       epoch-db-pruning-period-secs: 3600
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 100
+      checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
@@ -137,7 +137,7 @@ validator_configs:
       epoch-db-pruning-period-secs: 3600
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 100
+      checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
@@ -205,7 +205,7 @@ validator_configs:
       epoch-db-pruning-period-secs: 3600
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 100
+      checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
@@ -273,7 +273,7 @@ validator_configs:
       epoch-db-pruning-period-secs: 3600
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 100
+      checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
@@ -341,7 +341,7 @@ validator_configs:
       epoch-db-pruning-period-secs: 3600
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 100
+      checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
@@ -409,7 +409,7 @@ validator_configs:
       epoch-db-pruning-period-secs: 3600
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 100
+      checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
@@ -477,7 +477,7 @@ validator_configs:
       epoch-db-pruning-period-secs: 3600
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 100
+      checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
 account_keys:
   - 10wECHkYvXqL5/CY6WhjbfFPotZb5tjEbpmumqbRxuk=


### PR DESCRIPTION
It seems sometimes not enough transactions are fed into transaction manager concurrently.