### PR TITLE
[wallet-standard][wallet-ext][ts-sdk] Sign transaction

### DIFF
--- a/apps/wallet/src/background/Transactions.ts
+++ b/apps/wallet/src/background/Transactions.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { type SuiSignTransactionInput } from '@mysten/wallet-standard';
 import { filter, lastValueFrom, map, race, Subject, take } from 'rxjs';
 import { v4 as uuidV4 } from 'uuid';
 import Browser from 'webextension-polyfill';
@@ -23,6 +24,48 @@ function openTxWindow(txRequestID: string) {
 
 class Transactions {
     private _txResponseMessages = new Subject<TransactionRequestResponse>();
+
+    async signTransaction(
+        input: SuiSignTransactionInput,
+        connection: ContentScriptConnection
+    ) {
+        const txRequest = this.createTransactionRequest(
+            { type: 'v2', justSign: true, data: input.transaction },
+            connection.origin,
+            connection.originFavIcon
+        );
+        await this.storeTransactionRequest(txRequest);
+        const popUp = openTxWindow(txRequest.id);
+        const popUpClose = (await popUp.show()).pipe(
+            take(1),
+            map<number, false>(() => false)
+        );
+        const txResponseMessage = this._txResponseMessages.pipe(
+            filter((msg) => msg.txID === txRequest.id),
+            take(1)
+        );
+        return lastValueFrom(
+            race(popUpClose, txResponseMessage).pipe(
+                take(1),
+                map(async (response) => {
+                    if (response) {
+                        const { approved, txSigned } = response;
+                        if (approved) {
+                            txRequest.approved = approved;
+                            txRequest.txSigned = txSigned;
+                            if (!txSigned) {
+                                throw new Error('Missing signed TX');
+                            }
+                            await this.storeTransactionRequest(txRequest);
+                            return txSigned;
+                        }
+                    }
+                    await this.removeTransactionRequest(txRequest.id);
+                    throw new Error('Transaction rejected from user');
+                })
+            )
+        );
+    }
 
     public async executeTransaction(
         tx: TransactionDataType,

--- a/apps/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
@@ -15,6 +15,8 @@ export type PayloadType =
     | 'acquire-permissions-response'
     | 'execute-transaction-request'
     | 'execute-transaction-response'
+    | 'sign-transaction-request'
+    | 'sign-transaction-response'
     | 'get-transaction-requests'
     | 'get-transaction-requests-response'
     | 'transaction-request-response'

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type SuiSignAndExecuteTransactionOptions } from '@mysten/wallet-standard';
+import {
+    type SuiSignAndExecuteTransactionOptions,
+    type SuiSignTransactionInput,
+} from '@mysten/wallet-standard';
 
 import { isBasePayload } from '_payloads';
 
@@ -12,6 +15,7 @@ export type TransactionDataType =
     | {
           type: 'v2';
           data: SignableTransaction;
+          justSign?: boolean;
           options?: SuiSignAndExecuteTransactionOptions;
       }
     | { type: 'move-call'; data: MoveCallTransaction }
@@ -20,6 +24,19 @@ export type TransactionDataType =
 export interface ExecuteTransactionRequest extends BasePayload {
     type: 'execute-transaction-request';
     transaction: TransactionDataType;
+}
+
+export interface SignTransactionRequest extends BasePayload {
+    type: 'sign-transaction-request';
+    transaction: SuiSignTransactionInput;
+}
+
+export function isSignTransactionRequest(
+    payload: Payload
+): payload is SignTransactionRequest {
+    return (
+        isBasePayload(payload) && payload.type === 'sign-transaction-request'
+    );
 }
 
 export function isExecuteTransactionRequest(

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionResponse.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionResponse.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { type SuiSignTransactionOutput } from '@mysten/wallet-standard';
+
 import { isBasePayload } from '_payloads';
 
 import type { SuiTransactionResponse } from '@mysten/sui.js';
@@ -17,5 +19,18 @@ export function isExecuteTransactionResponse(
     return (
         isBasePayload(payload) &&
         payload.type === 'execute-transaction-response'
+    );
+}
+
+export interface SignTransactionResponse extends BasePayload {
+    type: 'sign-transaction-response';
+    result: SuiSignTransactionOutput;
+}
+
+export function isSignTransactionResponse(
+    payload: Payload
+): payload is SignTransactionResponse {
+    return (
+        isBasePayload(payload) && payload.type === 'sign-transaction-response'
     );
 }

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/TransactionRequest.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/TransactionRequest.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
+    SignedTransaction,
     SuiMoveNormalizedFunction,
     SuiTransactionResponse,
     UnserializedSignableTransaction,
@@ -15,6 +16,7 @@ export type TransactionRequest = {
     originFavIcon?: string;
     txResult?: SuiTransactionResponse;
     txResultError?: string;
+    txSigned?: SignedTransaction;
     metadata?: SuiMoveNormalizedFunction;
     createdDate: string;
     tx: TransactionDataType;

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ui/TransactionRequestResponse.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ui/TransactionRequestResponse.ts
@@ -3,7 +3,7 @@
 
 import { isBasePayload } from '_payloads';
 
-import type { SuiTransactionResponse } from '@mysten/sui.js';
+import type { SignedTransaction, SuiTransactionResponse } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 
 export interface TransactionRequestResponse extends BasePayload {
@@ -12,6 +12,7 @@ export interface TransactionRequestResponse extends BasePayload {
     approved: boolean;
     txResult?: SuiTransactionResponse;
     tsResultError?: string;
+    txSigned?: SignedTransaction;
 }
 
 export function isTransactionRequestResponse(

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Base64DataBuffer, publicKeyFromSerialized } from '@mysten/sui.js';
+import {
+    Base64DataBuffer,
+    publicKeyFromSerialized,
+    SignedTransaction,
+} from '@mysten/sui.js';
 import { lastValueFrom, map, take } from 'rxjs';
 
 import { growthbook } from '../experimentation/feature-gating';
@@ -96,7 +100,8 @@ export class BackgroundClient {
         txID: string,
         approved: boolean,
         txResult: SuiTransactionResponse | undefined,
-        tsResultError: string | undefined
+        tsResultError: string | undefined,
+        txSigned: SignedTransaction | undefined
     ) {
         this.sendMessage(
             createMessage<TransactionRequestResponse>({
@@ -105,6 +110,7 @@ export class BackgroundClient {
                 txID,
                 txResult,
                 tsResultError,
+                txSigned,
             })
         );
     }

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -6,6 +6,7 @@ import {
     getCertifiedTransaction,
     getTransactionEffects,
     LocalTxnDataSerializer,
+    type SignedTransaction,
 } from '@mysten/sui.js';
 import {
     createAsyncThunk,
@@ -127,6 +128,7 @@ export const respondToTransactionRequest = createAsyncThunk<
         txRequestID: string;
         approved: boolean;
         txResponse: SuiTransactionResponse | null;
+        txSigned: SignedTransaction | null;
     },
     { txRequestID: string; approved: boolean },
     AppThunkConfig
@@ -145,47 +147,54 @@ export const respondToTransactionRequest = createAsyncThunk<
         if (!txRequest) {
             throw new Error(`TransactionRequest ${txRequestID} not found`);
         }
+        let txSigned: SignedTransaction | undefined = undefined;
         let txResult: SuiTransactionResponse | undefined = undefined;
         let tsResultError: string | undefined;
         if (approved) {
             const signer = api.getSignerInstance(activeAddress, background);
             try {
-                let response: SuiExecuteTransactionResponse;
-                if (
-                    txRequest.tx.type === 'v2' ||
-                    txRequest.tx.type === 'move-call'
-                ) {
-                    const txn: SignableTransaction =
-                        txRequest.tx.type === 'move-call'
-                            ? {
-                                  kind: 'moveCall',
-                                  data: txRequest.tx.data,
-                              }
-                            : txRequest.tx.data;
-
-                    response = await signer.signAndExecuteTransaction(
-                        txn,
-                        txRequest.tx.type === 'v2'
-                            ? txRequest.tx.options?.requestType
-                            : undefined
-                    );
-                } else if (txRequest.tx.type === 'serialized-move-call') {
-                    const txBytes = new Base64DataBuffer(txRequest.tx.data);
-                    response = await signer.signAndExecuteTransaction(txBytes);
+                if (txRequest.tx.type === 'v2' && txRequest.tx.justSign) {
+                    // TODO: Try / catch
+                    // Just a signing request, do not submit
+                    txSigned = await signer.signTransaction(txRequest.tx.data);
                 } else {
-                    throw new Error(
-                        `Either tx or txBytes needs to be defined.`
-                    );
-                }
+                    let response: SuiExecuteTransactionResponse;
+                    if (
+                        txRequest.tx.type === 'v2' ||
+                        txRequest.tx.type === 'move-call'
+                    ) {
+                        const txn: SignableTransaction =
+                            txRequest.tx.type === 'move-call'
+                                ? {
+                                      kind: 'moveCall',
+                                      data: txRequest.tx.data,
+                                  }
+                                : txRequest.tx.data;
 
-                txResult = {
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    certificate: getCertifiedTransaction(response)!,
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    effects: getTransactionEffects(response)!,
-                    timestamp_ms: null,
-                    parsed_data: null,
-                };
+                        response = await signer.signAndExecuteTransaction(
+                            txn,
+                            txRequest.tx.type === 'v2'
+                                ? txRequest.tx.options?.requestType
+                                : undefined
+                        );
+                    } else if (txRequest.tx.type === 'serialized-move-call') {
+                        const txBytes = new Base64DataBuffer(txRequest.tx.data);
+                        response = await signer.signAndExecuteTransaction(
+                            txBytes
+                        );
+                    } else {
+                        throw new Error(
+                            `Either tx or txBytes needs to be defined.`
+                        );
+                    }
+
+                    txResult = {
+                        certificate: getCertifiedTransaction(response)!,
+                        effects: getTransactionEffects(response)!,
+                        timestamp_ms: null,
+                        parsed_data: null,
+                    };
+                }
             } catch (e) {
                 tsResultError = (e as Error).message;
             }
@@ -194,9 +203,15 @@ export const respondToTransactionRequest = createAsyncThunk<
             txRequestID,
             approved,
             txResult,
-            tsResultError
+            tsResultError,
+            txSigned
         );
-        return { txRequestID, approved: approved, txResponse: null };
+        return {
+            txRequestID,
+            approved: approved,
+            txResponse: null,
+            txSigned: null,
+        };
     }
 );
 
@@ -251,12 +266,18 @@ const slice = createSlice({
         build.addCase(
             respondToTransactionRequest.fulfilled,
             (state, { payload }) => {
-                const { txRequestID, approved: allowed, txResponse } = payload;
+                const {
+                    txRequestID,
+                    approved: allowed,
+                    txResponse,
+                    txSigned,
+                } = payload;
                 txRequestsAdapter.updateOne(state, {
                     id: txRequestID,
                     changes: {
                         approved: allowed,
                         txResult: txResponse || undefined,
+                        txSigned: txSigned || undefined,
                     },
                 });
             }

--- a/sdk/typescript/src/signers/signer.ts
+++ b/sdk/typescript/src/signers/signer.ts
@@ -7,6 +7,7 @@ import { Base64DataBuffer } from '../serialization/base64';
 ///////////////////////////////
 // Exported Types
 
+// TODO: Make a version of this that is easily serialized:
 /**
  * Pair of signature and corresponding public key
  */

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -9,6 +9,7 @@ import {
   SuiJsonValue,
   TypeTag,
 } from '../../types';
+import { SignaturePubkeyPair } from '../signer';
 
 ///////////////////////////////
 // Exported Types
@@ -106,6 +107,11 @@ export interface RawMoveCall {
   function: string;
   typeArguments: string[];
   arguments: SuiJsonValue[];
+}
+
+export interface SignedTransaction {
+  transactionBytes: Base64DataBuffer;
+  signature: SignaturePubkeyPair;
 }
 
 export type UnserializedSignableTransaction =

--- a/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
+++ b/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
@@ -4,6 +4,8 @@
 import {
   ExecuteTransactionRequestType,
   SignableTransaction,
+  SignaturePubkeyPair,
+  SignedTransaction,
   SuiAddress,
   SuiTransactionResponse,
 } from "@mysten/sui.js";
@@ -26,6 +28,9 @@ export interface WalletAdapter {
     event: E,
     callback: WalletAdapterEvents[E]
   ) => () => void;
+  signTransaction(
+    transaction: SignableTransaction
+  ): Promise<{ transactionBytes: string; signature: SignaturePubkeyPair }>;
   /**
    * Suggest a transaction for the user to sign. Supports all valid transaction types.
    */

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -49,6 +49,15 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
     return [this.#keypair.getPublicKey().toSuiAddress()];
   }
 
+  async signTransaction(transaction: SignableTransaction) {
+    const response = await this.#signer.signTransaction(transaction);
+
+    return {
+      transactionBytes: response.transactionBytes.toString(),
+      signature: response.signature,
+    };
+  }
+
   async signAndExecuteTransaction(
     transaction: SignableTransaction,
     options?: { requestType?: ExecuteTransactionRequestType }

--- a/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
+++ b/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
@@ -89,6 +89,12 @@ export class StandardWalletAdapter implements WalletAdapter {
     }
   }
 
+  async signTransaction(transaction: SignableTransaction) {
+    return this.#wallet.features["sui:signTransaction"].signTransaction({
+      transaction,
+    });
+  }
+
   async signAndExecuteTransaction(
     transaction: SignableTransaction,
     options?: { requestType?: ExecuteTransactionRequestType }

--- a/sdk/wallet-adapter/example/src/App.tsx
+++ b/sdk/wallet-adapter/example/src/App.tsx
@@ -6,7 +6,7 @@ import { ConnectButton, useWalletKit } from "@mysten/wallet-kit";
 import { useEffect } from "react";
 
 function App() {
-  const { currentWallet } = useWalletKit();
+  const { currentWallet, signTransaction } = useWalletKit();
 
   useEffect(() => {
     // You can do something with `currentWallet` here.
@@ -15,6 +15,25 @@ function App() {
   return (
     <div className="App">
       <ConnectButton />
+      <button
+        onClick={async () => {
+          console.log(
+            await signTransaction({
+              kind: "moveCall",
+              data: {
+                packageObjectId: "0x2",
+                module: "devnet_nft",
+                function: "mint",
+                typeArguments: [],
+                arguments: ["foo", "bar", "baz"],
+                gasBudget: 2000,
+              },
+            })
+          );
+        }}
+      >
+        Sign
+      </button>
     </div>
   );
 }

--- a/sdk/wallet-adapter/example/src/index.tsx
+++ b/sdk/wallet-adapter/example/src/index.tsx
@@ -12,7 +12,7 @@ export const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-    <WalletKitProvider>
+    <WalletKitProvider enableUnsafeBurner>
       <App />
     </WalletKitProvider>
   </React.StrictMode>

--- a/sdk/wallet-adapter/wallet-kit-core/src/index.ts
+++ b/sdk/wallet-adapter/wallet-kit-core/src/index.ts
@@ -4,6 +4,7 @@
 import {
   ExecuteTransactionRequestType,
   SignableTransaction,
+  SignaturePubkeyPair,
   SuiAddress,
   SuiTransactionResponse,
 } from "@mysten/sui.js";
@@ -52,6 +53,9 @@ export interface WalletKitCore {
   subscribe(handler: SubscribeHandler): Unsubscribe;
   connect(walletName: string): Promise<void>;
   disconnect(): Promise<void>;
+  signTransaction(
+    transaction: SignableTransaction
+  ): Promise<{ transactionBytes: string; signature: SignaturePubkeyPair }>;
   signAndExecuteTransaction(
     transaction: SignableTransaction,
     options?: { requestType?: ExecuteTransactionRequestType }
@@ -224,6 +228,16 @@ export function createWalletKitCore({
       } catch {}
       await internalState.currentWallet.disconnect();
       disconnected();
+    },
+
+    signTransaction(transaction) {
+      if (!internalState.currentWallet) {
+        throw new Error(
+          "No wallet is currently connected, cannot call `signTransaction`."
+        );
+      }
+
+      return internalState.currentWallet.signTransaction(transaction);
     },
 
     signAndExecuteTransaction(transaction, options) {

--- a/sdk/wallet-adapter/wallet-kit/src/WalletKitContext.tsx
+++ b/sdk/wallet-adapter/wallet-kit/src/WalletKitContext.tsx
@@ -75,7 +75,10 @@ export function WalletKitProvider({
 }
 
 type UseWalletKit = WalletKitCoreState &
-  Pick<WalletKitCore, "connect" | "disconnect" | "signAndExecuteTransaction">;
+  Pick<
+    WalletKitCore,
+    "connect" | "disconnect" | "signTransaction" | "signAndExecuteTransaction"
+  >;
 
 export function useWalletKit(): UseWalletKit {
   const walletKit = useContext(WalletKitContext);
@@ -92,6 +95,7 @@ export function useWalletKit(): UseWalletKit {
     () => ({
       connect: walletKit.connect,
       disconnect: walletKit.disconnect,
+      signTransaction: walletKit.signTransaction,
       signAndExecuteTransaction: walletKit.signAndExecuteTransaction,
       ...state,
     }),

--- a/sdk/wallet-adapter/wallet-standard/README.md
+++ b/sdk/wallet-adapter/wallet-standard/README.md
@@ -36,6 +36,7 @@ Features are standard methods consumers can use to interact with a wallet. To be
 
 - `standard:connect` - Used to initiate a connection to the wallet.
 - `standard:events` - Used to listen for changes that happen within the wallet, such as accounts being added or removed.
+- `sui:signTransaction` - Used to prompt the user to sign a transaction, and return the serializated transaction and transaction signature back to the user. This method does not submit the transaction for execution.
 - `sui:signAndExecuteTransaction` - Used to prompt the user to sign a transaction, then submit it for execution to the blockchain.
 
 You can implement these features in your wallet class under the `features` property:
@@ -46,6 +47,8 @@ import {
   ConnectMethod,
   EventsFeature,
   EventsOnMethod,
+  SuiSignTransactionFeature,
+  SuiSignTransactionMethod,
   SuiSignAndExecuteTransactionFeature,
   SuiSignAndExecuteTransactionMethod
 } from "@mysten/wallet-standard";
@@ -61,8 +64,12 @@ class YourWallet implements Wallet {
         version: "1.0.0",
         on: this.#on,
       }
-      "sui:signAndExecuteTransaction": {
+      "sui:signTransaction": {
         version: "1.0.0",
+        signTransaction: this.#signTransaction,
+      },
+      "sui:signAndExecuteTransaction": {
+        version: "1.1.0",
         signAndExecuteTransaction: this.#signAndExecuteTransaction,
       },
     };
@@ -74,6 +81,10 @@ class YourWallet implements Wallet {
 
   #connect: ConnectMethod = () => {
     // Your wallet's connect implementation
+  };
+
+  #signTransaction: SuiSignTransactionMethod = () => {
+    // Your wallet's signTransaction implementation
   };
 
   #signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod = () => {
@@ -104,7 +115,7 @@ class YourWallet implements Wallet {
           chains: [SUI_DEVNET_CHAIN],
           // The features that this account supports. This can be a subset of the wallet's supported features.
           // These features must exist on the wallet as well.
-          features: ["sui:signAndExecuteTransaction"],
+          features: ["sui:signTransaction", "sui:signAndExecuteTransaction"],
         })
     );
   }
@@ -116,7 +127,7 @@ class YourWallet implements Wallet {
 Once you have a compatible interface for your wallet, you can register it using the `registerWallet` function.
 
 ```typescript
-import { registerWallet } from '@mysten/wallet-standard';
+import { registerWallet } from "@mysten/wallet-standard";
 
 registerWallet(new YourWallet());
 ```

--- a/sdk/wallet-adapter/wallet-standard/src/detect.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/detect.ts
@@ -8,22 +8,25 @@ import {
   Wallet,
   WalletWithFeatures,
 } from "@wallet-standard/core";
-import { SuiSignAndExecuteTransactionFeature } from "./features";
+import { SuiFeatures } from "./features";
 
 export type StandardWalletAdapterWallet = WalletWithFeatures<
   ConnectFeature &
     EventsFeature &
-    SuiSignAndExecuteTransactionFeature &
+    SuiFeatures &
     // Disconnect is an optional feature:
     Partial<DisconnectFeature>
 >;
 
+// TODO: Enable filtering by subset of features:
 export function isStandardWalletAdapterCompatibleWallet(
   wallet: Wallet
 ): wallet is StandardWalletAdapterWallet {
   return (
     "standard:connect" in wallet.features &&
     "standard:events" in wallet.features &&
+    // TODO: Enable once ecosystem wallets adopt this:
+    // "sui:signTransaction" in wallet.features &&
     "sui:signAndExecuteTransaction" in wallet.features
   );
 }

--- a/sdk/wallet-adapter/wallet-standard/src/features/index.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/index.ts
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { WalletWithFeatures } from "@wallet-standard/core";
+import type { SuiSignTransactionFeature } from "./suiSignTransaction";
 import type { SuiSignAndExecuteTransactionFeature } from "./suiSignAndExecuteTransaction";
 
 /**
  * Wallet Standard features that are unique to Sui, and that all Sui wallets are expected to implement.
  */
-export type SuiFeatures = SuiSignAndExecuteTransactionFeature;
+export type SuiFeatures = SuiSignAndExecuteTransactionFeature &
+  SuiSignTransactionFeature;
 
 export type WalletWithSuiFeatures = WalletWithFeatures<SuiFeatures>;
 
+export * from "./suiSignTransaction";
 export * from "./suiSignAndExecuteTransaction";

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiSignTransaction.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiSignTransaction.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SignableTransaction, SignaturePubkeyPair } from "@mysten/sui.js";
+
+/** The latest API version of the signTransaction API. */
+export type SuiSignTransactionVersion = "1.0.0";
+
+/**
+ * A Wallet Standard feature for signing a transaction, and returning the
+ * serialized transaction and transaction signature.
+ */
+export type SuiSignTransactionFeature = {
+  /** Namespace for the feature. */
+  "sui:signTransaction": {
+    /** Version of the feature API. */
+    version: SuiSignTransactionVersion;
+    signTransaction: SuiSignTransactionMethod;
+  };
+};
+
+export type SuiSignTransactionMethod = (
+  input: SuiSignTransactionInput
+) => Promise<SuiSignTransactionOutput>;
+
+/** Input for signing transactions. */
+export interface SuiSignTransactionInput {
+  transaction: SignableTransaction;
+  options?: SuiSignTransactionOptions;
+}
+
+/** Output of signing transactions. */
+export interface SuiSignTransactionOutput {
+  transactionBytes: string;
+  signature: SignaturePubkeyPair;
+}
+
+/** Options for signing transactions. */
+export interface SuiSignTransactionOptions {}


### PR DESCRIPTION
- Add support in the SDK to call `signTransaction`, which just returns a serialized signed transaction.
- Add support in the wallet standard for new `sui:signTransaction` feature.
- Add support for new standard features in the Sui Wallet