### PR TITLE
[AuthAgg] Simplify validator handle_object_info read path

### DIFF
--- a/crates/sui-benchmark/src/embedded_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/embedded_reconfig_observer.rs
@@ -47,8 +47,9 @@ impl ReconfigObserver<NetworkAuthorityClient> for EmbeddedReconfigObserver {
             let cur_epoch = quorum_driver.current_epoch();
 
             match auth_agg
-                .get_committee_with_net_addresses(quorum_driver.current_epoch())
+                .get_latest_system_state_object_for_testing()
                 .await
+                .map(|state| state.get_current_epoch_committee())
             {
                 Err(err) => {
                     error!("Failed to get committee with network address: {}", err)

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -437,7 +437,7 @@ impl Validator for ValidatorService {
 
         let response = self.state.handle_object_info_request(request).await?;
 
-        Ok(tonic::Response::new(response.into()))
+        Ok(tonic::Response::new(response))
     }
 
     async fn transaction_info(

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -258,125 +258,22 @@ impl<C> SafeClient<C> {
         &self,
         request: &ObjectInfoRequest,
         response: ObjectInfoResponse,
-        // We skip the signature check when there's potentially an epoch change.
-        // In this case we don't have the latest committee info locally until reconfig finishes.
-        skip_committee_check_during_reconfig: bool,
     ) -> SuiResult<VerifiedObjectInfoResponse> {
         let ObjectInfoResponse {
-            parent_certificate,
-            requested_object_reference,
-            object_and_lock,
+            object,
+            layout: _,
+            lock_for_debugging: _,
         } = response;
 
-        // If we get a certificate make sure it is a valid certificate
-        let parent_certificate = if skip_committee_check_during_reconfig {
-            parent_certificate.map(VerifiedCertificate::new_unchecked)
-        } else if let Some(certificate) = parent_certificate {
-            let epoch = certificate.epoch();
-            Some(certificate.verify(&self.get_committee(&epoch)?)?)
-        } else {
-            None
-        };
-
-        // Check the right object ID and version is returned
-        if let Some((object_id, version, _)) = &requested_object_reference {
-            fp_ensure!(
-                object_id == &request.object_id,
-                SuiError::ByzantineAuthoritySuspicion {
-                    authority: self.address,
-                    reason: "Object ID mismatch".to_string()
-                }
-            );
-            if let ObjectInfoRequestKind::PastObjectInfo(requested_version) = &request.request_kind
-            {
-                fp_ensure!(
-                    version == requested_version,
-                    SuiError::ByzantineAuthoritySuspicion {
-                        authority: self.address,
-                        reason: "Object version mismatch".to_string()
-                    }
-                );
+        fp_ensure!(
+            request.object_id == object.id(),
+            SuiError::ByzantineAuthoritySuspicion {
+                authority: self.address,
+                reason: "Object id mismatch in the response".to_string()
             }
-        }
+        );
 
-        let object_and_lock = if let Some(object_and_lock) = object_and_lock {
-            let ObjectResponse {
-                object,
-                lock,
-                layout,
-            } = object_and_lock;
-            // We should only be returning the object and lock data if requesting the latest object info.
-            fp_ensure!(
-                matches!(
-                    request.request_kind,
-                    ObjectInfoRequestKind::LatestObjectInfo(_)
-                ),
-                SuiError::ByzantineAuthoritySuspicion {
-                    authority: self.address,
-                    reason:
-                        "Object and lock data returned when request kind is not LatestObjectInfo"
-                            .to_string()
-                }
-            );
-
-            match requested_object_reference {
-                Some(obj_ref) => {
-                    // Since we are requesting the latest version, we should validate that if the object's
-                    // reference actually match with the one from the responded object reference.
-                    fp_ensure!(
-                        object.compute_object_reference() == obj_ref,
-                        SuiError::ByzantineAuthoritySuspicion {
-                            authority: self.address,
-                            reason: "Requested object reference mismatch with returned object"
-                                .to_string()
-                        }
-                    );
-                }
-                None => {
-                    // Since we are returning the object for the latest version,
-                    // we must also have the requested object reference in the response.
-                    // Otherwise the authority has inconsistent data.
-                    return Err(SuiError::ByzantineAuthoritySuspicion {
-                        authority: self.address,
-                        reason: "Object returned without the object reference in response"
-                            .to_string(),
-                    });
-                }
-            };
-
-            let signed_transaction = if let Some(signed_transaction) = lock {
-                // We cannot reuse the committee fetched above since they may not be from the same
-                // epoch.
-                let epoch = signed_transaction.epoch();
-                let signed_transaction = signed_transaction.verify(&self.get_committee(&epoch)?)?;
-                // Check it has the right signer
-                fp_ensure!(
-                    signed_transaction.auth_sig().authority == self.address,
-                    SuiError::ByzantineAuthoritySuspicion {
-                        authority: self.address,
-                        reason: "Unexpected validator address in the signed tx signature"
-                            .to_string()
-                    }
-                );
-                Some(signed_transaction)
-            } else {
-                None
-            };
-
-            Some(ObjectResponse {
-                object,
-                lock: signed_transaction,
-                layout,
-            })
-        } else {
-            None
-        };
-
-        Ok(VerifiedObjectInfoResponse {
-            parent_certificate,
-            requested_object_reference,
-            object_and_lock,
-        })
+        Ok(VerifiedObjectInfoResponse { object })
     }
 
     pub fn address(&self) -> &AuthorityPublicKeyBytes {
@@ -437,12 +334,9 @@ where
         Ok(verified)
     }
 
-    /// Pass `skip_committee_check_during_reconfig = true` during reconfiguration, so that
-    /// we can tolerate missing committee information when processing the object data.
     pub async fn handle_object_info_request(
         &self,
         request: ObjectInfoRequest,
-        skip_committee_check_during_reconfig: bool,
     ) -> Result<VerifiedObjectInfoResponse, SuiError> {
         self.metrics.total_requests_handle_object_info_request.inc();
 
@@ -452,12 +346,8 @@ where
             .handle_object_info_request(request.clone())
             .await?;
         let response = self
-            .check_object_response(&request, response, skip_committee_check_during_reconfig)
-            .tap_err(|err|
-                error!(?err, authority=?self.address, "Client error in handle_object_info_request")
-
-
-                )?;
+            .check_object_response(&request, response)
+            .tap_err(|err| error!(?err, authority=?self.address, "Client error in handle_object_info_request"))?;
 
         self.metrics
             .total_ok_responses_handle_object_info_request

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -79,10 +79,7 @@ impl AuthorityAPI for LocalAuthorityClient {
         request: ObjectInfoRequest,
     ) -> Result<ObjectInfoResponse, SuiError> {
         let state = self.state.clone();
-        state
-            .handle_object_info_request(request)
-            .await
-            .map(|r| r.into())
+        state.handle_object_info_request(request).await
     }
 
     /// Handle Object information requests for this account.

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -15,12 +15,10 @@ use sui_types::crypto::{
     get_authority_key_pair, get_key_pair, AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes,
 };
 use sui_types::crypto::{KeypairTraits, Signature};
-use test_utils::sui_system_state::{test_sui_system_state, test_validator};
 
 use sui_macros::sim_test;
 use sui_types::messages::*;
 use sui_types::object::{MoveObject, Object, Owner, GAS_VALUE_FOR_TESTING};
-use test_utils::messages::make_random_certified_transaction;
 
 use super::*;
 use crate::authority_client::AuthorityAPI;
@@ -250,17 +248,13 @@ pub async fn get_latest_ref<A>(authority: &SafeClient<A>, object_id: ObjectID) -
 where
     A: AuthorityAPI + Send + Sync + Clone + 'static,
 {
-    if let Ok(ObjectInfoResponse {
-        requested_object_reference: Some(object_ref),
-        ..
-    }) = authority
-        .handle_object_info_request(
-            ObjectInfoRequest::latest_object_info_request(object_id, None),
-            false,
-        )
+    if let Ok(VerifiedObjectInfoResponse { object }) = authority
+        .handle_object_info_request(ObjectInfoRequest::latest_object_info_request(
+            object_id, None,
+        ))
         .await
     {
-        return object_ref;
+        return object.compute_object_reference();
     }
     panic!("Object not found!");
 }
@@ -670,265 +664,6 @@ fn get_agg<A>(
     )
 }
 
-#[tokio::test]
-async fn test_get_committee_with_net_addresses() {
-    telemetry_subscribers::init_for_testing();
-    let count = Arc::new(Mutex::new(0));
-    let new_client = |delay: u64| {
-        let delay = Duration::from_millis(delay);
-        let count = count.clone();
-        MockAuthorityApi::new(delay, count)
-    };
-
-    let (val0_pk, val0_addr) = get_authority_pub_key_bytes_and_address();
-    let (val1_pk, val1_addr) = get_authority_pub_key_bytes_and_address();
-    let (val2_pk, val2_addr) = get_authority_pub_key_bytes_and_address();
-    let (val3_pk, val3_addr) = get_authority_pub_key_bytes_and_address();
-
-    let mut clients = BTreeMap::from([
-        (val0_pk, new_client(1000)),
-        (val1_pk, new_client(1000)),
-        (val2_pk, new_client(1000)),
-        (val3_pk, new_client(1000)),
-    ]);
-    let authorities = BTreeMap::from([(val0_pk, 1), (val1_pk, 1), (val2_pk, 1), (val3_pk, 1)]);
-
-    let validators = vec![
-        test_validator(val0_pk, Multiaddr::empty().to_vec(), 1, 0),
-        test_validator(val1_pk, Multiaddr::empty().to_vec(), 1, 0),
-        test_validator(val2_pk, Multiaddr::empty().to_vec(), 1, 0),
-        test_validator(val3_pk, Multiaddr::empty().to_vec(), 1, 0),
-    ];
-    let system_state = test_sui_system_state(1, validators);
-    let good_result = make_response_from_sui_system_state(system_state.clone());
-
-    for client in clients.values_mut() {
-        client.set_handle_object_info_request(good_result.clone());
-    }
-    let clients = clients;
-    let agg = get_agg(authorities.clone(), clients.clone(), 0);
-    let res = agg.get_committee_with_net_addresses(1).await;
-
-    macro_rules! verify_good_result {
-        ($res: expr, $epoch: expr) => {{
-            let res = $res;
-            match res {
-                Ok(info) => {
-                    assert_eq!(info.committee.epoch, $epoch);
-                    assert_eq!(
-                        info.committee
-                            .voting_rights
-                            .into_iter()
-                            .collect::<BTreeMap<_, _>>(),
-                        BTreeMap::from([(val0_pk, 1), (val1_pk, 1), (val2_pk, 1), (val3_pk, 1),]),
-                    );
-                    assert_eq!(
-                        info.net_addresses,
-                        BTreeMap::from([
-                            (val0_pk, val0_addr.clone()),
-                            (val1_pk, val1_addr.clone()),
-                            (val2_pk, val2_addr.clone()),
-                            (val3_pk, val3_addr.clone()),
-                        ])
-                    );
-                }
-                Err(err) => panic!("expect Ok result but got {err}"),
-            };
-        }};
-    }
-
-    macro_rules! verify_bad_result {
-        ($res: expr, $epoch: expr) => {{
-            let res = $res;
-            match res {
-                Ok(info) => panic!(
-                    "expect SuiError::FailedToGetAgreedCommitteeFromMajority but got {:?}",
-                    info
-                ),
-                Err(SuiError::FailedToGetAgreedCommitteeFromMajority { minimal_epoch }) => {
-                    assert_eq!(minimal_epoch, $epoch);
-                }
-                Err(err) => panic!(
-                    "expect SuiError::FailedToGetAgreedCommitteeFromMajority but got {:?}",
-                    err
-                ),
-            };
-        }};
-    }
-    verify_good_result!(res, 1);
-
-    // 1 out of 4 gives bad result, we are good
-    let mut clone_clients = clients.clone();
-    let bad_result: SuiResult<ObjectInfoResponse> = Err(SuiError::GenericAuthorityError {
-        error: "foo".into(),
-    });
-
-    clone_clients
-        .get_mut(&val0_pk)
-        .unwrap()
-        .set_handle_object_info_request(bad_result.clone());
-
-    let agg = get_agg(authorities.clone(), clone_clients.clone(), 0);
-    let res = agg.get_committee_with_net_addresses(1).await;
-
-    verify_good_result!(res, 1);
-
-    // 2 out of 4 give bad result, get error
-    clone_clients
-        .get_mut(&val1_pk)
-        .unwrap()
-        .set_handle_object_info_request(bad_result.clone());
-    let agg = get_agg(authorities.clone(), clone_clients.clone(), 0);
-    let res = agg.get_committee_with_net_addresses(1).await;
-    verify_bad_result!(res, 1);
-
-    // val0 and val1 gives a slightly different system state but
-    // CommitteeWithNetAddresses is the same, we are good.
-    let mut system_state_clone = system_state.clone();
-    // In practice we wouldn't expect validator_stake differs in the same epoch.
-    // Here we update it for simplicity.
-    system_state_clone.validators.validator_stake += 1;
-    let different_result = make_response_from_sui_system_state(system_state_clone);
-
-    let mut clone_clients = clients.clone();
-    clone_clients
-        .get_mut(&val0_pk)
-        .unwrap()
-        .set_handle_object_info_request(different_result.clone());
-    clone_clients
-        .get_mut(&val1_pk)
-        .unwrap()
-        .set_handle_object_info_request(different_result.clone());
-
-    let agg = get_agg(authorities.clone(), clone_clients.clone(), 0);
-    let res = agg.get_committee_with_net_addresses(1).await;
-    verify_good_result!(res, 1);
-
-    // (val0, val1) disagree with (val2, val3) on network address, get error
-    let validators = vec![
-        test_validator(
-            val0_pk,
-            "/ip4/127.0.0.1".parse::<Multiaddr>().unwrap().to_vec(),
-            1,
-            0,
-        ),
-        test_validator(val1_pk, Multiaddr::empty().to_vec(), 1, 0),
-        test_validator(val2_pk, Multiaddr::empty().to_vec(), 1, 0),
-        test_validator(val3_pk, Multiaddr::empty().to_vec(), 1, 0),
-    ];
-    let system_state_with_different_net_addr = test_sui_system_state(1, validators);
-    let different_result =
-        make_response_from_sui_system_state(system_state_with_different_net_addr);
-
-    clone_clients
-        .get_mut(&val0_pk)
-        .unwrap()
-        .set_handle_object_info_request(different_result.clone());
-    clone_clients
-        .get_mut(&val1_pk)
-        .unwrap()
-        .set_handle_object_info_request(different_result.clone());
-
-    let agg = get_agg(authorities.clone(), clone_clients, 0);
-    let res = agg.get_committee_with_net_addresses(1).await;
-    verify_bad_result!(res, 1);
-
-    // val0, val1 and val2 are still in epoch0
-    let mut system_state_clone = system_state.clone();
-    system_state_clone.epoch = 0;
-    let epoch_0_result = make_response_from_sui_system_state(system_state_clone);
-
-    let mut clone_clients = clients.clone();
-    clone_clients
-        .get_mut(&val0_pk)
-        .unwrap()
-        .set_handle_object_info_request(epoch_0_result.clone());
-    clone_clients
-        .get_mut(&val1_pk)
-        .unwrap()
-        .set_handle_object_info_request(epoch_0_result.clone());
-    clone_clients
-        .get_mut(&val2_pk)
-        .unwrap()
-        .set_handle_object_info_request(epoch_0_result.clone());
-    let agg = get_agg(authorities.clone(), clone_clients, 0);
-    let res = agg.get_committee_with_net_addresses(1).await;
-    // Get error when asking with minimal epoch = 1
-    verify_bad_result!(res, 1);
-    // Get good results when asking with minimal epoch = 0
-    let res = agg.get_committee_with_net_addresses(0).await;
-    verify_good_result!(res, 0);
-}
-
-#[tokio::test]
-async fn test_get_committee_info() {
-    telemetry_subscribers::init_for_testing();
-
-    let count = Arc::new(Mutex::new(0));
-    // 4 out of 4 give good result
-    let (authorities, authorities_vec, mut clients) = get_authorities(count.clone(), 4);
-    let good_result = Ok(CommitteeInfoResponse {
-        epoch: 0,
-        protocol_version: ProtocolVersion::MIN,
-        committee_info: authorities_vec.clone(),
-    });
-    for client in clients.values_mut() {
-        client.set_handle_committee_info_request_result(good_result.clone());
-    }
-    let clients = clients;
-    let clone_clients = clients.clone();
-    let agg = get_agg(authorities.clone(), clone_clients, 0);
-    let res = agg.get_committee_info(Some(0)).await;
-    match res {
-        Ok(info) => {
-            assert_eq!(info.epoch, 0);
-            assert_eq!(info.committee_info, authorities_vec);
-        }
-        Err(err) => panic!("expect Ok result but got {err}"),
-    };
-
-    // 1 out 4 gives error
-    let mut clone_clients = clients.clone();
-    let bad_result = Err(SuiError::GenericAuthorityError {
-        error: "foo".into(),
-    });
-
-    clone_clients
-        .values_mut()
-        .next()
-        .unwrap()
-        .set_handle_committee_info_request_result(bad_result.clone());
-    let agg = get_agg(authorities.clone(), clone_clients, 0);
-    let res = agg.get_committee_info(Some(0)).await;
-    match res {
-        Ok(info) => {
-            assert_eq!(info.epoch, 0);
-            assert_eq!(info.committee_info, authorities_vec);
-        }
-        Err(_) => panic!("expect Ok result!"),
-    };
-
-    // 2 out 4 gives error
-    let mut clone_clients = clients.clone();
-    let mut i = 0;
-    for client in clone_clients.values_mut() {
-        client.set_handle_committee_info_request_result(bad_result.clone());
-        i += 1;
-        if i >= 2 {
-            break;
-        }
-    }
-    let agg = get_agg(authorities.clone(), clone_clients, 0);
-    let res = agg.get_committee_info(Some(0)).await;
-    match res {
-        Err(SuiError::TooManyIncorrectAuthorities { .. }) => (),
-        other => panic!(
-            "expect to get SuiError::TooManyIncorrectAuthorities but got {:?}",
-            other
-        ),
-    };
-}
-
 fn sign_tx(
     tx: VerifiedTransaction,
     epoch: EpochId,
@@ -1218,7 +953,6 @@ pub fn make_response_from_sui_system_state(
     system_state: SuiSystemState,
 ) -> SuiResult<ObjectInfoResponse> {
     let move_content = to_bytes(&system_state).unwrap();
-    let tx_cert = make_random_certified_transaction();
     let move_object = unsafe {
         MoveObject::new_from_execution(
             SuiSystemState::type_(),
@@ -1234,17 +968,12 @@ pub fn make_response_from_sui_system_state(
         Owner::Shared {
             initial_shared_version,
         },
-        *tx_cert.digest(),
+        TransactionDigest::random(),
     );
-    let obj_digest = object.compute_object_reference();
     Ok(ObjectInfoResponse {
-        parent_certificate: Some(tx_cert.into()),
-        requested_object_reference: Some(obj_digest),
-        object_and_lock: Some(ObjectResponse {
-            object,
-            lock: None,
-            layout: None,
-        }),
+        object,
+        layout: None,
+        lock_for_debugging: None,
     })
 }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1507,9 +1507,7 @@ async fn test_conflicting_transactions() {
         assert_eq!(
             ok.clone().into_signed_for_testing().digest(),
             object_info
-                .object_and_lock
-                .expect("object should exist")
-                .lock
+                .lock_for_debugging
                 .expect("object should be locked")
                 .digest()
         );
@@ -1517,9 +1515,7 @@ async fn test_conflicting_transactions() {
         assert_eq!(
             ok.into_signed_for_testing().digest(),
             gas_info
-                .object_and_lock
-                .expect("gas should exist")
-                .lock
+                .lock_for_debugging
                 .expect("gas should be locked")
                 .digest()
         );

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -172,7 +172,7 @@ async fn test_object_wrapping_unwrapping() {
     );
     // Make sure that the child's version gets increased after wrapped.
     assert_eq!(new_child_object_ref, expected_child_object_ref);
-    check_latest_object_ref(&authority, &expected_child_object_ref).await;
+    check_latest_object_ref(&authority, &expected_child_object_ref, true).await;
 
     let parent_object_ref = effects.created[0].0;
     assert_eq!(parent_object_ref.1, wrapped_version);
@@ -211,7 +211,7 @@ async fn test_object_wrapping_unwrapping() {
     );
     // Make sure that version increments again when unwrapped.
     assert_eq!(effects.unwrapped[0].0 .1, unwrapped_version);
-    check_latest_object_ref(&authority, &effects.unwrapped[0].0).await;
+    check_latest_object_ref(&authority, &effects.unwrapped[0].0, false).await;
     let child_object_ref = effects.unwrapped[0].0;
 
     let rewrap_version = SequenceNumber::lamport_increment([
@@ -251,7 +251,7 @@ async fn test_object_wrapping_unwrapping() {
         ObjectDigest::OBJECT_DIGEST_WRAPPED,
     );
     assert_eq!(effects.wrapped[0], expected_child_object_ref);
-    check_latest_object_ref(&authority, &expected_child_object_ref).await;
+    check_latest_object_ref(&authority, &expected_child_object_ref, true).await;
     let child_object_ref = effects.wrapped[0];
     let parent_object_ref = effects.mutated_excluding_gas().next().unwrap().0;
 
@@ -285,14 +285,14 @@ async fn test_object_wrapping_unwrapping() {
         ObjectDigest::OBJECT_DIGEST_DELETED,
     );
     assert!(effects.deleted.contains(&expected_child_object_ref));
-    check_latest_object_ref(&authority, &expected_child_object_ref).await;
+    check_latest_object_ref(&authority, &expected_child_object_ref, true).await;
     let expected_parent_object_ref = (
         parent_object_ref.0,
         deleted_version,
         ObjectDigest::OBJECT_DIGEST_DELETED,
     );
     assert!(effects.deleted.contains(&expected_parent_object_ref));
-    check_latest_object_ref(&authority, &expected_parent_object_ref).await;
+    check_latest_object_ref(&authority, &expected_parent_object_ref, true).await;
 }
 
 #[tokio::test]
@@ -1974,13 +1974,24 @@ async fn build_and_publish_test_package(
     effects.created[0].0
 }
 
-async fn check_latest_object_ref(authority: &AuthorityState, object_ref: &ObjectRef) {
+async fn check_latest_object_ref(
+    authority: &AuthorityState,
+    object_ref: &ObjectRef,
+    expect_not_found: bool,
+) {
     let response = authority
         .handle_object_info_request(ObjectInfoRequest {
             object_id: object_ref.0,
-            request_kind: ObjectInfoRequestKind::LatestObjectInfo(None),
+            object_format_options: None,
+            request_kind: ObjectInfoRequestKind::LatestObjectInfo,
         })
-        .await
-        .unwrap();
-    assert_eq!(&response.requested_object_reference.unwrap(), object_ref,);
+        .await;
+    if expect_not_found {
+        assert!(matches!(response, Err(SuiError::ObjectNotFound { .. })));
+    } else {
+        assert_eq!(
+            &response.unwrap().object.compute_object_reference(),
+            object_ref
+        );
+    }
 }

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -360,29 +360,17 @@ ObjectArg:
           - mutable: BOOL
 ObjectDigest:
   NEWTYPESTRUCT: BYTES
-ObjectFormatOptions:
-  STRUCT:
-    - include_types: BOOL
 ObjectID:
   NEWTYPESTRUCT:
     TYPENAME: AccountAddress
 ObjectInfoRequestKind:
   ENUM:
     0:
-      LatestObjectInfo:
-        NEWTYPE:
-          OPTION:
-            TYPENAME: ObjectFormatOptions
+      LatestObjectInfo: UNIT
     1:
-      PastObjectInfo:
+      PastObjectInfoDebug:
         NEWTYPE:
           TYPENAME: SequenceNumber
-    2:
-      PastObjectInfoDebug:
-        TUPLE:
-          - TYPENAME: SequenceNumber
-          - OPTION:
-              TYPENAME: ObjectFormatOptions
 Owner:
   ENUM:
     0:

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1246,16 +1246,13 @@ pub type TrustedCertificate = TrustedEnvelope<SenderSignedData, AuthorityStrongQ
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum ObjectInfoRequestKind {
-    /// Request the latest object state, if a format option is provided,
-    /// return the layout of the object in the given format.
-    LatestObjectInfo(Option<ObjectFormatOptions>),
-    /// Request the object state at a specific version
-    PastObjectInfo(SequenceNumber),
-    /// Similar to PastObjectInfo, except that it will also return the object content.
-    /// This is used only for debugging purpose and will not work in the long run when
-    /// we stop storing all historic versions of every object.
+    /// Request the latest object state.
+    LatestObjectInfo,
+    /// Request a specific version of the object.
+    /// This is used only for debugging purpose and will not work as a generic solution
+    /// since we don't keep around all historic object versions.
     /// No production code should depend on this kind.
-    PastObjectInfoDebug(SequenceNumber, Option<ObjectFormatOptions>),
+    PastObjectInfoDebug(SequenceNumber),
 }
 
 /// A request for information about an object and optionally its
@@ -1264,15 +1261,22 @@ pub enum ObjectInfoRequestKind {
 pub struct ObjectInfoRequest {
     /// The id of the object to retrieve, at the latest version.
     pub object_id: ObjectID,
+    /// if a format option is provided, return the layout of the object in the given format.
+    pub object_format_options: Option<ObjectFormatOptions>,
     /// The type of request, either latest object info or the past.
     pub request_kind: ObjectInfoRequestKind,
 }
 
 impl ObjectInfoRequest {
-    pub fn past_object_info_request(object_id: ObjectID, version: SequenceNumber) -> Self {
+    pub fn past_object_info_debug_request(
+        object_id: ObjectID,
+        version: SequenceNumber,
+        layout: Option<ObjectFormatOptions>,
+    ) -> Self {
         ObjectInfoRequest {
             object_id,
-            request_kind: ObjectInfoRequestKind::PastObjectInfo(version),
+            object_format_options: layout,
+            request_kind: ObjectInfoRequestKind::PastObjectInfoDebug(version),
         }
     }
 
@@ -1282,82 +1286,33 @@ impl ObjectInfoRequest {
     ) -> Self {
         ObjectInfoRequest {
             object_id,
-            request_kind: ObjectInfoRequestKind::LatestObjectInfo(layout),
+            object_format_options: layout,
+            request_kind: ObjectInfoRequestKind::LatestObjectInfo,
         }
     }
 }
 
+/// This message provides information about the latest object and its lock.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ObjectResponse<T = SignedTransaction> {
+pub struct ObjectInfoResponse {
     /// Value of the requested object in this authority
     pub object: Object,
-    /// Transaction the object is locked on in this authority.
-    /// None if the object is not currently locked by this authority.
-    pub lock: Option<T>,
     /// Schema of the Move value inside this object.
     /// None if the object is a Move package, or the request did not ask for the layout
     pub layout: Option<MoveStructLayout>,
+    /// Transaction the object is locked on in this authority.
+    /// None if the object is not currently locked by this authority.
+    /// This should be only used for debugging purpose, such as from sui-tool. No prod clients should
+    /// rely on it.
+    pub lock_for_debugging: Option<SignedTransaction>,
 }
 
-impl From<ObjectResponse<VerifiedSignedTransaction>> for ObjectResponse {
-    fn from(o: ObjectResponse<VerifiedSignedTransaction>) -> Self {
-        let ObjectResponse {
-            object,
-            lock,
-            layout,
-        } = o;
-
-        Self {
-            object,
-            lock: lock.map(|l| l.into()),
-            layout,
-        }
-    }
-}
-
-/// This message provides information about the latest object and its lock
-/// as well as the parent certificate of the object at a specific version.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ObjectInfoResponse<TxnT = SignedTransaction, CertT = CertifiedTransaction> {
-    /// The certificate that created or mutated the object at a given version.
-    /// If no parent certificate was requested the latest certificate concerning
-    /// this object is sent. If the parent was requested and not found a error
-    /// (ParentNotfound or CertificateNotfound) will be returned.
-    pub parent_certificate: Option<CertT>,
-    /// The full reference created by the above certificate
-    pub requested_object_reference: Option<ObjectRef>,
-
-    /// The object and its current lock, returned only if we are requesting
-    /// the latest state of an object.
-    /// If the object does not exist this is also None.
-    pub object_and_lock: Option<ObjectResponse<TxnT>>,
-}
-
-pub type VerifiedObjectInfoResponse =
-    ObjectInfoResponse<VerifiedSignedTransaction, VerifiedCertificate>;
-
-impl ObjectInfoResponse {
-    pub fn object(&self) -> Option<&Object> {
-        match &self.object_and_lock {
-            Some(ObjectResponse { object, .. }) => Some(object),
-            _ => None,
-        }
-    }
-}
-
-impl From<VerifiedObjectInfoResponse> for ObjectInfoResponse {
-    fn from(o: VerifiedObjectInfoResponse) -> Self {
-        let ObjectInfoResponse {
-            parent_certificate,
-            requested_object_reference,
-            object_and_lock,
-        } = o;
-        Self {
-            parent_certificate: parent_certificate.map(|p| p.into()),
-            requested_object_reference,
-            object_and_lock: object_and_lock.map(|o| o.into()),
-        }
-    }
+/// Verified version of `ObjectInfoResponse`. `layout` and `lock_for_debugging` are skipped because they
+/// are not needed and we don't want to verify them.
+#[derive(Debug, Clone)]
+pub struct VerifiedObjectInfoResponse {
+    /// Value of the requested object in this authority
+    pub object: Object,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -12,7 +12,7 @@ use sui_core::authority_client::NetworkAuthorityClient;
 pub use sui_node::{SuiNode, SuiNodeHandle};
 use sui_types::base_types::ObjectID;
 use sui_types::crypto::TEST_COMMITTEE_SIZE;
-use sui_types::messages::{ObjectInfoRequest, ObjectInfoRequestKind};
+use sui_types::messages::ObjectInfoRequest;
 use sui_types::object::Object;
 
 /// The default network buffer size of a test authority.
@@ -166,13 +166,10 @@ pub fn get_client(config: &ValidatorInfo) -> NetworkAuthorityClient {
 
 pub async fn get_object(config: &ValidatorInfo, object_id: ObjectID) -> Object {
     get_client(config)
-        .handle_object_info_request(ObjectInfoRequest {
-            object_id,
-            request_kind: ObjectInfoRequestKind::LatestObjectInfo(None),
-        })
+        .handle_object_info_request(ObjectInfoRequest::latest_object_info_request(
+            object_id, None,
+        ))
         .await
         .unwrap()
-        .object()
-        .unwrap()
-        .clone()
+        .object
 }

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -523,7 +523,7 @@ pub async fn get_framework_object(configs: &[ValidatorInfo]) -> Object {
 pub fn extract_obj(replies: Vec<ObjectInfoResponse>) -> Object {
     let mut all_objects = HashSet::new();
     for reply in replies {
-        all_objects.insert(reply.object_and_lock.unwrap().object);
+        all_objects.insert(reply.object);
     }
     assert_eq!(all_objects.len(), 1);
     all_objects.into_iter().next().unwrap()


### PR DESCRIPTION
Validators are not expected to serve object reads in production path. Ideally this should only be used for debugging and benchmarking. This means that we shouldn't really expose a complex generic object read in the authority aggregator.
We also won't always have parent certificates for objects. If a caller (e.g. sui-tool user) really needs it, they can get it through a separate call.
This PR simplifies this path and authority aggregator implementation by:
1. Simplify the request and response for validator handle_object_info RPC interface: Remove PastObjectInfo from ObjectInfoRequestKind, since no production code should ever need it; remove `parent_certificate` from the response; remove `requested_object_reference` from the response; merge `ObjectResponse` and `ObjectInfoResponse`; during the verification of the object info response, remove the signed transaction since we have no interest of verifying it (it shouldn't be used in prod but only for debugging).
2. Simplified the implementation of validator's `handle_object_info_request` to reflect above change.
3. AuthorityAggregator (most changes are here): a) Removed the complex `get_object_by_id` function as we no longer need it. b) Added a much much simpler version of `get_latest_object_version_for_testing` that simply return the latest version of a given object and doesn't care about byzantine validators (which is ok since it's untrusted and used only for benchmarking); added a thin helper function wrapper `get_latest_system_state_object_for_testing` to get the latest system state object from validators; removed `get_committee_info` and `get_committee_with_net_addresses` because they could be both derived from system state object; removed `get_object_info_execute` since it is no longer needed; removed `reconfig_from_genesis` which is not used

Things that we should do as follow up but not done in this PR:
1. In general, benchmarking code should not be reading from validators, we should remove this path completely. Then we could remove the object read path from authority aggregator entirely.
2. Fullnodes could consider exposing better API to obtain epoch metadata.