### PR TITLE
[AuthAgg] Change quorum_map_then_reduce to return result directly

### DIFF
--- a/crates/sui-core/src/stake_aggregator.rs
+++ b/crates/sui-core/src/stake_aggregator.rs
@@ -168,6 +168,7 @@ where
     K: Hash + Eq,
     V: Clone,
 {
+    // TODO: Change this to return the certificate instead.
     pub fn add(&mut self, k: K, v: &V, sig: AuthoritySignInfo) -> bool {
         let entry = self
             .stake_maps
@@ -211,7 +212,7 @@ where
         &self,
     ) -> Option<VerifiedEnvelope<V, AuthorityQuorumSignInfo<STRENGTH>>> {
         self.get_certificate().as_ref().map(|(message, sig)| {
-            // No verification is necessary since we constructed the signatures properly.
+            // TODO: This is in fact error prone, and we may want to verify the signature.
             VerifiedEnvelope::new_unchecked(Envelope::new_from_data_and_sig(
                 message.clone(),
                 sig.clone(),

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -360,29 +360,8 @@ async fn test_quorum_map_and_reduce_timeout() {
 async fn test_map_reducer() {
     let (authorities, _, _, _) = init_local_authorities(4, vec![]).await;
 
-    // Test: reducer errors get propagated up
-    let res = authorities
-        .quorum_map_then_reduce_with_timeout(
-            0usize,
-            |_name, _client| Box::pin(async move { Ok(()) }),
-            |_accumulated_state, _authority_name, _authority_weight, _result| {
-                Box::pin(async move {
-                    Err(SuiError::TooManyIncorrectAuthorities {
-                        errors: vec![],
-                        action: "".to_string(),
-                    })
-                })
-            },
-            Duration::from_millis(1000),
-        )
-        .await;
-    assert!(matches!(
-        res,
-        Err(SuiError::TooManyIncorrectAuthorities { .. })
-    ));
-
     // Test: mapper errors do not get propagated up, reducer works
-    let res = authorities
+    let res: Result<(), usize> = authorities
         .quorum_map_then_reduce_with_timeout(
             0usize,
             |_name, _client| {
@@ -401,13 +380,13 @@ async fn test_map_reducer() {
                         Err(SuiError::TooManyIncorrectAuthorities { .. })
                     ));
                     accumulated_state += 1;
-                    Ok(ReduceOutput::Continue(accumulated_state))
+                    ReduceOutput::Continue(accumulated_state)
                 })
             },
             Duration::from_millis(1000),
         )
         .await;
-    assert_eq!(Ok(4), res);
+    assert_eq!(Err(4), res);
 
     // Test: early end
     let res = authorities
@@ -417,10 +396,10 @@ async fn test_map_reducer() {
             |mut accumulated_state, _authority_name, _authority_weight, _result| {
                 Box::pin(async move {
                     if accumulated_state > 2 {
-                        Ok(ReduceOutput::End(accumulated_state))
+                        ReduceOutput::Success(accumulated_state)
                     } else {
                         accumulated_state += 1;
-                        Ok(ReduceOutput::Continue(accumulated_state))
+                        ReduceOutput::Continue(accumulated_state)
                     }
                 })
             },
@@ -430,7 +409,7 @@ async fn test_map_reducer() {
     assert_eq!(Ok(3), res);
 
     // Test: Global timeout works
-    let res = authorities
+    let res: Result<(), _> = authorities
         .quorum_map_then_reduce_with_timeout(
             0usize,
             |_name, _client| {
@@ -441,21 +420,16 @@ async fn test_map_reducer() {
                 })
             },
             |_accumulated_state, _authority_name, _authority_weight, _result| {
-                Box::pin(async move {
-                    Err(SuiError::TooManyIncorrectAuthorities {
-                        errors: vec![],
-                        action: "".to_string(),
-                    })
-                })
+                Box::pin(async move { ReduceOutput::Continue(0) })
             },
             Duration::from_millis(10),
         )
         .await;
-    assert_eq!(Ok(0), res);
+    assert_eq!(Err(0), res);
 
     // Test: Local timeout works
     let bad_auth = *authorities.committee.sample();
-    let res = authorities
+    let res: Result<(), _> = authorities
         .quorum_map_then_reduce_with_timeout(
             HashSet::new(),
             |_name, _client| {
@@ -471,12 +445,12 @@ async fn test_map_reducer() {
                 Box::pin(async move {
                     accumulated_state.insert(authority_name);
                     if accumulated_state.len() <= 3 {
-                        Ok(ReduceOutput::Continue(accumulated_state))
+                        ReduceOutput::Continue(accumulated_state)
                     } else {
-                        Ok(ReduceOutput::ContinueWithTimeout(
+                        ReduceOutput::ContinueWithTimeout(
                             accumulated_state,
                             Duration::from_millis(10),
-                        ))
+                        )
                     }
                 })
             },
@@ -484,8 +458,8 @@ async fn test_map_reducer() {
             Duration::from_millis(10 * 60),
         )
         .await;
-    assert_eq!(res.as_ref().unwrap().len(), 3);
-    assert!(!res.as_ref().unwrap().contains(&bad_auth));
+    assert_eq!(res.as_ref().unwrap_err().len(), 3);
+    assert!(!res.as_ref().unwrap_err().contains(&bad_auth));
 }
 
 #[sim_test]


### PR DESCRIPTION
Changes quorum_map_then_reduce to return result on success, and state on error. This makes result and error handling cleaner and easier to reason about.