### PR TITLE
[sui-json-rpc] Fix byte generation for dev inspect

### DIFF
--- a/crates/sui-indexer/src/apis/transaction_builder_api.rs
+++ b/crates/sui-indexer/src/apis/transaction_builder_api.rs
@@ -154,7 +154,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         type_arguments: Vec<SuiTypeTag>,
         rpc_arguments: Vec<SuiJsonValue>,
         gas: Option<ObjectID>,
-        gas_budget: u64,
+        gas_budget: Option<u64>,
         txn_builder_mode: Option<SuiTransactionBuilderMode>,
     ) -> RpcResult<TransactionBytes> {
         self.fullnode
@@ -177,7 +177,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         signer: SuiAddress,
         params: Vec<RPCTransactionRequestParams>,
         gas: Option<ObjectID>,
-        gas_budget: u64,
+        gas_budget: Option<u64>,
         txn_builder_mode: Option<SuiTransactionBuilderMode>,
     ) -> RpcResult<TransactionBytes> {
         self.fullnode

--- a/crates/sui-json-rpc/src/api/transaction_builder.rs
+++ b/crates/sui-json-rpc/src/api/transaction_builder.rs
@@ -130,10 +130,10 @@ pub trait TransactionBuilder {
         type_arguments: Vec<SuiTypeTag>,
         /// the arguments to be passed into the Move function, in [SuiJson](https://docs.sui.io/build/sui-json) format
         arguments: Vec<SuiJsonValue>,
-        /// gas object to be used in this transaction, node will pick one from the signer's possession if not provided
+        /// gas object to be used in this transaction, node will pick one from the signer's possession if not provided. It will be ignored if execution_mode is set to `SuiTransactionBuilderMode::DevInspect`
         gas: Option<ObjectID>,
-        /// the gas budget, the transaction will fail if the gas cost exceed the budget
-        gas_budget: u64,
+        /// the gas budget, the transaction will fail if the gas cost exceed the budget. It will be ignored if execution_mode is set to `SuiTransactionBuilderMode::DevInspect`
+        gas_budget: Option<u64>,
         /// Whether this is a Normal transaction or a Dev Inspect Transaction. Default to be `SuiTransactionBuilderMode::Commit` when it's None.
         execution_mode: Option<SuiTransactionBuilderMode>,
     ) -> RpcResult<TransactionBytes>;
@@ -208,10 +208,10 @@ pub trait TransactionBuilder {
         signer: SuiAddress,
         /// list of transaction request parameters
         single_transaction_params: Vec<RPCTransactionRequestParams>,
-        /// gas object to be used in this transaction, node will pick one from the signer's possession if not provided
+        /// gas object to be used in this transaction, node will pick one from the signer's possession if not provided. It will be ignored if execution_mode is set to `SuiTransactionBuilderMode::DevInspect`
         gas: Option<ObjectID>,
-        /// the gas budget, the transaction will fail if the gas cost exceed the budget
-        gas_budget: u64,
+        /// the gas budget, the transaction will fail if the gas cost exceed the budget. It will be ignored if execution_mode is set to `SuiTransactionBuilderMode::DevInspect`
+        gas_budget: Option<u64>,
         /// Whether this is a regular transaction or a Dev Inspect Transaction
         txn_builder_mode: Option<SuiTransactionBuilderMode>,
     ) -> RpcResult<TransactionBytes>;

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -160,7 +160,7 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
             vec![],
             vec![],
             Some(gas.object_id),
-            10_000,
+            Some(10_000),
             None,
         )
         .await?;
@@ -218,7 +218,7 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
                 SuiJsonValue::from_bcs_bytes(&sig).unwrap(),
             ],
             Some(gas.object_id),
-            10_000,
+            Some(10_000),
             None,
         )
         .await?;
@@ -301,7 +301,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
             vec![GAS::type_tag().into()],
             json_args,
             Some(gas.object_id),
-            10_000,
+            Some(10_000),
             None,
         )
         .await?;
@@ -543,7 +543,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
                 SuiJsonValue::from_str(&address.to_string()).unwrap(),
             ],
             Some(gas.object_id),
-            10_000,
+            Some(10_000),
             None,
         )
         .await?;
@@ -934,7 +934,7 @@ async fn test_locked_sui() -> Result<(), anyhow::Error> {
                 SuiJsonValue::from_bcs_bytes(&bcs::to_bytes(&"20")?)?,
             ],
             None,
-            1000,
+            Some(1000),
             None,
         )
         .await?;
@@ -1114,7 +1114,7 @@ async fn test_delegation_with_locked_sui() -> Result<(), anyhow::Error> {
                 SuiJsonValue::from_bcs_bytes(&bcs::to_bytes(&"20")?)?,
             ],
             None,
-            1000,
+            Some(1000),
             None,
         )
         .await?;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -45,15 +45,14 @@
         },
         {
           "name": "gas",
-          "description": "gas object to be used in this transaction, node will pick one from the signer's possession if not provided",
+          "description": "gas object to be used in this transaction, node will pick one from the signer's possession if not provided. It will be ignored if execution_mode is set to `SuiTransactionBuilderMode::DevInspect`",
           "schema": {
             "$ref": "#/components/schemas/ObjectID"
           }
         },
         {
           "name": "gas_budget",
-          "description": "the gas budget, the transaction will fail if the gas cost exceed the budget",
-          "required": true,
+          "description": "the gas budget, the transaction will fail if the gas cost exceed the budget. It will be ignored if execution_mode is set to `SuiTransactionBuilderMode::DevInspect`",
           "schema": {
             "type": "integer",
             "format": "uint64",
@@ -1913,15 +1912,14 @@
         },
         {
           "name": "gas",
-          "description": "gas object to be used in this transaction, node will pick one from the signer's possession if not provided",
+          "description": "gas object to be used in this transaction, node will pick one from the signer's possession if not provided. It will be ignored if execution_mode is set to `SuiTransactionBuilderMode::DevInspect`",
           "schema": {
             "$ref": "#/components/schemas/ObjectID"
           }
         },
         {
           "name": "gas_budget",
-          "description": "the gas budget, the transaction will fail if the gas cost exceed the budget",
-          "required": true,
+          "description": "the gas budget, the transaction will fail if the gas cost exceed the budget. It will be ignored if execution_mode is set to `SuiTransactionBuilderMode::DevInspect`",
           "schema": {
             "type": "integer",
             "format": "uint64",

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -168,7 +168,7 @@ impl SuiClientBuilder {
 #[derive(Clone)]
 pub struct SuiClient {
     api: Arc<RpcClient>,
-    transaction_builder: TransactionBuilder<Normal>,
+    transaction_builder: TransactionBuilder,
     read_api: Arc<ReadApi>,
     coin_read_api: CoinReadApi,
     event_api: EventApi,
@@ -241,7 +241,7 @@ impl SuiClient {
 }
 
 impl SuiClient {
-    pub fn transaction_builder(&self) -> &TransactionBuilder<Normal> {
+    pub fn transaction_builder(&self) -> &TransactionBuilder {
         &self.transaction_builder
     }
     pub fn read_api(&self) -> &ReadApi {

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -14,7 +14,6 @@ use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 
 use crate::error::{Error, SuiRpcResult};
 use serde_json::Value;
-use sui_adapter::execution_mode::Normal;
 pub use sui_json as json;
 
 use crate::apis::{CoinReadApi, EventApi, GovernanceApi, QuorumDriver, ReadApi};

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -534,13 +534,10 @@ impl TransactionBuilder {
         ))
     }
 
-    pub async fn batch_transaction<Mode: ExecutionMode>(
+    pub async fn batch_transaction_kinds<Mode: ExecutionMode>(
         &self,
-        signer: SuiAddress,
         single_transaction_params: Vec<RPCTransactionRequestParams>,
-        gas: Option<ObjectID>,
-        gas_budget: u64,
-    ) -> anyhow::Result<TransactionData> {
+    ) -> anyhow::Result<Vec<SingleTransactionKind>> {
         fp_ensure!(
             !single_transaction_params.is_empty(),
             SuiError::InvalidBatchTransaction {
@@ -570,6 +567,19 @@ impl TransactionBuilder {
             };
             tx_kinds.push(single_tx);
         }
+        Ok(tx_kinds)
+    }
+
+    pub async fn batch_transaction<Mode: ExecutionMode>(
+        &self,
+        signer: SuiAddress,
+        single_transaction_params: Vec<RPCTransactionRequestParams>,
+        gas: Option<ObjectID>,
+        gas_budget: u64,
+    ) -> anyhow::Result<TransactionData> {
+        let tx_kinds = self
+            .batch_transaction_kinds::<Mode>(single_transaction_params)
+            .await?;
 
         let all_inputs = tx_kinds
             .iter()


### PR DESCRIPTION
- incorrect bytes generated for dev-inspect Move call, where the full transaction data was serialized

Should fix #8119