### PR TITLE
Removed old Get Events examples

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -161,25 +161,6 @@ const txns = await provider.getTransactionWithEffectsBatch([
 ]);
 ```
 
-Fetch transaction events from a transaction digest:
-
-```typescript
-import { JsonRpcProvider } from '@mysten/sui.js';
-const provider = new JsonRpcProvider();
-const txEvents = await provider.getEventsByTransaction(
-  '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
-);
-```
-
-Fetch events by sender address:
-
-```typescript
-import { JsonRpcProvider } from '@mysten/sui.js';
-const provider = new JsonRpcProvider();
-const senderEvents = await provider.getEventsBySender(
-  '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3',
-);
-```
 
 Fetch coins of type `0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC` owned by an address:
 


### PR DESCRIPTION
Methods 
`getEventsByTransaction`
and
`getEventsBySender`

do not exist anymore, relevant examples should be removed. 
