### PR TITLE
[source-validation] Regression test for module-handle ordering bug

### DIFF
--- a/crates/sui-source-validation/fixture/z/Move.toml
+++ b/crates/sui-source-validation/fixture/z/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "z"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "$REPO_ROOT/crates/sui-framework" }

--- a/crates/sui-source-validation/fixture/z/sources/a.move
+++ b/crates/sui-source-validation/fixture/z/sources/a.move
@@ -1,0 +1,5 @@
+module z::a {
+    public fun bar(x: u64): u64 {
+        z::b::foo(sui::math::max(x, 42))
+    }
+}

--- a/crates/sui-source-validation/fixture/z/sources/a.move
+++ b/crates/sui-source-validation/fixture/z/sources/a.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module z::a {
     public fun bar(x: u64): u64 {
         z::b::foo(sui::math::max(x, 42))

--- a/crates/sui-source-validation/fixture/z/sources/b.move
+++ b/crates/sui-source-validation/fixture/z/sources/b.move
@@ -1,0 +1,5 @@
+module z::b {
+    public fun foo(x: u64): u64 {
+        x
+    }
+}

--- a/crates/sui-source-validation/fixture/z/sources/b.move
+++ b/crates/sui-source-validation/fixture/z/sources/b.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module z::b {
     public fun foo(x: u64): u64 {
         x


### PR DESCRIPTION
Regression test for a bug related to module-handle ordering changing after publish.

## Test Plan

Fails before the bugfix in https://github.com/move-language/move/pull/890, and succeeds after:

```
sui-source-validation$ cargo nextest run -- 'successful_verification_module_ordering'
```

