### PR TITLE
[core] Minor change to execute_certificate

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -377,13 +377,7 @@ impl ValidatorService {
 
         // 4) Execute the certificate if it contains only owned object transactions, or wait for
         // the execution results if it contains shared objects.
-        let res = if certificate.contains_shared_object() {
-            // The transaction needs sequencing by Narwhal before it can be sent for execution.
-            // So rely on the submission to consensus above to execute the certificate.
-            state.notify_read_effects(&certificate).await
-        } else {
-            state.execute_certificate(&certificate, &epoch_store).await
-        };
+        let res = state.execute_certificate(&certificate, &epoch_store).await;
         match res {
             Ok(signed_effects) => Ok(tonic::Response::new(HandleCertificateResponse {
                 signed_effects: signed_effects.into_inner(),

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2015,6 +2015,12 @@ async fn test_handle_certificate_with_shared_object_interrupted_retry() {
         std::mem::drop(g);
 
         // Now run the tx to completion. Interrupted tx should be retriable via TransactionManager.
+        // Must manually enqueue the cert to transaction manager because send_consensus_no_execution
+        // explicitly doesn't do so.
+        authority_state
+            .transaction_manager()
+            .enqueue(vec![shared_object_cert.clone()], &epoch_store)
+            .unwrap();
         authority_state
             .execute_certificate(
                 &shared_object_cert,


### PR DESCRIPTION
Some code merge in `execute_certificate` function to make it cleaner.