### PR TITLE
[core] Properly support finalized transactions for effects

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -25,10 +25,12 @@ use prometheus::{
 use serde::de::DeserializeOwned;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{collections::HashMap, pin::Pin};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_protocol_constants::{MAX_TX_GAS, STORAGE_GAS_PRICE};
+use sui_types::message_envelope::Message;
 use sui_types::parse_sui_struct_tag;
 use tap::TapFallible;
 use tokio::sync::mpsc::unbounded_channel;
@@ -593,20 +595,19 @@ impl AuthorityState {
 
         let observed_effects = self
             .database
-            .notify_read_effects(vec![digest])
+            .notify_read_executed_effects(vec![digest])
             .instrument(tracing::debug_span!(
                 "notify_read_effects_in_execute_certificate_with_effects"
             ))
             .await?
             .pop()
-            .expect("notify_read_effects should return exactly 1 element")
-            .into_inner();
+            .expect("notify_read_effects should return exactly 1 element");
 
         let observed_effects_digest = observed_effects.digest();
-        if observed_effects_digest != expected_effects_digest {
+        if &observed_effects_digest != expected_effects_digest {
             panic!(
                 "Locally executed effects do not match canonical effects! expected_effects_digest={:?} observed_effects_digest={:?} expected_effects={:?} observed_effects={:?} input_objects={:?}",
-                expected_effects_digest, observed_effects_digest, effects.data(), observed_effects.data(), certificate.data().intent_message.value.input_objects()
+                expected_effects_digest, observed_effects_digest, effects.data(), observed_effects, certificate.data().intent_message.value.input_objects()
             );
         }
         Ok(())
@@ -633,7 +634,8 @@ impl AuthorityState {
             self.enqueue_certificates_for_execution(vec![certificate.clone()], epoch_store)?;
         }
 
-        self.notify_read_effects(certificate).await
+        let effects = self.notify_read_effects(certificate).await?;
+        self.sign_effects(effects, epoch_store)
     }
 
     /// Internal logic to execute a certificate.
@@ -687,11 +689,11 @@ impl AuthorityState {
     pub async fn notify_read_effects(
         &self,
         certificate: &VerifiedCertificate,
-    ) -> SuiResult<VerifiedSignedTransactionEffects> {
+    ) -> SuiResult<TransactionEffects> {
         let tx_digest = *certificate.digest();
         Ok(self
             .database
-            .notify_read_effects(vec![tx_digest])
+            .notify_read_executed_effects(vec![tx_digest])
             .await?
             .pop()
             .expect("notify_read_effects should return exactly 1 element"))
@@ -772,7 +774,7 @@ impl AuthorityState {
         // If the cert is finalized in a previous epoch, it will be re-signed
         // with current epoch info and returned.
         if let Some(signed_effects) =
-            self.get_signed_effects_and_maybe_resign(epoch_store.epoch(), &digest)?
+            self.get_signed_effects_and_maybe_resign(&digest, epoch_store)?
         {
             tx_guard.release();
             return Ok(signed_effects);
@@ -875,7 +877,6 @@ impl AuthorityState {
         _execution_guard: ExecutionLockReadGuard<'_>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
-        let digest = *certificate.digest();
         let input_object_count = inner_temporary_store.objects.len();
         let shared_object_count = signed_effects.inner().data().shared_objects.len();
 
@@ -887,8 +888,13 @@ impl AuthorityState {
             .map(|(_, ((id, seq, _), _, _))| ObjectKey(*id, *seq))
             .collect();
 
-        self.commit_certificate(inner_temporary_store, certificate, signed_effects)
-            .await?;
+        self.commit_certificate(
+            inner_temporary_store,
+            certificate,
+            signed_effects,
+            epoch_store,
+        )
+        .await?;
 
         // Notifies transaction manager about available input objects. This allows the transaction
         // manager to schedule ready transactions.
@@ -907,7 +913,7 @@ impl AuthorityState {
 
         // index certificate
         let _ = self
-            .post_process_one_tx(&digest)
+            .post_process_one_tx(certificate, signed_effects.data())
             .await
             .tap_err(|e| error!("tx post processing failed: {e}"));
 
@@ -1124,7 +1130,7 @@ impl AuthorityState {
     }
 
     pub fn is_tx_already_executed(&self, digest: &TransactionDigest) -> SuiResult<bool> {
-        self.database.effects_exists(digest)
+        self.database.is_tx_already_executed(digest)
     }
 
     #[instrument(level = "debug", skip_all, err)]
@@ -1132,8 +1138,8 @@ impl AuthorityState {
         &self,
         indexes: &IndexStore,
         digest: &TransactionDigest,
-        cert: &VerifiedCertificate,
-        effects: &SignedTransactionEffects,
+        cert: &CertifiedTransaction,
+        effects: &TransactionEffects,
         timestamp_ms: u64,
     ) -> SuiResult<u64> {
         let changes = self
@@ -1149,7 +1155,6 @@ impl AuthorityState {
                 .iter()
                 .map(|o| o.object_id()),
             effects
-                .data()
                 .all_mutated()
                 .map(|(obj_ref, owner, _kind)| (*obj_ref, *owner)),
             cert.data()
@@ -1166,7 +1171,7 @@ impl AuthorityState {
 
     fn process_object_index(
         &self,
-        effects: &SignedTransactionEffects,
+        effects: &TransactionEffects,
     ) -> Result<ObjectIndexChanges, SuiError> {
         let modified_at_version = effects
             .modified_at_versions
@@ -1315,45 +1320,51 @@ impl AuthorityState {
     }
 
     #[instrument(level = "debug", skip_all, err)]
-    async fn post_process_one_tx(&self, digest: &TransactionDigest) -> SuiResult {
+    async fn post_process_one_tx(
+        &self,
+        certificate: &CertifiedTransaction,
+        effects: &TransactionEffects,
+    ) -> SuiResult {
         if self.indexes.is_none() && self.event_handler.is_none() {
             return Ok(());
         }
 
-        // Load cert and effects.
-        let info = (
-            self.database.get_certified_transaction(digest)?,
-            self.database.get_signed_effects(digest)?,
-        );
-        let (cert, effects) = match info {
-            (Some(cert), Some(effects)) => (cert, effects.into_inner()),
-            _ => {
-                return Err(SuiError::CertificateNotfound {
-                    certificate_digest: *digest,
-                })
-            }
-        };
-
+        let tx_digest = certificate.digest();
         let timestamp_ms = Self::unixtime_now_ms();
 
         // Index tx
         if let Some(indexes) = &self.indexes {
             let res = self
-                .index_tx(indexes.as_ref(), digest, &cert, &effects, timestamp_ms)
+                .index_tx(
+                    indexes.as_ref(),
+                    tx_digest,
+                    certificate,
+                    effects,
+                    timestamp_ms,
+                )
                 .tap_ok(|_| self.metrics.post_processing_total_tx_indexed.inc())
-                .tap_err(|e| error!(tx_digest=?digest, "Post processing - Couldn't index tx: {e}"));
+                .tap_err(|e| error!(?tx_digest, "Post processing - Couldn't index tx: {e}"));
 
             // Emit events
             if let (Some(event_handler), Ok(seq)) = (&self.event_handler, res) {
                 event_handler
-                    .process_events(effects.data(), timestamp_ms, seq)
+                    .process_events(effects, timestamp_ms, seq)
                     .await
-                    .tap_ok(|_| self.metrics.post_processing_total_tx_had_event_processed.inc())
-                    .tap_err(|e| warn!(tx_digest=?digest, "Post processing - Couldn't process events for tx: {}", e))?;
+                    .tap_ok(|_| {
+                        self.metrics
+                            .post_processing_total_tx_had_event_processed
+                            .inc()
+                    })
+                    .tap_err(|e| {
+                        warn!(
+                            ?tx_digest,
+                            "Post processing - Couldn't process events for tx: {}", e
+                        )
+                    })?;
 
                 self.metrics
                     .post_processing_total_events_emitted
-                    .inc_by(effects.data().events.len() as u64);
+                    .inc_by(effects.events.len() as u64);
             }
         };
 
@@ -2010,13 +2021,11 @@ impl AuthorityState {
         &self,
         digest: TransactionDigest,
     ) -> Result<(VerifiedCertificate, TransactionEffects), anyhow::Error> {
-        let opt = self.database.get_certified_transaction(&digest)?;
-        match opt {
-            Some(certificate) => Ok((
-                certificate,
-                AuthorityStore::get_effects(&self.database, &digest)?,
-            )),
-            None => Err(anyhow!(SuiError::TransactionNotFound { digest })),
+        let cert = self.database.get_certified_transaction(&digest)?;
+        let effects = self.database.get_executed_effects(&digest)?;
+        match (cert, effects) {
+            (Some(certificate), Some(effects)) => Ok((certificate, effects)),
+            _ => Err(anyhow!(SuiError::TransactionNotFound { digest })),
         }
     }
 
@@ -2228,7 +2237,7 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> Result<Option<VerifiedTransactionInfoResponse>, SuiError> {
         if let Some(effects) =
-            self.get_signed_effects_and_maybe_resign(epoch_store.epoch(), transaction_digest)?
+            self.get_signed_effects_and_maybe_resign(transaction_digest, epoch_store)?
         {
             if let Some(cert) = self
                 .database
@@ -2256,56 +2265,71 @@ impl AuthorityState {
     /// epoch.
     pub fn get_signed_effects_and_maybe_resign(
         &self,
-        cur_epoch: EpochId,
         transaction_digest: &TransactionDigest,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<Option<VerifiedSignedTransactionEffects>> {
-        let effects = self.database.get_signed_effects(transaction_digest)?;
-        // If the transaction was executed in previous epochs, the validator will
-        // re-sign the effects with new current epoch so that a client is always able to
-        // obtain an effects certificate at the current epoch.
-        //
-        // Why is this necessary? Consider the following case:
-        // - assume there are 4 validators
-        // - Quorum driver gets 2 signed effects before reconfig halt
-        // - The tx makes it into final checkpoint.
-        // - 2 validators go away and are replaced in the new epoch.
-        // - The new epoch begins.
-        // - The quorum driver cannot complete the partial effects cert from the previous epoch,
-        //   because it may not be able to reach either of the 2 former validators.
-        // - But, if the 2 validators that stayed are willing to re-sign the effects in the new
-        //   epoch, the QD can make a new effects cert and return it to the client.
-        //
-        // This is a considered a short-term workaround. Eventually, Quorum Driver should be able
-        // to return either an effects certificate, -or- a proof of inclusion in a checkpoint. In
-        // the case above, the Quorum Driver would return a proof of inclusion in the final
-        // checkpoint, and this code would no longer be necessary.
-        //
-        // Alternatively, some of the confusion around re-signing could be resolved if
-        // CertifiedTransactionEffects included both the epoch in which the transaction became
-        // final, as well as the epoch at which the effects were certified. In this case, there
-        // would be nothing terribly odd about the validators from epoch N certifying that a
-        // given TX became final in epoch N - 1. The confusion currently arises from the fact that
-        // the epoch field in AuthoritySignInfo is overloaded both to identify the provenance of
-        // the authority's signature, as well as to identify in which epoch the transaction was
-        // executed.
-        Ok(effects.map(|effects| {
-            let effects: VerifiedSignedTransactionEffects = effects.into();
-            if effects.epoch() < cur_epoch {
+        let effects = self.database.get_executed_effects(transaction_digest)?;
+        match effects {
+            Some(effects) => Ok(Some(self.sign_effects(effects, epoch_store)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn sign_effects(
+        &self,
+        effects: TransactionEffects,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> Result<VerifiedSignedTransactionEffects, SuiError> {
+        let tx_digest = effects.transaction_digest;
+        let signed_effects = match epoch_store.get_effects_signature(&tx_digest)? {
+            Some(sig) if sig.epoch == epoch_store.epoch() => {
+                SignedTransactionEffects::new_from_data_and_sig(effects, sig)
+            }
+            _ => {
+                // If the transaction was executed in previous epochs, the validator will
+                // re-sign the effects with new current epoch so that a client is always able to
+                // obtain an effects certificate at the current epoch.
+                //
+                // Why is this necessary? Consider the following case:
+                // - assume there are 4 validators
+                // - Quorum driver gets 2 signed effects before reconfig halt
+                // - The tx makes it into final checkpoint.
+                // - 2 validators go away and are replaced in the new epoch.
+                // - The new epoch begins.
+                // - The quorum driver cannot complete the partial effects cert from the previous epoch,
+                //   because it may not be able to reach either of the 2 former validators.
+                // - But, if the 2 validators that stayed are willing to re-sign the effects in the new
+                //   epoch, the QD can make a new effects cert and return it to the client.
+                //
+                // This is a considered a short-term workaround. Eventually, Quorum Driver should be able
+                // to return either an effects certificate, -or- a proof of inclusion in a checkpoint. In
+                // the case above, the Quorum Driver would return a proof of inclusion in the final
+                // checkpoint, and this code would no longer be necessary.
+                //
+                // Alternatively, some of the confusion around re-signing could be resolved if
+                // CertifiedTransactionEffects included both the epoch in which the transaction became
+                // final, as well as the epoch at which the effects were certified. In this case, there
+                // would be nothing terribly odd about the validators from epoch N certifying that a
+                // given TX became final in epoch N - 1. The confusion currently arises from the fact that
+                // the epoch field in AuthoritySignInfo is overloaded both to identify the provenance of
+                // the authority's signature, as well as to identify in which epoch the transaction was
+                // executed.
                 debug!(
-                    effects_epoch=?effects.epoch(),
-                    ?cur_epoch,
+                    ?tx_digest,
+                    epoch=?epoch_store.epoch(),
                     "Re-signing the effects with the current epoch"
                 );
-                VerifiedSignedTransactionEffects::new_unchecked(SignedTransactionEffects::new(
-                    cur_epoch,
-                    effects.into_message(),
+                SignedTransactionEffects::new(
+                    epoch_store.epoch(),
+                    effects,
                     &*self.secret,
                     self.name,
-                ))
-            } else {
-                effects
+                )
             }
-        }))
+        };
+        Ok(VerifiedSignedTransactionEffects::new_unchecked(
+            signed_effects,
+        ))
     }
 
     // Helper function to manage transaction_locks
@@ -2354,17 +2378,17 @@ impl AuthorityState {
         inner_temporary_store: InnerTemporaryStore,
         certificate: &VerifiedCertificate,
         signed_effects: &VerifiedSignedTransactionEffects,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         let _metrics_guard = self.metrics.commit_certificate_latency.start_timer();
 
-        let effects_digest = signed_effects.inner().digest();
+        // The insertion to epoch_store is not atomic with the insertion to the perpetual store. This is OK because
+        // we insert to the epoch store first. And during lookups we always look up in the perpetual store first.
+        epoch_store.insert_effects_signature(certificate.digest(), signed_effects.auth_sig())?;
+
+        let effects_digest = signed_effects.digest();
         self.database
-            .update_state(
-                inner_temporary_store,
-                certificate,
-                signed_effects,
-                effects_digest,
-            )
+            .update_state(inner_temporary_store, certificate, signed_effects.data())
             .await
             .tap_ok(|_| {
                 debug!(?effects_digest, "commit_certificate finished");
@@ -2373,7 +2397,7 @@ impl AuthorityState {
         // todo - ideally move this metric in NotifyRead once we have metrics in AuthorityStore
         self.metrics
             .pending_notify_read
-            .set(self.database.effects_notify_read.num_pending() as i64);
+            .set(self.database.executed_effects_notify_read.num_pending() as i64);
 
         Ok(())
     }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -40,7 +40,7 @@ pub struct AuthorityStore {
     pub(crate) perpetual_tables: Arc<AuthorityPerpetualTables>,
 
     // Implementation detail to support notify_read_effects().
-    pub(crate) effects_notify_read: NotifyRead<TransactionDigest, VerifiedSignedTransactionEffects>,
+    pub(crate) executed_effects_notify_read: NotifyRead<TransactionDigest, TransactionEffects>,
     _store_pruner: AuthorityStorePruner,
     /// This lock denotes current 'execution epoch'.
     /// Execution acquires read lock, checks certificate epoch and holds it until all writes are complete.
@@ -118,7 +118,7 @@ impl AuthorityStore {
             mutex_table: MutexTable::new(NUM_SHARDS, SHARD_SIZE),
             perpetual_tables,
             _store_pruner,
-            effects_notify_read: NotifyRead::new(),
+            executed_effects_notify_read: NotifyRead::new(),
             execution_lock: RwLock::new(epoch),
         };
         // Only initialize an empty database.
@@ -149,6 +149,8 @@ impl AuthorityStore {
                 .effects
                 .insert(&genesis.effects().digest(), genesis.effects())
                 .unwrap();
+            // We don't insert the effects to executed_effects yet because the genesis tx hasn't but will be executed.
+            // This is important for fullnodes to be able to generate indexing data right now.
         }
 
         Ok(store)
@@ -158,44 +160,63 @@ impl AuthorityStore {
         self.perpetual_tables.get_recovery_epoch_at_restart()
     }
 
-    pub(crate) fn get_signed_effects(
-        &self,
-        transaction_digest: &TransactionDigest,
-    ) -> SuiResult<Option<TrustedSignedTransactionEffects>> {
-        Ok(self
-            .perpetual_tables
-            .executed_effects
-            .get(transaction_digest)?)
-    }
-
-    /// Returns the TransactionEffects if we have an effects structure for this transaction digest
     pub fn get_effects(
         &self,
-        transaction_digest: &TransactionDigest,
-    ) -> SuiResult<TransactionEffects> {
-        self.get_effects_if_exists(transaction_digest)?
-            .ok_or(SuiError::TransactionNotFound {
-                digest: *transaction_digest,
-            })
-    }
-
-    pub fn get_effects_if_exists(
-        &self,
-        transaction_digest: &TransactionDigest,
+        effects_digest: &TransactionEffectsDigest,
     ) -> SuiResult<Option<TransactionEffects>> {
-        Ok(self
-            .perpetual_tables
-            .executed_effects
-            .get(transaction_digest)?
-            .map(|data| data.into_inner().into_data()))
+        Ok(self.perpetual_tables.effects.get(effects_digest)?)
     }
 
     /// Returns true if we have an effects structure for this transaction digest
-    pub fn effects_exists(&self, transaction_digest: &TransactionDigest) -> SuiResult<bool> {
+    pub fn effects_exists(&self, effects_digest: &TransactionEffectsDigest) -> SuiResult<bool> {
         self.perpetual_tables
-            .executed_effects
-            .contains_key(transaction_digest)
+            .effects
+            .contains_key(effects_digest)
             .map_err(|e| e.into())
+    }
+
+    pub fn multi_get_effects<'a>(
+        &self,
+        effects_digests: impl Iterator<Item = &'a TransactionEffectsDigest>,
+    ) -> SuiResult<Vec<Option<TransactionEffects>>> {
+        Ok(self.perpetual_tables.effects.multi_get(effects_digests)?)
+    }
+
+    pub fn get_executed_effects(
+        &self,
+        tx_digest: &TransactionDigest,
+    ) -> SuiResult<Option<TransactionEffects>> {
+        let effects_digest = self.perpetual_tables.executed_effects.get(tx_digest)?;
+        match effects_digest {
+            Some(digest) => Ok(self.perpetual_tables.effects.get(&digest)?),
+            None => Ok(None),
+        }
+    }
+
+    /// Given a list of transaction digests, returns a list of the corresponding effects only if they have been
+    /// executed. For transactions that have not been executed, None is returned.
+    pub fn multi_get_executed_effects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<TransactionEffects>>> {
+        let executed_effects_digests = self.perpetual_tables.executed_effects.multi_get(digests)?;
+        let effects = self.multi_get_effects(executed_effects_digests.iter().flatten())?;
+        let mut tx_to_effects_map = effects
+            .into_iter()
+            .flatten()
+            .map(|effects| (effects.transaction_digest, effects))
+            .collect::<HashMap<_, _>>();
+        Ok(digests
+            .iter()
+            .map(|digest| tx_to_effects_map.remove(digest))
+            .collect())
+    }
+
+    pub fn is_tx_already_executed(&self, digest: &TransactionDigest) -> SuiResult<bool> {
+        Ok(self
+            .perpetual_tables
+            .executed_effects
+            .contains_key(digest)?)
     }
 
     pub fn insert_executed_transactions(
@@ -589,8 +610,7 @@ impl AuthorityStore {
         &self,
         inner_temporary_store: InnerTemporaryStore,
         certificate: &VerifiedCertificate,
-        effects: &VerifiedSignedTransactionEffects,
-        effects_digest: &TransactionEffectsDigest,
+        effects: &TransactionEffects,
     ) -> SuiResult {
         // Extract the new state from the execution
         // TODO: events are already stored in the TxDigest -> TransactionEffects store. Is that enough?
@@ -604,12 +624,13 @@ impl AuthorityStore {
         )?;
 
         // Add batched writes for objects and locks.
+        let effects_digest = effects.digest();
         write_batch = self
             .update_objects_and_locks(
                 write_batch,
                 inner_temporary_store,
                 *transaction_digest,
-                UpdateType::Transaction(*effects_digest),
+                UpdateType::Transaction(effects_digest),
             )
             .await?;
 
@@ -618,19 +639,17 @@ impl AuthorityStore {
         // batch_update_objects), as effects_exists is used as a check in many places
         // for "did the tx finish".
         write_batch = write_batch
+            .insert_batch(&self.perpetual_tables.effects, [(effects_digest, effects)])?
             .insert_batch(
                 &self.perpetual_tables.executed_effects,
-                [(transaction_digest, effects.serializable_ref())],
-            )?
-            .insert_batch(
-                &self.perpetual_tables.effects,
-                [(effects_digest, effects.data())],
+                [(transaction_digest, effects_digest)],
             )?;
 
         // Commit.
         write_batch.write()?;
 
-        self.effects_notify_read.notify(transaction_digest, effects);
+        self.executed_effects_notify_read
+            .notify(transaction_digest, effects);
 
         Ok(())
     }
@@ -988,19 +1007,19 @@ impl AuthorityStore {
     /// 3. All new object states are deleted.
     /// 4. owner_index table change is reverted.
     pub async fn revert_state_update(&self, tx_digest: &TransactionDigest) -> SuiResult {
-        let effects = self.get_effects_if_exists(tx_digest)?;
-        let Some(effects) = effects else {
+        let Some(effects) = self.get_executed_effects(tx_digest)? else {
             debug!("Not reverting {:?} as it was not executed", tx_digest);
             return Ok(())
         };
 
         let mut write_batch = self.perpetual_tables.certificates.batch();
-        write_batch =
-            write_batch.delete_batch(&self.perpetual_tables.certificates, iter::once(tx_digest))?;
-        write_batch = write_batch.delete_batch(
-            &self.perpetual_tables.executed_effects,
-            iter::once(tx_digest),
-        )?;
+        write_batch = write_batch
+            .delete_batch(&self.perpetual_tables.certificates, iter::once(tx_digest))?
+            .delete_batch(&self.perpetual_tables.effects, iter::once(effects.digest()))?
+            .delete_batch(
+                &self.perpetual_tables.executed_effects,
+                iter::once(tx_digest),
+            )?;
 
         let all_new_refs = effects
             .mutated
@@ -1211,28 +1230,6 @@ impl<T: ModuleResolver> ModuleResolver for ResolverWrapper<T> {
 pub enum UpdateType {
     Transaction(TransactionEffectsDigest),
     Genesis,
-}
-
-pub trait EffectsStore {
-    fn get_effects<'a>(
-        &self,
-        transactions: impl Iterator<Item = &'a TransactionDigest> + Clone,
-    ) -> SuiResult<Vec<Option<VerifiedSignedTransactionEffects>>>;
-}
-
-impl EffectsStore for Arc<AuthorityStore> {
-    fn get_effects<'a>(
-        &self,
-        transactions: impl Iterator<Item = &'a TransactionDigest> + Clone,
-    ) -> SuiResult<Vec<Option<VerifiedSignedTransactionEffects>>> {
-        Ok(self
-            .perpetual_tables
-            .executed_effects
-            .multi_get(transactions)?
-            .into_iter()
-            .map(|e_opt| e_opt.map(|e| e.into()))
-            .collect())
-    }
 }
 
 pub type SuiLockResult = SuiResult<ObjectLockStatus>;

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -292,7 +292,7 @@ impl ValidatorService {
         // 1) Check if cert already executed
         let tx_digest = *certificate.digest();
         if let Some(signed_effects) =
-            state.get_signed_effects_and_maybe_resign(epoch_store.epoch(), &tx_digest)?
+            state.get_signed_effects_and_maybe_resign(&tx_digest, &epoch_store)?
         {
             return Ok(tonic::Response::new(HandleCertificateResponse {
                 signed_effects: signed_effects.into_inner(),
@@ -379,8 +379,8 @@ impl ValidatorService {
         // the execution results if it contains shared objects.
         let res = state.execute_certificate(&certificate, &epoch_store).await;
         match res {
-            Ok(signed_effects) => Ok(tonic::Response::new(HandleCertificateResponse {
-                signed_effects: signed_effects.into_inner(),
+            Ok(effects) => Ok(tonic::Response::new(HandleCertificateResponse {
+                signed_effects: effects.into_inner(),
             })),
             Err(e) => Err(tonic::Status::from(e)),
         }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -32,7 +32,7 @@ use sui_types::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
 use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::gas::GasCostSummary;
-use sui_types::messages::{TransactionEffects, VerifiedSignedTransactionEffects};
+use sui_types::messages::TransactionEffects;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
     CheckpointSignatureMessage, CheckpointSummary, CheckpointTimestamp, VerifiedCheckpoint,
@@ -469,7 +469,7 @@ impl CheckpointBuilder {
             .inc_by(pending.roots.len() as u64);
         let roots = self
             .effects_store
-            .notify_read_effects(pending.roots)
+            .notify_read_executed_effects(pending.roots)
             .in_monitored_scope("CheckpointNotifyRead")
             .await?;
         let _scope = monitored_scope("CheckpointBuilder");
@@ -728,7 +728,7 @@ impl CheckpointBuilder {
     /// This list includes the roots and all their dependencies, which are not part of checkpoint already
     fn complete_checkpoint_effects(
         &self,
-        mut roots: Vec<VerifiedSignedTransactionEffects>,
+        mut roots: Vec<TransactionEffects>,
     ) -> SuiResult<Vec<TransactionEffects>> {
         let _scope = monitored_scope("CheckpointBuilder::complete_checkpoint_effects");
         let mut results = vec![];
@@ -759,13 +759,13 @@ impl CheckpointBuilder {
                         pending.insert(*dependency);
                     }
                 }
-                results.push(effect.into_message());
+                results.push(effect);
             }
             if pending.is_empty() {
                 break;
             }
             let pending = pending.into_iter().collect::<Vec<_>>();
-            let effects = self.effects_store.get_effects(&pending)?;
+            let effects = self.effects_store.multi_get_executed_effects(&pending)?;
             let effects = effects
                 .into_iter()
                 .zip(pending.into_iter())
@@ -1197,7 +1197,6 @@ mod tests {
     use fastcrypto::traits::KeyPair;
     use std::collections::HashMap;
     use sui_types::crypto::Signature;
-    use sui_types::messages::{SignedTransactionEffects, TrustedSignedTransactionEffects};
     use sui_types::messages_checkpoint::SignedCheckpointSummary;
     use tempfile::tempdir;
     use tokio::sync::mpsc;
@@ -1215,38 +1214,19 @@ mod tests {
         let state =
             AuthorityState::new_for_testing(committee.clone(), &keypair, None, &genesis).await;
 
-        let mut store = HashMap::<TransactionDigest, TrustedSignedTransactionEffects>::new();
+        let mut store = HashMap::<TransactionDigest, TransactionEffects>::new();
         store.insert(
             d(1),
-            e(
-                &state,
-                d(1),
-                vec![d(2), d(3)],
-                GasCostSummary::new(11, 12, 13),
-            ),
+            e(d(1), vec![d(2), d(3)], GasCostSummary::new(11, 12, 13)),
         );
         store.insert(
             d(2),
-            e(
-                &state,
-                d(2),
-                vec![d(3), d(4)],
-                GasCostSummary::new(21, 22, 23),
-            ),
+            e(d(2), vec![d(3), d(4)], GasCostSummary::new(21, 22, 23)),
         );
-        store.insert(
-            d(3),
-            e(&state, d(3), vec![], GasCostSummary::new(31, 32, 33)),
-        );
-        store.insert(
-            d(4),
-            e(&state, d(4), vec![], GasCostSummary::new(41, 42, 43)),
-        );
+        store.insert(d(3), e(d(3), vec![], GasCostSummary::new(31, 32, 33)));
+        store.insert(d(4), e(d(4), vec![], GasCostSummary::new(41, 42, 43)));
         for i in [10, 11, 12, 13] {
-            store.insert(
-                d(i),
-                e(&state, d(i), vec![], GasCostSummary::new(41, 42, 43)),
-            );
+            store.insert(d(i), e(d(i), vec![], GasCostSummary::new(41, 42, 43)));
         }
         let all_digests: Vec<_> = store.iter().map(|(k, _v)| *k).collect();
         for digest in all_digests {
@@ -1353,25 +1333,22 @@ mod tests {
     }
 
     #[async_trait]
-    impl EffectsNotifyRead for HashMap<TransactionDigest, TrustedSignedTransactionEffects> {
-        async fn notify_read_effects(
+    impl EffectsNotifyRead for HashMap<TransactionDigest, TransactionEffects> {
+        async fn notify_read_executed_effects(
             &self,
             digests: Vec<TransactionDigest>,
-        ) -> SuiResult<Vec<VerifiedSignedTransactionEffects>> {
+        ) -> SuiResult<Vec<TransactionEffects>> {
             Ok(digests
                 .into_iter()
-                .map(|d| self.get(&d).expect("effects not found").clone().into())
+                .map(|d| self.get(&d).expect("effects not found").clone())
                 .collect())
         }
 
-        fn get_effects(
+        fn multi_get_executed_effects(
             &self,
             digests: &[TransactionDigest],
-        ) -> SuiResult<Vec<Option<VerifiedSignedTransactionEffects>>> {
-            Ok(digests
-                .iter()
-                .map(|d| self.get(d).cloned().map(|e_opt| e_opt.into()))
-                .collect())
+        ) -> SuiResult<Vec<Option<TransactionEffects>>> {
+            Ok(digests.iter().map(|d| self.get(d).cloned()).collect())
         }
     }
 
@@ -1417,23 +1394,15 @@ mod tests {
     }
 
     fn e(
-        state: &AuthorityState,
         transaction_digest: TransactionDigest,
         dependencies: Vec<TransactionDigest>,
         gas_used: GasCostSummary,
-    ) -> TrustedSignedTransactionEffects {
-        let effects = TransactionEffects {
+    ) -> TransactionEffects {
+        TransactionEffects {
             transaction_digest,
             dependencies,
             gas_used,
             ..Default::default()
-        };
-        VerifiedSignedTransactionEffects::new_unchecked(SignedTransactionEffects::new(
-            state.epoch_store_for_testing().epoch(),
-            effects,
-            &*state.secret,
-            state.name,
-        ))
-        .serializable()
+        }
     }
 }

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -4,9 +4,9 @@
 use std::sync::Arc;
 
 use sui_types::base_types::TransactionDigest;
-use sui_types::base_types::TransactionEffectsDigest;
 use sui_types::committee::Committee;
 use sui_types::committee::EpochId;
+use sui_types::digests::TransactionEffectsDigest;
 use sui_types::message_envelope::Message;
 use sui_types::messages::TransactionEffects;
 use sui_types::messages::VerifiedCertificate;

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -144,7 +144,7 @@ impl LocalAuthorityClient {
         let tx_digest = *certificate.digest();
         let epoch_store = state.epoch_store_for_testing();
         let signed_effects =
-            match state.get_signed_effects_and_maybe_resign(epoch_store.epoch(), &tx_digest) {
+            match state.get_signed_effects_and_maybe_resign(&tx_digest, &epoch_store) {
                 Ok(Some(effects)) => effects,
                 _ => {
                     let certificate = { certificate.verify(epoch_store.committee())? };

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -64,7 +64,7 @@ where
 pub async fn wait_for_tx(digest: TransactionDigest, state: Arc<AuthorityState>) {
     match timeout(
         WAIT_FOR_TX_TIMEOUT,
-        state.database.notify_read_effects(vec![digest]),
+        state.database.notify_read_executed_effects(vec![digest]),
     )
     .await
     {
@@ -79,7 +79,7 @@ pub async fn wait_for_tx(digest: TransactionDigest, state: Arc<AuthorityState>) 
 pub async fn wait_for_all_txes(digests: Vec<TransactionDigest>, state: Arc<AuthorityState>) {
     match timeout(
         WAIT_FOR_TX_TIMEOUT,
-        state.database.notify_read_effects(digests.clone()),
+        state.database.notify_read_executed_effects(digests.clone()),
     )
     .await
     {

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -127,7 +127,7 @@ impl TransactionManager {
                 continue;
             }
             // skip already executed txes
-            if self.authority_store.effects_exists(&digest)? {
+            if self.authority_store.is_tx_already_executed(&digest)? {
                 // also ensure the transaction will not be retried after restart.
                 let _ = epoch_store.remove_pending_certificate(&digest);
                 self.metrics

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -245,12 +245,11 @@ pub async fn do_cert_with_shared_objects(
     send_consensus(authority, cert).await;
     authority
         .database
-        .notify_read_effects(vec![*cert.digest()])
+        .notify_read_executed_effects(vec![*cert.digest()])
         .await
         .unwrap()
         .pop()
         .unwrap()
-        .into_message()
 }
 
 async fn execute_shared_on_first_three_authorities(
@@ -426,7 +425,7 @@ async fn test_transaction_manager() {
         .collect();
     authorities[3]
         .database
-        .notify_read_effects(digests)
+        .notify_read_executed_effects(digests)
         .await
         .unwrap();
 }
@@ -478,7 +477,7 @@ async fn test_per_object_overload() {
     for authority in authorities.iter().take(3) {
         authority
             .database
-            .notify_read_effects(vec![*create_counter_cert.digest()])
+            .notify_read_executed_effects(vec![*create_counter_cert.digest()])
             .await
             .unwrap()
             .pop()
@@ -493,7 +492,7 @@ async fn test_per_object_overload() {
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
         .database
-        .notify_read_effects(vec![*create_counter_cert.digest()])
+        .notify_read_executed_effects(vec![*create_counter_cert.digest()])
         .await
         .unwrap()
         .pop()

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -1179,6 +1179,8 @@ where
                 store
                     .insert_transaction_effects(effects)
                     .expect("store operation should not fail");
+                // TODO: If the transaction has already been executed, we should check that the executed
+                // effects match. If they don't, it's a bug and we should panic.
                 return Ok(());
             }
         }

--- a/crates/sui-network/src/state_sync/server.rs
+++ b/crates/sui-network/src/state_sync/server.rs
@@ -116,12 +116,12 @@ where
             effects,
         } = request.into_inner();
 
-        let transaction = if let Some(transaction) = self
+        let cert = if let Some(cert) = self
             .store
             .get_transaction(&transaction)
             .map_err(|e| Status::internal(e.to_string()))?
         {
-            transaction
+            cert
         } else {
             return Ok(Response::new(None));
         };
@@ -136,6 +136,6 @@ where
             return Ok(Response::new(None));
         };
 
-        Ok(Response::new(Some((transaction.into_inner(), effects))))
+        Ok(Response::new(Some((cert.into_inner(), effects))))
     }
 }

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::base_types::{SuiAddress, TransactionDigest, TransactionEffectsDigest, VersionNumber};
+use crate::base_types::{SuiAddress, TransactionDigest, VersionNumber};
 use crate::committee::{Committee, EpochId};
-use crate::digests::{CheckpointContentsDigest, CheckpointDigest};
+use crate::digests::{CheckpointContentsDigest, CheckpointDigest, TransactionEffectsDigest};
 use crate::message_envelope::Message;
 use crate::messages::InputObjectKind::{ImmOrOwnedMoveObject, MovePackage, SharedMoveObject};
 use crate::messages::{SenderSignedData, TransactionEffects, VerifiedCertificate};


### PR DESCRIPTION
This is part of supporting finalized transactions.
The core of this PR contains two db changes:
1. The effects signature is moved to a per-epoch table called `effects_signatures`. When we look up already executed certificates, we look for both executed effects and the signature. If a signature is not available (since it was from a previous epoch), we re-sign the effects.
2. `executed_effects` table now only contains a mapping from the transaction digest to the effects digest. This allows us to get rid of the duplicated effects storage. We still need this table because we need to know whether a transaction has been executed locally or not. This extra layer does make some lookups more complicated (we have to look up in two tables).