### PR TITLE
Use latest committee during bootstrap in embeeded reconfig observer

### DIFF
--- a/crates/sui-benchmark/src/embedded_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/embedded_reconfig_observer.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::anyhow;
 use async_trait::async_trait;
 use std::sync::Arc;
+use sui_core::authority_aggregator::AuthorityAggregator;
 use sui_core::{
     authority_client::NetworkAuthorityClient,
     quorum_driver::{reconfig_observer::ReconfigObserver, QuorumDriver},
@@ -31,6 +33,44 @@ impl EmbeddedReconfigObserver {
     }
 }
 
+impl EmbeddedReconfigObserver {
+    pub async fn get_committee(
+        &self,
+        auth_agg: Arc<AuthorityAggregator<NetworkAuthorityClient>>,
+    ) -> anyhow::Result<Arc<AuthorityAggregator<NetworkAuthorityClient>>> {
+        // auth_agg and cur_epoch is consistently in each iteration,
+        // assuming no other ReconfigObserver is working at the same time.
+        let cur_epoch = auth_agg.committee.epoch();
+        match auth_agg
+            .get_latest_system_state_object_for_testing()
+            .await
+            .map(|state| state.get_current_epoch_committee())
+        {
+            Err(err) => Err(err),
+            Ok(committee_info) => {
+                let network_config = default_mysten_network_config();
+                let new_epoch = committee_info.committee.epoch;
+                if new_epoch <= cur_epoch {
+                    trace!(
+                        cur_epoch,
+                        new_epoch,
+                        "Ignored Committee from a previous or current epoch",
+                    );
+                    return Ok(auth_agg);
+                }
+                info!(
+                    cur_epoch,
+                    new_epoch, "Observed a new epoch, attempting to reconfig: {committee_info}"
+                );
+                auth_agg
+                    .recreate_with_net_addresses(committee_info, &network_config, false)
+                    .map(Arc::new)
+                    .map_err(|se| anyhow!("Failed to recreate due to: {:?}", se.to_string()))
+            }
+        }
+    }
+}
+
 #[async_trait]
 impl ReconfigObserver<NetworkAuthorityClient> for EmbeddedReconfigObserver {
     fn clone_boxed(&self) -> Box<dyn ReconfigObserver<NetworkAuthorityClient> + Send + Sync> {
@@ -40,51 +80,15 @@ impl ReconfigObserver<NetworkAuthorityClient> for EmbeddedReconfigObserver {
     async fn run(&mut self, quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>) {
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-
-            // auth_agg and cur_epoch is consistently in each iteration,
-            // assuming no other ReconfigObserver is working at the same time.
             let auth_agg = quorum_driver.authority_aggregator().load();
-            let cur_epoch = quorum_driver.current_epoch();
-
-            match auth_agg
-                .get_latest_system_state_object_for_testing()
-                .await
-                .map(|state| state.get_current_epoch_committee())
-            {
+            match self.get_committee(auth_agg.clone()).await {
+                Ok(new_auth_agg) => quorum_driver.update_validators(new_auth_agg).await,
                 Err(err) => {
-                    error!("Failed to get committee with network address: {}", err)
-                }
-                Ok(committee_info) => {
-                    let network_config = default_mysten_network_config();
-                    let new_epoch = committee_info.committee.epoch;
-                    if new_epoch <= cur_epoch {
-                        trace!(
-                            cur_epoch,
-                            new_epoch,
-                            "Ignored Committee from a previous or current epoch",
-                        );
-                        continue;
-                    }
-                    info!(
-                        cur_epoch,
-                        new_epoch, "Observed a new epoch, attempting to reconfig: {committee_info}"
+                    error!(
+                        "Failed to recreate authority aggregator with committee: {}",
+                        err
                     );
-                    match auth_agg.recreate_with_net_addresses(
-                        committee_info,
-                        &network_config,
-                        false,
-                    ) {
-                        Err(err) => error!(
-                            cur_epoch,
-                            new_epoch,
-                            "Failed to recreate authority aggregator with committee: {}",
-                            err
-                        ),
-                        Ok(auth_agg) => {
-                            quorum_driver.update_validators(Arc::new(auth_agg)).await;
-                            info!(cur_epoch, new_epoch, "Reconfiguration to epoch is done");
-                        }
-                    }
+                    continue;
                 }
             }
         }

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -155,10 +155,11 @@ impl LocalValidatorAggregatorProxy {
         reconfig_fullnode_rpc_url: Option<&str>,
     ) -> Self {
         let quorum_driver_metrics = Arc::new(QuorumDriverMetrics::new(registry));
-        let qd_handler_builder =
-            QuorumDriverHandlerBuilder::new(Arc::new(aggregator.clone()), quorum_driver_metrics);
-
         let qd_handler = (if let Some(reconfig_fullnode_rpc_url) = reconfig_fullnode_rpc_url {
+            let qd_handler_builder = QuorumDriverHandlerBuilder::new(
+                Arc::new(aggregator.clone()),
+                quorum_driver_metrics,
+            );
             info!(
                 "Using FullNodeReconfigObserver: {:?}",
                 reconfig_fullnode_rpc_url
@@ -176,6 +177,14 @@ impl LocalValidatorAggregatorProxy {
             qd_handler_builder.with_reconfig_observer(reconfig_observer)
         } else {
             info!("Using EmbeddedReconfigObserver");
+            let observer = EmbeddedReconfigObserver::new();
+            // Get the latest committee from config observer
+            let new_agg = observer
+                .get_committee(Arc::new(aggregator))
+                .await
+                .expect("Failed to get latest committee");
+            let qd_handler_builder =
+                QuorumDriverHandlerBuilder::new(new_agg, quorum_driver_metrics);
             qd_handler_builder.with_reconfig_observer(Arc::new(EmbeddedReconfigObserver::new()))
         })
         .start();


### PR DESCRIPTION
In the current setup when using embedded reconfig observer for remote mode, we learn about the latest committee in the background but the validator proxy is initialized with the genesis committee. This causes initial gas requests to fail and eventually stress client to crash with error. In this PR, we fix the behavior by learning about the latest committee during validator proxy creation.