### PR TITLE
[Narwhal] make HeaderDigest, VoteDigest and CertificateDigest equal

### DIFF
--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -148,7 +148,7 @@ impl Core {
 
         let mut missing_parents: Vec<CertificateDigest> = Vec::new();
         let mut attempt: u32 = 0;
-        let vote = loop {
+        let vote: Vote = loop {
             attempt += 1;
 
             let parents = if missing_parents.is_empty() {
@@ -214,8 +214,10 @@ impl Core {
 
         // Verify the vote. Note that only the header digest is signed by the vote.
         ensure!(
-            vote.digest == header.digest(),
-            DagError::UnexpectedVote(vote.digest)
+            vote.header_digest == header.digest()
+                && vote.origin == header.author
+                && vote.author == authority,
+            DagError::UnexpectedVote(vote.header_digest)
         );
         // Possible equivocations.
         ensure!(
@@ -231,10 +233,6 @@ impl Core {
                 expected: header.round,
                 received: vote.round
             }
-        );
-        ensure!(
-            vote.origin == header.author && vote.author == authority,
-            DagError::UnexpectedVote(vote.digest)
         );
         vote.verify(&committee)?;
 

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -388,6 +388,7 @@ pub struct Vote {
     pub epoch: Epoch,
     pub origin: PublicKey,
     pub author: PublicKey,
+    // Signature of the HeaderDigest.
     pub signature: <PublicKey as VerifyingKey>::Sig,
 }
 
@@ -484,12 +485,7 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for Vote {
     type TypedDigest = VoteDigest;
 
     fn digest(&self) -> VoteDigest {
-        let mut hasher = crypto::DefaultHashFunction::default();
-        hasher.update(Digest::from(self.digest));
-        hasher.update(self.round.to_le_bytes());
-        hasher.update(self.epoch.to_le_bytes());
-        hasher.update(&self.origin);
-        VoteDigest(hasher.finalize().into())
+        VoteDigest(self.digest.0)
     }
 }
 
@@ -769,12 +765,7 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for Certificate {
     type TypedDigest = CertificateDigest;
 
     fn digest(&self) -> CertificateDigest {
-        let mut hasher = crypto::DefaultHashFunction::new();
-        hasher.update(Digest::from(self.header.digest()));
-        hasher.update(self.round().to_le_bytes());
-        hasher.update(self.epoch().to_le_bytes());
-        hasher.update(&self.origin());
-        CertificateDigest(hasher.finalize().into())
+        CertificateDigest(self.header.digest().0)
     }
 }
 

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -381,12 +381,16 @@ impl PartialEq for Header {
     }
 }
 
+/// A Vote on a Header is a claim by the voting authority that all payloads and the full history
+/// of Certificates included in the Header are available.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Vote {
-    pub digest: HeaderDigest,
+    // HeaderDigest, round, epoch and origin for the header being voted on.
+    pub header_digest: HeaderDigest,
     pub round: Round,
     pub epoch: Epoch,
     pub origin: PublicKey,
+    // Author of this vote.
     pub author: PublicKey,
     // Signature of the HeaderDigest.
     pub signature: <PublicKey as VerifyingKey>::Sig,
@@ -399,7 +403,7 @@ impl Vote {
         signature_service: &SignatureService<Signature, { crypto::DIGEST_LENGTH }>,
     ) -> Self {
         let vote = Self {
-            digest: header.digest(),
+            header_digest: header.digest(),
             round: header.round,
             epoch: header.epoch,
             origin: header.author.clone(),
@@ -417,7 +421,7 @@ impl Vote {
         S: Signer<Signature>,
     {
         let vote = Self {
-            digest: header.digest(),
+            header_digest: header.digest(),
             round: header.round,
             epoch: header.epoch,
             origin: header.author.clone(),
@@ -485,7 +489,7 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for Vote {
     type TypedDigest = VoteDigest;
 
     fn digest(&self) -> VoteDigest {
-        VoteDigest(self.digest.0)
+        VoteDigest(self.header_digest.0)
     }
 }
 
@@ -497,7 +501,7 @@ impl fmt::Debug for Vote {
             self.digest(),
             self.round,
             self.author.encode_base64(),
-            self.digest,
+            self.origin.encode_base64(),
             self.epoch
         )
     }


### PR DESCRIPTION
Currently CertificateDigest and VoteDigest are computed as a hash of HeaderDigest, round, epoch and origin. The latter 3 items are already included in the computation for HeaderDigest. This computation could be useful for future optimizations. But for now it seems simpler to keep them consistent.