### PR TITLE
Disable stat collection in smoke tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,7 +91,7 @@ jobs:
           cargo nextest run --profile ci
       - name: benchmark (smoke)
         run: |
-          cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s --stress-stat-collection
+          cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s
           pushd narwhal/benchmark && fab smoke && popd
       - name: doctests
         run: |


### PR DESCRIPTION
The smoke test seems to be crashing a lot recently. While I don't have any concrete data point, it seems to be correlated to the change around enabling system stat collection in smoke tests. My gut feeling is that we may not be closing some system handles in time before shutdown. With this PR we can observe if smoke tests are working any better and if so, we know where to look deeper. And if not, we have bigger problem and likely need to disable the smoke test until we can root cause it.