### PR TITLE
Add rocksdb graceful shutdown

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -189,6 +189,12 @@ macro_rules! delegate_call {
     }
 }
 
+impl Drop for RocksDB {
+    fn drop(&mut self) {
+        delegate_call!(self.cancel_all_background_work(/* wait */ true))
+    }
+}
+
 impl RocksDB {
     pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, rocksdb::Error> {
         delegate_call!(self.get(key))


### PR DESCRIPTION
Rocksdb has background jobs which could still be running when we terminate the process. We need to invoke this function for it to cancel all background jobs nicely and then drop the db. Not doing it could potentially corrupt the disk state as well.