### PR TITLE
sponsored tx

### DIFF
--- a/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
@@ -15,6 +15,7 @@ import {
     type ExecutionStatusType,
     type TransactionKindName,
     type JsonRpcProvider,
+    type CertifiedTransaction_v26,
 } from '@mysten/sui.js';
 import { Fragment } from 'react';
 
@@ -182,7 +183,8 @@ export const getDataOnTxDigests = (
                         transactionId ===
                         getTransactionDigest(txEff.certificate)
                 )[0];
-                const res: CertifiedTransaction = txEff.certificate;
+                const res: CertifiedTransaction | CertifiedTransaction_v26 =
+                    txEff.certificate;
                 // TODO: handle multiple transactions
                 const txns = getTransactions(res);
                 if (txns.length > 1) {

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -8,6 +8,7 @@ import {
     getTransactions,
     getTransactionSender,
     getTransferObjectTransaction,
+    getTransactionSignature,
     getMovePackageContent,
     getObjectId,
     SUI_TYPE_ARG,
@@ -357,7 +358,7 @@ function TransactionView({
         content: [
             {
                 label: 'Signature',
-                value: transaction.certificate.txSignature,
+                value: getTransactionSignature(transaction.certificate),
                 monotypeClass: true,
             },
         ],
@@ -442,7 +443,18 @@ function TransactionView({
 
     const txError = getExecutionStatusError(transaction);
 
-    const gasPrice = transaction.certificate.data.gasPrice || 1;
+    const gasPrice =
+        ('gasData' in transaction.certificate.data
+            ? transaction.certificate.data.gasData.price
+            : transaction.certificate.data.gasPrice) || 1;
+    const gasPayment =
+        'gasData' in transaction.certificate.data
+            ? transaction.certificate.data.gasData.payment
+            : transaction.certificate.data.gasPayment;
+    const gasBudget =
+        'gasData' in transaction.certificate.data
+            ? transaction.certificate.data.gasData.budget
+            : transaction.certificate.data.gasBudget;
 
     return (
         <div className={clsx(styles.txdetailsbg)}>
@@ -568,20 +580,12 @@ function TransactionView({
                                 <DescriptionItem title="Gas Payment">
                                     <ObjectLink
                                         noTruncate
-                                        objectId={
-                                            transaction.certificate.data
-                                                .gasPayment.objectId
-                                        }
+                                        objectId={gasPayment.objectId}
                                     />
                                 </DescriptionItem>
 
                                 <DescriptionItem title="Gas Budget">
-                                    <GasAmount
-                                        amount={
-                                            transaction.certificate.data
-                                                .gasBudget * gasPrice
-                                        }
-                                    />
+                                    <GasAmount amount={gasBudget * gasPrice} />
                                 </DescriptionItem>
 
                                 {gasFeesExpanded && (

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -134,7 +134,7 @@ impl TestContext {
             .get_fullnode_client()
             .quorum_driver()
             .execute_transaction(
-                Transaction::from_data(txn_data, Intent::default(), signature)
+                Transaction::from_data(txn_data, Intent::default(), vec![signature])
                     .verify()
                     .unwrap(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -804,7 +804,7 @@ fn create_genesis_transaction(
         );
 
         let transaction_data = genesis_transaction.data().intent_message.value.clone();
-        let signer = transaction_data.signer();
+        let signer = transaction_data.sender();
         let gas = transaction_data.gas();
         let (inner_temp_store, effects, _execution_error) =
             sui_adapter::execution_engine::execute_transaction_to_effects::<
@@ -1157,7 +1157,7 @@ mod test {
         );
 
         let transaction_data = genesis_transaction.data().intent_message.value.clone();
-        let signer = transaction_data.signer();
+        let signer = transaction_data.sender();
         let gas = transaction_data.gas();
         let (_inner_temp_store, effects, _execution_error) =
             sui_adapter::execution_engine::execute_transaction_to_effects::<

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -923,7 +923,7 @@ impl AuthorityState {
             epoch_store.protocol_config(),
         );
         let transaction_data = certificate.data().intent_message.value.clone();
-        let signer = transaction_data.signer();
+        let signer = transaction_data.sender();
         let gas = transaction_data.gas();
         let (inner_temp_store, effects, _execution_error) =
             execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
@@ -982,7 +982,7 @@ impl AuthorityState {
             transaction_digest,
             epoch_store.protocol_config(),
         );
-        let signer = transaction.signer();
+        let signer = transaction.sender();
         let gas = transaction.gas();
         let (_inner_temp_store, effects, _execution_error) =
             execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -224,7 +224,7 @@ pub struct AuthorityEpochTables {
 
     /// When we see certificate through consensus for the first time, we record
     /// user signature for this transaction here. This will be included in the checkpoint later.
-    user_signatures_for_checkpoints: DBMap<TransactionDigest, GenericSignature>,
+    user_signatures_for_checkpoints: DBMap<TransactionDigest, Vec<GenericSignature>>,
 
     /// Maps sequence number to checkpoint summary, used by CheckpointBuilder to build checkpoint within epoch
     builder_checkpoint_summary: DBMap<CheckpointSequenceNumber, CheckpointSummary>,
@@ -847,7 +847,7 @@ impl AuthorityPerEpochStore {
     pub async fn user_signatures_for_checkpoint(
         &self,
         digests: &[TransactionDigest],
-    ) -> SuiResult<Vec<GenericSignature>> {
+    ) -> SuiResult<Vec<Vec<GenericSignature>>> {
         // todo - use NotifyRead::register_all might be faster
         for digest in digests {
             self.consensus_message_processed_notify(ConsensusTransactionKey::Certificate(*digest))
@@ -858,11 +858,11 @@ impl AuthorityPerEpochStore {
             .user_signatures_for_checkpoints
             .multi_get(digests)?;
         let mut result = Vec::with_capacity(digests.len());
-        for (signature, digest) in signatures.into_iter().zip(digests.iter()) {
-            let Some(signature) = signature else {
+        for (signatures, digest) in signatures.into_iter().zip(digests.iter()) {
+            let Some(signatures) = signatures else {
                 return Err(SuiError::from(format!("Can not find user signature for checkpoint for transaction {:?}", digest).as_str()));
             };
-            result.push(signature);
+            result.push(signatures);
         }
         Ok(result)
     }
@@ -1144,11 +1144,11 @@ impl AuthorityPerEpochStore {
     pub fn test_insert_user_signature(
         &self,
         digest: TransactionDigest,
-        signature: &GenericSignature,
+        signatures: Vec<GenericSignature>,
     ) {
         self.tables
             .user_signatures_for_checkpoints
-            .insert(&digest, signature)
+            .insert(&digest, &signatures)
             .unwrap();
         let key = ConsensusTransactionKey::Certificate(digest);
         self.tables
@@ -1182,7 +1182,7 @@ impl AuthorityPerEpochStore {
             .contains_key(certificate.digest())?);
         let batch = batch.insert_batch(
             &self.tables.user_signatures_for_checkpoints,
-            [(*certificate.digest(), certificate.tx_signature.clone())],
+            [(*certificate.digest(), certificate.tx_signatures.clone())],
         )?;
         self.finish_consensus_transaction_process_with_batch(batch, key, consensus_index)
     }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1227,7 +1227,7 @@ mod tests {
             let signature = Signature::Ed25519SuiSignature(Default::default()).into();
             state
                 .epoch_store_for_testing()
-                .test_insert_user_signature(digest, &signature);
+                .test_insert_user_signature(digest, vec![signature]);
         }
 
         let (output, mut result) = mpsc::channel::<(CheckpointContents, CheckpointSummary)>(10);

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -209,7 +209,7 @@ mod tests {
             .into_iter()
             .map(|mut cert| {
                 // set it to an all-zero user signature
-                cert.tx_signature =
+                cert.tx_signatures[0] =
                     GenericSignature::Signature(sui_types::crypto::Signature::Ed25519SuiSignature(
                         Ed25519SuiSignature::default(),
                     ));

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -122,7 +122,7 @@ pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
         transaction_digest: *tx.digest(),
         gas_object: (
             random_object_ref(),
-            Owner::AddressOwner(tx.data().intent_message.value.signer()),
+            Owner::AddressOwner(tx.data().intent_message.value.sender()),
         ),
         ..Default::default()
     }

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -38,8 +38,8 @@ async fn get_gas_status(
         store,
         epoch_store,
         gas_object_ref,
-        transaction.gas_budget,
-        transaction.gas_price,
+        transaction.gas_budget(),
+        transaction.gas_price(),
         &transaction.kind,
         extra_gas_object_refs,
     )
@@ -266,9 +266,15 @@ async fn check_objects(
         if transfer_object_ids.contains(&object.id()) {
             object.ensure_public_transfer_eligible()?;
         }
+        // For Gas Object, we check the object is owned by gas owner
+        let owner_address = if object.id() == transaction.gas_payment_object_ref().0 {
+            transaction.gas_owner()
+        } else {
+            transaction.sender()
+        };
         // Check if the object contents match the type of lock we need for
         // this object.
-        match check_one_object(&transaction.signer(), object_kind, &object) {
+        match check_one_object(&owner_address, object_kind, &object) {
             Ok(()) => all_objects.push((object_kind, object)),
             Err(e) => {
                 errors.push(e);
@@ -292,7 +298,7 @@ async fn check_objects(
 /// The logic to check one object against a reference, and return the object if all is well
 /// or an error if not.
 fn check_one_object(
-    sender: &SuiAddress,
+    owner: &SuiAddress,
     object_kind: InputObjectKind,
     object: &Object,
 ) -> SuiResult {
@@ -339,12 +345,12 @@ fn check_one_object(
                 Owner::Immutable => {
                     // Nothing else to check for Immutable.
                 }
-                Owner::AddressOwner(owner) => {
-                    // Check the owner is the transaction sender.
+                Owner::AddressOwner(actual_owner) => {
+                    // Check the owner is correct.
                     fp_ensure!(
-                        sender == &owner,
+                        owner == &actual_owner,
                         SuiError::IncorrectSigner {
-                            error: format!("Object {:?} is owned by account address {:?}, but signer address is {:?}", object_id, owner, sender),
+                            error: format!("Object {:?} is owned by account address {:?}, but given owner/signer address is {:?}", object_id, actual_owner, owner),
                         }
                     );
                 }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -214,7 +214,7 @@ impl SimpleFaucet {
             .keystore
             .sign_secure(&self.active_address, &tx_data, Intent::default())
             .map_err(FaucetError::internal)?;
-        let tx = Transaction::from_data(tx_data, Intent::default(), signature)
+        let tx = Transaction::from_data(tx_data, Intent::default(), vec![signature])
             .verify()
             .unwrap();
         let tx_digest = *tx.digest();

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -131,8 +131,8 @@ pub fn transaction_response_to_new_transaction(
     })?;
     // canonical txn digest string is Base58 encoded
     let tx_digest = cer.transaction_digest.base58_encode();
-    let gas_budget = cer.data.gas_budget;
-    let gas_price = cer.data.gas_price;
+    let gas_budget = cer.data.gas_data.budget;
+    let gas_price = cer.data.gas_data.price;
     let sender = cer.data.sender.to_string();
     let txn_kind_iter = cer.data.transactions.iter().map(|k| k.to_string());
 

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -679,6 +679,18 @@ pub trait TransactionExecutionApi {
         /// The request type
         request_type: ExecuteTransactionRequestType,
     ) -> RpcResult<SuiExecuteTransactionResponse>;
+
+    // TODO: migrate above two rpc calls to this one eventually.
+    #[method(name = "submitTransaction")]
+    async fn submit_transaction(
+        &self,
+        /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
+        tx_bytes: Base64,
+        /// A list of signatures (`flag || signature || pubkey` bytes, as base-64 encoded string). Signature is committed to the intent message of the transaction data, as base-64 encoded string.
+        signatures: Vec<Base64>,
+        /// The request type
+        request_type: ExecuteTransactionRequestType,
+    ) -> RpcResult<SuiExecuteTransactionResponse>;
 }
 
 pub fn cap_page_limit(limit: Option<usize>) -> usize {

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -48,9 +48,15 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
     ) -> RpcResult<SuiExecuteTransactionResponse> {
         let tx_data =
             bcs::from_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?).map_err(|e| anyhow!(e))?;
-        let signature = GenericSignature::from_bytes(&signature.to_vec().map_err(|e| anyhow!(e))?)
-            .map_err(|e| anyhow!(e))?;
-        let txn = Transaction::from_generic_sig_data(tx_data, Intent::default(), signature);
+
+        let txn = Transaction::from_generic_sig_data(
+            tx_data,
+            Intent::default(),
+            vec![
+                GenericSignature::from_bytes(&signature.to_vec().map_err(|e| anyhow!(e))?)
+                    .map_err(|e| anyhow!(e))?,
+            ],
+        );
 
         let transaction_orchestrator = self.transaction_orchestrator.clone();
         let response = spawn_monitored_task!(transaction_orchestrator.execute_transaction(
@@ -70,6 +76,7 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
         .map_err(jsonrpsee::core::Error::from)
     }
 
+    // TODO: remove this or execute_transaction
     async fn execute_transaction_serialized_sig(
         &self,
         tx_bytes: Base64,
@@ -78,9 +85,53 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
     ) -> RpcResult<SuiExecuteTransactionResponse> {
         let tx_data =
             bcs::from_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?).map_err(|e| anyhow!(e))?;
-        let signature = GenericSignature::from_bytes(&signature.to_vec().map_err(|e| anyhow!(e))?)
-            .map_err(|e| anyhow!(e))?;
-        let txn = Transaction::from_generic_sig_data(tx_data, Intent::default(), signature);
+
+        let txn = Transaction::from_generic_sig_data(
+            tx_data,
+            Intent::default(),
+            vec![
+                GenericSignature::from_bytes(&signature.to_vec().map_err(|e| anyhow!(e))?)
+                    .map_err(|e| anyhow!(e))?,
+            ],
+        );
+
+        let transaction_orchestrator = self.transaction_orchestrator.clone();
+        let response = spawn_monitored_task!(transaction_orchestrator.execute_transaction(
+            ExecuteTransactionRequest {
+                transaction: txn,
+                request_type,
+            }
+        ))
+        .await
+        .map_err(|e| anyhow!(e))? // for JoinError
+        .map_err(|e| anyhow!(e))?; // For Sui transaction execution error (SuiResult<ExecuteTransactionResponse>)
+
+        SuiExecuteTransactionResponse::from_execute_transaction_response(
+            response,
+            self.module_cache.as_ref(),
+        )
+        .map_err(jsonrpsee::core::Error::from)
+    }
+
+    async fn submit_transaction(
+        &self,
+        tx_bytes: Base64,
+        signatures: Vec<Base64>,
+        request_type: ExecuteTransactionRequestType,
+    ) -> RpcResult<SuiExecuteTransactionResponse> {
+        let tx_data =
+            bcs::from_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?).map_err(|e| anyhow!(e))?;
+
+        let mut sigs = Vec::new();
+        for sig in signatures {
+            sigs.push(
+                GenericSignature::from_bytes(&sig.to_vec().map_err(|e| anyhow!(e))?)
+                    .map_err(|e| anyhow!(e))?,
+            );
+        }
+
+        let txn = Transaction::from_generic_sig_data(tx_data, Intent::default(), sigs);
+
         let transaction_orchestrator = self.transaction_orchestrator.clone();
         let response = spawn_monitored_task!(transaction_orchestrator.execute_transaction(
             ExecuteTransactionRequest {

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -69,14 +69,14 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
     let tx_bytes1 = tx_bytes.clone();
     let dryrun_response = http_client.dry_run_transaction(tx_bytes).await?;
 
     let tx_response: SuiExecuteTransactionResponse = http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes1,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -122,12 +122,12 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
         .publish(*address, compiled_modules, Some(gas.object_id), 10000)
         .await?;
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -166,12 +166,12 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
         .await?;
     let tx = transaction_bytes.to_data()?;
     let tx = to_sender_signed_transaction(tx, keystore.get_key(address)?);
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForEffectsCert,
         )
         .await?;
@@ -225,12 +225,12 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
         .await?;
     let tx = transaction_bytes.to_data()?;
     let tx = to_sender_signed_transaction(tx, keystore.get_key(address)?);
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForEffectsCert,
         )
         .await?;
@@ -260,12 +260,12 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -311,12 +311,12 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
 
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -418,12 +418,12 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
-    let (tx_bytes, signature) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -477,12 +477,12 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
-    let (tx_bytes, signature) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -555,12 +555,12 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let tx = transaction_bytes.to_data()?;
 
     let tx = to_sender_signed_transaction(tx, keystore.get_key(address)?);
-    let (tx_bytes, signature) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -595,12 +595,12 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
         let tx =
             to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
 
-        let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+        let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
         let response = http_client
-            .execute_transaction(
+            .submit_transaction(
                 tx_bytes,
-                signature_bytes,
+                signatures,
                 ExecuteTransactionRequestType::WaitForLocalExecution,
             )
             .await?;
@@ -949,12 +949,12 @@ async fn test_locked_sui() -> Result<(), anyhow::Error> {
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
 
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -1003,12 +1003,12 @@ async fn test_delegation() -> Result<(), anyhow::Error> {
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
 
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -1062,12 +1062,12 @@ async fn test_delegation_multiple_coins() -> Result<(), anyhow::Error> {
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
 
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -1129,12 +1129,12 @@ async fn test_delegation_with_locked_sui() -> Result<(), anyhow::Error> {
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
 
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;
@@ -1160,12 +1160,12 @@ async fn test_delegation_with_locked_sui() -> Result<(), anyhow::Error> {
         )
         .await?;
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
-    let (tx_bytes, signature_bytes) = tx.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .execute_transaction(
+        .submit_transaction(
             tx_bytes,
-            signature_bytes,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
         )
         .await?;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -123,7 +123,7 @@
           "result": {
             "name": "Result",
             "value": {
-              "txBytes": "AQICAAAAAAAAAAAAAAAAAAAAAAAAAAIKZGV2bmV0X25mdARtaW50AAMAC0V4YW1wbGUgTkZUACtBbiBORlQgY3JlYXRlZCBieSB0aGUgU3VpIENvbW1hbmQgTGluZSBUb29sAEJpcGZzOi8vYmFma3JlaWJuZ3FobDNnYWE3ZGFvYjRpMnZjY3ppYXkyampscDQzNWNmNjZ2aG9ubzducnZ3dzUzdHkAxhkVTEKhxhvpkCcXskuOwWj+SJbv75LL9EtYHyMiLBCRaxejabTaAwEAAAAAAAAAIJ0HWVK1gDbyp7VhRGWSQDxnLw2+Ep8eORE/n2Fk6ihnmweBXwRJfi4F0iysOqBhQQsghoz1twzLEPGnBeBh0P36GJYY0osNRAEAAAAAAAAAIPjezPPDxRjxRt6VVPA/J6g9WxGF855x7zV+K9nhOWJRAQAAAAAAAADoAwAAAAAAAA==",
+              "txBytes": "AQICAAAAAAAAAAAAAAAAAAAAAAAAAAIKZGV2bmV0X25mdARtaW50AAMAC0V4YW1wbGUgTkZUACtBbiBORlQgY3JlYXRlZCBieSB0aGUgU3VpIENvbW1hbmQgTGluZSBUb29sAEJpcGZzOi8vYmFma3JlaWJuZ3FobDNnYWE3ZGFvYjRpMnZjY3ppYXkyampscDQzNWNmNjZ2aG9ubzducnZ3dzUzdHkAxhkVTEKhxhvpkCcXskuOwWj+SJbv75LL9EtYHyMiLBCRaxejabTaAwEAAAAAAAAAIJ0HWVK1gDbyp7VhRGWSQDxnLw2+Ep8eORE/n2Fk6ihnmweBXwRJfi4F0iysOqBhQQsghoz1twzLEPGnBeBh0P36GJYY0osNRAEAAAAAAAAAIPjezPPDxRjxRt6VVPA/J6g9WxGF855x7zV+K9nhOWJRmweBXwRJfi4F0iysOqBhQQsghowBAAAAAAAAAOgDAAAAAAAA",
               "gas": {
                 "objectId": "0xf5b70ccb10f1a705e061d0fdfa189618d28b0d44",
                 "version": 1,
@@ -276,11 +276,11 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AABmzCnfsdpjc86U+dldylpA9OF2mRjuv5+64AvTjleHL0UiRGjh/BfIAgAAAAAAAAAgXwGimIeh2V5bVIthbaY7DOB9gW6J73uaOCF3tEIruqIC/zJV4AzkKt/uEhM/ciLdOKkz6xRwidxDGP3UANtnNk7zUMlSZ22FAgAAAAAAAAAgfcN/rn2TKYoSRcMbQgaIwWhstNE1bRcYDdguk6SDxasBAAAAAAAAAOgDAAAAAAAA"
+              "value": "AABmzCnfsdpjc86U+dldylpA9OF2mRjuv5+64AvTjleHL0UiRGjh/BfIAgAAAAAAAAAgXwGimIeh2V5bVIthbaY7DOB9gW6J73uaOCF3tEIruqIC/zJV4AzkKt/uEhM/ciLdOKkz6xRwidxDGP3UANtnNk7zUMlSZ22FAgAAAAAAAAAgfcN/rn2TKYoSRcMbQgaIwWhstNE1bRcYDdguk6SDxasC/zJV4AzkKt/uEhM/ciLdOKkz6wEAAAAAAAAA6AMAAAAAAAA="
             },
             {
               "name": "signature",
-              "value": "APTKkXWW1T8Vmz5xofVuEEo336IFluv69ByMuPwfvwTrU749/fOtpBw4Kffd0809C+EP/7+GNLWNIbZHH5eRnwUgZe9Z6CbTODIzbq3ZFq53AzRXBmnyBDiKgDwkZI8sdA=="
+              "value": "ALHyla2pZUPDolq3E5yOc8ojGuimSKwYLfAha9mP5KOtvJQl/s+t3u3cv3fz4wDBqprobPV7vW6ze79237ujGQwgZe9Z6CbTODIzbq3ZFq53AzRXBmnyBDiKgDwkZI8sdA=="
             },
             {
               "name": "request_type",
@@ -291,7 +291,7 @@
             "name": "Result",
             "value": {
               "certificate": {
-                "transactionDigest": "9WEY6uXPqJbJnpczE4YNJphe4w3g4M6YrJLt5yRFC6jK",
+                "transactionDigest": "7VjbrWg5vG11wLUkvAQwWGSPNxPNH1qw98o1e4Rjx1em",
                 "data": {
                   "transactions": [
                     {
@@ -306,15 +306,20 @@
                     }
                   ],
                   "sender": "0x02ff3255e00ce42adfee12133f7222dd38a933eb",
-                  "gasPayment": {
-                    "objectId": "0x147089dc4318fdd400db67364ef350c952676d85",
-                    "version": 2,
-                    "digest": "fcN/rn2TKYoSRcMbQgaIwWhstNE1bRcYDdguk6SDxas="
-                  },
-                  "gasPrice": 1,
-                  "gasBudget": 1000
+                  "gasData": {
+                    "payment": {
+                      "objectId": "0x147089dc4318fdd400db67364ef350c952676d85",
+                      "version": 2,
+                      "digest": "fcN/rn2TKYoSRcMbQgaIwWhstNE1bRcYDdguk6SDxas="
+                    },
+                    "owner": "0x02ff3255e00ce42adfee12133f7222dd38a933eb",
+                    "price": 1,
+                    "budget": 1000
+                  }
                 },
-                "txSignature": "APTKkXWW1T8Vmz5xofVuEEo336IFluv69ByMuPwfvwTrU749/fOtpBw4Kffd0809C+EP/7+GNLWNIbZHH5eRnwUgZe9Z6CbTODIzbq3ZFq53AzRXBmnyBDiKgDwkZI8sdA==",
+                "txSignatures": [
+                  "ALHyla2pZUPDolq3E5yOc8ojGuimSKwYLfAha9mP5KOtvJQl/s+t3u3cv3fz4wDBqprobPV7vW6ze79237ujGQwgZe9Z6CbTODIzbq3ZFq53AzRXBmnyBDiKgDwkZI8sdA=="
+                ],
                 "authSignInfo": {
                   "epoch": 0,
                   "signature": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -906,13 +911,13 @@
             {
               "name": "query",
               "value": {
-                "Transaction": "7evF3dnfutJFcUnABTo5sHXT4g8KeADbz7WzTCnLm1ES"
+                "Transaction": "8iMCefpmntJtAwXY7wVbQbMFDSUYTgDsAgfY2sUBKJDM"
               }
             },
             {
               "name": "cursor",
               "value": {
-                "txDigest": "7evF3dnfutJFcUnABTo5sHXT4g8KeADbz7WzTCnLm1ES",
+                "txDigest": "8iMCefpmntJtAwXY7wVbQbMFDSUYTgDsAgfY2sUBKJDM",
                 "eventSeq": 10
               }
             },
@@ -931,9 +936,9 @@
               "data": [
                 {
                   "timestamp": 0,
-                  "txDigest": "7evF3dnfutJFcUnABTo5sHXT4g8KeADbz7WzTCnLm1ES",
+                  "txDigest": "8iMCefpmntJtAwXY7wVbQbMFDSUYTgDsAgfY2sUBKJDM",
                   "id": {
-                    "txDigest": "7evF3dnfutJFcUnABTo5sHXT4g8KeADbz7WzTCnLm1ES",
+                    "txDigest": "8iMCefpmntJtAwXY7wVbQbMFDSUYTgDsAgfY2sUBKJDM",
                     "eventSeq": 0
                   },
                   "event": {
@@ -1494,14 +1499,14 @@
           "params": [
             {
               "name": "digest",
-              "value": "Aw4br5b7848eX3uiWVGbGr6KsLWd3xj22vReiS3Gkv7M"
+              "value": "Cqxa8ZrwLpL4Ecs3ziJQpjy4ruPx9vwiyygvxj3xhRum"
             }
           ],
           "result": {
             "name": "Result",
             "value": {
               "certificate": {
-                "transactionDigest": "Aw4br5b7848eX3uiWVGbGr6KsLWd3xj22vReiS3Gkv7M",
+                "transactionDigest": "Cqxa8ZrwLpL4Ecs3ziJQpjy4ruPx9vwiyygvxj3xhRum",
                 "data": {
                   "transactions": [
                     {
@@ -1516,15 +1521,20 @@
                     }
                   ],
                   "sender": "0xd4783daffa7f6913e7b0b8f7c0f1790bdc021fe6",
-                  "gasPayment": {
-                    "objectId": "0xb3c83cfb9c683fb7d0526e29d77e89e7bfefd4f7",
-                    "version": 2,
-                    "digest": "Oto9GayH1FNR8BlqiAuVw+okTdBg0rZTgZbQSLem0Ew="
-                  },
-                  "gasPrice": 1,
-                  "gasBudget": 1000
+                  "gasData": {
+                    "payment": {
+                      "objectId": "0xb3c83cfb9c683fb7d0526e29d77e89e7bfefd4f7",
+                      "version": 2,
+                      "digest": "Oto9GayH1FNR8BlqiAuVw+okTdBg0rZTgZbQSLem0Ew="
+                    },
+                    "owner": "0xd4783daffa7f6913e7b0b8f7c0f1790bdc021fe6",
+                    "price": 1,
+                    "budget": 1000
+                  }
                 },
-                "txSignature": "ABR/DtRSEtwJxHYihyjRE8ukXGkkPHcusVx+EECSiHTuGUaIKZOtaYl172/e7+ejKmGeKEwD48in3TAlGF+90wS6hmV5ZkKODtgnokS0vmNHVDWXWuuoOmN18GDl2YAdDg==",
+                "txSignatures": [
+                  "AFdT/wKbbIKMyRE8mj08LUrd3mp0R3krdfADLA+bqJzUbiaXmL4+OvXVRqYgCbVVxJKHDrr1NIGTLUzgpdR4xQG6hmV5ZkKODtgnokS0vmNHVDWXWuuoOmN18GDl2YAdDg=="
+                ],
                 "authSignInfo": {
                   "epoch": 0,
                   "signature": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -1637,7 +1647,7 @@
           "params": [
             {
               "name": "digest",
-              "value": "26UNMHQNxsCqZeRSDm9WrR3NnHPup4PyscQjTXUfD3c9"
+              "value": "2uFaBTdFBY6B7hgPEY7xSk8GT4kTJWJs1yXtvXBCWjf3"
             }
           ],
           "result": {
@@ -2535,6 +2545,182 @@
       }
     },
     {
+      "name": "sui_submitTransaction",
+      "tags": [
+        {
+          "name": "APIs to execute transactions."
+        }
+      ],
+      "params": [
+        {
+          "name": "tx_bytes",
+          "description": "BCS serialized transaction data bytes without its type tag, as base-64 encoded string.",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Base64"
+          }
+        },
+        {
+          "name": "signatures",
+          "description": "A list of signatures (`flag || signature || pubkey` bytes, as base-64 encoded string). Signature is committed to the intent message of the transaction data, as base-64 encoded string.",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Base64"
+            }
+          }
+        },
+        {
+          "name": "request_type",
+          "description": "The request type",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ExecuteTransactionRequestType"
+          }
+        }
+      ],
+      "result": {
+        "name": "SuiExecuteTransactionResponse",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/SuiExecuteTransactionResponse"
+        }
+      },
+      "examples": [
+        {
+          "name": "Execute an transaction with serialized signature",
+          "params": [
+            {
+              "name": "tx_bytes",
+              "value": "AABVfcQqrv7rjBVNfdxFa4rqoxMsdANTHcmOg/bhmNLX0XupHdx+cXz3AgAAAAAAAAAg/crD3OjYx86GPzE9o9vZKoPvJtEouI/ma/JuDg0Jza9PuIgKC69cF+3DB1mtlwVnAyS6rgjJNwYPBASHNuwz+xdG2Zml5YzVAgAAAAAAAAAgxnftgE+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNFPuIgKC69cF+3DB1mtlwVnAyS6rgEAAAAAAAAA6AMAAAAAAAA="
+            },
+            {
+              "name": "signatures",
+              "value": [
+                "ANgH1IBtGjHZZtLZ22RgN+TW3u0OBaMRWFi3zKk2mQ2+jlexYCSLN6VouUq3Fy6nletdAInp2UWcgTl4MktwlQttqSk/XTlS5stFH/W02Kxeyb0TWYjhlUjBKhMcXPgTNg=="
+              ]
+            },
+            {
+              "name": "request_type",
+              "value": "WaitForLocalExecution"
+            }
+          ],
+          "result": {
+            "name": "Result",
+            "value": {
+              "certificate": {
+                "transactionDigest": "Ew8MVt67nHtZQfuZwwAq3yfg4J3MmTTXp5AD3Ssa5wTw",
+                "data": {
+                  "transactions": [
+                    {
+                      "TransferObject": {
+                        "recipient": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c74",
+                        "objectRef": {
+                          "objectId": "0x03531dc98e83f6e198d2d7d17ba91ddc7e717cf7",
+                          "version": 2,
+                          "digest": "/crD3OjYx86GPzE9o9vZKoPvJtEouI/ma/JuDg0Jza8="
+                        }
+                      }
+                    }
+                  ],
+                  "sender": "0x4fb8880a0baf5c17edc30759ad9705670324baae",
+                  "gasData": {
+                    "payment": {
+                      "objectId": "0x08c937060f04048736ec33fb1746d999a5e58cd5",
+                      "version": 2,
+                      "digest": "xnftgE+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNE="
+                    },
+                    "owner": "0x4fb8880a0baf5c17edc30759ad9705670324baae",
+                    "price": 1,
+                    "budget": 1000
+                  }
+                },
+                "txSignatures": [
+                  "ANgH1IBtGjHZZtLZ22RgN+TW3u0OBaMRWFi3zKk2mQ2+jlexYCSLN6VouUq3Fy6nletdAInp2UWcgTl4MktwlQttqSk/XTlS5stFH/W02Kxeyb0TWYjhlUjBKhMcXPgTNg=="
+                ],
+                "authSignInfo": {
+                  "epoch": 0,
+                  "signature": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                  "signers_map": [
+                    58,
+                    48,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ]
+                }
+              },
+              "effects": {
+                "status": {
+                  "status": "success"
+                },
+                "executedEpoch": 0,
+                "gasUsed": {
+                  "computationCost": 100,
+                  "storageCost": 100,
+                  "storageRebate": 10
+                },
+                "transactionDigest": "8hv8YrDFYqGcKDaNRtjhJXfSVWkUuVr4PNuYrzrqcJea",
+                "mutated": [
+                  {
+                    "owner": {
+                      "AddressOwner": "0x4fb8880a0baf5c17edc30759ad9705670324baae"
+                    },
+                    "reference": {
+                      "objectId": "0x08c937060f04048736ec33fb1746d999a5e58cd5",
+                      "version": 2,
+                      "digest": "xnftgE+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNE="
+                    }
+                  },
+                  {
+                    "owner": {
+                      "AddressOwner": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c74"
+                    },
+                    "reference": {
+                      "objectId": "0x03531dc98e83f6e198d2d7d17ba91ddc7e717cf7",
+                      "version": 2,
+                      "digest": "/crD3OjYx86GPzE9o9vZKoPvJtEouI/ma/JuDg0Jza8="
+                    }
+                  }
+                ],
+                "gasObject": {
+                  "owner": {
+                    "ObjectOwner": "0x4fb8880a0baf5c17edc30759ad9705670324baae"
+                  },
+                  "reference": {
+                    "objectId": "0x08c937060f04048736ec33fb1746d999a5e58cd5",
+                    "version": 2,
+                    "digest": "xnftgE+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNE="
+                  }
+                },
+                "events": [
+                  {
+                    "transferObject": {
+                      "packageId": "0x0000000000000000000000000000000000000002",
+                      "transactionModule": "native",
+                      "sender": "0x4fb8880a0baf5c17edc30759ad9705670324baae",
+                      "recipient": {
+                        "AddressOwner": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c74"
+                      },
+                      "objectType": "0x2::example::Object",
+                      "objectId": "0x03531dc98e83f6e198d2d7d17ba91ddc7e717cf7",
+                      "version": 2
+                    }
+                  }
+                ]
+              },
+              "timestamp_ms": null,
+              "parsed_data": null
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "sui_subscribeEvent",
       "tags": [
         {
@@ -2843,7 +3029,7 @@
           "authSignInfo",
           "data",
           "transactionDigest",
-          "txSignature"
+          "txSignatures"
         ],
         "properties": {
           "authSignInfo": {
@@ -2860,13 +3046,12 @@
           "transactionDigest": {
             "$ref": "#/components/schemas/TransactionDigest"
           },
-          "txSignature": {
-            "description": "tx_signature is signed by the transaction sender, committing to the intent message containing the transaction data and intent.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/GenericSignature"
-              }
-            ]
+          "txSignatures": {
+            "description": "tx_signatures is a list of signatures signed by transaction participants, committing to the intent message containing the transaction data and intent.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GenericSignature"
+            }
           }
         }
       },
@@ -2888,7 +3073,10 @@
             "description": "This field 'pins' user signatures for the checkpoint:\n\n* For normal checkpoint this field will contain same number of elements as transactions. * Genesis checkpoint has transactions but this field is empty. * Last checkpoint in the epoch will have (last)extra system transaction in the transactions list not covered in the signatures list",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/GenericSignature"
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GenericSignature"
+              }
             }
           }
         }
@@ -4278,6 +4466,33 @@
             "minimum": 0.0
           },
           "storageRebate": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      },
+      "GasData": {
+        "type": "object",
+        "required": [
+          "budget",
+          "owner",
+          "payment",
+          "price"
+        ],
+        "properties": {
+          "budget": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "owner": {
+            "$ref": "#/components/schemas/SuiAddress"
+          },
+          "payment": {
+            "$ref": "#/components/schemas/ObjectRef"
+          },
+          "price": {
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
@@ -6277,25 +6492,13 @@
       "TransactionData": {
         "type": "object",
         "required": [
-          "gasBudget",
-          "gasPayment",
-          "gasPrice",
+          "gasData",
           "sender",
           "transactions"
         ],
         "properties": {
-          "gasBudget": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "gasPayment": {
-            "$ref": "#/components/schemas/ObjectRef"
-          },
-          "gasPrice": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+          "gasData": {
+            "$ref": "#/components/schemas/GasData"
           },
           "sender": {
             "$ref": "#/components/schemas/SuiAddress"

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -84,6 +84,7 @@ impl RpcExampleProvider {
             self.get_transactions(),
             self.get_events(),
             self.execute_transaction_example(),
+            self.submit_transaction_example(),
         ]
         .into_iter()
         .map(|example| (example.function_name, example.examples))
@@ -163,8 +164,35 @@ impl RpcExampleProvider {
         )
     }
 
+    fn submit_transaction_example(&mut self) -> Examples {
+        let (data, signatures, _, _, result, _) = self.get_transfer_data_response();
+        let tx_bytes = TransactionBytes::from_data(data).unwrap();
+
+        Examples::new(
+            "sui_submitTransaction",
+            vec![ExamplePairing::new(
+                "Execute an transaction with serialized signature",
+                vec![
+                    ("tx_bytes", json!(tx_bytes.tx_bytes)),
+                    (
+                        "signatures",
+                        json!(signatures
+                            .into_iter()
+                            .map(|sig| sig.encode_base64())
+                            .collect::<Vec<_>>()),
+                    ),
+                    (
+                        "request_type",
+                        json!(ExecuteTransactionRequestType::WaitForLocalExecution),
+                    ),
+                ],
+                json!(result),
+            )],
+        )
+    }
+
     fn execute_transaction_example(&mut self) -> Examples {
-        let (data, signature, _, _, result, _) = self.get_transfer_data_response();
+        let (data, signatures, _, _, result, _) = self.get_transfer_data_response();
         let tx_bytes = TransactionBytes::from_data(data).unwrap();
 
         Examples::new(
@@ -173,7 +201,7 @@ impl RpcExampleProvider {
                 "Execute an transaction with serialized signature",
                 vec![
                     ("tx_bytes", json!(tx_bytes.tx_bytes)),
-                    ("signature", json!(signature.encode_base64())),
+                    ("signature", json!(signatures[0].encode_base64())),
                     (
                         "request_type",
                         json!(ExecuteTransactionRequestType::WaitForLocalExecution),
@@ -387,7 +415,7 @@ impl RpcExampleProvider {
         &mut self,
     ) -> (
         TransactionData,
-        GenericSignature,
+        Vec<GenericSignature>,
         SuiAddress,
         ObjectID,
         SuiTransactionResponse,
@@ -415,7 +443,7 @@ impl RpcExampleProvider {
 
         let tx = to_sender_signed_transaction(data, &kp);
         let tx1 = tx.clone();
-        let signature = tx.into_inner().tx_signature.clone();
+        let signatures = tx.into_inner().tx_signatures.clone();
 
         let tx_digest = tx1.digest();
         let sui_event = SuiEvent::TransferObject {
@@ -437,7 +465,7 @@ impl RpcExampleProvider {
             certificate: SuiCertifiedTransaction {
                 transaction_digest: *tx_digest,
                 data: SuiTransactionData::try_from(data1).unwrap(),
-                tx_signature: signature.clone(),
+                tx_signatures: signatures.clone(),
                 auth_sign_info: SuiAuthorityStrongQuorumSignInfo::from(&AuthorityQuorumSignInfo {
                     epoch: 0,
                     // We create a dummy signature since there is no such thing as a default valid
@@ -484,7 +512,7 @@ impl RpcExampleProvider {
             parsed_data: None,
         };
 
-        (data2, signature, recipient, obj_id, result, events)
+        (data2, signatures, recipient, obj_id, result, events)
     }
 
     fn get_events(&mut self) -> Examples {

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -96,7 +96,9 @@ pub async fn combine(
     let signed_tx = Transaction::from_generic_sig_data(
         intent_msg.value,
         Intent::default(),
-        GenericSignature::from_bytes(&[&*flag, &*sig_bytes, &*pub_key].concat())?,
+        vec![GenericSignature::from_bytes(
+            &[&*flag, &*sig_bytes, &*pub_key].concat(),
+        )?],
     );
     signed_tx.verify_signature()?;
     let signed_tx_bytes = bcs::to_bytes(&signed_tx)?;
@@ -302,7 +304,7 @@ pub async fn parse(
         intent.value
     };
     let account_identifier_signers = if request.signed {
-        vec![data.signer().into()]
+        vec![data.sender().into()]
     } else {
         vec![]
     };

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -551,7 +551,7 @@ async fn test_transaction(
     );
 
     let signature = keystore
-        .sign_secure(&data.signer(), &data, Intent::default())
+        .sign_secure(&data.sender(), &data, Intent::default())
         .unwrap();
 
     // Balance before execution
@@ -565,7 +565,7 @@ async fn test_transaction(
     let response = client
         .quorum_driver()
         .execute_transaction(
-            Transaction::from_data(data.clone(), Intent::default(), signature)
+            Transaction::from_data(data.clone(), Intent::default(), vec![signature])
                 .verify()
                 .unwrap(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -102,7 +102,8 @@ impl TicTacToe {
             .client
             .quorum_driver()
             .execute_transaction(
-                Transaction::from_data(create_game_call, Intent::default(), signature).verify()?,
+                Transaction::from_data(create_game_call, Intent::default(), vec![signature])
+                    .verify()?,
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;
@@ -198,7 +199,7 @@ impl TicTacToe {
                 .client
                 .quorum_driver()
                 .execute_transaction(
-                    Transaction::from_data(place_mark_call, Intent::default(), signature)
+                    Transaction::from_data(place_mark_call, Intent::default(), vec![signature])
                         .verify()?,
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let transaction_response = sui
         .quorum_driver()
         .execute_transaction(
-            Transaction::from_data(transfer_tx, Intent::default(), signature).verify()?,
+            Transaction::from_data(transfer_tx, Intent::default(), vec![signature]).verify()?,
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -472,17 +472,17 @@ impl QuorumDriver {
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> SuiRpcResult<TransactionExecutionResult> {
         let tx_digest = *tx.digest();
-        let (tx_bytes, signature) = tx.to_tx_bytes_and_signature();
+        let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
         let request_type =
             request_type.unwrap_or(ExecuteTransactionRequestType::WaitForLocalExecution);
         let SuiExecuteTransactionResponse {
             certificate,
             effects,
             confirmed_local_execution,
-        } = TransactionExecutionApiClient::execute_transaction_serialized_sig(
+        } = TransactionExecutionApiClient::submit_transaction(
             &self.api.http,
             tx_bytes,
-            signature,
+            signatures,
             request_type.clone(),
         )
         .await?;

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -582,7 +582,7 @@ impl<'a> SuiTestAdapter<'a> {
             &PROTOCOL_CONSTANTS,
         );
         let transaction_data = transaction.into_inner().into_data().intent_message.value;
-        let signer = transaction_data.signer();
+        let signer = transaction_data.sender();
         let gas = transaction_data.gas();
         let (
             inner,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -106,6 +106,10 @@ pub enum SuiError {
     // Signature verification
     #[error("Signature is not valid: {}", error)]
     InvalidSignature { error: String },
+    #[error("Required Signature from {signer} is absent.")]
+    SignerSignatureAbsent { signer: String },
+    #[error("Expect {actual} signer signatures but got {expected}.")]
+    SignerSignatureNumberMismatch { expected: usize, actual: usize },
     #[error("Sender Signature must be verified separately from Authority Signature")]
     SenderSigUnbatchable,
     #[error("Value was not signed by the correct sender: {}", error)]
@@ -326,6 +330,8 @@ pub enum SuiError {
         gas_budget: u128,
         gas_price: u64,
     },
+    #[error("Transaction kind does not support Sponsored Transaction")]
+    UnsupportedSponsoredTransactionKind,
 
     // Internal state errors
     #[error("Attempt to update state of TxContext from a different instance than original.")]

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -6,7 +6,7 @@ use crate::certificate_proof::CertificateProof;
 use crate::committee::{EpochId, ProtocolVersion, StakeUnit};
 use crate::crypto::{
     sha3_hash, AuthoritySignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo,
-    Ed25519SuiSignature, EmptySignInfo, Signature,
+    Ed25519SuiSignature, EmptySignInfo, Signature, Signer, SuiSignatureInner, ToFromBytes,
 };
 use crate::gas::GasCostSummary;
 use crate::intent::{Intent, IntentMessage};
@@ -21,7 +21,6 @@ use crate::{
 };
 use byteorder::{BigEndian, ReadBytesExt};
 use fastcrypto::encoding::Base64;
-use fastcrypto::traits::Signer;
 use itertools::Either;
 use move_binary_format::access::ModuleAccess;
 use move_binary_format::file_format::{CodeOffset, LocalIndex, TypeParameterIndex};
@@ -983,12 +982,18 @@ impl Display for TransactionKind {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct GasData {
+    pub payment: ObjectRef,
+    pub owner: SuiAddress,
+    pub price: u64,
+    pub budget: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct TransactionData {
     pub kind: TransactionKind,
-    sender: SuiAddress,
-    gas_payment: ObjectRef,
-    pub gas_price: u64,
-    pub gas_budget: u64,
+    pub sender: SuiAddress,
+    pub gas_data: GasData,
 }
 
 impl TransactionData {
@@ -1001,12 +1006,14 @@ impl TransactionData {
         TransactionData {
             kind,
             sender,
-            gas_price: DUMMY_GAS_PRICE,
-            gas_payment,
-            gas_budget,
+            gas_data: GasData {
+                price: DUMMY_GAS_PRICE,
+                owner: sender,
+                payment: gas_payment,
+                budget: gas_budget,
+            },
         }
     }
-
     pub fn new(
         kind: TransactionKind,
         sender: SuiAddress,
@@ -1017,9 +1024,20 @@ impl TransactionData {
         TransactionData {
             kind,
             sender,
-            gas_price,
-            gas_payment,
-            gas_budget,
+            gas_data: GasData {
+                price: gas_price,
+                owner: sender,
+                payment: gas_payment,
+                budget: gas_budget,
+            },
+        }
+    }
+
+    pub fn new_with_gas_data(kind: TransactionKind, sender: SuiAddress, gas_data: GasData) -> Self {
+        TransactionData {
+            kind,
+            sender,
+            gas_data,
         }
     }
 
@@ -1240,16 +1258,41 @@ impl TransactionData {
         Self::new(kind, sender, gas_payment, gas_budget, gas_price)
     }
 
-    pub fn gas(&self) -> ObjectRef {
-        self.gas_payment
-    }
-
-    pub fn signer(&self) -> SuiAddress {
+    pub fn sender(&self) -> SuiAddress {
         self.sender
     }
 
+    /// Transaction signer and Gas owner
+    pub fn signers(&self) -> Vec<SuiAddress> {
+        let mut signers = vec![self.sender];
+        if self.gas_owner() != self.sender {
+            signers.push(self.gas_owner());
+        }
+        signers
+    }
+
+    pub fn gas_data(&self) -> &GasData {
+        &self.gas_data
+    }
+
+    pub fn gas_owner(&self) -> SuiAddress {
+        self.gas_data.owner
+    }
+
+    pub fn gas(&self) -> ObjectRef {
+        self.gas_data.payment
+    }
+
     pub fn gas_payment_object_ref(&self) -> &ObjectRef {
-        &self.gas_payment
+        &self.gas_data.payment
+    }
+
+    pub fn gas_price(&self) -> u64 {
+        self.gas_data.price
+    }
+
+    pub fn gas_budget(&self) -> u64 {
+        self.gas_data.budget
     }
 
     pub fn contains_shared_object(&self) -> bool {
@@ -1282,7 +1325,38 @@ impl TransactionData {
     }
 
     pub fn validity_check(&self) -> SuiResult {
-        Self::validity_check_impl(&self.kind, &self.gas_payment)
+        Self::validity_check_impl(&self.kind, self.gas_payment_object_ref())?;
+        self.check_sponsorship()
+    }
+
+    /// Check if the transaction is compliant with sponsorship.
+    fn check_sponsorship(&self) -> SuiResult {
+        // Not a sponsored transaction, nothing to check
+        if self.gas_owner() == self.sender() {
+            return Ok(());
+        }
+        let allow_sponsored_tx = match &self.kind {
+            // For the sake of simplicity, we do not allow batched transaction
+            // to be sponsored.
+            TransactionKind::Batch(_b) => false,
+            TransactionKind::Single(s) => match s {
+                SingleTransactionKind::Call(_)
+                | SingleTransactionKind::TransferObject(_)
+                | SingleTransactionKind::Pay(_)
+                | SingleTransactionKind::Publish(_) => true,
+                SingleTransactionKind::TransferSui(_)
+                | SingleTransactionKind::PaySui(_)
+                | SingleTransactionKind::PayAllSui(_)
+                | SingleTransactionKind::ChangeEpoch(_)
+                | SingleTransactionKind::ConsensusCommitPrologue(_)
+                | SingleTransactionKind::ProgrammableTransaction(_)
+                | SingleTransactionKind::Genesis(_) => false,
+            },
+        };
+        if allow_sponsored_tx {
+            return Ok(());
+        }
+        Err(SuiError::UnsupportedSponsoredTransactionKind)
     }
 
     pub fn validity_check_impl(kind: &TransactionKind, gas_payment: &ObjectRef) -> SuiResult {
@@ -1311,8 +1385,8 @@ impl TransactionData {
                 fp_ensure!(
                     valid,
                     SuiError::InvalidBatchTransaction {
-                        error: "Batch transaction contains non-batchable transactions. Only Call \
-                        and TransferObject are allowed"
+                        error: "Batch transaction contains non-batchable transactions. Only Call,
+                        Pay and TransferObject are allowed"
                             .to_string()
                     }
                 );
@@ -1329,15 +1403,52 @@ impl TransactionData {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SenderSignedData {
     pub intent_message: IntentMessage<TransactionData>,
-    pub tx_signature: GenericSignature,
+    /// A list of signatures signed by all transaction participants.
+    /// 1. non participant signature must not be present.
+    /// 2. signature order does not matter.
+    pub tx_signatures: Vec<GenericSignature>,
 }
 
 impl SenderSignedData {
-    pub fn new(tx_data: TransactionData, intent: Intent, tx_signature: GenericSignature) -> Self {
+    pub fn new(
+        tx_data: TransactionData,
+        intent: Intent,
+        tx_signatures: Vec<GenericSignature>,
+    ) -> Self {
         Self {
             intent_message: IntentMessage::new(intent, tx_data),
-            tx_signature,
+            tx_signatures,
         }
+    }
+
+    pub fn new_from_sender_signature(
+        tx_data: TransactionData,
+        intent: Intent,
+        tx_signature: Signature,
+    ) -> Self {
+        Self {
+            intent_message: IntentMessage::new(intent, tx_data),
+            tx_signatures: vec![tx_signature.into()],
+        }
+    }
+
+    // This function does not check validity of the signature
+    // or perform any de-dup checks.
+    pub fn add_signature(&mut self, new_signature: Signature) {
+        self.tx_signatures.push(new_signature.into());
+    }
+
+    fn get_signer_sig_mapping(&self) -> SuiResult<BTreeMap<SuiAddress, &GenericSignature>> {
+        let mut mapping = BTreeMap::new();
+        for sig in &self.tx_signatures {
+            let address = sig.try_into()?;
+            mapping.insert(address, sig);
+        }
+        Ok(mapping)
+    }
+
+    pub fn transaction_data(&self) -> &TransactionData {
+        &self.intent_message.value
     }
 }
 
@@ -1352,8 +1463,32 @@ impl Message for SenderSignedData {
         if self.intent_message.value.kind.is_system_tx() {
             return Ok(());
         }
-        self.tx_signature
-            .verify_secure_generic(&self.intent_message, self.intent_message.value.sender)
+
+        // Verify signatures. Steps are ordered in asc complexity order to minimize abuse.
+        let signers = self.intent_message.value.signers();
+        // Signature number needs to match
+        fp_ensure!(
+            self.tx_signatures.len() == signers.len(),
+            SuiError::SignerSignatureNumberMismatch {
+                actual: self.tx_signatures.len(),
+                expected: signers.len()
+            }
+        );
+        // All required signers need to be sign.
+        let present_sigs = self.get_signer_sig_mapping()?;
+        for s in signers {
+            if !present_sigs.contains_key(&s) {
+                return Err(SuiError::SignerSignatureAbsent {
+                    signer: s.to_string(),
+                });
+            }
+        }
+
+        // Verify all present signatures.
+        for (signer, signature) in present_sigs {
+            signature.verify_secure_generic(&self.intent_message, signer)?;
+        }
+        Ok(())
     }
 }
 
@@ -1405,32 +1540,52 @@ impl Transaction {
     pub fn from_data_and_signer(
         data: TransactionData,
         intent: Intent,
-        signer: &dyn Signer<Signature>,
+        signers: Vec<&dyn Signer<Signature>>,
     ) -> Self {
-        let data1 = data.clone();
-        let intent1 = intent.clone();
-        let intent_msg = IntentMessage::new(intent, data);
-        let signature = Signature::new_secure(&intent_msg, signer);
-        Self::new(SenderSignedData::new(data1, intent1, signature.into()))
+        let intent_msg = IntentMessage::new(intent.clone(), data.clone());
+        let mut signatures = Vec::with_capacity(signers.len());
+        for signer in signers {
+            signatures.push(Signature::new_secure(&intent_msg, signer));
+        }
+        Self::from_data(data, intent, signatures)
     }
 
-    pub fn from_data(data: TransactionData, intent: Intent, signature: Signature) -> Self {
-        Self::from_generic_sig_data(data, intent, signature.into())
+    pub fn from_data(data: TransactionData, intent: Intent, signatures: Vec<Signature>) -> Self {
+        Self::from_generic_sig_data(
+            data,
+            intent,
+            signatures.into_iter().map(|s| s.into()).collect(),
+        )
+    }
+
+    // FIXME move this to another place
+    pub fn signature_from_signer(
+        data: TransactionData,
+        intent: Intent,
+        signer: &dyn Signer<Signature>,
+    ) -> Signature {
+        let intent_msg = IntentMessage::new(intent, data);
+        Signature::new_secure(&intent_msg, signer)
     }
 
     pub fn from_generic_sig_data(
         data: TransactionData,
         intent: Intent,
-        signature: GenericSignature,
+        signatures: Vec<GenericSignature>,
     ) -> Self {
-        Self::new(SenderSignedData::new(data, intent, signature))
+        Self::new(SenderSignedData::new(data, intent, signatures))
     }
 
-    /// Returns the Base64 encoded tx_bytes and the Base64 encoded [enum GenericSignature].
-    pub fn to_tx_bytes_and_signature(&self) -> (Base64, Base64) {
+    /// Returns the Base64 encoded tx_bytes
+    /// and a list of Base64 encoded [enum GenericSignature].
+    pub fn to_tx_bytes_and_signatures(&self) -> (Base64, Vec<Base64>) {
         (
             Base64::from_bytes(&bcs::to_bytes(&self.data().intent_message.value).unwrap()),
-            Base64::from_bytes(self.data().tx_signature.as_ref()),
+            self.data()
+                .tx_signatures
+                .iter()
+                .map(|s| Base64::from_bytes(s.as_ref()))
+                .collect(),
         )
     }
 }
@@ -1481,9 +1636,14 @@ impl VerifiedTransaction {
                     0,
                 )
             })
-            .pipe(|data| SenderSignedData {
-                intent_message: IntentMessage::new(Intent::default(), data),
-                tx_signature: GenericSignature::Signature(Ed25519SuiSignature::default().into()),
+            .pipe(|data| {
+                SenderSignedData::new_from_sender_signature(
+                    data,
+                    Intent::default(),
+                    Ed25519SuiSignature::from_bytes(&[0; Ed25519SuiSignature::LENGTH])
+                        .unwrap()
+                        .into(),
+                )
             })
             .pipe(Transaction::new)
             .pipe(Self::new_from_verified)

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -405,7 +405,7 @@ pub struct CheckpointContents {
     /// * Genesis checkpoint has transactions but this field is empty.
     /// * Last checkpoint in the epoch will have (last)extra system transaction
     /// in the transactions list not covered in the signatures list
-    user_signatures: Vec<GenericSignature>,
+    user_signatures: Vec<Vec<GenericSignature>>,
 }
 
 impl CheckpointSignatureMessage {
@@ -427,7 +427,7 @@ impl CheckpointContents {
 
     pub fn new_with_causally_ordered_transactions_and_signatures<T>(
         contents: T,
-        signatures: Vec<GenericSignature>,
+        signatures: Vec<Vec<GenericSignature>>,
     ) -> Self
     where
         T: IntoIterator<Item = ExecutionDigests>,

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -68,7 +68,7 @@ pub struct MultiSig {
     #[serde_as(as = "SuiBitmap")]
     bitmap: RoaringBitmap,
     /// The public key encoded with each public key with its signature scheme used along with the corresponding weight.
-    multisig_pk: MultiSigPublicKey,
+    pub multisig_pk: MultiSigPublicKey,
     /// A bytes representation of [struct MultiSig]. This helps with implementing [trait AsRef<[u8]>].
     #[serde(skip)]
     bytes: OnceCell<Vec<u8>>,

--- a/crates/sui-types/src/unit_tests/intent_tests.rs
+++ b/crates/sui-types/src/unit_tests/intent_tests.rs
@@ -69,13 +69,13 @@ fn test_authority_signature_intent() {
     let data2 = data.clone();
     let signature =
         Signature::new_secure(&IntentMessage::new(Intent::default(), data1), &sender_key);
-    let tx = Transaction::from_data(data2, Intent::default(), signature);
+    let tx = Transaction::from_data(data2, Intent::default(), vec![signature]);
     let tx1 = tx.clone();
     assert!(tx.verify().is_ok());
 
     // signature does not sign on intent fails.
     let signature_insecure = Signature::new(&data, &sender_key);
-    let tx_1 = Transaction::from_data(data, Intent::default(), signature_insecure);
+    let tx_1 = Transaction::from_data(data, Intent::default(), vec![signature_insecure]);
     assert!(tx_1.verify().is_err());
 
     // Create an intent with signed data.

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -53,7 +53,7 @@ fn test_signed_values() {
             10000,
         ),
         Intent::default(),
-        &sender_sec,
+        vec![&sender_sec],
     )
     .verify()
     .unwrap();
@@ -67,7 +67,7 @@ fn test_signed_values() {
             10000,
         ),
         Intent::default(),
-        &sender_sec2,
+        vec![&sender_sec2],
     ));
 
     let v = SignedTransaction::new(
@@ -130,7 +130,7 @@ fn test_certificates() {
             10000,
         ),
         Intent::default(),
-        &sender_sec,
+        vec![&sender_sec],
     )
     .verify()
     .unwrap();
@@ -443,7 +443,7 @@ fn test_digest_caching() {
             10000,
         ),
         Intent::default(),
-        &ssec2,
+        vec![&ssec2],
     )
     .verify()
     .unwrap();
@@ -462,7 +462,8 @@ fn test_digest_caching() {
         .data_mut_for_testing()
         .intent_message
         .value
-        .gas_budget += 1;
+        .gas_data
+        .budget += 1;
 
     // digest is cached
     assert_eq!(initial_digest, *signed_tx.digest());
@@ -520,13 +521,14 @@ fn test_user_signature_committed_in_transactions() {
     );
 
     let mut tx_data_2 = tx_data.clone();
-    tx_data_2.gas_budget += 1;
+    tx_data_2.gas_data.budget += 1;
 
     let transaction_a =
-        Transaction::from_data_and_signer(tx_data.clone(), Intent::default(), &sender_sec);
-    let transaction_b = Transaction::from_data_and_signer(tx_data, Intent::default(), &sender_sec2);
+        Transaction::from_data_and_signer(tx_data.clone(), Intent::default(), vec![&sender_sec]);
+    let transaction_b =
+        Transaction::from_data_and_signer(tx_data, Intent::default(), vec![&sender_sec2]);
     let transaction_c =
-        Transaction::from_data_and_signer(tx_data_2, Intent::default(), &sender_sec2);
+        Transaction::from_data_and_signer(tx_data_2, Intent::default(), vec![&sender_sec2]);
 
     let tx_digest_a = transaction_a.digest();
     let tx_digest_b = transaction_b.digest();
@@ -567,14 +569,14 @@ fn test_user_signature_committed_in_signed_transactions() {
         10000,
     );
     let transaction_a =
-        Transaction::from_data_and_signer(tx_data.clone(), Intent::default(), &sender_sec)
+        Transaction::from_data_and_signer(tx_data.clone(), Intent::default(), vec![&sender_sec])
             .verify()
             .unwrap();
     // transaction_b intentionally invalid (sender does not match signer).
     let transaction_b = VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
         tx_data,
         Intent::default(),
-        &sender_sec2,
+        vec![&sender_sec2],
     ));
 
     let signed_tx_a = SignedTransaction::new(
@@ -621,6 +623,245 @@ fn test_user_signature_committed_in_signed_transactions() {
     assert_ne!(signed_tx_a, signed_tx_b)
 }
 
+fn signature_from_signer(
+    data: TransactionData,
+    intent: Intent,
+    signer: &dyn Signer<Signature>,
+) -> Signature {
+    let intent_msg = IntentMessage::new(intent, data);
+    Signature::new_secure(&intent_msg, signer)
+}
+
+#[test]
+fn test_sponsored_transaction_message() {
+    let sender_kp = SuiKeyPair::Ed25519(get_key_pair().1);
+    let sender = (&sender_kp.public()).into();
+    let sponsor_kp = SuiKeyPair::Ed25519(get_key_pair().1);
+    let sponsor = (&sponsor_kp.public()).into();
+    let kind = TransactionKind::Single(SingleTransactionKind::TransferObject(TransferObject {
+        recipient: get_new_address::<AccountKeyPair>(),
+        object_ref: random_object_ref(),
+    }));
+    let gas_obj_ref = random_object_ref();
+    let gas_data = GasData {
+        payment: gas_obj_ref,
+        owner: sponsor,
+        price: DUMMY_GAS_PRICE,
+        budget: 10000,
+    };
+    let tx_data = TransactionData::new_with_gas_data(kind, sender, gas_data.clone());
+    let intent = Intent::default();
+    let sender_sig: GenericSignature =
+        signature_from_signer(tx_data.clone(), intent.clone(), &sender_kp).into();
+    let sponsor_sig: GenericSignature =
+        signature_from_signer(tx_data.clone(), intent.clone(), &sponsor_kp).into();
+    let transaction = Transaction::from_generic_sig_data(
+        tx_data.clone(),
+        intent.clone(),
+        vec![sender_sig.clone(), sponsor_sig.clone()],
+    )
+    .verify()
+    .unwrap();
+
+    assert_eq!(
+        transaction.get_signer_sig_mapping().unwrap(),
+        BTreeMap::from([(sender, &sender_sig), (sponsor, &sponsor_sig)]),
+    );
+
+    assert_eq!(transaction.sender_address(), sender,);
+    assert_eq!(transaction.gas_payment_object_ref(), &gas_obj_ref);
+
+    // Sig order does not matter
+    let transaction = Transaction::from_generic_sig_data(
+        tx_data.clone(),
+        intent.clone(),
+        vec![sponsor_sig.clone(), sender_sig.clone()],
+    )
+    .verify()
+    .unwrap();
+
+    // Test incomplete signature lists (missing sponsor sig)
+    assert!(matches!(
+        Transaction::from_generic_sig_data(
+            tx_data.clone(),
+            intent.clone(),
+            vec![sender_sig.clone()],
+        )
+        .verify()
+        .unwrap_err(),
+        SuiError::SignerSignatureNumberMismatch { .. }
+    ));
+
+    // Test incomplete signature lists (missing sender sig)
+    assert!(matches!(
+        Transaction::from_generic_sig_data(
+            tx_data.clone(),
+            intent.clone(),
+            vec![sponsor_sig.clone()],
+        )
+        .verify()
+        .unwrap_err(),
+        SuiError::SignerSignatureNumberMismatch { .. }
+    ));
+
+    // Test incomplete signature lists (more sigs than expected)
+    let thrid_party_kp = SuiKeyPair::Ed25519(get_key_pair().1);
+    let third_party_sig: GenericSignature =
+        signature_from_signer(tx_data.clone(), intent.clone(), &thrid_party_kp).into();
+    assert!(matches!(
+        Transaction::from_generic_sig_data(
+            tx_data.clone(),
+            intent.clone(),
+            vec![sender_sig, sponsor_sig.clone(), third_party_sig.clone()],
+        )
+        .verify()
+        .unwrap_err(),
+        SuiError::SignerSignatureNumberMismatch { .. }
+    ));
+
+    // Test irrelevant sigs
+    assert!(matches!(
+        Transaction::from_generic_sig_data(tx_data, intent, vec![sponsor_sig, third_party_sig],)
+            .verify()
+            .unwrap_err(),
+        SuiError::SignerSignatureAbsent { .. }
+    ));
+
+    let tx = transaction.data().transaction_data();
+    assert_eq!(tx.gas(), gas_obj_ref,);
+    assert_eq!(tx.gas_data(), &gas_data,);
+    assert_eq!(tx.sender(), sender,);
+    assert_eq!(tx.gas_owner(), sponsor,);
+}
+
+#[test]
+fn test_sponsored_transaction_validity_check() {
+    let sender_kp = SuiKeyPair::Ed25519(get_key_pair().1);
+    let sender = (&sender_kp.public()).into();
+    let sponsor_kp = SuiKeyPair::Ed25519(get_key_pair().1);
+    let sponsor = (&sponsor_kp.public()).into();
+
+    // This is a sponsored transation
+    assert_ne!(sender, sponsor);
+    let gas_data = GasData {
+        payment: random_object_ref(),
+        owner: sponsor,
+        price: DUMMY_GAS_PRICE,
+        budget: 10000,
+    };
+
+    TransactionData::new_with_gas_data(
+        TransactionKind::Single(SingleTransactionKind::TransferObject(TransferObject {
+            recipient: get_new_address::<AccountKeyPair>(),
+            object_ref: random_object_ref(),
+        })),
+        sender,
+        gas_data.clone(),
+    )
+    .validity_check()
+    .unwrap();
+
+    TransactionData::new_with_gas_data(
+        TransactionKind::Single(SingleTransactionKind::Call(MoveCall {
+            package: ObjectID::random(),
+            module: Identifier::new("random_module").unwrap(),
+            function: Identifier::new("random_function").unwrap(),
+            type_arguments: vec![],
+            arguments: vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(
+                random_object_ref(),
+            ))],
+        })),
+        sender,
+        gas_data.clone(),
+    )
+    .validity_check()
+    .unwrap();
+
+    TransactionData::new_with_gas_data(
+        TransactionKind::Single(SingleTransactionKind::Publish(MoveModulePublish {
+            modules: vec![vec![]],
+        })),
+        sender,
+        gas_data.clone(),
+    )
+    .validity_check()
+    .unwrap();
+
+    TransactionData::new_with_gas_data(
+        TransactionKind::Single(SingleTransactionKind::Pay(Pay {
+            coins: vec![random_object_ref()],
+            recipients: vec![SuiAddress::random_for_testing_only()],
+            amounts: vec![100000],
+        })),
+        sender,
+        gas_data.clone(),
+    )
+    .validity_check()
+    .unwrap();
+
+    // TransferSui cannot be sponsored
+    assert_eq!(
+        TransactionData::new_with_gas_data(
+            TransactionKind::Single(SingleTransactionKind::TransferSui(TransferSui {
+                recipient: SuiAddress::random_for_testing_only(),
+                amount: Some(50000),
+            })),
+            sender,
+            gas_data.clone(),
+        )
+        .validity_check()
+        .unwrap_err(),
+        SuiError::UnsupportedSponsoredTransactionKind
+    );
+
+    // PaySui cannot be sponsored
+    assert_eq!(
+        TransactionData::new_with_gas_data(
+            TransactionKind::Single(SingleTransactionKind::PaySui(PaySui {
+                coins: vec![(gas_data.payment)],
+                recipients: vec![],
+                amounts: vec![],
+            })),
+            sender,
+            gas_data.clone(),
+        )
+        .validity_check()
+        .unwrap_err(),
+        SuiError::UnsupportedSponsoredTransactionKind
+    );
+
+    // PayAllSui cannot be sponsored
+    assert_eq!(
+        TransactionData::new_with_gas_data(
+            TransactionKind::Single(SingleTransactionKind::PayAllSui(PayAllSui {
+                coins: vec![(gas_data.payment)],
+                recipient: SuiAddress::random_for_testing_only(),
+            })),
+            sender,
+            gas_data.clone(),
+        )
+        .validity_check()
+        .unwrap_err(),
+        SuiError::UnsupportedSponsoredTransactionKind
+    );
+
+    // Batch is non-sponsorable
+    assert_eq!(
+        TransactionData::new_with_gas_data(
+            TransactionKind::Batch(vec![SingleTransactionKind::Pay(Pay {
+                coins: vec![random_object_ref()],
+                recipients: vec![SuiAddress::random_for_testing_only()],
+                amounts: vec![100000],
+            })]),
+            sender,
+            gas_data,
+        )
+        .validity_check()
+        .unwrap_err(),
+        SuiError::UnsupportedSponsoredTransactionKind
+    );
+}
+
 #[test]
 fn verify_sender_signature_correctly_with_flag() {
     // set up authorities
@@ -650,15 +891,18 @@ fn verify_sender_signature_correctly_with_flag() {
     let sender_kp_2 = SuiKeyPair::Ed25519(get_key_pair().1);
     let mut tx_data_2 = tx_data.clone();
     tx_data_2.sender = (&sender_kp_2.public()).into();
+    tx_data_2.gas_data.owner = tx_data_2.sender;
 
     // create a sender keypair with Secp256r1
     let sender_kp_3 = SuiKeyPair::Secp256r1(get_key_pair().1);
     let mut tx_data_3 = tx_data.clone();
     tx_data_3.sender = (&sender_kp_3.public()).into();
+    tx_data_3.gas_data.owner = tx_data_3.sender;
 
-    let transaction = Transaction::from_data_and_signer(tx_data, Intent::default(), &sender_kp)
-        .verify()
-        .unwrap();
+    let transaction =
+        Transaction::from_data_and_signer(tx_data, Intent::default(), vec![&sender_kp])
+            .verify()
+            .unwrap();
 
     // create tx also signed by authority
     let signed_tx = SignedTransaction::new(
@@ -668,7 +912,7 @@ fn verify_sender_signature_correctly_with_flag() {
         AuthorityPublicKeyBytes::from(sec1.public()),
     );
 
-    let s = match &transaction.data().tx_signature {
+    let s = match &transaction.data().tx_signatures[0] {
         GenericSignature::Signature(s) => s,
         _ => panic!("invalid"),
     };
@@ -682,7 +926,7 @@ fn verify_sender_signature_correctly_with_flag() {
         .is_ok());
 
     let transaction_1 =
-        Transaction::from_data_and_signer(tx_data_2, Intent::default(), &sender_kp_2)
+        Transaction::from_data_and_signer(tx_data_2, Intent::default(), vec![&sender_kp_2])
             .verify()
             .unwrap();
 
@@ -692,7 +936,7 @@ fn verify_sender_signature_correctly_with_flag() {
         &sec1,
         AuthorityPublicKeyBytes::from(sec1.public()),
     );
-    let s = match &transaction_1.data().tx_signature {
+    let s = match &transaction_1.data().tx_signatures[0] {
         GenericSignature::Signature(s) => s,
         _ => panic!("unexpected signature scheme"),
     };
@@ -712,7 +956,7 @@ fn verify_sender_signature_correctly_with_flag() {
         .is_err());
 
     // create transaction with r1 signer
-    let tx_3 = Transaction::from_data_and_signer(tx_data_3, Intent::default(), &sender_kp_3);
+    let tx_3 = Transaction::from_data_and_signer(tx_data_3, Intent::default(), vec![&sender_kp_3]);
     let tx_31 = tx_3.clone();
     let tx_32 = tx_3.clone();
 

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -70,10 +70,17 @@ pub fn to_sender_signed_transaction(
     data: TransactionData,
     signer: &dyn Signer<Signature>,
 ) -> VerifiedTransaction {
+    to_sender_signed_transaction_with_multi_signers(data, vec![signer])
+}
+
+pub fn to_sender_signed_transaction_with_multi_signers(
+    data: TransactionData,
+    signers: Vec<&dyn Signer<Signature>>,
+) -> VerifiedTransaction {
     VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
         data,
         Intent::default(),
-        signer,
+        signers,
     ))
 }
 

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -1141,10 +1141,10 @@ async fn test_execute_signed_tx() -> Result<(), anyhow::Error> {
     let mut txns = make_transactions_with_wallet_context(context, 1).await;
     let txn = txns.swap_remove(0);
 
-    let (tx_data, signature) = txn.to_tx_bytes_and_signature();
+    let (tx_data, signatures) = txn.to_tx_bytes_and_signatures();
     SuiClientCommands::ExecuteSignedTx {
         tx_bytes: tx_data.encoded(),
-        signature: signature.encoded(),
+        signatures: signatures.into_iter().map(|s| s.encoded()).collect(),
     }
     .execute(context)
     .await?;

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -11,7 +11,7 @@ use move_core_types::parser::parse_struct_tag;
 use move_core_types::value::MoveStructLayout;
 use mysten_metrics::RegistryService;
 use prometheus::Registry;
-use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
+use sui::client_commands::{SuiClientCommandResult, SuiClientCommands, WalletContext};
 use sui_json_rpc_types::{
     type_and_fields_from_move_struct, EventPage, SuiEvent, SuiEventEnvelope, SuiEventFilter,
     SuiExecuteTransactionResponse, SuiExecutionStatus, SuiMoveStruct, SuiMoveValue,
@@ -26,11 +26,12 @@ use sui_types::event::BalanceChangeType;
 use sui_types::event::Event;
 use sui_types::message_envelope::Message;
 use sui_types::messages::{
-    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    QuorumDriverResponse,
+    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse, GasData,
+    QuorumDriverResponse, SingleTransactionKind, TransactionData, TransactionKind, TransferObject,
 };
 use sui_types::object::{Object, ObjectRead, Owner, PastObjectRead};
 use sui_types::query::{EventQuery, TransactionQuery};
+use sui_types::utils::to_sender_signed_transaction_with_multi_signers;
 use sui_types::{
     base_types::{ObjectID, SuiAddress, TransactionDigest},
     messages::TransactionInfoRequest,
@@ -50,6 +51,7 @@ use test_utils::transaction::{wait_for_all_txes, wait_for_tx};
 use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tokio::time::{sleep, Duration};
+use tracing::info;
 
 #[sim_test]
 async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
@@ -97,6 +99,82 @@ async fn test_full_node_shared_objects() -> Result<(), anyhow::Error> {
     let digest = tx_cert.transaction_digest;
     wait_for_tx(digest, node.state().clone()).await;
 
+    Ok(())
+}
+
+#[sim_test]
+async fn test_sponsored_transaction() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let sender = test_cluster.get_address_0();
+    let sponsor = test_cluster.get_address_1();
+    let another_addr = test_cluster.get_address_2();
+
+    let context = &mut test_cluster.wallet;
+
+    // This makes sender send one coin to sponsor.
+    // The sent coin is used as sponsor gas in the following sponsored tx.
+    let (sent_coin, sender_, receiver, _, object_ref, _) = transfer_coin(context).await.unwrap();
+    assert_eq!(sender, sender_);
+    assert_eq!(sponsor, receiver);
+    let context: &WalletContext = &test_cluster.wallet;
+    let object_ref: ObjectRef = context
+        .get_object_ref(object_ref.0)
+        .await
+        .unwrap()
+        .into_object()
+        .unwrap()
+        .reference
+        .to_object_ref();
+    let gas_obj: ObjectRef = context
+        .get_object_ref(sent_coin)
+        .await
+        .unwrap()
+        .into_object()
+        .unwrap()
+        .reference
+        .to_object_ref();
+    info!("updated obj ref: {:?}", object_ref);
+    info!("updated gas ref: {:?}", gas_obj);
+
+    // Construct the sponsored transction
+    let kind = TransactionKind::Single(SingleTransactionKind::TransferObject(TransferObject {
+        recipient: another_addr,
+        object_ref,
+    }));
+    let tx_data = TransactionData::new_with_gas_data(
+        kind,
+        sender,
+        GasData {
+            payment: gas_obj,
+            owner: sponsor,
+            price: 100,
+            budget: 10000,
+        },
+    );
+
+    let tx = to_sender_signed_transaction_with_multi_signers(
+        tx_data,
+        vec![
+            context.config.keystore.get_key(&sender).unwrap(),
+            context.config.keystore.get_key(&sponsor).unwrap(),
+        ],
+    );
+
+    context.execute_transaction(tx).await.unwrap();
+
+    assert_eq!(
+        sponsor,
+        context
+            .get_object_ref(sent_coin)
+            .await
+            .unwrap()
+            .into_object()
+            .unwrap()
+            .owner
+            .get_owner_address()
+            .unwrap(),
+    );
     Ok(())
 }
 
@@ -964,14 +1042,14 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
     let txns = make_transactions_with_wallet_context(context, txn_count).await;
     for txn in txns {
         let tx_digest = txn.digest();
-        let (tx_bytes, signature) = txn.to_tx_bytes_and_signature();
+        let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
         let params = rpc_params![
             tx_bytes,
-            signature,
+            signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution
         ];
         let response: SuiExecuteTransactionResponse = jsonrpc_client
-            .request("sui_executeTransactionSerializedSig", params)
+            .request("sui_submitTransaction", params)
             .await
             .unwrap();
 
@@ -1004,14 +1082,14 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
     let tx_digest = txn.digest();
 
     // Test request with ExecuteTransactionRequestType::WaitForLocalExecution
-    let (tx_bytes, signature) = txn.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
     let params = rpc_params![
         tx_bytes,
-        signature,
+        signatures,
         ExecuteTransactionRequestType::WaitForLocalExecution
     ];
     let response: SuiExecuteTransactionResponse = jsonrpc_client
-        .request("sui_executeTransactionSerializedSig", params)
+        .request("sui_submitTransaction", params)
         .await
         .unwrap();
 
@@ -1029,14 +1107,14 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
         .unwrap();
 
     // Test request with ExecuteTransactionRequestType::WaitForEffectsCert
-    let (tx_bytes, signature) = txn.to_tx_bytes_and_signature();
+    let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
     let params = rpc_params![
         tx_bytes,
-        signature,
+        signatures,
         ExecuteTransactionRequestType::WaitForEffectsCert
     ];
     let response: SuiExecuteTransactionResponse = jsonrpc_client
-        .request("sui_executeTransactionSerializedSig", params)
+        .request("sui_submitTransaction", params)
         .await
         .unwrap();
 

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -29,6 +29,8 @@ use sui_types::base_types::{AuthorityName, SuiAddress};
 use sui_types::committee::EpochId;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::SuiKeyPair;
+use sui_types::intent::Intent;
+use sui_types::messages::TransactionData;
 
 const NUM_VALIDAOTR: usize = 4;
 
@@ -51,6 +53,10 @@ pub struct TestCluster {
 impl TestCluster {
     pub fn rpc_client(&self) -> &HttpClient {
         &self.fullnode_handle.rpc_client
+    }
+
+    pub fn sui_client(&self) -> &SuiClient {
+        &self.fullnode_handle.sui_client
     }
 
     pub fn rpc_url(&self) -> &str {
@@ -80,6 +86,30 @@ impl TestCluster {
             .addresses()
             .get(1)
             .cloned()
+            .unwrap()
+    }
+
+    // Helper function to get the 2nd address in WalletContext
+    pub fn get_address_2(&self) -> SuiAddress {
+        self.wallet
+            .config
+            .keystore
+            .addresses()
+            .get(2)
+            .cloned()
+            .unwrap()
+    }
+
+    // Sign a transaction with a key currently managed by the WalletContext
+    pub fn sign_transaction(
+        &self,
+        signer_address: &SuiAddress,
+        data: &TransactionData,
+    ) -> sui_types::crypto::Signature {
+        self.wallet
+            .config
+            .keystore
+            .sign_secure(signer_address, data, Intent::default())
             .unwrap()
     }
 

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -104,7 +104,7 @@ pub async fn publish_package_with_wallet(
             .keystore
             .sign_secure(&sender, &data, Intent::default())
             .unwrap();
-        Transaction::from_data(data, Intent::default(), signature)
+        Transaction::from_data(data, Intent::default(), vec![signature])
             .verify()
             .unwrap()
     };
@@ -162,7 +162,7 @@ pub async fn submit_move_transaction(
         .sign_secure(&sender, &data, Intent::default())
         .unwrap();
 
-    let tx = Transaction::from_data(data, Intent::default(), signature)
+    let tx = Transaction::from_data(data, Intent::default(), vec![signature])
         .verify()
         .unwrap();
     let tx_digest = tx.digest();
@@ -332,7 +332,7 @@ pub async fn transfer_coin(
     let (digest, gas, gas_used) = if let SuiClientCommandResult::Transfer(_, cert, effect) = res {
         (
             cert.transaction_digest,
-            cert.data.gas_payment,
+            cert.data.gas_data.payment,
             effect.gas_used.computation_cost + effect.gas_used.storage_cost
                 - effect.gas_used.storage_rebate,
         )
@@ -388,7 +388,7 @@ pub async fn delete_devnet_nft(
         .sign_secure(sender, &data, Intent::default())
         .unwrap();
 
-    let tx = Transaction::from_data(data, Intent::default(), signature)
+    let tx = Transaction::from_data(data, Intent::default(), vec![signature])
         .verify()
         .unwrap();
     let client = context.get_client().await.unwrap();

--- a/sdk/typescript/genversion.mjs
+++ b/sdk/typescript/genversion.mjs
@@ -8,7 +8,10 @@ const LICENSE =
 import pkg from './package.json' assert { type: 'json' };
 
 async function main() {
-  await writeFile('src/pkg-version.ts', LICENSE + `export const version = '${pkg.version}';\n`);
+  await writeFile(
+    'src/pkg-version.ts',
+    LICENSE + `export const version = '${pkg.version}';\n`,
+  );
 }
 
 await main();

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -14,10 +14,13 @@ import {
   TransactionData,
   TransactionKind,
   TypeTag,
-  SuiObjectRef,
   deserializeTransactionBytesToTransactionData,
   normalizeSuiObjectId,
   bcsForVersion,
+  GasData,
+  TransactionData_v26,
+  RpcApiVersion,
+  toTransactionData,
 } from '../../types';
 import {
   MoveCallTransaction,
@@ -44,6 +47,10 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
    * should cache the object reference locally
    */
   constructor(private provider: Provider) {}
+
+  async getRpcApiVersion(): Promise<RpcApiVersion | undefined> {
+    return await this.provider.getRpcApiVersion();
+  }
 
   async serializeToBytes(
     signerAddress: string,
@@ -246,7 +253,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
   async constructTransactionData(
     signerAddress: string,
     unserializedTxn: UnserializedSignableTransaction,
-  ): Promise<TransactionData> {
+  ): Promise<TransactionData | TransactionData_v26> {
     const [tx, gasPayment] = await this.constructTransactionKindAndPayment(
       signerAddress,
       unserializedTxn,
@@ -336,7 +343,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     originalTx: UnserializedSignableTransaction,
     gasObjectId: ObjectId | undefined,
     signerAddress: SuiAddress,
-  ): Promise<TransactionData> {
+  ): Promise<TransactionData | TransactionData_v26> {
     // TODO: Allow people to add tip to the reference gas price by using originalTx.data.gasPrice
     originalTx.data.gasPrice = await this.provider.getReferenceGasPrice();
     if (gasObjectId === undefined) {
@@ -356,12 +363,25 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
         'Must provide a valid gas budget for contructing TransactionData',
       );
     }
+    let version = await this.provider.getRpcApiVersion();
+    if (version?.major === 0 && version?.minor <= 26) {
+      return {
+        kind: tx,
+        sender: signerAddress,
+        gasPayment: gasPayment!,
+        gasPrice: originalTx.data.gasPrice!,
+        gasBudget: originalTx.data.gasBudget!,
+      };
+    }
     return {
       kind: tx,
-      gasPayment: gasPayment!,
-      gasPrice: originalTx.data.gasPrice!,
-      gasBudget: originalTx.data.gasBudget!,
       sender: signerAddress,
+      gasData: {
+        payment: gasPayment!,
+        price: originalTx.data.gasPrice!,
+        budget: originalTx.data.gasBudget!,
+        owner: signerAddress,
+      },
     };
   }
 
@@ -369,7 +389,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
    * Serialize `TransactionData` into BCS encoded bytes
    */
   public async serializeTransactionData(
-    tx: TransactionData,
+    tx: TransactionData | TransactionData_v26,
     // TODO: derive the buffer size automatically
     size: number = 8192,
   ): Promise<Uint8Array> {
@@ -412,35 +432,27 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
    * Deserialize `TransactionData` to `SignableTransaction`
    */
   public async transformTransactionDataToSignableTransaction(
-    tx: TransactionData,
+    tx: TransactionData | TransactionData_v26,
   ): Promise<
     UnserializedSignableTransaction | UnserializedSignableTransaction[]
   > {
-    if ('Single' in tx.kind) {
+    let tx_data = toTransactionData(tx);
+    if ('Single' in tx_data.kind) {
       return this.transformTransactionToSignableTransaction(
-        tx.kind.Single,
-        tx.gasBudget,
-        tx.gasPayment,
-        tx.gasPrice,
+        tx_data.kind.Single,
+        tx_data.gasData,
       );
     }
     return Promise.all(
-      tx.kind.Batch.map((t) =>
-        this.transformTransactionToSignableTransaction(
-          t,
-          tx.gasBudget,
-          tx.gasPayment,
-          tx.gasPrice,
-        ),
+      tx_data.kind.Batch.map((t) =>
+        this.transformTransactionToSignableTransaction(t, tx_data.gasData),
       ),
     );
   }
 
   public async transformTransactionToSignableTransaction(
     tx: Transaction,
-    gasBudget: number,
-    gasPayment?: SuiObjectRef,
-    gasPrice?: number,
+    gasData: GasData,
   ): Promise<UnserializedSignableTransaction> {
     if ('Pay' in tx) {
       return {
@@ -449,9 +461,10 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
           inputCoins: tx.Pay.coins.map((c) => c.objectId),
           recipients: tx.Pay.recipients,
           amounts: tx.Pay.amounts,
-          gasPayment: gasPayment?.objectId,
-          gasBudget,
-          gasPrice,
+          gasPayment: gasData.payment?.objectId,
+          gasBudget: gasData.budget,
+          gasOwner: gasData.owner,
+          gasPrice: gasData.price,
         },
       };
     } else if ('Call' in tx) {
@@ -470,9 +483,10 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
           arguments: await new CallArgSerializer(
             this.provider,
           ).deserializeCallArgs(tx),
-          gasPayment: gasPayment?.objectId,
-          gasBudget,
-          gasPrice,
+          gasPayment: gasData.payment?.objectId,
+          gasBudget: gasData.budget,
+          gasOwner: gasData.owner,
+          gasPrice: gasData.price,
         },
       };
     } else if ('TransferObject' in tx) {
@@ -481,21 +495,22 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
         data: {
           objectId: tx.TransferObject.object_ref.objectId,
           recipient: tx.TransferObject.recipient,
-          gasPayment: gasPayment?.objectId,
-          gasBudget,
-          gasPrice,
+          gasPayment: gasData.payment?.objectId,
+          gasBudget: gasData.budget,
+          gasOwner: gasData.owner,
+          gasPrice: gasData.price,
         },
       };
     } else if ('TransferSui' in tx) {
       return {
         kind: 'transferSui',
         data: {
-          suiObjectId: gasPayment!.objectId,
+          suiObjectId: gasData.payment!.objectId,
           recipient: tx.TransferSui.recipient,
           amount:
             'Some' in tx.TransferSui.amount ? tx.TransferSui.amount.Some : null,
-          gasBudget,
-          gasPrice,
+          gasBudget: gasData.budget,
+          gasPrice: gasData.price,
         },
       };
     } else if ('Publish' in tx) {
@@ -503,9 +518,9 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
         kind: 'publish',
         data: {
           compiledModules: tx.Publish.modules,
-          gasPayment: gasPayment?.objectId,
-          gasBudget,
-          gasPrice,
+          gasPayment: gasData.payment?.objectId,
+          gasBudget: gasData.budget,
+          gasOwner: gasData.owner,
         },
       };
     } else if ('PaySui' in tx) {

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -23,6 +23,7 @@ export interface TransferObjectTransaction extends TransactionCommon {
   objectId: ObjectId;
   recipient: SuiAddress;
   gasPayment?: ObjectId;
+  gasOwner?: SuiAddress;
 }
 
 export interface TransferSuiTransaction extends TransactionCommon {
@@ -45,6 +46,7 @@ export interface PayTransaction extends TransactionCommon {
   recipients: SuiAddress[];
   amounts: number[];
   gasPayment?: ObjectId;
+  gasOwner?: SuiAddress;
 }
 
 /// Send SUI coins to a list of addresses, following a list of amounts.
@@ -83,12 +85,14 @@ export interface MergeCoinTransaction extends TransactionCommon {
   primaryCoin: ObjectId;
   coinToMerge: ObjectId;
   gasPayment?: ObjectId;
+  gasOwner?: SuiAddress;
 }
 
 export interface SplitCoinTransaction extends TransactionCommon {
   coinObjectId: ObjectId;
   splitAmounts: number[];
   gasPayment?: ObjectId;
+  gasOwner?: SuiAddress;
 }
 
 export interface MoveCallTransaction extends TransactionCommon {
@@ -98,6 +102,7 @@ export interface MoveCallTransaction extends TransactionCommon {
   typeArguments: string[] | TypeTag[];
   arguments: (SuiJsonValue | PureArg)[];
   gasPayment?: ObjectId;
+  gasOwner?: SuiAddress;
 }
 
 export interface RawMoveCall {
@@ -186,6 +191,7 @@ export type SignableTransactionData = SignableTransaction['data'];
 export interface PublishTransaction extends TransactionCommon {
   compiledModules: ArrayLike<string> | ArrayLike<ArrayLike<number>>;
   gasPayment?: ObjectId;
+  gasOwner?: SuiAddress;
 }
 
 export type TransactionBuilderMode = 'Commit' | 'DevInspect';

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -11,7 +11,7 @@ import {
   unknown,
 } from 'superstruct';
 import bs58 from 'bs58';
-import { CallArg, TransactionData } from './sui-bcs';
+import { CallArg, TransactionData, TransactionData_v26 } from './sui-bcs';
 import { sha256Hash } from '../cryptography/hash';
 import { BCS } from '@mysten/bcs';
 
@@ -124,7 +124,7 @@ export function normalizeSuiObjectId(
  * @param publicKey public key
  */
 export function generateTransactionDigest(
-  data: TransactionData,
+  data: TransactionData | TransactionData_v26,
   bcs: BCS,
 ): string {
   const txBytes = bcs.ser('TransactionData', data).toBytes();

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -30,6 +30,15 @@ export const SuiObjectRef = object({
 });
 export type SuiObjectRef = Infer<typeof SuiObjectRef>;
 
+export const SuiGasData = object({
+  payment: SuiObjectRef,
+  /** Gas Object's owner */
+  owner: string(),
+  price: number(),
+  budget: number(),
+});
+export type SuiGasData = Infer<typeof SuiGasData>;
+
 export const SuiObjectInfo = assign(
   SuiObjectRef,
   object({

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -16,7 +16,7 @@ import {
   tuple,
 } from 'superstruct';
 import { SuiEvent } from './events';
-import { SuiMovePackage, SuiObject, SuiObjectRef } from './objects';
+import { SuiGasData, SuiMovePackage, SuiObject, SuiObjectRef } from './objects';
 import {
   ObjectId,
   ObjectOwner,
@@ -125,10 +125,7 @@ export type SuiTransactionKind = Infer<typeof SuiTransactionKind>;
 export const SuiTransactionData = object({
   transactions: array(SuiTransactionKind),
   sender: SuiAddress,
-  gasPayment: SuiObjectRef,
-  // TODO: remove optional after 0.21.0 is released
-  gasPrice: optional(number()),
-  gasBudget: number(),
+  gasData: SuiGasData,
 });
 export type SuiTransactionData = Infer<typeof SuiTransactionData>;
 
@@ -148,7 +145,7 @@ export type AuthorityQuorumSignInfo = Infer<typeof AuthorityQuorumSignInfo>;
 export const CertifiedTransaction = object({
   transactionDigest: TransactionDigest,
   data: SuiTransactionData,
-  txSignature: string(),
+  txSignatures: array(string()),
   authSignInfo: AuthorityQuorumSignInfo,
 });
 export type CertifiedTransaction = Infer<typeof CertifiedTransaction>;
@@ -264,6 +261,49 @@ export const SuiFinalizedEffects = object({
 });
 export type SuiFinalizedEffects = Infer<typeof SuiFinalizedEffects>;
 
+export const SuiTransactionData_v26 = object({
+  transactions: array(SuiTransactionKind),
+  sender: SuiAddress,
+  gasPayment: SuiObjectRef,
+  // TODO: remove optional after 0.21.0 is released
+  gasPrice: optional(number()),
+  gasBudget: number(),
+});
+export type SuiTransactionData_v26 = Infer<typeof SuiTransactionData_v26>;
+
+export function toSuiTransactionData(
+  tx_data: SuiTransactionData_v26,
+): SuiTransactionData {
+  return {
+    transactions: tx_data.transactions,
+    sender: tx_data.sender,
+    gasData: {
+      payment: tx_data.gasPayment,
+      owner: tx_data.sender,
+      budget: tx_data.gasBudget,
+      price: tx_data.gasPrice!,
+    },
+  };
+}
+
+export const CertifiedTransaction_v26 = object({
+  transactionDigest: TransactionDigest,
+  data: SuiTransactionData_v26,
+  txSignature: string(),
+  authSignInfo: AuthorityQuorumSignInfo,
+});
+export type CertifiedTransaction_v26 = Infer<typeof CertifiedTransaction_v26>;
+
+export const SuiExecuteTransactionResponse_v26 = object({
+  certificate: optional(CertifiedTransaction_v26),
+  effects: SuiFinalizedEffects,
+  confirmed_local_execution: boolean(),
+});
+
+export type SuiExecuteTransactionResponse_v26 = Infer<
+  typeof SuiExecuteTransactionResponse_v26
+>;
+
 export const SuiExecuteTransactionResponse = union([
   // TODO: remove after devnet 0.25.0(or 0.24.0) is released
   object({
@@ -361,7 +401,7 @@ export type SuiParsedTransactionResponse = Infer<
 >;
 
 export const SuiTransactionResponse = object({
-  certificate: CertifiedTransaction,
+  certificate: union([CertifiedTransaction, CertifiedTransaction_v26]),
   effects: TransactionEffects,
   timestamp_ms: union([number(), literal(null)]),
   parsed_data: union([SuiParsedTransactionResponse, literal(null)]),
@@ -376,7 +416,7 @@ export type SuiTransactionResponse = Infer<typeof SuiTransactionResponse>;
 
 export function getCertifiedTransaction(
   tx: SuiTransactionResponse | SuiExecuteTransactionResponse,
-): CertifiedTransaction | undefined {
+): CertifiedTransaction | CertifiedTransaction_v26 | undefined {
   if ('certificate' in tx) {
     return tx.certificate;
   } else if ('EffectsCert' in tx) {
@@ -388,6 +428,7 @@ export function getCertifiedTransaction(
 export function getTransactionDigest(
   tx:
     | CertifiedTransaction
+    | CertifiedTransaction_v26
     | SuiTransactionResponse
     | SuiExecuteTransactionResponse,
 ): TransactionDigest {
@@ -398,8 +439,13 @@ export function getTransactionDigest(
   return effects.transactionDigest;
 }
 
-export function getTransactionSignature(tx: CertifiedTransaction): string {
-  return tx.txSignature;
+export function getTransactionSignature(
+  tx: CertifiedTransaction | CertifiedTransaction_v26,
+): string[] {
+  if ('txSignatures' in tx) {
+    return tx.txSignatures;
+  }
+  return [tx.txSignature];
 }
 
 export function getTransactionAuthorityQuorumSignInfo(
@@ -416,22 +462,24 @@ export function getTransactionData(
 
 /* ----------------------------- TransactionData ---------------------------- */
 
-export function getTransactionSender(tx: CertifiedTransaction): SuiAddress {
+export function getTransactionSender(
+  tx: CertifiedTransaction | CertifiedTransaction_v26,
+): SuiAddress {
   return tx.data.sender;
 }
 
 export function getTransactionGasObject(
   tx: CertifiedTransaction,
 ): SuiObjectRef {
-  return tx.data.gasPayment;
+  return tx.data.gasData.payment;
 }
 
 export function getTransactionGasPrice(tx: CertifiedTransaction) {
-  return tx.data.gasPrice;
+  return tx.data.gasData.price;
 }
 
 export function getTransactionGasBudget(tx: CertifiedTransaction): number {
-  return tx.data.gasBudget;
+  return tx.data.gasData.budget;
 }
 
 export function getTransferObjectTransaction(
@@ -489,7 +537,7 @@ export function getConsensusCommitPrologueTransaction(
 }
 
 export function getTransactions(
-  data: CertifiedTransaction,
+  data: CertifiedTransaction | CertifiedTransaction_v26,
 ): SuiTransactionKind[] {
   return data.data.transactions;
 }

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -21,6 +21,7 @@ import {
   getObjectId,
   PayAllSuiTx,
   PayAllSuiTransaction,
+  TransactionData_v26,
 } from '../../src';
 import { CallArgSerializer } from '../../src/signers/txn-data-serializers/call-arg-serializer';
 import {
@@ -104,6 +105,7 @@ describe('Transaction Serialization and deserialization', () => {
         'An NFT created by the wallet Command Line Tool',
         'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
       ],
+      gasOwner: toolbox.address(),
       gasBudget: DEFAULT_GAS_BUDGET,
       gasPayment: coins[0].objectId,
     };
@@ -147,6 +149,7 @@ describe('Transaction Serialization and deserialization', () => {
         coins[2].objectId,
         validator_address,
       ],
+      gasOwner: toolbox.address(),
       gasBudget: DEFAULT_GAS_BUDGET,
       gasPayment: coins[3].objectId,
     };
@@ -219,13 +222,26 @@ describe('Transaction Serialization and deserialization', () => {
       },
     } as PaySuiTx;
 
-    const tx_data = {
-      sender: DEFAULT_RECIPIENT_2,
-      gasBudget: gasBudget,
-      gasPrice: 100,
-      kind: { Single: paySuiTx } as TransactionKind,
-      gasPayment: getObjectReference(coins[1]),
-    } as TransactionData;
+    const version = await localSerializer.getRpcApiVersion();
+    const tx_data =
+      version?.major === 0 && version?.minor <= 26
+        ? ({
+            sender: DEFAULT_RECIPIENT_2,
+            gasBudget: gasBudget,
+            gasPrice: 100,
+            kind: { Single: paySuiTx } as TransactionKind,
+            gasPayment: getObjectReference(coins[1]),
+          } as TransactionData_v26)
+        : ({
+            sender: DEFAULT_RECIPIENT_2,
+            kind: { Single: paySuiTx } as TransactionKind,
+            gasData: {
+              owner: DEFAULT_RECIPIENT_2,
+              budget: gasBudget,
+              price: 100,
+              payment: getObjectReference(coins[1]),
+            },
+          } as TransactionData);
 
     const serializedData = await localSerializer.serializeTransactionData(
       tx_data,
@@ -262,13 +278,26 @@ describe('Transaction Serialization and deserialization', () => {
       },
     } as PayAllSuiTx;
 
-    const tx_data = {
-      sender: DEFAULT_RECIPIENT_2,
-      gasBudget: gasBudget,
-      gasPrice: 100,
-      kind: { Single: payAllSui } as TransactionKind,
-      gasPayment: getObjectReference(coins[1]),
-    } as TransactionData;
+    const version = await localSerializer.getRpcApiVersion();
+    const tx_data =
+      version?.major === 0 && version?.minor <= 26
+        ? ({
+            sender: DEFAULT_RECIPIENT_2,
+            gasBudget: gasBudget,
+            gasPrice: 100,
+            kind: { Single: payAllSui } as TransactionKind,
+            gasPayment: getObjectReference(coins[1]),
+          } as TransactionData_v26)
+        : ({
+            sender: DEFAULT_RECIPIENT_2,
+            kind: { Single: payAllSui } as TransactionKind,
+            gasData: {
+              owner: DEFAULT_RECIPIENT_2,
+              budget: gasBudget,
+              price: 100,
+              payment: getObjectReference(coins[1]),
+            },
+          } as TransactionData);
 
     const serializedData = await localSerializer.serializeTransactionData(
       tx_data,

--- a/sdk/typescript/test/unit/types/common.test.ts
+++ b/sdk/typescript/test/unit/types/common.test.ts
@@ -19,18 +19,21 @@ describe('Test common functions', () => {
           },
         },
         sender: 'cba4a48bb0f8b586c167e5dcefaa1c5e96ab3f08',
-        gasPayment: {
-          objectId: '2fab642a835afc9d68d296f50c332c9d32b5a0d5',
-          version: 7,
-          digest: 'lGmQDt2ch1/4HwdgOlHmeeZZvCHUjfrKvBOND/c67n4=',
+        gasData: {
+          owner: 'cba4a48bb0f8b586c167e5dcefaa1c5e96ab3f08',
+          payment: {
+            objectId: '2fab642a835afc9d68d296f50c332c9d32b5a0d5',
+            version: 7,
+            digest: 'lGmQDt2ch1/4HwdgOlHmeeZZvCHUjfrKvBOND/c67n4=',
+          },
+          price: 1,
+          budget: 100,
         },
-        gasPrice: 1,
-        gasBudget: 100,
       };
 
       const transactionDigest = generateTransactionDigest(transactionData, bcs);
       expect(transactionDigest).toEqual(
-        'HZaXLHhraTyRJjQAEbaEn9ruT1LrjUMG9Sq9EeGY2JLZ',
+        '3DBBCLZWejuZWVbGPHB3n4AtWjNf4gHWDUPV1hE45Kb9',
       );
     });
   });


### PR DESCRIPTION
This PR contains core changes for sponsored tx, including:
1. `SenderSignedData` now contains a list of user signatures (so does `user_signatures_for_checkpoints` table and `user_signatures` in `CheckpointContents`)
2. add `GasData` to consolidate gas related info, including `gas_owner`. When `gas_owner` is different from transaction sender, the tx is a sponsored transaction.
3. check transaction sponsorship - not every transaction kind can be sponsored. All "sui" kinds (e.g. `PaySui`) cannot be sponsored, system tx kind (e.g. `ChangeEpoch`) cannot be sponsored. Batch tx can be sponsored. This happens in `TransactionData::check_sponsorship`
4. check gas ownership happens in `fn check_one_object`. When object is gas object, pass in `gas_owner` v.s. `sender`
5. transaction verification now checks all required signatures (`SenderSignedData::verify`) and disallow dup/irrelevant signatures.
6. order of user sigs does not matter. The canonical order is decided in narwhal.
7. transaction execution api now takes a list of signatures.
