### PR TITLE
Disable stress smoke test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,7 +91,7 @@ jobs:
           cargo nextest run --profile ci
       - name: benchmark (smoke)
         run: |
-          cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s --stress-stat-collection
+          # cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s --stress-stat-collection
           pushd narwhal/benchmark && fab smoke && popd
       - name: doctests
         run: |


### PR DESCRIPTION
Using this PR to disable the smoke test to unblock people to land their PRs while we root cause the issue.