### PR TITLE
wallet-ext: settings menu account or accounts item

### DIFF
--- a/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
@@ -6,10 +6,10 @@ import AccountAddress from '_components/account-address';
 import { useNextMenuUrl } from '_components/menu/hooks';
 import { Text } from '_src/ui/app/shared/text';
 
-export function AccountSettings() {
+export function AccountsSettings() {
     const backUrl = useNextMenuUrl(true, '/');
     return (
-        <MenuLayout title="Account" back={backUrl}>
+        <MenuLayout title="Accounts" back={backUrl}>
             <div className="flex flex-col gap-3">
                 <Text color="gray-90" weight="medium" variant="p1">
                     Address

--- a/apps/wallet/src/ui/app/components/menu/content/MenuList.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/MenuList.tsx
@@ -1,7 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Account24, ArrowUpRight12, Domain24, Version24 } from '@mysten/icons';
+import { useFeature } from '@growthbook/growthbook-react';
+import {
+    Account24,
+    ArrowUpRight12,
+    Copy16,
+    Domain24,
+    Version24,
+} from '@mysten/icons';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Browser from 'webextension-polyfill';
@@ -15,14 +22,16 @@ import { lockWallet } from '_app/wallet/actions';
 import { useNextMenuUrl } from '_components/menu/hooks';
 import { useAppDispatch, useAppSelector, useMiddleEllipsis } from '_hooks';
 import { ToS_LINK } from '_src/shared/constants';
+import { FEATURES } from '_src/shared/experimentation/features';
 import { useAutoLockInterval } from '_src/ui/app/hooks/useAutoLockInterval';
+import { useCopyToClipboard } from '_src/ui/app/hooks/useCopyToClipboard';
 import { logout } from '_src/ui/app/redux/slices/account';
 import { Link } from '_src/ui/app/shared/Link';
 import FaucetRequestButton from '_src/ui/app/shared/faucet/FaucetRequestButton';
 import { Text } from '_src/ui/app/shared/text';
 
 function MenuList() {
-    const accountUrl = useNextMenuUrl(true, '/account');
+    const accountUrl = useNextMenuUrl(true, '/accounts');
     const networkUrl = useNextMenuUrl(true, '/network');
     const autoLockUrl = useNextMenuUrl(true, '/auto-lock');
     const address = useAppSelector(({ account }) => account.address);
@@ -34,14 +43,24 @@ function MenuList() {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const [logoutInProgress, setLogoutInProgress] = useState(false);
+    const copyAddressCallback = useCopyToClipboard(address || '', {
+        copySuccessMessage: 'Address copied',
+    });
+    const isMultiAccountsEnabled = useFeature(
+        FEATURES.WALLET_MULTI_ACCOUNTS
+    ).on;
     return (
         <MenuLayout title="Wallet Settings">
             <div className="flex flex-col divide-y divide-x-0 divide-solid divide-gray-45">
                 <MenuListItem
-                    to={accountUrl}
+                    to={isMultiAccountsEnabled ? accountUrl : undefined}
                     icon={<Account24 />}
-                    title="Account"
+                    title={isMultiAccountsEnabled ? 'Accounts' : 'Account'}
                     subtitle={shortenAddress}
+                    onClick={
+                        isMultiAccountsEnabled ? undefined : copyAddressCallback
+                    }
+                    iconAfter={isMultiAccountsEnabled ? undefined : <Copy16 />}
                 />
                 <MenuListItem
                     to={networkUrl}

--- a/apps/wallet/src/ui/app/components/menu/content/MenuListItem.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/MenuListItem.tsx
@@ -2,21 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ChevronRight16 } from '@mysten/icons';
-import { type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
+
+import type { MouseEventHandler, ReactNode } from 'react';
 
 export type ItemProps = {
     icon: ReactNode;
     title: ReactNode;
     subtitle?: ReactNode;
-    to: string;
+    iconAfter?: ReactNode;
+    to?: string;
+    onClick?: MouseEventHandler<Element>;
 };
 
-function MenuListItem({ icon, title, subtitle, to }: ItemProps) {
+function MenuListItem({
+    icon,
+    title,
+    subtitle,
+    iconAfter,
+    to = '',
+    onClick,
+}: ItemProps) {
+    const Component = to ? Link : 'div';
     return (
-        <Link
+        <Component
+            className="flex flex-nowrap items-center px-1 py-4.5 first:pt-3 last:pb-3 gap-5 no-underline overflow-hidden group cursor-pointer"
             to={to}
-            className="flex flex-nowrap items-center px-1 py-4.5 first:pt-3 last:pb-3 gap-5 no-underline overflow-hidden"
+            onClick={onClick}
         >
             <div className="flex flex-nowrap flex-1 gap-2 items-center overflow-hidden basis-3/5">
                 <div className="flex text-steel text-2xl flex-none">{icon}</div>
@@ -26,13 +38,15 @@ function MenuListItem({ icon, title, subtitle, to }: ItemProps) {
             </div>
             <div className="flex flex-nowrap flex-1 justify-end gap-1 items-center overflow-hidden basis-2/5">
                 {subtitle ? (
-                    <div className="truncate text-steel-dark text-bodySmall font-medium">
+                    <div className="transition truncate text-steel-dark text-bodySmall font-medium group-hover:text-steel-darker">
                         {subtitle}
                     </div>
                 ) : null}
-                <ChevronRight16 className="text-steel flex-none text-base" />
+                <div className="transition flex text-steel flex-none text-base group-hover:text-steel-darker">
+                    {iconAfter || (to && <ChevronRight16 />) || null}
+                </div>
             </div>
-        </Link>
+        </Component>
     );
 }
 

--- a/apps/wallet/src/ui/app/components/menu/content/index.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/index.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useFeature } from '@growthbook/growthbook-react';
 import { useCallback } from 'react';
 import {
     Navigate,
@@ -10,7 +11,7 @@ import {
     useNavigate,
 } from 'react-router-dom';
 
-import { AccountSettings } from './AccountSettings';
+import { AccountsSettings } from './AccountsSettings';
 import { AutoLockSettings } from './AutoLockSettings';
 import MenuList from './MenuList';
 import { NetworkSettings } from './NetworkSettings';
@@ -22,6 +23,7 @@ import {
     useNextMenuUrl,
 } from '_components/menu/hooks';
 import { useOnKeyboardEvent } from '_hooks';
+import { FEATURES } from '_src/shared/experimentation/features';
 
 import type { MouseEvent } from 'react';
 
@@ -44,6 +46,9 @@ function MenuContent() {
         [isOpen, navigate, closeMenuUrl]
     );
     useOnKeyboardEvent('keydown', CLOSE_KEY_CODES, handleOnCloseMenu, isOpen);
+    const isMultiAccountsEnabled = useFeature(
+        FEATURES.WALLET_MULTI_ACCOUNTS
+    ).on;
     if (!isOpen) {
         return null;
     }
@@ -53,7 +58,12 @@ function MenuContent() {
                 <MainLocationContext.Provider value={mainLocation}>
                     <Routes location={menuUrl || ''}>
                         <Route path="/" element={<MenuList />} />
-                        <Route path="/account" element={<AccountSettings />} />
+                        {isMultiAccountsEnabled ? (
+                            <Route
+                                path="/accounts"
+                                element={<AccountsSettings />}
+                            />
+                        ) : null}
                         <Route path="/network" element={<NetworkSettings />} />
                         <Route
                             path="/auto-lock"


### PR DESCRIPTION
* when multi accounts is enabled show Accounts menu item and navigate to accounts settings on click
* otherwise show Account menu item that copies the address on click

when multi account feature is enabled


https://user-images.githubusercontent.com/10210143/218827060-63007f68-565e-43ed-9b18-f2a8ccf6577e.mov

when multi account is disabled


https://user-images.githubusercontent.com/10210143/218828484-98019e2e-7aba-4bb4-91e3-23ad764a251b.mov



part of APPS-286