### PR TITLE
Turn a few execution errors into panics

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -174,7 +174,6 @@ pub struct AuthorityMetrics {
     pub(crate) transaction_manager_num_ready: IntGauge,
 
     pub(crate) execution_driver_executed_transactions: IntCounter,
-    pub(crate) execution_driver_execution_failures: IntCounter,
 
     pub(crate) skipped_consensus_txns: IntCounter,
 
@@ -337,12 +336,6 @@ impl AuthorityMetrics {
             execution_driver_executed_transactions: register_int_counter_with_registry!(
                 "execution_driver_executed_transactions",
                 "Cumulative number of transaction executed by execution driver",
-                registry,
-            )
-            .unwrap(),
-            execution_driver_execution_failures: register_int_counter_with_registry!(
-                "execution_driver_execution_failures",
-                "Cumulative number of transactions failed to be executed by execution driver",
                 registry,
             )
             .unwrap(),
@@ -611,13 +604,10 @@ impl AuthorityState {
 
         let observed_effects_digest = observed_effects.digest();
         if observed_effects_digest != expected_effects_digest {
-            error!(
-                ?expected_effects_digest,
-                ?observed_effects_digest,
-                expected_effects=?effects.data(),
-                observed_effects=?observed_effects.data(),
-                input_objects = ?certificate.data().intent_message.value.input_objects(),
-                "Locally executed effects do not match canonical effects!");
+            panic!(
+                "Locally executed effects do not match canonical effects! expected_effects_digest={:?} observed_effects_digest={:?} expected_effects={:?} observed_effects={:?} input_objects={:?}",
+                expected_effects_digest, observed_effects_digest, effects.data(), observed_effects.data(), certificate.data().intent_message.value.input_objects()
+            );
         }
         Ok(())
     }

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -91,13 +91,11 @@ pub async fn execution_process(
                     .await;
                 if let Err(e) = res {
                     if attempts == EXECUTION_MAX_ATTEMPTS {
-                        error!("Failed to execute certified transaction after {attempts} attempts! error={e} certificate={:?}", certificate);
-                        authority.metrics.execution_driver_execution_failures.inc();
-                        return;
+                        panic!("Failed to execute certified transaction {digest:?} after {attempts} attempts! error={e} certificate={certificate:?}");
                     }
                     // Assume only transient failure can happen. Permanent failure is probably
                     // a bug. There is nothing that can be done to recover from permanent failures.
-                    error!(tx_digest=?digest, "Failed to execute certified transaction! attempt {attempts}, {e}");
+                    error!(tx_digest=?digest, "Failed to execute certified transaction {digest:?}! attempt {attempts}, {e}");
                     sleep(EXECUTION_FAILURE_RETRY_INTERVAL).await;
                 } else {
                     break;

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use sui_types::{base_types::ObjectID, committee::EpochId, storage::ObjectKey};
 use sui_types::{base_types::TransactionDigest, error::SuiResult, messages::VerifiedCertificate};
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::{debug, error, warn};
+use tracing::{debug, warn};
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::{AuthorityMetrics, AuthorityStore};
@@ -267,17 +267,12 @@ impl TransactionManager {
             let cert = match epoch_store.get_pending_certificate(digest) {
                 Ok(Some(cert)) => cert,
                 Ok(None) => {
-                    error!(tx_digest = ?digest,
-                        "Ready certificate not found in the pending table",
+                    panic!(
+                        "Ready certificate {digest:?} not found in the pending_certificates table!",
                     );
-                    continue;
                 }
                 Err(e) => {
-                    error!(tx_digest = ?digest,
-                        "Failed to read pending table: {e}",
-                    );
-
-                    continue;
+                    panic!("Failed to read certificate {digest:?} pending_certificates table: {e}",);
                 }
             };
             self.certificate_ready(cert);


### PR DESCRIPTION
Now we are reasonably sure these checks will not produce spurious errors. And when they fail validators will get into inconsistent states. So turning them into panics.