### PR TITLE
[fix] build owner index from genesis objects

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2522,6 +2522,7 @@ async fn test_authority_persist() {
             checkpoint_store,
             &registry,
             &AuthorityStorePruningConfig::default(),
+            &[], // no genesis objects
         )
         .await
     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -217,6 +217,7 @@ impl SuiNode {
             checkpoint_store.clone(),
             &prometheus_registry,
             &config.authority_store_pruning_config,
+            genesis.objects(),
         )
         .await;
 


### PR DESCRIPTION
Chris found that some genesis's objects ownership were not properly indexed, the root cause can be, the owner index was built on top of `objects` table instead of genesis objects, which means that it is possible that when owner index is being built, the `objects` table did not have all objects yet.

After this PR, instead of building owner index on top of `objects` table, it directly reads from genesis.