### PR TITLE
Write certificates to pending_certificates table in SuiTxValidator

### DIFF
--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -105,11 +105,10 @@ impl TransactionValidator for SuiTxValidator {
             .verify_all()
             .wrap_err("Malformed batch (failed to verify)")?;
 
-        // all certificates had valid signatures, schedule them for execution prior to sequencing.
-        // Note that this does not persist the certs to pending_certificates - that happens in
-        // consensus_handler.rs - this is an optimization only, to start executing single-writer
-        // certs as soon as possible. Persistent state should only be updated due to consensus
-        // output.
+        // all certificates had valid signatures, schedule them for execution prior to sequencing
+        // which is unnecessary for owned object transactions.
+        self.epoch_store
+            .insert_pending_certificates(&owned_tx_certs)?;
         self.transaction_manager
             .enqueue(owned_tx_certs, &self.epoch_store)
             .wrap_err("Failed to schedule certificates for execution")


### PR DESCRIPTION
Currently `TransactionManager` loads certificates from `pending_certificates` table when they are read to be executed. So it is always necessary to writes certificates to the table before enqueueing them to `TransactionManager`. We can consider keeping certificates in memory in `TransactionManager`, and only persist certificates from Narwhal output. But that would be another change.