### PR TITLE
Consolidate publishing and loading verification

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -530,7 +530,7 @@ pub fn verify_and_link<
     // Run the Move bytecode verifier and linker.
     // It is important to do this before running the Sui verifier, since the sui
     // verifier may assume well-formedness conditions enforced by the Move verifier hold
-    let vm = MoveVM::new(natives)
+    let vm = new_move_vm(natives, protocol_config)
         .expect("VM creation only fails if natives are invalid, and we created the natives");
     let mut session = new_session(
         &vm,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -103,6 +103,7 @@ use crate::{
     event_handler::EventHandler, transaction_input_checker, transaction_manager::TransactionManager,
 };
 use sui_adapter::execution_engine;
+use sui_protocol_config::ProtocolConfig;
 use sui_types::epoch_data::EpochData;
 
 #[cfg(test)]
@@ -1592,6 +1593,7 @@ impl AuthorityState {
         genesis_committee: Committee,
         key: &AuthorityKeyPair,
         store_base_path: Option<PathBuf>,
+        protocol_config: Option<ProtocolConfig>,
         genesis: &Genesis,
     ) -> Arc<Self> {
         let secret = Arc::pin(key.copy());
@@ -1618,13 +1620,14 @@ impl AuthorityState {
             .unwrap(),
         );
         let registry = Registry::new();
-        let epoch_store = AuthorityPerEpochStore::new(
+        let epoch_store = AuthorityPerEpochStore::new_with_config_for_testing(
             name,
             genesis_committee.clone(),
             &path.join("store"),
             None,
             EpochMetrics::new(&registry),
             Some(Default::default()),
+            protocol_config,
         );
 
         let epochs = Arc::new(CommitteeStore::new(

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -319,9 +319,14 @@ async fn init_executor_test(
     let keypair = network_config.validator_configs[0]
         .protocol_key_pair()
         .copy();
-    let state =
-        AuthorityState::new_for_testing(committee.committee().clone(), &keypair, None, &genesis)
-            .await;
+    let state = AuthorityState::new_for_testing(
+        committee.committee().clone(),
+        &keypair,
+        None,
+        None,
+        &genesis,
+    )
+    .await;
 
     let (checkpoint_sender, _): (Sender<VerifiedCheckpoint>, Receiver<VerifiedCheckpoint>) =
         broadcast::channel(buffer_size);

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1265,7 +1265,8 @@ mod tests {
             .protocol_key_pair()
             .copy();
         let state =
-            AuthorityState::new_for_testing(committee.clone(), &keypair, None, &genesis).await;
+            AuthorityState::new_for_testing(committee.clone(), &keypair, None, None, &genesis)
+                .await;
 
         let mut store = HashMap::<TransactionDigest, TransactionEffects>::new();
         store.insert(

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -113,7 +113,7 @@ impl AuthorityAPI for LocalAuthorityClient {
 
 impl LocalAuthorityClient {
     pub async fn new(committee: Committee, secret: AuthorityKeyPair, genesis: &Genesis) -> Self {
-        let state = AuthorityState::new_for_testing(committee, &secret, None, genesis).await;
+        let state = AuthorityState::new_for_testing(committee, &secret, None, None, genesis).await;
         Self {
             state,
             fault_config: LocalAuthorityClientFaultConfig::default(),

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -95,7 +95,7 @@ async fn test_narwhal_manager() {
         let genesis_committee = genesis.committee().unwrap();
 
         let state =
-            AuthorityState::new_for_testing(genesis_committee, &secret, None, genesis).await;
+            AuthorityState::new_for_testing(genesis_committee, &secret, None, None, genesis).await;
 
         let system_state = state
             .get_sui_system_state_object()

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -516,6 +516,14 @@ impl ProtocolConfig {
         }
     }
 
+    // Add more arguments for different test scenarios
+    pub fn get_for_move_publish_testing(max_function_definitions: Option<usize>) -> Self {
+        Self {
+            max_function_definitions,
+            ..Self::get_for_version(ProtocolVersion::MAX)
+        }
+    }
+
     /// Override one or more settings in the config, for testing.
     /// This must be called at the beginning of the test, before get_for_(min|max)_version is
     /// called, since those functions cache their return value.


### PR DESCRIPTION
Publishing and loading verification must be the same, with the same config.
This is a one line change with a bunch of stuff added to build a test.

@mystenmark please take a look at the `ProtoclConfig` changes. We need a way to control that for testing so that limits can be tested in a sane matter. I reworked some code to make it possible and it's hopefully straightforward.

@amnn I wonder if we a have a way to build complex packages programmatically, relying on source code is really not a good option for testing limits and complex scenarios.
