### PR TITLE
Better error message for config loading failures 

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1043,10 +1043,10 @@ impl WalletContext {
         request_timeout: Option<std::time::Duration>,
     ) -> Result<Self, anyhow::Error> {
         let config: SuiClientConfig = PersistedConfig::read(config_path).map_err(|err| {
-            err.context(format!(
-                "Cannot open wallet config file at {:?}",
-                config_path
-            ))
+            anyhow!("Cannot open wallet config file at {:?}. Error: {}",
+                config_path,
+                err
+            )
         })?;
 
         let config = config.persisted(config_path);


### PR DESCRIPTION
I had an old installation and I see that my `client.yaml` is outdated. The message was something like
```
Cannot open wallet config file at "/Users/tufan/.sui/sui_config/client.yaml"
```
This can happen due to various reasons, so I added the root error message now I see that;


```
➜  sui git:(main) ✗ ./target/debug/sui  client 
Cannot open wallet config file at "/Users/tufan/.sui/sui_config/client.yaml". Error: missing field `envs` at line 2 column 9
```

and
```
➜  sui git:(main) ✗ ./target/debug/sui client
Cannot open wallet config file at "/Users/tufan/.sui/sui_config/client.yaml". Error: "Invalid Keypair file \"Invalid bytes\" \"/Users/tufan/.sui/sui_config/sui.keystore\" at line 2 column 9"
```

for different cases.

I also see the original error is ignored in some other places but I did not want to mess that PR