### PR TITLE
[core] Add executed_epoch to transaction effects

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -112,6 +112,7 @@ pub fn execute_transaction_to_effects<
         gas_cost_summary,
         status,
         gas_object_ref,
+        epoch,
     );
     (inner, effects, execution_result)
 }

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -30,9 +30,8 @@ use sui_types::{
     },
     committee::Committee,
     crypto::{AuthoritySignInfo, AuthoritySignature},
-    gas::GasCostSummary,
     message_envelope::Message,
-    messages::{CertifiedTransaction, ExecutionStatus, Transaction, TransactionEffects},
+    messages::{CertifiedTransaction, Transaction, TransactionEffects},
     object::{Object, Owner},
 };
 use tokio::time::timeout;
@@ -120,26 +119,12 @@ pub fn create_fake_cert_and_effect_digest<'a>(
 
 pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
     TransactionEffects {
-        status: ExecutionStatus::Success,
-        gas_used: GasCostSummary {
-            computation_cost: 0,
-            storage_cost: 0,
-            storage_rebate: 0,
-        },
-        modified_at_versions: Vec::new(),
-        shared_objects: Vec::new(),
         transaction_digest: *tx.digest(),
-        created: Vec::new(),
-        mutated: Vec::new(),
-        unwrapped: Vec::new(),
-        deleted: Vec::new(),
-        wrapped: Vec::new(),
         gas_object: (
             random_object_ref(),
             Owner::AddressOwner(tx.data().intent_message.value.signer()),
         ),
-        events: Vec::new(),
-        dependencies: Vec::new(),
+        ..Default::default()
     }
 }
 

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1931,6 +1931,8 @@ impl SuiFinalizedEffects {
 pub struct SuiTransactionEffects {
     // The status of the execution
     pub status: SuiExecutionStatus,
+    /// The epoch when this transaction was executed.
+    pub executed_epoch: EpochId,
     pub gas_used: SuiGasCostSummary,
     // The object references of the shared objects used in this transaction. Empty if no shared objects were used.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1977,6 +1979,7 @@ impl SuiTransactionEffects {
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
             status: effect.status.into(),
+            executed_epoch: effect.executed_epoch,
             gas_used: effect.gas_used.into(),
             shared_objects: to_sui_object_ref(effect.shared_objects),
             transaction_digest: effect.transaction_digest,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -334,6 +334,7 @@
                 "status": {
                   "status": "success"
                 },
+                "executedEpoch": 0,
                 "gasUsed": {
                   "computationCost": 100,
                   "storageCost": 100,
@@ -1543,6 +1544,7 @@
                 "status": {
                   "status": "success"
                 },
+                "executedEpoch": 0,
                 "gasUsed": {
                   "computationCost": 100,
                   "storageCost": 100,
@@ -6318,6 +6320,7 @@
         "description": "The response from processing a transaction or a certified transaction",
         "type": "object",
         "required": [
+          "executedEpoch",
           "gasObject",
           "gasUsed",
           "status",
@@ -6349,6 +6352,12 @@
             "items": {
               "$ref": "#/components/schemas/Event"
             }
+          },
+          "executedEpoch": {
+            "description": "The epoch when this transaction was executed.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "gasObject": {
             "$ref": "#/components/schemas/OwnedObjectRef"

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -451,6 +451,7 @@ impl RpcExampleProvider {
             },
             effects: SuiTransactionEffects {
                 status: SuiExecutionStatus::Success,
+                executed_epoch: 0,
                 gas_used: SuiGasCostSummary {
                     computation_cost: 100,
                     storage_cost: 100,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2202,6 +2202,8 @@ impl From<InvalidSharedByValue> for ExecutionFailureStatus {
 pub struct TransactionEffects {
     /// The status of the execution
     pub status: ExecutionStatus,
+    /// The epoch when this transaction was executed.
+    pub executed_epoch: EpochId,
     pub gas_used: GasCostSummary,
     /// The version that every modified (mutated or deleted) object had before it was modified by
     /// this transaction.
@@ -2362,6 +2364,7 @@ impl Default for TransactionEffects {
     fn default() -> Self {
         TransactionEffects {
             status: ExecutionStatus::Success,
+            executed_epoch: 0,
             gas_used: GasCostSummary {
                 computation_cost: 0,
                 storage_cost: 0,

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -14,6 +14,7 @@ use sui_protocol_constants::STORAGE_REBATE_RATE;
 use tracing::trace;
 
 use crate::coin::Coin;
+use crate::committee::EpochId;
 use crate::event::BalanceChangeType;
 use crate::storage::SingleTxContext;
 use crate::{
@@ -497,6 +498,7 @@ impl<S> TemporaryStore<S> {
         gas_cost_summary: GasCostSummary,
         status: ExecutionStatus,
         gas_object_ref: ObjectRef,
+        epoch: EpochId,
     ) -> (InnerTemporaryStore, TransactionEffects) {
         let mut modified_at_versions = vec![];
 
@@ -548,6 +550,7 @@ impl<S> TemporaryStore<S> {
 
         let effects = TransactionEffects {
             status,
+            executed_epoch: epoch,
             gas_used: gas_cost_summary,
             modified_at_versions,
             shared_objects: shared_object_refs,

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -182,6 +182,11 @@ export type OwnedObjectRef = Infer<typeof OwnedObjectRef>;
 export const TransactionEffects = object({
   /** The status of the execution */
   status: ExecutionStatus,
+  /**
+   * The epoch when this transaction was executed
+   * TODO: Changed it to non-optional once this is stable.
+   * */
+  executedEpoch: optional(EpochId),
   gasUsed: GasCostSummary,
   /** The object references of the shared objects used in this transaction. Empty if no shared objects were used. */
   sharedObjects: optional(array(SuiObjectRef)),


### PR DESCRIPTION
Since we may resign transaction effects at a different epoch than it was executed, it is useful to keep track of when the effects was actually executed in the effects itself.