### PR TITLE
crypto: Use AsBytes for all sigs

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -3207,7 +3207,7 @@
         }
       },
       "CompressedSignature": {
-        "description": "Unlike `enum Signature`, `enum CompressedSignature` does not contain public key.",
+        "description": "Unlike [enum Signature], [enum CompressedSignature] does not contain public key.",
         "oneOf": [
           {
             "type": "object",

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -7,9 +7,15 @@ use fastcrypto::bls12381::min_sig::{
     BLS12381AggregateSignature, BLS12381AggregateSignatureAsBytes, BLS12381KeyPair,
     BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature,
 };
-use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature};
-use fastcrypto::secp256k1::{Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1Signature};
-use fastcrypto::secp256r1::{Secp256r1KeyPair, Secp256r1PublicKey, Secp256r1Signature};
+use fastcrypto::ed25519::{
+    Ed25519KeyPair, Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature, Ed25519SignatureAsBytes,
+};
+use fastcrypto::secp256k1::{
+    Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1Signature, Secp256k1SignatureAsBytes,
+};
+use fastcrypto::secp256r1::{
+    Secp256r1KeyPair, Secp256r1PublicKey, Secp256r1Signature, Secp256r1SignatureAsBytes,
+};
 pub use fastcrypto::traits::KeyPair as KeypairTraits;
 pub use fastcrypto::traits::{
     AggregateAuthenticator, Authenticator, EncodeDecodeBase64, SigningKey, ToFromBytes,
@@ -33,13 +39,12 @@ use crate::committee::{Committee, EpochId, StakeUnit};
 use crate::error::{SuiError, SuiResult};
 use crate::intent::IntentMessage;
 use crate::sui_serde::{Readable, SuiBitmap};
-use fastcrypto::encoding::{Base64, Encoding, Hex};
-use fastcrypto::hash::{HashFunction, Sha3_256};
-use std::fmt::Debug;
-
 pub use enum_dispatch::enum_dispatch;
+use fastcrypto::encoding::{Base64, Encoding, Hex};
 use fastcrypto::error::FastCryptoError;
+use fastcrypto::hash::{HashFunction, Sha3_256};
 pub use fastcrypto::traits::Signer;
+use std::fmt::Debug;
 
 #[cfg(test)]
 #[path = "unit_tests/crypto_tests.rs"]
@@ -411,15 +416,6 @@ where {
     }
 }
 
-// this is probably derivable, but we'd rather have it explicitly laid out for instructional purposes,
-// see [#34](https://github.com/MystenLabs/narwhal/issues/34)
-impl Default for AuthorityPublicKeyBytes {
-    #[allow(dead_code)]
-    fn default() -> Self {
-        Self([0u8; AuthorityPublicKey::LENGTH])
-    }
-}
-
 impl FromStr for AuthorityPublicKeyBytes {
     type Err = Error;
 
@@ -631,7 +627,7 @@ where
 
 // Enums for signature scheme signatures
 #[enum_dispatch]
-#[derive(Clone, JsonSchema, PartialEq, Eq, Hash)]
+#[derive(Clone, JsonSchema, Debug, PartialEq, Eq, Hash)]
 pub enum Signature {
     Ed25519SuiSignature,
     Secp256k1SuiSignature,
@@ -700,19 +696,26 @@ impl Signature {
         let bytes = self.signature_bytes();
         match self.scheme() {
             SignatureScheme::ED25519 => Ok(CompressedSignature::Ed25519(
-                Ed25519Signature::from_bytes(bytes).map_err(|_| SuiError::InvalidSignature {
+                (&Ed25519Signature::from_bytes(bytes).map_err(|_| SuiError::InvalidSignature {
                     error: "Cannot parse sig".to_string(),
-                })?,
+                })?)
+                    .into(),
             )),
             SignatureScheme::Secp256k1 => Ok(CompressedSignature::Secp256k1(
-                Secp256k1Signature::from_bytes(bytes).map_err(|_| SuiError::InvalidSignature {
-                    error: "Cannot parse sig".to_string(),
-                })?,
+                (&Secp256k1Signature::from_bytes(bytes).map_err(|_| {
+                    SuiError::InvalidSignature {
+                        error: "Cannot parse sig".to_string(),
+                    }
+                })?)
+                    .into(),
             )),
             SignatureScheme::Secp256r1 => Ok(CompressedSignature::Secp256r1(
-                Secp256r1Signature::from_bytes(bytes).map_err(|_| SuiError::InvalidSignature {
-                    error: "Cannot parse sig".to_string(),
-                })?,
+                (&Secp256r1Signature::from_bytes(bytes).map_err(|_| {
+                    SuiError::InvalidSignature {
+                        error: "Cannot parse sig".to_string(),
+                    }
+                })?)
+                    .into(),
             )),
             _ => Err(SuiError::UnsupportedFeatureError {
                 error: "Unsupported signature scheme in MultiSig".to_string(),
@@ -785,16 +788,6 @@ impl ToFromBytes for Signature {
             }
             _ => Err(FastCryptoError::InvalidInput),
         }
-    }
-}
-
-impl Debug for Signature {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        let flag = Base64::encode([self.scheme().flag()]);
-        let s = Base64::encode(self.signature_bytes());
-        let p = Base64::encode(self.public_key_bytes());
-        write!(f, "{flag}@{s}@{p}")?;
-        Ok(())
     }
 }
 
@@ -1685,15 +1678,13 @@ pub fn construct_tbls_randomness_object_message(epoch: EpochId, obj_id: &ObjectI
     msg.extend_from_slice(obj_id.as_ref());
     msg
 }
-/// Unlike `enum Signature`, `enum CompressedSignature` does not contain public key.
-#[derive(Debug, From, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+
+/// Unlike [enum Signature], [enum CompressedSignature] does not contain public key.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 pub enum CompressedSignature {
-    #[schemars(with = "Base64")]
-    Ed25519(Ed25519Signature),
-    #[schemars(with = "Base64")]
-    Secp256k1(Secp256k1Signature),
-    #[schemars(with = "Base64")]
-    Secp256r1(Secp256r1Signature),
+    Ed25519(Ed25519SignatureAsBytes),
+    Secp256k1(Secp256k1SignatureAsBytes),
+    Secp256r1(Secp256r1SignatureAsBytes),
 }
 
 impl FromStr for Signature {

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -133,7 +133,7 @@ impl AuthenticatorTrait for MultiSig {
                             error: "Invalid public key".to_string(),
                         }
                     })?;
-                    pk.verify(&message, s)
+                    pk.verify(&message, &s.try_into()?)
                 }
                 CompressedSignature::Secp256k1(s) => {
                     let pk = Secp256k1PublicKey::from_bytes(pk_map.0.as_ref()).map_err(|_| {
@@ -141,7 +141,7 @@ impl AuthenticatorTrait for MultiSig {
                             error: "Invalid public key".to_string(),
                         }
                     })?;
-                    pk.verify(&message, s)
+                    pk.verify(&message, &s.try_into()?)
                 }
                 CompressedSignature::Secp256r1(s) => {
                     let pk = Secp256r1PublicKey::from_bytes(pk_map.0.as_ref()).map_err(|_| {
@@ -149,7 +149,7 @@ impl AuthenticatorTrait for MultiSig {
                             error: "Invalid public key".to_string(),
                         }
                     })?;
-                    pk.verify(&message, s)
+                    pk.verify(&message, &s.try_into()?)
                 }
             };
             if res.is_ok() {


### PR DESCRIPTION
This is to make sure internals of the signature is not leaked in deserialized form. They are all represented by most compact bytes form. 

Tested against multisig: 
```
Transaction Signature: [MultiSig(MultiSig { sigs: [Ed25519(BytesRepresentation([137, 0, 3, 0, 83, 5, 203, 65, 148, 249, 180, 196, 154, 208, 118, 179, 20, 105, 110, 178, 125, 66, 208, 104, 101, 175, 248, 225, 21, 252, 3, 87, 207, 181, 34, 185, 225, 173, 211, 71, 18, 249, 67, 104, 88, 110, 223, 73, 70, 241, 160, 133, 196, 166, 55, 15, 214, 165, 245, 187, 202, 94, 163, 14])), Ed25519(BytesRepresentation([78, 15, 59, 212, 161, 192, 200, 61, 187, 236, 66, 249, 139, 38, 215, 68, 30, 77, 18, 21, 28, 43, 82, 245, 120, 56, 39, 154, 230, 124, 72, 83, 245, 4, 107, 247, 166, 145, 50, 168, 194, 19, 146, 112, 243, 166, 196, 183, 186, 237, 201, 48, 238, 166, 99, 157, 59, 121, 241, 208, 163, 72, 137, 6]))], bitmap: RoaringBitmap<[0, 1]>, multisig_pk: MultiSigPublicKey { pk_map: [("ALxuoRJ5GDSKXZlmv1mi4r3dRVgZMRvh34V5MloLPbj+", 1), ("AGqxM3he1LvdIz+Enfjq9e3PgPZGL4iaQhEAGxLdBR21", 1), ("ACJkf+7vNjBgvUIFoWcaFfEKEjZ2WRixtfY42C8zz8Rp", 1)], threshold: 2 }, bytes: OnceCell(Uninit) })]
```
Tested against single sig:
```
Transaction Signature: [Signature(Ed25519SuiSignature(Ed25519SuiSignature([0, 164, 255, 112, 232, 29, 43, 199, 143, 61, 41, 226, 51, 98, 127, 146, 49, 121, 180, 47, 118, 99, 22, 160, 223, 197, 167, 211, 115, 67, 254, 255, 71, 209, 124, 83, 222, 208, 2, 121, 212, 44, 230, 32, 138, 68, 74, 105, 101, 4, 96, 174, 158, 134, 100, 94, 160, 8, 240, 0, 50, 38, 127, 33, 7, 188, 110, 161, 18, 121, 24, 52, 138, 93, 153, 102, 191, 89, 162, 226, 189, 221, 69, 88, 25, 49, 27, 225, 223, 133, 121, 50, 90, 11, 61, 184, 254])))]
```