### PR TITLE
Expose RGP (Reference Gas Price) to transaction validation

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -417,6 +417,12 @@ impl AuthorityPerEpochStore {
         self.committee.epoch
     }
 
+    pub fn reference_gas_price(&self) -> u64 {
+        self.epoch_start_configuration
+            .system_state
+            .reference_gas_price
+    }
+
     pub async fn acquire_tx_guard(&self, cert: &VerifiedCertificate) -> SuiResult<CertTxGuard> {
         let digest = cert.digest();
         let guard = self.wal.begin_tx(digest, cert.serializable_ref()).await?;

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -171,6 +171,13 @@ async fn check_gas(
             TransactionKind::Single(SingleTransactionKind::PaySui(t)) => t.amounts.iter().sum(),
             _ => 0,
         };
+        let reference_gas_price = epoch_store.reference_gas_price();
+        if computation_gas_price < reference_gas_price {
+            return Err(SuiError::GasPriceUnderRGP {
+                gas_price: computation_gas_price,
+                reference_gas_price,
+            });
+        }
         let protocol_config = epoch_store.protocol_config();
         let cost_table = SuiCostTable::new(protocol_config);
         let storage_gas_price = protocol_config.storage_gas_price();

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -576,6 +576,25 @@ async fn test_storage_gas_unit_price() -> SuiResult {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_tx_gas_price_less_than_reference_gas_price() {
+    let gas_balance = *MAX_GAS_BUDGET;
+    let budget = *MIN_GAS_BUDGET;
+    let gas_price = 0;
+    let result = execute_transfer_with_price(gas_balance, budget, gas_price, false).await;
+    assert_eq!(
+        result
+            .response
+            .unwrap_err()
+            .collapse_if_single_transaction_input_error()
+            .unwrap(),
+        &SuiError::GasPriceUnderRGP {
+            gas_price: 0,
+            reference_gas_price: 1
+        }
+    );
+}
+
 struct TransferResult {
     pub authority_state: Arc<AuthorityState>,
     pub object_id: ObjectID,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -332,6 +332,15 @@ pub enum SuiError {
     },
     #[error("Transaction kind does not support Sponsored Transaction")]
     UnsupportedSponsoredTransactionKind,
+    #[error(
+        "Gas price {:?} under reference gas price (RGP) {:?}",
+        gas_price,
+        reference_gas_price
+    )]
+    GasPriceUnderRGP {
+        gas_price: u64,
+        reference_gas_price: u64,
+    },
 
     // Internal state errors
     #[error("Attempt to update state of TxContext from a different instance than original.")]
@@ -697,6 +706,7 @@ impl SuiError {
             SuiError::GasBudgetTooHigh { .. } => (false, true),
             SuiError::GasBudgetTooLow { .. } => (false, true),
             SuiError::GasBalanceTooLowToCoverGasBudget { .. } => (false, true),
+            SuiError::GasPriceUnderRGP { .. } => (false, true),
             _ => (false, false),
         }
     }


### PR DESCRIPTION
We are loading RGP in the per epoch store and use it when checking gas for the transaction.
Few todo left in case they matter, please advise.

Testing is light for now (I stole a test from @bmwill) but I plan to add more around the epoch changes aspect and more transaction kind.
If people are happy with this as is I can get it in, if we want more tests, those are coming soon