### PR TITLE
[wallet-standard][wallet-ext] Sign transaction

### DIFF
--- a/apps/wallet/src/background/Transactions.ts
+++ b/apps/wallet/src/background/Transactions.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+    type SignedTransaction,
+    type SuiTransactionResponse,
+} from '@mysten/sui.js';
 import { type SuiSignTransactionInput } from '@mysten/wallet-standard';
 import { filter, lastValueFrom, map, race, Subject, take } from 'rxjs';
 import { v4 as uuidV4 } from 'uuid';
@@ -8,14 +12,10 @@ import Browser from 'webextension-polyfill';
 
 import { Window } from './Window';
 
-import type {
-    ExecuteTransactionRequest,
-    TransactionDataType,
-} from '_messages/payloads/transactions/ExecuteTransactionRequest';
+import type { TransactionDataType } from '_messages/payloads/transactions/ExecuteTransactionRequest';
 import type { TransactionRequest } from '_payloads/transactions';
 import type { TransactionRequestResponse } from '_payloads/transactions/ui/TransactionRequestResponse';
 import type { ContentScriptConnection } from '_src/background/connections/ContentScriptConnection';
-import { SignedTransaction, SuiTransactionResponse } from '@mysten/sui.js';
 
 const TX_STORE_KEY = 'transactions';
 

--- a/apps/wallet/src/background/Transactions.ts
+++ b/apps/wallet/src/background/Transactions.ts
@@ -8,10 +8,14 @@ import Browser from 'webextension-polyfill';
 
 import { Window } from './Window';
 
-import type { TransactionDataType } from '_messages/payloads/transactions/ExecuteTransactionRequest';
+import type {
+    ExecuteTransactionRequest,
+    TransactionDataType,
+} from '_messages/payloads/transactions/ExecuteTransactionRequest';
 import type { TransactionRequest } from '_payloads/transactions';
 import type { TransactionRequestResponse } from '_payloads/transactions/ui/TransactionRequestResponse';
 import type { ContentScriptConnection } from '_src/background/connections/ContentScriptConnection';
+import { SignedTransaction, SuiTransactionResponse } from '@mysten/sui.js';
 
 const TX_STORE_KEY = 'transactions';
 
@@ -25,60 +29,17 @@ function openTxWindow(txRequestID: string) {
 class Transactions {
     private _txResponseMessages = new Subject<TransactionRequestResponse>();
 
-    async signTransaction(
-        input: SuiSignTransactionInput,
-        connection: ContentScriptConnection
-    ) {
-        const txRequest = this.createTransactionRequest(
-            { type: 'v2', justSign: true, data: input.transaction },
-            connection.origin,
-            connection.originFavIcon
-        );
-        await this.storeTransactionRequest(txRequest);
-        const popUp = openTxWindow(txRequest.id);
-        const popUpClose = (await popUp.show()).pipe(
-            take(1),
-            map<number, false>(() => false)
-        );
-        const txResponseMessage = this._txResponseMessages.pipe(
-            filter((msg) => msg.txID === txRequest.id),
-            take(1)
-        );
-        return lastValueFrom(
-            race(popUpClose, txResponseMessage).pipe(
-                take(1),
-                map(async (response) => {
-                    if (response) {
-                        const { approved, txSigned, tsResultError } = response;
-                        if (approved) {
-                            txRequest.approved = approved;
-                            txRequest.txSigned = txSigned;
-                            txRequest.txResultError = tsResultError;
-                            if (tsResultError) {
-                                throw new Error(
-                                    `Transaction failed with the following error. ${tsResultError}`
-                                );
-                            }
-                            if (!txSigned) {
-                                throw new Error('Missing signed transaction');
-                            }
-                            await this.storeTransactionRequest(txRequest);
-                            return txSigned;
-                        }
-                    }
-                    await this.removeTransactionRequest(txRequest.id);
-                    throw new Error('Transaction rejected from user');
-                })
-            )
-        );
-    }
-
-    public async executeTransaction(
-        tx: TransactionDataType,
-        connection: ContentScriptConnection
-    ) {
-        const txRequest = this.createTransactionRequest(
+    public async executeOrSignTransaction(
+        {
             tx,
+            sign,
+        }:
+            | { tx: TransactionDataType; sign?: undefined }
+            | { tx?: undefined; sign: SuiSignTransactionInput },
+        connection: ContentScriptConnection
+    ): Promise<SuiTransactionResponse | SignedTransaction> {
+        const txRequest = this.createTransactionRequest(
+            tx ?? { type: 'v2', justSign: true, data: sign.transaction },
             connection.origin,
             connection.originFavIcon
         );
@@ -97,21 +58,28 @@ class Transactions {
                 take(1),
                 map(async (response) => {
                     if (response) {
-                        const { approved, txResult, tsResultError } = response;
+                        const { approved, txResult, txSigned, tsResultError } =
+                            response;
                         if (approved) {
                             txRequest.approved = approved;
                             txRequest.txResult = txResult;
                             txRequest.txResultError = tsResultError;
+                            txRequest.txSigned = txSigned;
                             await this.storeTransactionRequest(txRequest);
                             if (tsResultError) {
                                 throw new Error(
                                     `Transaction failed with the following error. ${tsResultError}`
                                 );
                             }
-                            if (!txResult) {
+                            if (sign && !txSigned) {
+                                throw new Error(
+                                    'Transaction signature is empty'
+                                );
+                            }
+                            if (tx && !txResult) {
                                 throw new Error(`Transaction result is empty`);
                             }
-                            return txResult;
+                            return tx ? txResult! : txSigned!;
                         }
                     }
                     await this.removeTransactionRequest(txRequest.id);

--- a/apps/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/apps/wallet/src/background/connections/ContentScriptConnection.ts
@@ -17,7 +17,7 @@ import {
     isExecuteTransactionRequest,
     isSignTransactionRequest,
     isStakeRequest,
-    SignTransactionResponse,
+    type SignTransactionResponse,
 } from '_payloads/transactions';
 import Permissions from '_src/background/Permissions';
 import Transactions from '_src/background/Transactions';

--- a/apps/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/apps/wallet/src/background/connections/ContentScriptConnection.ts
@@ -15,7 +15,9 @@ import {
 } from '_payloads/permissions';
 import {
     isExecuteTransactionRequest,
+    isSignTransactionRequest,
     isStakeRequest,
+    SignTransactionResponse,
 } from '_payloads/transactions';
 import Permissions from '_src/background/Permissions';
 import Transactions from '_src/background/Transactions';
@@ -102,6 +104,28 @@ export class ContentScriptConnection extends Connection {
                         createMessage<ExecuteTransactionResponse>(
                             {
                                 type: 'execute-transaction-response',
+                                result,
+                            },
+                            msg.id
+                        )
+                    );
+                } else {
+                    this.sendNotAllowedError(msg.id);
+                }
+            } else if (isSignTransactionRequest(payload)) {
+                const allowed = await Permissions.hasPermissions(this.origin, [
+                    'viewAccount',
+                    'suggestTransactions',
+                ]);
+                if (allowed) {
+                    const result = await Transactions.signTransaction(
+                        payload.transaction,
+                        this
+                    );
+                    this.send(
+                        createMessage<SignTransactionResponse>(
+                            {
+                                type: 'sign-transaction-response',
                                 result,
                             },
                             msg.id

--- a/apps/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/apps/wallet/src/background/connections/ContentScriptConnection.ts
@@ -22,7 +22,11 @@ import {
 import Permissions from '_src/background/Permissions';
 import Transactions from '_src/background/Transactions';
 
-import type { SuiAddress } from '@mysten/sui.js';
+import type {
+    SignedTransaction,
+    SuiAddress,
+    SuiTransactionResponse,
+} from '@mysten/sui.js';
 import type { Message } from '_messages';
 import type { PortChannelName } from '_messaging/PortChannelName';
 import type { GetAccountResponse } from '_payloads/account/GetAccountResponse';
@@ -96,15 +100,15 @@ export class ContentScriptConnection extends Connection {
                     'suggestTransactions',
                 ]);
                 if (allowed) {
-                    const result = await Transactions.executeTransaction(
-                        payload.transaction,
+                    const result = await Transactions.executeOrSignTransaction(
+                        { tx: payload.transaction },
                         this
                     );
                     this.send(
                         createMessage<ExecuteTransactionResponse>(
                             {
                                 type: 'execute-transaction-response',
-                                result,
+                                result: result as SuiTransactionResponse,
                             },
                             msg.id
                         )
@@ -118,15 +122,15 @@ export class ContentScriptConnection extends Connection {
                     'suggestTransactions',
                 ]);
                 if (allowed) {
-                    const result = await Transactions.signTransaction(
-                        payload.transaction,
+                    const result = await Transactions.executeOrSignTransaction(
+                        { sign: payload.transaction },
                         this
                     );
                     this.send(
                         createMessage<SignTransactionResponse>(
                             {
                                 type: 'sign-transaction-response',
-                                result,
+                                result: result as SignedTransaction,
                             },
                             msg.id
                         )

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -4,7 +4,10 @@
 import {
     SUI_CHAINS,
     ReadonlyWalletAccount,
-    type SuiSignAndExecuteTransactionFeature,
+    SUI_DEVNET_CHAIN,
+    SUI_TESTNET_CHAIN,
+    SUI_LOCALNET_CHAIN,
+    type SuiFeatures,
     type SuiSignAndExecuteTransactionMethod,
     type ConnectFeature,
     type ConnectMethod,
@@ -12,9 +15,7 @@ import {
     type EventsFeature,
     type EventsOnMethod,
     type EventsListeners,
-    SUI_DEVNET_CHAIN,
-    SUI_TESTNET_CHAIN,
-    SUI_LOCALNET_CHAIN,
+    type SuiSignTransactionMethod,
 } from '@mysten/wallet-standard';
 import mitt, { type Emitter } from 'mitt';
 import { filter, map, type Observable } from 'rxjs';
@@ -41,6 +42,8 @@ import type {
     StakeRequest,
     ExecuteTransactionRequest,
     ExecuteTransactionResponse,
+    SignTransactionRequest,
+    SignTransactionResponse,
 } from '_payloads/transactions';
 import type { NetworkEnvType } from '_src/background/NetworkEnv';
 
@@ -95,7 +98,7 @@ export class SuiWallet implements Wallet {
 
     get features(): ConnectFeature &
         EventsFeature &
-        SuiSignAndExecuteTransactionFeature &
+        SuiFeatures &
         SuiWalletStakeFeature {
         return {
             'standard:connect': {
@@ -105,6 +108,10 @@ export class SuiWallet implements Wallet {
             'standard:events': {
                 version: '1.0.0',
                 on: this.#on,
+            },
+            'sui:signTransaction': {
+                version: '1.0.0',
+                signTransaction: this.#signTransaction,
             },
             'sui:signAndExecuteTransaction': {
                 version: '1.1.0',
@@ -205,6 +212,16 @@ export class SuiWallet implements Wallet {
         await this.#connected();
 
         return { accounts: this.accounts };
+    };
+
+    #signTransaction: SuiSignTransactionMethod = async (input) => {
+        return mapToPromise(
+            this.#send<SignTransactionRequest, SignTransactionResponse>({
+                type: 'sign-transaction-request',
+                transaction: input,
+            }),
+            (response) => response.result
+        );
     };
 
     #signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod = async (

--- a/apps/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
@@ -15,6 +15,8 @@ export type PayloadType =
     | 'acquire-permissions-response'
     | 'execute-transaction-request'
     | 'execute-transaction-response'
+    | 'sign-transaction-request'
+    | 'sign-transaction-response'
     | 'get-transaction-requests'
     | 'get-transaction-requests-response'
     | 'transaction-request-response'

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type SuiSignAndExecuteTransactionOptions } from '@mysten/wallet-standard';
+import {
+    type SuiSignTransactionInput,
+    type SuiSignAndExecuteTransactionOptions,
+} from '@mysten/wallet-standard';
 
 import { isBasePayload } from '_payloads';
 
@@ -11,6 +14,7 @@ import type { BasePayload, Payload } from '_payloads';
 export type TransactionDataType =
     | {
           type: 'v2';
+          justSign?: boolean;
           data: SignableTransaction;
           options?: SuiSignAndExecuteTransactionOptions;
       }
@@ -27,5 +31,18 @@ export function isExecuteTransactionRequest(
 ): payload is ExecuteTransactionRequest {
     return (
         isBasePayload(payload) && payload.type === 'execute-transaction-request'
+    );
+}
+
+export interface SignTransactionRequest extends BasePayload {
+    type: 'sign-transaction-request';
+    transaction: SuiSignTransactionInput;
+}
+
+export function isSignTransactionRequest(
+    payload: Payload
+): payload is SignTransactionRequest {
+    return (
+        isBasePayload(payload) && payload.type === 'sign-transaction-request'
     );
 }

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionResponse.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionResponse.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { type SuiSignTransactionOutput } from '@mysten/wallet-standard';
+
 import { isBasePayload } from '_payloads';
 
 import type { SuiTransactionResponse } from '@mysten/sui.js';
@@ -17,5 +19,18 @@ export function isExecuteTransactionResponse(
     return (
         isBasePayload(payload) &&
         payload.type === 'execute-transaction-response'
+    );
+}
+
+export interface SignTransactionResponse extends BasePayload {
+    type: 'sign-transaction-response';
+    result: SuiSignTransactionOutput;
+}
+
+export function isSignTransactionResponse(
+    payload: Payload
+): payload is SignTransactionResponse {
+    return (
+        isBasePayload(payload) && payload.type === 'sign-transaction-response'
     );
 }

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/TransactionRequest.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/TransactionRequest.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
+    SignedTransaction,
     SuiMoveNormalizedFunction,
     SuiTransactionResponse,
     UnserializedSignableTransaction,
@@ -15,6 +16,7 @@ export type TransactionRequest = {
     originFavIcon?: string;
     txResult?: SuiTransactionResponse;
     txResultError?: string;
+    txSigned?: SignedTransaction;
     metadata?: SuiMoveNormalizedFunction;
     createdDate: string;
     tx: TransactionDataType;

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ui/TransactionRequestResponse.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ui/TransactionRequestResponse.ts
@@ -3,7 +3,7 @@
 
 import { isBasePayload } from '_payloads';
 
-import type { SuiTransactionResponse } from '@mysten/sui.js';
+import type { SignedTransaction, SuiTransactionResponse } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 
 export interface TransactionRequestResponse extends BasePayload {
@@ -12,6 +12,7 @@ export interface TransactionRequestResponse extends BasePayload {
     approved: boolean;
     txResult?: SuiTransactionResponse;
     tsResultError?: string;
+    txSigned?: SignedTransaction;
 }
 
 export function isTransactionRequestResponse(

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -4,7 +4,7 @@
 import {
     type SerializedSignature,
     toB64,
-    SignedTransaction,
+    type SignedTransaction,
 } from '@mysten/sui.js';
 import { lastValueFrom, map, take } from 'rxjs';
 
@@ -99,7 +99,6 @@ export class BackgroundClient {
         tsResultError?: string,
         txSigned?: SignedTransaction
     ) {
-        console.log('RESPOPNSE', txSigned);
         this.sendMessage(
             createMessage<TransactionRequestResponse>({
                 type: 'transaction-request-response',

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type SerializedSignature, toB64 } from '@mysten/sui.js';
+import {
+    type SerializedSignature,
+    toB64,
+    SignedTransaction,
+} from '@mysten/sui.js';
 import { lastValueFrom, map, take } from 'rxjs';
 
 import { growthbook } from '../experimentation/feature-gating';
@@ -91,9 +95,11 @@ export class BackgroundClient {
     public async sendTransactionRequestResponse(
         txID: string,
         approved: boolean,
-        txResult: SuiTransactionResponse | undefined,
-        tsResultError: string | undefined
+        txResult?: SuiTransactionResponse,
+        tsResultError?: string,
+        txSigned?: SignedTransaction
     ) {
+        console.log('RESPOPNSE', txSigned);
         this.sendMessage(
             createMessage<TransactionRequestResponse>({
                 type: 'transaction-request-response',
@@ -101,6 +107,7 @@ export class BackgroundClient {
                 txID,
                 txResult,
                 tsResultError,
+                txSigned,
             })
         );
     }

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -6,6 +6,7 @@ import {
     getCertifiedTransaction,
     getTransactionEffects,
     LocalTxnDataSerializer,
+    type SignedTransaction,
 } from '@mysten/sui.js';
 import {
     createAsyncThunk,
@@ -145,47 +146,54 @@ export const respondToTransactionRequest = createAsyncThunk<
         if (!txRequest) {
             throw new Error(`TransactionRequest ${txRequestID} not found`);
         }
+        let txSigned: SignedTransaction | undefined = undefined;
         let txResult: SuiTransactionResponse | undefined = undefined;
         let tsResultError: string | undefined;
         if (approved) {
             const signer = api.getSignerInstance(activeAddress, background);
             try {
-                let response: SuiExecuteTransactionResponse;
-                if (
-                    txRequest.tx.type === 'v2' ||
-                    txRequest.tx.type === 'move-call'
-                ) {
-                    const txn: SignableTransaction =
-                        txRequest.tx.type === 'move-call'
-                            ? {
-                                  kind: 'moveCall',
-                                  data: txRequest.tx.data,
-                              }
-                            : txRequest.tx.data;
-
-                    response = await signer.signAndExecuteTransaction(
-                        txn,
-                        txRequest.tx.type === 'v2'
-                            ? txRequest.tx.options?.requestType
-                            : undefined
-                    );
-                } else if (txRequest.tx.type === 'serialized-move-call') {
-                    const txBytes = fromB64(txRequest.tx.data);
-                    response = await signer.signAndExecuteTransaction(txBytes);
+                if (txRequest.tx.type === 'v2' && txRequest.tx.justSign) {
+                    // TODO: Try / catch
+                    // Just a signing request, do not submit
+                    txSigned = await signer.signTransaction(txRequest.tx.data);
                 } else {
-                    throw new Error(
-                        `Either tx or txBytes needs to be defined.`
-                    );
-                }
+                    let response: SuiExecuteTransactionResponse;
+                    if (
+                        txRequest.tx.type === 'v2' ||
+                        txRequest.tx.type === 'move-call'
+                    ) {
+                        const txn: SignableTransaction =
+                            txRequest.tx.type === 'move-call'
+                                ? {
+                                      kind: 'moveCall',
+                                      data: txRequest.tx.data,
+                                  }
+                                : txRequest.tx.data;
 
-                txResult = {
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    certificate: getCertifiedTransaction(response)!,
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    effects: getTransactionEffects(response)!,
-                    timestamp_ms: null,
-                    parsed_data: null,
-                };
+                        response = await signer.signAndExecuteTransaction(
+                            txn,
+                            txRequest.tx.type === 'v2'
+                                ? txRequest.tx.options?.requestType
+                                : undefined
+                        );
+                    } else if (txRequest.tx.type === 'serialized-move-call') {
+                        const txBytes = fromB64(txRequest.tx.data);
+                        response = await signer.signAndExecuteTransaction(
+                            txBytes
+                        );
+                    } else {
+                        throw new Error(
+                            `Either tx or txBytes needs to be defined.`
+                        );
+                    }
+
+                    txResult = {
+                        certificate: getCertifiedTransaction(response)!,
+                        effects: getTransactionEffects(response)!,
+                        timestamp_ms: null,
+                        parsed_data: null,
+                    };
+                }
             } catch (e) {
                 tsResultError = (e as Error).message;
             }
@@ -194,7 +202,8 @@ export const respondToTransactionRequest = createAsyncThunk<
             txRequestID,
             approved,
             txResult,
-            tsResultError
+            tsResultError,
+            txSigned
         );
         return { txRequestID, approved: approved, txResponse: null };
     }

--- a/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
+++ b/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
@@ -4,6 +4,7 @@
 import {
   ExecuteTransactionRequestType,
   SignableTransaction,
+  SignedTransaction,
   SuiAddress,
   SuiTransactionResponse,
 } from "@mysten/sui.js";
@@ -26,6 +27,7 @@ export interface WalletAdapter {
     event: E,
     callback: WalletAdapterEvents[E]
   ) => () => void;
+  signTransaction(transaction: SignableTransaction): Promise<SignedTransaction>;
   /**
    * Suggest a transaction for the user to sign. Supports all valid transaction types.
    */

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -49,6 +49,10 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
     return [this.#keypair.getPublicKey().toSuiAddress()];
   }
 
+  async signTransaction(transaction: SignableTransaction) {
+    return this.#signer.signTransaction(transaction);
+  }
+
   async signAndExecuteTransaction(
     transaction: SignableTransaction,
     options?: { requestType?: ExecuteTransactionRequestType }

--- a/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
+++ b/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
@@ -89,6 +89,12 @@ export class StandardWalletAdapter implements WalletAdapter {
     }
   }
 
+  async signTransaction(transaction: SignableTransaction) {
+    return this.#wallet.features["sui:signTransaction"].signTransaction({
+      transaction,
+    });
+  }
+
   async signAndExecuteTransaction(
     transaction: SignableTransaction,
     options?: { requestType?: ExecuteTransactionRequestType }

--- a/sdk/wallet-adapter/example/src/App.tsx
+++ b/sdk/wallet-adapter/example/src/App.tsx
@@ -6,7 +6,7 @@ import { ConnectButton, useWalletKit } from "@mysten/wallet-kit";
 import { useEffect } from "react";
 
 function App() {
-  const { currentWallet } = useWalletKit();
+  const { currentWallet, signTransaction } = useWalletKit();
 
   useEffect(() => {
     // You can do something with `currentWallet` here.
@@ -15,6 +15,25 @@ function App() {
   return (
     <div className="App">
       <ConnectButton />
+      <button
+        onClick={async () => {
+          console.log(
+            await signTransaction({
+              kind: "moveCall",
+              data: {
+                packageObjectId: "0x2",
+                module: "devnet_nft",
+                function: "mint",
+                typeArguments: [],
+                arguments: ["foo", "bar", "baz"],
+                gasBudget: 2000,
+              },
+            })
+          );
+        }}
+      >
+        Sign
+      </button>
     </div>
   );
 }

--- a/sdk/wallet-adapter/example/src/index.tsx
+++ b/sdk/wallet-adapter/example/src/index.tsx
@@ -12,7 +12,7 @@ export const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-    <WalletKitProvider>
+    <WalletKitProvider enableUnsafeBurner>
       <App />
     </WalletKitProvider>
   </React.StrictMode>

--- a/sdk/wallet-adapter/wallet-kit-core/src/index.ts
+++ b/sdk/wallet-adapter/wallet-kit-core/src/index.ts
@@ -4,6 +4,7 @@
 import {
   ExecuteTransactionRequestType,
   SignableTransaction,
+  SignedTransaction,
   SuiAddress,
   SuiTransactionResponse,
 } from "@mysten/sui.js";
@@ -52,6 +53,7 @@ export interface WalletKitCore {
   subscribe(handler: SubscribeHandler): Unsubscribe;
   connect(walletName: string): Promise<void>;
   disconnect(): Promise<void>;
+  signTransaction(transaction: SignableTransaction): Promise<SignedTransaction>;
   signAndExecuteTransaction(
     transaction: SignableTransaction,
     options?: { requestType?: ExecuteTransactionRequestType }
@@ -224,6 +226,16 @@ export function createWalletKitCore({
       } catch {}
       await internalState.currentWallet.disconnect();
       disconnected();
+    },
+
+    signTransaction(transaction) {
+      if (!internalState.currentWallet) {
+        throw new Error(
+          "No wallet is currently connected, cannot call `signAndExecuteTransaction`."
+        );
+      }
+
+      return internalState.currentWallet.signTransaction(transaction);
     },
 
     signAndExecuteTransaction(transaction, options) {

--- a/sdk/wallet-adapter/wallet-kit/src/WalletKitContext.tsx
+++ b/sdk/wallet-adapter/wallet-kit/src/WalletKitContext.tsx
@@ -75,7 +75,10 @@ export function WalletKitProvider({
 }
 
 type UseWalletKit = WalletKitCoreState &
-  Pick<WalletKitCore, "connect" | "disconnect" | "signAndExecuteTransaction">;
+  Pick<
+    WalletKitCore,
+    "connect" | "disconnect" | "signTransaction" | "signAndExecuteTransaction"
+  >;
 
 export function useWalletKit(): UseWalletKit {
   const walletKit = useContext(WalletKitContext);
@@ -92,6 +95,7 @@ export function useWalletKit(): UseWalletKit {
     () => ({
       connect: walletKit.connect,
       disconnect: walletKit.disconnect,
+      signTransaction: walletKit.signTransaction,
       signAndExecuteTransaction: walletKit.signAndExecuteTransaction,
       ...state,
     }),

--- a/sdk/wallet-adapter/wallet-standard/README.md
+++ b/sdk/wallet-adapter/wallet-standard/README.md
@@ -36,6 +36,7 @@ Features are standard methods consumers can use to interact with a wallet. To be
 
 - `standard:connect` - Used to initiate a connection to the wallet.
 - `standard:events` - Used to listen for changes that happen within the wallet, such as accounts being added or removed.
+- `sui:signTransaction` - Used to prompt the user to sign a transaction, and return the serializated transaction and transaction signature back to the user. This method does not submit the transaction for execution.
 - `sui:signAndExecuteTransaction` - Used to prompt the user to sign a transaction, then submit it for execution to the blockchain.
 
 You can implement these features in your wallet class under the `features` property:
@@ -46,12 +47,13 @@ import {
   ConnectMethod,
   EventsFeature,
   EventsOnMethod,
-  SuiSignAndExecuteTransactionFeature,
+  SuiFeatures,
+  SuiTransactionMethod,
   SuiSignAndExecuteTransactionMethod
 } from "@mysten/wallet-standard";
 
 class YourWallet implements Wallet {
-  get features(): ConnectFeature & EventsFeature & SuiSignAndExecuteTransactionFeature {
+  get features(): ConnectFeature & EventsFeature & SuiFeatures {
     return {
       "standard:connect": {
         version: "1.0.0",
@@ -60,9 +62,13 @@ class YourWallet implements Wallet {
       "standard:events": {
         version: "1.0.0",
         on: this.#on,
-      }
-      "sui:signAndExecuteTransaction": {
+      },
+      "sui:signTransaction": {
         version: "1.0.0",
+        signTransaction: this.#signTransaction,
+      },
+      "sui:signAndExecuteTransaction": {
+        version: "1.1.0",
         signAndExecuteTransaction: this.#signAndExecuteTransaction,
       },
     };
@@ -74,6 +80,10 @@ class YourWallet implements Wallet {
 
   #connect: ConnectMethod = () => {
     // Your wallet's connect implementation
+  };
+
+  #signTransaction: SuiTransactionMethod = () => {
+    // Your wallet's signTransaction implementation
   };
 
   #signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod = () => {
@@ -116,7 +126,7 @@ class YourWallet implements Wallet {
 Once you have a compatible interface for your wallet, you can register it using the `registerWallet` function.
 
 ```typescript
-import { registerWallet } from '@mysten/wallet-standard';
+import { registerWallet } from "@mysten/wallet-standard";
 
 registerWallet(new YourWallet());
 ```

--- a/sdk/wallet-adapter/wallet-standard/src/detect.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/detect.ts
@@ -8,22 +8,25 @@ import {
   Wallet,
   WalletWithFeatures,
 } from "@wallet-standard/core";
-import { SuiSignAndExecuteTransactionFeature } from "./features";
+import { SuiFeatures } from "./features";
 
 export type StandardWalletAdapterWallet = WalletWithFeatures<
   ConnectFeature &
     EventsFeature &
-    SuiSignAndExecuteTransactionFeature &
+    SuiFeatures &
     // Disconnect is an optional feature:
     Partial<DisconnectFeature>
 >;
 
+// TODO: Enable filtering by subset of features:
 export function isStandardWalletAdapterCompatibleWallet(
   wallet: Wallet
 ): wallet is StandardWalletAdapterWallet {
   return (
     "standard:connect" in wallet.features &&
     "standard:events" in wallet.features &&
+    // TODO: Enable once ecosystem wallets adopt this:
+    // "sui:signTransaction" in wallet.features &&
     "sui:signAndExecuteTransaction" in wallet.features
   );
 }

--- a/sdk/wallet-adapter/wallet-standard/src/features/index.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/index.ts
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { WalletWithFeatures } from "@wallet-standard/core";
+import type { SuiSignTransactionFeature } from "./suiSignTransaction";
 import type { SuiSignAndExecuteTransactionFeature } from "./suiSignAndExecuteTransaction";
 
 /**
  * Wallet Standard features that are unique to Sui, and that all Sui wallets are expected to implement.
  */
-export type SuiFeatures = SuiSignAndExecuteTransactionFeature;
+export type SuiFeatures = SuiSignTransactionFeature &
+  SuiSignAndExecuteTransactionFeature;
 
 export type WalletWithSuiFeatures = WalletWithFeatures<SuiFeatures>;
 
+export * from "./suiSignTransaction";
 export * from "./suiSignAndExecuteTransaction";

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiSignTransaction.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiSignTransaction.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SignableTransaction, SignedTransaction } from "@mysten/sui.js";
+
+/** The latest API version of the signTransaction API. */
+export type SuiSignTransactionVersion = "1.0.0";
+
+/**
+ * A Wallet Standard feature for signing a transaction, and returning the
+ * serialized transaction and transaction signature.
+ */
+export type SuiSignTransactionFeature = {
+  /** Namespace for the feature. */
+  "sui:signTransaction": {
+    /** Version of the feature API. */
+    version: SuiSignTransactionVersion;
+    signTransaction: SuiSignTransactionMethod;
+  };
+};
+
+export type SuiSignTransactionMethod = (
+  input: SuiSignTransactionInput
+) => Promise<SuiSignTransactionOutput>;
+
+/** Input for signing transactions. */
+export interface SuiSignTransactionInput {
+  transaction: SignableTransaction;
+  options?: SuiSignTransactionOptions;
+}
+
+/** Output of signing transactions. */
+export interface SuiSignTransactionOutput extends SignedTransaction {}
+
+/** Options for signing transactions. */
+export interface SuiSignTransactionOptions {}


### PR DESCRIPTION
This adds support for `sui:signTransaction`, which will not execute the transaction and just returns the bytes + signature that can be passed to `executeTransaction` in dapps. This helps improve read-after-write consistency. 