### PR TITLE
[RPC backward compatibility] - RPC method routing base on client version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9052,6 +9052,7 @@ dependencies = [
  "sui-json-rpc-types",
  "sui-types",
  "tokio",
+ "versions",
  "workspace-hack",
 ]
 
@@ -10642,6 +10643,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "versions"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee97e1d97bd593fb513912a07691b742361b3dd64ad56f2c694ea2dbfe0665d3"
+dependencies = [
+ "itertools",
+ "nom 7.1.2",
+]
 
 [[package]]
 name = "vte"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,21 +2839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,19 +3492,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -5700,24 +5672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static 1.4.0",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nested"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6016,49 +5970,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -7281,12 +7196,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7296,7 +7209,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -10040,16 +9952,6 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,6 +2839,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,6 +3507,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -5672,6 +5700,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static 1.4.0",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nested"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5970,10 +6016,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -7196,10 +7281,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7209,6 +7296,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -8839,6 +8927,7 @@ dependencies = [
  "mysten-metrics",
  "prometheus",
  "rand 0.8.5",
+ "reqwest",
  "scopeguard",
  "serde 1.0.152",
  "signature 1.6.4",
@@ -9951,6 +10040,16 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11731,6 +11731,7 @@ dependencies = [
  "vcpkg",
  "vec_map",
  "version_check",
+ "versions",
  "vte",
  "vte_generate_state_changes",
  "wait-timeout",

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -52,3 +52,4 @@ sui-sdk = { path = "../sui-sdk" }
 rand = "0.8.5"
 sui-macros = { path = "../sui-macros" }
 sui-simulator = { path = "../sui-simulator" }
+reqwest = "0.11.13"

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -52,4 +52,4 @@ sui-sdk = { path = "../sui-sdk" }
 rand = "0.8.5"
 sui-macros = { path = "../sui-macros" }
 sui-simulator = { path = "../sui-simulator" }
-reqwest = "0.11.13"
+reqwest = { version = "0.11.13", default_features = false, features = ["rustls-tls"] }

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -677,7 +677,7 @@ pub trait TransactionExecutionApi {
         request_type: ExecuteTransactionRequestType,
     ) -> RpcResult<SuiExecuteTransactionResponse>;
 
-    #[method(name = "executeTransactionSerializedSig")]
+    #[method(name = "executeTransactionSerializedSig", deprecated)]
     async fn execute_transaction_serialized_sig(
         &self,
         /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -42,6 +42,8 @@ pub const CLIENT_SDK_VERSION_HEADER: &str = "client-sdk-version";
 pub const CLIENT_TARGET_API_VERSION_HEADER: &str = "client-target-api-version";
 pub const APP_NAME_HEADER: &str = "app-name";
 
+pub const MAX_REQUEST_SIZE: u32 = 2 << 30;
+
 #[cfg(test)]
 #[path = "unit_tests/rpc_server_tests.rs"]
 mod rpc_server_test;
@@ -147,7 +149,7 @@ impl JsonRpcServerBuilder {
             .layer(metrics_layer);
 
         let server = ServerBuilder::default()
-            .max_response_body_size(2 << 30)
+            .max_response_body_size(MAX_REQUEST_SIZE)
             .max_connections(max_connection)
             .set_host_filtering(AllowHosts::Any)
             .set_middleware(middleware)

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -125,7 +125,21 @@ impl JsonRpcServerBuilder {
             .unwrap_or(u32::MAX);
 
         let metrics_layer = MetricsLayer::new(&self.registry, &methods_names);
-        let routing_layer = RoutingLayer::new(routing);
+
+        let disable_routing = env::var("DISABLE_BACKWARD_COMPATIBILITY")
+            .ok()
+            .and_then(|v| bool::from_str(&v).ok())
+            .unwrap_or_default();
+        info!(
+            "Compatibility method routing {}.",
+            if disable_routing {
+                "disabled"
+            } else {
+                "enabled"
+            }
+        );
+        // We need to use the routing layer to block access to the old methods when routing is disabled.
+        let routing_layer = RoutingLayer::new(routing, disable_routing);
 
         let middleware = tower::ServiceBuilder::new()
             .layer(cors)

--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -220,7 +220,7 @@ where
     }
 }
 
-fn is_json(content_type: Option<&hyper::header::HeaderValue>) -> bool {
+pub fn is_json(content_type: Option<&hyper::header::HeaderValue>) -> bool {
     content_type
         .and_then(|val| val.to_str().ok())
         .map_or(false, |content| {

--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -137,7 +137,7 @@ where
 
         let res_fut = async move {
             // Parse request to retrieve RPC method name.
-            let (rpc_name, req) = if is_json(req.headers().get(http::header::CONTENT_TYPE)) {
+            let (rpc_name, req) = if is_json(&req) {
                 let (part, body) = req.into_parts();
                 let bytes = body::to_bytes(body).await?;
                 #[derive(Deserialize)]
@@ -220,8 +220,10 @@ where
     }
 }
 
-pub fn is_json(content_type: Option<&hyper::header::HeaderValue>) -> bool {
-    content_type
+pub fn is_json(request: &hyper::Request<hyper::Body>) -> bool {
+    request
+        .headers()
+        .get(http::header::CONTENT_TYPE)
         .and_then(|val| val.to_str().ok())
         .map_or(false, |content| {
             content.eq_ignore_ascii_case("application/json")

--- a/crates/sui-json-rpc/src/routing_layer.rs
+++ b/crates/sui-json-rpc/src/routing_layer.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metrics::is_json;
+use hyper::body::Bytes;
+use hyper::{body, http, Body, Request, Response};
+use jsonrpsee::core::__reexports::serde_json;
+use jsonrpsee::types::Request as RpcRequest;
+use std::collections::HashMap;
+use std::error::Error;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use sui_open_rpc::MethodRouting;
+use tower::{Layer, Service};
+#[derive(Debug, Clone)]
+pub struct RoutingLayer {
+    routes: HashMap<String, MethodRouting>,
+}
+
+impl RoutingLayer {
+    pub fn new(routes: HashMap<String, MethodRouting>) -> Self {
+        Self { routes }
+    }
+}
+
+impl<S> Layer<S> for RoutingLayer {
+    type Service = RpcRoutingService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RpcRoutingService::new(inner, self.routes.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RpcRoutingService<S> {
+    inner: S,
+    routes: HashMap<String, MethodRouting>,
+}
+
+impl<S> RpcRoutingService<S> {
+    pub fn new(inner: S, routes: HashMap<String, MethodRouting>) -> Self {
+        Self { inner, routes }
+    }
+}
+
+impl<S> Service<Request<Body>> for RpcRoutingService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Response: 'static,
+    S::Error: Into<Box<dyn Error + Send + Sync>> + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = Box<dyn Error + Send + Sync + 'static>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let clone = self.inner.clone();
+        let routes = self.routes.clone();
+        // take the service that was ready
+        // https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        let res_fut = async move {
+            // Get version from header.
+            let version = req
+                .headers()
+                .get("client_api_version")
+                .as_ref()
+                .and_then(|h| h.to_str().ok().map(|s| s.to_string()));
+
+            let req = match (
+                version,
+                is_json(req.headers().get(http::header::CONTENT_TYPE)),
+            ) {
+                (Some(version), true) => {
+                    // We checked version is_some already, safe to unwrap.
+                    let (part, body) = req.into_parts();
+                    let bytes = body::to_bytes(body).await?;
+                    let mut request: RpcRequest = serde_json::from_slice(&bytes)?;
+
+                    if let Some(route) = routes.get(request.method.as_ref()) {
+                        if route.matches(&version) {
+                            request.method = route.route_to.clone().into();
+                        }
+                    };
+                    let bytes = Bytes::from(serde_json::to_vec(&request)?);
+                    Request::from_parts(part, Body::from(bytes))
+                }
+                _ => req,
+            };
+            inner.call(req).await.map_err(|err| err.into())
+        };
+        Box::pin(res_fut)
+    }
+}

--- a/crates/sui-json-rpc/src/routing_layer.rs
+++ b/crates/sui-json-rpc/src/routing_layer.rs
@@ -153,7 +153,7 @@ fn process_batched_requests(
     let requests: Vec<&JsonRawValue> = serde_json::from_slice(body)?;
     let mut processed_reqs = Vec::new();
     for request in requests {
-        let req = process_single_request(
+        let req = process_rpc_request(
             serde_json::from_str(request.get())?,
             version,
             routes,

--- a/crates/sui-json-rpc/src/routing_layer.rs
+++ b/crates/sui-json-rpc/src/routing_layer.rs
@@ -49,7 +49,7 @@ pub struct RpcRoutingService<S> {
 
 impl<S> RpcRoutingService<S> {
     pub fn new(inner: S, routes: HashMap<String, MethodRouting>, disable_routing: bool) -> Self {
-        let route_to_methods = routes.iter().map(|(_, v)| v.route_to.clone()).collect();
+        let route_to_methods = routes.values().map(|v| v.route_to.clone()).collect();
         Self {
             inner,
             routes,

--- a/crates/sui-json-rpc/src/routing_layer.rs
+++ b/crates/sui-json-rpc/src/routing_layer.rs
@@ -2,25 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::metrics::is_json;
+use crate::CLIENT_TARGET_API_VERSION_HEADER;
 use hyper::body::Bytes;
 use hyper::{body, http, Body, Request, Response};
 use jsonrpsee::core::__reexports::serde_json;
-use jsonrpsee::types::Request as RpcRequest;
-use std::collections::HashMap;
+use jsonrpsee::core::server::helpers::MethodResponse;
+use jsonrpsee::types::error::ErrorCode;
+use jsonrpsee::types::{ErrorObject, Request as RpcRequest};
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use sui_open_rpc::MethodRouting;
 use tower::{Layer, Service};
+
 #[derive(Debug, Clone)]
 pub struct RoutingLayer {
     routes: HashMap<String, MethodRouting>,
+    disable_routing: bool,
 }
 
 impl RoutingLayer {
-    pub fn new(routes: HashMap<String, MethodRouting>) -> Self {
-        Self { routes }
+    pub fn new(routes: HashMap<String, MethodRouting>, disable_routing: bool) -> Self {
+        Self {
+            routes,
+            disable_routing,
+        }
     }
 }
 
@@ -28,7 +36,7 @@ impl<S> Layer<S> for RoutingLayer {
     type Service = RpcRoutingService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        RpcRoutingService::new(inner, self.routes.clone())
+        RpcRoutingService::new(inner, self.routes.clone(), self.disable_routing)
     }
 }
 
@@ -36,11 +44,19 @@ impl<S> Layer<S> for RoutingLayer {
 pub struct RpcRoutingService<S> {
     inner: S,
     routes: HashMap<String, MethodRouting>,
+    route_to_methods: HashSet<String>,
+    disable_routing: bool,
 }
 
 impl<S> RpcRoutingService<S> {
-    pub fn new(inner: S, routes: HashMap<String, MethodRouting>) -> Self {
-        Self { inner, routes }
+    pub fn new(inner: S, routes: HashMap<String, MethodRouting>, disable_routing: bool) -> Self {
+        let route_to_methods = routes.iter().map(|(_, v)| v.route_to.clone()).collect();
+        Self {
+            inner,
+            routes,
+            route_to_methods,
+            disable_routing,
+        }
     }
 }
 
@@ -64,6 +80,8 @@ where
     fn call(&mut self, req: Request<Body>) -> Self::Future {
         let clone = self.inner.clone();
         let routes = self.routes.clone();
+        let route_to_methods = self.route_to_methods.clone();
+        let disable_routing = self.disable_routing;
         // take the service that was ready
         // https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
         let mut inner = std::mem::replace(&mut self.inner, clone);
@@ -71,29 +89,48 @@ where
             // Get version from header.
             let version = req
                 .headers()
-                .get("client_api_version")
+                .get(CLIENT_TARGET_API_VERSION_HEADER)
                 .as_ref()
                 .and_then(|h| h.to_str().ok().map(|s| s.to_string()));
 
-            let req = match (
-                version,
-                is_json(req.headers().get(http::header::CONTENT_TYPE)),
-            ) {
-                (Some(version), true) => {
-                    // We checked version is_some already, safe to unwrap.
-                    let (part, body) = req.into_parts();
-                    let bytes = body::to_bytes(body).await?;
-                    let mut request: RpcRequest = serde_json::from_slice(&bytes)?;
+            let req = if is_json(req.headers().get(http::header::CONTENT_TYPE)) {
+                let (part, body) = req.into_parts();
+                let bytes = body::to_bytes(body).await?;
+                let mut request: RpcRequest = serde_json::from_slice(&bytes)?;
 
-                    if let Some(route) = routes.get(request.method.as_ref()) {
-                        if route.matches(&version) {
-                            request.method = route.route_to.clone().into();
-                        }
-                    };
-                    let bytes = Bytes::from(serde_json::to_vec(&request)?);
-                    Request::from_parts(part, Body::from(bytes))
+                // Reject direct access to the old methods
+                if route_to_methods.contains(request.method.as_ref()) {
+                    let error = MethodResponse::error(
+                        request.id,
+                        ErrorObject::from(ErrorCode::MethodNotFound),
+                    );
+                    let response = hyper::Response::builder()
+                        .status(hyper::StatusCode::OK)
+                        .header(
+                            "content-type",
+                            hyper::header::HeaderValue::from_static(
+                                "application/json; charset=utf-8",
+                            ),
+                        )
+                        .body(Body::from(error.result))?;
+                    return Ok(response);
                 }
-                _ => req,
+
+                // Modify the method name if routing is enabled
+                if !disable_routing {
+                    if let Some(version) = version {
+                        if let Some(route) = routes.get(request.method.as_ref()) {
+                            if route.matches(&version) {
+                                request.method = route.route_to.clone().into();
+                            }
+                        };
+                    }
+                }
+
+                let bytes = Bytes::from(serde_json::to_vec(&request)?);
+                Request::from_parts(part, Body::from(bytes))
+            } else {
+                req
             };
             inner.call(req).await.map_err(|err| err.into())
         };

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -1,4 +1,3 @@
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::api::CoinReadApiClient;
@@ -7,11 +6,6 @@ use crate::api::{RpcFullNodeReadApiClient, ThresholdBlsApiClient, TransactionExe
 use crate::api::{RpcReadApiClient, RpcTransactionBuilderClient};
 use std::path::Path;
 
-use hyper::HeaderMap;
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::http_client::{HeaderValue, HttpClientBuilder};
-use jsonrpsee::rpc_params;
-use prometheus::Registry;
 #[cfg(not(msim))]
 use std::str::FromStr;
 use sui_config::SUI_KEYSTORE_FILENAME;
@@ -40,8 +34,6 @@ use test_utils::network::TestClusterBuilder;
 use sui_macros::sim_test;
 use sui_types::governance::{DelegatedStake, DelegationStatus};
 
-use crate::JsonRpcServerBuilder;
-use sui_config::utils::get_available_port;
 use tokio::time::{sleep, Duration};
 
 #[sim_test]
@@ -1190,112 +1182,4 @@ async fn test_delegation_with_locked_sui() -> Result<(), anyhow::Error> {
     ));
 
     Ok(())
-}
-
-#[tokio::test]
-async fn test_rpc_backward_compatibility() {
-    use crate::SuiRpcModule;
-    use async_trait::async_trait;
-    use jsonrpsee::core::RpcResult;
-    use jsonrpsee::RpcModule;
-    use jsonrpsee_proc_macros::rpc;
-    use sui_open_rpc::Module;
-    use sui_open_rpc_macros::open_rpc;
-
-    #[open_rpc(namespace = "test")]
-    #[rpc(server, client, namespace = "test")]
-    trait TestApi {
-        #[method(name = "foo")]
-        async fn foo(&self, some_bool: bool) -> RpcResult<String>;
-
-        #[method(name = "foo", version <= "1.5")]
-        async fn bar(&self, some_str: String) -> RpcResult<String>;
-    }
-
-    struct TestApiModule;
-
-    #[async_trait]
-    impl TestApiServer for TestApiModule {
-        async fn foo(&self, _some_bool: bool) -> RpcResult<String> {
-            Ok("Some string".into())
-        }
-
-        async fn bar(&self, _some_str: String) -> RpcResult<String> {
-            Ok("Some string from old method".into())
-        }
-    }
-
-    impl SuiRpcModule for TestApiModule {
-        fn rpc(self) -> RpcModule<Self> {
-            self.into_rpc()
-        }
-        fn rpc_doc_module() -> Module {
-            TestApiOpenRpc::module_doc()
-        }
-    }
-
-    let mut builder = JsonRpcServerBuilder::new("1.5", &Registry::new()).unwrap();
-    builder.register_module(TestApiModule).unwrap();
-
-    let port = get_available_port("0.0.0.0");
-    let handle = builder
-        .start(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)))
-        .await
-        .unwrap();
-    let url = format!("http://0.0.0.0:{}", port);
-
-    // Test with un-versioned client
-    let client = HttpClientBuilder::default().build(&url).unwrap();
-    let response: String = client.request("test_foo", rpc_params!(true)).await.unwrap();
-    assert_eq!("Some string", response);
-
-    // Test with versioned client, version > backward compatible method version
-    let mut versioned_header = HeaderMap::new();
-    versioned_header.insert("client_api_version", HeaderValue::from_static("1.6"));
-    let client_with_new_header = HttpClientBuilder::default()
-        .set_headers(versioned_header)
-        .build(&url)
-        .unwrap();
-
-    let response: String = client_with_new_header
-        .request("test_foo", rpc_params!(true))
-        .await
-        .unwrap();
-    assert_eq!("Some string", response);
-
-    // Test with versioned client, version = backward compatible method version
-    let mut versioned_header = HeaderMap::new();
-    versioned_header.insert("client_api_version", HeaderValue::from_static("1.5"));
-    let client_with_new_header = HttpClientBuilder::default()
-        .set_headers(versioned_header)
-        .build(&url)
-        .unwrap();
-
-    let response: String = client_with_new_header
-        .request(
-            "test_foo",
-            rpc_params!("old version expect string as input"),
-        )
-        .await
-        .unwrap();
-    assert_eq!("Some string from old method", response);
-
-    // Test with versioned client, version < backward compatible method version
-    let mut versioned_header = HeaderMap::new();
-    versioned_header.insert("client_api_version", HeaderValue::from_static("1.4"));
-    let client_with_new_header = HttpClientBuilder::default()
-        .set_headers(versioned_header)
-        .build(&url)
-        .unwrap();
-
-    let response: String = client_with_new_header
-        .request(
-            "test_foo",
-            rpc_params!("old version expect string as input"),
-        )
-        .await
-        .unwrap();
-    assert_eq!("Some string from old method", response);
-
-    handle.stop().unwrap()
 }

--- a/crates/sui-json-rpc/tests/routing_tests.rs
+++ b/crates/sui-json-rpc/tests/routing_tests.rs
@@ -1,0 +1,174 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use hyper::header::HeaderValue;
+use hyper::HeaderMap;
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::rpc_params;
+use jsonrpsee::RpcModule;
+use jsonrpsee_proc_macros::rpc;
+use prometheus::Registry;
+use std::env;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use sui_config::utils::get_available_port;
+use sui_json_rpc::{JsonRpcServerBuilder, SuiRpcModule, CLIENT_TARGET_API_VERSION_HEADER};
+use sui_open_rpc::Module;
+use sui_open_rpc_macros::open_rpc;
+
+#[tokio::test]
+async fn test_rpc_backward_compatibility() {
+    let mut builder = JsonRpcServerBuilder::new("1.5", &Registry::new()).unwrap();
+    builder.register_module(TestApiModule).unwrap();
+
+    let port = get_available_port("0.0.0.0");
+    let handle = builder
+        .start(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)))
+        .await
+        .unwrap();
+    let url = format!("http://0.0.0.0:{}", port);
+
+    // Test with un-versioned client
+    let client = HttpClientBuilder::default().build(&url).unwrap();
+    let response: String = client.request("test_foo", rpc_params!(true)).await.unwrap();
+    assert_eq!("Some string", response);
+
+    // try to access old method directly should fail
+    let client = HttpClientBuilder::default().build(&url).unwrap();
+    let response: RpcResult<String> = client.request("test_foo_1_5", rpc_params!("string")).await;
+    assert!(response.is_err());
+
+    // Test with versioned client, version > backward compatible method version
+    let mut versioned_header = HeaderMap::new();
+    versioned_header.insert(
+        CLIENT_TARGET_API_VERSION_HEADER,
+        HeaderValue::from_static("1.6"),
+    );
+    let client_with_new_header = HttpClientBuilder::default()
+        .set_headers(versioned_header)
+        .build(&url)
+        .unwrap();
+
+    let response: String = client_with_new_header
+        .request("test_foo", rpc_params!(true))
+        .await
+        .unwrap();
+    assert_eq!("Some string", response);
+
+    // Test with versioned client, version = backward compatible method version
+    let mut versioned_header = HeaderMap::new();
+    versioned_header.insert(
+        CLIENT_TARGET_API_VERSION_HEADER,
+        HeaderValue::from_static("1.5"),
+    );
+    let client_with_new_header = HttpClientBuilder::default()
+        .set_headers(versioned_header)
+        .build(&url)
+        .unwrap();
+
+    let response: String = client_with_new_header
+        .request(
+            "test_foo",
+            rpc_params!("old version expect string as input"),
+        )
+        .await
+        .unwrap();
+    assert_eq!("Some string from old method", response);
+
+    // Test with versioned client, version < backward compatible method version
+    let mut versioned_header = HeaderMap::new();
+    versioned_header.insert(
+        CLIENT_TARGET_API_VERSION_HEADER,
+        HeaderValue::from_static("1.4"),
+    );
+    let client_with_new_header = HttpClientBuilder::default()
+        .set_headers(versioned_header)
+        .build(&url)
+        .unwrap();
+
+    let response: String = client_with_new_header
+        .request(
+            "test_foo",
+            rpc_params!("old version expect string as input"),
+        )
+        .await
+        .unwrap();
+    assert_eq!("Some string from old method", response);
+
+    handle.stop().unwrap()
+}
+
+#[tokio::test]
+async fn test_disable_routing() {
+    env::set_var("DISABLE_BACKWARD_COMPATIBILITY", "true");
+
+    let mut builder = JsonRpcServerBuilder::new("1.5", &Registry::new()).unwrap();
+    builder.register_module(TestApiModule).unwrap();
+
+    let port = get_available_port("0.0.0.0");
+    let handle = builder
+        .start(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)))
+        .await
+        .unwrap();
+    let url = format!("http://0.0.0.0:{}", port);
+
+    // try to access old method directly should fail
+    let client = HttpClientBuilder::default().build(&url).unwrap();
+    let response: RpcResult<String> = client.request("test_foo_1_5", rpc_params!("string")).await;
+    assert!(response.is_err());
+
+    // Test with versioned client, version = backward compatible method version, should fail because routing is disabled.
+    let mut versioned_header = HeaderMap::new();
+    versioned_header.insert(
+        CLIENT_TARGET_API_VERSION_HEADER,
+        HeaderValue::from_static("1.5"),
+    );
+    let client_with_new_header = HttpClientBuilder::default()
+        .set_headers(versioned_header)
+        .build(&url)
+        .unwrap();
+
+    let response: RpcResult<String> = client_with_new_header
+        .request(
+            "test_foo",
+            rpc_params!("old version expect string as input"),
+        )
+        .await;
+    assert!(response.is_err());
+
+    handle.stop().unwrap()
+}
+
+#[open_rpc(namespace = "test")]
+#[rpc(server, client, namespace = "test")]
+trait TestApi {
+    #[method(name = "foo")]
+    async fn foo(&self, some_bool: bool) -> RpcResult<String>;
+
+    #[method(name = "foo", version <= "1.5")]
+    async fn bar(&self, some_str: String) -> RpcResult<String>;
+}
+
+struct TestApiModule;
+
+#[async_trait]
+impl TestApiServer for TestApiModule {
+    async fn foo(&self, _some_bool: bool) -> RpcResult<String> {
+        Ok("Some string".into())
+    }
+
+    async fn bar(&self, _some_str: String) -> RpcResult<String> {
+        Ok("Some string from old method".into())
+    }
+}
+
+impl SuiRpcModule for TestApiModule {
+    fn rpc(self) -> RpcModule<Self> {
+        self.into_rpc()
+    }
+    fn rpc_doc_module() -> Module {
+        TestApiOpenRpc::module_doc()
+    }
+}

--- a/crates/sui-open-rpc-macros/src/lib.rs
+++ b/crates/sui-open-rpc-macros/src/lib.rs
@@ -7,15 +7,18 @@ use derive_syn_parse::Parse;
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenTree};
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::quote;
+use quote::{quote, ToTokens, TokenStreamExt};
+use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::token::Paren;
+use syn::token::{Comma, Paren};
 use syn::{
     parse, parse_macro_input, Attribute, GenericArgument, LitStr, PatType, Path, PathArguments,
     Token, TraitItem, Type,
 };
 use unescape::unescape;
+
+const SUI_RPC_ATTRS: [&str; 2] = ["deprecated", "version"];
 
 /// Add a [Service name]OpenRpc struct and implementation providing access to Open RPC doc builder.
 /// This proc macro must be use in conjunction with `jsonrpsee_proc_macro::rpc`
@@ -39,13 +42,13 @@ pub fn open_rpc(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let tag = attr.find_attr("tag").to_quote();
 
-    let mut methods = Vec::new();
-    for method in rpc_definition.methods {
-        let name = method.name;
-        let doc = method.doc;
+    let methods = rpc_definition.methods.iter().map(|method|{
+        let name = &method.name;
+        let deprecated = method.deprecated;
+        let doc = &method.doc;
         let mut inputs = Vec::new();
-        for (name, ty, description) in method.params {
-            let (ty, required) = extract_type_from_option(ty);
+        for (name, ty, description) in &method.params {
+            let (ty, required) = extract_type_from_option(ty.clone());
             let description = if let Some(description) = description {
                 quote! {Some(#description.to_string())}
             } else {
@@ -57,21 +60,45 @@ pub fn open_rpc(attr: TokenStream, item: TokenStream) -> TokenStream {
                 inputs.push(des);
             })
         }
-        let returns_ty = if let Some(ty) = method.returns {
-            let (ty, required) = extract_type_from_option(ty);
+        let returns_ty = if let Some(ty) = &method.returns {
+            let (ty, required) = extract_type_from_option(ty.clone());
             let name = quote! {#ty}.to_string();
             quote! {Some(builder.create_content_descriptor::<#ty>(#name, None, None, #required));}
         } else {
             quote! {None;}
         };
-        let is_pubsub = method.is_pubsub;
-        methods.push(quote! {
-            let mut inputs: Vec<sui_open_rpc::ContentDescriptor> = Vec::new();
-            #(#inputs)*
-            let result = #returns_ty
-            builder.add_method(#namespace, #name, inputs, result, #doc, #tag, #is_pubsub);
+
+        if method.is_pubsub {
+            quote! {
+                let mut inputs: Vec<sui_open_rpc::ContentDescriptor> = Vec::new();
+                #(#inputs)*
+                let result = #returns_ty
+                builder.add_subscription(#namespace, #name, inputs, result, #doc, #tag, #deprecated);
+            }
+        } else {
+            quote! {
+                let mut inputs: Vec<sui_open_rpc::ContentDescriptor> = Vec::new();
+                #(#inputs)*
+                let result = #returns_ty
+                builder.add_method(#namespace, #name, inputs, result, #doc, #tag, #deprecated);
+            }
+        }
+    }).collect::<Vec<_>>();
+
+    let routes = rpc_definition
+        .version_routing
+        .into_iter()
+        .map(|route| {
+            let name = route.name;
+            let route_to = route.route_to;
+            let comparator = route.token.to_string();
+            let version = route.version;
+            quote! {
+                builder.add_method_routing(#namespace, #name, #route_to, #comparator, #version);
+            }
         })
-    }
+        .collect::<Vec<_>>();
+
     let open_rpc_name = quote::format_ident!("{}OpenRpc", &rpc_definition.name);
 
     quote! {
@@ -81,6 +108,7 @@ pub fn open_rpc(attr: TokenStream, item: TokenStream) -> TokenStream {
             pub fn module_doc() -> sui_open_rpc::Module{
                 let mut builder = sui_open_rpc::RpcModuleDocBuilder::default();
                 #(#methods)*
+                #(#routes)*
                 builder.build()
             }
         }
@@ -120,6 +148,7 @@ impl OptionalQuote for Option<LitStr> {
 struct RpcDefinition {
     name: Ident,
     methods: Vec<Method>,
+    version_routing: Vec<Routing>,
 }
 struct Method {
     name: String,
@@ -127,34 +156,21 @@ struct Method {
     returns: Option<Type>,
     doc: String,
     is_pubsub: bool,
+    deprecated: bool,
+}
+struct Routing {
+    name: String,
+    route_to: String,
+    token: TokenStream2,
+    version: String,
 }
 
 fn parse_rpc_method(trait_data: &mut syn::ItemTrait) -> Result<RpcDefinition, syn::Error> {
     let mut methods = Vec::new();
+    let mut version_routing = Vec::new();
     for trait_item in &mut trait_data.items {
         if let TraitItem::Method(method) = trait_item {
-            let (method_name, returns, is_pubsub) =
-                if let Some(attr) = find_attr(&method.attrs, "method") {
-                    let token: TokenStream = attr.tokens.clone().into();
-                    let returns = match &method.sig.output {
-                        syn::ReturnType::Default => None,
-                        syn::ReturnType::Type(_, output) => extract_type_from(output, "RpcResult"),
-                    };
-                    (
-                        parse::<NamedAttribute>(token)?.value.value(),
-                        returns,
-                        false,
-                    )
-                } else if let Some(attr) = find_attr(&method.attrs, "subscription") {
-                    let token: TokenStream = attr.tokens.clone().into();
-                    let attribute = parse::<SubscriptionNamedAttribute>(token)?;
-                    (attribute.value.value(), Some(attribute.item), true)
-                } else {
-                    panic!("Unknown method name")
-                };
-
             let doc = extract_doc_comments(&method.attrs).to_string();
-
             let params: Vec<_> = method
                 .sig
                 .inputs
@@ -188,19 +204,80 @@ fn parse_rpc_method(trait_data: &mut syn::ItemTrait) -> Result<RpcDefinition, sy
                 })
                 .collect::<Result<_, _>>()?;
 
+            let (method_name, returns, is_pubsub, deprecated) = if let Some(attr) =
+                find_attr(&mut method.attrs, "method")
+            {
+                let token: TokenStream = attr.tokens.clone().into();
+                let returns = match &method.sig.output {
+                    syn::ReturnType::Default => None,
+                    syn::ReturnType::Type(_, output) => extract_type_from(output, "RpcResult"),
+                };
+                let mut attributes = parse::<Attributes>(token)?;
+                let method_name = attributes.get_value("name");
+                let deprecated = attributes.find("deprecated").is_some();
+
+                if let Some(version_attr) = attributes.find("version") {
+                    if let (Some(token), Some(version)) = (&version_attr.token, &version_attr.value)
+                    {
+                        let route_to =
+                            format!("{method_name}_{}", version.value().replace('.', "_"));
+                        version_routing.push(Routing {
+                            name: method_name,
+                            route_to: route_to.clone(),
+                            token: token.to_token_stream(),
+                            version: version.value(),
+                        });
+                        if let Some(name) = attributes.find_mut("name") {
+                            name.value
+                                .replace(LitStr::new(&route_to, Span::call_site()));
+                        }
+                        attr.tokens = remove_sui_rpc_attributes(attributes);
+                        continue;
+                    }
+                }
+                attr.tokens = remove_sui_rpc_attributes(attributes);
+                (method_name, returns, false, deprecated)
+            } else if let Some(attr) = find_attr(&mut method.attrs, "subscription") {
+                let token: TokenStream = attr.tokens.clone().into();
+                let attributes = parse::<Attributes>(token)?;
+                let name = attributes.get_value("name");
+                let type_ = attributes
+                    .find("item")
+                    .expect("Subscription should have a [item] attribute")
+                    .type_
+                    .clone()
+                    .expect("[item] attribute should have a value");
+                let deprecated = attributes.find("deprecated").is_some();
+                attr.tokens = remove_sui_rpc_attributes(attributes);
+                (name, Some(type_), true, deprecated)
+            } else {
+                panic!("Unknown method name")
+            };
+
             methods.push(Method {
                 name: method_name,
                 params,
                 returns,
                 doc,
                 is_pubsub,
+                deprecated,
             });
         }
     }
     Ok(RpcDefinition {
         name: trait_data.ident.clone(),
         methods,
+        version_routing,
     })
+}
+// Remove Sui rpc specific attributes.
+fn remove_sui_rpc_attributes(attributes: Attributes) -> TokenStream2 {
+    let attrs = attributes
+        .attrs
+        .into_iter()
+        .filter(|r| !SUI_RPC_ATTRS.contains(&r.key.to_string().as_str()))
+        .collect::<Punctuated<Attr, Comma>>();
+    quote! {(#attrs)}
 }
 
 fn extract_type_from(ty: &Type, from_ty: &str) -> Option<Type> {
@@ -251,8 +328,8 @@ fn get_type(pat_type: &mut PatType) -> Result<Type, syn::Error> {
     )
 }
 
-fn find_attr<'a>(attrs: &'a [Attribute], ident: &str) -> Option<&'a Attribute> {
-    attrs.iter().find(|a| a.path.is_ident(ident))
+fn find_attr<'a>(attrs: &'a mut [Attribute], ident: &str) -> Option<&'a mut Attribute> {
+    attrs.iter_mut().find(|a| a.path.is_ident(ident))
 }
 
 fn respan_token_stream(stream: TokenStream2, span: Span) -> TokenStream2 {
@@ -320,22 +397,90 @@ struct NamedAttribute {
     value: syn::LitStr,
 }
 
-#[derive(Parse, Debug)]
-struct SubscriptionNamedAttribute {
-    #[paren]
-    _paren_token: Paren,
-    #[inside(_paren_token)]
-    _ident: Ident,
-    #[inside(_paren_token)]
-    _eq_token: Token![=],
-    #[inside(_paren_token)]
-    value: syn::LitStr,
-    #[inside(_paren_token)]
-    _comma: Token![,],
-    #[inside(_paren_token)]
-    _item_ident: Ident,
-    #[inside(_paren_token)]
-    _item_eq_token: Token![=],
-    #[inside(_paren_token)]
-    item: Type,
+#[derive(Debug)]
+struct Attributes {
+    pub attrs: Punctuated<Attr, syn::token::Comma>,
+}
+
+impl Attributes {
+    pub fn find(&self, attr_name: &str) -> Option<&Attr> {
+        self.attrs.iter().find(|attr| attr.key == attr_name)
+    }
+    pub fn find_mut(&mut self, attr_name: &str) -> Option<&mut Attr> {
+        self.attrs.iter_mut().find(|attr| attr.key == attr_name)
+    }
+    pub fn get_value(&self, attr_name: &str) -> String {
+        self.attrs
+            .iter()
+            .find(|attr| attr.key == attr_name)
+            .unwrap_or_else(|| panic!("Method should have a [{attr_name}] attribute."))
+            .value
+            .as_ref()
+            .unwrap_or_else(|| panic!("[{attr_name}] attribute should have a value"))
+            .value()
+    }
+}
+
+impl Parse for Attributes {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        let _paren = syn::parenthesized!(content in input);
+        let attrs = content.parse_terminated(Attr::parse)?;
+        Ok(Self { attrs })
+    }
+}
+
+#[derive(Debug)]
+struct Attr {
+    pub key: Ident,
+    pub token: Option<TokenStream2>,
+    pub value: Option<syn::LitStr>,
+    pub type_: Option<Type>,
+}
+
+impl ToTokens for Attr {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        tokens.append(self.key.clone());
+        if let Some(token) = &self.token {
+            tokens.extend(token.to_token_stream());
+        }
+        if let Some(value) = &self.value {
+            tokens.append(value.token());
+        }
+        if let Some(type_) = &self.type_ {
+            tokens.extend(type_.to_token_stream());
+        }
+    }
+}
+
+impl Parse for Attr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let key = input.parse()?;
+        let token = if input.peek(Token!(=)) {
+            Some(input.parse::<Token!(=)>()?.to_token_stream())
+        } else if input.peek(Token!(<=)) {
+            Some(input.parse::<Token!(<=)>()?.to_token_stream())
+        } else {
+            None
+        };
+
+        let value = if token.is_some() && input.peek(syn::LitStr) {
+            Some(input.parse::<syn::LitStr>()?)
+        } else {
+            None
+        };
+
+        let type_ = if token.is_some() && input.peek(syn::Ident) {
+            Some(input.parse::<Type>()?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            key,
+            token,
+            value,
+            type_,
+        })
+    }
 }

--- a/crates/sui-open-rpc/Cargo.toml
+++ b/crates/sui-open-rpc/Cargo.toml
@@ -12,6 +12,7 @@ serde = "1.0.141"
 serde_json = "1.0.88"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 bcs = "0.1.3"
+versions = "4.1.0"
 
 [dev-dependencies]
 anyhow = { version = "1.0.64", features = ["backtrace"] }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -441,7 +441,8 @@
         "schema": {
           "$ref": "#/components/schemas/SuiExecuteTransactionResponse"
         }
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "sui_getAllBalances",

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -637,6 +637,7 @@ url = { version = "2" }
 utf8parse = { version = "0.2" }
 uuid = { version = "1", features = ["fast-rng", "v4"] }
 vec_map = { version = "0.8", default-features = false }
+versions = { version = "4", default-features = false }
 vte = { version = "0.10" }
 wait-timeout = { version = "0.2", default-features = false }
 waker-fn = { version = "1", default-features = false }
@@ -1387,6 +1388,7 @@ variant_count = { version = "1", default-features = false }
 vcpkg = { version = "0.2", default-features = false }
 vec_map = { version = "0.8", default-features = false }
 version_check = { version = "0.9", default-features = false }
+versions = { version = "4", default-features = false }
 vte = { version = "0.10" }
 vte_generate_state_changes = { version = "0.1", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }


### PR DESCRIPTION
## Summary
This PR adds method routing capability to RPC server base on client's information provided in the request header, this provides some level of backward compatibility on the server side.

### List of client header
"client-sdk-type";
"client-sdk-version";
"client-target-api-version";

## How it works
The RPC server construct a routing table of all the methods on start up, the `RoutingLayer` uses the mapping to redirect incoming jsonrpc request to corresponding methods base on client version. 

When there is a breaking change to a rpc method, we can retain the old method in the RPC API and annotate it with the version information, e.g.
```
#[open_rpc(namespace = "test")]
#[rpc(server, client, namespace = "test")]
trait TestApi {
    #[method(name = "foo")]
    async fn foo(&self, some_bool: bool) -> RpcResult<String>;

    #[method(name = "foo", version <= "1.5")]
    async fn bar(&self, some_str: String) -> RpcResult<String>;
}
```
In this example, `bar` is the older version of `foo`, all client with version less than or eq to 1.5 will be routed to the bar method.

Also in this PR:
added deprecated flag to openrpc spec