### PR TITLE
[move-prover] model dynamic fields with built-in vec and map ops

### DIFF
--- a/crates/sui-framework/sources/prover.move
+++ b/crates/sui-framework/sources/prover.move
@@ -2,8 +2,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui::prover {
-
     use sui::object;
+
+    #[verify_only]
+    /// The intrinsic map type simulated by a dummy struct
+    struct Map<phantom K: copy + drop, phantom V> has store {}
+    spec Map {
+        pragma intrinsic = map,
+        map_spec_new = map_new,
+        map_spec_get = map_get,
+        map_spec_set = map_set,
+        map_spec_del = map_del,
+        map_spec_len = map_len,
+        map_spec_has_key = map_contains;
+    }
+
+    /// Create a new map with no entries, emulated by a fake native function
+    spec native fun map_new<K: copy + drop, V: store>(): Map<K, V>;
+
+    /// Obtain the number of key-value pairs in the map
+    spec native fun map_len<K, V>(m: Map<K, V>): num;
+
+    /// Check whether the map contains a certain key
+    spec native fun map_contains<K, V>(m: Map<K, V>, k: K): bool;
+
+    /// Update the map at `(k, v)` and return the updated map
+    spec native fun map_set<K, V>(m: Map<K, V>, k: K, v: V): Map<K, V>;
+
+    /// Delete the map at key `k` and return the updated map
+    spec native fun map_del<K, V>(m: Map<K, V>, k: K): Map<K, V>;
+
+    /// Get the value `v` associated with key `k`, if `k` does not exist,
+    /// return an uninterpreted value.
+    spec native fun map_get<K, V>(m: Map<K, V>, k: K): V;
 
     const OWNED: u64 = 1;
     const SHARED: u64 = 2;
@@ -15,63 +46,28 @@ module sui::prover {
     spec fun owned<T: key>(obj: T): bool {
         let addr = object::id(obj).bytes;
         exists<object::Ownership>(addr) &&
-        global<object::Ownership>(addr).status == OWNED
+            global<object::Ownership>(addr).status == OWNED
     }
 
     /// Verifies if a given object is owned.
     spec fun owned_by<T: key>(obj: T, owner: address): bool {
         let addr = object::id(obj).bytes;
         exists<object::Ownership>(addr) &&
-        global<object::Ownership>(addr).status == OWNED &&
-        global<object::Ownership>(addr).owner == owner
+            global<object::Ownership>(addr).status == OWNED &&
+            global<object::Ownership>(addr).owner == owner
     }
 
     /// Verifies if a given object is shared.
     spec fun shared<T: key>(obj: T): bool {
         let addr = object::id(obj).bytes;
         exists<object::Ownership>(addr) &&
-        global<object::Ownership>(addr).status == SHARED
+            global<object::Ownership>(addr).status == SHARED
     }
 
     /// Verifies if a given object is immutable.
     spec fun immutable<T: key>(obj: T): bool {
         let addr = object::id(obj).bytes;
         exists<object::Ownership>(addr) &&
-        global<object::Ownership>(addr).status == IMMUTABLE
+            global<object::Ownership>(addr).status == IMMUTABLE
     }
-
-    /// Verifies if a given object has field with a given name.
-    spec fun has_field<T: key, K: copy + drop + store>(obj: T, name: K): bool {
-        let uid = object::borrow_uid(obj);
-        uid_has_field<K>(uid, name)
-    }
-
-    /// Returns number of K-type fields of a given object.
-    spec fun num_fields<T: key, K: copy + drop + store>(obj: T): u64 {
-        let uid = object::borrow_uid(obj);
-        uid_num_fields<K>(uid)
-    }
-
-    // "helper" function - may also be used in specs but mostly opaque ones defining behavior of key
-    // framework functions
-
-    spec fun uid_has_field<K: copy + drop + store>(uid: sui::object::UID, name: K): bool {
-        let addr = object::uid_to_address(uid);
-        exists<object::DynamicFields<K>>(addr) && contains(global<object::DynamicFields<K>>(addr).names, name)
-    }
-
-    spec fun uid_num_fields<K: copy + drop + store>(uid: sui::object::UID): u64 {
-        let addr = object::uid_to_address(uid);
-        if (!exists<object::DynamicFields<K>>(addr)) {
-            0
-        } else {
-            len(global<object::DynamicFields<K>>(addr).names)
-        }
-    }
-
-
-    // remove an element at index from a vector and return the resulting vector (redirects to a
-    // function in vector theory)
-    spec native fun vec_remove<T>(v: vector<T>, elem_idx: u64): vector<T>;
-
 }

--- a/crates/sui-framework/sources/prover_vec.move
+++ b/crates/sui-framework/sources/prover_vec.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::prover_vec {
+    // remove an element at index from a vector and return the resulting vector (redirects to a
+    // function in vector theory)
+    spec native fun remove<T>(v: vector<T>, elem_idx: u64): vector<T>;
+}

--- a/crates/sui-framework/tests/prover_tests.move
+++ b/crates/sui-framework/tests/prover_tests.move
@@ -3,9 +3,10 @@
 
 module sui::prover_tests {
     use sui::object::UID;
+    use sui::dynamic_field;
 
     struct Obj has key, store {
-        id: UID
+        id: UID,
     }
 
     // ====================================================================
@@ -54,30 +55,113 @@ module sui::prover_tests {
     // ====================================================================
 
     public fun simple_field_add(o: &mut Obj, n1: u64, v1: u8, n2: u8, v2: u64) {
-        sui::dynamic_field::add(&mut o.id, n1, v1);
-        sui::dynamic_field::add(&mut o.id, n2, v2);
+        dynamic_field::add(&mut o.id, n1, v1);
+        dynamic_field::add(&mut o.id, n2, v2);
     }
 
     spec simple_field_add {
-        aborts_if sui::prover::has_field(o, n1);
-        aborts_if sui::prover::has_field(o, n2);
-        ensures sui::prover::has_field(o, n1);
-        ensures sui::prover::has_field(o, n2);
-        ensures sui::prover::num_fields<Obj,u64>(o) == old(sui::prover::num_fields<Obj,u64>(o)) + 1;
-        ensures sui::prover::num_fields<Obj,u8>(o) == old(sui::prover::num_fields<Obj,u8>(o)) + 1;
+        aborts_if dynamic_field::spec_has_field(o, n1);
+        aborts_if dynamic_field::spec_has_field(o, n2);
+
+        ensures dynamic_field::spec_has_field(o, n1);
+        ensures dynamic_field::spec_has_field(o, n2);
+        ensures dynamic_field::spec_num_fields<Obj, u64>(o) ==
+            old(dynamic_field::spec_num_fields<Obj, u64>(o)) + 1;
+        ensures dynamic_field::spec_num_fields<Obj, u8>(o) ==
+            old(dynamic_field::spec_num_fields<Obj, u8>(o)) + 1;
+
+        ensures dynamic_field::spec_has_field_with_type<Obj, u64, u8>(o, n1);
+        ensures dynamic_field::spec_has_field_with_type<Obj, u8, u64>(o, n2);
+        ensures dynamic_field::spec_num_fields_with_type<Obj, u64, u8>(o) ==
+            old(dynamic_field::spec_num_fields_with_type<Obj, u64, u8>(o)) + 1;
+        ensures dynamic_field::spec_num_fields_with_type<Obj, u8, u64>(o) ==
+            old(dynamic_field::spec_num_fields_with_type<Obj, u8, u64>(o)) + 1;
     }
 
     public fun simple_field_remove(o: &mut Obj, n1: u64, n2: u8) {
-        sui::dynamic_field::remove<u64,u8>(&mut o.id, n1);
-        sui::dynamic_field::remove<u8,u64>(&mut o.id, n2);
+        sui::dynamic_field::remove<u64, u8>(&mut o.id, n1);
+        sui::dynamic_field::remove<u8, u64>(&mut o.id, n2);
     }
 
     spec simple_field_remove {
-        aborts_if !sui::prover::has_field(o, n1);
-        aborts_if !sui::prover::has_field(o, n2);
-        ensures !sui::prover::has_field(o, n1);
-        ensures !sui::prover::has_field(o, n2);
-        ensures sui::prover::num_fields<Obj,u64>(o) == old(sui::prover::num_fields<Obj,u64>(o)) - 1;
-        ensures sui::prover::num_fields<Obj,u8>(o) == old(sui::prover::num_fields<Obj,u8>(o)) - 1;
+        aborts_if !dynamic_field::spec_has_field(o, n1);
+        aborts_if !dynamic_field::spec_has_field(o, n2);
+        aborts_if !dynamic_field::spec_has_field_with_type<Obj, u64, u8>(o, n1);
+        aborts_if !dynamic_field::spec_has_field_with_type<Obj, u8, u64>(o, n2);
+
+        ensures !dynamic_field::spec_has_field(o, n1);
+        ensures !dynamic_field::spec_has_field(o, n2);
+        ensures dynamic_field::spec_num_fields<Obj, u64>(o) ==
+            old(dynamic_field::spec_num_fields<Obj, u64>(o)) - 1;
+        ensures dynamic_field::spec_num_fields<Obj, u8>(o) ==
+            old(dynamic_field::spec_num_fields<Obj, u8>(o)) - 1;
+
+        ensures !dynamic_field::spec_has_field_with_type<Obj, u64, u8>(o, n1);
+        ensures !dynamic_field::spec_has_field_with_type<Obj, u8, u64>(o, n2);
+        ensures dynamic_field::spec_num_fields_with_type<Obj, u64, u8>(o) ==
+            old(dynamic_field::spec_num_fields_with_type<Obj, u64, u8>(o)) - 1;
+        ensures dynamic_field::spec_num_fields_with_type<Obj, u8, u64>(o) ==
+            old(dynamic_field::spec_num_fields_with_type<Obj, u8, u64>(o)) - 1;
+    }
+
+    public fun simple_field_borrow(o: &mut Obj, n1: u64, n2: u8): (u8, u64) {
+        let r1 = dynamic_field::borrow<u64, u8>(&o.id, n1);
+        let r2 = dynamic_field::borrow<u8, u64>(&o.id, n2);
+        (*r1, *r2)
+    }
+
+    spec simple_field_borrow {
+        aborts_if !dynamic_field::spec_has_field(o, n1);
+        aborts_if !dynamic_field::spec_has_field(o, n2);
+        aborts_if !dynamic_field::spec_has_field_with_type<Obj, u64, u8>(o, n1);
+        aborts_if !dynamic_field::spec_has_field_with_type<Obj, u8, u64>(o, n2);
+
+        ensures result_1 == dynamic_field::spec_get_value<Obj, u64, u8>(o, n1);
+        ensures result_2 == dynamic_field::spec_get_value<Obj, u8, u64>(o, n2);
+    }
+
+
+    public fun simple_field_add_and_borrow(o: &mut Obj, n1: u64, v1: u8, n2: u8, v2: u64): (u8, u64) {
+        dynamic_field::add(&mut o.id, n1, v1);
+        dynamic_field::add(&mut o.id, n2, v2);
+        let r1 = dynamic_field::borrow<u64, u8>(&o.id, n1);
+        let r2 = dynamic_field::borrow<u8, u64>(&o.id, n2);
+        (*r1, *r2)
+    }
+    spec simple_field_add_and_borrow {
+        aborts_if dynamic_field::spec_has_field(o, n1);
+        aborts_if dynamic_field::spec_has_field(o, n2);
+
+        ensures dynamic_field::spec_has_field(o, n1);
+        ensures dynamic_field::spec_has_field(o, n2);
+        ensures dynamic_field::spec_num_fields<Obj, u64>(o) ==
+            old(dynamic_field::spec_num_fields<Obj, u64>(o)) + 1;
+        ensures dynamic_field::spec_num_fields<Obj, u8>(o) ==
+            old(dynamic_field::spec_num_fields<Obj, u8>(o)) + 1;
+
+        ensures dynamic_field::spec_has_field_with_type<Obj, u64, u8>(o, n1);
+        ensures dynamic_field::spec_has_field_with_type<Obj, u8, u64>(o, n2);
+        ensures dynamic_field::spec_num_fields_with_type<Obj, u64, u8>(o) ==
+            old(dynamic_field::spec_num_fields_with_type<Obj, u64, u8>(o)) + 1;
+        ensures dynamic_field::spec_num_fields_with_type<Obj, u8, u64>(o) ==
+            old(dynamic_field::spec_num_fields_with_type<Obj, u8, u64>(o)) + 1;
+
+        ensures result_1 == v1;
+        ensures result_2 == v2;
+    }
+
+    public fun simple_field_borrow_mut(o: &mut Obj, n1: u64, v1: u8, n2: u8, v2: u64) {
+        let r1 = dynamic_field::borrow_mut(&mut o.id, n1);
+        *r1 = v1;
+
+        let r2 = dynamic_field::borrow_mut(&mut o.id, n2);
+        *r2 = v2;
+    }
+    spec simple_field_borrow_mut {
+        aborts_if !dynamic_field::spec_has_field(o, n1);
+        aborts_if !dynamic_field::spec_has_field(o, n2);
+        aborts_if !dynamic_field::spec_has_field_with_type<Obj, u64, u8>(o, n1);
+        aborts_if !dynamic_field::spec_has_field_with_type<Obj, u8, u64>(o, n2);
+        // TODO(mengxu): currently incomplete about the borrowed value
     }
 }


### PR DESCRIPTION
PR in current status is for demonstration and discussion only. The code needs polishing before landing.

This PR is to demonstrate a proof-of-concept on how we might be able to model pre/post conditions on both key and value in dynamic fields / dynamic object fields using `Vec` (to emulate a set actually) and `Map` that is already supported in the Prover.

In particular, the `Vec` (or set) tracks a
```rust
struct NameShard<Name: copy + drop + store> has key {
    names: vector<Name>,
}
```
which hosts all keys of a particular type `Name` associated with an object ID

And the `Map` tracks a
```rust
struct PairShard<phantom Name: copy + drop + store, phantom Value: store> has key {
    entries: prover::Map<Name, Value>,
}
```
which holds the key-value pairs of a particular `(Name, Value)` type pair associated with an object ID.