### PR TITLE
assert loaded object version match, remove UnexpectedSequenceNumber error

### DIFF
--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -294,22 +294,17 @@ fn check_one_object(
                 SuiError::InvalidSequenceNumber
             );
 
-            // Check that the seq number is the same
-            // Note that this generally can't fail, because we fetch objects at the version
-            // specified by the input objects. This makes check_transaction_input idempotent.
-            // A tx that tries to operate on older versions will fail later when checking the
-            // object locks.
-            fp_ensure!(
-                object.version() == sequence_number,
-                SuiError::UnexpectedSequenceNumber {
-                    object_id,
-                    expected_sequence: object.version(),
-                    given_sequence: sequence_number,
-                }
+            // This is an invariant - we just load the object with the given ID and version.
+            assert_eq!(
+                object.version(),
+                sequence_number,
+                "The fetched object version {} does not match the requested version {}, object id: {}",
+                object.version(),
+                sequence_number,
+                object.id(),
             );
 
-            // Check the digest matches
-
+            // Check the digest matches - uesr could give a mismatched ObjectDigest
             let expected_digest = object.digest();
             fp_ensure!(
                 expected_digest == object_digest,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -138,14 +138,6 @@ pub enum SuiError {
     CertificateRequiresQuorum,
     #[error("Authority {authority_name:?} could not sync certificate: {err:?}")]
     CertificateSyncError { authority_name: String, err: String },
-    #[error(
-        "The given sequence number ({given_sequence:?}) must match the next expected sequence ({expected_sequence:?}) number of the object ({object_id:?})"
-    )]
-    UnexpectedSequenceNumber {
-        object_id: ObjectID,
-        expected_sequence: SequenceNumber,
-        given_sequence: SequenceNumber,
-    },
     #[error("Invalid Authority Bitmap: {}", error)]
     InvalidAuthorityBitmap { error: String },
     #[error("Transaction certificate processing failed: {err}")]


### PR DESCRIPTION
The `Object`s we check in `fn check_one_object` are the ones we just loaded from DB given the object ID and sequence number. Therefore the version should always match.