### PR TITLE
Removing a few custom serde-s

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -44,7 +44,6 @@ use sui_types::{
     committee::{Committee, EpochId, ProtocolVersion},
     error::SuiResult,
     object::Object,
-    sui_serde::AuthSignature,
 };
 use tracing::trace;
 
@@ -268,7 +267,6 @@ impl<'de> Deserialize<'de> for Genesis {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GenesisValidatorInfo {
     pub info: ValidatorInfo,
-    #[serde_as(as = "AuthSignature")]
     pub proof_of_possession: AuthoritySignature,
 }
 

--- a/crates/sui-config/src/genesis_config.rs
+++ b/crates/sui-config/src/genesis_config.rs
@@ -15,7 +15,6 @@ use sui_types::crypto::{
     get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair, NetworkKeyPair, SuiKeyPair,
 };
 use sui_types::object::Object;
-use sui_types::sui_serde::KeyPairBase64;
 
 use crate::genesis::GenesisChainParameters;
 use crate::node::DEFAULT_GRPC_CONCURRENCY_LIMIT;
@@ -102,12 +101,9 @@ impl GenesisConfig {
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ValidatorGenesisInfo {
-    #[serde_as(as = "KeyPairBase64")]
     pub key_pair: AuthorityKeyPair,
-    #[serde_as(as = "KeyPairBase64")]
     pub worker_key_pair: NetworkKeyPair,
     pub account_key_pair: SuiKeyPair,
-    #[serde_as(as = "KeyPairBase64")]
     pub network_key_pair: NetworkKeyPair,
     pub network_address: Multiaddr,
     pub p2p_address: Multiaddr,

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -20,7 +20,6 @@ use sui_types::committee::Committee;
 use sui_types::crypto::{
     get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair, NetworkKeyPair, SuiKeyPair,
 };
-use sui_types::sui_serde::KeyPairBase64;
 
 /// This is a config that is used for testing or local use as it contains the config and keys for
 /// all validators
@@ -28,7 +27,6 @@ use sui_types::sui_serde::KeyPairBase64;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NetworkConfig {
     pub validator_configs: Vec<NodeConfig>,
-    #[serde_as(as = "Vec<KeyPairBase64>")]
     pub account_keys: Vec<AccountKeyPair>,
     pub genesis: genesis::Genesis,
 }

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -32,7 +32,7 @@ use crate::base_types::{AuthorityName, ObjectID, SuiAddress};
 use crate::committee::{Committee, EpochId, StakeUnit};
 use crate::error::{SuiError, SuiResult};
 use crate::intent::IntentMessage;
-use crate::sui_serde::{AggrAuthSignature, Readable, SuiBitmap};
+use crate::sui_serde::{Readable, SuiBitmap};
 use fastcrypto::encoding::{Base64, Encoding, Hex};
 use fastcrypto::hash::{HashFunction, Sha3_256};
 use std::fmt::Debug;
@@ -1230,7 +1230,6 @@ impl PartialEq for AuthoritySignInfo {
 pub struct AuthorityQuorumSignInfo<const STRONG_THRESHOLD: bool> {
     pub epoch: EpochId,
     #[schemars(with = "Base64")]
-    #[serde_as(as = "AggrAuthSignature")]
     pub signature: AggregateAuthoritySignature,
     #[schemars(with = "Base64")]
     #[serde_as(as = "SuiBitmap")]

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -194,32 +194,6 @@ where
     }
 }
 
-pub struct AggrAuthSignature {}
-
-impl SerializeAs<AggregateAuthoritySignature> for AggrAuthSignature {
-    fn serialize_as<S>(
-        value: &AggregateAuthoritySignature,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        Base64::encode(value.as_ref()).serialize(serializer)
-    }
-}
-
-impl<'de> DeserializeAs<'de, AggregateAuthoritySignature> for AggrAuthSignature {
-    fn deserialize_as<D>(deserializer: D) -> Result<AggregateAuthoritySignature, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        let sig_bytes = Base64::decode(&s).map_err(to_custom_error::<'de, D, _>)?;
-        AggregateAuthoritySignature::from_bytes(&sig_bytes[..])
-            .map_err(to_custom_error::<'de, D, _>)
-    }
-}
-
 #[macro_export]
 macro_rules! serde_to_from_bytes {
     ($type:ty) => {

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -5,17 +5,13 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use anyhow::anyhow;
-use fastcrypto::encoding::{Base64, Encoding};
-use fastcrypto::traits::ToFromBytes;
+use fastcrypto::encoding::Encoding;
 use move_core_types::account_address::AccountAddress;
 use serde;
 use serde::de::{Deserializer, Error};
 use serde::ser::{Error as SerError, Serializer};
 use serde::Deserialize;
-use serde::Serialize;
 use serde_with::{Bytes, DeserializeAs, SerializeAs};
-
-use crate::crypto::{AggregateAuthoritySignature, KeypairTraits};
 
 #[inline]
 fn to_custom_error<'de, D, E>(e: E) -> D::Error
@@ -165,32 +161,6 @@ impl<'de> DeserializeAs<'de, roaring::RoaringBitmap> for SuiBitmap {
     {
         let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
         roaring::RoaringBitmap::deserialize_from(&bytes[..]).map_err(to_custom_error::<'de, D, _>)
-    }
-}
-pub struct KeyPairBase64 {}
-
-impl<T> SerializeAs<T> for KeyPairBase64
-where
-    T: KeypairTraits,
-{
-    fn serialize_as<S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        value.encode_base64().serialize(serializer)
-    }
-}
-
-impl<'de, T> DeserializeAs<'de, T> for KeyPairBase64
-where
-    T: KeypairTraits,
-{
-    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        T::decode_base64(&s).map_err(to_custom_error::<'de, D, _>)
     }
 }
 

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -164,6 +164,9 @@ impl<'de> DeserializeAs<'de, roaring::RoaringBitmap> for SuiBitmap {
     }
 }
 
+/// Macro for implementing serde Serialize/Deserialize for a type that implements AsRef<[u8]>.
+/// To be used only for non-fixed-size types (see `serialize_deserialize_with_to_from_bytes` in
+/// FastCrypto for fixed-size types).
 #[macro_export]
 macro_rules! serde_to_from_bytes {
     ($type:ty) => {

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_with::{Bytes, DeserializeAs, SerializeAs};
 
-use crate::crypto::{AggregateAuthoritySignature, AuthoritySignature, KeypairTraits};
+use crate::crypto::{AggregateAuthoritySignature, KeypairTraits};
 
 #[inline]
 fn to_custom_error<'de, D, E>(e: E) -> D::Error
@@ -191,28 +191,6 @@ where
     {
         let s = String::deserialize(deserializer)?;
         T::decode_base64(&s).map_err(to_custom_error::<'de, D, _>)
-    }
-}
-
-pub struct AuthSignature {}
-
-impl SerializeAs<AuthoritySignature> for AuthSignature {
-    fn serialize_as<S>(value: &AuthoritySignature, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        Base64::encode(value.as_ref()).serialize(serializer)
-    }
-}
-
-impl<'de> DeserializeAs<'de, AuthoritySignature> for AuthSignature {
-    fn deserialize_as<D>(deserializer: D) -> Result<AuthoritySignature, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        let sig_bytes = Base64::decode(&s).map_err(to_custom_error::<'de, D, _>)?;
-        AuthoritySignature::from_bytes(&sig_bytes[..]).map_err(to_custom_error::<'de, D, _>)
     }
 }
 


### PR DESCRIPTION
Removing several customized serialize/deserialize implementations from sui. They are not needed now as the relevant fastcrypto types implement serde in a consistent way.

None of the snapshot files needed to be updated.