### PR TITLE
[pruner] keep last N epochs of objects data

### DIFF
--- a/crates/sui-config/data/fullnode-template-with-path.yaml
+++ b/crates/sui-config/data/fullnode-template-with-path.yaml
@@ -17,6 +17,7 @@ authority-store-pruning-config:
   objects-pruning-initial-delay-secs: 3600
   num-latest-epoch-dbs-to-retain: 3
   epoch-db-pruning-period-secs: 3600
+  num-epochs-to-retain: 18446744073709551615
 
 protocol-key-pair:
   path: "protocol.key"

--- a/crates/sui-config/data/fullnode-template.yaml
+++ b/crates/sui-config/data/fullnode-template.yaml
@@ -17,3 +17,4 @@ authority-store-pruning-config:
   objects-pruning-initial-delay-secs: 3600
   num-latest-epoch-dbs-to-retain: 3
   epoch-db-pruning-period-secs: 3600
+  num-epochs-to-retain: 18446744073709551615

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -277,6 +277,7 @@ pub struct AuthorityStorePruningConfig {
     pub objects_pruning_initial_delay_secs: u64,
     pub num_latest_epoch_dbs_to_retain: usize,
     pub epoch_db_pruning_period_secs: u64,
+    pub num_epochs_to_retain: u64,
 }
 
 impl Default for AuthorityStorePruningConfig {
@@ -287,6 +288,7 @@ impl Default for AuthorityStorePruningConfig {
             objects_pruning_initial_delay_secs: 60 * 60,
             num_latest_epoch_dbs_to_retain: usize::MAX,
             epoch_db_pruning_period_secs: u64::MAX,
+            num_epochs_to_retain: u64::MAX,
         }
     }
 }
@@ -301,6 +303,7 @@ impl AuthorityStorePruningConfig {
             objects_pruning_initial_delay_secs: 60 * 60,
             num_latest_epoch_dbs_to_retain: 3,
             epoch_db_pruning_period_secs: 60 * 60,
+            num_epochs_to_retain: if cfg!(msim) { 1 } else { u64::MAX },
         }
     }
     pub fn fullnode_config() -> Self {
@@ -310,6 +313,7 @@ impl AuthorityStorePruningConfig {
             objects_pruning_initial_delay_secs: 60 * 60,
             num_latest_epoch_dbs_to_retain: 3,
             epoch_db_pruning_period_secs: 60 * 60,
+            num_epochs_to_retain: if cfg!(msim) { 1 } else { u64::MAX },
         }
     }
 }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -67,6 +67,7 @@ validator_configs:
       objects-pruning-initial-delay-secs: 3600
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
+      num-epochs-to-retain: 18446744073709551615
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -135,6 +136,7 @@ validator_configs:
       objects-pruning-initial-delay-secs: 3600
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
+      num-epochs-to-retain: 18446744073709551615
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -203,6 +205,7 @@ validator_configs:
       objects-pruning-initial-delay-secs: 3600
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
+      num-epochs-to-retain: 18446744073709551615
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -271,6 +274,7 @@ validator_configs:
       objects-pruning-initial-delay-secs: 3600
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
+      num-epochs-to-retain: 18446744073709551615
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -339,6 +343,7 @@ validator_configs:
       objects-pruning-initial-delay-secs: 3600
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
+      num-epochs-to-retain: 18446744073709551615
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -407,6 +412,7 @@ validator_configs:
       objects-pruning-initial-delay-secs: 3600
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
+      num-epochs-to-retain: 18446744073709551615
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -475,6 +481,7 @@ validator_configs:
       objects-pruning-initial-delay-secs: 3600
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
+      num-epochs-to-retain: 18446744073709551615
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -91,6 +91,7 @@ use crate::authority::authority_per_epoch_store::{
 };
 use crate::authority::authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner;
 use crate::authority::authority_store::{ExecutionLockReadGuard, ObjectLockStatus};
+use crate::authority::authority_store_pruner::AuthorityStorePruner;
 use crate::authority_aggregator::TransactionCertifier;
 use crate::checkpoints::CheckpointStore;
 use crate::epoch::committee_store::CommitteeStore;
@@ -425,7 +426,8 @@ pub struct AuthorityState {
     tx_execution_shutdown: Mutex<Option<oneshot::Sender<()>>>,
 
     pub metrics: Arc<AuthorityMetrics>,
-    _pruner: AuthorityPerEpochStorePruner,
+    _objects_pruner: AuthorityStorePruner,
+    _authority_per_epoch_pruner: AuthorityPerEpochStorePruner,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures safety.
@@ -1450,6 +1452,7 @@ impl AuthorityState {
         prometheus_registry: &Registry,
         pruning_config: &AuthorityStorePruningConfig,
         genesis_objects: &[Object],
+        epoch_duration_ms: u64,
     ) -> Arc<Self> {
         let native_functions =
             sui_framework::natives::all_natives(MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS);
@@ -1473,7 +1476,13 @@ impl AuthorityState {
         ));
         let (tx_execution_shutdown, rx_execution_shutdown) = oneshot::channel();
 
-        let _pruner =
+        let _objects_pruner = AuthorityStorePruner::new(
+            store.perpetual_tables.clone(),
+            checkpoint_store.clone(),
+            pruning_config,
+            epoch_duration_ms,
+        );
+        let _authority_per_epoch_pruner =
             AuthorityPerEpochStorePruner::new(epoch_store.get_parent_path(), pruning_config);
 
         let state = Arc::new(AuthorityState {
@@ -1493,7 +1502,8 @@ impl AuthorityState {
             transaction_manager,
             tx_execution_shutdown: Mutex::new(Some(tx_execution_shutdown)),
             metrics,
-            _pruner,
+            _objects_pruner,
+            _authority_per_epoch_pruner,
         });
 
         prometheus_registry
@@ -1548,7 +1558,6 @@ impl AuthorityState {
                 None,
                 &genesis_committee,
                 genesis,
-                &AuthorityStorePruningConfig::default(),
             )
             .await
             .unwrap(),
@@ -1585,6 +1594,7 @@ impl AuthorityState {
             &registry,
             &AuthorityStorePruningConfig::default(),
             genesis.objects(),
+            10000,
         )
         .await;
 

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -1,25 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::checkpoints::checkpoint_executor::{
-    CheckpointExecutionMessage, CheckpointExecutionState,
-};
+use crate::checkpoints::CheckpointStore;
 use mysten_metrics::monitored_scope;
 use std::cmp::max;
 use std::collections::HashMap;
 use std::{sync::Arc, time::Duration};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_types::base_types::SequenceNumber;
+use sui_types::messages::TransactionEffects;
 use sui_types::object::Object;
 use sui_types::{
     base_types::{ObjectID, VersionNumber},
     storage::ObjectKey,
 };
 use tokio::{
-    sync::{
-        mpsc,
-        oneshot::{self, Sender},
-    },
+    sync::oneshot::{self, Sender},
     time::{self, Instant},
 };
 use tracing::log::{error, info};
@@ -29,7 +25,6 @@ use typed_store::Map;
 use super::authority_store_tables::AuthorityPerpetualTables;
 
 const MAX_OPS_IN_ONE_WRITE_BATCH: u64 = 10000;
-const ENABLE_LIVE_PRUNER: bool = cfg!(test) || cfg!(msim);
 
 pub struct AuthorityStorePruner {
     _objects_pruner_cancel_handle: oneshot::Sender<()>,
@@ -134,7 +129,7 @@ impl AuthorityStorePruner {
     }
 
     fn handle_checkpoint(
-        checkpoint_execution_state: CheckpointExecutionState,
+        checkpoint_effects: impl IntoIterator<Item = TransactionEffects>,
         objects: &DBMap<ObjectKey, Object>,
     ) -> anyhow::Result<usize> {
         let _scope = monitored_scope("ObjectsLivePruner");
@@ -142,7 +137,7 @@ impl AuthorityStorePruner {
         let mut wb = objects.batch();
         let mut updates = HashMap::new();
 
-        for effects in checkpoint_execution_state.effects {
+        for effects in checkpoint_effects {
             for (object_id, seq_number) in effects.modified_at_versions {
                 updates
                     .entry(object_id)
@@ -165,12 +160,49 @@ impl AuthorityStorePruner {
         Ok(pruned)
     }
 
+    fn process_checkpoints(
+        perpetual_db: &Arc<AuthorityPerpetualTables>,
+        checkpoint_store: &Arc<CheckpointStore>,
+        num_epochs_to_retain: u64,
+    ) -> anyhow::Result<()> {
+        let mut pruned_seq_number = checkpoint_store
+            .get_highest_pruned_checkpoint_seq_number()?
+            .unwrap_or_default();
+        let current_epoch = checkpoint_store
+            .get_highest_executed_checkpoint()?
+            .map(|c| c.epoch())
+            .unwrap_or_default();
+        loop {
+            let Some(checkpoint) = checkpoint_store.get_checkpoint_by_sequence_number(pruned_seq_number + 1)?
+                else {return Ok(());};
+            // checkpoint's epoch is too new. Skipping for now
+            if current_epoch < checkpoint.epoch() + num_epochs_to_retain {
+                return Ok(());
+            }
+            let content = checkpoint_store
+                .get_checkpoint_contents(&checkpoint.content_digest())?
+                .ok_or_else(|| anyhow::anyhow!("checkpoint content data is missing"))?;
+            let effects = perpetual_db
+                .effects
+                .multi_get(content.iter().map(|tx| tx.effects))?;
+
+            if effects.iter().any(|effect| effect.is_none()) {
+                return Err(anyhow::anyhow!("transaction effects data is missing"));
+            }
+            Self::handle_checkpoint(effects.into_iter().flatten(), &perpetual_db.objects)?;
+            checkpoint_store.update_highest_pruned_checkpoint(&checkpoint)?;
+            pruned_seq_number += 1;
+        }
+    }
+
     fn setup_objects_pruning(
         num_versions_to_retain: u64,
         pruning_timeperiod: Duration,
         pruning_initial_delay: Duration,
+        num_epochs_to_retain: u64,
+        epoch_duration_ms: u64,
         perpetual_db: Arc<AuthorityPerpetualTables>,
-        mut checkpoint_stream: mpsc::Receiver<CheckpointExecutionMessage>,
+        checkpoint_store: Arc<CheckpointStore>,
     ) -> Sender<()> {
         let (sender, mut recv) = tokio::sync::oneshot::channel();
         info!(
@@ -179,6 +211,14 @@ impl AuthorityStorePruner {
         let mut prune_interval =
             tokio::time::interval_at(Instant::now() + pruning_initial_delay, pruning_timeperiod);
         prune_interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+        let duration_ms = if num_epochs_to_retain > 0 {
+            epoch_duration_ms / 2
+        } else {
+            1000
+        };
+        let mut live_prune_interval = tokio::time::interval(Duration::from_millis(duration_ms));
+
         tokio::task::spawn(async move {
             loop {
                 tokio::select! {
@@ -192,23 +232,10 @@ impl AuthorityStorePruner {
                             error!("Failed to flush objects table");
                         }
                     },
-                    Some((state, callback)) = checkpoint_stream.recv() => {
-                        if !ENABLE_LIVE_PRUNER {
-                            callback.send(()).expect("failed to notify checkpoint executor");
-                            continue;
-                        }
-                        loop {
-                            match Self::handle_checkpoint(state.clone(), &perpetual_db.objects) {
-                                Ok(pruned) => {
-                                    info!("Pruned {} objects", pruned);
-                                    callback.send(()).expect("failed to notify checkpoint executor");
-                                    break;
-                                }
-                                Err(err) => {
-                                    error!("Failed to prune objects: {:?}, blocking checkpoint execution", err);
-                                    tokio::time::sleep(Duration::from_millis(50)).await;
-                                }
-                            }
+                    _ = live_prune_interval.tick(), if num_epochs_to_retain != u64::MAX => {
+                        match Self::process_checkpoints(&perpetual_db, &checkpoint_store, num_epochs_to_retain) {
+                            Ok(()) => info!("Pruned checkpoints"),
+                            Err(err) => error!("Failed to prune objects: {:?}", err),
                         }
                     },
                     _ = &mut recv => break,
@@ -219,16 +246,19 @@ impl AuthorityStorePruner {
     }
     pub fn new(
         perpetual_db: Arc<AuthorityPerpetualTables>,
+        checkpoint_store: Arc<CheckpointStore>,
         pruning_config: &AuthorityStorePruningConfig,
-        checkpoint_stream: mpsc::Receiver<CheckpointExecutionMessage>,
+        epoch_duration_ms: u64,
     ) -> Self {
         AuthorityStorePruner {
             _objects_pruner_cancel_handle: Self::setup_objects_pruning(
                 pruning_config.objects_num_latest_versions_to_retain,
                 Duration::from_secs(pruning_config.objects_pruning_period_secs),
                 Duration::from_secs(pruning_config.objects_pruning_initial_delay_secs),
+                pruning_config.num_epochs_to_retain,
+                epoch_duration_ms,
                 perpetual_db,
-                checkpoint_stream,
+                checkpoint_store,
             ),
         }
     }
@@ -244,7 +274,6 @@ mod tests {
     use tracing::log::{error, info};
 
     use crate::authority::authority_store_tables::AuthorityPerpetualTables;
-    use crate::checkpoints::checkpoint_executor::CheckpointExecutionState;
     #[cfg(not(target_env = "msvc"))]
     use pprof::Symbol;
     use sui_types::base_types::VersionNumber;
@@ -360,12 +389,8 @@ mod tests {
                 modified_at_versions: to_delete.into_iter().map(|o| (o.0, o.1)).collect(),
                 ..Default::default()
             };
-            let checkpoint_state = CheckpointExecutionState {
-                effects: vec![effects],
-                checkpoint_sequence_number: 0,
-            };
             let pruned =
-                AuthorityStorePruner::handle_checkpoint(checkpoint_state, &db.objects).unwrap();
+                AuthorityStorePruner::handle_checkpoint(vec![effects], &db.objects).unwrap();
             assert_eq!(pruned, 1000);
             to_keep
         };

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -26,10 +26,10 @@ use std::{
 
 use futures::stream::FuturesOrdered;
 use itertools::izip;
-use mysten_metrics::{monitored_scope, spawn_monitored_task};
+use mysten_metrics::spawn_monitored_task;
 use prometheus::Registry;
 use sui_config::node::CheckpointExecutorConfig;
-use sui_types::error::SuiError;
+use sui_types::error::SuiResult;
 use sui_types::{
     base_types::{ExecutionDigests, TransactionDigest},
     messages::{TransactionEffects, VerifiedCertificate},
@@ -41,10 +41,7 @@ use sui_types::{
 };
 use tap::TapFallible;
 use tokio::{
-    sync::{
-        broadcast::{self, error::RecvError},
-        mpsc, oneshot,
-    },
+    sync::broadcast::{self, error::RecvError},
     task::JoinHandle,
     time::timeout,
 };
@@ -63,15 +60,7 @@ mod metrics;
 #[cfg(test)]
 pub(crate) mod tests;
 
-#[derive(Debug, Clone)]
-pub struct CheckpointExecutionState {
-    pub effects: Vec<TransactionEffects>,
-    pub checkpoint_sequence_number: CheckpointSequenceNumber,
-}
-pub type CheckpointExecutionMessage = (CheckpointExecutionState, oneshot::Sender<()>);
-
-type CheckpointExecutionBuffer =
-    FuturesOrdered<JoinHandle<(VerifiedCheckpoint, CheckpointExecutionState)>>;
+type CheckpointExecutionBuffer = FuturesOrdered<JoinHandle<VerifiedCheckpoint>>;
 
 pub struct CheckpointExecutor {
     mailbox: broadcast::Receiver<VerifiedCheckpoint>,
@@ -80,7 +69,6 @@ pub struct CheckpointExecutor {
     tx_manager: Arc<TransactionManager>,
     config: CheckpointExecutorConfig,
     metrics: Arc<CheckpointExecutorMetrics>,
-    pruner_subscriber: mpsc::Sender<CheckpointExecutionMessage>,
 }
 
 impl CheckpointExecutor {
@@ -91,7 +79,6 @@ impl CheckpointExecutor {
         tx_manager: Arc<TransactionManager>,
         config: CheckpointExecutorConfig,
         prometheus_registry: &Registry,
-        pruner_subscriber: mpsc::Sender<CheckpointExecutionMessage>,
     ) -> Self {
         Self {
             mailbox,
@@ -100,7 +87,6 @@ impl CheckpointExecutor {
             tx_manager,
             config,
             metrics: CheckpointExecutorMetrics::new(prometheus_registry),
-            pruner_subscriber,
         }
     }
 
@@ -117,7 +103,6 @@ impl CheckpointExecutor {
             tx_manager,
             config: Default::default(),
             metrics: CheckpointExecutorMetrics::new_for_tests(),
-            pruner_subscriber: mpsc::channel(2).0,
         }
     }
 
@@ -174,8 +159,8 @@ impl CheckpointExecutor {
                 // watermark accordingly. Note that given that checkpoints are guaranteed to
                 // be processed (added to FuturesOrdered) in seq_number order, using FuturesOrdered
                 // guarantees that we will also ratchet the watermarks in order.
-                Some(Ok((checkpoint, checkpoint_execution_state))) = pending.next() => {
-                    self.process_executed_checkpoint(&checkpoint, checkpoint_execution_state).await;
+                Some(Ok(checkpoint)) = pending.next() => {
+                    self.process_executed_checkpoint(&checkpoint);
                     highest_executed = Some(checkpoint);
                 }
                 // Check for newly synced checkpoints from StateSync.
@@ -210,12 +195,7 @@ impl CheckpointExecutor {
 
     /// Post processing and plumbing after we executed a checkpoint. This function is guaranteed
     /// to be called in the order of checkpoint sequence number.
-    async fn process_executed_checkpoint(
-        &self,
-        checkpoint: &VerifiedCheckpoint,
-        execution_state: CheckpointExecutionState,
-    ) {
-        let _scope = monitored_scope("ProcessExecutedCheckpoint");
+    fn process_executed_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {
         // Ensure that we are not skipping checkpoints at any point
         let seq = checkpoint.sequence_number();
         if let Some(prev_highest) = self
@@ -228,18 +208,6 @@ impl CheckpointExecutor {
             assert_eq!(seq, 0);
         }
         debug!("Bumping highest_executed_checkpoint watermark to {:?}", seq,);
-
-        let (callback_sender, callback_receiver) = oneshot::channel();
-        match self
-            .pruner_subscriber
-            .send((execution_state, callback_sender))
-            .await
-        {
-            Ok(_) => callback_receiver
-                .await
-                .expect("failed to get callback from pruner"),
-            Err(err) => error!("no active receivers for checkpoint stream: {:?}", err),
-        }
 
         self.checkpoint_store
             .update_highest_executed_checkpoint(checkpoint)
@@ -291,7 +259,6 @@ impl CheckpointExecutor {
         pending: &mut CheckpointExecutionBuffer,
         epoch_store: Arc<AuthorityPerEpochStore>,
     ) {
-        let _scope = monitored_scope("ScheduleCheckpoint");
         debug!("Executing checkpoint {:?}", checkpoint.sequence_number());
 
         // Mismatch between node epoch and checkpoint epoch after startup
@@ -318,29 +285,25 @@ impl CheckpointExecutor {
 
         pending.push_back(spawn_monitored_task!(async move {
             let epoch_store = epoch_store.clone();
-            loop {
-                match execute_checkpoint(
-                    checkpoint.clone(),
-                    authority_store.clone(),
-                    checkpoint_store.clone(),
-                    &epoch_store,
-                    tx_manager.clone(),
-                    local_execution_timeout_sec,
-                    &metrics,
-                )
-                .await
-                {
-                    Ok(execution_state) => return (checkpoint, execution_state),
-                    Err(err) => {
-                        error!(
-                            "Error while executing checkpoint, will retry in 1s: {:?}",
-                            err
-                        );
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                        metrics.checkpoint_exec_errors.inc();
-                    }
-                }
+            while let Err(err) = execute_checkpoint(
+                checkpoint.clone(),
+                authority_store.clone(),
+                checkpoint_store.clone(),
+                &epoch_store,
+                tx_manager.clone(),
+                local_execution_timeout_sec,
+                &metrics,
+            )
+            .await
+            {
+                error!(
+                    "Error while executing checkpoint, will retry in 1s: {:?}",
+                    err
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                metrics.checkpoint_exec_errors.inc();
             }
+            checkpoint
         }));
     }
 }
@@ -388,7 +351,7 @@ pub async fn execute_checkpoint(
     transaction_manager: Arc<TransactionManager>,
     local_execution_timeout_sec: u64,
     metrics: &Arc<CheckpointExecutorMetrics>,
-) -> Result<CheckpointExecutionState, SuiError> {
+) -> SuiResult {
     debug!(
         "Scheduling checkpoint {:?} for execution",
         checkpoint.sequence_number(),
@@ -430,7 +393,7 @@ async fn execute_transactions(
     transaction_manager: Arc<TransactionManager>,
     log_timeout_sec: u64,
     checkpoint_sequence: CheckpointSequenceNumber,
-) -> Result<CheckpointExecutionState, SuiError> {
+) -> SuiResult {
     let all_tx_digests: Vec<TransactionDigest> =
         execution_digests.iter().map(|tx| tx.transaction).collect();
 
@@ -523,11 +486,7 @@ async fn execute_transactions(
                     checkpoint_sequence,
                 )?;
 
-                let execution_state = CheckpointExecutionState {
-                    effects,
-                    checkpoint_sequence_number: checkpoint_sequence,
-                };
-                return Ok(execution_state);
+                return Ok(());
             }
         }
     }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2669,6 +2669,7 @@ async fn test_authority_persist() {
             &registry,
             &AuthorityStorePruningConfig::default(),
             &[], // no genesis objects
+            10000,
         )
         .await
     }
@@ -2684,15 +2685,9 @@ async fn test_authority_persist() {
 
     // Create an authority
     let store = Arc::new(
-        AuthorityStore::open_with_committee_for_testing(
-            &path,
-            None,
-            &committee,
-            &genesis,
-            &AuthorityStorePruningConfig::default(),
-        )
-        .await
-        .unwrap(),
+        AuthorityStore::open_with_committee_for_testing(&path, None, &committee, &genesis)
+            .await
+            .unwrap(),
     );
     let authority = init_state(committee, authority_key, store).await;
 
@@ -2716,15 +2711,9 @@ async fn test_authority_persist() {
     let (genesis, authority_key) = init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     let committee = genesis.committee().unwrap();
     let store = Arc::new(
-        AuthorityStore::open_with_committee_for_testing(
-            &path,
-            None,
-            &committee,
-            &genesis,
-            &AuthorityStorePruningConfig::default(),
-        )
-        .await
-        .unwrap(),
+        AuthorityStore::open_with_committee_for_testing(&path, None, &committee, &genesis)
+            .await
+            .unwrap(),
     );
     let authority2 = init_state(committee, authority_key, store).await;
     let obj2 = authority2.get_object(&object_id).await.unwrap().unwrap();

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -51,7 +51,7 @@ use sui_storage::{
 use sui_types::committee::Committee;
 use sui_types::crypto::KeypairTraits;
 use sui_types::quorum_driver_types::QuorumDriverEffectsQueueResult;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::broadcast;
 use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
 use tower::ServiceBuilder;
@@ -66,7 +66,6 @@ use narwhal_types::TransactionsClient;
 use sui_core::authority::authority_per_epoch_store::{
     AuthorityPerEpochStore, EpochStartConfiguration,
 };
-use sui_core::checkpoints::checkpoint_executor::CheckpointExecutionMessage;
 use sui_core::checkpoints::{
     CheckpointMetrics, CheckpointService, CheckpointStore, SendCheckpointToStateSync,
     SubmitCheckpointToConsensus,
@@ -144,15 +143,12 @@ impl SuiNode {
             &genesis_committee,
             None,
         ));
-        let (checkpoint_sender, checkpoint_receiver) = mpsc::channel(10);
         let store = Arc::new(
             AuthorityStore::open(
                 &config.db_path().join("store"),
                 None,
                 genesis,
                 &committee_store,
-                &config.authority_store_pruning_config,
-                checkpoint_receiver,
             )
             .await?,
         );
@@ -225,6 +221,7 @@ impl SuiNode {
             &prometheus_registry,
             &config.authority_store_pruning_config,
             genesis.objects(),
+            config.epoch_duration_ms,
         )
         .await;
 
@@ -309,9 +306,7 @@ impl SuiNode {
         info!("SuiNode started!");
         let node = Arc::new(node);
         let node_copy = node.clone();
-        spawn_monitored_task!(async move {
-            Self::monitor_reconfiguration(node_copy, checkpoint_sender).await
-        });
+        spawn_monitored_task!(async move { Self::monitor_reconfiguration(node_copy).await });
 
         Ok(node)
     }
@@ -727,10 +722,7 @@ impl SuiNode {
 
     /// This function waits for a signal from the checkpoint executor to indicate that on-chain
     /// epoch has changed. Upon receiving such signal, we reconfigure the entire system.
-    pub async fn monitor_reconfiguration(
-        self: Arc<Self>,
-        checkpoint_sender: mpsc::Sender<CheckpointExecutionMessage>,
-    ) -> Result<()> {
+    pub async fn monitor_reconfiguration(self: Arc<Self>) -> Result<()> {
         let mut checkpoint_executor = CheckpointExecutor::new(
             self.state_sync.subscribe_to_synced_checkpoints(),
             self.checkpoint_store.clone(),
@@ -738,7 +730,6 @@ impl SuiNode {
             self.state.transaction_manager().clone(),
             self.config.checkpoint_executor_config.clone(),
             &self.registry_service.default_registry(),
-            checkpoint_sender,
         );
 
         loop {


### PR DESCRIPTION
the current version of pruner is implemented in an aggressive fashion: it subscribes to executed checkpoint stream and removes all previous object versions. This allows to remove stale data ASAP, but doesn’t work well with the following use cases:
* in future iterations of the product, indexer will need a reasonable time window to access old versions of objects
* we might need to delay pruning for debugging purposes

This PR changes the flow to keep old object versions for the last N epochs of data and makes the parameter configurable.
To simulate aggressive behaviour it can be set to 0
