### PR TITLE
[3/x][programmable transaction] Start of execution runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8413,6 +8413,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "once_cell",
+ "serde 1.0.152",
  "sui-cost-tables",
  "sui-framework",
  "sui-json",

--- a/crates/sui-adapter/Cargo.toml
+++ b/crates/sui-adapter/Cargo.toml
@@ -14,6 +14,7 @@ leb128 = "0.2.5"
 once_cell = "1.16"
 linked-hash-map = "0.5.6"
 tracing = "0.1.36"
+serde = { version = "1.0.140", features = ["derive"] }
 
 move-binary-format.workspace = true
 move-bytecode-verifier.workspace = true

--- a/crates/sui-adapter/src/lib.rs
+++ b/crates/sui-adapter/src/lib.rs
@@ -11,13 +11,15 @@ macro_rules! invariant_violation {
 }
 
 macro_rules! assert_invariant {
-    ($cond:expr, $msg:expr) => {
+    ($cond:expr, $msg:expr) => {{
         if !$cond {
             invariant_violation!($msg)
         }
-    };
+    }};
 }
 
 pub mod adapter;
 pub mod execution_engine;
 pub mod execution_mode;
+pub mod genesis;
+pub mod programmable_transactions;

--- a/crates/sui-adapter/src/lib.rs
+++ b/crates/sui-adapter/src/lib.rs
@@ -21,5 +21,4 @@ macro_rules! assert_invariant {
 pub mod adapter;
 pub mod execution_engine;
 pub mod execution_mode;
-pub mod genesis;
 pub mod programmable_transactions;

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -1,0 +1,224 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, fmt};
+
+use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_vm_runtime::{move_vm::MoveVM, session::Session};
+use sui_cost_tables::bytecode_tables::GasStatus;
+use sui_types::{
+    base_types::{ObjectID, SuiAddress, TxContext},
+    error::ExecutionError,
+    messages::{Argument, CallArg, ObjectArg},
+    object::Owner,
+    storage::{ChildObjectResolver, ParentSync, Storage},
+};
+
+use crate::adapter::new_session;
+
+use super::types::*;
+
+pub struct ExecutionContext<
+    'v,
+    's,
+    'a,
+    'b,
+    E: fmt::Debug,
+    S: ResourceResolver<Error = E>
+        + ModuleResolver<Error = E>
+        + Storage
+        + ParentSync
+        + ChildObjectResolver,
+> {
+    vm: &'v MoveVM,
+    state_view: &'s S,
+    ctx: &'a mut TxContext,
+    gas_status: &'a mut GasStatus<'b>,
+    session: Option<Session<'s, 'v, S>>,
+    object_owner_map: BTreeMap<ObjectID, Owner>,
+    pub gas: Option<Value>,
+    pub inputs: Vec<Option<Value>>,
+    pub results: Vec<Vec<Option<Value>>>,
+    // transfers not from the Move runtime
+    additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
+}
+impl<'v, 's, 'a, 'b, E, S> ExecutionContext<'v, 's, 'a, 'b, E, S>
+where
+    E: fmt::Debug,
+    S: ResourceResolver<Error = E>
+        + ModuleResolver<Error = E>
+        + Storage
+        + ParentSync
+        + ChildObjectResolver,
+{
+    pub fn new(
+        vm: &'v MoveVM,
+        state_view: &'s S,
+        ctx: &'a mut TxContext,
+        gas_status: &'a mut GasStatus<'b>,
+        gas_coin: ObjectID,
+        inputs: Vec<CallArg>,
+    ) -> Result<Self, ExecutionError> {
+        let mut object_owner_map = BTreeMap::new();
+        let inputs = inputs
+            .into_iter()
+            .map(|call_arg| {
+                Ok(Some(load_call_arg(
+                    state_view,
+                    &mut object_owner_map,
+                    call_arg,
+                )?))
+            })
+            .collect::<Result<_, ExecutionError>>()?;
+        let gas = Some(Value::Object(load_object(
+            state_view,
+            &mut object_owner_map,
+            gas_coin,
+        )?));
+        Ok(Self {
+            vm,
+            state_view,
+            ctx,
+            gas_status,
+            session: None,
+            object_owner_map,
+            gas,
+            inputs,
+            results: vec![],
+            additional_transfers: vec![],
+        })
+    }
+
+    pub fn session(&mut self) -> &Session<'s, 'v, S> {
+        self.session.get_or_insert_with(|| {
+            new_session(
+                self.vm,
+                self.state_view,
+                self.object_owner_map.clone(),
+                self.gas_status.is_metered(),
+            )
+        })
+    }
+
+    pub fn fresh_id(&mut self) -> Result<ObjectID, ExecutionError> {
+        if true {
+            todo!("update native context set")
+        }
+        Ok(self.ctx.fresh_id())
+    }
+
+    pub fn delete_id(&mut self, _object_id: ObjectID) -> Result<(), ExecutionError> {
+        if true {
+            todo!("update native context set")
+        }
+        Ok(())
+    }
+
+    pub fn take_args<V: TryFromValue>(
+        &mut self,
+        args: Vec<Argument>,
+    ) -> Result<Vec<V>, ExecutionError> {
+        args.into_iter()
+            .map(|arg| self.take_arg::<V>(arg))
+            .collect()
+    }
+
+    pub fn take_arg<V: TryFromValue>(&mut self, arg: Argument) -> Result<V, ExecutionError> {
+        let val_opt = self.borrow_mut(arg)?;
+        if val_opt.is_none() {
+            panic!("taken value")
+        }
+        V::try_from_value(val_opt.take().unwrap())
+    }
+
+    pub fn restore_arg(&mut self, arg: Argument, value: Value) -> Result<(), ExecutionError> {
+        let val_opt = self.borrow_mut(arg)?;
+        assert_invariant!(
+            val_opt.is_none(),
+            "Should never restore a non-taken value. \
+            The take+restore is an implementation detail of mutable references"
+        );
+        *val_opt = Some(value);
+        Ok(())
+    }
+
+    fn borrow_mut(&mut self, arg: Argument) -> Result<&mut Option<Value>, ExecutionError> {
+        Ok(match arg {
+            Argument::GasCoin => &mut self.gas,
+            Argument::Input(i) => {
+                let Some(inner_opt) = self.inputs.get_mut(i as usize) else {
+                    panic!("out of bounds")
+                };
+                inner_opt
+            }
+            Argument::Result(i) => {
+                let Some(command_result) = self.results.get_mut(i as usize) else {
+                    panic!("out of bounds")
+                };
+                if command_result.len() != 1 {
+                    panic!("expected a single result")
+                }
+                &mut command_result[0]
+            }
+            Argument::NestedResult(i, j) => {
+                let Some(command_result) = self.results.get_mut(i as usize) else {
+                    panic!("out of bounds")
+                };
+                let Some(inner_opt) = command_result.get_mut(j as usize) else {
+                    panic!("out of bounds")
+                };
+                inner_opt
+            }
+        })
+    }
+
+    pub fn transfer_object(
+        &mut self,
+        obj: ObjectValue,
+        arg: SuiAddress,
+    ) -> Result<(), ExecutionError> {
+        self.additional_transfers.push((arg, obj));
+        Ok(())
+    }
+}
+
+fn load_object<S: Storage>(
+    state_view: &S,
+    object_owner_map: &mut BTreeMap<ObjectID, Owner>,
+    id: ObjectID,
+) -> Result<ObjectValue, ExecutionError> {
+    let Some(obj) = state_view.read_object(&id) else {
+        invariant_violation!(format!("Object {} does not exist yet", id));
+    };
+    let prev = object_owner_map.insert(id, obj.owner);
+    assert_invariant!(prev.is_none(), format!("Duplicate input object {}", id));
+    ObjectValue::from_object(obj)
+}
+
+fn load_call_arg<S: Storage>(
+    state_view: &S,
+    object_owner_map: &mut BTreeMap<ObjectID, Owner>,
+    call_arg: CallArg,
+) -> Result<Value, ExecutionError> {
+    Ok(match call_arg {
+        CallArg::Pure(bytes) => Value::Raw(ValueType::Any, bytes),
+        CallArg::Object(obj_arg) => {
+            Value::Object(load_object_arg(state_view, object_owner_map, obj_arg)?)
+        }
+        CallArg::ObjVec(_) => {
+            invariant_violation!("ObjVec is not supported in programmable transactions")
+        }
+    })
+}
+
+fn load_object_arg<S: Storage>(
+    state_view: &S,
+    object_owner_map: &mut BTreeMap<ObjectID, Owner>,
+    obj_arg: ObjectArg,
+) -> Result<ObjectValue, ExecutionError> {
+    match obj_arg {
+        ObjectArg::ImmOrOwnedObject((id, _, _)) | ObjectArg::SharedObject { id, .. } => {
+            load_object(state_view, object_owner_map, id)
+        }
+    }
+}

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use move_vm_runtime::move_vm::MoveVM;
 use sui_cost_tables::bytecode_tables::GasStatus;
+use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     balance::Balance,
     base_types::{ObjectID, SuiAddress, TxContext},
@@ -26,6 +27,7 @@ pub fn execute<
         + ParentSync
         + ChildObjectResolver,
 >(
+    protocol_config: &ProtocolConfig,
     vm: &MoveVM,
     state_view: &mut S,
     ctx: &mut TxContext,
@@ -34,7 +36,15 @@ pub fn execute<
     pt: ProgrammableTransaction,
 ) -> Result<(), ExecutionError> {
     let ProgrammableTransaction { inputs, commands } = pt;
-    let mut context = ExecutionContext::new(vm, state_view, ctx, gas_status, gas_coin, inputs)?;
+    let mut context = ExecutionContext::new(
+        protocol_config,
+        vm,
+        state_view,
+        ctx,
+        gas_status,
+        gas_coin,
+        inputs,
+    )?;
     for command in commands {
         execute_command(&mut context, command)?;
     }

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_vm_runtime::move_vm::MoveVM;
+use sui_cost_tables::bytecode_tables::GasStatus;
+use sui_types::{
+    balance::Balance,
+    base_types::{ObjectID, SuiAddress, TxContext},
+    coin::Coin,
+    error::ExecutionError,
+    id::UID,
+    messages::{Command, ProgrammableTransaction},
+    storage::{ChildObjectResolver, ParentSync, Storage},
+};
+
+use super::{context::*, types::*};
+
+pub fn execute<
+    E: fmt::Debug,
+    S: ResourceResolver<Error = E>
+        + ModuleResolver<Error = E>
+        + Storage
+        + ParentSync
+        + ChildObjectResolver,
+>(
+    vm: &MoveVM,
+    state_view: &mut S,
+    ctx: &mut TxContext,
+    gas_status: &mut GasStatus,
+    gas_coin: ObjectID,
+    pt: ProgrammableTransaction,
+) -> Result<(), ExecutionError> {
+    let ProgrammableTransaction { inputs, commands } = pt;
+    let mut context = ExecutionContext::new(vm, state_view, ctx, gas_status, gas_coin, inputs)?;
+    for command in commands {
+        execute_command(&mut context, command)?;
+    }
+    Ok(())
+}
+
+fn execute_command<
+    E: fmt::Debug,
+    S: ResourceResolver<Error = E>
+        + ModuleResolver<Error = E>
+        + Storage
+        + ParentSync
+        + ChildObjectResolver,
+>(
+    context: &mut ExecutionContext<E, S>,
+    command: Command,
+) -> Result<(), ExecutionError> {
+    let is_transfer_objects = matches!(command, Command::TransferObjects(_, _));
+    let results = match command {
+        Command::TransferObjects(objs, addr_arg) => {
+            let objs: Vec<ObjectValue> = context.take_args(objs)?;
+            let addr: SuiAddress = context.take_arg(addr_arg)?;
+            for obj in objs {
+                obj.ensure_public_transfer_eligible()?;
+                context.transfer_object(obj, addr)?;
+            }
+            vec![]
+        }
+        Command::SplitCoin(coin_arg, amount_arg) => {
+            let mut obj: ObjectValue = context.take_arg(coin_arg)?;
+            let ObjectContents::Coin(coin) = &mut obj.contents else {
+                panic!("not a coin")
+            };
+            let amount: u64 = context.take_arg(amount_arg)?;
+            let new_coin_id = context.fresh_id()?;
+            let new_coin = coin.split_coin(amount, UID::new(new_coin_id))?;
+            let coin_type = obj.type_.clone();
+            context.restore_arg(coin_arg, Value::Object(obj))?;
+            vec![Some(Value::Object(ObjectValue::coin(coin_type, new_coin)?))]
+        }
+        Command::MergeCoins(target_arg, coin_args) => {
+            let mut target: ObjectValue = context.take_arg(target_arg)?;
+            let ObjectContents::Coin(target_coin) = &mut target.contents else {
+                panic!("not a coin")
+            };
+            let coins: Vec<ObjectValue> = context.take_args(coin_args)?;
+            for coin in coins {
+                let ObjectContents::Coin(Coin { id, balance }) = coin.contents else {
+                    panic!("not a coin")
+                };
+                context.delete_id(*id.object_id())?;
+                let Some(new_value) = target_coin.balance.value().checked_add(balance.value())
+                    else {
+                        panic!("coin overflow")
+                    };
+                target_coin.balance = Balance::new(new_value);
+            }
+            context.restore_arg(target_arg, Value::Object(target))?;
+            vec![]
+        }
+        Command::MoveCall(_) => todo!(),
+        Command::Publish(_) => todo!(),
+    };
+    context.results.push(results);
+    if !is_transfer_objects && context.gas.is_none() {
+        panic!("todo gas taken error")
+    }
+    Ok(())
+}

--- a/crates/sui-adapter/src/programmable_transactions/mod.rs
+++ b/crates/sui-adapter/src/programmable_transactions/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod context;
+pub mod execution;
+pub mod types;

--- a/crates/sui-adapter/src/programmable_transactions/types.rs
+++ b/crates/sui-adapter/src/programmable_transactions/types.rs
@@ -1,0 +1,161 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::file_format::AbilitySet;
+use move_core_types::language_storage::StructTag;
+use move_vm_types::loaded_data::runtime_types::Type;
+use serde::Deserialize;
+use sui_types::{
+    base_types::SuiAddress,
+    coin::Coin,
+    error::{ExecutionError, ExecutionErrorKind},
+    object::{Data, MoveObject, Object, Owner},
+};
+
+pub enum Value {
+    Object(ObjectValue),
+    Raw(ValueType, Vec<u8>),
+}
+
+pub struct ObjectValue {
+    pub type_: StructTag,
+    pub has_public_transfer: bool,
+    // None for objects created this transaction
+    pub owner: Option<Owner>,
+    // true if it has been used in a public Move call
+    // In other words, false if all usages have been with non-Move comamnds or
+    // entry Move functions
+    pub used_in_public_move_call: bool,
+    pub contents: ObjectContents,
+}
+
+pub enum ObjectContents {
+    Coin(Coin),
+    Raw(Vec<u8>),
+}
+
+pub enum ValueType {
+    Any,
+    Loaded { ty: Type, abilities: AbilitySet },
+}
+
+impl Value {}
+
+impl ObjectValue {
+    pub fn from_object(object: &Object) -> Result<Self, ExecutionError> {
+        let Object { data, owner, .. } = object;
+        match data {
+            Data::Package(_) => invariant_violation!("Expected a Move object"),
+            Data::Move(move_object) => Self::from_move_object(*owner, move_object),
+        }
+    }
+
+    pub fn from_move_object(owner: Owner, object: &MoveObject) -> Result<Self, ExecutionError> {
+        let type_ = object.type_.clone();
+        let has_public_transfer = object.has_public_transfer();
+        let contents = object.contents();
+        let owner = Some(owner);
+        let used_in_public_move_call = false;
+        let contents = if Coin::is_coin(&type_) {
+            ObjectContents::Coin(Coin::from_bcs_bytes(contents)?)
+        } else {
+            ObjectContents::Raw(contents.to_vec())
+        };
+        Ok(Self {
+            type_,
+            has_public_transfer,
+            owner,
+            used_in_public_move_call,
+            contents,
+        })
+    }
+
+    pub fn coin(type_: StructTag, coin: Coin) -> Result<Self, ExecutionError> {
+        assert_invariant!(
+            Coin::is_coin(&type_),
+            "Cannot make a coin without a coin type"
+        );
+        Ok(Self {
+            type_,
+            has_public_transfer: true,
+            owner: None,
+            used_in_public_move_call: false,
+            contents: ObjectContents::Coin(coin),
+        })
+    }
+
+    pub fn ensure_public_transfer_eligible(&self) -> Result<(), ExecutionError> {
+        if !matches!(self.owner, None | Some(Owner::AddressOwner(_))) {
+            return Err(ExecutionErrorKind::InvalidTransferObject.into());
+        }
+        if !self.has_public_transfer {
+            return Err(ExecutionErrorKind::InvalidTransferObject.into());
+        }
+        Ok(())
+    }
+}
+
+impl ObjectContents {}
+impl ValueType {}
+
+pub trait TryFromValue: Sized {
+    fn try_from_value(value: Value) -> Result<Self, ExecutionError>;
+}
+
+impl TryFromValue for Value {
+    fn try_from_value(value: Value) -> Result<Self, ExecutionError> {
+        Ok(value)
+    }
+}
+
+impl TryFromValue for ObjectValue {
+    fn try_from_value(value: Value) -> Result<Self, ExecutionError> {
+        match value {
+            Value::Object(o) => Ok(o),
+            Value::Raw(ty, _) => {
+                if let ValueType::Loaded { abilities, .. } = ty {
+                    assert_invariant!(!abilities.has_key(), "Raw values should not be objects")
+                }
+                panic!("expected object")
+            }
+        }
+    }
+}
+
+impl TryFromValue for SuiAddress {
+    fn try_from_value(value: Value) -> Result<Self, ExecutionError> {
+        try_from_value_prim(&value, Type::Address)
+    }
+}
+
+impl TryFromValue for u64 {
+    fn try_from_value(value: Value) -> Result<Self, ExecutionError> {
+        try_from_value_prim(&value, Type::U64)
+    }
+}
+
+fn try_from_value_prim<'a, T: Deserialize<'a>>(
+    value: &'a Value,
+    expected_ty: Type,
+) -> Result<T, ExecutionError> {
+    match value {
+        Value::Object(_obj) => panic!("expected raw"),
+        Value::Raw(ValueType::Any, bytes) => {
+            let Ok(val) = bcs::from_bytes(bytes) else {
+                panic!("invalid pure arg")
+            };
+            Ok(val)
+        }
+        Value::Raw(ValueType::Loaded { ty, .. }, bytes) => {
+            if ty == &expected_ty {
+                panic!("type mismatch")
+            }
+            let res = bcs::from_bytes(bytes);
+            assert_invariant!(
+                res.is_ok(),
+                "Move values should be able to deserialize into their type"
+            );
+            Ok(res.unwrap())
+        }
+    }
+}

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -370,7 +370,7 @@ pub enum Command {
 }
 
 /// An argument to a programmable transaction command
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
 pub enum Argument {
     /// The gas coin. The gas coin can only be used by-ref, except for with
     /// `TransferObjects`, which can use it by-value.


### PR DESCRIPTION
- New module in sui-adapter for programmable_transactions
- types contains runtime type information
- context maintains the internal state and execution context
- execution applies changes to the context as the commands run

Built on #8356 