### PR TITLE
Only share peers in discovery with explicitly configured external addresses.

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -198,12 +198,6 @@ pub struct DiscoveryConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peers_to_query: Option<usize>,
 
-    /// Per-peer rate-limit (in requests/sec) for the GetExternalAddress RPC.
-    ///
-    /// If unspecified, this will default to no limit.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub get_external_address_rate_limit: Option<NonZeroU32>,
-
     /// Per-peer rate-limit (in requests/sec) for the GetKnownPeers RPC.
     ///
     /// If unspecified, this will default to no limit.

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -96,15 +96,6 @@ fn build_anemo_services(out_dir: &Path) {
         .package("sui")
         .method(
             anemo_build::manual::Method::builder()
-                .name("get_external_address")
-                .route_name("GetExternalAddress")
-                .request_type("()")
-                .response_type("std::net::SocketAddr")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
-                .build(),
-        )
-        .method(
-            anemo_build::manual::Method::builder()
                 .name("get_known_peers")
                 .route_name("GetKnownPeers")
                 .request_type("()")

--- a/crates/sui-network/src/discovery/builder.rs
+++ b/crates/sui-network/src/discovery/builder.rs
@@ -38,14 +38,6 @@ impl Builder {
         let mut discovery_server = DiscoveryServer::new(server);
 
         // Apply rate limits from configuration as needed.
-        if let Some(limit) = discovery_config.get_external_address_rate_limit {
-            discovery_server = discovery_server.add_layer_for_get_external_address(
-                InboundRequestLayer::new(rate_limit::RateLimitLayer::new(
-                    governor::Quota::per_second(limit),
-                    rate_limit::WaitMode::Block,
-                )),
-            );
-        }
         if let Some(limit) = discovery_config.get_known_peers_rate_limit {
             discovery_server = discovery_server.add_layer_for_get_known_peers(
                 InboundRequestLayer::new(rate_limit::RateLimitLayer::new(

--- a/crates/sui-network/src/discovery/server.rs
+++ b/crates/sui-network/src/discovery/server.rs
@@ -18,20 +18,6 @@ pub(super) struct Server {
 
 #[anemo::async_trait]
 impl Discovery for Server {
-    async fn get_external_address(
-        &self,
-        request: Request<()>,
-    ) -> Result<Response<std::net::SocketAddr>, anemo::rpc::Status> {
-        request
-            .extensions()
-            .get::<std::net::SocketAddr>()
-            .copied()
-            .map(Response::new)
-            .ok_or_else(|| {
-                anemo::rpc::Status::internal("unable to query caller's external address")
-            })
-    }
-
     async fn get_known_peers(
         &self,
         _request: Request<()>,

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -487,15 +487,10 @@ pub(crate) fn make_anemo_config() -> anemo_cli::Config {
         // Sui discovery
         .add_service(
             "Discovery",
-            anemo_cli::ServiceInfo::new()
-                .add_method(
-                    "GetExternalAddress",
-                    anemo_cli::ron_method!(DiscoveryClient, get_external_address, ()),
-                )
-                .add_method(
-                    "GetKnownPeers",
-                    anemo_cli::ron_method!(DiscoveryClient, get_known_peers, ()),
-                ),
+            anemo_cli::ServiceInfo::new().add_method(
+                "GetKnownPeers",
+                anemo_cli::ron_method!(DiscoveryClient, get_known_peers, ()),
+            ),
         )
         // Sui state sync
         .add_service(


### PR DESCRIPTION
Removes external address discovery method.