### PR TITLE
[core] Make certificate optional in validator handle tx/cert API

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -364,8 +364,10 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                                 metrics_cloned.latency_s.with_label_values(&[&b.1.get_workload_type().to_string()]).observe(latency.as_secs_f64());
                                                 metrics_cloned.num_success.with_label_values(&[&b.1.get_workload_type().to_string()]).inc();
                                                 metrics_cloned.num_in_flight.with_label_values(&[&b.1.get_workload_type().to_string()]).dec();
-                                                let auth_sign_info = AuthorityStrongQuorumSignInfo::try_from(&cert.auth_sign_info).unwrap();
-                                                auth_sign_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_tx_cert.with_label_values(&[&name.unwrap().to_string()]).inc());
+                                                if let Some(cert) = cert {
+                                                    let auth_sign_info = AuthorityStrongQuorumSignInfo::try_from(&cert.auth_sign_info).unwrap();
+                                                    auth_sign_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_tx_cert.with_label_values(&[&name.unwrap().to_string()]).inc());
+                                                }
                                                 if let Some(sig_info) = effects.quorum_sig() {
                                                     sig_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_effects_cert.with_label_values(&[&name.unwrap().to_string()]).inc())
                                                 }
@@ -412,8 +414,10 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                             metrics_cloned.latency_s.with_label_values(&[&payload.get_workload_type().to_string()]).observe(latency.as_secs_f64());
                                             metrics_cloned.num_success.with_label_values(&[&payload.get_workload_type().to_string()]).inc();
                                             metrics_cloned.num_in_flight.with_label_values(&[&payload.get_workload_type().to_string()]).dec();
-                                            let auth_sign_info = AuthorityStrongQuorumSignInfo::try_from(&cert.auth_sign_info).unwrap();
-                                            auth_sign_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_tx_cert.with_label_values(&[&name.unwrap().to_string()]).inc());
+                                            if let Some(cert) = cert {
+                                                let auth_sign_info = AuthorityStrongQuorumSignInfo::try_from(&cert.auth_sign_info).unwrap();
+                                                auth_sign_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_tx_cert.with_label_values(&[&name.unwrap().to_string()]).inc());
+                                            }
                                             if let Some(sig_info) = effects.quorum_sig() { sig_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_effects_cert.with_label_values(&[&name.unwrap().to_string()]).inc()) }
                                             NextOp::Response(Some((
                                                 latency,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2160,7 +2160,7 @@ impl AuthorityState {
             .expect("Cannot insert genesis object")
     }
 
-    /// Make an status response for a transaction
+    /// Make a status response for a transaction
     pub fn get_transaction_status(
         &self,
         transaction_digest: &TransactionDigest,

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -224,7 +224,10 @@ struct ProcessCertificateState {
 #[derive(Debug)]
 pub enum ProcessTransactionResult {
     Certified(VerifiedCertificate),
-    Executed(VerifiedCertificate, VerifiedCertifiedTransactionEffects),
+    Executed(
+        Option<VerifiedCertificate>,
+        VerifiedCertifiedTransactionEffects,
+    ),
 }
 
 impl ProcessTransactionResult {
@@ -1057,9 +1060,13 @@ where
                 debug!(?tx_digest, name=?name.concise(), weight, "Received signed transaction from validator handle_transaction");
                 self.handle_transaction_response_with_signed(state, signed)
             }
-            Ok(VerifiedTransactionInfoResponse::Executed(cert, effects)) => {
-                debug!(?tx_digest, name=?name.concise(), weight, "Received prev certificate from validator handle_transaction");
-                self.handle_transaction_response_with_executed(state, cert, effects)
+            Ok(VerifiedTransactionInfoResponse::ExecutedWithCert(cert, effects)) => {
+                debug!(?tx_digest, name=?name.concise(), weight, "Received prev certificate and effects from validator handle_transaction");
+                self.handle_transaction_response_with_executed(state, Some(cert), effects)
+            }
+            Ok(VerifiedTransactionInfoResponse::ExecutedWithoutCert(_, effects)) => {
+                debug!(?tx_digest, name=?name.concise(), weight, "Received prev effects from validator handle_transaction");
+                self.handle_transaction_response_with_executed(state, None, effects)
             }
             Err(err) => {
                 self.record_conflicting_transaction_if_any(state, name, weight, &err);
@@ -1111,28 +1118,32 @@ where
     fn handle_transaction_response_with_executed(
         &self,
         state: &mut ProcessTransactionState,
-        certificate: VerifiedCertificate,
+        certificate: Option<VerifiedCertificate>,
         signed_effects: VerifiedSignedTransactionEffects,
     ) -> SuiResult<Option<ProcessTransactionResult>> {
-        // If we get a certificate in the same epoch, then we use it.
-        // A certificate in a past epoch does not guarantee finality
-        // and validators may reject to process it.
-        if certificate.epoch() == self.committee.epoch {
-            Ok(Some(ProcessTransactionResult::Certified(certificate)))
-        } else {
-            // If we get 2f+1 effects, it's an proof that the transaction
-            // has already been finalized. This works because validators would re-sign effects for transactions
-            // that were finalized in previous epochs.
-            let (effects, sig) = signed_effects.into_inner().into_data_and_sig();
-            match state.effects_map.insert(effects.digest(), &effects, sig) {
-                InsertResult::NotEnoughVotes => Ok(None),
-                InsertResult::Failed { error } => Err(error),
-                InsertResult::QuorumReached(cert_sig) => {
-                    let ct = CertifiedTransactionEffects::new_from_data_and_sig(effects, cert_sig);
-                    Ok(Some(ProcessTransactionResult::Executed(
-                        certificate,
-                        ct.verify(&self.committee)?,
-                    )))
+        match certificate {
+            Some(certificate) if certificate.epoch() == self.committee.epoch => {
+                // If we get a certificate in the same epoch, then we use it.
+                // A certificate in a past epoch does not guarantee finality
+                // and validators may reject to process it.
+                Ok(Some(ProcessTransactionResult::Certified(certificate)))
+            }
+            _ => {
+                // If we get 2f+1 effects, it's an proof that the transaction
+                // has already been finalized. This works because validators would re-sign effects for transactions
+                // that were finalized in previous epochs.
+                let (effects, sig) = signed_effects.into_inner().into_data_and_sig();
+                match state.effects_map.insert(effects.digest(), &effects, sig) {
+                    InsertResult::NotEnoughVotes => Ok(None),
+                    InsertResult::Failed { error } => Err(error),
+                    InsertResult::QuorumReached(cert_sig) => {
+                        let ct =
+                            CertifiedTransactionEffects::new_from_data_and_sig(effects, cert_sig);
+                        Ok(Some(ProcessTransactionResult::Executed(
+                            certificate,
+                            ct.verify(&self.committee)?,
+                        )))
+                    }
                 }
             }
         }
@@ -1292,7 +1303,13 @@ where
     pub async fn execute_transaction(
         &self,
         transaction: &VerifiedTransaction,
-    ) -> Result<(VerifiedCertificate, VerifiedCertifiedTransactionEffects), anyhow::Error> {
+    ) -> Result<
+        (
+            Option<VerifiedCertificate>,
+            VerifiedCertifiedTransactionEffects,
+        ),
+        anyhow::Error,
+    > {
         let result = self
             .process_transaction(transaction.clone())
             .instrument(tracing::debug_span!("process_tx"))
@@ -1309,7 +1326,7 @@ where
             .instrument(tracing::debug_span!("process_cert"))
             .await?;
 
-        Ok((cert, response))
+        Ok((Some(cert), response))
     }
 
     /// This function tries to get SignedTransaction OR CertifiedTransaction from
@@ -1355,8 +1372,15 @@ where
                 }
                 match self.process_transaction(transaction.clone()).await {
                     Ok(ProcessTransactionResult::Certified(cert))
-                    | Ok(ProcessTransactionResult::Executed(cert, _)) => {
+                    | Ok(ProcessTransactionResult::Executed(Some(cert), _)) => {
                         return cert;
+                    }
+                    Ok(ProcessTransactionResult::Executed(None, _)) => {
+                        // Note: This will go away as soon as fianlized transaction work finishes,
+                        // since we will no longer need a cert.
+                        debug!(
+                            "The network has executed this transaction, but no cert is available"
+                        );
                     }
                     Err(err) => {
                         debug!("Did not create advance epoch transaction cert: {:?}", err);

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1129,7 +1129,7 @@ where
                 Ok(Some(ProcessTransactionResult::Certified(certificate)))
             }
             _ => {
-                // If we get 2f+1 effects, it's an proof that the transaction
+                // If we get 2f+1 effects, it's a proof that the transaction
                 // has already been finalized. This works because validators would re-sign effects for transactions
                 // that were finalized in previous epochs.
                 let (effects, sig) = signed_effects.into_inner().into_data_and_sig();
@@ -1376,7 +1376,7 @@ where
                         return cert;
                     }
                     Ok(ProcessTransactionResult::Executed(None, _)) => {
-                        // Note: This will go away as soon as fianlized transaction work finishes,
+                        // Note: This will go away as soon as finalized transaction work finishes,
                         // since we will no longer need a cert.
                         debug!(
                             "The network has executed this transaction, but no cert is available"

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -27,7 +27,7 @@ pub trait AuthorityAPI {
     async fn handle_transaction(
         &self,
         transaction: Transaction,
-    ) -> Result<TransactionInfoResponse, SuiError>;
+    ) -> Result<HandleTransactionResponse, SuiError>;
 
     /// Execute a certificate.
     async fn handle_certificate(
@@ -94,7 +94,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
     async fn handle_transaction(
         &self,
         transaction: Transaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
+    ) -> Result<HandleTransactionResponse, SuiError> {
         self.client()
             .transaction(transaction)
             .await

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -240,7 +240,7 @@ impl ValidatorService {
         state: Arc<AuthorityState>,
         request: tonic::Request<Transaction>,
         metrics: Arc<ValidatorServiceMetrics>,
-    ) -> Result<tonic::Response<TransactionInfoResponse>, tonic::Status> {
+    ) -> Result<tonic::Response<HandleTransactionResponse>, tonic::Status> {
         let transaction = request.into_inner();
 
         let _metrics_guard = metrics.handle_transaction_latency.start_timer();
@@ -266,7 +266,7 @@ impl ValidatorService {
                 }
             })?;
 
-        Ok(tonic::Response::new(info.into()))
+        Ok(tonic::Response::new(info))
     }
 
     // TODO: reject certificate if TransactionManager or Narwhal is backlogged.
@@ -392,7 +392,7 @@ impl Validator for ValidatorService {
     async fn transaction(
         &self,
         request: tonic::Request<Transaction>,
-    ) -> Result<tonic::Response<TransactionInfoResponse>, tonic::Status> {
+    ) -> Result<tonic::Response<HandleTransactionResponse>, tonic::Status> {
         let state = self.state.clone();
 
         // Spawns a task which handles the transaction. The task will unconditionally continue
@@ -442,7 +442,7 @@ impl Validator for ValidatorService {
 
         let response = self.state.handle_transaction_info_request(request).await?;
 
-        Ok(tonic::Response::new(response.into()))
+        Ok(tonic::Response::new(response))
     }
 
     async fn checkpoint(

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -367,7 +367,7 @@ where
             .await
             .map_err(QuorumDriverInternalError::CertificateError)?;
         let response = QuorumDriverResponse {
-            tx_cert: certificate,
+            tx_cert: Some(certificate),
             effects_cert: effects,
         };
 
@@ -471,8 +471,10 @@ where
             )
             .await?;
 
-        match response {
-            VerifiedTransactionInfoResponse::Executed(cert, _) => {
+        // If we are able to get a certificate right away, we use it and execute the cert;
+        // otherwise, we have to re-form a cert and execute it.
+        let verified_transaction = match response {
+            VerifiedTransactionInfoResponse::ExecutedWithCert(cert, _) => {
                 self.metrics
                     .total_times_conflicting_transaction_already_finalized_when_retrying
                     .inc();
@@ -499,35 +501,34 @@ where
                         );
                     });
                 // We only try it once.
-                Ok(result.is_ok())
+                return Ok(result.is_ok());
             }
-            VerifiedTransactionInfoResponse::Signed(signed) => {
-                let verified_transaction = signed.into_unsigned();
-                // Now ask validators to execute this transaction.
-                let result = self
-                    .validators
-                    .load()
-                    .execute_transaction(&verified_transaction)
-                    .await
-                    .tap_ok(|_resp| {
-                        debug!(
-                            ?tx_digest,
-                            ?original_tx_digest,
-                            "Retry conflicting transaction succeeded."
-                        );
-                    })
-                    .tap_err(|err| {
-                        debug!(
-                            ?tx_digest,
-                            ?original_tx_digest,
-                            "Retry conflicting transaction got an error: {:?}",
-                            err
-                        );
-                    });
-                // We only try it once
-                Ok(result.is_ok())
-            }
-        }
+            VerifiedTransactionInfoResponse::Signed(signed) => signed.into_unsigned(),
+            VerifiedTransactionInfoResponse::ExecutedWithoutCert(transaction, _) => transaction,
+        };
+        // Now ask validators to execute this transaction.
+        let result = self
+            .validators
+            .load()
+            .execute_transaction(&verified_transaction)
+            .await
+            .tap_ok(|_resp| {
+                debug!(
+                    ?tx_digest,
+                    ?original_tx_digest,
+                    "Retry conflicting transaction succeeded."
+                );
+            })
+            .tap_err(|err| {
+                debug!(
+                    ?tx_digest,
+                    ?original_tx_digest,
+                    "Retry conflicting transaction got an error: {:?}",
+                    err
+                );
+            });
+        // We only try it once
+        Ok(result.is_ok())
     }
 }
 

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -74,7 +74,7 @@ async fn test_quorum_driver_submit_transaction() {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(*tx_cert.digest(), digest);
+        assert_eq!(*tx_cert.unwrap().digest(), digest);
         assert_eq!(effects_cert.data().transaction_digest, digest);
     });
     let ticket = quorum_driver_handler.submit_transaction(tx).await.unwrap();
@@ -107,7 +107,7 @@ async fn test_quorum_driver_submit_transaction_no_ticket() {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(*tx_cert.digest(), digest);
+        assert_eq!(*tx_cert.unwrap().digest(), digest);
         assert_eq!(effects_cert.data().transaction_digest, digest);
     });
     quorum_driver_handler
@@ -125,7 +125,7 @@ async fn verify_ticket_response<'a>(
         tx_cert,
         effects_cert,
     } = ticket.await.unwrap();
-    assert_eq!(tx_cert.digest(), tx_digest);
+    assert_eq!(tx_cert.unwrap().digest(), tx_digest);
     assert_eq!(&effects_cert.data().transaction_digest, tx_digest);
 }
 
@@ -156,7 +156,7 @@ async fn test_quorum_driver_with_given_notify_read() {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(*tx_cert.digest(), digest);
+        assert_eq!(*tx_cert.unwrap().digest(), digest);
         assert_eq!(effects_cert.data().transaction_digest, digest);
     });
     let ticket1 = notifier.register_one(&digest);
@@ -326,7 +326,7 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
         tx_cert,
         effects_cert: _,
     } = res;
-    assert_eq!(tx_cert.digest(), &tx2_digest);
+    assert_eq!(tx_cert.unwrap().digest(), &tx2_digest);
 
     // Case 4 - object is locked by 2 txes with weight 2 and 1 respectivefully. Then try to execute the third txn
     let gas = gas_objects.pop().unwrap();
@@ -390,7 +390,7 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
         tx_cert,
         effects_cert: _,
     } = res;
-    assert_eq!(*tx_cert.digest(), tx_digest);
+    assert_eq!(*tx_cert.unwrap().digest(), tx_digest);
 
     // Case 7 - three validators lock the object, by different txes
     let gas = gas_objects.pop().unwrap();

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -16,8 +16,9 @@ use sui_types::{
     crypto::AuthorityKeyPair,
     error::SuiError,
     messages::{
-        CertifiedTransaction, CommitteeInfoRequest, CommitteeInfoResponse, ObjectInfoRequest,
-        ObjectInfoResponse, Transaction, TransactionInfoRequest, TransactionInfoResponse,
+        CertifiedTransaction, CommitteeInfoRequest, CommitteeInfoResponse,
+        HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, Transaction,
+        TransactionInfoRequest, TransactionInfoResponse,
     },
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
 };
@@ -48,7 +49,7 @@ impl AuthorityAPI for LocalAuthorityClient {
     async fn handle_transaction(
         &self,
         transaction: Transaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
+    ) -> Result<HandleTransactionResponse, SuiError> {
         if self.fault_config.fail_before_handle_transaction {
             return Err(SuiError::from("Mock error before handle_transaction"));
         }
@@ -60,7 +61,7 @@ impl AuthorityAPI for LocalAuthorityClient {
                 error: "Mock error after handle_transaction".to_owned(),
             });
         }
-        result.map(|v| v.into())
+        result
     }
 
     async fn handle_certificate(
@@ -88,10 +89,7 @@ impl AuthorityAPI for LocalAuthorityClient {
         request: TransactionInfoRequest,
     ) -> Result<TransactionInfoResponse, SuiError> {
         let state = self.state.clone();
-        state
-            .handle_transaction_info_request(request)
-            .await
-            .map(|r| r.into())
+        state.handle_transaction_info_request(request).await
     }
 
     async fn handle_checkpoint(
@@ -198,7 +196,7 @@ impl AuthorityAPI for MockAuthorityApi {
     async fn handle_transaction(
         &self,
         _transaction: Transaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
+    ) -> Result<HandleTransactionResponse, SuiError> {
         unreachable!();
     }
 
@@ -256,7 +254,7 @@ impl AuthorityAPI for MockAuthorityApi {
 
 #[derive(Clone)]
 pub struct HandleTransactionTestAuthorityClient {
-    pub tx_info_resp_to_return: SuiResult<TransactionInfoResponse>,
+    pub tx_info_resp_to_return: SuiResult<HandleTransactionResponse>,
 }
 
 #[async_trait]
@@ -264,7 +262,7 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
     async fn handle_transaction(
         &self,
         _transaction: Transaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
+    ) -> Result<HandleTransactionResponse, SuiError> {
         self.tx_info_resp_to_return.clone()
     }
 
@@ -311,7 +309,7 @@ impl HandleTransactionTestAuthorityClient {
         }
     }
 
-    pub fn set_tx_info_response(&mut self, resp: TransactionInfoResponse) {
+    pub fn set_tx_info_response(&mut self, resp: HandleTransactionResponse) {
         self.tx_info_resp_to_return = Ok(resp);
     }
 

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -216,11 +216,14 @@ where
                 } = response;
                 if !wait_for_local_execution {
                     return Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
-                        Some(tx_cert.into()),
+                        tx_cert.map(|cert| cert.into()),
                         FinalizedEffects::new_from_effects_cert(effects_cert.into()),
                         false,
                     ))));
                 }
+                // TODO: Once we support executing transactions without a cert, we won't need this unwrap.
+                let tx_cert = tx_cert.expect("Currently we always obtain a cert");
+
                 match Self::execute_finalized_tx_locally_with_timeout(
                     &self.validator_state,
                     &tx_cert,
@@ -345,6 +348,8 @@ where
                     tx_cert,
                     effects_cert,
                 })) => {
+                    // TODO: Once we support executing transactions without a cert, we won't need this unwrap.
+                    let tx_cert = tx_cert.expect("Currently we always obtain a cert");
                     let tx_digest = tx_cert.digest();
                     if let Err(err) = pending_transaction_log.finish_transaction(tx_digest) {
                         error!(

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -76,10 +76,10 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
             .handle_transaction(transaction.clone())
             .await
             .unwrap();
-        let vote = response.into_signed_for_testing();
+        let vote = response.status.into_signed_for_testing();
         let certificate = CertifiedTransaction::new(
             transaction.into_message(),
-            vec![vote.auth_sig().clone()],
+            vec![vote.clone()],
             &authority.clone_committee_for_testing(),
         )
         .unwrap();

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
                 .name("transaction")
                 .route_name("Transaction")
                 .input_type("sui_types::messages::Transaction")
-                .output_type("sui_types::messages::TransactionInfoResponse")
+                .output_type("sui_types::messages::HandleTransactionResponse")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -321,20 +321,18 @@ pub async fn get_transaction(tx_digest: TransactionDigest, genesis: PathBuf) -> 
         .map(|r| {
             let key =
                 r.2.as_ref()
-                    .map(|ok_result| match ok_result {
-                        TransactionInfoResponse::Signed(_) => None,
-                        TransactionInfoResponse::Executed(_, effects) => Some(effects.digest()),
+                    .map(|ok_result| match &ok_result.status {
+                        TransactionStatus::Signed(_) => None,
+                        TransactionStatus::Executed(_, effects) => Some(effects.digest()),
                     })
                     .ok();
             (key, r)
         })
         .sorted_by(|(k1, _), (k2, _)| Ord::cmp(k1, k2))
         .group_by(|(_, r)| {
-            r.2.as_ref().map(|ok_result| match ok_result {
-                TransactionInfoResponse::Signed(_) => None,
-                TransactionInfoResponse::Executed(_, effects) => {
-                    Some((effects.data(), effects.digest()))
-                }
+            r.2.as_ref().map(|ok_result| match &ok_result.status {
+                TransactionStatus::Signed(_) => None,
+                TransactionStatus::Executed(_, effects) => Some((effects.data(), effects.digest())),
             })
         });
     let mut s = String::new();

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -51,6 +51,10 @@ impl<T: Message, S> Envelope<T, S> {
         self.data
     }
 
+    pub fn into_sig(self) -> S {
+        self.auth_signature
+    }
+
     pub fn into_data_and_sig(self) -> (T, S) {
         let Self {
             data,

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -424,7 +424,7 @@ async fn test_full_node_cold_sync() -> Result<(), anyhow::Error> {
         })
         .await?;
     // Check that it has been executed.
-    info.into_executed_for_testing();
+    info.status.into_effects_for_testing();
 
     Ok(())
 }
@@ -895,7 +895,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     } = rx.recv().await.unwrap().unwrap();
     let (ct, cte, is_executed_locally) = *res;
     assert_eq!(*ct.unwrap().digest(), digest);
-    assert_eq!(*certified_txn.digest(), digest);
+    assert_eq!(*certified_txn.unwrap().digest(), digest);
     assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(is_executed_locally);
     // verify that the node has sequenced and executed the txn
@@ -920,7 +920,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     } = rx.recv().await.unwrap().unwrap();
     let (ct, cte, is_executed_locally) = *res;
     assert_eq!(*ct.unwrap().digest(), digest);
-    assert_eq!(*certified_txn.digest(), digest);
+    assert_eq!(*certified_txn.unwrap().digest(), digest);
     assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(!is_executed_locally);
     wait_for_tx(digest, node.state().clone()).await;


### PR DESCRIPTION
With finalized transactions, validator can no longer guarantee to return transaction certificates. Hence we need to change validator grpc APIs to return optional certificate in the executed case.
This PR makes such change. The core of the change is in messages.rs.
For handle_transaction, this PR also makes an optimization where we don't actually need to return the transaction data, but only the transaction signature in the signed and cert case.