### PR TITLE
[staking] remove Delegation objects and the distribution of them

### DIFF
--- a/.changeset/mean-foxes-perform.md
+++ b/.changeset/mean-foxes-perform.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Change StakingPool structure by removing pool token supply and adding exchange rates.

--- a/apps/explorer/src/components/validator/calculateAPY.ts
+++ b/apps/explorer/src/components/validator/calculateAPY.ts
@@ -8,15 +8,13 @@ import { roundFloat } from '~/utils/roundFloat';
 const APY_DECIMALS = 4;
 
 export function calculateAPY(validator: Validator, epoch: number) {
-    const { sui_balance, starting_epoch, delegation_token_supply } =
+    const { sui_balance, starting_epoch, pool_token_balance } =
         validator.delegation_staking_pool;
 
     const num_epochs_participated = +epoch - +starting_epoch;
     const apy =
         Math.pow(
-            1 +
-                (+sui_balance - +delegation_token_supply.value) /
-                    +delegation_token_supply.value,
+            1 + (+sui_balance - +pool_token_balance) / +pool_token_balance,
             365 / num_epochs_participated
         ) - 1;
 

--- a/apps/wallet/src/ui/app/staking/calculateAPY.ts
+++ b/apps/wallet/src/ui/app/staking/calculateAPY.ts
@@ -8,15 +8,13 @@ import { roundFloat } from '_helpers';
 const APY_DECIMALS = 4;
 
 export function calculateAPY(validators: Validator, epoch: number) {
-    const { sui_balance, starting_epoch, delegation_token_supply } =
+    const { sui_balance, starting_epoch, pool_token_balance } =
         validators.delegation_staking_pool;
 
     const num_epochs_participated = +epoch - +starting_epoch;
     const apy =
         Math.pow(
-            1 +
-                (+sui_balance - +delegation_token_supply.value) /
-                    +delegation_token_supply.value,
+            1 + (+sui_balance - +pool_token_balance) / +pool_token_balance,
             365 / num_epochs_participated
         ) - 1;
 

--- a/apps/wallet/src/ui/app/staking/getStakingRewards.ts
+++ b/apps/wallet/src/ui/app/staking/getStakingRewards.ts
@@ -26,7 +26,7 @@ export function getStakingRewards(
         delegation.delegation_status.Active.pool_tokens.value
     );
     const delegationTokenSupply = new BigNumber(
-        validator.delegation_staking_pool.delegation_token_supply.value
+        validator.delegation_staking_pool.pool_token_balance
     );
     const suiBalance = new BigNumber(
         validator.delegation_staking_pool.sui_balance

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -243,7 +243,7 @@ system_state:
         gas_price: 1
         delegation_staking_pool:
           id: "0xab8235dace3d68c7fb48110d63cbf4d6fd81ce10"
-          starting_epoch: 1
+          starting_epoch: 0
           sui_balance: 0
           rewards_pool:
             value: 0

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -242,20 +242,16 @@ system_state:
         pending_withdraw: 0
         gas_price: 1
         delegation_staking_pool:
-          id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f"
+          id: "0xab8235dace3d68c7fb48110d63cbf4d6fd81ce10"
           starting_epoch: 1
           sui_balance: 0
           rewards_pool:
             value: 0
-          delegation_token_supply:
-            value: 0
-          pending_delegations:
-            id: "0xab8235dace3d68c7fb48110d63cbf4d6fd81ce10"
-            size: 0
-            head:
-              vec: []
-            tail:
-              vec: []
+          pool_token_balance: 0
+          exchange_rates:
+            id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f"
+            size: 1
+          pending_delegation: 0
           pending_withdraws:
             contents:
               id: "0x18b8140c8a6ea340142f128061016fc4bd8220ec"

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -238,20 +238,16 @@ validators:
       pending_withdraw: 0
       gas_price: 1
       delegation_staking_pool:
-        id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f"
+        id: "0xab8235dace3d68c7fb48110d63cbf4d6fd81ce10"
         starting_epoch: 1
         sui_balance: 0
         rewards_pool:
           value: 0
-        delegation_token_supply:
-          value: 0
-        pending_delegations:
-          id: "0xab8235dace3d68c7fb48110d63cbf4d6fd81ce10"
-          size: 0
-          head:
-            vec: []
-          tail:
-            vec: []
+        pool_token_balance: 0
+        exchange_rates:
+          id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f"
+          size: 1
+        pending_delegation: 0
         pending_withdraws:
           contents:
             id: "0x18b8140c8a6ea340142f128061016fc4bd8220ec"

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -239,7 +239,7 @@ validators:
       gas_price: 1
       delegation_staking_pool:
         id: "0xab8235dace3d68c7fb48110d63cbf4d6fd81ce10"
-        starting_epoch: 1
+        starting_epoch: 0
         sui_balance: 0
         rewards_pool:
           value: 0

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -173,6 +173,7 @@ all the information we need in the system.
             <a href="_none">option::none</a>(),
             gas_price,
             commission_rate,
+            0, // start operating right away at epoch 0
             ctx
         ));
         i = i + 1;

--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -8,33 +8,24 @@
 -  [Resource `StakingPool`](#0x2_staking_pool_StakingPool)
 -  [Struct `PoolTokenExchangeRate`](#0x2_staking_pool_PoolTokenExchangeRate)
 -  [Resource `InactiveStakingPool`](#0x2_staking_pool_InactiveStakingPool)
--  [Struct `DelegationToken`](#0x2_staking_pool_DelegationToken)
--  [Struct `PendingDelegationEntry`](#0x2_staking_pool_PendingDelegationEntry)
 -  [Struct `PendingWithdrawEntry`](#0x2_staking_pool_PendingWithdrawEntry)
--  [Resource `Delegation`](#0x2_staking_pool_Delegation)
 -  [Resource `StakedSui`](#0x2_staking_pool_StakedSui)
 -  [Constants](#@Constants_0)
 -  [Function `new`](#0x2_staking_pool_new)
 -  [Function `request_add_delegation`](#0x2_staking_pool_request_add_delegation)
 -  [Function `request_withdraw_delegation`](#0x2_staking_pool_request_withdraw_delegation)
 -  [Function `withdraw_from_principal`](#0x2_staking_pool_withdraw_from_principal)
--  [Function `destroy_delegation_and_return_pool_tokens`](#0x2_staking_pool_destroy_delegation_and_return_pool_tokens)
 -  [Function `unwrap_staked_sui`](#0x2_staking_pool_unwrap_staked_sui)
 -  [Function `deposit_rewards`](#0x2_staking_pool_deposit_rewards)
 -  [Function `process_pending_delegation_withdraws`](#0x2_staking_pool_process_pending_delegation_withdraws)
--  [Function `process_pending_delegations`](#0x2_staking_pool_process_pending_delegations)
+-  [Function `process_pending_delegation`](#0x2_staking_pool_process_pending_delegation)
 -  [Function `withdraw_rewards_and_burn_pool_tokens`](#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens)
--  [Function `mint_delegation_tokens_to_delegator`](#0x2_staking_pool_mint_delegation_tokens_to_delegator)
 -  [Function `deactivate_staking_pool`](#0x2_staking_pool_deactivate_staking_pool)
--  [Function `withdraw_from_inactive_pool`](#0x2_staking_pool_withdraw_from_inactive_pool)
--  [Function `destroy_empty_delegation`](#0x2_staking_pool_destroy_empty_delegation)
--  [Function `destroy_empty_staked_sui`](#0x2_staking_pool_destroy_empty_staked_sui)
 -  [Function `sui_balance`](#0x2_staking_pool_sui_balance)
 -  [Function `pool_id`](#0x2_staking_pool_pool_id)
 -  [Function `staked_sui_amount`](#0x2_staking_pool_staked_sui_amount)
--  [Function `delegation_request_epoch`](#0x2_staking_pool_delegation_request_epoch)
--  [Function `delegation_token_amount`](#0x2_staking_pool_delegation_token_amount)
--  [Function `pool_token_exchange_rate`](#0x2_staking_pool_pool_token_exchange_rate)
+-  [Function `delegation_activation_epoch`](#0x2_staking_pool_delegation_activation_epoch)
+-  [Function `pool_token_exchange_rate_at_epoch`](#0x2_staking_pool_pool_token_exchange_rate_at_epoch)
 -  [Function `new_pending_withdraw_entry`](#0x2_staking_pool_new_pending_withdraw_entry)
 -  [Function `get_sui_amount`](#0x2_staking_pool_get_sui_amount)
 -  [Function `get_token_amount`](#0x2_staking_pool_get_token_amount)
@@ -44,11 +35,11 @@
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
-<b>use</b> <a href="linked_table.md#0x2_linked_table">0x2::linked_table</a>;
 <b>use</b> <a href="locked_coin.md#0x2_locked_coin">0x2::locked_coin</a>;
 <b>use</b> <a href="math.md#0x2_math">0x2::math</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="table.md#0x2_table">0x2::table</a>;
 <b>use</b> <a href="table_vec.md#0x2_table_vec">0x2::table_vec</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
@@ -90,7 +81,7 @@ A staking pool embedded in each validator struct in the system state object.
 </dt>
 <dd>
  The total number of SUI tokens in this pool, including the SUI in the rewards_pool, as well as in all the principal
- in the <code><a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a></code> object, updated at epoch boundaries.
+ in the <code><a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a></code> object, updated at epoch boundaries.
 </dd>
 <dt>
 <code>rewards_pool: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
@@ -99,19 +90,22 @@ A staking pool embedded in each validator struct in the system state object.
  The epoch delegation rewards will be added here at the end of each epoch.
 </dd>
 <dt>
-<code>delegation_token_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;</code>
+<code>pool_token_balance: u64</code>
 </dt>
 <dd>
- The number of delegation pool tokens we have issued so far. This number should equal the sum of
- pool token balance in all the <code><a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a></code> objects delegated to this pool. Updated at epoch boundaries.
+ Total number of pool tokens issued by the pool.
 </dd>
 <dt>
-<code>pending_delegations: <a href="linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;<a href="object.md#0x2_object_ID">object::ID</a>, <a href="staking_pool.md#0x2_staking_pool_PendingDelegationEntry">staking_pool::PendingDelegationEntry</a>&gt;</code>
+<code>exchange_rates: <a href="table.md#0x2_table_Table">table::Table</a>&lt;u64, <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>&gt;</code>
 </dt>
 <dd>
- Delegations requested during the current epoch. We will activate these delegation at the end of current epoch
- and distribute staking pool tokens at the end-of-epoch exchange rate after the rewards for the current epoch
- have been deposited.
+ Exchange rate history of previous epochs. Key is the epoch number.
+</dd>
+<dt>
+<code>pending_delegation: u64</code>
+</dt>
+<dd>
+ Pending delegation amount for this epoch.
 </dd>
 <dt>
 <code>pending_withdraws: <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;<a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">staking_pool::PendingWithdrawEntry</a>&gt;</code>
@@ -132,7 +126,7 @@ A staking pool embedded in each validator struct in the system state object.
 Struct representing the exchange rate of the delegation pool token to SUI.
 
 
-<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> <b>has</b> <b>copy</b>, drop
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -194,68 +188,6 @@ Only withdraws can be made from this pool.
 
 </details>
 
-<a name="0x2_staking_pool_DelegationToken"></a>
-
-## Struct `DelegationToken`
-
-The staking pool token.
-
-
-<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a> <b>has</b> drop
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>dummy_field: bool</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a name="0x2_staking_pool_PendingDelegationEntry"></a>
-
-## Struct `PendingDelegationEntry`
-
-Struct representing a pending delegation.
-
-
-<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_PendingDelegationEntry">PendingDelegationEntry</a> <b>has</b> drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>delegator: <b>address</b></code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>sui_amount: u64</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
 <a name="0x2_staking_pool_PendingWithdrawEntry"></a>
 
 ## Struct `PendingWithdrawEntry`
@@ -286,58 +218,10 @@ Struct representing a pending delegation withdraw.
 
 </dd>
 <dt>
-<code>withdrawn_pool_tokens: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;</code>
+<code>pool_token_withdraw_amount: u64</code>
 </dt>
 <dd>
 
-</dd>
-</dl>
-
-
-</details>
-
-<a name="0x2_staking_pool_Delegation"></a>
-
-## Resource `Delegation`
-
-A self-custodial delegation object, serving as evidence that the delegator
-has delegated to a staking pool.
-
-
-<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>staked_sui_id: <a href="object.md#0x2_object_ID">object::ID</a></code>
-</dt>
-<dd>
- The ID of the corresponding <code><a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a></code> object.
-</dd>
-<dt>
-<code>pool_tokens: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;</code>
-</dt>
-<dd>
- The pool tokens representing the amount of rewards the delegator can get back when they withdraw
- from the pool.
-</dd>
-<dt>
-<code>principal_sui_amount: u64</code>
-</dt>
-<dd>
- Number of SUI token staked originally.
 </dd>
 </dl>
 
@@ -380,10 +264,10 @@ A self-custodial object holding the staked SUI tokens.
 
 </dd>
 <dt>
-<code>delegation_request_epoch: u64</code>
+<code>delegation_activation_epoch: u64</code>
 </dt>
 <dd>
- The epoch at which the delegation is requested.
+ The epoch at which the delegation becomes active.
 </dd>
 <dt>
 <code>principal: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
@@ -506,13 +390,20 @@ Create a new, empty staking pool.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(ctx: &<b>mut</b> TxContext) : <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> {
+    <b>let</b> exchange_rates = <a href="table.md#0x2_table_new">table::new</a>(ctx);
+    <a href="table.md#0x2_table_add">table::add</a>(
+        &<b>mut</b> exchange_rates,
+        <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
+        <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> { sui_amount: 0, pool_token_amount: 0 }
+    );
     <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> {
         id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
         starting_epoch: <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1, // active beginning next epoch
         sui_balance: 0,
         rewards_pool: <a href="balance.md#0x2_balance_zero">balance::zero</a>(),
-        delegation_token_supply: <a href="balance.md#0x2_balance_create_supply">balance::create_supply</a>(<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a> {}),
-        pending_delegations: <a href="linked_table.md#0x2_linked_table_new">linked_table::new</a>(ctx),
+        pool_token_balance: 0,
+        exchange_rates,
+        pending_delegation: 0,
         pending_withdraws: <a href="table_vec.md#0x2_table_vec_empty">table_vec::empty</a>(ctx),
     }
 }
@@ -553,16 +444,11 @@ when the delegation object containing the pool tokens is distributed to the dele
         id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
         pool_id: <a href="object.md#0x2_object_id">object::id</a>(pool),
         validator_address,
-        delegation_request_epoch: <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
+        delegation_activation_epoch: <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1,
         principal: <a href="stake.md#0x2_stake">stake</a>,
         sui_token_lock,
     };
-    // insert delegation info into the pending_delegations <a href="table.md#0x2_table">table</a>.
-    <a href="linked_table.md#0x2_linked_table_push_back">linked_table::push_back</a>(
-        &<b>mut</b> pool.pending_delegations,
-        <a href="object.md#0x2_object_id">object::id</a>(&staked_sui),
-        <a href="staking_pool.md#0x2_staking_pool_PendingDelegationEntry">PendingDelegationEntry</a> { delegator, sui_amount }
-    );
+    pool.pending_delegation = pool.pending_delegation + sui_amount;
     <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(staked_sui, delegator);
 }
 </code></pre>
@@ -582,7 +468,7 @@ The rewards portion will be withdrawn at the end of the epoch, after the rewards
 can use the new exchange rate to calculate the rewards.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_withdraw_delegation">request_withdraw_delegation</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_withdraw_delegation">request_withdraw_delegation</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
 </code></pre>
 
 
@@ -593,17 +479,16 @@ can use the new exchange rate to calculate the rewards.
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_withdraw_delegation">request_withdraw_delegation</a>(
     pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
-    delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>,
     staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>,
     ctx: &<b>mut</b> TxContext
 ) : u64 {
-    <b>let</b> (withdrawn_pool_tokens, principal_withdraw, time_lock) =
-        <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(pool, delegation, staked_sui);
+    <b>let</b> (pool_token_withdraw_amount, principal_withdraw, time_lock) =
+        <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(pool, staked_sui);
 
     <b>let</b> delegator = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
     <b>let</b> principal_withdraw_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&principal_withdraw);
     <a href="table_vec.md#0x2_table_vec_push_back">table_vec::push_back</a>(&<b>mut</b> pool.pending_withdraws, <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> {
-        delegator, principal_withdraw_amount, withdrawn_pool_tokens });
+        delegator, principal_withdraw_amount, pool_token_withdraw_amount });
 
     // TODO: implement withdraw bonding period here.
     <b>if</b> (<a href="_is_some">option::is_some</a>(&time_lock)) {
@@ -633,7 +518,7 @@ Returns values are withdrawn pool tokens, withdrawn principal portion of SUI, an
 time lock if applicable.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): (<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;, <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): (u64, <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;)
 </code></pre>
 
 
@@ -644,51 +529,21 @@ time lock if applicable.
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(
     pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
-    delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>,
     staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>,
-) : (Balance&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a>&gt;, Balance&lt;SUI&gt;, Option&lt;EpochTimeLock&gt;) {
-    // Check that the delegation and staked <a href="sui.md#0x2_sui">sui</a> objects match.
-    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(&staked_sui) == delegation.staked_sui_id, <a href="staking_pool.md#0x2_staking_pool_EWrongDelegation">EWrongDelegation</a>);
+) : (u64, Balance&lt;SUI&gt;, Option&lt;EpochTimeLock&gt;) {
 
     // Check that the delegation information matches the pool.
     <b>assert</b>!(staked_sui.pool_id == <a href="object.md#0x2_object_id">object::id</a>(pool), <a href="staking_pool.md#0x2_staking_pool_EWrongPool">EWrongPool</a>);
 
-    <b>assert</b>!(delegation.principal_sui_amount == <a href="balance.md#0x2_balance_value">balance::value</a>(&staked_sui.principal), <a href="staking_pool.md#0x2_staking_pool_EInsufficientSuiTokenBalance">EInsufficientSuiTokenBalance</a>);
-
-    <b>let</b> pool_tokens = <a href="staking_pool.md#0x2_staking_pool_destroy_delegation_and_return_pool_tokens">destroy_delegation_and_return_pool_tokens</a>(delegation);
+    <b>let</b> exchange_rate_at_staking_epoch = <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(pool, staked_sui.delegation_activation_epoch);
     <b>let</b> (principal_withdraw, time_lock) = <a href="staking_pool.md#0x2_staking_pool_unwrap_staked_sui">unwrap_staked_sui</a>(staked_sui);
+    <b>let</b> pool_token_withdraw_amount = <a href="staking_pool.md#0x2_staking_pool_get_token_amount">get_token_amount</a>(&exchange_rate_at_staking_epoch, <a href="balance.md#0x2_balance_value">balance::value</a>(&principal_withdraw));
 
     (
-        pool_tokens,
+        pool_token_withdraw_amount,
         principal_withdraw,
         time_lock
     )
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_staking_pool_destroy_delegation_and_return_pool_tokens"></a>
-
-## Function `destroy_delegation_and_return_pool_tokens`
-
-
-
-<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_delegation_and_return_pool_tokens">destroy_delegation_and_return_pool_tokens</a>(delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_delegation_and_return_pool_tokens">destroy_delegation_and_return_pool_tokens</a>(delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>): Balance&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a>&gt; {
-    <b>let</b> <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a> { id, staked_sui_id: _, pool_tokens, principal_sui_amount: _ } = delegation;
-    <a href="object.md#0x2_object_delete">object::delete</a>(id);
-    pool_tokens
 }
 </code></pre>
 
@@ -716,7 +571,7 @@ time lock if applicable.
         id,
         pool_id: _,
         validator_address: _,
-        delegation_request_epoch: _,
+        delegation_activation_epoch: _,
         principal,
         sui_token_lock
     } = staked_sui;
@@ -736,7 +591,7 @@ time lock if applicable.
 Called at epoch advancement times to add rewards (in SUI) to the staking pool.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deposit_rewards">deposit_rewards</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, rewards: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deposit_rewards">deposit_rewards</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, rewards: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, new_epoch: u64)
 </code></pre>
 
 
@@ -745,9 +600,14 @@ Called at epoch advancement times to add rewards (in SUI) to the staking pool.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deposit_rewards">deposit_rewards</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, rewards: Balance&lt;SUI&gt;) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deposit_rewards">deposit_rewards</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, rewards: Balance&lt;SUI&gt;, new_epoch: u64) {
     pool.sui_balance = pool.sui_balance + <a href="balance.md#0x2_balance_value">balance::value</a>(&rewards);
     <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> pool.rewards_pool, rewards);
+    <a href="table.md#0x2_table_add">table::add</a>(
+        &<b>mut</b> pool.exchange_rates,
+        new_epoch,
+        <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> { sui_amount: pool.sui_balance, pool_token_amount: pool.pool_token_balance },
+    );
 }
 </code></pre>
 
@@ -764,7 +624,7 @@ For each pending withdraw entry, we withdraw the rewards from the pool at the ne
 tokens.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation_withdraws">process_pending_delegation_withdraws</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation_withdraws">process_pending_delegation_withdraws</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, new_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
 </code></pre>
 
 
@@ -773,14 +633,15 @@ tokens.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation_withdraws">process_pending_delegation_withdraws</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, ctx: &<b>mut</b> TxContext) : u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation_withdraws">process_pending_delegation_withdraws</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, new_epoch: u64, ctx: &<b>mut</b> TxContext) : u64 {
     <b>let</b> total_reward_withdraw = 0;
 
     <b>while</b> (!<a href="table_vec.md#0x2_table_vec_is_empty">table_vec::is_empty</a>(&pool.pending_withdraws)) {
         <b>let</b> <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> {
-            delegator, principal_withdraw_amount, withdrawn_pool_tokens
+            delegator, principal_withdraw_amount, pool_token_withdraw_amount
         } = <a href="table_vec.md#0x2_table_vec_pop_back">table_vec::pop_back</a>(&<b>mut</b> pool.pending_withdraws);
-        <b>let</b> reward_withdraw = <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(pool, principal_withdraw_amount, withdrawn_pool_tokens);
+        <b>let</b> reward_withdraw = <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(
+            pool, principal_withdraw_amount, pool_token_withdraw_amount, new_epoch);
         total_reward_withdraw = total_reward_withdraw + <a href="balance.md#0x2_balance_value">balance::value</a>(&reward_withdraw);
         <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(reward_withdraw, ctx), delegator);
     };
@@ -792,14 +653,14 @@ tokens.
 
 </details>
 
-<a name="0x2_staking_pool_process_pending_delegations"></a>
+<a name="0x2_staking_pool_process_pending_delegation"></a>
 
-## Function `process_pending_delegations`
+## Function `process_pending_delegation`
 
-Called at epoch boundaries to mint new pool tokens to new delegators at the new exchange rate.
+Called at epoch boundaries to process the pending delegation.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegations">process_pending_delegations</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation">process_pending_delegation</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, new_epoch: u64)
 </code></pre>
 
 
@@ -808,13 +669,11 @@ Called at epoch boundaries to mint new pool tokens to new delegators at the new 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegations">process_pending_delegations</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, ctx: &<b>mut</b> TxContext) {
-    <b>while</b> (!<a href="linked_table.md#0x2_linked_table_is_empty">linked_table::is_empty</a>(&pool.pending_delegations)) {
-        <b>let</b> (staked_sui_id, <a href="staking_pool.md#0x2_staking_pool_PendingDelegationEntry">PendingDelegationEntry</a> { delegator, sui_amount }) =
-            <a href="linked_table.md#0x2_linked_table_pop_back">linked_table::pop_back</a>(&<b>mut</b> pool.pending_delegations);
-        <a href="staking_pool.md#0x2_staking_pool_mint_delegation_tokens_to_delegator">mint_delegation_tokens_to_delegator</a>(pool, delegator, sui_amount, staked_sui_id, ctx);
-        pool.sui_balance = pool.sui_balance + sui_amount;
-    };
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation">process_pending_delegation</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, new_epoch: u64) {
+    <b>let</b> new_epoch_exchange_rate = <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(pool, new_epoch);
+    pool.sui_balance = pool.sui_balance + pool.pending_delegation;
+    pool.pool_token_balance = pool.pool_token_balance + <a href="staking_pool.md#0x2_staking_pool_get_token_amount">get_token_amount</a>(&new_epoch_exchange_rate, pool.pending_delegation);
+    pool.pending_delegation = 0;
 }
 </code></pre>
 
@@ -838,7 +697,7 @@ time in <code>request_withdraw_stake</code>.
 5. Updates the SUI balance amount of the pool.
 
 
-<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, principal_withdraw_amount: u64, withdrawn_pool_tokens: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, principal_withdraw_amount: u64, pool_token_withdraw_amount: u64, new_epoch: u64): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
 </code></pre>
 
 
@@ -850,10 +709,11 @@ time in <code>request_withdraw_stake</code>.
 <pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(
     pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
     principal_withdraw_amount: u64,
-    withdrawn_pool_tokens: Balance&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a>&gt;,
+    pool_token_withdraw_amount: u64,
+    new_epoch: u64,
 ) : Balance&lt;SUI&gt; {
-    <b>let</b> pool_token_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&withdrawn_pool_tokens);
-    <b>let</b> total_sui_withdraw_amount = <a href="staking_pool.md#0x2_staking_pool_get_sui_amount">get_sui_amount</a>(pool, pool_token_amount);
+    <b>let</b> new_epoch_exchange_rate = <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(pool, new_epoch);
+    <b>let</b> total_sui_withdraw_amount = <a href="staking_pool.md#0x2_staking_pool_get_sui_amount">get_sui_amount</a>(&new_epoch_exchange_rate, pool_token_withdraw_amount);
     <b>let</b> reward_withdraw_amount =
         <b>if</b> (total_sui_withdraw_amount &gt;= principal_withdraw_amount)
             total_sui_withdraw_amount - principal_withdraw_amount
@@ -862,56 +722,9 @@ time in <code>request_withdraw_stake</code>.
     // the rewards pool <a href="balance.md#0x2_balance">balance</a> may be less than reward_withdraw_amount.
     // TODO: FIGURE OUT EXACTLY WHY THIS CAN HAPPEN.
     reward_withdraw_amount = <a href="math.md#0x2_math_min">math::min</a>(reward_withdraw_amount, <a href="balance.md#0x2_balance_value">balance::value</a>(&pool.rewards_pool));
-    <a href="balance.md#0x2_balance_decrease_supply">balance::decrease_supply</a>(
-        &<b>mut</b> pool.delegation_token_supply,
-        withdrawn_pool_tokens
-    );
     pool.sui_balance = pool.sui_balance - (principal_withdraw_amount + reward_withdraw_amount);
+    pool.pool_token_balance = pool.pool_token_balance - pool_token_withdraw_amount;
     <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> pool.rewards_pool, reward_withdraw_amount)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_staking_pool_mint_delegation_tokens_to_delegator"></a>
-
-## Function `mint_delegation_tokens_to_delegator`
-
-Given the <code>sui_amount</code>, mint the corresponding amount of pool tokens at the current exchange
-rate, puts the pool tokens in a delegation object, and gives the delegation object to the delegator.
-
-
-<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_mint_delegation_tokens_to_delegator">mint_delegation_tokens_to_delegator</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, delegator: <b>address</b>, sui_amount: u64, staked_sui_id: <a href="object.md#0x2_object_ID">object::ID</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_mint_delegation_tokens_to_delegator">mint_delegation_tokens_to_delegator</a>(
-    pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
-    delegator: <b>address</b>,
-    sui_amount: u64,
-    staked_sui_id: ID,
-    ctx: &<b>mut</b> TxContext
-) {
-    <b>let</b> new_pool_token_amount = <a href="staking_pool.md#0x2_staking_pool_get_token_amount">get_token_amount</a>(pool, sui_amount);
-
-    // Mint new pool tokens at the current exchange rate.
-    <b>let</b> pool_tokens = <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(&<b>mut</b> pool.delegation_token_supply, new_pool_token_amount);
-
-    <b>let</b> delegation = <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a> {
-        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
-        staked_sui_id,
-        pool_tokens,
-        principal_sui_amount: sui_amount,
-    };
-
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(delegation, delegator);
 }
 </code></pre>
 
@@ -939,126 +752,6 @@ After this pool deactivation, the pool stops earning rewards. Only delegation wi
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">deactivate_staking_pool</a>(pool: <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, ctx: &<b>mut</b> TxContext) {
     <b>let</b> inactive_pool = <a href="staking_pool.md#0x2_staking_pool_InactiveStakingPool">InactiveStakingPool</a> { id: <a href="object.md#0x2_object_new">object::new</a>(ctx), pool};
     <a href="transfer.md#0x2_transfer_share_object">transfer::share_object</a>(inactive_pool);
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_staking_pool_withdraw_from_inactive_pool"></a>
-
-## Function `withdraw_from_inactive_pool`
-
-Withdraw delegation from an inactive pool. Since no epoch rewards will be added to an inactive pool,
-the exchange rate between pool tokens and SUI tokens stay the same. Therefore, unlike withdrawing
-from an active pool, we can handle both principal and rewards withdraws directly here.
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_from_inactive_pool">withdraw_from_inactive_pool</a>(inactive_pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_InactiveStakingPool">staking_pool::InactiveStakingPool</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_withdraw_from_inactive_pool">withdraw_from_inactive_pool</a>(
-    inactive_pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_InactiveStakingPool">InactiveStakingPool</a>,
-    staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>,
-    delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>,
-    ctx: &<b>mut</b> TxContext
-) {
-    <b>let</b> pool = &<b>mut</b> inactive_pool.pool;
-    <b>let</b> (withdrawn_pool_tokens, principal_withdraw, time_lock) =
-        <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(pool, delegation, staked_sui);
-    <b>let</b> principal_withdraw_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&principal_withdraw);
-    <b>let</b> rewards_withdraw = <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(pool, principal_withdraw_amount, withdrawn_pool_tokens);
-    <b>let</b> total_withdraw_amount = principal_withdraw_amount + <a href="balance.md#0x2_balance_value">balance::value</a>(&rewards_withdraw);
-    pool.sui_balance = pool.sui_balance - total_withdraw_amount;
-
-    <b>let</b> delegator = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
-    // TODO: implement withdraw bonding period here.
-    <b>if</b> (<a href="_is_some">option::is_some</a>(&time_lock)) {
-        <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(principal_withdraw, <a href="_destroy_some">option::destroy_some</a>(time_lock), delegator, ctx);
-        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(rewards_withdraw, ctx), delegator);
-    } <b>else</b> {
-        <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> principal_withdraw, rewards_withdraw);
-        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(principal_withdraw, ctx), delegator);
-        <a href="_destroy_none">option::destroy_none</a>(time_lock);
-    };
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_staking_pool_destroy_empty_delegation"></a>
-
-## Function `destroy_empty_delegation`
-
-Destroy an empty delegation that no longer contains any SUI or pool tokens.
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_empty_delegation">destroy_empty_delegation</a>(delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_empty_delegation">destroy_empty_delegation</a>(delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>) {
-    <b>let</b> <a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a> {
-        id,
-        staked_sui_id: _,
-        pool_tokens,
-        principal_sui_amount,
-    } = delegation;
-    <a href="object.md#0x2_object_delete">object::delete</a>(id);
-    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&pool_tokens) == 0, <a href="staking_pool.md#0x2_staking_pool_EDestroyNonzeroBalance">EDestroyNonzeroBalance</a>);
-    <b>assert</b>!(principal_sui_amount == 0, <a href="staking_pool.md#0x2_staking_pool_EDestroyNonzeroBalance">EDestroyNonzeroBalance</a>);
-    <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(pool_tokens);
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_staking_pool_destroy_empty_staked_sui"></a>
-
-## Function `destroy_empty_staked_sui`
-
-Destroy an empty delegation that no longer contains any SUI or pool tokens.
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_empty_staked_sui">destroy_empty_staked_sui</a>(staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_empty_staked_sui">destroy_empty_staked_sui</a>(staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>) {
-    <b>let</b> <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a> {
-        id,
-        pool_id: _,
-        validator_address: _,
-        delegation_request_epoch: _,
-        principal,
-        sui_token_lock
-    } = staked_sui;
-    <a href="object.md#0x2_object_delete">object::delete</a>(id);
-    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&principal) == 0, <a href="staking_pool.md#0x2_staking_pool_EDestroyNonzeroBalance">EDestroyNonzeroBalance</a>);
-    <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(principal);
-    <b>assert</b>!(<a href="_is_none">option::is_none</a>(&sui_token_lock), <a href="staking_pool.md#0x2_staking_pool_ETokenTimeLockIsSome">ETokenTimeLockIsSome</a>);
-    <a href="_destroy_none">option::destroy_none</a>(sui_token_lock);
 }
 </code></pre>
 
@@ -1132,13 +825,13 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
 
 </details>
 
-<a name="0x2_staking_pool_delegation_request_epoch"></a>
+<a name="0x2_staking_pool_delegation_activation_epoch"></a>
 
-## Function `delegation_request_epoch`
+## Function `delegation_activation_epoch`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_request_epoch">delegation_request_epoch</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_activation_epoch">delegation_activation_epoch</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): u64
 </code></pre>
 
 
@@ -1147,8 +840,8 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_request_epoch">delegation_request_epoch</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>): u64 {
-    staked_sui.delegation_request_epoch
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_activation_epoch">delegation_activation_epoch</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>): u64 {
+    staked_sui.delegation_activation_epoch
 }
 </code></pre>
 
@@ -1156,13 +849,13 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
 
 </details>
 
-<a name="0x2_staking_pool_delegation_token_amount"></a>
+<a name="0x2_staking_pool_pool_token_exchange_rate_at_epoch"></a>
 
-## Function `delegation_token_amount`
+## Function `pool_token_exchange_rate_at_epoch`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_token_amount">delegation_token_amount</a>(delegation: &<a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, epoch: u64): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>
 </code></pre>
 
 
@@ -1171,33 +864,8 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_delegation_token_amount">delegation_token_amount</a>(delegation: &<a href="staking_pool.md#0x2_staking_pool_Delegation">Delegation</a>): u64 { <a href="balance.md#0x2_balance_value">balance::value</a>(&delegation.pool_tokens) }
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_staking_pool_pool_token_exchange_rate"></a>
-
-## Function `pool_token_exchange_rate`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate">pool_token_exchange_rate</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate">pool_token_exchange_rate</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> {
-    <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> {
-        sui_amount: pool.sui_balance,
-        pool_token_amount: <a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(&pool.delegation_token_supply),
-    }
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, epoch: u64): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> {
+    *<a href="table.md#0x2_table_borrow">table::borrow</a>(&pool.exchange_rates, epoch)
 }
 </code></pre>
 
@@ -1212,7 +880,7 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
 Create a new pending withdraw entry.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new_pending_withdraw_entry">new_pending_withdraw_entry</a>(delegator: <b>address</b>, principal_withdraw_amount: u64, withdrawn_pool_tokens: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">staking_pool::DelegationToken</a>&gt;): <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">staking_pool::PendingWithdrawEntry</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new_pending_withdraw_entry">new_pending_withdraw_entry</a>(delegator: <b>address</b>, principal_withdraw_amount: u64, pool_token_withdraw_amount: u64): <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">staking_pool::PendingWithdrawEntry</a>
 </code></pre>
 
 
@@ -1224,9 +892,9 @@ Create a new pending withdraw entry.
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new_pending_withdraw_entry">new_pending_withdraw_entry</a>(
     delegator: <b>address</b>,
     principal_withdraw_amount: u64,
-    withdrawn_pool_tokens: Balance&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a>&gt;,
+    pool_token_withdraw_amount: u64,
 ) : <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> {
-    <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> { delegator, principal_withdraw_amount, withdrawn_pool_tokens }
+    <a href="staking_pool.md#0x2_staking_pool_PendingWithdrawEntry">PendingWithdrawEntry</a> { delegator, principal_withdraw_amount, pool_token_withdraw_amount }
 }
 </code></pre>
 
@@ -1240,7 +908,7 @@ Create a new pending withdraw entry.
 
 
 
-<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_sui_amount">get_sui_amount</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, token_amount: u64): u64
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_sui_amount">get_sui_amount</a>(exchange_rate: &<a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>, token_amount: u64): u64
 </code></pre>
 
 
@@ -1249,14 +917,13 @@ Create a new pending withdraw entry.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_sui_amount">get_sui_amount</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, token_amount: u64): u64 {
-    <b>let</b> token_supply = <a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(&pool.delegation_token_supply);
-    <b>if</b> (token_supply == 0) {
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_sui_amount">get_sui_amount</a>(exchange_rate: &<a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a>, token_amount: u64): u64 {
+    <b>if</b> (exchange_rate.pool_token_amount == 0) {
         <b>return</b> token_amount
     };
-    <b>let</b> res = (pool.sui_balance <b>as</b> u128)
+    <b>let</b> res = (exchange_rate.sui_amount <b>as</b> u128)
             * (token_amount <b>as</b> u128)
-            / (token_supply <b>as</b> u128);
+            / (exchange_rate.pool_token_amount <b>as</b> u128);
     (res <b>as</b> u64)
 }
 </code></pre>
@@ -1271,7 +938,7 @@ Create a new pending withdraw entry.
 
 
 
-<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_token_amount">get_token_amount</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, sui_amount: u64): u64
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_token_amount">get_token_amount</a>(exchange_rate: &<a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>, sui_amount: u64): u64
 </code></pre>
 
 
@@ -1280,14 +947,13 @@ Create a new pending withdraw entry.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_token_amount">get_token_amount</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, sui_amount: u64): u64 {
-    <b>if</b> (pool.sui_balance == 0) {
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_get_token_amount">get_token_amount</a>(exchange_rate: &<a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a>, sui_amount: u64): u64 {
+    <b>if</b> (exchange_rate.sui_amount == 0) {
         <b>return</b> sui_amount
     };
-    <b>let</b> token_supply = <a href="balance.md#0x2_balance_supply_value">balance::supply_value</a>(&pool.delegation_token_supply);
-    <b>let</b> res = (token_supply <b>as</b> u128)
+    <b>let</b> res = (exchange_rate.pool_token_amount <b>as</b> u128)
             * (sui_amount <b>as</b> u128)
-            / (pool.sui_balance <b>as</b> u128);
+            / (exchange_rate.sui_amount <b>as</b> u128);
     (res <b>as</b> u64)
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -522,6 +522,7 @@ The amount of stake in the <code><a href="validator.md#0x2_validator">validator<
         <a href="_none">option::none</a>(),
         gas_price,
         commission_rate,
+        <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1, // starting next epoch
         ctx
     );
 
@@ -1091,7 +1092,6 @@ gas coins.
         <a href="balance.md#0x2_balance_value">balance::value</a>(&computation_reward)+ <a href="balance.md#0x2_balance_value">balance::value</a>(&storage_fund_reward);
 
     <a href="validator_set.md#0x2_validator_set_advance_epoch">validator_set::advance_epoch</a>(
-        new_epoch,
         &<b>mut</b> self.validators,
         &<b>mut</b> computation_reward,
         &<b>mut</b> storage_fund_reward,

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -901,7 +901,7 @@ Add delegated stake to a validator's staking pool using multiple locked SUI coin
 Withdraw some portion of a delegation from a validator's staking pool.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_withdraw_delegation">request_withdraw_delegation</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_withdraw_delegation">request_withdraw_delegation</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -912,16 +912,12 @@ Withdraw some portion of a delegation from a validator's staking pool.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_withdraw_delegation">request_withdraw_delegation</a>(
     wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
-    delegation: Delegation,
     staked_sui: StakedSui,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
     <a href="validator_set.md#0x2_validator_set_request_withdraw_delegation">validator_set::request_withdraw_delegation</a>(
-        &<b>mut</b> self.validators,
-        delegation,
-        staked_sui,
-        ctx,
+        &<b>mut</b> self.validators, staked_sui, ctx,
     );
 }
 </code></pre>

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -34,7 +34,7 @@
 -  [Function `pending_withdraw`](#0x2_validator_pending_withdraw)
 -  [Function `gas_price`](#0x2_validator_gas_price)
 -  [Function `commission_rate`](#0x2_validator_commission_rate)
--  [Function `pool_token_exchange_rate`](#0x2_validator_pool_token_exchange_rate)
+-  [Function `pool_token_exchange_rate_at_epoch`](#0x2_validator_pool_token_exchange_rate_at_epoch)
 -  [Function `staking_pool_id`](#0x2_validator_staking_pool_id)
 -  [Function `is_duplicate`](#0x2_validator_is_duplicate)
 
@@ -576,7 +576,7 @@ Request to add delegation to the validator's staking pool, processed at the end 
 Request to withdraw delegation from the validator's staking pool, processed at the end of the epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_withdraw_delegation">request_withdraw_delegation</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, delegation: <a href="staking_pool.md#0x2_staking_pool_Delegation">staking_pool::Delegation</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_withdraw_delegation">request_withdraw_delegation</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -587,12 +587,11 @@ Request to withdraw delegation from the validator's staking pool, processed at t
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_withdraw_delegation">request_withdraw_delegation</a>(
     self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>,
-    delegation: Delegation,
     staked_sui: StakedSui,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> principal_withdraw_amount = <a href="staking_pool.md#0x2_staking_pool_request_withdraw_delegation">staking_pool::request_withdraw_delegation</a>(
-            &<b>mut</b> self.delegation_staking_pool, delegation, staked_sui, ctx);
+            &<b>mut</b> self.delegation_staking_pool, staked_sui, ctx);
     <a href="validator.md#0x2_validator_decrease_next_epoch_delegation">decrease_next_epoch_delegation</a>(self, principal_withdraw_amount);
 }
 </code></pre>
@@ -682,7 +681,7 @@ Request to set new gas price for the next epoch.
 Deposit delegations rewards into the validator's staking pool, called at the end of the epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deposit_delegation_rewards">deposit_delegation_rewards</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, reward: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deposit_delegation_rewards">deposit_delegation_rewards</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, reward: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, new_epoch: u64)
 </code></pre>
 
 
@@ -691,9 +690,9 @@ Deposit delegations rewards into the validator's staking pool, called at the end
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deposit_delegation_rewards">deposit_delegation_rewards</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, reward: Balance&lt;SUI&gt;) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deposit_delegation_rewards">deposit_delegation_rewards</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, reward: Balance&lt;SUI&gt;, new_epoch: u64) {
     self.next_epoch_delegation = self.next_epoch_delegation + <a href="balance.md#0x2_balance_value">balance::value</a>(&reward);
-    <a href="staking_pool.md#0x2_staking_pool_deposit_rewards">staking_pool::deposit_rewards</a>(&<b>mut</b> self.delegation_staking_pool, reward);
+    <a href="staking_pool.md#0x2_staking_pool_deposit_rewards">staking_pool::deposit_rewards</a>(&<b>mut</b> self.delegation_staking_pool, reward, new_epoch);
 }
 </code></pre>
 
@@ -708,7 +707,7 @@ Deposit delegations rewards into the validator's staking pool, called at the end
 Process pending delegations and withdraws, called at the end of the epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_process_pending_delegations_and_withdraws">process_pending_delegations_and_withdraws</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_process_pending_delegations_and_withdraws">process_pending_delegations_and_withdraws</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, new_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -717,11 +716,11 @@ Process pending delegations and withdraws, called at the end of the epoch.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_process_pending_delegations_and_withdraws">process_pending_delegations_and_withdraws</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, ctx: &<b>mut</b> TxContext) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_process_pending_delegations_and_withdraws">process_pending_delegations_and_withdraws</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, new_epoch: u64, ctx: &<b>mut</b> TxContext) {
     <b>let</b> reward_withdraw_amount = <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation_withdraws">staking_pool::process_pending_delegation_withdraws</a>(
-        &<b>mut</b> self.delegation_staking_pool, ctx);
+        &<b>mut</b> self.delegation_staking_pool, new_epoch, ctx);
     self.next_epoch_delegation = self.next_epoch_delegation - reward_withdraw_amount;
-    <a href="staking_pool.md#0x2_staking_pool_process_pending_delegations">staking_pool::process_pending_delegations</a>(&<b>mut</b> self.delegation_staking_pool, ctx);
+    <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation">staking_pool::process_pending_delegation</a>(&<b>mut</b> self.delegation_staking_pool, new_epoch);
     // TODO: consider bringing this <b>assert</b> back when we are more confident.
     // <b>assert</b>!(<a href="validator.md#0x2_validator_delegate_amount">delegate_amount</a>(self) == self.metadata.next_epoch_delegation, 0);
 }
@@ -1063,13 +1062,13 @@ Set the voting power of this validator, called only from validator_set.
 
 </details>
 
-<a name="0x2_validator_pool_token_exchange_rate"></a>
+<a name="0x2_validator_pool_token_exchange_rate_at_epoch"></a>
 
-## Function `pool_token_exchange_rate`
+## Function `pool_token_exchange_rate_at_epoch`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pool_token_exchange_rate">pool_token_exchange_rate</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>, epoch: u64): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>
 </code></pre>
 
 
@@ -1078,8 +1077,8 @@ Set the voting power of this validator, called only from validator_set.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pool_token_exchange_rate">pool_token_exchange_rate</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): PoolTokenExchangeRate {
-    <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate">staking_pool::pool_token_exchange_rate</a>(&self.delegation_staking_pool)
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>, epoch: u64): PoolTokenExchangeRate {
+    <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate_at_epoch">staking_pool::pool_token_exchange_rate_at_epoch</a>(&self.delegation_staking_pool, epoch)
 }
 </code></pre>
 

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -109,6 +109,7 @@ module sui::genesis {
                 option::none(),
                 gas_price,
                 commission_rate,
+                0, // start operating right away at epoch 0
                 ctx
             ));
             i = i + 1;

--- a/crates/sui-framework/sources/governance/staking_pool.move
+++ b/crates/sui-framework/sources/governance/staking_pool.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui::staking_pool {
-    use sui::balance::{Self, Balance, Supply};
+    use sui::balance::{Self, Balance};
     use sui::sui::SUI;
     use std::option::{Self, Option};
     use sui::tx_context::{Self, TxContext};
@@ -12,12 +12,12 @@ module sui::staking_pool {
     use sui::locked_coin;
     use sui::coin;
     use sui::table_vec::{Self, TableVec};
-    use sui::linked_table::{Self, LinkedTable};
     use sui::math;
+    use sui::table::{Self, Table};
 
     friend sui::validator;
     friend sui::validator_set;
-    
+
     const EInsufficientPoolTokenBalance: u64 = 0;
     const EWrongPool: u64 = 1;
     const EWithdrawAmountCannotBeZero: u64 = 2;
@@ -34,24 +34,23 @@ module sui::staking_pool {
         /// The epoch at which this pool started operating. Should be the epoch at which the validator became active.
         starting_epoch: u64,
         /// The total number of SUI tokens in this pool, including the SUI in the rewards_pool, as well as in all the principal
-        /// in the `Delegation` object, updated at epoch boundaries.
+        /// in the `StakedSui` object, updated at epoch boundaries.
         sui_balance: u64,
-        /// The epoch delegation rewards will be added here at the end of each epoch. 
+        /// The epoch delegation rewards will be added here at the end of each epoch.
         rewards_pool: Balance<SUI>,
-        /// The number of delegation pool tokens we have issued so far. This number should equal the sum of
-        /// pool token balance in all the `Delegation` objects delegated to this pool. Updated at epoch boundaries.
-        delegation_token_supply: Supply<DelegationToken>,
-        /// Delegations requested during the current epoch. We will activate these delegation at the end of current epoch
-        /// and distribute staking pool tokens at the end-of-epoch exchange rate after the rewards for the current epoch
-        /// have been deposited.
-        pending_delegations: LinkedTable<ID, PendingDelegationEntry>,
+        /// Total number of pool tokens issued by the pool.
+        pool_token_balance: u64,
+        /// Exchange rate history of previous epochs. Key is the epoch number.
+        exchange_rates: Table<u64, PoolTokenExchangeRate>,
+        /// Pending delegation amount for this epoch.
+        pending_delegation: u64,
         /// Delegation withdraws requested during the current epoch. Similar to new delegation, the withdraws are processed
-        /// at epoch boundaries. Rewards are withdrawn and distributed after the rewards for the current epoch have come in. 
+        /// at epoch boundaries. Rewards are withdrawn and distributed after the rewards for the current epoch have come in.
         pending_withdraws: TableVec<PendingWithdrawEntry>,
     }
 
     /// Struct representing the exchange rate of the delegation pool token to SUI.
-    struct PoolTokenExchangeRate has copy, drop {
+    struct PoolTokenExchangeRate has store, copy, drop {
         sui_amount: u64,
         pool_token_amount: u64,
     }
@@ -63,33 +62,11 @@ module sui::staking_pool {
         pool: StakingPool,
     }
 
-    /// The staking pool token.
-    struct DelegationToken has drop {}
-
-    /// Struct representing a pending delegation.
-    struct PendingDelegationEntry has store, drop {
-        delegator: address, 
-        sui_amount: u64,
-    }
-
     /// Struct representing a pending delegation withdraw.
     struct PendingWithdrawEntry has store {
-        delegator: address, 
+        delegator: address,
         principal_withdraw_amount: u64,
-        withdrawn_pool_tokens: Balance<DelegationToken>,
-    }
-
-    /// A self-custodial delegation object, serving as evidence that the delegator
-    /// has delegated to a staking pool.
-    struct Delegation has key {
-        id: UID,
-        /// The ID of the corresponding `StakedSui` object.
-        staked_sui_id: ID,
-        /// The pool tokens representing the amount of rewards the delegator can get back when they withdraw
-        /// from the pool.
-        pool_tokens: Balance<DelegationToken>,
-        /// Number of SUI token staked originally.
-        principal_sui_amount: u64,
+        pool_token_withdraw_amount: u64,
     }
 
     /// A self-custodial object holding the staked SUI tokens.
@@ -99,8 +76,8 @@ module sui::staking_pool {
         pool_id: ID,
         // TODO: keeping this field here because the apps depend on it. consider removing it.
         validator_address: address,
-        /// The epoch at which the delegation is requested.
-        delegation_request_epoch: u64,
+        /// The epoch at which the delegation becomes active.
+        delegation_activation_epoch: u64,
         /// The staked SUI tokens.
         principal: Balance<SUI>,
         /// If the stake comes from a Coin<SUI>, this field is None. If it comes from a LockedCoin<SUI>, this
@@ -112,13 +89,20 @@ module sui::staking_pool {
 
     /// Create a new, empty staking pool.
     public(friend) fun new(ctx: &mut TxContext) : StakingPool {
+        let exchange_rates = table::new(ctx);
+        table::add(
+            &mut exchange_rates,
+            tx_context::epoch(ctx),
+            PoolTokenExchangeRate { sui_amount: 0, pool_token_amount: 0 }
+        );
         StakingPool {
             id: object::new(ctx),
             starting_epoch: tx_context::epoch(ctx) + 1, // active beginning next epoch
             sui_balance: 0,
             rewards_pool: balance::zero(),
-            delegation_token_supply: balance::create_supply(DelegationToken {}),
-            pending_delegations: linked_table::new(ctx),
+            pool_token_balance: 0,
+            exchange_rates,
+            pending_delegation: 0,
             pending_withdraws: table_vec::empty(ctx),
         }
     }
@@ -126,12 +110,11 @@ module sui::staking_pool {
 
     // ==== delegation requests ====
 
-    // TODO: implement rate limiting new delegations per epoch.
     /// Request to delegate to a staking pool. The delegation gets counted at the beginning of the next epoch,
     /// when the delegation object containing the pool tokens is distributed to the delegator.
     public(friend) fun request_add_delegation(
-        pool: &mut StakingPool, 
-        stake: Balance<SUI>, 
+        pool: &mut StakingPool,
+        stake: Balance<SUI>,
         sui_token_lock: Option<EpochTimeLock>,
         validator_address: address,
         delegator: address,
@@ -143,16 +126,11 @@ module sui::staking_pool {
             id: object::new(ctx),
             pool_id: object::id(pool),
             validator_address,
-            delegation_request_epoch: tx_context::epoch(ctx),
+            delegation_activation_epoch: tx_context::epoch(ctx) + 1,
             principal: stake,
             sui_token_lock,
         };
-        // insert delegation info into the pending_delegations table.
-        linked_table::push_back(
-            &mut pool.pending_delegations,
-            object::id(&staked_sui),
-            PendingDelegationEntry { delegator, sui_amount }
-        );
+        pool.pending_delegation = pool.pending_delegation + sui_amount;
         transfer::transfer(staked_sui, delegator);
     }
 
@@ -162,18 +140,17 @@ module sui::staking_pool {
     /// The rewards portion will be withdrawn at the end of the epoch, after the rewards have come in so we
     /// can use the new exchange rate to calculate the rewards.
     public(friend) fun request_withdraw_delegation(
-        pool: &mut StakingPool,  
-        delegation: Delegation, 
+        pool: &mut StakingPool,
         staked_sui: StakedSui,
         ctx: &mut TxContext
     ) : u64 {
-        let (withdrawn_pool_tokens, principal_withdraw, time_lock) = 
-            withdraw_from_principal(pool, delegation, staked_sui);
-        
+        let (pool_token_withdraw_amount, principal_withdraw, time_lock) =
+            withdraw_from_principal(pool, staked_sui);
+
         let delegator = tx_context::sender(ctx);
         let principal_withdraw_amount = balance::value(&principal_withdraw);
         table_vec::push_back(&mut pool.pending_withdraws, PendingWithdrawEntry {
-            delegator, principal_withdraw_amount, withdrawn_pool_tokens });
+            delegator, principal_withdraw_amount, pool_token_withdraw_amount });
 
         // TODO: implement withdraw bonding period here.
         if (option::is_some(&time_lock)) {
@@ -187,46 +164,36 @@ module sui::staking_pool {
 
     /// Withdraw the requested amount of the principal SUI stored in the StakedSui object, as
     /// well as a proportional amount of pool tokens from the delegation object.
-    /// For example, suppose the delegation object contains 15 pool tokens and the principal SUI 
+    /// For example, suppose the delegation object contains 15 pool tokens and the principal SUI
     /// amount is 21. Then if `principal_withdraw_amount` is 7, 5 pool tokens and 7 SUI tokens will
     /// be withdrawn.
-    /// Returns values are withdrawn pool tokens, withdrawn principal portion of SUI, and its 
+    /// Returns values are withdrawn pool tokens, withdrawn principal portion of SUI, and its
     /// time lock if applicable.
     public(friend) fun withdraw_from_principal(
-        pool: &mut StakingPool,  
-        delegation: Delegation, 
+        pool: &mut StakingPool,
         staked_sui: StakedSui,
-    ) : (Balance<DelegationToken>, Balance<SUI>, Option<EpochTimeLock>) {
-        // Check that the delegation and staked sui objects match.
-        assert!(object::id(&staked_sui) == delegation.staked_sui_id, EWrongDelegation);
+    ) : (u64, Balance<SUI>, Option<EpochTimeLock>) {
 
-        // Check that the delegation information matches the pool. 
+        // Check that the delegation information matches the pool.
         assert!(staked_sui.pool_id == object::id(pool), EWrongPool);
 
-        assert!(delegation.principal_sui_amount == balance::value(&staked_sui.principal), EInsufficientSuiTokenBalance);
-
-        let pool_tokens = destroy_delegation_and_return_pool_tokens(delegation);
+        let exchange_rate_at_staking_epoch = pool_token_exchange_rate_at_epoch(pool, staked_sui.delegation_activation_epoch);
         let (principal_withdraw, time_lock) = unwrap_staked_sui(staked_sui);
+        let pool_token_withdraw_amount = get_token_amount(&exchange_rate_at_staking_epoch, balance::value(&principal_withdraw));
 
         (
-            pool_tokens,
+            pool_token_withdraw_amount,
             principal_withdraw,
             time_lock
         )
     }
 
-    fun destroy_delegation_and_return_pool_tokens(delegation: Delegation): Balance<DelegationToken> {
-        let Delegation { id, staked_sui_id: _, pool_tokens, principal_sui_amount: _ } = delegation;
-        object::delete(id);
-        pool_tokens
-    }
-
     fun unwrap_staked_sui(staked_sui: StakedSui): (Balance<SUI>, Option<EpochTimeLock>) {
-        let StakedSui { 
+        let StakedSui {
             id,
             pool_id: _,
             validator_address: _,
-            delegation_request_epoch: _,
+            delegation_activation_epoch: _,
             principal,
             sui_token_lock
         } = staked_sui;
@@ -236,56 +203,61 @@ module sui::staking_pool {
 
     // ==== functions called at epoch boundaries ===
 
-    /// Called at epoch advancement times to add rewards (in SUI) to the staking pool. 
-    public(friend) fun deposit_rewards(pool: &mut StakingPool, rewards: Balance<SUI>) {
+    /// Called at epoch advancement times to add rewards (in SUI) to the staking pool.
+    public(friend) fun deposit_rewards(pool: &mut StakingPool, rewards: Balance<SUI>, new_epoch: u64) {
         pool.sui_balance = pool.sui_balance + balance::value(&rewards);
         balance::join(&mut pool.rewards_pool, rewards);
+        table::add(
+            &mut pool.exchange_rates,
+            new_epoch,
+            PoolTokenExchangeRate { sui_amount: pool.sui_balance, pool_token_amount: pool.pool_token_balance },
+        );
     }
 
     /// Called at epoch boundaries to process pending delegation withdraws requested during the epoch.
     /// For each pending withdraw entry, we withdraw the rewards from the pool at the new exchange rate and burn the pool
     /// tokens.
-    public(friend) fun process_pending_delegation_withdraws(pool: &mut StakingPool, ctx: &mut TxContext) : u64 {
+    public(friend) fun process_pending_delegation_withdraws(pool: &mut StakingPool, new_epoch: u64, ctx: &mut TxContext) : u64 {
         let total_reward_withdraw = 0;
 
         while (!table_vec::is_empty(&pool.pending_withdraws)) {
             let PendingWithdrawEntry {
-                delegator, principal_withdraw_amount, withdrawn_pool_tokens
+                delegator, principal_withdraw_amount, pool_token_withdraw_amount
             } = table_vec::pop_back(&mut pool.pending_withdraws);
-            let reward_withdraw = withdraw_rewards_and_burn_pool_tokens(pool, principal_withdraw_amount, withdrawn_pool_tokens);
+            let reward_withdraw = withdraw_rewards_and_burn_pool_tokens(
+                pool, principal_withdraw_amount, pool_token_withdraw_amount, new_epoch);
             total_reward_withdraw = total_reward_withdraw + balance::value(&reward_withdraw);
             transfer::transfer(coin::from_balance(reward_withdraw, ctx), delegator);
         };
         total_reward_withdraw
     }
 
-    /// Called at epoch boundaries to mint new pool tokens to new delegators at the new exchange rate.
-    public(friend) fun process_pending_delegations(pool: &mut StakingPool, ctx: &mut TxContext) {
-        while (!linked_table::is_empty(&pool.pending_delegations)) {
-            let (staked_sui_id, PendingDelegationEntry { delegator, sui_amount }) =
-                linked_table::pop_back(&mut pool.pending_delegations);
-            mint_delegation_tokens_to_delegator(pool, delegator, sui_amount, staked_sui_id, ctx);
-            pool.sui_balance = pool.sui_balance + sui_amount;
-        };
+    /// Called at epoch boundaries to process the pending delegation.
+    public(friend) fun process_pending_delegation(pool: &mut StakingPool, new_epoch: u64) {
+        let new_epoch_exchange_rate = pool_token_exchange_rate_at_epoch(pool, new_epoch);
+        pool.sui_balance = pool.sui_balance + pool.pending_delegation;
+        pool.pool_token_balance = pool.pool_token_balance + get_token_amount(&new_epoch_exchange_rate, pool.pending_delegation);
+        pool.pending_delegation = 0;
     }
 
     /// This function does the following:
     ///     1. Calculates the total amount of SUI (including principal and rewards) that the provided pool tokens represent
     ///        at the current exchange rate.
-    ///     2. Using the above number and the given `principal_withdraw_amount`, calculates the rewards portion of the 
+    ///     2. Using the above number and the given `principal_withdraw_amount`, calculates the rewards portion of the
     ///        delegation we should withdraw.
     ///     3. Withdraws the rewards portion from the rewards pool at the current exchange rate. We only withdraw the rewards
-    ///        portion because the principal portion was already taken out of the delegator's self custodied StakedSui at request 
+    ///        portion because the principal portion was already taken out of the delegator's self custodied StakedSui at request
     ///        time in `request_withdraw_stake`.
     ///     4. Since SUI tokens are withdrawn, we need to burn the corresponding pool tokens to keep the exchange rate the same.
     ///     5. Updates the SUI balance amount of the pool.
     fun withdraw_rewards_and_burn_pool_tokens(
-        pool: &mut StakingPool, 
-        principal_withdraw_amount: u64, 
-        withdrawn_pool_tokens: Balance<DelegationToken>,
+        pool: &mut StakingPool,
+        principal_withdraw_amount: u64,
+        pool_token_withdraw_amount: u64,
+        new_epoch: u64,
     ) : Balance<SUI> {
-        let pool_token_amount = balance::value(&withdrawn_pool_tokens);
-        let total_sui_withdraw_amount = get_sui_amount(pool, pool_token_amount);
+        let new_epoch_exchange_rate = pool_token_exchange_rate_at_epoch(pool, new_epoch);
+        let total_sui_withdraw_amount = get_sui_amount(&new_epoch_exchange_rate, pool_token_withdraw_amount);
         let reward_withdraw_amount =
             if (total_sui_withdraw_amount >= principal_withdraw_amount)
                 total_sui_withdraw_amount - principal_withdraw_amount
@@ -294,111 +266,19 @@ module sui::staking_pool {
         // the rewards pool balance may be less than reward_withdraw_amount.
         // TODO: FIGURE OUT EXACTLY WHY THIS CAN HAPPEN.
         reward_withdraw_amount = math::min(reward_withdraw_amount, balance::value(&pool.rewards_pool));
-        balance::decrease_supply(
-            &mut pool.delegation_token_supply, 
-            withdrawn_pool_tokens
-        );
         pool.sui_balance = pool.sui_balance - (principal_withdraw_amount + reward_withdraw_amount);
+        pool.pool_token_balance = pool.pool_token_balance - pool_token_withdraw_amount;
         balance::split(&mut pool.rewards_pool, reward_withdraw_amount)
     }
 
-    /// Given the `sui_amount`, mint the corresponding amount of pool tokens at the current exchange
-    /// rate, puts the pool tokens in a delegation object, and gives the delegation object to the delegator.
-    fun mint_delegation_tokens_to_delegator(
-        pool: &mut StakingPool, 
-        delegator: address, 
-        sui_amount: u64, 
-        staked_sui_id: ID,
-        ctx: &mut TxContext
-    ) {
-        let new_pool_token_amount = get_token_amount(pool, sui_amount);   
-
-        // Mint new pool tokens at the current exchange rate.
-        let pool_tokens = balance::increase_supply(&mut pool.delegation_token_supply, new_pool_token_amount);
-
-        let delegation = Delegation {
-            id: object::new(ctx),
-            staked_sui_id,
-            pool_tokens,
-            principal_sui_amount: sui_amount,
-        };
-
-        transfer::transfer(delegation, delegator);
-    }
-
-
     // ==== inactive pool related ====
 
-    /// Deactivate a staking pool by wrapping it in an `InactiveStakingPool` and sharing this newly created object. 
+    /// Deactivate a staking pool by wrapping it in an `InactiveStakingPool` and sharing this newly created object.
     /// After this pool deactivation, the pool stops earning rewards. Only delegation withdraws can be made to the pool.
     public(friend) fun deactivate_staking_pool(pool: StakingPool, ctx: &mut TxContext) {
         let inactive_pool = InactiveStakingPool { id: object::new(ctx), pool};
         transfer::share_object(inactive_pool);
     }
-
-    /// Withdraw delegation from an inactive pool. Since no epoch rewards will be added to an inactive pool,
-    /// the exchange rate between pool tokens and SUI tokens stay the same. Therefore, unlike withdrawing
-    /// from an active pool, we can handle both principal and rewards withdraws directly here.
-    public entry fun withdraw_from_inactive_pool(
-        inactive_pool: &mut InactiveStakingPool, 
-        staked_sui: StakedSui, 
-        delegation: Delegation, 
-        ctx: &mut TxContext
-    ) {
-        let pool = &mut inactive_pool.pool;
-        let (withdrawn_pool_tokens, principal_withdraw, time_lock) = 
-            withdraw_from_principal(pool, delegation, staked_sui);
-        let principal_withdraw_amount = balance::value(&principal_withdraw);
-        let rewards_withdraw = withdraw_rewards_and_burn_pool_tokens(pool, principal_withdraw_amount, withdrawn_pool_tokens);
-        let total_withdraw_amount = principal_withdraw_amount + balance::value(&rewards_withdraw);
-        pool.sui_balance = pool.sui_balance - total_withdraw_amount;
-
-        let delegator = tx_context::sender(ctx);
-        // TODO: implement withdraw bonding period here.
-        if (option::is_some(&time_lock)) {
-            locked_coin::new_from_balance(principal_withdraw, option::destroy_some(time_lock), delegator, ctx);
-            transfer::transfer(coin::from_balance(rewards_withdraw, ctx), delegator);
-        } else {
-            balance::join(&mut principal_withdraw, rewards_withdraw);
-            transfer::transfer(coin::from_balance(principal_withdraw, ctx), delegator);
-            option::destroy_none(time_lock);
-        };
-    }
-
-
-    // ==== destroyers ====
-
-    /// Destroy an empty delegation that no longer contains any SUI or pool tokens.
-    public entry fun destroy_empty_delegation(delegation: Delegation) {
-        let Delegation {
-            id,
-            staked_sui_id: _,
-            pool_tokens,
-            principal_sui_amount,
-        } = delegation;
-        object::delete(id);
-        assert!(balance::value(&pool_tokens) == 0, EDestroyNonzeroBalance);
-        assert!(principal_sui_amount == 0, EDestroyNonzeroBalance);
-        balance::destroy_zero(pool_tokens);
-    }
-
-    /// Destroy an empty delegation that no longer contains any SUI or pool tokens.
-    public entry fun destroy_empty_staked_sui(staked_sui: StakedSui) {
-        let StakedSui {
-            id,
-            pool_id: _,
-            validator_address: _,
-            delegation_request_epoch: _,
-            principal,
-            sui_token_lock
-        } = staked_sui;
-        object::delete(id);
-        assert!(balance::value(&principal) == 0, EDestroyNonzeroBalance);
-        balance::destroy_zero(principal);
-        assert!(option::is_none(&sui_token_lock), ETokenTimeLockIsSome);
-        option::destroy_none(sui_token_lock);
-    }
-
 
     // ==== getters and misc utility functions ====
 
@@ -408,46 +288,39 @@ module sui::staking_pool {
 
     public fun staked_sui_amount(staked_sui: &StakedSui): u64 { balance::value(&staked_sui.principal) }
 
-    public fun delegation_request_epoch(staked_sui: &StakedSui): u64 {
-        staked_sui.delegation_request_epoch
+    public fun delegation_activation_epoch(staked_sui: &StakedSui): u64 {
+        staked_sui.delegation_activation_epoch
     }
 
-    public fun delegation_token_amount(delegation: &Delegation): u64 { balance::value(&delegation.pool_tokens) }
-
-    public fun pool_token_exchange_rate(pool: &StakingPool): PoolTokenExchangeRate {
-        PoolTokenExchangeRate {
-            sui_amount: pool.sui_balance,
-            pool_token_amount: balance::supply_value(&pool.delegation_token_supply),
-        }
+    public fun pool_token_exchange_rate_at_epoch(pool: &StakingPool, epoch: u64): PoolTokenExchangeRate {
+        *table::borrow(&pool.exchange_rates, epoch)
     }
     /// Create a new pending withdraw entry.
     public(friend) fun new_pending_withdraw_entry(
-        delegator: address, 
+        delegator: address,
         principal_withdraw_amount: u64,
-        withdrawn_pool_tokens: Balance<DelegationToken>,
+        pool_token_withdraw_amount: u64,
     ) : PendingWithdrawEntry {
-        PendingWithdrawEntry { delegator, principal_withdraw_amount, withdrawn_pool_tokens }
+        PendingWithdrawEntry { delegator, principal_withdraw_amount, pool_token_withdraw_amount }
     }
 
-    fun get_sui_amount(pool: &StakingPool, token_amount: u64): u64 {
-        let token_supply = balance::supply_value(&pool.delegation_token_supply);
-        if (token_supply == 0) { 
-            return token_amount 
+    fun get_sui_amount(exchange_rate: &PoolTokenExchangeRate, token_amount: u64): u64 {
+        if (exchange_rate.pool_token_amount == 0) {
+            return token_amount
         };
-        let res = (pool.sui_balance as u128) 
-                * (token_amount as u128) 
-                / (token_supply as u128);
+        let res = (exchange_rate.sui_amount as u128)
+                * (token_amount as u128)
+                / (exchange_rate.pool_token_amount as u128);
         (res as u64)
     }
 
-    fun get_token_amount(pool: &StakingPool, sui_amount: u64): u64 {
-        if (pool.sui_balance == 0) { 
+    fun get_token_amount(exchange_rate: &PoolTokenExchangeRate, sui_amount: u64): u64 {
+        if (exchange_rate.sui_amount == 0) {
             return sui_amount
         };
-        let token_supply = balance::supply_value(&pool.delegation_token_supply);
-        let res = (token_supply as u128) 
+        let res = (exchange_rate.pool_token_amount as u128)
                 * (sui_amount as u128)
-                / (pool.sui_balance as u128);
+                / (exchange_rate.sui_amount as u128);
         (res as u64)
-    }    
+    }
 }

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -5,8 +5,8 @@ module sui::sui_system {
     use sui::balance::{Self, Balance};
     use sui::clock::{Self, Clock};
     use sui::coin::{Self, Coin};
-    use sui::staking_pool::{Delegation, StakedSui};
     use sui::object::{Self, ID, UID};
+    use sui::staking_pool::StakedSui;
     use sui::locked_coin::{Self, LockedCoin};
     use sui::sui::SUI;
     use sui::transfer;
@@ -378,16 +378,12 @@ module sui::sui_system {
     /// Withdraw some portion of a delegation from a validator's staking pool.
     public entry fun request_withdraw_delegation(
         wrapper: &mut SuiSystemState,
-        delegation: Delegation,
         staked_sui: StakedSui,
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
         validator_set::request_withdraw_delegation(
-            &mut self.validators,
-            delegation,
-            staked_sui,
-            ctx,
+            &mut self.validators, staked_sui, ctx,
         );
     }
 

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -208,6 +208,7 @@ module sui::sui_system {
             option::none(),
             gas_price,
             commission_rate,
+            tx_context::epoch(ctx) + 1, // starting next epoch
             ctx
         );
 
@@ -497,7 +498,6 @@ module sui::sui_system {
             balance::value(&computation_reward)+ balance::value(&storage_fund_reward);
 
         validator_set::advance_epoch(
-            new_epoch,
             &mut self.validators,
             &mut computation_reward,
             &mut storage_fund_reward,

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -15,7 +15,7 @@ module sui::validator {
     use sui::object::{Self, ID};
     use std::option::Option;
     use sui::bls12381::bls12381_min_sig_verify_with_domain;
-    use sui::staking_pool::{Self, Delegation, PoolTokenExchangeRate, StakedSui, StakingPool};
+    use sui::staking_pool::{Self, PoolTokenExchangeRate, StakedSui, StakingPool};
     use std::string::{Self, String};
     use sui::url::Url;
     use sui::url;
@@ -255,12 +255,11 @@ module sui::validator {
     /// Request to withdraw delegation from the validator's staking pool, processed at the end of the epoch.
     public(friend) fun request_withdraw_delegation(
         self: &mut Validator,
-        delegation: Delegation,
         staked_sui: StakedSui,
         ctx: &mut TxContext,
     ) {
         let principal_withdraw_amount = staking_pool::request_withdraw_delegation(
-                &mut self.delegation_staking_pool, delegation, staked_sui, ctx);
+                &mut self.delegation_staking_pool, staked_sui, ctx);
         decrease_next_epoch_delegation(self, principal_withdraw_amount);
     }
 
@@ -279,17 +278,17 @@ module sui::validator {
     }
 
     /// Deposit delegations rewards into the validator's staking pool, called at the end of the epoch.
-    public(friend) fun deposit_delegation_rewards(self: &mut Validator, reward: Balance<SUI>) {
+    public(friend) fun deposit_delegation_rewards(self: &mut Validator, reward: Balance<SUI>, new_epoch: u64) {
         self.next_epoch_delegation = self.next_epoch_delegation + balance::value(&reward);
-        staking_pool::deposit_rewards(&mut self.delegation_staking_pool, reward);
+        staking_pool::deposit_rewards(&mut self.delegation_staking_pool, reward, new_epoch);
     }
 
     /// Process pending delegations and withdraws, called at the end of the epoch.
-    public(friend) fun process_pending_delegations_and_withdraws(self: &mut Validator, ctx: &mut TxContext) {
+    public(friend) fun process_pending_delegations_and_withdraws(self: &mut Validator, new_epoch: u64, ctx: &mut TxContext) {
         let reward_withdraw_amount = staking_pool::process_pending_delegation_withdraws(
-            &mut self.delegation_staking_pool, ctx);
+            &mut self.delegation_staking_pool, new_epoch, ctx);
         self.next_epoch_delegation = self.next_epoch_delegation - reward_withdraw_amount;
-        staking_pool::process_pending_delegations(&mut self.delegation_staking_pool, ctx);
+        staking_pool::process_pending_delegation(&mut self.delegation_staking_pool, new_epoch);
         // TODO: consider bringing this assert back when we are more confident.
         // assert!(delegate_amount(self) == self.metadata.next_epoch_delegation, 0);
     }
@@ -358,8 +357,8 @@ module sui::validator {
         self.commission_rate
     }
 
-    public fun pool_token_exchange_rate(self: &Validator): PoolTokenExchangeRate {
-        staking_pool::pool_token_exchange_rate(&self.delegation_staking_pool)
+    public fun pool_token_exchange_rate_at_epoch(self: &Validator, epoch: u64): PoolTokenExchangeRate {
+        staking_pool::pool_token_exchange_rate_at_epoch(&self.delegation_staking_pool, epoch)
     }
 
     public fun staking_pool_id(self: &Validator): ID {

--- a/crates/sui-framework/tests/delegation_tests.move
+++ b/crates/sui-framework/tests/delegation_tests.move
@@ -6,7 +6,8 @@ module sui::delegation_tests {
     use sui::coin;
     use sui::test_scenario::{Self, Scenario};
     use sui::sui_system::{Self, SuiSystemState};
-    use sui::staking_pool::{Self, Delegation, StakedSui};
+    use sui::staking_pool::{Self, StakedSui};
+
 
     use sui::governance_test_utils::{
         Self,
@@ -48,9 +49,6 @@ module sui::delegation_tests {
         test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
         {
 
-            let delegation = test_scenario::take_from_sender<Delegation>(scenario);
-            assert!(staking_pool::delegation_token_amount(&delegation) == 60, 105);
-
             let staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
             assert!(staking_pool::staked_sui_amount(&staked_sui) == 60, 105);
 
@@ -64,8 +62,7 @@ module sui::delegation_tests {
             let ctx = test_scenario::ctx(scenario);
 
             // Undelegate from VALIDATOR_ADDR_1
-            sui_system::request_withdraw_delegation(
-                system_state_mut_ref, delegation, staked_sui, ctx);
+            sui_system::request_withdraw_delegation(system_state_mut_ref, staked_sui, ctx);
 
             assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_1) == 60, 107);
             test_scenario::return_shared(system_state);

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -8,7 +8,7 @@ module sui::governance_test_utils {
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
     use sui::stake::{Self, Stake};
-    use sui::staking_pool::{StakedSui, Delegation};
+    use sui::staking_pool::StakedSui;
     use sui::tx_context::{Self, TxContext};
     use sui::validator::{Self, Validator};
     use sui::sui_system::{Self, SuiSystemState};
@@ -131,17 +131,15 @@ module sui::governance_test_utils {
     }
 
     public fun undelegate(
-        delegator: address, staked_sui_idx: u64, delegation_obj_idx: u64, scenario: &mut Scenario
+        delegator: address, staked_sui_idx: u64, scenario: &mut Scenario
     ) {
         test_scenario::next_tx(scenario, delegator);
         let stake_sui_ids = test_scenario::ids_for_sender<StakedSui>(scenario);
         let staked_sui = test_scenario::take_from_sender_by_id(scenario, *vector::borrow(&stake_sui_ids, staked_sui_idx));
-        let delegation_ids = test_scenario::ids_for_sender<Delegation>(scenario);
-        let delegation = test_scenario::take_from_sender_by_id(scenario, *vector::borrow(&delegation_ids, delegation_obj_idx));
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
 
         let ctx = test_scenario::ctx(scenario);
-        sui_system::request_withdraw_delegation(&mut system_state, delegation, staked_sui, ctx);
+        sui_system::request_withdraw_delegation(&mut system_state, staked_sui, ctx);
         test_scenario::return_shared(system_state);
     }
 

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -37,6 +37,7 @@ module sui::governance_test_utils {
             option::none(),
             1,
             0,
+            0,
             ctx
         )
     }
@@ -90,14 +91,15 @@ module sui::governance_test_utils {
     public fun advance_epoch_with_reward_amounts(
         storage_charge: u64, computation_charge: u64, scenario: &mut Scenario
     ) {
-        test_scenario::next_epoch(scenario, @0x0);
-        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario));
+        test_scenario::next_tx(scenario, @0x0);
+        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario)) + 1;
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
 
         let ctx = test_scenario::ctx(scenario);
 
         sui_system::advance_epoch(&mut system_state, new_epoch, 1, storage_charge, computation_charge, 0, 0, 0, 0,  ctx);
         test_scenario::return_shared(system_state);
+        test_scenario::next_epoch(scenario, @0x0);
     }
 
     public fun advance_epoch_with_reward_amounts_and_slashing_rates(
@@ -106,8 +108,8 @@ module sui::governance_test_utils {
         reward_slashing_rate: u64,
         scenario: &mut Scenario
     ) {
-        test_scenario::next_epoch(scenario, @0x0);
-        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario));
+        test_scenario::next_tx(scenario, @0x0);
+        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario)) + 1;
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
 
         let ctx = test_scenario::ctx(scenario);
@@ -116,6 +118,7 @@ module sui::governance_test_utils {
             &mut system_state, new_epoch, 1, storage_charge, computation_charge, 0, 0, reward_slashing_rate, 0, ctx
         );
         test_scenario::return_shared(system_state);
+        test_scenario::next_epoch(scenario, @0x0);
     }
 
     public fun delegate_to(

--- a/crates/sui-framework/tests/rewards_distribution_tests.move
+++ b/crates/sui-framework/tests/rewards_distribution_tests.move
@@ -87,19 +87,19 @@ module sui::rewards_distribution_tests {
         // 10 SUI rewards for each 100 SUI of stake
         advance_epoch_with_reward_amounts(0, 130, scenario);
         assert_validator_stake_amounts(validator_addrs(), vector[110, 220, 330, 440], scenario);
-        undelegate(DELEGATOR_ADDR_1, 0, 0, scenario);
+        undelegate(DELEGATOR_ADDR_1, 0, scenario);
         delegate_to(DELEGATOR_ADDR_2, VALIDATOR_ADDR_1, 600, scenario);
         // 10 SUI rewards for each 110 SUI of stake
         advance_epoch_with_reward_amounts(0, 130, scenario);
         assert!(total_sui_balance(DELEGATOR_ADDR_1, scenario) == 240, 0); // 40 SUI of rewards received
         assert_validator_stake_amounts(validator_addrs(), vector[120, 240, 360, 480], scenario);
-        undelegate(DELEGATOR_ADDR_2, 0, 0, scenario);
+        undelegate(DELEGATOR_ADDR_2, 0, scenario);
         governance_test_utils::advance_epoch(scenario);
         assert!(total_sui_balance(DELEGATOR_ADDR_2, scenario) == 120, 0); // 20 SUI of rewards received
 
         // 10 SUI rewards for each 120 SUI of stake
         advance_epoch_with_reward_amounts(0, 150, scenario);
-        undelegate(DELEGATOR_ADDR_2, 0, 0, scenario); // unstake 600 principal SUI
+        undelegate(DELEGATOR_ADDR_2, 0, scenario); // unstake 600 principal SUI
         governance_test_utils::advance_epoch(scenario);
         // additional 600 SUI of principal and 50 SUI of rewards withdrawn to Coin<SUI>
         assert!(total_sui_balance(DELEGATOR_ADDR_2, scenario) == 770, 0);
@@ -124,7 +124,7 @@ module sui::rewards_distribution_tests {
         advance_epoch_with_reward_amounts(0, 130, scenario);
 
         // undelegate the delegations
-        undelegate(DELEGATOR_ADDR_1, 1, 1, scenario);
+        undelegate(DELEGATOR_ADDR_1, 1, scenario);
 
         // and advance epoch should succeed
         advance_epoch_with_reward_amounts(0, 150, scenario);
@@ -206,8 +206,8 @@ module sui::rewards_distribution_tests {
         assert_validator_stake_amounts(validator_addrs(), vector[203, 380, 610, 813], scenario);
 
         // Undelegate so we can check the delegation rewards as well.
-        undelegate(DELEGATOR_ADDR_1, 0, 0, scenario);
-        undelegate(DELEGATOR_ADDR_2, 0, 0, scenario);
+        undelegate(DELEGATOR_ADDR_1, 0, scenario);
+        undelegate(DELEGATOR_ADDR_2, 0, scenario);
 
         advance_epoch(scenario);
 
@@ -251,8 +251,8 @@ module sui::rewards_distribution_tests {
         assert_validator_stake_amounts(validator_addrs(), vector[294, 508, 722, 780], scenario);
 
         // Undelegate so we can check the delegation rewards as well.
-        undelegate(DELEGATOR_ADDR_1, 0, 0, scenario);
-        undelegate(DELEGATOR_ADDR_2, 0, 0, scenario);
+        undelegate(DELEGATOR_ADDR_1, 0, scenario);
+        undelegate(DELEGATOR_ADDR_2, 0, scenario);
 
         advance_epoch(scenario);
 

--- a/crates/sui-framework/tests/rewards_distribution_tests.move
+++ b/crates/sui-framework/tests/rewards_distribution_tests.move
@@ -19,6 +19,7 @@ module sui::rewards_distribution_tests {
         delegate_to,
         total_sui_balance, undelegate
     };
+    use sui::test_utils::assert_eq;
 
     const VALIDATOR_ADDR_1: address = @0x1;
     const VALIDATOR_ADDR_2: address = @0x2;
@@ -27,6 +28,8 @@ module sui::rewards_distribution_tests {
 
     const DELEGATOR_ADDR_1: address = @0x42;
     const DELEGATOR_ADDR_2: address = @0x43;
+    const DELEGATOR_ADDR_3: address = @0x44;
+    const DELEGATOR_ADDR_4: address = @0x45;
 
     #[test]
     fun test_validator_rewards() {
@@ -77,8 +80,6 @@ module sui::rewards_distribution_tests {
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
         set_up_sui_system_state(scenario);
-
-        // need to advance epoch so validator's staking starts counting
 
         delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 200, scenario);
         delegate_to(DELEGATOR_ADDR_2, VALIDATOR_ADDR_2, 100, scenario);
@@ -259,6 +260,68 @@ module sui::rewards_distribution_tests {
         assert!(total_sui_balance(DELEGATOR_ADDR_1, scenario) == 215, 0);
         assert!(total_sui_balance(DELEGATOR_ADDR_2, scenario) == 180, 0);
 
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_mul_rewards_withdraws_at_same_epoch() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 220, scenario);
+
+        // 10 SUI rewards for each 100 SUI of stake
+        advance_epoch_with_reward_amounts(0, 100, scenario);
+
+        delegate_to(DELEGATOR_ADDR_2, VALIDATOR_ADDR_1, 480, scenario);
+
+        // 10 SUI rewards for each 110 SUI of stake
+        advance_epoch_with_reward_amounts(0, 120, scenario);
+
+        delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 130, scenario);
+        delegate_to(DELEGATOR_ADDR_3, VALIDATOR_ADDR_1, 390, scenario);
+
+        // 10 SUI rewards for each 120 SUI of stake
+        advance_epoch_with_reward_amounts(0, 160, scenario);
+        delegate_to(DELEGATOR_ADDR_3, VALIDATOR_ADDR_1, 280, scenario);
+        delegate_to(DELEGATOR_ADDR_4, VALIDATOR_ADDR_1, 1400, scenario);
+
+        // 10 SUI rewards for each 130 SUI of stake
+        advance_epoch_with_reward_amounts(0, 200, scenario);
+
+        test_scenario::next_tx(scenario, @0x0);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        // Check that we have the right amount of SUI in the staking pool.
+        assert_eq(sui_system::validator_delegate_amount(&system_state, VALIDATOR_ADDR_1), 140 * 22);
+        test_scenario::return_shared(system_state);
+
+        // Withdraw all delegations at once.
+        undelegate(DELEGATOR_ADDR_1, 0, scenario);
+        undelegate(DELEGATOR_ADDR_1, 0, scenario);
+        undelegate(DELEGATOR_ADDR_2, 0, scenario);
+        undelegate(DELEGATOR_ADDR_3, 0, scenario);
+        undelegate(DELEGATOR_ADDR_3, 0, scenario);
+        undelegate(DELEGATOR_ADDR_4, 0, scenario);
+
+        advance_epoch_with_reward_amounts(0, 0, scenario);
+
+        // delegator 1's first delegation was active for 3 epochs so got 20 * 3 = 60 SUI of rewards
+        // and her second delegation was active for only one epoch and got 10 SUI of rewards.
+        assert_eq(total_sui_balance(DELEGATOR_ADDR_1, scenario), 220 + 130 + 20 * 3 + 10);
+        // delegator 2's delegation was active for 2 epochs so got 40 * 2 = 80 SUI of rewards
+        assert_eq(total_sui_balance(DELEGATOR_ADDR_2, scenario), 480 + 40 * 2);
+        // delegator 3's first delegation was active for 1 epoch and got 30 SUI of rewards
+        // and her second delegation didn't get any rewards.
+        assert_eq(total_sui_balance(DELEGATOR_ADDR_3, scenario), 390 + 280 + 30);
+        // delegator 4 joined and left in an epoch where no rewards were earned so she got no rewards.
+        assert_eq(total_sui_balance(DELEGATOR_ADDR_4, scenario), 1400);
+
+        test_scenario::next_tx(scenario, @0x0);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        // Since all the delegations are gone the pool is empty.
+        assert_eq(sui_system::validator_delegate_amount(&system_state, VALIDATOR_ADDR_1), 0);
+        test_scenario::return_shared(system_state);
         test_scenario::end(scenario_val);
     }
 

--- a/crates/sui-framework/tests/validator_set_tests.move
+++ b/crates/sui-framework/tests/validator_set_tests.move
@@ -5,7 +5,7 @@
 module sui::validator_set_tests {
     use sui::balance;
     use sui::coin;
-    use sui::tx_context::TxContext;
+    use sui::tx_context::{Self, TxContext};
     use sui::validator::{Self, Validator};
     use sui::validator_set::{Self, ValidatorSet};
     use sui::test_scenario;
@@ -218,8 +218,10 @@ module sui::validator_set_tests {
         let dummy_computation_reward = balance::zero();
         let dummy_storage_fund_reward = balance::zero();
 
+        tx_context::increment_epoch_number(ctx);
+
         validator_set::advance_epoch(
-            1, // dummy new epoch number
+            tx_context::epoch(ctx), // dummy new epoch number
             validator_set,
             &mut dummy_computation_reward,
             &mut dummy_storage_fund_reward,

--- a/crates/sui-framework/tests/validator_set_tests.move
+++ b/crates/sui-framework/tests/validator_set_tests.move
@@ -178,6 +178,7 @@ module sui::validator_set_tests {
             option::none(),
             1,
             0,
+            0,
             ctx
         )
     }
@@ -205,6 +206,7 @@ module sui::validator_set_tests {
             option::none(),
             gas_price,
             0,
+            0,
             ctx
         )
     }
@@ -221,7 +223,6 @@ module sui::validator_set_tests {
         tx_context::increment_epoch_number(ctx);
 
         validator_set::advance_epoch(
-            tx_context::epoch(ctx), // dummy new epoch number
             validator_set,
             &mut dummy_computation_reward,
             &mut dummy_storage_fund_reward,

--- a/crates/sui-framework/tests/validator_tests.move
+++ b/crates/sui-framework/tests/validator_tests.move
@@ -40,6 +40,7 @@ module sui::validator_tests {
                 option::none(),
                 1,
                 0,
+                0,
                 ctx
             );
             assert!(validator::stake_amount(&validator) == 10, 0);
@@ -83,6 +84,7 @@ module sui::validator_tests {
             init_stake,
             option::none(),
             1,
+            0,
             0,
             ctx
         );

--- a/crates/sui-framework/tests/voting_power_tests.move
+++ b/crates/sui-framework/tests/voting_power_tests.move
@@ -6,8 +6,9 @@ module sui::voting_power_tests {
     use sui::governance_test_utils as gtu;
     use sui::validator_set;
     use sui::voting_power;
+    use sui::test_scenario;
     use sui::test_utils;
-    use sui::tx_context;
+    use sui::tx_context::TxContext;
     use std::vector;
     use sui::validator::Validator;
     use sui::validator;
@@ -15,44 +16,49 @@ module sui::voting_power_tests {
     const TOTAL_VOTING_POWER: u64 = 10_000;
     const MAX_VOTING_POWER: u64 = 1_000;
 
-    fun check(stakes: vector<u64>, voting_power: vector<u64>) {
-        let ctx = tx_context::dummy();
-        let validators = gtu::create_validators_with_stakes(stakes, &mut ctx);
+    fun check(stakes: vector<u64>, voting_power: vector<u64>, ctx: &mut TxContext) {
+        let validators = gtu::create_validators_with_stakes(stakes, ctx);
         voting_power::set_voting_power(&mut validators);
         test_utils::assert_eq(get_voting_power(&validators), voting_power);
-        validator_set::destroy_validators_for_testing(validators)
+        validator_set::destroy_validators_for_testing(validators);
     }
 
     #[test]
     fun test_small_validator_sets() {
-        check(vector[1], vector[TOTAL_VOTING_POWER]);
-        check(vector[77], vector[TOTAL_VOTING_POWER]);
-        check(vector[TOTAL_VOTING_POWER * 93], vector[TOTAL_VOTING_POWER]);
-        check(vector[1, 1], vector[5_000, 5_000]);
-        check(vector[1, 2], vector[5_000, 5_000]);
-        check(vector[1, 1, 1], vector[3_333, 3_333, 3_334]);
-        check(vector[1, 1, 2], vector[3_333, 3_333, 3_334]);
-        check(vector[1, 1, 1, 1], vector[2_500, 2_500, 2_500, 2_500]);
-        check(vector[1, 1, 1, 1, 1, 1], vector[1666, 1666, 1667, 1667, 1667, 1667]);
-        check(vector[1, 1, 1, 1, 1, 1, 1], vector[1428, 1428, 1428, 1429, 1429, 1429, 1429]);
-        check(vector[1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1111, 1111, 1111, 1111, 1111, 1111, 1111, 1111, 1112]);
+        let scenario = test_scenario::begin(@0x0);
+        let ctx = test_scenario::ctx(&mut scenario);
+        check(vector[1], vector[TOTAL_VOTING_POWER], ctx);
+        check(vector[77], vector[TOTAL_VOTING_POWER], ctx);
+        check(vector[TOTAL_VOTING_POWER * 93], vector[TOTAL_VOTING_POWER], ctx);
+        check(vector[1, 1], vector[5_000, 5_000], ctx);
+        check(vector[1, 2], vector[5_000, 5_000], ctx);
+        check(vector[1, 1, 1], vector[3_333, 3_333, 3_334], ctx);
+        check(vector[1, 1, 2], vector[3_333, 3_333, 3_334], ctx);
+        check(vector[1, 1, 1, 1], vector[2_500, 2_500, 2_500, 2_500], ctx);
+        check(vector[1, 1, 1, 1, 1, 1], vector[1666, 1666, 1667, 1667, 1667, 1667], ctx);
+        check(vector[1, 1, 1, 1, 1, 1, 1], vector[1428, 1428, 1428, 1429, 1429, 1429, 1429], ctx);
+        check(vector[1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1111, 1111, 1111, 1111, 1111, 1111, 1111, 1111, 1112], ctx);
         // different stake distributions that all lead to 10 validators, all with max voting power
-        check(vector[1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000]);
-        check(vector[2, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000]);
-        check(vector[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vector[1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000]);
+        check(vector[1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000], ctx);
+        check(vector[2, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000], ctx);
+        check(vector[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], vector[1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000, 1_000], ctx);
+        test_scenario::end(scenario);
     }
 
     #[test]
     fun test_medium_validator_sets() {
+        let scenario = test_scenario::begin(@0x0);
+        let ctx = test_scenario::ctx(&mut scenario);
         // >10 validators. now things get a bit more interesting because we can redistribute stake away from the max validators
-        check(vector[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[909, 909, 909, 909, 909, 909, 909, 909, 909, 909, 910]);
-        check(vector[2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900]);
-        check(vector[2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 1000, 888, 889, 889, 889, 889, 889, 889, 889, 889]);
-        check(vector[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], vector[522, 674, 826, 978, 1000, 1000, 1000, 1000, 1000, 1000, 1000]);
+        check(vector[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[909, 909, 909, 909, 909, 909, 909, 909, 909, 909, 910], ctx);
+        check(vector[2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900], ctx);
+        check(vector[2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 1000, 888, 889, 889, 889, 889, 889, 889, 889, 889], ctx);
+        check(vector[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], vector[522, 674, 826, 978, 1000, 1000, 1000, 1000, 1000, 1000, 1000], ctx);
 
         // more validators, harder to reach max
-        check(vector[2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[953, 953, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 477, 477]);
-        check(vector[4, 3, 3, 3, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 951, 951, 951, 639, 639, 639, 325, 325, 325, 325, 325, 325, 325, 325, 326, 326, 326, 326, 326]);
+        check(vector[2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[953, 953, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 477, 477], ctx);
+        check(vector[4, 3, 3, 3, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 951, 951, 951, 639, 639, 639, 325, 325, 325, 325, 325, 325, 325, 325, 326, 326, 326, 326, 326], ctx);
+        test_scenario::end(scenario);
     }
 
     fun get_voting_power(validators: &vector<Validator>): vector<u64> {

--- a/crates/sui-json-rpc/src/api/transaction_builder.rs
+++ b/crates/sui-json-rpc/src/api/transaction_builder.rs
@@ -240,6 +240,7 @@ pub trait TransactionBuilder {
         &self,
         /// the transaction signer's Sui address
         signer: SuiAddress,
+        // TODO: remove this parameter
         /// Delegation object ID
         delegation: ObjectID,
         /// StakedSui object ID

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -849,8 +849,8 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
         )
         .await
         .unwrap();
-    // 17 events created by this test + 39 Genesis event
-    assert_eq!(56, page2.data.len());
+    // 17 events created by this test + 43 Genesis event
+    assert_eq!(60, page2.data.len());
     assert_eq!(None, page2.next_cursor);
 
     // test get sender events

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4547,32 +4547,6 @@
           }
         ]
       },
-      "LinkedTable_for_ObjectID": {
-        "description": "Rust version of the Move sui::linked_table::LinkedTable type. Putting it here since we only use it in sui_system in the framework.",
-        "type": "object",
-        "required": [
-          "head",
-          "id",
-          "size",
-          "tail"
-        ],
-        "properties": {
-          "head": {
-            "$ref": "#/components/schemas/MoveOption_for_ObjectID"
-          },
-          "id": {
-            "$ref": "#/components/schemas/ObjectID"
-          },
-          "size": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "tail": {
-            "$ref": "#/components/schemas/MoveOption_for_ObjectID"
-          }
-        }
-      },
       "MoveCall": {
         "type": "object",
         "required": [
@@ -4658,21 +4632,6 @@
             "additionalProperties": false
           }
         ]
-      },
-      "MoveOption_for_ObjectID": {
-        "description": "Rust version of the Move std::option::Option type. Putting it in this file because it's only used here.",
-        "type": "object",
-        "required": [
-          "vec"
-        ],
-        "properties": {
-          "vec": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ObjectID"
-            }
-          }
-        }
       },
       "MovePackage": {
         "type": "object",
@@ -5522,26 +5481,34 @@
         "description": "Rust version of the Move sui::staking_pool::StakingPool type",
         "type": "object",
         "required": [
-          "delegation_token_supply",
+          "exchange_rates",
           "id",
-          "pending_delegations",
+          "pending_delegation",
           "pending_withdraws",
+          "pool_token_balance",
           "rewards_pool",
           "starting_epoch",
           "sui_balance"
         ],
         "properties": {
-          "delegation_token_supply": {
-            "$ref": "#/components/schemas/Supply"
+          "exchange_rates": {
+            "$ref": "#/components/schemas/Table"
           },
           "id": {
             "$ref": "#/components/schemas/ObjectID"
           },
-          "pending_delegations": {
-            "$ref": "#/components/schemas/LinkedTable_for_ObjectID"
+          "pending_delegation": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "pending_withdraws": {
             "$ref": "#/components/schemas/TableVec"
+          },
+          "pool_token_balance": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "rewards_pool": {
             "$ref": "#/components/schemas/Balance"

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -669,12 +669,11 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
     pub async fn request_withdraw_delegation(
         &self,
         signer: SuiAddress,
-        delegation: ObjectID,
+        _delegation: ObjectID,
         staked_sui: ObjectID,
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> anyhow::Result<TransactionData> {
-        let delegation = self.get_object_ref(delegation).await?;
         let staked_sui = self.get_object_ref(staked_sui).await?;
         let gas_price = self.0.get_reference_gas_price().await?;
         let gas = self
@@ -693,7 +692,6 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                     initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
                     mutable: true,
                 }),
-                CallArg::Object(ObjectArg::ImmOrOwnedObject(delegation)),
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(staked_sui)),
             ],
             gas_budget,

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -25,6 +25,7 @@ pub const ADD_DELEGATION_LOCKED_COIN_FUN_NAME: &IdentStr =
     ident_str!("request_add_delegation_mul_locked_coin");
 pub const WITHDRAW_DELEGATION_FUN_NAME: &IdentStr = ident_str!("request_withdraw_delegation");
 
+// TODO: this no longer exists at Move level, we need to remove this and update the governance API.
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct Delegation {
     pub id: UID,
@@ -86,5 +87,6 @@ pub struct DelegatedStake {
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub enum DelegationStatus {
     Pending,
+    // TODO: remove the `Delegation` object here.
     Active(Delegation),
 }

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -7,11 +7,7 @@ use crate::committee::{Committee, CommitteeWithNetAddresses, ProtocolVersion, St
 use crate::crypto::{AuthorityPublicKeyBytes, NetworkPublicKey};
 use crate::error::SuiError;
 use crate::storage::ObjectStore;
-use crate::{
-    balance::{Balance, Supply},
-    id::UID,
-    SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
-};
+use crate::{balance::Balance, id::UID, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID};
 use fastcrypto::traits::ToFromBytes;
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use multiaddr::Multiaddr;

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -168,8 +168,9 @@ pub struct StakingPool {
     pub starting_epoch: u64,
     pub sui_balance: u64,
     pub rewards_pool: Balance,
-    pub delegation_token_supply: Supply,
-    pub pending_delegations: LinkedTable<ObjectID>,
+    pub pool_token_balance: u64,
+    pub exchange_rates: Table,
+    pub pending_delegation: u64,
     pub pending_withdraws: TableVec,
 }
 

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_types::balance::{Balance, Supply};
+use sui_types::balance::Balance;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::collection_types::VecMap;
 use sui_types::committee::{EpochId, ProtocolVersion};

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -11,8 +11,8 @@ use sui_types::crypto::{
 use sui_types::id::UID;
 use sui_types::sui_system_state::SystemParameters;
 use sui_types::sui_system_state::{
-    LinkedTable, StakeSubsidy, StakingPool, SuiSystemState, Table, TableVec, Validator,
-    ValidatorMetadata, ValidatorSet,
+    StakeSubsidy, StakingPool, SuiSystemState, Table, TableVec, Validator, ValidatorMetadata,
+    ValidatorSet,
 };
 use sui_types::SUI_SYSTEM_STATE_OBJECT_ID;
 
@@ -45,8 +45,9 @@ pub fn test_staking_pool(sui_balance: u64) -> StakingPool {
         starting_epoch: 0,
         sui_balance,
         rewards_pool: Balance::new(0),
-        delegation_token_supply: Supply { value: 0 },
-        pending_delegations: LinkedTable::default(),
+        pool_token_balance: 0,
+        exchange_rates: Table::default(),
+        pending_delegation: 0,
         pending_withdraws: TableVec::default(),
     }
 }

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -121,10 +121,14 @@ export const PendingWithdawFields = object({
 });
 
 export const DelegationStakingPoolFields = object({
+  exchange_rates: object({
+    id: string(),
+    size: number(),
+  }),
   id: string(),
-  delegation_token_supply: SuiSupplyFields,
-  pending_delegations: ContentsFields,
+  pending_delegation: number(),
   pending_withdraws: PendingWithdawFields,
+  pool_token_balance: number(),
   rewards_pool: object({ value: number() }),
   starting_epoch: number(),
   sui_balance: number(),


### PR DESCRIPTION
This PR removes the distribution of `Delegation` objects at epoch change transaction by keeping track of the historical exchange rates between pool token and SUI token of each validator, and dynamically calculating the amount of pool tokens a delegation corresponds to at withdraw time.