### PR TITLE
[epoch_data] Define EpochData and pass it to transaction context (1/n)

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -14,7 +14,7 @@ use sui_protocol_constants::{
     REWARD_SLASHING_RATE, STAKE_SUBSIDY_RATE, STORAGE_FUND_REINVEST_RATE,
 };
 use sui_types::coin::{transfer_coin, update_input_coins, Coin};
-use sui_types::committee::EpochId;
+use sui_types::epoch_data::EpochData;
 use sui_types::error::{ExecutionError, ExecutionErrorKind};
 use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
@@ -69,13 +69,13 @@ pub fn execute_transaction_to_effects<
     move_vm: &Arc<MoveVM>,
     native_functions: &NativeFunctionTable,
     gas_status: SuiGasStatus,
-    epoch: EpochId,
+    epoch_data: &EpochData,
 ) -> (
     InnerTemporaryStore,
     TransactionEffects,
     Result<Mode::ExecutionResults, ExecutionError>,
 ) {
-    let mut tx_ctx = TxContext::new(&transaction_signer, &transaction_digest, epoch);
+    let mut tx_ctx = TxContext::new(&transaction_signer, &transaction_digest, epoch_data);
 
     let (gas_cost_summary, execution_result) = execute_transaction::<Mode, _>(
         &mut temporary_store,
@@ -112,7 +112,7 @@ pub fn execute_transaction_to_effects<
         gas_cost_summary,
         status,
         gas_object_ref,
-        epoch,
+        epoch_data.epoch_id(),
     );
     (inner, effects, execution_result)
 }

--- a/crates/sui-adapter/src/genesis.rs
+++ b/crates/sui-adapter/src/genesis.rs
@@ -5,6 +5,7 @@ use move_binary_format::CompiledModule;
 use once_cell::sync::Lazy;
 use sui_types::base_types::{ObjectRef, SuiAddress, TxContext};
 use sui_types::clock::Clock;
+use sui_types::epoch_data::EpochData;
 use sui_types::id::UID;
 use sui_types::object::{MoveObject, Owner};
 use sui_types::{base_types::TransactionDigest, object::Object};
@@ -40,7 +41,11 @@ pub fn get_framework_object_ref() -> ObjectRef {
 }
 
 pub fn get_genesis_context() -> TxContext {
-    TxContext::new(&SuiAddress::default(), &TransactionDigest::genesis(), 0)
+    TxContext::new(
+        &SuiAddress::default(),
+        &TransactionDigest::genesis(),
+        &EpochData::genesis(),
+    )
 }
 
 /// Create and return objects wrapping the genesis modules for sui

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -25,6 +25,7 @@ use sui_types::crypto::{
     AuthorityKeyPair, AuthorityPublicKeyBytes, AuthoritySignInfo, AuthoritySignature,
     AuthorityStrongQuorumSignInfo, SuiAuthoritySignature, ToFromBytes,
 };
+use sui_types::epoch_data::EpochData;
 use sui_types::gas::SuiGasStatus;
 use sui_types::in_memory_storage::InMemoryStorage;
 use sui_types::message_envelope::Message;
@@ -818,7 +819,7 @@ fn create_genesis_transaction(
                 &move_vm,
                 &native_functions,
                 SuiGasStatus::new_unmetered(),
-                0,
+                &EpochData::genesis(),
             );
         assert!(inner_temp_store.objects.is_empty());
         assert!(inner_temp_store.mutable_inputs.is_empty());
@@ -1148,7 +1149,7 @@ mod test {
                 &move_vm,
                 &native_functions,
                 SuiGasStatus::new_unmetered(),
-                0,
+                &EpochData::genesis(),
             );
 
         assert_eq!(effects, genesis.effects);

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -103,6 +103,7 @@ use crate::{
     event_handler::EventHandler, transaction_input_checker, transaction_manager::TransactionManager,
 };
 use sui_adapter::execution_engine;
+use sui_types::epoch_data::EpochData;
 
 #[cfg(test)]
 #[path = "unit_tests/authority_tests.rs"]
@@ -928,7 +929,7 @@ impl AuthorityState {
                 &self.move_vm,
                 &self._native_functions,
                 gas_status,
-                epoch_store.epoch(),
+                &epoch_store.epoch_start_configuration().epoch_data(),
             );
 
         let signed_effects = VerifiedSignedTransactionEffects::new_unchecked(
@@ -979,7 +980,7 @@ impl AuthorityState {
                 &self.move_vm,
                 &self._native_functions,
                 gas_status,
-                epoch_store.epoch(),
+                &epoch_store.epoch_start_configuration().epoch_data(),
             );
         SuiTransactionEffects::try_from(effects, self.module_cache.as_ref())
     }
@@ -1044,7 +1045,7 @@ impl AuthorityState {
                 &self.move_vm,
                 &self._native_functions,
                 gas_status,
-                epoch,
+                &EpochData::new(epoch), /* TODO(epoch_data): this needs to be figured out */
             );
         DevInspectResults::new(effects, execution_result, self.module_cache.as_ref())
     }
@@ -2496,6 +2497,7 @@ impl AuthorityState {
         info!(new_epoch = ?new_committee.epoch, "re-opening AuthorityEpochTables for new epoch");
 
         let epoch_start_configuration = EpochStartConfiguration {
+            epoch_id: new_epoch,
             epoch_start_timestamp_ms,
         };
         let new_epoch_store =

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1251,7 +1251,8 @@ async fn test_publish_dependent_module_ok() {
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
 
-    let dependent_module_id = TxContext::new(&sender, transaction.digest(), 0).fresh_id();
+    let dependent_module_id =
+        TxContext::new(&sender, transaction.digest(), &EpochData::genesis()).fresh_id();
 
     // Object does not exist
     assert!(authority
@@ -1291,7 +1292,8 @@ async fn test_publish_module_no_dependencies_ok() {
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
-    let _module_object_id = TxContext::new(&sender, transaction.digest(), 0).fresh_id();
+    let _module_object_id =
+        TxContext::new(&sender, transaction.digest(), &EpochData::genesis()).fresh_id();
     let signed_effects = send_and_confirm_transaction(&authority, transaction)
         .await
         .unwrap()

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -163,8 +163,11 @@ impl SuiNode {
             .get_committee(&cur_epoch)?
             .expect("Committee of the current epoch must exist");
         let epoch_start_configuration = if cur_epoch == genesis.epoch() {
+            let checkpoint = genesis.checkpoint();
+            let summary = &checkpoint.summary;
             Some(EpochStartConfiguration {
-                epoch_start_timestamp_ms: genesis.checkpoint().summary.timestamp_ms,
+                epoch_id: summary.epoch,
+                epoch_start_timestamp_ms: summary.timestamp_ms,
             })
         } else {
             None

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -39,6 +39,7 @@ use std::{
 use sui_adapter::execution_engine;
 use sui_adapter::{adapter::new_move_vm, execution_mode, genesis};
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
+use sui_types::epoch_data::EpochData;
 use sui_types::in_memory_storage::InMemoryStorage;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
@@ -53,6 +54,7 @@ use sui_types::{
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
 use sui_types::{gas::SuiGasStatus, temporary_store::TemporaryStore};
+
 pub(crate) type FakeID = u64;
 
 // initial value for fake object ID mapping
@@ -519,7 +521,7 @@ impl<'a> SuiTestAdapter<'a> {
             &self.native_functions,
             gas_status,
             // TODO: Support different epochs in transactional tests.
-            0,
+            &EpochData::genesis(),
         );
 
         let mut created_ids: Vec<_> = created.iter().map(|((id, _, _), _)| *id).collect();

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -23,6 +23,7 @@ use crate::crypto::{
     SuiPublicKey,
 };
 pub use crate::digests::{ObjectDigest, TransactionDigest, TransactionEffectsDigest};
+use crate::epoch_data::EpochData;
 use crate::error::ExecutionError;
 use crate::error::ExecutionErrorKind;
 use crate::error::SuiError;
@@ -347,11 +348,11 @@ pub struct TxContext {
 }
 
 impl TxContext {
-    pub fn new(sender: &SuiAddress, digest: &TransactionDigest, epoch: EpochId) -> Self {
+    pub fn new(sender: &SuiAddress, digest: &TransactionDigest, epoch_data: &EpochData) -> Self {
         Self {
             sender: AccountAddress::new(sender.0),
             digest: digest.into_inner().to_vec(),
-            epoch,
+            epoch: epoch_data.epoch_id(),
             ids_created: 0,
         }
     }
@@ -401,13 +402,13 @@ impl TxContext {
         Self::new(
             &SuiAddress::random_for_testing_only(),
             &TransactionDigest::random(),
-            0,
+            &EpochData::genesis(),
         )
     }
 
     // for testing
     pub fn with_sender_for_testing_only(sender: &SuiAddress) -> Self {
-        Self::new(sender, &TransactionDigest::random(), 0)
+        Self::new(sender, &TransactionDigest::random(), &EpochData::genesis())
     }
 }
 

--- a/crates/sui-types/src/epoch_data.rs
+++ b/crates/sui-types/src/epoch_data.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::base_types::EpochId;
+
+/// The static epoch information that is accessible to move smart contracts
+pub struct EpochData {
+    epoch_id: EpochId,
+}
+
+impl EpochData {
+    pub fn new(epoch_id: EpochId) -> Self {
+        Self { epoch_id }
+    }
+
+    pub fn genesis() -> Self {
+        Self { epoch_id: 0 }
+    }
+
+    pub fn epoch_id(&self) -> EpochId {
+        self.epoch_id
+    }
+}

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -53,6 +53,7 @@ pub mod sui_serde;
 pub mod sui_system_state;
 pub mod temporary_store;
 
+pub mod epoch_data;
 #[path = "./unit_tests/utils.rs"]
 pub mod utils;
 


### PR DESCRIPTION
This PR adds new data structure, `EpochData` and passes it to the transaction context.

This data structure is the bridge between sui's internal `EpochStartConfiguration` and the `TxContext` that is passed to every move call and allows to specify epoch-level data all move calls at a zero cost.

Future PR will add more fields to `EpochData`.