### PR TITLE
[epoch_data] Pass entire SuiSystemState into EpochStartConfiguration (3/n)

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -55,6 +55,7 @@ use sui_types::messages_checkpoint::{
     CheckpointSignatureMessage, CheckpointSummary, CheckpointTimestamp,
 };
 use sui_types::storage::{transaction_input_object_keys, ObjectKey, ParentSync};
+use sui_types::sui_system_state::SuiSystemState;
 use sui_types::temporary_store::InnerTemporaryStore;
 use tokio::time::Instant;
 use typed_store::{retry_transaction_forever, Map};
@@ -239,9 +240,7 @@ pub struct AuthorityEpochTables {
 /// Parameters of the epoch fixed at epoch start.
 #[derive(Default, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct EpochStartConfiguration {
-    pub epoch_id: EpochId,
-    pub epoch_start_timestamp_ms: CheckpointTimestamp,
-    // Current epoch committee can eventually move here too, though right now it is served from a different table
+    pub system_state: SuiSystemState,
 }
 
 impl AuthorityEpochTables {
@@ -322,7 +321,7 @@ impl AuthorityPerEpochStore {
         // is initialized during epoch change
         let epoch_start_configuration =
             if let Some(epoch_start_configuration) = epoch_start_configuration {
-                assert_eq!(epoch_start_configuration.epoch_id, epoch_id);
+                assert_eq!(epoch_start_configuration.epoch_id(), epoch_id);
                 tables
                     .epoch_start_configuration
                     .insert(&(), &epoch_start_configuration)
@@ -1717,6 +1716,14 @@ fn transactions_table_default_config() -> DBOptions {
 
 impl EpochStartConfiguration {
     pub fn epoch_data(&self) -> EpochData {
-        EpochData::new(self.epoch_id)
+        EpochData::new(self.epoch_id())
+    }
+
+    pub fn epoch_id(&self) -> EpochId {
+        self.system_state.epoch
+    }
+
+    pub fn epoch_start_timestamp_ms(&self) -> CheckpointTimestamp {
+        self.system_state.epoch_start_timestamp_ms
     }
 }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -15,6 +15,7 @@ use tokio::{sync::broadcast, time::timeout};
 use crate::{authority::AuthorityState, checkpoints::CheckpointStore};
 
 use sui_network::state_sync::test_utils::{empty_contents, CommitteeFixture};
+use sui_types::sui_system_state::SuiSystemState;
 
 /// Test checkpoint executor happy path, test that checkpoint executor correctly
 /// picks up where it left off in the event of a mid-epoch node crash.
@@ -170,11 +171,15 @@ pub async fn test_checkpoint_executor_cross_epoch() {
         num_to_sync_per_epoch as u64,
     );
 
+    let sui_system_state = SuiSystemState {
+        epoch: 1,
+        ..Default::default()
+    };
     let new_epoch_store = authority_state
         .reconfigure(
             &authority_state.epoch_store_for_testing(),
             second_committee.committee().clone(),
-            0,
+            sui_system_state,
         )
         .await
         .unwrap();

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -99,6 +99,7 @@ pub struct ValidatorComponents {
     sui_tx_validator_metrics: Arc<SuiTxValidatorMetrics>,
 }
 use sui_json_rpc::governance_api::GovernanceReadApi;
+use sui_types::sui_system_state::SuiSystemState;
 
 pub struct SuiNode {
     config: NodeConfig,
@@ -163,11 +164,8 @@ impl SuiNode {
             .get_committee(&cur_epoch)?
             .expect("Committee of the current epoch must exist");
         let epoch_start_configuration = if cur_epoch == genesis.epoch() {
-            let checkpoint = genesis.checkpoint();
-            let summary = &checkpoint.summary;
             Some(EpochStartConfiguration {
-                epoch_id: summary.epoch,
-                epoch_start_timestamp_ms: summary.timestamp_ms,
+                system_state: genesis.sui_system_object(),
             })
         } else {
             None
@@ -593,7 +591,7 @@ impl SuiNode {
             authority: config.protocol_public_key(),
             next_reconfiguration_timestamp_ms: epoch_store
                 .epoch_start_configuration()
-                .epoch_start_timestamp_ms
+                .epoch_start_timestamp_ms()
                 .checked_add(config.epoch_duration_ms)
                 .expect("Overflow calculating next_reconfiguration_timestamp_ms"),
             metrics: checkpoint_metrics.clone(),
@@ -795,11 +793,7 @@ impl SuiNode {
                 narwhal_manager.shutdown().await;
 
                 let new_epoch_store = self
-                    .reconfigure_state(
-                        &cur_epoch_store,
-                        next_epoch_committee,
-                        system_state.epoch_start_timestamp_ms,
-                    )
+                    .reconfigure_state(&cur_epoch_store, next_epoch_committee, system_state)
                     .await;
 
                 narwhal_epoch_data_remover
@@ -830,11 +824,7 @@ impl SuiNode {
                 }
             } else {
                 let new_epoch_store = self
-                    .reconfigure_state(
-                        &cur_epoch_store,
-                        next_epoch_committee,
-                        system_state.epoch_start_timestamp_ms,
-                    )
+                    .reconfigure_state(&cur_epoch_store, next_epoch_committee, system_state)
                     .await;
 
                 if self.state.is_validator(&new_epoch_store) {
@@ -864,16 +854,12 @@ impl SuiNode {
         &self,
         cur_epoch_store: &AuthorityPerEpochStore,
         next_epoch_committee: Committee,
-        epoch_start_timestamp_ms: u64,
+        sui_system_state: SuiSystemState,
     ) -> Arc<AuthorityPerEpochStore> {
         let next_epoch = next_epoch_committee.epoch();
         let new_epoch_store = self
             .state
-            .reconfigure(
-                cur_epoch_store,
-                next_epoch_committee,
-                epoch_start_timestamp_ms,
-            )
+            .reconfigure(cur_epoch_store, next_epoch_committee, sui_system_state)
             .await
             .expect("Reconfigure authority state cannot fail");
         info!(next_epoch, "Validator State has been reconfigured");

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -8,7 +8,7 @@ use crate::crypto::{AuthorityPublicKeyBytes, NetworkPublicKey};
 use crate::{
     balance::{Balance, Supply},
     id::UID,
-    SUI_FRAMEWORK_ADDRESS,
+    SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use fastcrypto::traits::ToFromBytes;
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
@@ -312,6 +312,42 @@ impl SuiSystemState {
         WorkerCache {
             workers,
             epoch: self.epoch,
+        }
+    }
+}
+
+// The default implementation for tests
+impl Default for SuiSystemState {
+    fn default() -> Self {
+        let validator_set = ValidatorSet {
+            validator_stake: 1,
+            delegation_stake: 1,
+            active_validators: vec![],
+            pending_validators: vec![],
+            pending_removals: vec![],
+            next_epoch_validators: vec![],
+            pending_delegation_switches: VecMap { contents: vec![] },
+        };
+        SuiSystemState {
+            info: UID::new(SUI_SYSTEM_STATE_OBJECT_ID),
+            epoch: 0,
+            protocol_version: ProtocolVersion::MIN.0,
+            validators: validator_set,
+            treasury_cap: Supply { value: 0 },
+            storage_fund: Balance::new(0),
+            parameters: SystemParameters {
+                min_validator_stake: 1,
+                max_validator_candidate_count: 100,
+            },
+            reference_gas_price: 1,
+            validator_report_records: VecMap { contents: vec![] },
+            stake_subsidy: StakeSubsidy {
+                epoch_counter: 0,
+                balance: Balance::new(0),
+                current_epoch_amount: 0,
+            },
+            safe_mode: false,
+            epoch_start_timestamp_ms: 0,
         }
     }
 }


### PR DESCRIPTION
We still maintain separate data structure (EpochStartConfiguration) because some fields we are going to add soon to EpochStartConfiguration does not necessarily need to be added to SuiSystemState.