### PR TITLE
[staking] use object id to identify a staking pool instead of validator address

### DIFF
--- a/.changeset/popular-jeans-enjoy.md
+++ b/.changeset/popular-jeans-enjoy.md
@@ -1,0 +1,13 @@
+---
+"@mysten/wallet-adapter-wallet-standard": minor
+"@mysten/wallet-adapter-unsafe-burner": minor
+"@mysten/wallet-adapter-base": minor
+"@mysten/wallet-adapter-all-wallets": minor
+"@mysten/wallet-kit-core": minor
+"@mysten/wallet-standard": minor
+"@mysten/wallet-kit": minor
+"@mysten/sui.js": minor
+"@mysten/bcs": minor
+---
+
+Add object id to staking pool and pool id to staked sui.

--- a/apps/wallet/src/ui/app/shared/delegated-apy/index.tsx
+++ b/apps/wallet/src/ui/app/shared/delegated-apy/index.tsx
@@ -33,8 +33,7 @@ export function DelegatedAPY({ stakedValidators }: DelegatedAPYProps) {
         validators.forEach((validator) => {
             if (
                 stakedValidators.includes(
-                    validator.fields.delegation_staking_pool.fields
-                        .validator_address
+                    validator.fields.metadata.fields.sui_address
                 )
             ) {
                 stakedAPYs += calculateAPY(validator, +validatorsData.epoch);

--- a/apps/wallet/src/ui/app/staking/getStakingRewards.ts
+++ b/apps/wallet/src/ui/app/staking/getStakingRewards.ts
@@ -15,11 +15,9 @@ export function getStakingRewards(
         delegation.delegation_status === 'Pending'
     )
         return 0;
-    const validatorAddress = delegation.staked_sui.validator_address;
+    const pool_id = delegation.staked_sui.pool_id;
     const validator = activeValidators.find(
-        ({ fields }) =>
-            fields.delegation_staking_pool.fields.validator_address ===
-            validatorAddress
+        ({ fields }) => fields.delegation_staking_pool.fields.id.id === pool_id
     );
 
     if (!validator) return 0;

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -241,7 +241,7 @@ validators:
       pending_withdraw: 0
       gas_price: 1
       delegation_staking_pool:
-        validator_address: "0x21b60aa9a8cb189ccbe20461dbfad2202fdef55b"
+        id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f"
         starting_epoch: 1
         sui_balance: 0
         rewards_pool:
@@ -249,7 +249,7 @@ validators:
         delegation_token_supply:
           value: 0
         pending_delegations:
-          id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f"
+          id: "0xab8235dace3d68c7fb48110d63cbf4d6fd81ce10"
           size: 0
           head:
             vec: []
@@ -257,7 +257,7 @@ validators:
             vec: []
         pending_withdraws:
           contents:
-            id: "0xab8235dace3d68c7fb48110d63cbf4d6fd81ce10"
+            id: "0x18b8140c8a6ea340142f128061016fc4bd8220ec"
             size: 0
       commission_rate: 0
   pending_validators: []
@@ -487,6 +487,9 @@ validators:
       next_epoch_delegation: 0
       next_epoch_gas_price: 1
       next_epoch_commission_rate: 0
+  staking_pool_mappings:
+    id: "0x628ffd0e51e9a6ea32c13c2739a31a8f344b557d"
+    size: 1
 treasury_cap:
   value: 2
 storage_fund:

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -171,6 +171,7 @@ all the information we need in the system.
         <a href="genesis.md#0x2_genesis_INIT_STAKE_SUBSIDY_AMOUNT">INIT_STAKE_SUBSIDY_AMOUNT</a>,
         protocol_version,
         epoch_start_timestamp_ms,
+        ctx,
     );
 
     <a href="clock.md#0x2_clock_create">clock::create</a>();

--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -5,7 +5,7 @@
 
 
 
--  [Struct `StakingPool`](#0x2_staking_pool_StakingPool)
+-  [Resource `StakingPool`](#0x2_staking_pool_StakingPool)
 -  [Struct `PoolTokenExchangeRate`](#0x2_staking_pool_PoolTokenExchangeRate)
 -  [Resource `InactiveStakingPool`](#0x2_staking_pool_InactiveStakingPool)
 -  [Struct `DelegationToken`](#0x2_staking_pool_DelegationToken)
@@ -30,7 +30,7 @@
 -  [Function `destroy_empty_delegation`](#0x2_staking_pool_destroy_empty_delegation)
 -  [Function `destroy_empty_staked_sui`](#0x2_staking_pool_destroy_empty_staked_sui)
 -  [Function `sui_balance`](#0x2_staking_pool_sui_balance)
--  [Function `validator_address`](#0x2_staking_pool_validator_address)
+-  [Function `pool_id`](#0x2_staking_pool_pool_id)
 -  [Function `staked_sui_amount`](#0x2_staking_pool_staked_sui_amount)
 -  [Function `delegation_request_epoch`](#0x2_staking_pool_delegation_request_epoch)
 -  [Function `delegation_token_amount`](#0x2_staking_pool_delegation_token_amount)
@@ -58,12 +58,12 @@
 
 <a name="0x2_staking_pool_StakingPool"></a>
 
-## Struct `StakingPool`
+## Resource `StakingPool`
 
 A staking pool embedded in each validator struct in the system state object.
 
 
-<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> <b>has</b> store
+<pre><code><b>struct</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> <b>has</b> store, key
 </code></pre>
 
 
@@ -74,10 +74,10 @@ A staking pool embedded in each validator struct in the system state object.
 
 <dl>
 <dt>
-<code>validator_address: <b>address</b></code>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
 </dt>
 <dd>
- The sui address of the validator associated with this pool.
+
 </dd>
 <dt>
 <code>starting_epoch: u64</code>
@@ -368,16 +368,16 @@ A self-custodial object holding the staked SUI tokens.
 
 </dd>
 <dt>
+<code>pool_id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+ ID of the staking pool we are staking with.
+</dd>
+<dt>
 <code>validator_address: <b>address</b></code>
 </dt>
 <dd>
- The validator we are staking with.
-</dd>
-<dt>
-<code>pool_starting_epoch: u64</code>
-</dt>
-<dd>
- The epoch at which the staking pool started operating.
+
 </dd>
 <dt>
 <code>delegation_request_epoch: u64</code>
@@ -496,7 +496,7 @@ A self-custodial object holding the staked SUI tokens.
 Create a new, empty staking pool.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(validator_address: <b>address</b>, starting_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>
 </code></pre>
 
 
@@ -505,10 +505,10 @@ Create a new, empty staking pool.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(validator_address: <b>address</b>, starting_epoch: u64, ctx: &<b>mut</b> TxContext) : <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(ctx: &<b>mut</b> TxContext) : <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> {
     <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> {
-        validator_address,
-        starting_epoch,
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        starting_epoch: <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1, // active beginning next epoch
         sui_balance: 0,
         rewards_pool: <a href="balance.md#0x2_balance_zero">balance::zero</a>(),
         delegation_token_supply: <a href="balance.md#0x2_balance_create_supply">balance::create_supply</a>(<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a> {}),
@@ -530,7 +530,7 @@ Request to delegate to a staking pool. The delegation gets counted at the beginn
 when the delegation object containing the pool tokens is distributed to the delegator.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_add_delegation">request_add_delegation</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, <a href="stake.md#0x2_stake">stake</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, sui_token_lock: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, delegator: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_add_delegation">request_add_delegation</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, <a href="stake.md#0x2_stake">stake</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, sui_token_lock: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, validator_address: <b>address</b>, delegator: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -543,6 +543,7 @@ when the delegation object containing the pool tokens is distributed to the dele
     pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
     <a href="stake.md#0x2_stake">stake</a>: Balance&lt;SUI&gt;,
     sui_token_lock: Option&lt;EpochTimeLock&gt;,
+    validator_address: <b>address</b>,
     delegator: <b>address</b>,
     ctx: &<b>mut</b> TxContext
 ) {
@@ -550,8 +551,8 @@ when the delegation object containing the pool tokens is distributed to the dele
     <b>assert</b>!(sui_amount &gt; 0, 0);
     <b>let</b> staked_sui = <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a> {
         id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
-        validator_address: pool.validator_address,
-        pool_starting_epoch: pool.starting_epoch,
+        pool_id: <a href="object.md#0x2_object_id">object::id</a>(pool),
+        validator_address,
         delegation_request_epoch: <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
         principal: <a href="stake.md#0x2_stake">stake</a>,
         sui_token_lock,
@@ -650,11 +651,7 @@ time lock if applicable.
     <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(&staked_sui) == delegation.staked_sui_id, <a href="staking_pool.md#0x2_staking_pool_EWrongDelegation">EWrongDelegation</a>);
 
     // Check that the delegation information matches the pool.
-    <b>assert</b>!(
-        staked_sui.validator_address == pool.validator_address &&
-        staked_sui.pool_starting_epoch == pool.starting_epoch,
-        <a href="staking_pool.md#0x2_staking_pool_EWrongPool">EWrongPool</a>
-    );
+    <b>assert</b>!(staked_sui.pool_id == <a href="object.md#0x2_object_id">object::id</a>(pool), <a href="staking_pool.md#0x2_staking_pool_EWrongPool">EWrongPool</a>);
 
     <b>assert</b>!(delegation.principal_sui_amount == <a href="balance.md#0x2_balance_value">balance::value</a>(&staked_sui.principal), <a href="staking_pool.md#0x2_staking_pool_EInsufficientSuiTokenBalance">EInsufficientSuiTokenBalance</a>);
 
@@ -717,8 +714,8 @@ time lock if applicable.
 <pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_unwrap_staked_sui">unwrap_staked_sui</a>(staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>): (Balance&lt;SUI&gt;, Option&lt;EpochTimeLock&gt;) {
     <b>let</b> <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a> {
         id,
+        pool_id: _,
         validator_address: _,
-        pool_starting_epoch: _,
         delegation_request_epoch: _,
         principal,
         sui_token_lock
@@ -1051,8 +1048,8 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_destroy_empty_staked_sui">destroy_empty_staked_sui</a>(staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>) {
     <b>let</b> <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a> {
         id,
+        pool_id: _,
         validator_address: _,
-        pool_starting_epoch: _,
         delegation_request_epoch: _,
         principal,
         sui_token_lock
@@ -1091,13 +1088,13 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
 
 </details>
 
-<a name="0x2_staking_pool_validator_address"></a>
+<a name="0x2_staking_pool_pool_id"></a>
 
-## Function `validator_address`
+## Function `pool_id`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_validator_address">validator_address</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_id">pool_id</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>): <a href="object.md#0x2_object_ID">object::ID</a>
 </code></pre>
 
 
@@ -1106,7 +1103,7 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_validator_address">validator_address</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>) : <b>address</b> { staked_sui.validator_address }
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_id">pool_id</a>(staked_sui: &<a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>) : ID { staked_sui.pool_id }
 </code></pre>
 
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -31,6 +31,8 @@
 -  [Function `epoch_start_timestamp_ms`](#0x2_sui_system_epoch_start_timestamp_ms)
 -  [Function `validator_delegate_amount`](#0x2_sui_system_validator_delegate_amount)
 -  [Function `validator_stake_amount`](#0x2_sui_system_validator_stake_amount)
+-  [Function `validator_staking_pool_id`](#0x2_sui_system_validator_staking_pool_id)
+-  [Function `validator_staking_pool_mappings`](#0x2_sui_system_validator_staking_pool_mappings)
 -  [Function `get_reporters_of`](#0x2_sui_system_get_reporters_of)
 -  [Function `extract_coin_balance`](#0x2_sui_system_extract_coin_balance)
 -  [Function `extract_locked_coin_balance`](#0x2_sui_system_extract_locked_coin_balance)
@@ -50,6 +52,7 @@
 <b>use</b> <a href="stake_subsidy.md#0x2_stake_subsidy">0x2::stake_subsidy</a>;
 <b>use</b> <a href="staking_pool.md#0x2_staking_pool">0x2::staking_pool</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="table.md#0x2_table">0x2::table</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="validator.md#0x2_validator">0x2::validator</a>;
@@ -365,7 +368,7 @@ Create a new SuiSystemState object and make it shared.
 This function will be called only once in genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, sui_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_candidate_count: u64, min_validator_stake: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, epoch_start_timestamp_ms: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, sui_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_candidate_count: u64, min_validator_stake: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -383,8 +386,9 @@ This function will be called only once in genesis.
     initial_stake_subsidy_amount: u64,
     protocol_version: u64,
     epoch_start_timestamp_ms: u64,
+    ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> validators = <a href="validator_set.md#0x2_validator_set_new">validator_set::new</a>(validators);
+    <b>let</b> validators = <a href="validator_set.md#0x2_validator_set_new">validator_set::new</a>(validators, ctx);
     <b>let</b> reference_gas_price = <a href="validator_set.md#0x2_validator_set_derive_reference_gas_price">validator_set::derive_reference_gas_price</a>(&validators);
     <b>let</b> state = <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a> {
         // Use a hardcoded ID.
@@ -1257,6 +1261,57 @@ Aborts if <code>validator_addr</code> is not an active validator.
 
 <pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validator_stake_amount">validator_stake_amount</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>, validator_addr: <b>address</b>): u64 {
     <a href="validator_set.md#0x2_validator_set_validator_stake_amount">validator_set::validator_stake_amount</a>(&self.validators, validator_addr)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_validator_staking_pool_id"></a>
+
+## Function `validator_staking_pool_id`
+
+Returns the staking pool id of a given validator.
+Aborts if <code>validator_addr</code> is not an active validator.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validator_staking_pool_id">validator_staking_pool_id</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, validator_addr: <b>address</b>): <a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validator_staking_pool_id">validator_staking_pool_id</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>, validator_addr: <b>address</b>): ID {
+    <a href="validator_set.md#0x2_validator_set_validator_staking_pool_id">validator_set::validator_staking_pool_id</a>(&self.validators, validator_addr)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_validator_staking_pool_mappings"></a>
+
+## Function `validator_staking_pool_mappings`
+
+Returns reference to the staking pool mappings that map pool ids to active validator addresses
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validator_staking_pool_mappings">validator_staking_pool_mappings</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>): &<a href="table.md#0x2_table_Table">table::Table</a>&lt;<a href="object.md#0x2_object_ID">object::ID</a>, <b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x2_sui_system_validator_staking_pool_mappings">validator_staking_pool_mappings</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>): &Table&lt;ID, <b>address</b>&gt; {
+    <a href="validator_set.md#0x2_validator_set_staking_pool_mappings">validator_set::staking_pool_mappings</a>(&self.validators)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -35,6 +35,7 @@
 -  [Function `gas_price`](#0x2_validator_gas_price)
 -  [Function `commission_rate`](#0x2_validator_commission_rate)
 -  [Function `pool_token_exchange_rate`](#0x2_validator_pool_token_exchange_rate)
+-  [Function `staking_pool_id`](#0x2_validator_staking_pool_id)
 -  [Function `is_duplicate`](#0x2_validator_is_duplicate)
 
 
@@ -46,6 +47,7 @@
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="bls12381.md#0x2_bls12381">0x2::bls12381</a>;
 <b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="stake.md#0x2_stake">0x2::stake</a>;
 <b>use</b> <a href="staking_pool.md#0x2_staking_pool">0x2::staking_pool</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
@@ -373,7 +375,7 @@
         pending_stake: 0,
         pending_withdraw: 0,
         gas_price,
-        delegation_staking_pool: <a href="staking_pool.md#0x2_staking_pool_new">staking_pool::new</a>(sui_address, <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1, ctx),
+        delegation_staking_pool: <a href="staking_pool.md#0x2_staking_pool_new">staking_pool::new</a>(ctx),
         commission_rate,
     }
 }
@@ -543,7 +545,9 @@ Request to add delegation to the validator's staking pool, processed at the end 
 ) {
     <b>let</b> delegate_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&delegated_stake);
     <b>assert</b>!(delegate_amount &gt; 0, 0);
-    <a href="staking_pool.md#0x2_staking_pool_request_add_delegation">staking_pool::request_add_delegation</a>(&<b>mut</b> self.delegation_staking_pool, delegated_stake, locking_period, delegator, ctx);
+    <a href="staking_pool.md#0x2_staking_pool_request_add_delegation">staking_pool::request_add_delegation</a>(
+        &<b>mut</b> self.delegation_staking_pool, delegated_stake, locking_period, self.metadata.sui_address, delegator, ctx
+    );
     self.metadata.next_epoch_delegation = self.metadata.next_epoch_delegation + delegate_amount;
 }
 </code></pre>
@@ -1063,6 +1067,30 @@ Set the voting power of this validator, called only from validator_set.
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_pool_token_exchange_rate">pool_token_exchange_rate</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): PoolTokenExchangeRate {
     <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate">staking_pool::pool_token_exchange_rate</a>(&self.delegation_staking_pool)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_staking_pool_id"></a>
+
+## Function `staking_pool_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_staking_pool_id">staking_pool_id</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): <a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_staking_pool_id">staking_pool_id</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): ID {
+    <a href="object.md#0x2_object_id">object::id</a>(&self.delegation_staking_pool)
 }
 </code></pre>
 

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -114,6 +114,7 @@ module sui::genesis {
             INIT_STAKE_SUBSIDY_AMOUNT,
             protocol_version,
             epoch_start_timestamp_ms,
+            ctx,
         );
 
         clock::create();

--- a/crates/sui-framework/tests/delegation_tests.move
+++ b/crates/sui-framework/tests/delegation_tests.move
@@ -89,6 +89,6 @@ module sui::delegation_tests {
             create_validator_for_testing(VALIDATOR_ADDR_1, 100, ctx),
             create_validator_for_testing(VALIDATOR_ADDR_2, 100, ctx)
         ];
-        create_sui_system_state_for_testing(validators, 300, 100);
+        create_sui_system_state_for_testing(validators, 300, 100, ctx);
     }
 }

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -53,7 +53,7 @@ module sui::governance_test_utils {
     }
 
     public fun create_sui_system_state_for_testing(
-        validators: vector<Validator>, sui_supply_amount: u64, storage_fund_amount: u64
+        validators: vector<Validator>, sui_supply_amount: u64, storage_fund_amount: u64, ctx: &mut TxContext
     ) {
         sui_system::create(
             validators,
@@ -64,6 +64,7 @@ module sui::governance_test_utils {
             0, // stake subsidy
             1, // protocol version
             0, // epoch_start_timestamp_ms
+            ctx,
         )
     }
 
@@ -78,7 +79,7 @@ module sui::governance_test_utils {
             );
         };
 
-        create_sui_system_state_for_testing(validators, 1000, 0);
+        create_sui_system_state_for_testing(validators, 1000, 0, ctx);
     }
 
     public fun advance_epoch(scenario: &mut Scenario) {
@@ -153,6 +154,46 @@ module sui::governance_test_utils {
 
         let ctx = test_scenario::ctx(scenario);
         sui_system::request_withdraw_delegation(&mut system_state, delegation, staked_sui, ctx);
+        test_scenario::return_shared(system_state);
+    }
+
+    public fun add_validator(validator: address, init_stake_amount: u64, scenario: &mut Scenario) {
+        test_scenario::next_tx(scenario, validator);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+        let ctx = test_scenario::ctx(scenario);
+
+        sui_system::request_add_validator(
+            &mut system_state,
+            vector[131, 117, 151, 65, 106, 116, 161, 1, 125, 44, 138, 143, 162, 193, 244, 241, 19, 159, 175, 120, 76, 35, 83, 213, 49, 79, 36, 21, 121, 79, 86, 242, 16, 1, 185, 176, 31, 191, 121, 156, 221, 167, 20, 33, 126, 19, 4, 105, 15, 229, 33, 187, 35, 99, 208, 103, 214, 176, 193, 196, 168, 154, 172, 78, 102, 5, 52, 113, 233, 213, 195, 23, 172, 220, 90, 232, 23, 17, 97, 66, 153, 105, 253, 219, 145, 125, 216, 254, 125, 49, 227, 8, 6, 206, 88, 13],
+            vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38],
+            vector[],
+            vector[150, 32, 70, 34, 231, 29, 255, 62, 248, 219, 245, 72, 85, 77, 190, 195, 251, 255, 166, 250, 229, 133, 29, 117, 17, 182, 0, 164, 162, 59, 36, 250, 78, 129, 8, 46, 106, 112, 197, 152, 219, 114, 241, 121, 242, 189, 75, 204],
+            b"name",
+            b"description",
+            b"image_url",
+            b"project_url",
+            x"",
+            x"",
+            x"",
+            coin::mint_for_testing<SUI>(init_stake_amount, ctx),
+            1,
+            0,
+            ctx
+        );
+        test_scenario::return_shared(system_state);
+    }
+
+    public fun remove_validator(validator: address, scenario: &mut Scenario) {
+        test_scenario::next_tx(scenario, validator);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+        let ctx = test_scenario::ctx(scenario);
+
+        sui_system::request_remove_validator(
+            &mut system_state,
+            ctx
+        );
         test_scenario::return_shared(system_state);
     }
 

--- a/crates/sui-framework/tests/rewards_distribution_tests.move
+++ b/crates/sui-framework/tests/rewards_distribution_tests.move
@@ -272,7 +272,7 @@ module sui::rewards_distribution_tests {
             create_validator_for_testing(VALIDATOR_ADDR_3, 300, ctx),
             create_validator_for_testing(VALIDATOR_ADDR_4, 400, ctx),
         ];
-        create_sui_system_state_for_testing(validators, 1000, 0);
+        create_sui_system_state_for_testing(validators, 1000, 0, ctx);
     }
 
     fun set_up_sui_system_state_with_big_amounts(scenario: &mut Scenario) {
@@ -284,7 +284,7 @@ module sui::rewards_distribution_tests {
             create_validator_for_testing(VALIDATOR_ADDR_3, 300000000, ctx),
             create_validator_for_testing(VALIDATOR_ADDR_4, 400000000, ctx),
         ];
-        create_sui_system_state_for_testing(validators, 1000000000, 0);
+        create_sui_system_state_for_testing(validators, 1000000000, 0, ctx);
     }
 
     fun validator_addrs() : vector<address> {

--- a/crates/sui-framework/tests/validator_set_tests.move
+++ b/crates/sui-framework/tests/validator_set_tests.move
@@ -27,7 +27,7 @@ module sui::validator_set_tests {
         let validator4 = create_validator(@0x4, 4, ctx1);
 
         // Create a validator set with only the first validator in it.
-        let validator_set = validator_set::new(vector[validator1]);
+        let validator_set = validator_set::new(vector[validator1], ctx1);
         assert!(validator_set::next_epoch_validator_count(&validator_set) == 1, 0);
         assert!(validator_set::total_validator_stake(&validator_set) == 100, 0);
 
@@ -115,7 +115,7 @@ module sui::validator_set_tests {
         let v5 = create_validator_with_gas_price(@0x5, 10, 43, ctx1);
 
         // Create a validator set with only the first validator in it.
-        let validator_set = validator_set::new(vector[v1]);
+        let validator_set = validator_set::new(vector[v1], ctx1);
 
         assert_eq(validator_set::derive_reference_gas_price(&validator_set), 45);
 

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -849,8 +849,8 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
         )
         .await
         .unwrap();
-    // 17 events created by this test + 34 Genesis event
-    assert_eq!(51, page2.data.len());
+    // 17 events created by this test + 38 Genesis event
+    assert_eq!(55, page2.data.len());
     assert_eq!(None, page2.next_cursor);
 
     // test get sender events

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5486,7 +5486,7 @@
         "required": [
           "delegation_request_epoch",
           "id",
-          "pool_starting_epoch",
+          "pool_id",
           "principal",
           "validator_address"
         ],
@@ -5499,10 +5499,8 @@
           "id": {
             "$ref": "#/components/schemas/UID"
           },
-          "pool_starting_epoch": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+          "pool_id": {
+            "$ref": "#/components/schemas/ObjectID"
           },
           "principal": {
             "$ref": "#/components/schemas/Balance"
@@ -5525,16 +5523,19 @@
         "type": "object",
         "required": [
           "delegation_token_supply",
+          "id",
           "pending_delegations",
           "pending_withdraws",
           "rewards_pool",
           "starting_epoch",
-          "sui_balance",
-          "validator_address"
+          "sui_balance"
         ],
         "properties": {
           "delegation_token_supply": {
             "$ref": "#/components/schemas/Supply"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ObjectID"
           },
           "pending_delegations": {
             "$ref": "#/components/schemas/LinkedTable_for_ObjectID"
@@ -5554,9 +5555,6 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
-          },
-          "validator_address": {
-            "$ref": "#/components/schemas/SuiAddress"
           }
         }
       },
@@ -6903,6 +6901,7 @@
           "next_epoch_validators",
           "pending_removals",
           "pending_validators",
+          "staking_pool_mappings",
           "validator_stake"
         ],
         "properties": {
@@ -6936,6 +6935,9 @@
             "items": {
               "$ref": "#/components/schemas/Validator"
             }
+          },
+          "staking_pool_mappings": {
+            "$ref": "#/components/schemas/Table"
           },
           "validator_stake": {
             "type": "integer",

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -47,8 +47,8 @@ impl Delegation {
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct StakedSui {
     id: UID,
+    pool_id: ID,
     validator_address: SuiAddress,
-    pool_starting_epoch: u64,
     delegation_request_epoch: u64,
     principal: Balance,
     sui_token_lock: Option<EpochId>,

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -139,6 +139,15 @@ pub struct Table {
     pub size: u64,
 }
 
+impl Default for Table {
+    fn default() -> Self {
+        Table {
+            id: ObjectID::from(SuiAddress::ZERO),
+            size: 0,
+        }
+    }
+}
+
 /// Rust version of the Move sui::linked_table::LinkedTable type. Putting it here since
 /// we only use it in sui_system in the framework.
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
@@ -163,7 +172,7 @@ impl<K> Default for LinkedTable<K> {
 /// Rust version of the Move sui::staking_pool::StakingPool type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct StakingPool {
-    pub validator_address: SuiAddress,
+    pub id: ObjectID,
     pub starting_epoch: u64,
     pub sui_balance: u64,
     pub rewards_pool: Balance,
@@ -188,6 +197,7 @@ pub struct ValidatorSet {
     pub pending_validators: Vec<Validator>,
     pub pending_removals: Vec<u64>,
     pub next_epoch_validators: Vec<ValidatorMetadata>,
+    pub staking_pool_mappings: Table,
 }
 
 /// Rust version of the Move sui::sui_system::SuiSystemState type
@@ -325,6 +335,7 @@ impl Default for SuiSystemState {
             pending_validators: vec![],
             pending_removals: vec![],
             next_epoch_validators: vec![],
+            staking_pool_mappings: Table::default(),
         };
         SuiSystemState {
             info: UID::new(SUI_SYSTEM_STATE_OBJECT_ID),

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sui_types::balance::{Balance, Supply};
-use sui_types::base_types::SuiAddress;
+use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::collection_types::VecMap;
 use sui_types::committee::{EpochId, ProtocolVersion};
 use sui_types::crypto::{
@@ -11,8 +11,8 @@ use sui_types::crypto::{
 use sui_types::id::UID;
 use sui_types::sui_system_state::SystemParameters;
 use sui_types::sui_system_state::{
-    LinkedTable, StakeSubsidy, StakingPool, SuiSystemState, TableVec, Validator, ValidatorMetadata,
-    ValidatorSet,
+    LinkedTable, StakeSubsidy, StakingPool, SuiSystemState, Table, TableVec, Validator,
+    ValidatorMetadata, ValidatorSet,
 };
 use sui_types::SUI_SYSTEM_STATE_OBJECT_ID;
 
@@ -42,9 +42,9 @@ pub fn test_validatdor_metadata(
     }
 }
 
-pub fn test_staking_pool(sui_address: SuiAddress, sui_balance: u64) -> StakingPool {
+pub fn test_staking_pool(sui_balance: u64) -> StakingPool {
     StakingPool {
-        validator_address: sui_address,
+        id: ObjectID::from(SuiAddress::ZERO),
         starting_epoch: 0,
         sui_balance,
         rewards_pool: Balance::new(0),
@@ -68,7 +68,7 @@ pub fn test_validator(
         pending_stake: 1,
         pending_withdraw: 1,
         gas_price: 1,
-        delegation_staking_pool: test_staking_pool(sui_address, delegated_amount),
+        delegation_staking_pool: test_staking_pool(delegated_amount),
         commission_rate: 0,
     }
 }
@@ -81,6 +81,7 @@ pub fn test_sui_system_state(epoch: EpochId, validators: Vec<Validator>) -> SuiS
         pending_validators: vec![],
         pending_removals: vec![],
         next_epoch_validators: vec![],
+        staking_pool_mappings: Table::default(),
     };
     SuiSystemState {
         info: UID::new(SUI_SYSTEM_STATE_OBJECT_ID),

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -53,8 +53,8 @@ export const StakedSui = object({
   id: object({
     id: string(),
   }),
-  validator_address: SuiAddress,
-  pool_starting_epoch: number(),
+  pool_id: string(),
+  validator_address: string(),
   delegation_request_epoch: number(),
   principal: Balance,
   sui_token_lock: union([number(), literal(null)]),
@@ -126,13 +126,13 @@ export const PendingWithdawFields = object({
 });
 
 export const DelegationStakingPoolFields = object({
+  id: string(),
   delegation_token_supply: SuiSupplyFields,
   pending_delegations: ContentsFields,
   pending_withdraws: PendingWithdawFields,
   rewards_pool: object({ value: number() }),
   starting_epoch: number(),
   sui_balance: number(),
-  validator_address: string(),
 });
 
 export const DelegationStakingPool = object({
@@ -181,6 +181,10 @@ export const ValidatorSet = object({
   pending_delegation_switches: optional(
     object({ contents: array(ValidatorPair) }),
   ),
+  staking_pool_mappings: object({
+    id: string(),
+    size: number(),
+  }),
 });
 
 export const SuiSystemState = object({
@@ -237,12 +241,12 @@ export const MoveDelegationStakingPoolFields = object({
       value: string(),
     }),
   }),
+  id: object({ id: string() }),
   pending_delegations: MovePendingDelegations,
   pending_withdraws: MovePendingWithdrawals,
   rewards_pool: string(),
   starting_epoch: string(),
   sui_balance: string(),
-  validator_address: string(),
 });
 
 export type MoveSuiSystemObjectFields = Infer<typeof MoveSuiSystemObjectFields>;
@@ -299,6 +303,16 @@ export const MoveActiveValidator = object({
   fields: MoveActiveValidatorFields,
 });
 
+export const MoveStakingPoolMappings = object({
+  type: string(),
+  fields: object({
+    id: object({
+      id: string(),
+    }),
+    size: string(),
+  }),
+});
+
 export const MoveValidatorsFieldsClass = object({
   active_validators: array(MoveActiveValidator),
   next_epoch_validators: array(MoveNextEpochValidator),
@@ -307,6 +321,7 @@ export const MoveValidatorsFieldsClass = object({
   pending_removals: array(number()),
   pending_validators: array(number()),
   quorum_stake_threshold: optional(string()),
+  staking_pool_mappings: MoveStakingPoolMappings,
   total_delegation_stake: string(),
   total_validator_stake: string(),
 });


### PR DESCRIPTION
Since we may make validator account pubkey rotatable and thus validator address changeable, it makes sense to use staking pool's object id to identify a staking pool instead. 