### PR TITLE
[explorer] - comment out client-api-version headers which are causing cors preflight check to fail

### DIFF
--- a/sdk/typescript/src/rpc/client.ts
+++ b/sdk/typescript/src/rpc/client.ts
@@ -68,8 +68,8 @@ export class JsonRpcClient {
           headers: Object.assign(
             {
               'Content-Type': 'application/json',
-              'Client-Type': 'ts-sdk',
-              'Client-Api-Version': version,
+              // 'Client-Type': 'ts-sdk',
+              // 'Client-Api-Version': version,
             },
             httpHeaders || {},
           ),

--- a/sdk/typescript/src/rpc/client.ts
+++ b/sdk/typescript/src/rpc/client.ts
@@ -13,7 +13,6 @@ import {
   string,
   Struct,
 } from 'superstruct';
-import { version } from '../pkg-version';
 
 /**
  * An object defining headers to be passed to the RPC server


### PR DESCRIPTION
[this commit](https://github.com/MystenLabs/sui/commit/24bdb66c6ce22bb4193bc5232f8119eabb3854b3) added a `client-api-version` header to requests which is causing the cors preflight check to fail. not 100% sure where the failure is at but this is a quick fix if we want it. 

