### PR TITLE
Do not commit the change epoch tx in checkpoint builder

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -737,22 +737,38 @@ impl CheckpointBuilder {
 
         let span =
             error_span!("augment_epoch_last_checkpoint", tx_digest = ?executable_tx.digest());
-        let signed_effect = self
+        let signed_effects = self
             .state
-            .try_execute_immediately(&executable_tx, &self.epoch_store)
+            // Get the effects without committing execution to the db.
+            .get_change_epoch_tx_effects(&executable_tx, &self.epoch_store)
             .instrument(span)
             .await?;
+
+        // We must write cert and effects to the state sync tables so that state sync is able to
+        // deliver to the transaction to CheckpointExecutor after it is included in a certified
+        // checkpoint.
+        let synced_txns = &self.state.database.perpetual_tables.synced_transactions;
+        let synced_effects = &self.state.database.perpetual_tables.effects;
+        synced_txns
+            .batch()
+            .insert_batch(synced_txns, [(*cert.digest(), cert.serializable_ref())])?
+            .insert_batch(
+                synced_effects,
+                [(signed_effects.digest(), signed_effects.data())],
+            )?
+            .write()?;
+
         debug!(
             "Effects summary of the change epoch transaction: {:?}",
-            signed_effect.summary_for_debug()
+            signed_effects.summary_for_debug()
         );
         self.epoch_store.record_is_safe_mode_metric(
             self.state.get_sui_system_state_object().unwrap().safe_mode,
         );
         // The change epoch transaction cannot fail to execute.
         // TODO: Audit the advance_epoch move call to make sure there is no way for it to fail.
-        assert!(signed_effect.status.is_ok());
-        effects.push(signed_effect.into_message());
+        assert!(signed_effects.status.is_ok());
+        effects.push(signed_effects.into_message());
         Ok(())
     }
 


### PR DESCRIPTION
This ensures that as we add fields to ChangeEpoch that may diverge (e.g. next protocol version), validators that did not vote for the change will only commit to the database the execution of the certified ChangeEpoch tx.