### PR TITLE
SuiNode/Authority state are now aware of what protocol versions they support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5029,7 +5029,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=95269e60b8570411e0b09ffbd8ac95a506259bdb#95269e60b8570411e0b09ffbd8ac95a506259bdb"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=d9f001161fb8c8362c8644013bb7dc1572bbeb45#d9f001161fb8c8362c8644013bb7dc1572bbeb45"
 dependencies = [
  "ahash 0.7.6",
  "async-task",
@@ -5059,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=95269e60b8570411e0b09ffbd8ac95a506259bdb#95269e60b8570411e0b09ffbd8ac95a506259bdb"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=d9f001161fb8c8362c8644013bb7dc1572bbeb45#d9f001161fb8c8362c8644013bb7dc1572bbeb45"
 dependencies = [
  "darling",
  "proc-macro2 1.0.51",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8381,6 +8381,7 @@ dependencies = [
  "sui-keys",
  "sui-macros",
  "sui-node",
+ "sui-protocol-config",
  "sui-sdk",
  "sui-simulator",
  "sui-source-validation",

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -21,6 +21,7 @@ use std::{
     num::NonZeroUsize,
     path::{Path, PathBuf},
 };
+use sui_protocol_config::SupportedProtocolVersions;
 use sui_types::committee::ProtocolVersion;
 use sui_types::crypto::{
     generate_proof_of_possession, get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair,
@@ -113,6 +114,11 @@ impl<R> ConfigBuilder<R> {
 
     pub fn with_epoch_duration(mut self, epoch_duration_ms: u64) -> Self {
         self.epoch_duration_ms = epoch_duration_ms;
+        self
+    }
+
+    pub fn with_protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
+        self.protocol_version = protocol_version;
         self
     }
 
@@ -277,14 +283,16 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             })
             .collect::<Vec<_>>();
 
-        let initial_accounts_config = self
+        let mut initial_accounts_config = self
             .initial_accounts_config
             .unwrap_or_else(GenesisConfig::for_local_testing);
+
+        initial_accounts_config.parameters.protocol_version = self.protocol_version;
+
         let (account_keys, objects) = initial_accounts_config.generate_accounts(&mut rng).unwrap();
 
         let genesis = {
             let mut builder = genesis::Builder::new()
-                .with_protocol_version(self.protocol_version)
                 .with_parameters(initial_accounts_config.parameters)
                 .add_objects(objects)
                 .add_objects(self.additional_objects);
@@ -381,6 +389,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     end_of_epoch_broadcast_channel_capacity:
                         default_end_of_epoch_broadcast_channel_capacity(),
                     checkpoint_executor_config: Default::default(),
+                    supported_protocol_versions: Some(SupportedProtocolVersions::SYSTEM_DEFAULT),
                 }
             })
             .collect();

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::usize;
 use sui_keys::keypair_file::{read_authority_keypair_from_file, read_keypair_from_file};
+use sui_protocol_config::SupportedProtocolVersions;
 use sui_types::base_types::SuiAddress;
 use sui_types::committee::StakeUnit;
 use sui_types::crypto::AuthorityPublicKeyBytes;
@@ -89,6 +90,12 @@ pub struct NodeConfig {
 
     #[serde(default)]
     pub checkpoint_executor_config: CheckpointExecutorConfig,
+
+    /// In a `sui-node` binary, this is set to SupportedProtocolVersions::SYSTEM_DEFAULT
+    /// in sui-node/src/main.rs. It is present in the config so that it can be changed by tests in
+    /// order to test protocol upgrades.
+    #[serde(skip)]
+    pub supported_protocol_versions: Option<SupportedProtocolVersions>,
 }
 
 fn default_authority_store_pruning_config() -> AuthorityStorePruningConfig {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -16,6 +16,7 @@ use serde_with::serde_as;
 use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+use sui_protocol_config::SupportedProtocolVersions;
 use sui_types::committee::Committee;
 use sui_types::crypto::{
     get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair, NetworkKeyPair, SuiKeyPair,
@@ -239,6 +240,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             end_of_epoch_broadcast_channel_capacity:
                 default_end_of_epoch_broadcast_channel_capacity(),
             checkpoint_executor_config: Default::default(),
+            supported_protocol_versions: Some(SupportedProtocolVersions::SYSTEM_DEFAULT),
         })
     }
 }

--- a/crates/sui-config/tests/snapshot_tests.rs
+++ b/crates/sui-config/tests/snapshot_tests.rs
@@ -32,6 +32,7 @@ use sui_types::crypto::{
 };
 
 #[test]
+#[cfg_attr(msim, ignore)]
 fn genesis_config_snapshot_matches() {
     // Test creating fake SuiAddress from PublicKeyBytes.
     let keypair: AuthorityKeyPair = get_key_pair_from_rng(&mut StdRng::from_seed([0; 32])).1;
@@ -51,6 +52,7 @@ fn genesis_config_snapshot_matches() {
 }
 
 #[test]
+#[cfg_attr(msim, ignore)]
 fn populated_genesis_snapshot_matches() {
     let genesis_config = GenesisConfig::for_local_testing();
     let (_account_keys, objects) = genesis_config

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1592,7 +1592,6 @@ impl AuthorityState {
         let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
         let index_store = Some(Arc::new(IndexStore::new(path.join("indexes"))));
 
-        // add the object_basics module
         let state = AuthorityState::new(
             secret.public().into(),
             secret.clone(),

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -8,6 +8,7 @@ use tempfile::tempdir;
 use std::{sync::Arc, time::Duration};
 
 use broadcast::{Receiver, Sender};
+use sui_protocol_config::SupportedProtocolVersions;
 use sui_types::committee::ProtocolVersion;
 use sui_types::messages_checkpoint::VerifiedCheckpoint;
 use tokio::{sync::broadcast, time::timeout};
@@ -178,6 +179,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
     let new_epoch_store = authority_state
         .reconfigure(
             &authority_state.epoch_store_for_testing(),
+            SupportedProtocolVersions::SYSTEM_DEFAULT,
             second_committee.committee().clone(),
             sui_system_state,
         )

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -40,7 +40,7 @@ use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_FRAMEW
 use crate::epoch::epoch_metrics::EpochMetrics;
 use std::{convert::TryInto, env};
 use sui_macros::sim_test;
-use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::object::Data;
 use sui_types::{
@@ -2660,6 +2660,7 @@ async fn test_authority_persist() {
         AuthorityState::new(
             name,
             secrete,
+            SupportedProtocolVersions::SYSTEM_DEFAULT,
             store,
             epoch_store,
             committee_store,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -216,6 +216,7 @@ impl SuiNode {
         let state = AuthorityState::new(
             config.protocol_public_key(),
             secret,
+            config.supported_protocol_versions.unwrap(),
             store,
             epoch_store.clone(),
             committee_store.clone(),
@@ -854,7 +855,12 @@ impl SuiNode {
         let next_epoch = next_epoch_committee.epoch();
         let new_epoch_store = self
             .state
-            .reconfigure(cur_epoch_store, next_epoch_committee, sui_system_state)
+            .reconfigure(
+                cur_epoch_store,
+                self.config.supported_protocol_versions.unwrap(),
+                next_epoch_committee,
+                sui_system_state,
+            )
             .await
             .expect("Reconfigure authority state cannot fail");
         info!(next_epoch, "Validator State has been reconfigured");

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use sui_config::{Config, NodeConfig};
 use sui_node::metrics;
-use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use sui_telemetry::send_telemetry_event;
 use tokio::task;
 use tokio::time::sleep;
@@ -45,11 +45,16 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Ensure that a validator never calls get_for_min_version.
+    // Ensure that a validator never calls get_for_min_version/get_for_max_version.
     ProtocolConfig::poison_get_for_min_version();
 
     let args = Args::parse();
     let mut config = NodeConfig::load(&args.config_path)?;
+    assert!(
+        config.supported_protocol_versions.is_none(),
+        "supported_protocol_versions cannot be read from the config file"
+    );
+    config.supported_protocol_versions = Some(SupportedProtocolVersions::SYSTEM_DEFAULT);
 
     let registry_service = metrics::start_prometheus_server(config.metrics_address);
     let prometheus_registry = registry_service.default_registry();
@@ -64,6 +69,10 @@ async fn main() -> Result<()> {
         .init();
 
     info!("Sui Node version: {VERSION}");
+    info!(
+        "Supported protocol versions: {:?}",
+        config.supported_protocol_versions
+    );
 
     info!(
         "Started Prometheus HTTP endpoint at {}",

--- a/crates/sui-proc-macros/Cargo.toml
+++ b/crates/sui-proc-macros/Cargo.toml
@@ -16,4 +16,4 @@ syn = "1.0.104"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "95269e60b8570411e0b09ffbd8ac95a506259bdb", package = "msim-macros" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d9f001161fb8c8362c8644013bb7dc1572bbeb45", package = "msim-macros" }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -20,16 +20,18 @@ impl ProtocolVersion {
     // use a protocol version that is actually supported by the binary.
     pub const MIN: Self = Self(MIN_PROTOCOL_VERSION);
 
-    #[cfg(not(msim))]
     pub const MAX: Self = Self(MAX_PROTOCOL_VERSION);
+
+    #[cfg(not(msim))]
+    const MAX_ALLOWED: Self = Self::MAX;
 
     // We create one additional "fake" version in simulator builds so that we can test upgrades.
     #[cfg(msim)]
-    pub const MAX: Self = Self(MAX_PROTOCOL_VERSION + 1);
+    const MAX_ALLOWED: Self = Self(MAX_PROTOCOL_VERSION + 1);
 
     pub fn new(v: u64) -> Self {
         assert!(v >= Self::MIN.0, "{:?}", v);
-        assert!(v <= Self::MAX.0, "{:?}", v);
+        assert!(v <= Self::MAX_ALLOWED.0, "{:?}", v);
         Self(v)
     }
 
@@ -377,7 +379,7 @@ impl ProtocolConfig {
     pub fn get_for_version(version: ProtocolVersion) -> Self {
         // ProtocolVersion can be deserialized so we need to check it here as well.
         assert!(version.0 >= ProtocolVersion::MIN.0, "{:?}", version);
-        assert!(version.0 <= ProtocolVersion::MAX.0, "{:?}", version);
+        assert!(version.0 <= ProtocolVersion::MAX_ALLOWED.0, "{:?}", version);
 
         Self::get_for_version_impl(version)
     }
@@ -416,7 +418,7 @@ impl ProtocolConfig {
         #[cfg(msim)]
         {
             // populate the fake simulator version # with a different base tx cost.
-            if version == ProtocolVersion::MAX {
+            if version == ProtocolVersion::MAX_ALLOWED {
                 let mut config = Self::get_for_version_impl(version - 1);
                 config.base_tx_cost_fixed = Some(config.base_tx_cost_fixed() + 1000);
                 return config;

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -19,11 +19,17 @@ impl ProtocolVersion {
     // ensures that when a new network (such as a testnet) is created, its genesis committee will
     // use a protocol version that is actually supported by the binary.
     pub const MIN: Self = Self(MIN_PROTOCOL_VERSION);
+
+    #[cfg(not(msim))]
     pub const MAX: Self = Self(MAX_PROTOCOL_VERSION);
 
+    // We create one additional "fake" version in simulator builds so that we can test upgrades.
+    #[cfg(msim)]
+    pub const MAX: Self = Self(MAX_PROTOCOL_VERSION + 1);
+
     pub fn new(v: u64) -> Self {
-        assert!(v >= MIN_PROTOCOL_VERSION, "{:?}", v);
-        assert!(v <= MAX_PROTOCOL_VERSION, "{:?}", v);
+        assert!(v >= Self::MIN.0, "{:?}", v);
+        assert!(v <= Self::MAX.0, "{:?}", v);
         Self(v)
     }
 
@@ -35,6 +41,46 @@ impl ProtocolVersion {
     // universally appropriate default value.
     pub fn max() -> Self {
         Self::MAX
+    }
+}
+
+impl std::ops::Sub<u64> for ProtocolVersion {
+    type Output = Self;
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self::new(self.0 - rhs)
+    }
+}
+
+impl std::ops::Add<u64> for ProtocolVersion {
+    type Output = Self;
+    fn add(self, rhs: u64) -> Self::Output {
+        Self::new(self.0 + rhs)
+    }
+}
+
+/// Models the set of protocol versions supported by a validator.
+/// The `sui-node` binary will always use the SYSTEM_DEFAULT constant, but for testing we need
+/// to be able to inject arbitrary versions into SuiNode.
+#[derive(Debug, Clone, Copy)]
+pub struct SupportedProtocolVersions {
+    min: ProtocolVersion,
+    max: ProtocolVersion,
+}
+
+impl SupportedProtocolVersions {
+    pub const SYSTEM_DEFAULT: Self = Self {
+        min: ProtocolVersion::MIN,
+        max: ProtocolVersion::MAX,
+    };
+
+    pub fn new_for_testing(min: u64, max: u64) -> Self {
+        let min = ProtocolVersion::new(min);
+        let max = ProtocolVersion::new(max);
+        Self { min, max }
+    }
+
+    pub fn is_version_supported(&self, v: ProtocolVersion) -> bool {
+        v.0 >= self.min.0 && v.0 <= self.max.0
     }
 }
 
@@ -330,8 +376,8 @@ impl ProtocolConfig {
     /// Get the value ProtocolConfig that are in effect during the given protocol version.
     pub fn get_for_version(version: ProtocolVersion) -> Self {
         // ProtocolVersion can be deserialized so we need to check it here as well.
-        assert!(version.0 >= MIN_PROTOCOL_VERSION, "{:?}", version);
-        assert!(version.0 <= MAX_PROTOCOL_VERSION, "{:?}", version);
+        assert!(version.0 >= ProtocolVersion::MIN.0, "{:?}", version);
+        assert!(version.0 <= ProtocolVersion::MAX.0, "{:?}", version);
 
         Self::get_for_version_impl(version)
     }
@@ -367,6 +413,16 @@ impl ProtocolConfig {
     }
 
     fn get_for_version_impl(version: ProtocolVersion) -> Self {
+        #[cfg(msim)]
+        {
+            // populate the fake simulator version # with a different base tx cost.
+            if version == ProtocolVersion::MAX {
+                let mut config = Self::get_for_version_impl(version - 1);
+                config.base_tx_cost_fixed = Some(config.base_tx_cost_fixed() + 1000);
+                return config;
+            }
+        }
+
         // IMPORTANT: Never modify the value of any constant for a pre-existing protocol version.
         // To change the values here you must create a new protocol version with the new values!
         match version.0 {

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -21,4 +21,4 @@ telemetry-subscribers.workspace = true
 tower = "0.4.13"
 
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "95269e60b8570411e0b09ffbd8ac95a506259bdb", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d9f001161fb8c8362c8644013bb7dc1572bbeb45", package = "msim" }

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -35,6 +35,7 @@ sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 sui-sdk = { path = "../sui-sdk" }
 sui-keys = { path = "../sui-keys" }
 sui-source-validation = { path = "../sui-source-validation" }
+sui-protocol-config = { path = "../sui-protocol-config" }
 
 fastcrypto.workspace = true
 

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use mysten_metrics::RegistryService;
+use prometheus::Registry;
+use sui_macros::*;
+use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
+use test_utils::authority::start_node;
+
+#[sim_test]
+#[should_panic]
+async fn test_validator_panics_on_unsupported_protocol_version() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut network_config = sui_config::builder::ConfigBuilder::new(&dir)
+        .with_protocol_version(ProtocolVersion::new(2))
+        .build();
+    network_config.validator_configs[0].supported_protocol_versions =
+        Some(SupportedProtocolVersions::new_for_testing(1, 1));
+
+    let registry_service = RegistryService::new(Registry::new());
+    let _sui_node = start_node(&network_config.validator_configs[0], registry_service).await;
+}

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -43,4 +43,4 @@ typed-store-derive = {path = "../typed-store-derive"}
 # Most packages should depend on sui-simulator instead of directly on msim, but for typed-store
 # that creates a circular dependency.
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "95269e60b8570411e0b09ffbd8ac95a506259bdb", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d9f001161fb8c8362c8644013bb7dc1572bbeb45", package = "msim" }

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -54,9 +54,9 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "95269e60b8570411e0b09ffbd8ac95a506259bdb"'
+    --config 'patch.crates-io.tokio.rev = "d9f001161fb8c8362c8644013bb7dc1572bbeb45"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "95269e60b8570411e0b09ffbd8ac95a506259bdb"'
+    --config 'patch.crates-io.futures-timer.rev = "d9f001161fb8c8362c8644013bb7dc1572bbeb45"'
   )
 fi
 


### PR DESCRIPTION
Also, some basic testing infrastructure, and a simple panic test for when the validator encounters an unsupported protocol.