### PR TITLE
wallet-ext: support executing transactions for different account than the active one

### DIFF
--- a/apps/wallet/src/background/Permissions.ts
+++ b/apps/wallet/src/background/Permissions.ts
@@ -236,7 +236,8 @@ class Permissions {
     public async hasPermissions(
         origin: string,
         permissionTypes: readonly PermissionType[],
-        permission?: Permission | null
+        permission?: Permission | null,
+        address?: SuiAddress
     ): Promise<boolean> {
         const existingPermission = await this.getPermission(origin, permission);
         return Boolean(
@@ -244,7 +245,9 @@ class Permissions {
                 existingPermission.allowed &&
                 permissionTypes.every((permissionType) =>
                     existingPermission.permissions.includes(permissionType)
-                )
+                ) &&
+                (!address ||
+                    (address && existingPermission.accounts.includes(address)))
         );
     }
 

--- a/apps/wallet/src/background/Transactions.ts
+++ b/apps/wallet/src/background/Transactions.ts
@@ -5,14 +5,16 @@ import {
     type SignedTransaction,
     type SuiTransactionResponse,
 } from '@mysten/sui.js';
-import { type SuiSignTransactionInput } from '@mysten/wallet-standard';
 import { filter, lastValueFrom, map, race, Subject, take } from 'rxjs';
 import { v4 as uuidV4 } from 'uuid';
 import Browser from 'webextension-polyfill';
 
 import { Window } from './Window';
 
-import type { TransactionDataType } from '_messages/payloads/transactions/ExecuteTransactionRequest';
+import type {
+    SignTransactionRequest,
+    TransactionDataType,
+} from '_messages/payloads/transactions/ExecuteTransactionRequest';
 import type { TransactionRequest } from '_payloads/transactions';
 import type { TransactionRequestResponse } from '_payloads/transactions/ui/TransactionRequestResponse';
 import type { ContentScriptConnection } from '_src/background/connections/ContentScriptConnection';
@@ -35,11 +37,16 @@ class Transactions {
             sign,
         }:
             | { tx: TransactionDataType; sign?: undefined }
-            | { tx?: undefined; sign: SuiSignTransactionInput },
+            | { tx?: undefined; sign: SignTransactionRequest['transaction'] },
         connection: ContentScriptConnection
     ): Promise<SuiTransactionResponse | SignedTransaction> {
         const txRequest = this.createTransactionRequest(
-            tx ?? { type: 'v2', justSign: true, data: sign.transaction },
+            tx ?? {
+                type: 'v2',
+                justSign: true,
+                data: sign.transaction,
+                account: sign.account,
+            },
             connection.origin,
             connection.originFavIcon
         );

--- a/apps/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/apps/wallet/src/background/connections/ContentScriptConnection.ts
@@ -95,10 +95,16 @@ export class ContentScriptConnection extends Connection {
                     this.permissionReply(permission, msg.id);
                 }
             } else if (isExecuteTransactionRequest(payload)) {
-                const allowed = await Permissions.hasPermissions(this.origin, [
-                    'viewAccount',
-                    'suggestTransactions',
-                ]);
+                if (!payload.transaction.account) {
+                    // make sure we don't execute transactions that doesn't have a specified account
+                    throw new Error('Missing account');
+                }
+                const allowed = await Permissions.hasPermissions(
+                    this.origin,
+                    ['viewAccount', 'suggestTransactions'],
+                    null,
+                    payload.transaction.account
+                );
                 if (allowed) {
                     const result = await Transactions.executeOrSignTransaction(
                         { tx: payload.transaction },
@@ -117,10 +123,16 @@ export class ContentScriptConnection extends Connection {
                     this.sendNotAllowedError(msg.id);
                 }
             } else if (isSignTransactionRequest(payload)) {
-                const allowed = await Permissions.hasPermissions(this.origin, [
-                    'viewAccount',
-                    'suggestTransactions',
-                ]);
+                if (!payload.transaction.account) {
+                    // make sure we don't execute transactions that doesn't have a specified account
+                    throw new Error('Missing account');
+                }
+                const allowed = await Permissions.hasPermissions(
+                    this.origin,
+                    ['viewAccount', 'suggestTransactions'],
+                    null,
+                    payload.transaction.account
+                );
                 if (allowed) {
                     const result = await Transactions.executeOrSignTransaction(
                         { sign: payload.transaction },

--- a/apps/wallet/src/dapp-interface/DAppInterface.ts
+++ b/apps/wallet/src/dapp-interface/DAppInterface.ts
@@ -77,20 +77,21 @@ export class DAppInterface {
         );
     }
 
-    public signAndExecuteTransaction(transaction: SignableTransaction) {
+    public async signAndExecuteTransaction(transaction: SignableTransaction) {
         return mapToPromise(
             this.send<ExecuteTransactionRequest, ExecuteTransactionResponse>({
                 type: 'execute-transaction-request',
                 transaction: {
                     type: 'v2',
                     data: transaction,
+                    account: (await this.getAccounts())[0],
                 },
             }),
             (response) => response.result
         );
     }
 
-    public executeMoveCall(transaction: MoveCallTransaction) {
+    public async executeMoveCall(transaction: MoveCallTransaction) {
         // eslint-disable-next-line no-console
         console.warn(
             'You are using the deprecated `executeMoveCall` method on the `suiWallet` interface. This method will be removed in a future release of the Sui Wallet. Please migrate to the new `signAndExecuteTransaction` method.'
@@ -102,13 +103,14 @@ export class DAppInterface {
                 transaction: {
                     type: 'move-call',
                     data: transaction,
+                    account: (await this.getAccounts())[0],
                 },
             }),
             (response) => response.result
         );
     }
 
-    public executeSerializedMoveCall(tx: string | Uint8Array) {
+    public async executeSerializedMoveCall(tx: string | Uint8Array) {
         // eslint-disable-next-line no-console
         console.warn(
             'You are using the deprecated `executeSerializedMoveCall` method on the `suiWallet` interface. This method will be removed in a future release of the Sui Wallet. Please migrate to the new `signAndExecuteTransaction` method.'
@@ -122,6 +124,7 @@ export class DAppInterface {
                 transaction: {
                     type: 'serialized-move-call',
                     data,
+                    account: (await this.getAccounts())[0],
                 },
             }),
             (response) => response.result

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -220,7 +220,15 @@ export class SuiWallet implements Wallet {
         return mapToPromise(
             this.#send<SignTransactionRequest, SignTransactionResponse>({
                 type: 'sign-transaction-request',
-                transaction: input,
+                transaction: {
+                    ...input,
+                    // account might be undefined if previous version of adapters is used
+                    // in that case use the first account address
+                    account:
+                        input.account?.address ||
+                        this.#accounts[0]?.address ||
+                        '',
+                },
             }),
             (response) => response.result
         );
@@ -236,6 +244,12 @@ export class SuiWallet implements Wallet {
                     type: 'v2',
                     data: input.transaction,
                     options: input.options,
+                    // account might be undefined if previous version of adapters is used
+                    // in that case use the first account address
+                    account:
+                        input.account?.address ||
+                        this.#accounts[0]?.address ||
+                        '',
                 },
             }),
             (response) => response.result

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
@@ -8,7 +8,11 @@ import {
 
 import { isBasePayload } from '_payloads';
 
-import type { MoveCallTransaction, SignableTransaction } from '@mysten/sui.js';
+import type {
+    MoveCallTransaction,
+    SignableTransaction,
+    SuiAddress,
+} from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 
 export type TransactionDataType =
@@ -17,9 +21,10 @@ export type TransactionDataType =
           justSign?: boolean;
           data: SignableTransaction;
           options?: SuiSignAndExecuteTransactionOptions;
+          account: SuiAddress;
       }
-    | { type: 'move-call'; data: MoveCallTransaction }
-    | { type: 'serialized-move-call'; data: string };
+    | { type: 'move-call'; data: MoveCallTransaction; account: SuiAddress }
+    | { type: 'serialized-move-call'; data: string; account: SuiAddress };
 
 export interface ExecuteTransactionRequest extends BasePayload {
     type: 'execute-transaction-request';
@@ -36,7 +41,9 @@ export function isExecuteTransactionRequest(
 
 export interface SignTransactionRequest extends BasePayload {
     type: 'sign-transaction-request';
-    transaction: SuiSignTransactionInput;
+    transaction: Omit<SuiSignTransactionInput, 'account'> & {
+        account: SuiAddress;
+    };
 }
 
 export function isSignTransactionRequest(

--- a/apps/wallet/src/ui/app/components/account-address/index.tsx
+++ b/apps/wallet/src/ui/app/components/account-address/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { formatAddress } from '@mysten/sui.js';
+import { formatAddress, type SuiAddress } from '@mysten/sui.js';
 import cl from 'classnames';
 
 import CopyToClipboard from '_components/copy-to-clipboard';
@@ -18,6 +18,7 @@ type AccountAddressProps = {
     shorten?: boolean;
     copyable?: boolean;
     mode?: 'normal' | 'faded';
+    address?: SuiAddress;
 };
 
 function AccountAddress({
@@ -26,24 +27,25 @@ function AccountAddress({
     shorten = true,
     copyable,
     mode = 'normal',
+    address,
 }: AccountAddressProps) {
     const network = useAppSelector(({ app }) => app.apiEnv);
     const showExplorerLink = API_ENV.customRPC !== network;
-
-    const address = useAppSelector(({ account: { address } }) => address);
+    const activeAddress = useAppSelector(({ account }) => account.address);
+    const addressToShow = address || activeAddress;
     const cpIconMode = mode === 'normal' ? 'normal' : 'highlighted';
 
-    const addressLink = address && (
-        <span className={cl(st.address, st[mode])} title={address}>
-            {shorten ? formatAddress(address) : address}
+    const addressLink = addressToShow && (
+        <span className={cl(st.address, st[mode])} title={addressToShow}>
+            {shorten ? formatAddress(addressToShow) : addressToShow}
         </span>
     );
 
-    return address ? (
+    return addressToShow ? (
         <span className={cl(st.addressContainer, className)}>
             {copyable ? (
                 <CopyToClipboard
-                    txt={address}
+                    txt={addressToShow}
                     mode={cpIconMode}
                     copySuccessMessage="Address copied"
                 >

--- a/apps/wallet/src/ui/app/components/user-approve-container/index.tsx
+++ b/apps/wallet/src/ui/app/components/user-approve-container/index.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { type SuiAddress } from '@mysten/sui.js';
 import cl from 'classnames';
-import { memo, useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { Button } from '../../shared/ButtonUI';
 import AccountAddress from '_components/account-address';
@@ -23,9 +24,10 @@ type UserApproveContainerProps = {
     isConnect?: boolean;
     isWarning?: boolean;
     addressHidden?: boolean;
+    address?: SuiAddress;
 };
 
-function UserApproveContainer({
+export function UserApproveContainer({
     origin,
     originFavIcon,
     children,
@@ -36,6 +38,7 @@ function UserApproveContainer({
     isConnect,
     isWarning,
     addressHidden = false,
+    address,
 }: UserApproveContainerProps) {
     const [submitting, setSubmitting] = useState(false);
     const handleOnResponse = useCallback(
@@ -80,6 +83,7 @@ function UserApproveContainer({
                                 mode="normal"
                                 copyable
                                 className={st.address}
+                                address={address}
                             />
                         </div>
                     ) : null}
@@ -114,5 +118,3 @@ function UserApproveContainer({
         </div>
     );
 }
-
-export default memo(UserApproveContainer);

--- a/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
@@ -5,16 +5,19 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useSigner } from '_hooks';
 
-import type { SignerWithProvider } from '@mysten/sui.js';
+import type { SignerWithProvider, SuiAddress } from '@mysten/sui.js';
 
 export type TransactionDryRun = Parameters<
     SignerWithProvider['dryRunTransaction']
 >['0'];
 
-export function useTransactionDryRun(txData: TransactionDryRun) {
-    const signer = useSigner();
+export function useTransactionDryRun(
+    txData: TransactionDryRun,
+    addressForTransaction: SuiAddress
+) {
+    const signer = useSigner(addressForTransaction);
     const response = useQuery({
-        queryKey: ['executeDryRunTxn', txData],
+        queryKey: ['executeDryRunTxn', txData, addressForTransaction],
         queryFn: async () => {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             return signer!.dryRunTransaction(txData);

--- a/apps/wallet/src/ui/app/hooks/useTransactionSummary.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionSummary.ts
@@ -14,7 +14,7 @@ import type { TxnMetaResponse } from '../helpers/getEventsSummary';
 
 type ExecuteDryRunTransactionRequestProps = {
     txData: TransactionDryRun;
-    activeAddress: string;
+    addressForTransaction: string;
 };
 
 type ExecuteDryRunTransactionReqResponse = [
@@ -24,13 +24,13 @@ type ExecuteDryRunTransactionReqResponse = [
 
 export function useTransactionSummary({
     txData,
-    activeAddress,
+    addressForTransaction,
 }: ExecuteDryRunTransactionRequestProps): ExecuteDryRunTransactionReqResponse {
-    const { data } = useTransactionDryRun(txData);
+    const { data } = useTransactionDryRun(txData, addressForTransaction);
 
     const eventsSummary = useMemo(
-        () => (data ? getEventsSummary(data, activeAddress) : null),
-        [data, activeAddress]
+        () => (data ? getEventsSummary(data, addressForTransaction) : null),
+        [data, addressForTransaction]
     );
     const txGasEstimation = data && getTotalGasUsed(data);
 

--- a/apps/wallet/src/ui/app/pages/dapp-tx-approval/TransactionSummaryCard.tsx
+++ b/apps/wallet/src/ui/app/pages/dapp-tx-approval/TransactionSummaryCard.tsx
@@ -1,19 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { formatAddress } from '@mysten/sui.js';
+import { formatAddress, type SuiAddress } from '@mysten/sui.js';
 
 import { MiniNFT } from './MiniNFT';
 import { SummaryCard } from './SummaryCard';
 import AccountAddress from '_components/account-address';
 import ExplorerLink from '_components/explorer-link';
 import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
-import {
-    useFormatCoin,
-    useGetNFTMeta,
-    useAppSelector,
-    useTransactionSummary,
-} from '_hooks';
+import { useFormatCoin, useGetNFTMeta, useTransactionSummary } from '_hooks';
 import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 
 import type { CoinsMetaProps } from '../../helpers/getEventsSummary';
@@ -24,9 +19,9 @@ import st from './DappTxApprovalPage.module.scss';
 
 type TransferSummerCardProps = {
     coinsMeta: CoinsMetaProps[];
-    origin: string;
     objectIDs: string[];
     gasEstimate: number | null;
+    addressForTransaction: SuiAddress;
 };
 
 function MiniNFTLink({ id }: { id: string }) {
@@ -55,22 +50,20 @@ function MiniNFTLink({ id }: { id: string }) {
 function CoinMeta({
     receiverAddress,
     coinMeta,
-    origin,
+    addressForTransaction,
 }: {
     receiverAddress: string;
     coinMeta: CoinsMetaProps;
-    origin: string;
+    addressForTransaction: SuiAddress;
 }) {
     const [formattedAmount, symbol] = useFormatCoin(
         coinMeta.amount ? Math.abs(coinMeta.amount) : 0,
         coinMeta.coinType
     );
 
-    const activeAccount = useAppSelector(({ account }) => account.address);
-
     // TODO add receiver address;
     // Currently dry_run does not return receiver address for transactions init by Move contract
-    const showAddress = receiverAddress !== activeAccount;
+    const showAddress = receiverAddress !== addressForTransaction;
 
     /// A net positive amount means the user received coins and verse versa.
     const sendLabel = coinMeta.amount < 0 ? 'Send' : 'Receive';
@@ -110,7 +103,7 @@ function TransactionSummary({
     objectIDs,
     coinsMeta,
     gasEstimate,
-    origin,
+    addressForTransaction,
 }: TransferSummerCardProps) {
     const [gasEst, gasSymbol] = useFormatCoin(gasEstimate || 0, GAS_TYPE_ARG);
 
@@ -122,7 +115,7 @@ function TransactionSummary({
                         receiverAddress={coinMeta.receiverAddress}
                         key={coinMeta.receiverAddress + coinMeta.coinType}
                         coinMeta={coinMeta}
-                        origin={origin}
+                        addressForTransaction={addressForTransaction}
                     />
                 ))}
             {objectIDs.length > 0 && (
@@ -144,6 +137,7 @@ function TransactionSummary({
                                 copyable={false}
                                 className={st.ownerAddress}
                                 mode="normal"
+                                address={addressForTransaction}
                             />
                         </div>
                     </div>
@@ -176,7 +170,7 @@ export function TransactionSummaryCard({
 
     const txReqData = {
         txData: txData,
-        activeAddress: address,
+        addressForTransaction: address,
     };
 
     const [transactionSummary, gasEstimation] =
@@ -190,7 +184,7 @@ export function TransactionSummaryCard({
             objectIDs={transactionSummary.objectIDs}
             coinsMeta={transactionSummary.coins}
             gasEstimate={gasEstimation}
-            origin={txRequest.origin}
+            addressForTransaction={address}
         />
     );
 }

--- a/apps/wallet/src/ui/app/pages/site-connect/index.tsx
+++ b/apps/wallet/src/ui/app/pages/site-connect/index.tsx
@@ -11,7 +11,7 @@ import { SummaryCard } from '../../components/SummaryCard';
 import { WalletListSelect } from '../../components/WalletListSelect';
 import { Text } from '../../shared/text';
 import Loading from '_components/loading';
-import UserApproveContainer from '_components/user-approve-container';
+import { UserApproveContainer } from '_components/user-approve-container';
 import { useAppDispatch, useAppSelector } from '_hooks';
 import {
     permissionsSelectors,


### PR DESCRIPTION
* updated permissions to check that the specified account has the required permissions
* ignore transactions that do not specify an account
* make WalletStandardInterface and DAppInterface backwards compatible by adding the first account of the connected accounts for the case the account is missing
* UI always expects the account to be defined and doesn't default to the active one
before (only happens on dev multi-account is not enabled in prod)


https://user-images.githubusercontent.com/10210143/220488723-9118d0f8-6c39-41ff-9379-1b5c42f05573.mov


https://user-images.githubusercontent.com/10210143/220488849-63134f26-3eb2-42f2-80ea-33a1443b6921.mov

after


https://user-images.githubusercontent.com/10210143/220488869-9ec744f7-1d3a-49be-b5b7-8d78ac030956.mov



part of APPS-281