### PR TITLE
Add metrics/logging to report excessively large messages in anemo.

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -26,6 +26,12 @@ pub struct P2pConfig {
     pub state_sync: Option<StateSyncConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discovery: Option<DiscoveryConfig>,
+    /// Size in bytes above which network messages are considered excessively large. Excessively
+    /// large messages will still be handled, but logged and reported in metrics for debugging.
+    ///
+    /// If unspecified, this will default to 8 MiB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excessive_message_size: Option<usize>,
 }
 
 fn default_listen_address() -> SocketAddr {
@@ -41,7 +47,17 @@ impl Default for P2pConfig {
             anemo_config: Default::default(),
             state_sync: None,
             discovery: None,
+            excessive_message_size: None,
         }
+    }
+}
+
+impl P2pConfig {
+    pub fn excessive_message_size(&self) -> usize {
+        const EXCESSIVE_MESSAGE_SIZE: usize = 8 << 20;
+
+        self.excessive_message_size
+            .unwrap_or(EXCESSIVE_MESSAGE_SIZE)
     }
 }
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -412,6 +412,7 @@ impl SuiNode {
                 )
                 .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                     Arc::new(inbound_network_metrics),
+                    config.p2p_config.excessive_message_size(),
                 )))
                 .service(routes);
 
@@ -423,6 +424,7 @@ impl SuiNode {
                 )
                 .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                     Arc::new(outbound_network_metrics),
+                    config.p2p_config.excessive_message_size(),
                 )))
                 .into_inner();
 

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -85,6 +85,7 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
                             )
                             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                                 Arc::new(inbound_network_metrics),
+                                usize::MAX,
                             )))
                             .service(::sui_simulator::anemo::Router::new());
 
@@ -96,6 +97,7 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
                             )
                             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                                 Arc::new(outbound_network_metrics),
+                                usize::MAX,
                             )))
                             .into_inner();
 

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -221,6 +221,22 @@ pub struct AnemoParameters {
     /// Per-peer rate-limits (in requests/sec) for the WorkerToWorker service.
     pub report_batch_rate_limit: Option<NonZeroU32>,
     pub request_batch_rate_limit: Option<NonZeroU32>,
+
+    /// Size in bytes above which network messages are considered excessively large. Excessively
+    /// large messages will still be handled, but logged and reported in metrics for debugging.
+    ///
+    /// If unspecified, this will default to 8 MiB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excessive_message_size: Option<usize>,
+}
+
+impl AnemoParameters {
+    pub fn excessive_message_size(&self) -> usize {
+        const EXCESSIVE_MESSAGE_SIZE: usize = 8 << 20;
+
+        self.excessive_message_size
+            .unwrap_or(EXCESSIVE_MESSAGE_SIZE)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -314,6 +314,7 @@ impl Primary {
             )
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 inbound_network_metrics,
+                parameters.anemo.excessive_message_size(),
             )))
             .layer(CallbackLayer::new(FailpointsMakeCallbackHandler::new()))
             .layer(SetResponseHeaderLayer::overriding(
@@ -330,6 +331,7 @@ impl Primary {
             )
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 outbound_network_metrics,
+                parameters.anemo.excessive_message_size(),
             )))
             .layer(CallbackLayer::new(FailpointsMakeCallbackHandler::new()))
             .layer(SetRequestHeaderLayer::overriding(

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -197,6 +197,7 @@ impl Worker {
             )
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 inbound_network_metrics,
+                parameters.anemo.excessive_message_size(),
             )))
             .layer(CallbackLayer::new(FailpointsMakeCallbackHandler::new()))
             .layer(SetResponseHeaderLayer::overriding(
@@ -213,6 +214,7 @@ impl Worker {
             )
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 outbound_network_metrics,
+                parameters.anemo.excessive_message_size(),
             )))
             .layer(CallbackLayer::new(FailpointsMakeCallbackHandler::new()))
             .layer(SetRequestHeaderLayer::overriding(


### PR DESCRIPTION
This lets us set a "soft" limit to alert on, without throwing away large RPCs.