### PR TITLE
[TypeScript SDK] Add back request headers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,10 +111,9 @@ jobs:
         if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
 
-      # Re-enable when it's more stable
-      # - name: Run Explorer e2e tests
-      #   if: ${{ needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
-      #   run: pnpm explorer playwright test
+      - name: Run Explorer e2e tests
+        if: ${{ needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
+        run: pnpm explorer playwright test
 
       # TODO: add wallet e2e when available
 

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -38,6 +38,7 @@ pub const CLIENT_SDK_VERSION_HEADER: &str = "client-sdk-version";
 /// The RPC API version that the client is targeting. Different SDK versions may target the same
 /// API version.
 pub const CLIENT_TARGET_API_VERSION_HEADER: &str = "client-target-api-version";
+pub const APP_NAME_HEADER: &str = "app-name";
 
 #[cfg(test)]
 #[path = "unit_tests/rpc_server_tests.rs"]
@@ -103,6 +104,7 @@ impl JsonRpcServerBuilder {
                 HeaderName::from_static(CLIENT_SDK_TYPE_HEADER),
                 HeaderName::from_static(CLIENT_SDK_VERSION_HEADER),
                 HeaderName::from_static(CLIENT_TARGET_API_VERSION_HEADER),
+                HeaderName::from_static(APP_NAME_HEADER),
             ]);
 
         self.module

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -32,6 +32,9 @@ pub mod threshold_bls_api;
 pub mod transaction_builder_api;
 pub mod transaction_execution_api;
 
+pub const CLIENT_TYPE_HEADER: &str = "client-type";
+pub const CLIENT_VERSION_HEADER: &str = "client-api-version";
+
 #[cfg(test)]
 #[path = "unit_tests/rpc_server_tests.rs"]
 mod rpc_server_test;
@@ -86,8 +89,8 @@ impl JsonRpcServerBuilder {
         };
         info!(?acl);
 
-        let client_type: HeaderName = HeaderName::from_static("client-type");
-        let client_api_version: HeaderName = HeaderName::from_static("client-api-version");
+        let client_type: HeaderName = HeaderName::from_static(CLIENT_TYPE_HEADER);
+        let client_api_version: HeaderName = HeaderName::from_static(CLIENT_VERSION_HEADER);
 
         let cors = CorsLayer::new()
             // Allow `POST` when accessing the resource

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -32,8 +32,8 @@ pub mod threshold_bls_api;
 pub mod transaction_builder_api;
 pub mod transaction_execution_api;
 
-pub const CLIENT_TYPE_HEADER: &str = "client-type";
-pub const CLIENT_VERSION_HEADER: &str = "client-api-version";
+pub const CLIENT_SDK_TYPE_HEADER: &str = "client-sdk-type";
+pub const CLIENT_SDK_VERSION_HEADER: &str = "client-sdk-version";
 
 #[cfg(test)]
 #[path = "unit_tests/rpc_server_tests.rs"]
@@ -89,8 +89,8 @@ impl JsonRpcServerBuilder {
         };
         info!(?acl);
 
-        let client_type: HeaderName = HeaderName::from_static(CLIENT_TYPE_HEADER);
-        let client_api_version: HeaderName = HeaderName::from_static(CLIENT_VERSION_HEADER);
+        let client_type: HeaderName = HeaderName::from_static(CLIENT_SDK_TYPE_HEADER);
+        let client_api_version: HeaderName = HeaderName::from_static(CLIENT_SDK_VERSION_HEADER);
 
         let cors = CorsLayer::new()
             // Allow `POST` when accessing the resource

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -33,7 +33,11 @@ pub mod transaction_builder_api;
 pub mod transaction_execution_api;
 
 pub const CLIENT_SDK_TYPE_HEADER: &str = "client-sdk-type";
+/// The version number of the SDK itself. This can be different from the API version.
 pub const CLIENT_SDK_VERSION_HEADER: &str = "client-sdk-version";
+/// The RPC API version that the client is targeting. Different SDK versions may target the same
+/// API version.
+pub const CLIENT_TARGET_API_VERSION_HEADER: &str = "client-target-api-version";
 
 #[cfg(test)]
 #[path = "unit_tests/rpc_server_tests.rs"]
@@ -89,15 +93,17 @@ impl JsonRpcServerBuilder {
         };
         info!(?acl);
 
-        let client_type: HeaderName = HeaderName::from_static(CLIENT_SDK_TYPE_HEADER);
-        let client_api_version: HeaderName = HeaderName::from_static(CLIENT_SDK_VERSION_HEADER);
-
         let cors = CorsLayer::new()
             // Allow `POST` when accessing the resource
             .allow_methods([Method::POST])
             // Allow requests from any origin
             .allow_origin(acl)
-            .allow_headers([hyper::header::CONTENT_TYPE, client_type, client_api_version]);
+            .allow_headers([
+                hyper::header::CONTENT_TYPE,
+                HeaderName::from_static(CLIENT_SDK_TYPE_HEADER),
+                HeaderName::from_static(CLIENT_SDK_VERSION_HEADER),
+                HeaderName::from_static(CLIENT_TARGET_API_VERSION_HEADER),
+            ]);
 
         self.module
             .register_method("rpc.discover", move |_, _| Ok(self.rpc_doc.clone()))?;

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -19,7 +19,9 @@ use sui_adapter::execution_mode::Normal;
 pub use sui_json as json;
 
 use crate::apis::{CoinReadApi, EventApi, GovernanceApi, QuorumDriver, ReadApi};
-use sui_json_rpc::{CLIENT_SDK_TYPE_HEADER, CLIENT_SDK_VERSION_HEADER};
+use sui_json_rpc::{
+    CLIENT_SDK_TYPE_HEADER, CLIENT_SDK_VERSION_HEADER, CLIENT_TARGET_API_VERSION_HEADER,
+};
 pub use sui_json_rpc_types as rpc_types;
 use sui_json_rpc_types::{GetRawObjectDataResponse, SuiObjectInfo};
 use sui_transaction_builder::{DataReader, TransactionBuilder};
@@ -76,6 +78,11 @@ impl SuiClientBuilder {
     pub async fn build(self, http: impl AsRef<str>) -> SuiRpcResult<SuiClient> {
         let client_version = env!("CARGO_PKG_VERSION");
         let mut headers = HeaderMap::new();
+        headers.insert(
+            CLIENT_TARGET_API_VERSION_HEADER,
+            // for rust, the client version is the same as the target api version
+            HeaderValue::from_static(client_version),
+        );
         headers.insert(
             CLIENT_SDK_VERSION_HEADER,
             HeaderValue::from_static(client_version),

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -21,6 +21,7 @@ pub use sui_json as json;
 use crate::apis::{CoinReadApi, EventApi, GovernanceApi, QuorumDriver, ReadApi};
 pub use sui_json_rpc_types as rpc_types;
 use sui_json_rpc_types::{GetRawObjectDataResponse, SuiObjectInfo};
+use sui_json_rpc::{CLIENT_TYPE_HEADER, CLIENT_VERSION_HEADER};
 use sui_transaction_builder::{DataReader, TransactionBuilder};
 pub use sui_types as types;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
@@ -76,10 +77,10 @@ impl SuiClientBuilder {
         let client_version = env!("CARGO_PKG_VERSION");
         let mut headers = HeaderMap::new();
         headers.insert(
-            "client_api_version",
+            CLIENT_VERSION_HEADER,
             HeaderValue::from_static(client_version),
         );
-        headers.insert("client_type", HeaderValue::from_static("rust_sdk"));
+        headers.insert(CLIENT_TYPE_HEADER, HeaderValue::from_static("rust_sdk"));
 
         let ws = if let Some(url) = self.ws_url {
             Some(

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -19,9 +19,9 @@ use sui_adapter::execution_mode::Normal;
 pub use sui_json as json;
 
 use crate::apis::{CoinReadApi, EventApi, GovernanceApi, QuorumDriver, ReadApi};
+use sui_json_rpc::{CLIENT_SDK_TYPE_HEADER, CLIENT_SDK_VERSION_HEADER};
 pub use sui_json_rpc_types as rpc_types;
 use sui_json_rpc_types::{GetRawObjectDataResponse, SuiObjectInfo};
-use sui_json_rpc::{CLIENT_TYPE_HEADER, CLIENT_VERSION_HEADER};
 use sui_transaction_builder::{DataReader, TransactionBuilder};
 pub use sui_types as types;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
@@ -77,10 +77,10 @@ impl SuiClientBuilder {
         let client_version = env!("CARGO_PKG_VERSION");
         let mut headers = HeaderMap::new();
         headers.insert(
-            CLIENT_VERSION_HEADER,
+            CLIENT_SDK_VERSION_HEADER,
             HeaderValue::from_static(client_version),
         );
-        headers.insert(CLIENT_TYPE_HEADER, HeaderValue::from_static("rust_sdk"));
+        headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("rust"));
 
         let ws = if let Some(url) = self.ws_url {
             Some(

--- a/sdk/typescript/genversion.mjs
+++ b/sdk/typescript/genversion.mjs
@@ -10,7 +10,7 @@ import pkg from './package.json' assert { type: 'json' };
 async function main() {
   await writeFile(
     'src/pkg-version.ts',
-    LICENSE + `export const version = '${pkg.version}';\n`,
+    LICENSE + `export const pkgVersion = '${pkg.version}';\n`,
   );
 }
 

--- a/sdk/typescript/src/pkg-version.ts
+++ b/sdk/typescript/src/pkg-version.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export const version = '0.27.0';
+export const pkgVersion = '0.27.0';

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -75,7 +75,9 @@ import { UnserializedSignableTransaction } from '../signers/txn-data-serializers
 import { LocalTxnDataSerializer } from '../signers/txn-data-serializers/local-txn-data-serializer';
 import { toB64 } from '@mysten/bcs';
 import { SerializedSignature } from '../cryptography/signature';
-import { version as packageVersion } from '../pkg-version';
+import { pkgVersion } from '../pkg-version';
+
+export const TARGETED_RPC_VERSION = '0.27.0';
 
 /**
  * Configuration options for the JsonRpcProvider. If the value of a field is not provided,
@@ -154,7 +156,8 @@ export class JsonRpcProvider extends Provider {
     // method
     // this.client = new JsonRpcClient(this.endpoints.fullNode, {
     //   'Client-Sdk-Type': 'typescript',
-    //   'Client-Sdk-Version': packageVersion,
+    //   'Client-Sdk-Version': pkgVersion,
+    //   'Client-Target-Api-Version': TARGETED_RPC_VERSION,
     // });
     // TODO: add header for websocket request
     this.wsClient = new WebsocketClient(
@@ -188,7 +191,8 @@ export class JsonRpcProvider extends Provider {
       ) {
         this.client = new JsonRpcClient(this.endpoints.fullNode, {
           'Client-Sdk-Type': 'typescript',
-          'Client-Sdk-Version': packageVersion,
+          'Client-Sdk-Version': pkgVersion,
+          'Client-Target-Api-Version': TARGETED_RPC_VERSION,
         });
         this.addedHeaders = true;
       }

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -69,12 +69,13 @@ import {
 } from '../rpc/websocket-client';
 import { ApiEndpoints, Network, NETWORK_TO_API } from '../utils/api-endpoints';
 import { requestSuiFromFaucet } from '../rpc/faucet-client';
-import { lt } from '@suchipi/femver';
+import { lt, gt } from '@suchipi/femver';
 import { any, is, number, array } from 'superstruct';
 import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
 import { LocalTxnDataSerializer } from '../signers/txn-data-serializers/local-txn-data-serializer';
 import { toB64 } from '@mysten/bcs';
 import { SerializedSignature } from '../cryptography/signature';
+import { version as packageVersion } from '../pkg-version';
 
 /**
  * Configuration options for the JsonRpcProvider. If the value of a field is not provided,
@@ -121,6 +122,7 @@ export class JsonRpcProvider extends Provider {
   protected wsClient: WebsocketClient;
   private rpcApiVersion: RpcApiVersion | undefined;
   private cacheExpiry: number | undefined;
+  private addedHeaders = false;
   /**
    * Establish a connection to a Sui RPC endpoint
    *
@@ -145,6 +147,16 @@ export class JsonRpcProvider extends Provider {
     const opts = { ...DEFAULT_OPTIONS, ...options };
 
     this.client = new JsonRpcClient(this.endpoints.fullNode);
+    // TODO: uncomment this when 0.27.0 is released. We cannot do this now because
+    // the current Devnet(0.26.0) does not support the header. And we need to make
+    // a request to RPC to know which version it is running. Therefore, we do not
+    // add headers here, instead we add headers in the first call of the `getRpcApiVersion`
+    // method
+    // this.client = new JsonRpcClient(this.endpoints.fullNode, {
+    //   'Client-Type': 'ts-sdk',
+    //   'Client-Api-Version': packageVersion,
+    // });
+    // TODO: add header for websocket request
     this.wsClient = new WebsocketClient(
       this.endpoints.fullNode,
       opts.skipDataValidation!,
@@ -168,8 +180,21 @@ export class JsonRpcProvider extends Provider {
         this.options.skipDataValidation,
       );
       this.rpcApiVersion = parseVersionFromString(resp.info.version);
+      // TODO: Remove this once 0.27.0 is released
+      if (
+        !this.addedHeaders &&
+        this.rpcApiVersion &&
+        gt(versionToString(this.rpcApiVersion), '0.26.0')
+      ) {
+        this.client = new JsonRpcClient(this.endpoints.fullNode, {
+          'Client-Type': 'ts-sdk',
+          'Client-Api-Version': packageVersion,
+        });
+        this.addedHeaders = true;
+      }
       this.cacheExpiry =
-        Date.now() + (this.options.versionCacheTimoutInSeconds ?? 0);
+        // Date.now() is in milliseonds, but the timeout is in seconds
+        Date.now() + (this.options.versionCacheTimoutInSeconds ?? 0) * 1000;
       return this.rpcApiVersion;
     } catch (err) {
       console.warn('Error fetching version number of the RPC API', err);

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -153,8 +153,8 @@ export class JsonRpcProvider extends Provider {
     // add headers here, instead we add headers in the first call of the `getRpcApiVersion`
     // method
     // this.client = new JsonRpcClient(this.endpoints.fullNode, {
-    //   'Client-Type': 'ts-sdk',
-    //   'Client-Api-Version': packageVersion,
+    //   'Client-Sdk-Type': 'typescript',
+    //   'Client-Sdk-Version': packageVersion,
     // });
     // TODO: add header for websocket request
     this.wsClient = new WebsocketClient(
@@ -187,8 +187,8 @@ export class JsonRpcProvider extends Provider {
         gt(versionToString(this.rpcApiVersion), '0.26.0')
       ) {
         this.client = new JsonRpcClient(this.endpoints.fullNode, {
-          'Client-Type': 'ts-sdk',
-          'Client-Api-Version': packageVersion,
+          'Client-Sdk-Type': 'typescript',
+          'Client-Sdk-Version': packageVersion,
         });
         this.addedHeaders = true;
       }

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -69,7 +69,7 @@ import {
 } from '../rpc/websocket-client';
 import { ApiEndpoints, Network, NETWORK_TO_API } from '../utils/api-endpoints';
 import { requestSuiFromFaucet } from '../rpc/faucet-client';
-import { lt, gt } from '@suchipi/femver';
+import { lt } from '@suchipi/femver';
 import { any, is, number, array } from 'superstruct';
 import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
 import { LocalTxnDataSerializer } from '../signers/txn-data-serializers/local-txn-data-serializer';
@@ -187,7 +187,7 @@ export class JsonRpcProvider extends Provider {
       if (
         !this.addedHeaders &&
         this.rpcApiVersion &&
-        gt(versionToString(this.rpcApiVersion), '0.26.0')
+        !lt(versionToString(this.rpcApiVersion), '0.27.0')
       ) {
         this.client = new JsonRpcClient(this.endpoints.fullNode, {
           'Client-Sdk-Type': 'typescript',

--- a/sdk/typescript/src/rpc/client.ts
+++ b/sdk/typescript/src/rpc/client.ts
@@ -67,8 +67,6 @@ export class JsonRpcClient {
           headers: Object.assign(
             {
               'Content-Type': 'application/json',
-              // 'Client-Type': 'ts-sdk',
-              // 'Client-Api-Version': version,
             },
             httpHeaders || {},
           ),


### PR DESCRIPTION
Changes in https://github.com/MystenLabs/sui/pull/8139 broke the Explorer for DevNet(0.26.0), because the CORS header whitelist is only added on 0.27.0. This PR fixes this so that we only send the headers when the RPC version >= 0.27.0
- standardize the naming of the existing two headers from `client_type` and `client_api_version` to `client-target-api-version` and `client-sdk-type`
- add two new headers `client-sdk-version`(for ts and community sdks, this will be different from `client-target-api-version`) and `app_name`(e.g., sui-faucet, sui-explorer, etc)

# Test Plan
1. Added the `println!("headers: {:?}", req.headers());` to https://github.com/MystenLabs/sui/blob/229a845c195c604803e64c4714ef864aafd9f13d/crates/sui-json-rpc/src/metrics.rs#L141
2. run `pnpm test:e2e` and verify the headers show up in logs

for request from the faucet
```
headers: {"content-type": "application/json", "accept": "application/json", "client-target-api-version": "0.27.0", "client-sdk-version": "0.27.0", "client-sdk-type": "rust", "host": "127.0.0.1:9000", "content-length": "107"}
```

for request from the SDK test

```
headers: {"content-type": "application/json", "accept": "application/json", "client-target-api-version": "0.27.0", "client-sdk-version": "0.27.0", "client-sdk-type": "rust", "host": "127.0.0.1:9000", "content-length": "107"}

```
4. run `pnpm explorer dev` and verify the headers show up in logs:
```
headers: {"host": "127.0.0.1:9000", "connection": "keep-alive", "content-length": "151", "sec-ch-ua": "\"Chromium\";v=\"110\", \"Not A(Brand\";v=\"24\", \"Google Chrome\";v=\"110\"", "client-target-api-version": "0.27.0", "client-sdk-type": "typescript", "sec-ch-ua-mobile": "?0", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36", "client-sdk-version": "0.27.0", "content-type": "application/json", "sec-ch-ua-platform": "\"macOS\"", "accept": "*/*", "origin": "http://localhost:3000", "sec-fetch-site": "cross-site", "sec-fetch-mode": "cors", "sec-fetch-dest": "empty", "referer": "http://localhost:3000/", "accept-encoding": "gzip, deflate, br", "accept-language": "en-US,en;q=0.9"}
```


5. Also make sure the change is backward compatible by re-enabling the Explorer backward compatibility test
6. Verify [Vercel preview](https://explorer-git-chris-fix-header-mysten-labs.vercel.app/)





