### PR TITLE
wallet-ext: WalletStandardInterface expose all connected accounts

### DIFF
--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -72,7 +72,7 @@ export class SuiWallet implements Wallet {
     readonly #events: Emitter<WalletEventsMap>;
     readonly #version = '1.0.0' as const;
     readonly #name = name;
-    #account: ReadonlyWalletAccount | null;
+    #accounts: ReadonlyWalletAccount[];
     #messagesStream: WindowMessageStream;
     #activeChain: ChainType | null = null;
 
@@ -118,26 +118,25 @@ export class SuiWallet implements Wallet {
     }
 
     get accounts() {
-        return this.#account ? [this.#account] : [];
+        return this.#accounts;
     }
 
-    #setAccount(address: SuiAddress | null) {
-        if (!address) {
-            this.#account = null;
-            return;
-        }
-        this.#account = new ReadonlyWalletAccount({
-            address,
-            // TODO: Expose public key instead of address:
-            publicKey: new Uint8Array(),
-            chains: this.#activeChain ? [this.#activeChain] : [],
-            features: ['sui:signAndExecuteTransaction'],
-        });
+    #setAccounts(addresses: SuiAddress[]) {
+        this.#accounts = addresses.map(
+            (address) =>
+                new ReadonlyWalletAccount({
+                    address,
+                    // TODO: Expose public key instead of address:
+                    publicKey: new Uint8Array(),
+                    chains: this.#activeChain ? [this.#activeChain] : [],
+                    features: ['sui:signAndExecuteTransaction'],
+                })
+        );
     }
 
     constructor() {
         this.#events = mitt();
-        this.#account = null;
+        this.#accounts = [];
         this.#messagesStream = new WindowMessageStream(
             'sui_in-page',
             'sui_content-script'
@@ -147,19 +146,26 @@ export class SuiWallet implements Wallet {
                 const { network, accounts } = payload;
                 if (network) {
                     this.#setActiveChain(network);
-                    if (
-                        this.#account &&
-                        this.#activeChain &&
-                        this.#account.chains[0] !== this.#activeChain
-                    ) {
-                        this.#setAccount(this.#account.address);
+                    if (!accounts) {
+                        // in case an accounts change exists skip updating chains of current accounts
+                        // accounts will be updated in the if block below
+                        this.#accounts = this.#accounts.map(
+                            ({ address, features, icon, label, publicKey }) =>
+                                new ReadonlyWalletAccount({
+                                    address,
+                                    publicKey,
+                                    chains: this.#activeChain
+                                        ? [this.#activeChain]
+                                        : [],
+                                    features,
+                                    label,
+                                    icon,
+                                })
+                        );
                     }
                 }
                 if (accounts) {
-                    const [address = null] = accounts;
-                    if (address !== this.#account?.address) {
-                        this.#setAccount(address);
-                    }
+                    this.#setAccounts(accounts);
                 }
                 this.#events.emit('change', { accounts: this.accounts });
             }
@@ -177,14 +183,10 @@ export class SuiWallet implements Wallet {
         if (!(await this.#hasPermissions(['viewAccount']))) {
             return;
         }
-        const accounts = await this.#getAccount();
-        const [address] = accounts;
-        if (address) {
-            const account = this.#account;
-            if (!account || account.address !== address) {
-                this.#setAccount(address);
-                this.#events.emit('change', { accounts: this.accounts });
-            }
+        const accounts = await this.#getAccounts();
+        this.#setAccounts(accounts);
+        if (this.#accounts.length) {
+            this.#events.emit('change', { accounts: this.accounts });
         }
     };
 
@@ -240,7 +242,7 @@ export class SuiWallet implements Wallet {
         );
     }
 
-    #getAccount() {
+    #getAccounts() {
         return mapToPromise(
             this.#send<GetAccount, GetAccountResponse>({
                 type: 'get-account',


### PR DESCRIPTION
* after adding multi-accounts wallet will be able to be connected with many accounts with a dapp. This updates WalletStandardInterface to use and expose to dapp all of the accounts


part of APPS-281