### PR TITLE
Use committed certificate round instead of highest (last) committed round to remove certificates from DAG

### DIFF
--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -173,7 +173,7 @@ impl ConsensusState {
             .retain(|r, _| r + gc_depth >= self.last_committed_round);
         // Also purge all certificates at and below last committed round of the certificate origin
         self.dag.retain(|r, authorities| {
-            if r <= &self.last_committed_round {
+            if r <= &certificate.round() {
                 authorities.remove(&certificate.origin());
                 !authorities.is_empty()
             } else {

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -143,7 +143,7 @@ impl ConsensusState {
             .is_none()
     }
 
-    /// Update and clean up internal state base on committed certificates.
+    /// Update and clean up internal state after committing a certificate.
     pub fn update(&mut self, certificate: &Certificate, gc_depth: Round) {
         self.last_committed
             .entry(certificate.origin())
@@ -155,23 +155,23 @@ impl ConsensusState {
             .last_committed_round
             .with_label_values(&[])
             .set(self.last_committed_round as i64);
+        let elapsed = certificate.metadata.created_at.elapsed().as_secs_f64();
+        self.metrics
+            .certificate_commit_latency
+            .observe(certificate.metadata.created_at.elapsed().as_secs_f64());
 
         // NOTE: This log entry is used to compute performance.
         tracing::debug!(
             "Certificate {:?} took {} seconds to be committed at round {}",
             certificate.digest(),
-            certificate.metadata.created_at.elapsed().as_secs_f64(),
-            self.last_committed_round
+            elapsed,
+            certificate.round(),
         );
 
-        self.metrics
-            .certificate_commit_latency
-            .observe(certificate.metadata.created_at.elapsed().as_secs_f64());
-
-        // We purge all certificates past the gc depth
+        // Purge all certificates past the gc depth.
         self.dag
             .retain(|r, _| r + gc_depth >= self.last_committed_round);
-        // Also purge all certificates at and below last committed round of the certificate origin
+        // Also purge this certificate, and other certificates at the same origin below its round.
         self.dag.retain(|r, authorities| {
             if r <= &certificate.round() {
                 authorities.remove(&certificate.origin());


### PR DESCRIPTION
After a sub-dag is selected, each of its certificate will be committed and removed from the DAG. The current cleanup algorithm also removes all certificates at origin `A` from rounds below `r` from the DAG, when committing a certificate from origin `A` at round `r`.

A mistake was made in https://github.com/MystenLabs/sui/commit/2eb8979218e4dac844c5ab539e93c6dd6aab286c. I tried to simplify the cleanup logic to only remove certificates from the committed certificate's own origin, instead of going through all origins and their last committed rounds. However I used the overall last committed round instead of the round of certificate for cleanup. This change fixes the mistake.

Further simplifications and testing of the logic will definitely be needed. But I think they belong to another PR.