### PR TITLE
[CI] Fix changeset release CI

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -50,6 +50,6 @@ jobs:
         with:
           # Generates src/version.ts file using genVersion
           # https://github.com/changesets/action#with-version-script
-          version: pnpm run codegen:version
+          version: pnpm changeset-version
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "wallet-adapter": "pnpm --filter ./sdk/wallet-adapter",
     "sdk": "pnpm --filter ./sdk/typescript",
     "bcs": "pnpm --filter ./sdk/bcs",
-    "frenemies": "pnpm --filter ./dapps/frenemies"
+    "frenemies": "pnpm --filter ./dapps/frenemies",
+    "changeset-version": "pnpm changeset version && pnpm sdk codegen:version"
   },
   "pnpm": {
     "overrides": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rm -rf tsconfig.tsbuildinfo ./dist",
-    "codegen:version": "pnpm changeset version && node genversion.mjs",
+    "codegen:version": "node genversion.mjs",
     "build": "node genversion.mjs && pnpm build:types && tsup ./src/index.ts --format esm,cjs --sourcemap",
     "build:types": "tsc --build",
     "doc": "typedoc",


### PR DESCRIPTION
As flagged by @Jordan-Mysten , the CI for changeset is broken: https://github.com/MystenLabs/sui/actions/runs/4208593096/jobs/7304775572 due to changes in https://github.com/MystenLabs/sui/pull/8139. 

When I verified the change locally by running `pnpm run codegen:version`, it was mistakenly done in the `sui/sdk/typescript` directory rather than `sui/` directory, and therefore I failed to catch the error.

# Testing

1. run `pnpm changeset-version` in the root directory locally, which produced the diff in https://gist.github.com/666lcz/4da72841576f1bf0e3b69c3c91bfef9c#file-changesets-diff-L82-L89
2. verify that version in `pkg-version.ts` is [incremented](https://gist.github.com/666lcz/4da72841576f1bf0e3b69c3c91bfef9c#file-changesets-diff-L82-L89) from 0.27.0 to 0.28.0

