### PR TITLE
remove SharedObjectLockNotSetErr 

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -171,8 +171,6 @@ pub enum SuiError {
         effects_digests: Vec<TransactionEffectsDigest>,
         checkpoint: CheckpointSequenceNumber,
     },
-    #[error("The shared locks for this transaction have not yet been set.")]
-    SharedObjectLockNotSetError,
     #[error("The certificate needs to be sequenced by Narwhal before execution: {digest:?}")]
     CertificateNotSequencedError { digest: TransactionDigest },
 


### PR DESCRIPTION
`SharedObjectLockNotSetError` is a legacy error prior to TransactionManager. This PR cleans it up.

`SharedObjectLockNotSetError` currently exists in two places:
1. `get_missing_input_objects`, which is called in `transaction_manager.enqueue` (a)
2. `check_sequenced_input_objects`, triggered in the call path of `authority_state.process_certificate`, which is called in `authority_state.try_execute_immediately` and `authority_state.process_tx_recovery_log`. `try_execute_immediately` is called in the execution_driver loop (b) for non-epoch change txes. `process_tx_recovery_log` is called when a node restarts to clean up execution wal. For a tx to appear in the wal log, it needs to be `try_execute_immediately`-ed first. 

In both (a) and (b), the tx's shared object lock must have been set unless there's a bug, where it's better to fail fast by panic.