### PR TITLE
wallet-ext: export account private key

### DIFF
--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -284,6 +284,30 @@ export class Keyring {
                     throw new Error('Wrong password');
                 }
                 uiConnection.send(createMessage({ type: 'done' }, id));
+            } else if (
+                isKeyringPayload(payload, 'exportAccount') &&
+                payload.args
+            ) {
+                const keyPair = await this.exportAccountKeypair(
+                    payload.args.accountAddress,
+                    payload.args.password
+                );
+
+                if (!keyPair) {
+                    throw new Error(
+                        `Account ${payload.args.accountAddress} not found`
+                    );
+                }
+                uiConnection.send(
+                    createMessage<KeyringPayload<'exportAccount'>>(
+                        {
+                            type: 'keyring',
+                            method: 'exportAccount',
+                            return: { keyPair },
+                        },
+                        id
+                    )
+                );
             }
         } catch (e) {
             uiConnection.send(

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -274,6 +274,16 @@ export class Keyring {
                     throw new Error('Failed to derive next account');
                 }
                 uiConnection.send(createMessage({ type: 'done' }, id));
+            } else if (
+                isKeyringPayload(payload, 'verifyPassword') &&
+                payload.args
+            ) {
+                if (
+                    !(await VaultStorage.verifyPassword(payload.args.password))
+                ) {
+                    throw new Error('Wrong password');
+                }
+                uiConnection.send(createMessage({ type: 'done' }, id));
             }
         } catch (e) {
             uiConnection.send(

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -3,7 +3,11 @@
 
 import { isBasePayload } from '_payloads';
 
-import type { SerializedSignature, SuiAddress } from '@mysten/sui.js';
+import type {
+    ExportedKeypair,
+    SerializedSignature,
+    SuiAddress,
+} from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 import type { AccountSerialized } from '_src/background/keyring/Account';
 
@@ -60,6 +64,10 @@ type MethodToPayloads = {
     verifyPassword: {
         args: { password: string };
         return: void;
+    };
+    exportAccount: {
+        args: { password: string; accountAddress: SuiAddress };
+        return: { keyPair: ExportedKeypair };
     };
 };
 

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -57,6 +57,10 @@ type MethodToPayloads = {
         args: void;
         return: void;
     };
+    verifyPassword: {
+        args: { password: string };
+        return: void;
+    };
 };
 
 export interface KeyringPayload<Method extends keyof MethodToPayloads>

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -47,7 +47,7 @@ export class BackgroundClient {
     private _dispatch: AppDispatch | null = null;
     private _initialized = false;
 
-    public async init(dispatch: AppDispatch) {
+    public init(dispatch: AppDispatch) {
         if (this._initialized) {
             throw new Error('[BackgroundClient] already initialized');
         }
@@ -82,7 +82,7 @@ export class BackgroundClient {
         );
     }
 
-    public async sendGetPermissionRequests() {
+    public sendGetPermissionRequests() {
         return lastValueFrom(
             this.sendMessage(
                 createMessage<GetPermissionRequests>({
@@ -92,7 +92,7 @@ export class BackgroundClient {
         );
     }
 
-    public async sendTransactionRequestResponse(
+    public sendTransactionRequestResponse(
         txID: string,
         approved: boolean,
         txResult?: SuiTransactionResponse,
@@ -111,7 +111,7 @@ export class BackgroundClient {
         );
     }
 
-    public async sendGetTransactionRequests() {
+    public sendGetTransactionRequests() {
         return lastValueFrom(
             this.sendMessage(
                 createMessage<GetTransactionRequests>({
@@ -129,8 +129,8 @@ export class BackgroundClient {
         );
     }
 
-    public async createVault(password: string, importedEntropy?: string) {
-        return await lastValueFrom(
+    public createVault(password: string, importedEntropy?: string) {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'create'>>({
                     type: 'keyring',
@@ -142,8 +142,8 @@ export class BackgroundClient {
         );
     }
 
-    public async unlockWallet(password: string) {
-        return await lastValueFrom(
+    public unlockWallet(password: string) {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'unlock'>>({
                     type: 'keyring',
@@ -155,8 +155,8 @@ export class BackgroundClient {
         );
     }
 
-    public async lockWallet() {
-        return await lastValueFrom(
+    public lockWallet() {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'lock'>>({
                     type: 'keyring',
@@ -166,8 +166,8 @@ export class BackgroundClient {
         );
     }
 
-    public async clearWallet() {
-        return await lastValueFrom(
+    public clearWallet() {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'clear'>>({
                     type: 'keyring',
@@ -177,8 +177,8 @@ export class BackgroundClient {
         );
     }
 
-    public async getEntropy(password?: string) {
-        return await lastValueFrom(
+    public getEntropy(password?: string) {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'getEntropy'>>({
                     type: 'keyring',
@@ -201,8 +201,8 @@ export class BackgroundClient {
         );
     }
 
-    public async setKeyringLockTimeout(timeout: number) {
-        return await lastValueFrom(
+    public setKeyringLockTimeout(timeout: number) {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'setLockTimeout'>>({
                     type: 'keyring',
@@ -213,11 +213,11 @@ export class BackgroundClient {
         );
     }
 
-    public async signData(
+    public signData(
         address: SuiAddress,
         data: Uint8Array
     ): Promise<SerializedSignature> {
-        return await lastValueFrom(
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'signData'>>({
                     type: 'keyring',
@@ -241,8 +241,8 @@ export class BackgroundClient {
         );
     }
 
-    public async setActiveNetworkEnv(network: NetworkEnvType) {
-        return await lastValueFrom(
+    public setActiveNetworkEnv(network: NetworkEnvType) {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<SetNetworkPayload>({
                     type: 'set-network',
@@ -252,8 +252,8 @@ export class BackgroundClient {
         );
     }
 
-    public async selectAccount(address: SuiAddress) {
-        return await lastValueFrom(
+    public selectAccount(address: SuiAddress) {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'switchAccount'>>({
                     type: 'keyring',
@@ -264,8 +264,8 @@ export class BackgroundClient {
         );
     }
 
-    public async deriveNextAccount() {
-        return await lastValueFrom(
+    public deriveNextAccount() {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'deriveNextAccount'>>({
                     type: 'keyring',
@@ -275,8 +275,8 @@ export class BackgroundClient {
         );
     }
 
-    public async verifyPassword(password: string) {
-        return await lastValueFrom(
+    public verifyPassword(password: string) {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'verifyPassword'>>({
                     type: 'keyring',
@@ -287,8 +287,8 @@ export class BackgroundClient {
         );
     }
 
-    public async exportAccount(password: string, accountAddress: SuiAddress) {
-        return await lastValueFrom(
+    public exportAccount(password: string, accountAddress: SuiAddress) {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'exportAccount'>>({
                     type: 'keyring',
@@ -329,8 +329,8 @@ export class BackgroundClient {
         );
     }
 
-    private async getWalletStatus() {
-        return await lastValueFrom(
+    private getWalletStatus() {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'walletStatusUpdate'>>({
                     type: 'keyring',
@@ -340,8 +340,8 @@ export class BackgroundClient {
         );
     }
 
-    private async loadFeatures() {
-        return await lastValueFrom(
+    private loadFeatures() {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<BasePayload>({
                     type: 'get-features',
@@ -350,8 +350,8 @@ export class BackgroundClient {
         );
     }
 
-    private async getNetwork() {
-        return await lastValueFrom(
+    private getNetwork() {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<BasePayload>({
                     type: 'get-network',

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -287,6 +287,31 @@ export class BackgroundClient {
         );
     }
 
+    public async exportAccount(password: string, accountAddress: SuiAddress) {
+        return await lastValueFrom(
+            this.sendMessage(
+                createMessage<KeyringPayload<'exportAccount'>>({
+                    type: 'keyring',
+                    method: 'exportAccount',
+                    args: { password, accountAddress },
+                })
+            ).pipe(
+                take(1),
+                map(({ payload }) => {
+                    if (
+                        isKeyringPayload(payload, 'exportAccount') &&
+                        payload.return
+                    ) {
+                        return payload.return.keyPair;
+                    }
+                    throw new Error(
+                        'Error unknown response for export account message'
+                    );
+                })
+            )
+        );
+    }
+
     private setupAppStatusUpdateInterval() {
         setInterval(() => {
             this.sendAppStatus();

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -275,6 +275,18 @@ export class BackgroundClient {
         );
     }
 
+    public async verifyPassword(password: string) {
+        return await lastValueFrom(
+            this.sendMessage(
+                createMessage<KeyringPayload<'verifyPassword'>>({
+                    type: 'keyring',
+                    method: 'verifyPassword',
+                    args: { password },
+                })
+            ).pipe(take(1))
+        );
+    }
+
     private setupAppStatusUpdateInterval() {
         setInterval(() => {
             this.sendAppStatus();

--- a/apps/wallet/src/ui/app/components/HideShowDisplayBox.tsx
+++ b/apps/wallet/src/ui/app/components/HideShowDisplayBox.tsx
@@ -5,7 +5,6 @@ import { Copy16, EyeClose16, EyeOpen16 } from '@mysten/icons';
 import { useState } from 'react';
 
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
-import { Button } from '../shared/ButtonUI';
 import { Link } from '../shared/Link';
 import { Text } from '../shared/text';
 
@@ -48,10 +47,15 @@ export function HideShowDisplayBox({
                     />
                 </div>
                 <div>
-                    <Button
-                        variant="plain"
-                        size="tiny"
-                        text={valueHidden ? <EyeClose16 /> : <EyeOpen16 />}
+                    <Link
+                        color="steelDark"
+                        text={
+                            valueHidden ? (
+                                <EyeClose16 className="block" />
+                            ) : (
+                                <EyeOpen16 className="block" />
+                            )
+                        }
                         onClick={() => setValueHidden((v) => !v)}
                     />
                 </div>

--- a/apps/wallet/src/ui/app/components/HideShowDisplayBox.tsx
+++ b/apps/wallet/src/ui/app/components/HideShowDisplayBox.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Copy16, EyeClose16, EyeOpen16 } from '@mysten/icons';
+import { useState } from 'react';
+
+import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
+import { Button } from '../shared/ButtonUI';
+import { Link } from '../shared/Link';
+import { Text } from '../shared/text';
+
+export type HideShowDisplayBoxProps = {
+    value: string;
+    copiedMessage?: string;
+};
+
+export function HideShowDisplayBox({
+    value,
+    copiedMessage,
+}: HideShowDisplayBoxProps) {
+    const [valueHidden, setValueHidden] = useState(true);
+    const copyCallback = useCopyToClipboard(value, {
+        copySuccessMessage: copiedMessage,
+    });
+    return (
+        <div className="flex flex-col flex-nowrap items-stretch gap-2 bg-white border border-solid border-gray-60 rounded-lg overflow-hidden py-4 px-5">
+            <div className="break-all">
+                {valueHidden ? (
+                    <div className="flex flex-col gap-1.5">
+                        <div className="h-3.5 bg-gray-40 rounded-md" />
+                        <div className="h-3.5 bg-gray-40 rounded-md" />
+                        <div className="h-3.5 bg-gray-40 rounded-md w-1/2" />
+                    </div>
+                ) : (
+                    <Text variant="p1" weight="medium" color="steel-darker">
+                        {value}
+                    </Text>
+                )}
+            </div>
+            <div className="flex flex-row flex-nowrap items-center justify-between">
+                <div>
+                    <Link
+                        color="heroDark"
+                        weight="medium"
+                        text="Copy"
+                        before={<Copy16 />}
+                        onClick={copyCallback}
+                    />
+                </div>
+                <div>
+                    <Button
+                        variant="plain"
+                        size="tiny"
+                        text={valueHidden ? <EyeClose16 /> : <EyeOpen16 />}
+                        onClick={() => setValueHidden((v) => !v)}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/wallet/src/ui/app/components/menu/content/Account.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/Account.tsx
@@ -1,9 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Copy16 } from '@mysten/icons';
+import { Disclosure, Transition } from '@headlessui/react';
+import { ChevronDown16, Copy16 } from '@mysten/icons';
 import { formatAddress } from '@mysten/sui.js';
+import { cx } from 'class-variance-authority';
 
+import { AccountActions } from './AccountActions';
 import { useCopyToClipboard } from '_src/ui/app/hooks/useCopyToClipboard';
 import { Heading } from '_src/ui/app/shared/heading';
 
@@ -16,22 +19,50 @@ export function Account({ address }: AccountProps) {
         copySuccessMessage: 'Address copied',
     });
     return (
-        <div className="flex flex-nowrap items-center border border-solid border-gray-60 rounded-lg p-5">
-            <div className="flex-1">
-                <Heading
-                    mono
-                    weight="semibold"
-                    variant="heading6"
-                    color="steel-dark"
-                    leading="none"
+        <Disclosure>
+            {({ open }) => (
+                <div
+                    className={cx(
+                        'transition flex flex-col flex-nowrap border border-solid rounded-lg',
+                        open
+                            ? 'bg-gray-40 border-transparent'
+                            : 'hover:border-steel border-gray-60'
+                    )}
                 >
-                    {formatAddress(address)}
-                </Heading>
-            </div>
-            <Copy16
-                onClick={copyCallback}
-                className="transition text-base leading-none text-gray-60 active:text-gray-60 hover:text-hero-darkest cursor-pointer p1"
-            />
-        </div>
+                    <Disclosure.Button
+                        as="div"
+                        className="flex flex-nowrap items-center p-5 self-stretch cursor-pointer gap-3 group"
+                    >
+                        <div className="transition flex flex-1 justify-start text-steel-dark group-hover:text-steel-darker ui-open:text-steel-darker">
+                            <Heading
+                                mono
+                                weight="semibold"
+                                variant="heading6"
+                                leading="none"
+                            >
+                                {formatAddress(address)}
+                            </Heading>
+                        </div>
+                        <Copy16
+                            onClick={copyCallback}
+                            className="transition text-base leading-none text-gray-60 active:text-gray-60 hover:text-hero-darkest cursor-pointer p1"
+                        />
+                        <ChevronDown16 className="transition text-base leading-none text-gray-60 ui-open:rotate-180 ui-open:text-hero-darkest group-hover:text-hero-darkest" />
+                    </Disclosure.Button>
+                    <Transition
+                        enter="transition duration-100 ease-out"
+                        enterFrom="transform opacity-0"
+                        enterTo="transform opacity-100"
+                        leave="transition duration-75 ease-out"
+                        leaveFrom="transform opacity-100"
+                        leaveTo="transform opacity-0"
+                    >
+                        <Disclosure.Panel className="px-5 pb-4">
+                            <AccountActions accountAddress={address} />
+                        </Disclosure.Panel>
+                    </Transition>
+                </div>
+            )}
+        </Disclosure>
     );
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type SuiAddress } from '@mysten/sui.js';
+
+import { useNextMenuUrl } from '../hooks';
+import { Link } from '_src/ui/app/shared/Link';
+
+export type AccountActionsProps = {
+    accountAddress: SuiAddress;
+};
+
+export function AccountActions({ accountAddress }: AccountActionsProps) {
+    const exportAccountUrl = useNextMenuUrl(true, `/export/${accountAddress}`);
+    return (
+        <div className="flex flex-row flex-nowrap items-center flex-1">
+            <div>
+                <Link
+                    text="Export Private Key"
+                    to={exportAccountUrl}
+                    color="heroDark"
+                    weight="medium"
+                />
+            </div>
+        </div>
+    );
+}

--- a/apps/wallet/src/ui/app/components/menu/content/ExportAccount.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/ExportAccount.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMutation } from '@tanstack/react-query';
+import { Navigate, useParams } from 'react-router-dom';
+
+import { HideShowDisplayBox } from '../../HideShowDisplayBox';
+import Alert from '../../alert';
+import { useNextMenuUrl } from '../hooks';
+import { MenuLayout } from './MenuLayout';
+import { PasswordInputDialog } from './PasswordInputDialog';
+import { useBackgroundClient } from '_src/ui/app/hooks/useBackgroundClient';
+
+export function ExportAccount() {
+    const accountUrl = useNextMenuUrl(true, `/accounts`);
+    const { account } = useParams();
+    const backgroundClient = useBackgroundClient();
+    const exportMutation = useMutation({
+        mutationKey: ['export-account', account],
+        mutationFn: async (password: string) => {
+            if (!account) {
+                return null;
+            }
+            return await backgroundClient.exportAccount(password, account);
+        },
+    });
+    if (!account) {
+        return <Navigate to={accountUrl} replace />;
+    }
+    if (exportMutation.data) {
+        return (
+            <MenuLayout title="Your Private Key" back={accountUrl}>
+                <div className="flex flex-col flex-nowrap items-stretch gap-3">
+                    <Alert mode="warning">
+                        Do not share your private key! It provides full control
+                        of your account.
+                    </Alert>
+                    <HideShowDisplayBox
+                        value={exportMutation.data.privateKey}
+                        copiedMessage="Private key copied"
+                    />
+                </div>
+            </MenuLayout>
+        );
+    }
+    return (
+        <PasswordInputDialog
+            title="Export Private Key"
+            onPasswordVerified={async (password) => {
+                await exportMutation.mutateAsync(password);
+            }}
+        />
+    );
+}

--- a/apps/wallet/src/ui/app/components/menu/content/ExportAccount.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/ExportAccount.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { fromB64 } from '@mysten/sui.js';
+import { bytesToHex } from '@noble/hashes/utils';
 import { useMutation } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 
 import { HideShowDisplayBox } from '../../HideShowDisplayBox';
@@ -24,10 +27,18 @@ export function ExportAccount() {
             return await backgroundClient.exportAccount(password, account);
         },
     });
+    const privateKey = useMemo(() => {
+        if (exportMutation.data?.privateKey) {
+            return `0x${bytesToHex(
+                fromB64(exportMutation.data.privateKey).slice(0, 32)
+            )}`;
+        }
+        return null;
+    }, [exportMutation.data?.privateKey]);
     if (!account) {
         return <Navigate to={accountUrl} replace />;
     }
-    if (exportMutation.data) {
+    if (privateKey) {
         return (
             <MenuLayout title="Your Private Key" back={accountUrl}>
                 <div className="flex flex-col flex-nowrap items-stretch gap-3">
@@ -36,7 +47,7 @@ export function ExportAccount() {
                         of your account.
                     </Alert>
                     <HideShowDisplayBox
-                        value={exportMutation.data.privateKey}
+                        value={privateKey}
                         copiedMessage="Private key copied"
                     />
                 </div>

--- a/apps/wallet/src/ui/app/components/menu/content/ExportAccount.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/ExportAccount.tsx
@@ -43,8 +43,8 @@ export function ExportAccount() {
             <MenuLayout title="Your Private Key" back={accountUrl}>
                 <div className="flex flex-col flex-nowrap items-stretch gap-3">
                     <Alert mode="warning">
-                        Do not share your private key! It provides full control
-                        of your account.
+                        <div>Do not share your Private Key!</div>
+                        <div>It provides full control of your account.</div>
                     </Alert>
                     <HideShowDisplayBox
                         value={privateKey}

--- a/apps/wallet/src/ui/app/components/menu/content/MenuList.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/MenuList.tsx
@@ -125,6 +125,8 @@ function MenuList() {
                         href={ToS_LINK}
                         text="Terms of service"
                         after={<ArrowUpRight12 />}
+                        color="steelDark"
+                        weight="semibold"
                     />
                     <Text variant="bodySmall" weight="medium" color="steel">
                         Wallet Version v{version}

--- a/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Field, Formik, Form, ErrorMessage } from 'formik';
+import { toast } from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+import { object, string as YupString } from 'yup';
+
+import Alert from '../../alert';
+import { useBackgroundClient } from '_src/ui/app/hooks/useBackgroundClient';
+import { Button } from '_src/ui/app/shared/ButtonUI';
+import { Link } from '_src/ui/app/shared/Link';
+import FieldLabel from '_src/ui/app/shared/field-label';
+import { Heading } from '_src/ui/app/shared/heading';
+import PasswordInput from '_src/ui/app/shared/input/password';
+
+const validation = object({
+    password: YupString().ensure().required().label('Password'),
+});
+
+export type PasswordExportDialogProps = {
+    title: string;
+    onPasswordVerified: (password: string) => Promise<void> | void;
+};
+
+export function PasswordInputDialog({
+    title,
+    onPasswordVerified,
+}: PasswordExportDialogProps) {
+    const navigate = useNavigate();
+    const backgroundService = useBackgroundClient();
+    return (
+        <Formik
+            initialValues={{ password: '' }}
+            onSubmit={async ({ password }) => {
+                try {
+                    await backgroundService.verifyPassword(password);
+                    await onPasswordVerified(password);
+                } catch (e) {
+                    toast.error((e as Error).message || 'Wrong password');
+                }
+            }}
+            validationSchema={validation}
+            validateOnMount
+        >
+            {({ isSubmitting, isValid }) => (
+                <Form className="bg-white px-5 pt-10 flex flex-col flex-nowrap items-center flex-1 gap-7.5">
+                    <Heading variant="heading1" color="gray-90" weight="bold">
+                        {title}
+                    </Heading>
+                    <div className="self-stretch flex-1">
+                        <FieldLabel txt="Enter Wallet Password to Continue">
+                            <Field name="password" component={PasswordInput} />
+                            <ErrorMessage
+                                render={(error) => <Alert>{error}</Alert>}
+                                name="password"
+                            />
+                        </FieldLabel>
+                    </div>
+                    <div className="flex flex-col flex-nowrap gap-3.75 self-stretch">
+                        <Button
+                            type="submit"
+                            variant="primary"
+                            size="tall"
+                            text="Continue"
+                            loading={isSubmitting}
+                            disabled={!isValid}
+                        />
+                        <Link
+                            text="Cancel"
+                            color="heroDark"
+                            onClick={() => {
+                                navigate(-1);
+                            }}
+                            disabled={isSubmitting}
+                        />
+                    </div>
+                </Form>
+            )}
+        </Formik>
+    );
+}

--- a/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
@@ -32,12 +32,19 @@ export function PasswordInputDialog({
     return (
         <Formik
             initialValues={{ password: '' }}
-            onSubmit={async ({ password }) => {
+            onSubmit={async ({ password }, { setFieldError }) => {
                 try {
                     await backgroundService.verifyPassword(password);
-                    await onPasswordVerified(password);
+                    try {
+                        await onPasswordVerified(password);
+                    } catch (e) {
+                        toast.error((e as Error).message || 'Wrong password');
+                    }
                 } catch (e) {
-                    toast.error((e as Error).message || 'Wrong password');
+                    setFieldError(
+                        'password',
+                        (e as Error).message || 'Wrong password'
+                    );
                 }
             }}
             validationSchema={validation}

--- a/apps/wallet/src/ui/app/components/menu/content/index.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/index.tsx
@@ -13,6 +13,7 @@ import {
 
 import { AccountsSettings } from './AccountsSettings';
 import { AutoLockSettings } from './AutoLockSettings';
+import { ExportAccount } from './ExportAccount';
 import MenuList from './MenuList';
 import { NetworkSettings } from './NetworkSettings';
 import { ErrorBoundary } from '_components/error-boundary';
@@ -59,10 +60,17 @@ function MenuContent() {
                     <Routes location={menuUrl || ''}>
                         <Route path="/" element={<MenuList />} />
                         {isMultiAccountsEnabled ? (
-                            <Route
-                                path="/accounts"
-                                element={<AccountsSettings />}
-                            />
+                            <>
+                                <Route
+                                    path="/accounts"
+                                    element={<AccountsSettings />}
+                                />
+
+                                <Route
+                                    path="/export/:account"
+                                    element={<ExportAccount />}
+                                />
+                            </>
                         ) : null}
                         <Route path="/network" element={<NetworkSettings />} />
                         <Route

--- a/apps/wallet/src/ui/app/shared/ButtonUI.tsx
+++ b/apps/wallet/src/ui/app/shared/ButtonUI.tsx
@@ -117,7 +117,6 @@ export const Button = forwardRef(
         {
             variant = 'primary',
             size = 'narrow',
-            disabled,
             before,
             after,
             text,

--- a/apps/wallet/src/ui/app/shared/Link.stories.tsx
+++ b/apps/wallet/src/ui/app/shared/Link.stories.tsx
@@ -27,5 +27,7 @@ export const Default: StoryObj<typeof Link> = {
     args: {
         text: 'Default Link',
         after: <ArrowUpRight12 />,
+        color: 'steelDark',
+        weight: 'semibold',
     },
 };

--- a/apps/wallet/src/ui/app/shared/Link.tsx
+++ b/apps/wallet/src/ui/app/shared/Link.tsx
@@ -6,25 +6,50 @@ import { forwardRef, type ReactNode, type Ref } from 'react';
 
 import { ButtonOrLink, type ButtonOrLinkProps } from './utils/ButtonOrLink';
 
-const styles = cva([
-    'flex flex-nowrap items-center justify-center outline-none gap-1 w-full',
-    'no-underline bg-transparent p-0 border-none',
-    'text-bodySmall font-semibold text-steel-dark',
-    'hover:text-steel-darker focus:text-steel-darker',
-    'active:opacity-70',
-    'disabled:opacity-40 disabled:text-steel-dark',
-    'cursor-pointer group',
-]);
+const styles = cva(
+    [
+        'transition flex flex-nowrap items-center justify-center outline-none gap-1 w-full',
+        'no-underline bg-transparent p-0 border-none',
+        'text-bodySmall',
+        'active:opacity-70',
+        'disabled:opacity-40',
+        'cursor-pointer group',
+    ],
+    {
+        variants: {
+            color: {
+                steelDark: [
+                    'text-steel-dark hover:text-steel-darker focus:text-steel-darker disabled:text-steel-dark',
+                ],
+                heroDark: [
+                    'text-hero-dark hover:text-hero-darkest focus:text-hero-darkest disabled:text-hero-dark',
+                ],
+            },
+            weight: {
+                semibold: 'font-semibold',
+                medium: 'font-medium',
+            },
+        },
+    }
+);
 
-const iconStyles = cva([
-    'flex text-steel',
-    'group-hover:text-steel-darker group-focus:text-steel-darker group-disabled:text-steel-dark',
-]);
+const iconStyles = cva(['transition flex'], {
+    variants: {
+        color: {
+            steelDark: [
+                'text-steel group-hover:text-steel-darker group-focus:text-steel-darker group-disabled:text-steel-dark',
+            ],
+            heroDark: [
+                'text-hero group-hover:text-hero-darkest group-focus:text-hero-darkest group-disabled:text-hero-dark',
+            ],
+        },
+    },
+});
 
 interface LinkProps
     extends VariantProps<typeof styles>,
         VariantProps<typeof iconStyles>,
-        Omit<ButtonOrLinkProps, 'className'> {
+        Omit<ButtonOrLinkProps, 'className' | 'color'> {
     before?: ReactNode;
     after?: ReactNode;
     text?: ReactNode;
@@ -32,11 +57,17 @@ interface LinkProps
 
 export const Link = forwardRef(
     (
-        { before, after, text, ...otherProps }: LinkProps,
+        { before, after, text, color, weight, ...otherProps }: LinkProps,
         ref: Ref<HTMLAnchorElement | HTMLButtonElement>
     ) => (
-        <ButtonOrLink className={styles()} {...otherProps} ref={ref}>
-            {before ? <div className={iconStyles()}>{before}</div> : null}
+        <ButtonOrLink
+            className={styles({ color, weight })}
+            {...otherProps}
+            ref={ref}
+        >
+            {before ? (
+                <div className={iconStyles({ color })}>{before}</div>
+            ) : null}
             {text ? (
                 <div className={'truncate leading-tight'}>{text}</div>
             ) : null}


### PR DESCRIPTION
* button fix disabled
* Link component add color and weight variants
* PasswordInputDialog component 
  * verifies the password that was inserted by the user
  * when password is correct notifies the parent component with the password
  * if the parent returns a promise waits and shows a loader
* HideShowDisplayBox component 
  * initially the value is hidden and allows the user to reveal it
  * will be used to display the exported key
* add export private key to account in settings
* export and display the private key of an account
* export private key as hex and always 32 bytes 
  * makes it compatible with metamask


https://user-images.githubusercontent.com/10210143/219970956-7c930f87-14a0-44e9-b32c-e65af2ceef26.mov

Key now is formatted as hex starting with `0x` and always 32 bytes


https://user-images.githubusercontent.com/10210143/220103637-6d263325-f289-4c88-9945-1b7fed74c2ec.mov



closes APPS-289