### PR TITLE
[TypeScript SDK] clean up version gating code

### DIFF
--- a/sdk/typescript/src/rpc/client.ts
+++ b/sdk/typescript/src/rpc/client.ts
@@ -12,6 +12,7 @@ import {
   optional,
   string,
   Struct,
+  validate,
 } from 'superstruct';
 
 /**
@@ -105,16 +106,17 @@ export class JsonRpcClient {
     if (is(response, ErrorResponse)) {
       throw new Error(`RPC Error: ${response.error.message}`);
     } else if (is(response, ValidResponse)) {
-      // TODO: Improve error messaging here using superstruct asserts
-      const expectedSchema = is(response.result, struct);
+      const err = validate(response.result, struct)[0];
       const errMsg =
         TYPE_MISMATCH_ERROR +
-        `Result received was: ${JSON.stringify(response.result)}`;
+        `Result received was: ${JSON.stringify(
+          response.result,
+        )}. Debug info: ${err}`;
 
-      if (skipDataValidation && !expectedSchema) {
+      if (skipDataValidation && err) {
         console.warn(errMsg);
         return response.result;
-      } else if (!expectedSchema) {
+      } else if (err) {
         throw new Error(`RPC Error: ${errMsg}`);
       }
       return response.result;

--- a/sdk/typescript/src/signers/raw-signer.ts
+++ b/sdk/typescript/src/signers/raw-signer.ts
@@ -1,14 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { gt } from '@suchipi/femver';
 import { Keypair } from '../cryptography/keypair';
 import {
   SerializedSignature,
   toSerializedSignature,
 } from '../cryptography/signature';
 import { Provider } from '../providers/provider';
-import { SuiAddress, versionToString } from '../types';
+import { SuiAddress } from '../types';
 import { SignerWithProvider } from './signer-with-provider';
 import { TxnDataSerializer } from './txn-data-serializers/txn-data-serializer';
 
@@ -29,14 +28,8 @@ export class RawSigner extends SignerWithProvider {
   }
 
   async signData(data: Uint8Array): Promise<SerializedSignature> {
-    // Starting Sui 0.25.0, only 64-byte nonrecoverable signatures are accepted.
-    // TODO(joyqvq): Remove once 0.25.0 is released.
-    const version = await this.provider.getRpcApiVersion();
-    let useRecoverable =
-      version && gt(versionToString(version), '0.24.0') ? false : true;
-
     const pubkey = this.keypair.getPublicKey();
-    const signature = this.keypair.signData(data, useRecoverable);
+    const signature = this.keypair.signData(data, false);
     const signatureScheme = this.keypair.getKeyScheme();
 
     return toSerializedSignature({

--- a/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
@@ -159,14 +159,8 @@ export class CallArgSerializer {
     const initialSharedVersion = getSharedObjectInitialVersion(object);
 
     const mutable = true; // Defaulted to True to match current behavior.
-    const api = await this.provider.getRpcApiVersion();
-
     if (initialSharedVersion) {
-      const object_args =
-        api?.major === 0 && api?.minor < 25
-          ? { Shared: { objectId, initialSharedVersion } }
-          : { Shared: { objectId, initialSharedVersion, mutable } };
-      return object_args;
+      return { Shared: { objectId, initialSharedVersion, mutable } };
     }
     return { ImmOrOwned: getObjectReference(object)! };
   }

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -181,13 +181,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
         break;
       case 'moveCall':
         const moveCall = unserializedTxn.data as MoveCallTransaction;
-        const api = await this.provider.getRpcApiVersion();
-
-        // TODO: remove after 0.24.0 is deployed for devnet and testnet
-        const pkg =
-          api?.major === 0 && api?.minor < 24
-            ? (await this.provider.getObjectRef(moveCall.packageObjectId))!
-            : normalizeSuiObjectId(moveCall.packageObjectId);
+        const pkg = normalizeSuiObjectId(moveCall.packageObjectId);
 
         tx = {
           Call: {

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -404,41 +404,6 @@ const BCS_SPEC = {
   },
 };
 
-const BCS_0_23_SPEC = {
-  structs: {
-    ...BCS_SPEC.structs,
-    MoveCallTx: {
-      package: 'SuiObjectRef',
-      module: BCS.STRING,
-      function: BCS.STRING,
-      typeArguments: 'vector<TypeTag>',
-      arguments: 'vector<CallArg>',
-    },
-    SharedObjectRef: {
-      objectId: BCS.ADDRESS,
-      initialSharedVersion: BCS.U64,
-    },
-  },
-  enums: BCS_SPEC.enums,
-  aliases: {
-    ObjectDigest: BCS.BASE64,
-  },
-};
-
-const BCS_0_24_SPEC = {
-  structs: {
-    ...BCS_SPEC.structs,
-    SharedObjectRef: {
-      objectId: BCS.ADDRESS,
-      initialSharedVersion: BCS.U64,
-    },
-  },
-  enums: BCS_SPEC.enums,
-  aliases: {
-    ObjectDigest: BCS.BASE64,
-  },
-};
-
 // for version <= 0.26.0
 const BCS_0_26_SPEC = {
   structs: {
@@ -465,22 +430,10 @@ const bcs = new BCS({ ...getSuiMoveConfig(), types: BCS_SPEC });
 registerUTF8String(bcs);
 
 // ========== Backward Compatibility (remove after v0.24 deploys) ===========
-const bcs_0_23 = new BCS({ ...getSuiMoveConfig(), types: BCS_0_23_SPEC });
-registerUTF8String(bcs_0_23);
-
-const bcs_0_24 = new BCS({ ...getSuiMoveConfig(), types: BCS_0_24_SPEC });
-registerUTF8String(bcs_0_24);
-
 const bcs_0_26 = new BCS({ ...getSuiMoveConfig(), types: BCS_0_26_SPEC });
 registerUTF8String(bcs_0_26);
 
 export function bcsForVersion(v?: RpcApiVersion) {
-  if (v?.major === 0 && v?.minor < 24) {
-    return bcs_0_23;
-  }
-  if (v?.major === 0 && v?.minor === 24) {
-    return bcs_0_24;
-  }
   if (v?.major === 0 && v?.minor <= 26) {
     return bcs_0_26;
   }

--- a/sdk/typescript/test/e2e/checkpoint.test.ts
+++ b/sdk/typescript/test/e2e/checkpoint.test.ts
@@ -6,14 +6,9 @@ import { setup, TestToolbox } from './utils/setup';
 
 describe('Checkpoints Reading API', () => {
   let toolbox: TestToolbox;
-  let shouldSkip: boolean;
 
   beforeAll(async () => {
     toolbox = await setup();
-    // TODO(cleanup): remove this after TestNet Wave 2(0.22.0) or backward compatibility
-    // is supported
-    const version = await toolbox.provider.getRpcApiVersion()!;
-    shouldSkip = version?.major === 0 && version?.minor < 23;
   });
 
   it('Get latest checkpoint sequence number', async () => {
@@ -33,9 +28,6 @@ describe('Checkpoints Reading API', () => {
   });
 
   it('get checkpoint summary by digest', async () => {
-    if (shouldSkip) {
-      return;
-    }
     const checkpoint_resp = await toolbox.provider.getCheckpointSummary(1);
     const digest = checkpoint_resp.previous_digest;
     expect(digest).not.toBeNull();
@@ -49,24 +41,11 @@ describe('Checkpoints Reading API', () => {
   });
 
   it('get checkpoint contents', async () => {
-    if (shouldSkip) {
-      // Test for previous versions
-      const checkpoint_resp = await toolbox.provider.getCheckpointSummary(0);
-      const digest = checkpoint_resp.content_digest;
-      expect(digest).not.toBeNull();
-      const resp = await toolbox.provider.getCheckpointContents(digest!);
-      expect(resp.transactions.length).greaterThan(0);
-      return;
-    }
-
     const resp = await toolbox.provider.getCheckpointContents(0);
     expect(resp.transactions.length).greaterThan(0);
   });
 
   it('get checkpoint contents by digest', async () => {
-    if (shouldSkip) {
-      return;
-    }
     const checkpoint_resp = await toolbox.provider.getCheckpointSummary(0);
     const digest = checkpoint_resp.content_digest;
     const resp = await toolbox.provider.getCheckpointContentsByDigest(digest);

--- a/sdk/typescript/test/e2e/raw-signer.test.ts
+++ b/sdk/typescript/test/e2e/raw-signer.test.ts
@@ -9,13 +9,10 @@ import {
   RawSigner,
   Secp256k1Keypair,
   verifyMessage,
-  versionToString,
 } from '../../src';
 import * as secp from '@noble/secp256k1';
 import { Signature } from '@noble/secp256k1';
 import { setup, TestToolbox } from './utils/setup';
-import { gt } from '@suchipi/femver';
-import { toB64 } from '@mysten/bcs';
 
 describe('RawSigner', () => {
   let toolbox: TestToolbox;
@@ -67,29 +64,9 @@ describe('RawSigner', () => {
     const serializedSignature = await signer.signData(signData);
     const { signature, pubKey } = fromSerializedSignature(serializedSignature);
 
-    const version = await toolbox.provider.getRpcApiVersion();
-    // TODO(joyqvq): Remove recoverable signature test once 0.25.0 is released.
-    let useRecoverable =
-      version && gt(versionToString(version), '0.24.0') ? false : true;
-    if (useRecoverable) {
-      const recovered_pubkey = secp.recoverPublicKey(
-        msgHash,
-        Signature.fromCompact(signature.slice(0, 64)),
-        signature[64],
-        true,
-      );
-      const expected = keypair.getPublicKey().toBase64();
-      expect(pubKey).toEqual(expected);
-      expect(toB64(recovered_pubkey)).toEqual(expected);
-    } else {
-      expect(
-        secp.verify(
-          Signature.fromCompact(signature),
-          msgHash,
-          pubKey.toBytes(),
-        ),
-      ).toBeTruthy();
-    }
+    expect(
+      secp.verify(Signature.fromCompact(signature), msgHash, pubKey.toBytes()),
+    ).toBeTruthy();
   });
 
   it('Secp256k1 keypair signMessage', async () => {

--- a/sdk/typescript/test/unit/rpc/client.test.ts
+++ b/sdk/typescript/test/unit/rpc/client.test.ts
@@ -58,15 +58,7 @@ describe('JSON-RPC Client', () => {
   it('requestWithType should succeed if skipDataValidation if true', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     await requestAndValidate(OBJECT_WITH_WRONG_SCHEMA, true);
-    expect(warn).toBeCalledWith(
-      'The response returned from RPC server does not match the TypeScript definition.' +
-        ' This is likely because the SDK version is not compatible with the RPC server.' +
-        ' Please update your SDK version to the latest. Result received was: [{"objectId"' +
-        ':"8dc6a6f70564e29a01c7293a9c03818fda2d049f","version":0,"digest":"CI8Sf+t3Xrt5h9' +
-        'ENlmyR8bbMVfg6df3vSDc08Gbk9/g=","owner":{"AddressOwner1":"0x215592226abfec8d03fb' +
-        'beb8b30eb0d2129c94b0"},"type":"moveObject","previousTransaction":"4RJfkN9SgLYdb0' +
-        'LqxBHh6lfRPicQ8FLJgzi9w2COcTo="}]',
-    );
+    expect(warn).toHaveBeenCalled();
     warn.mockReset();
   });
 


### PR DESCRIPTION
Remove code for old RPC versions(<0.26.0)

# Testing

1. run `pnpm build`
2. CI