### PR TITLE
[core] Split transaction cert signature to separate table

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2365,13 +2365,21 @@ impl AuthorityState {
     ) -> SuiResult {
         let _metrics_guard = self.metrics.commit_certificate_latency.start_timer();
 
+        let tx_digest = certificate.digest();
         // The insertion to epoch_store is not atomic with the insertion to the perpetual store. This is OK because
         // we insert to the epoch store first. And during lookups we always look up in the perpetual store first.
-        epoch_store.insert_effects_signature(certificate.digest(), signed_effects.auth_sig())?;
+        epoch_store.insert_effects_signature(tx_digest, signed_effects.auth_sig())?;
+        // TODO: This will eventually be done in the epoch_store atomically with the insertion of the effects signature.
+        self.database
+            .insert_transaction_cert_sig(tx_digest, certificate.auth_sig())?;
 
         let effects_digest = signed_effects.digest();
         self.database
-            .update_state(inner_temporary_store, certificate, signed_effects.data())
+            .update_state(
+                inner_temporary_store,
+                &certificate.clone().into_unsigned(),
+                signed_effects.data(),
+            )
             .await
             .tap_ok(|_| {
                 debug!(?effects_digest, "commit_certificate finished");
@@ -2432,16 +2440,6 @@ impl AuthorityState {
             tx_option = epoch_store.get_signed_transaction(tx_digest)?;
         }
         Ok(tx_option)
-    }
-
-    // Helper functions to manage certificates
-
-    /// Read from the DB of certificates
-    pub async fn read_certificate(
-        &self,
-        digest: &TransactionDigest,
-    ) -> Result<Option<VerifiedCertificate>, SuiError> {
-        self.database.read_certificate(digest)
     }
 
     pub async fn parent(&self, object_ref: &ObjectRef) -> Option<TransactionDigest> {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use std::sync::Arc;
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_storage::mutex_table::{LockGuard, MutexTable};
+use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::message_envelope::Message;
 use sui_types::object::Owner;
 use sui_types::object::PACKAGE_VERSION;
@@ -21,7 +22,7 @@ use sui_types::storage::{ChildObjectResolver, ObjectKey};
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
 use tokio::sync::{mpsc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::{debug, info, trace};
-use typed_store::rocks::DBBatch;
+use typed_store::rocks::{DBBatch, TypedStoreError};
 use typed_store::traits::Map;
 
 const NUM_SHARDS: usize = 4096;
@@ -140,7 +141,7 @@ impl AuthorityStore {
 
             store
                 .perpetual_tables
-                .certificates
+                .synced_transactions
                 .insert(transaction.digest(), transaction.serializable_ref())
                 .unwrap();
 
@@ -219,7 +220,28 @@ impl AuthorityStore {
             .contains_key(digest)?)
     }
 
-    pub fn insert_executed_transactions(
+    pub fn get_transaction_cert_sig(
+        &self,
+        tx_digest: &TransactionDigest,
+    ) -> Result<Option<AuthorityStrongQuorumSignInfo>, TypedStoreError> {
+        self.perpetual_tables
+            .transaction_cert_signatures
+            .get(tx_digest)
+    }
+
+    // TODO: Move this to epoch store.
+    pub fn insert_transaction_cert_sig(
+        &self,
+        tx_digest: &TransactionDigest,
+        sig: &AuthorityStrongQuorumSignInfo,
+    ) -> SuiResult {
+        self.perpetual_tables
+            .transaction_cert_signatures
+            .insert(tx_digest, sig)
+            .map_err(|e| e.into())
+    }
+
+    pub fn insert_finalized_transactions(
         &self,
         digests: &[TransactionDigest],
         epoch: EpochId,
@@ -465,18 +487,6 @@ impl AuthorityStore {
         }
     }
 
-    /// Read a certificate and return an option with None if it does not exist.
-    pub fn read_certificate(
-        &self,
-        digest: &TransactionDigest,
-    ) -> Result<Option<VerifiedCertificate>, SuiError> {
-        self.perpetual_tables
-            .certificates
-            .get(digest)
-            .map(|r| r.map(|c| c.into()))
-            .map_err(|e| e.into())
-    }
-
     /// Read the transactionDigest that is the parent of an object reference
     /// (ie. the transaction that created an object at this version.)
     pub fn parent(&self, object_ref: &ObjectRef) -> Result<Option<TransactionDigest>, SuiError> {
@@ -609,18 +619,18 @@ impl AuthorityStore {
     pub async fn update_state(
         &self,
         inner_temporary_store: InnerTemporaryStore,
-        certificate: &VerifiedCertificate,
+        transaction: &VerifiedTransaction,
         effects: &TransactionEffects,
     ) -> SuiResult {
         // Extract the new state from the execution
         // TODO: events are already stored in the TxDigest -> TransactionEffects store. Is that enough?
-        let mut write_batch = self.perpetual_tables.certificates.batch();
+        let mut write_batch = self.perpetual_tables.executed_transactions.batch();
 
         // Store the certificate indexed by transaction digest
-        let transaction_digest: &TransactionDigest = certificate.digest();
+        let transaction_digest = transaction.digest();
         write_batch = write_batch.insert_batch(
-            &self.perpetual_tables.certificates,
-            iter::once((transaction_digest, certificate.serializable_ref())),
+            &self.perpetual_tables.executed_transactions,
+            iter::once((transaction_digest, transaction.serializable_ref())),
         )?;
 
         // Add batched writes for objects and locks.
@@ -1012,9 +1022,12 @@ impl AuthorityStore {
             return Ok(())
         };
 
-        let mut write_batch = self.perpetual_tables.certificates.batch();
+        let mut write_batch = self.perpetual_tables.executed_transactions.batch();
         write_batch = write_batch
-            .delete_batch(&self.perpetual_tables.certificates, iter::once(tx_digest))?
+            .delete_batch(
+                &self.perpetual_tables.executed_transactions,
+                iter::once(tx_digest),
+            )?
             .delete_batch(&self.perpetual_tables.effects, iter::once(effects.digest()))?
             .delete_batch(
                 &self.perpetual_tables.executed_effects,
@@ -1124,25 +1137,34 @@ impl AuthorityStore {
         }
     }
 
-    pub fn get_certified_transaction(
+    pub fn get_executed_transaction(
         &self,
-        transaction_digest: &TransactionDigest,
-    ) -> SuiResult<Option<VerifiedCertificate>> {
-        let transaction = self.perpetual_tables.certificates.get(transaction_digest)?;
-        Ok(transaction.map(|t| t.into()))
+        tx_digest: &TransactionDigest,
+    ) -> Result<Option<VerifiedTransaction>, TypedStoreError> {
+        self.perpetual_tables
+            .executed_transactions
+            .get(tx_digest)
+            .map(|v_opt| v_opt.map(|v| v.into()))
     }
 
-    pub fn multi_get_certified_transaction(
+    // TODO: This function will be moved to authority.rs since it will need to access the per-epoch store
+    // for the certificate signature.
+    pub fn get_certified_transaction(
         &self,
-        transaction_digests: &[TransactionDigest],
-    ) -> SuiResult<Vec<Option<VerifiedCertificate>>> {
-        Ok(self
-            .perpetual_tables
-            .certificates
-            .multi_get(transaction_digests)?
-            .into_iter()
-            .map(|o| o.map(|c| c.into()))
-            .collect())
+        tx_digest: &TransactionDigest,
+    ) -> Result<Option<VerifiedCertificate>, TypedStoreError> {
+        let Some(transaction) = self.get_executed_transaction(tx_digest)? else {
+            return Ok(None);
+        };
+        let Some(cert_sig) = self.get_transaction_cert_sig(tx_digest)? else {
+            return Ok(None);
+        };
+        Ok(Some(VerifiedCertificate::new_unchecked(
+            CertifiedTransaction::new_from_data_and_sig(
+                transaction.into_inner().into_data(),
+                cert_sig,
+            ),
+        )))
     }
 
     pub fn get_sui_system_state_object(&self) -> SuiResult<SuiSystemState> {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -517,7 +517,7 @@ async fn execute_transactions(
                         panic!("When executing checkpoint {checkpoint_sequence}, transaction {tx_digest} is expected to have effects digest {expected_effects_digest}, but got {}!", actual_effects.digest());
                     }
                 }
-                authority_store.insert_executed_transactions(
+                authority_store.insert_finalized_transactions(
                     &all_tx_digests,
                     epoch_store.epoch(),
                     checkpoint_sequence,

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -96,13 +96,8 @@ impl ReadStore for RocksDbStore {
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<VerifiedCertificate>, Self::Error> {
-        if let Some(transaction) = self
-            .authority_store
-            .perpetual_tables
-            .certificates
-            .get(digest)?
-        {
-            return Ok(Some(transaction.into()));
+        if let Some(transaction) = self.authority_store.get_certified_transaction(digest)? {
+            return Ok(Some(transaction));
         }
 
         if let Some(transaction) = self

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2004,7 +2004,10 @@ async fn test_handle_confirmation_transaction_ok() {
             .parent(&(object_id, new_account.version(), new_account.digest()))
             .await
             .unwrap();
-        authority_state.read_certificate(&refx).await.unwrap()
+        authority_state
+            .database
+            .get_certified_transaction(&refx)
+            .unwrap()
     };
     if let Some(certified_transaction) = opt_cert {
         // valid since our test authority should not update its certificate set

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1670,6 +1670,7 @@ impl VerifiedSignedTransaction {
 /// A transaction that is signed by a sender but not yet by an authority.
 pub type Transaction = Envelope<SenderSignedData, EmptySignInfo>;
 pub type VerifiedTransaction = VerifiedEnvelope<SenderSignedData, EmptySignInfo>;
+pub type TrustedTransaction = TrustedEnvelope<SenderSignedData, EmptySignInfo>;
 
 /// A transaction that is signed by a sender and also by an authority.
 pub type SignedTransaction = Envelope<SenderSignedData, AuthoritySignInfo>;


### PR DESCRIPTION
Split the `certificates` table into two tables, one with VerifiedTransaction (the raw transaction data), and one with cert signature. Once we are fully ready with finalized transaction, we could move the signature table to the per epoch store.