### PR TITLE
[jsonrpc] - Added new combined get checkpoint endpoint

### DIFF
--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -51,7 +51,10 @@ use sui_types::messages::{
     ObjectArg, Pay, PayAllSui, PaySui, SingleTransactionKind, TransactionData, TransactionEffects,
     TransactionKind, VerifiedCertificate,
 };
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::messages_checkpoint::{
+    CheckpointContents, CheckpointDigest, CheckpointSequenceNumber, CheckpointSummary,
+    CheckpointTimestamp, EndOfEpochData,
+};
 use sui_types::move_package::{disassemble_modules, MovePackage};
 use sui_types::object::{
     Data, MoveObject, Object, ObjectFormatOptions, ObjectRead, Owner, PastObjectRead,
@@ -3035,4 +3038,78 @@ impl TransactionBytes {
 pub struct Page<T, C> {
     pub data: Vec<T>,
     pub next_cursor: Option<C>,
+}
+
+#[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Checkpoint {
+    /// Checkpoint's epoch ID
+    pub epoch: EpochId,
+    /// Checkpoint sequence number
+    pub sequence_number: CheckpointSequenceNumber,
+    /// Checkpoint digest
+    pub digest: CheckpointDigest,
+    /// Total number of transactions committed since genesis, including those in this
+    /// checkpoint.
+    pub network_total_transactions: u64,
+    /// Digest of the previous checkpoint
+    pub previous_digest: Option<CheckpointDigest>,
+    /// The running total gas costs of all transactions included in the current epoch so far
+    /// until this checkpoint.
+    pub epoch_rolling_gas_cost_summary: GasCostSummary,
+    /// Timestamp of the checkpoint - number of milliseconds from the Unix epoch
+    /// Checkpoint timestamps are monotonic, but not strongly monotonic - subsequent
+    /// checkpoints can have same timestamp if they originate from the same underlining consensus commit
+    pub timestamp_ms: CheckpointTimestamp,
+    /// Present only on the final checkpoint of the epoch.
+    pub end_of_epoch_data: Option<EndOfEpochData>,
+    /// Transaction digests
+    pub transactions: Vec<TransactionDigest>,
+}
+
+impl From<(CheckpointSummary, CheckpointContents)> for Checkpoint {
+    fn from((summary, contents): (CheckpointSummary, CheckpointContents)) -> Self {
+        let digest = summary.digest();
+        let CheckpointSummary {
+            epoch,
+            sequence_number,
+            network_total_transactions,
+            previous_digest,
+            epoch_rolling_gas_cost_summary,
+            timestamp_ms,
+            end_of_epoch_data,
+            ..
+        } = summary;
+
+        Checkpoint {
+            epoch,
+            sequence_number,
+            digest,
+            network_total_transactions,
+            previous_digest,
+            epoch_rolling_gas_cost_summary,
+            timestamp_ms,
+            end_of_epoch_data,
+            transactions: contents.iter().map(|digest| digest.transaction).collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CheckpointId {
+    SequenceNumber(CheckpointSequenceNumber),
+    Digest(CheckpointDigest),
+}
+
+impl From<CheckpointSequenceNumber> for CheckpointId {
+    fn from(seq: CheckpointSequenceNumber) -> Self {
+        Self::SequenceNumber(seq)
+    }
+}
+
+impl From<CheckpointDigest> for CheckpointId {
+    fn from(digest: CheckpointDigest) -> Self {
+        Self::Digest(digest)
+    }
 }

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -9,14 +9,14 @@ use jsonrpsee_proc_macros::rpc;
 
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
-    Balance, CoinPage, DevInspectResults, DynamicFieldPage, EventPage, GetObjectDataResponse,
-    GetPastObjectDataResponse, GetRawObjectDataResponse, MoveFunctionArgType,
-    RPCTransactionRequestParams, SuiCoinMetadata, SuiEventEnvelope, SuiEventFilter,
-    SuiExecuteTransactionResponse, SuiMoveNormalizedFunction, SuiMoveNormalizedModule,
-    SuiMoveNormalizedStruct, SuiObjectInfo, SuiTBlsSignObjectCommitmentType,
-    SuiTBlsSignRandomnessObjectResponse, SuiTransactionAuthSignersResponse,
-    SuiTransactionBuilderMode, SuiTransactionEffects, SuiTransactionResponse, SuiTypeTag,
-    TransactionBytes, TransactionsPage,
+    Balance, Checkpoint, CheckpointId, CoinPage, DevInspectResults, DynamicFieldPage, EventPage,
+    GetObjectDataResponse, GetPastObjectDataResponse, GetRawObjectDataResponse,
+    MoveFunctionArgType, RPCTransactionRequestParams, SuiCoinMetadata, SuiEventEnvelope,
+    SuiEventFilter, SuiExecuteTransactionResponse, SuiMoveNormalizedFunction,
+    SuiMoveNormalizedModule, SuiMoveNormalizedStruct, SuiObjectInfo,
+    SuiTBlsSignObjectCommitmentType, SuiTBlsSignRandomnessObjectResponse,
+    SuiTransactionAuthSignersResponse, SuiTransactionBuilderMode, SuiTransactionEffects,
+    SuiTransactionResponse, SuiTypeTag, TransactionBytes, TransactionsPage,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::balance::Supply;
@@ -273,6 +273,14 @@ pub trait RpcFullNodeReadApi {
     /// Return the sequence number of the latest checkpoint that has been executed
     #[method(name = "getLatestCheckpointSequenceNumber")]
     fn get_latest_checkpoint_sequence_number(&self) -> RpcResult<CheckpointSequenceNumber>;
+
+    /// Return a checkpoint summary
+    #[method(name = "getCheckpoint")]
+    fn get_checkpoint(
+        &self,
+        /// Checkpoint identifier, can use either checkpoint digest, or checkpoint sequence number as input.
+        id: CheckpointId,
+    ) -> RpcResult<Checkpoint>;
 
     /// Return a checkpoint summary based on a checkpoint sequence number
     #[method(name = "getCheckpointSummary")]

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -274,7 +274,7 @@ pub trait RpcFullNodeReadApi {
     #[method(name = "getLatestCheckpointSequenceNumber")]
     fn get_latest_checkpoint_sequence_number(&self) -> RpcResult<CheckpointSequenceNumber>;
 
-    /// Return a checkpoint summary
+    /// Return a checkpoint
     #[method(name = "getCheckpoint")]
     fn get_checkpoint(
         &self,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -548,6 +548,63 @@
       }
     },
     {
+      "name": "sui_getCheckpoint",
+      "tags": [
+        {
+          "name": "Full Node API"
+        }
+      ],
+      "description": "Return a checkpoint summary",
+      "params": [
+        {
+          "name": "id",
+          "description": "Checkpoint identifier, can use either checkpoint digest, or checkpoint sequence number as input.",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/CheckpointId"
+          }
+        }
+      ],
+      "result": {
+        "name": "Checkpoint",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/Checkpoint"
+        }
+      },
+      "examples": [
+        {
+          "name": "Get checkpoint",
+          "params": [
+            {
+              "name": "id",
+              "value": 1000
+            }
+          ],
+          "result": {
+            "name": "Result",
+            "value": {
+              "epoch": 5000,
+              "sequenceNumber": 1000,
+              "digest": "G3pGMDciKzooy3YgygMNqDiRVbBYexo95ymqxqwuczLz",
+              "networkTotalTransactions": 792385,
+              "previousDigest": "G18VrHdiBVJ7zcyu3TwQbtHdCKNLF9pAEsMUHqXDQ8v5",
+              "epochRollingGasCostSummary": {
+                "computation_cost": 0,
+                "storage_cost": 0,
+                "storage_rebate": 0
+              },
+              "timestampMs": 1676911928,
+              "endOfEpochData": null,
+              "transactions": [
+                "4qBuxNt9KoyC4xUbY8jJMJfmonAnMgTjDG6Nq1F1jbbH"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "sui_getCheckpointContents",
       "tags": [
         {
@@ -3058,6 +3115,89 @@
           }
         }
       },
+      "Checkpoint": {
+        "type": "object",
+        "required": [
+          "digest",
+          "epoch",
+          "epochRollingGasCostSummary",
+          "networkTotalTransactions",
+          "sequenceNumber",
+          "timestampMs",
+          "transactions"
+        ],
+        "properties": {
+          "digest": {
+            "description": "Checkpoint digest",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CheckpointDigest"
+              }
+            ]
+          },
+          "endOfEpochData": {
+            "description": "Present only on the final checkpoint of the epoch.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EndOfEpochData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "epoch": {
+            "description": "Checkpoint's epoch ID",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "epochRollingGasCostSummary": {
+            "description": "The running total gas costs of all transactions included in the current epoch so far until this checkpoint.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GasCostSummary"
+              }
+            ]
+          },
+          "networkTotalTransactions": {
+            "description": "Total number of transactions committed since genesis, including those in this checkpoint.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "previousDigest": {
+            "description": "Digest of the previous checkpoint",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CheckpointDigest"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sequenceNumber": {
+            "description": "Checkpoint sequence number",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "timestampMs": {
+            "description": "Timestamp of the checkpoint - number of milliseconds from the Unix epoch Checkpoint timestamps are monotonic, but not strongly monotonic - subsequent checkpoints can have same timestamp if they originate from the same underlining consensus commit",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "transactions": {
+            "description": "Transaction digests",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransactionDigest"
+            }
+          }
+        }
+      },
       "CheckpointContents": {
         "description": "CheckpointContents are the transactions included in an upcoming checkpoint. They must have already been causally ordered. Since the causal order algorithm is the same among validators, we expect all honest validators to come up with the same order for each checkpoint content.",
         "type": "object",
@@ -3092,6 +3232,18 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/Sha3Digest"
+          }
+        ]
+      },
+      "CheckpointId": {
+        "anyOf": [
+          {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          {
+            "$ref": "#/components/schemas/CheckpointDigest"
           }
         ]
       },

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -554,7 +554,7 @@
           "name": "Full Node API"
         }
       ],
-      "description": "Return a checkpoint summary",
+      "description": "Return a checkpoint",
       "params": [
         {
           "name": "id",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -17,12 +17,12 @@ use sui::client_commands::EXAMPLE_NFT_NAME;
 use sui::client_commands::EXAMPLE_NFT_URL;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
-    EventPage, MoveCallParams, OwnedObjectRef, RPCTransactionRequestParams,
-    SuiCertifiedTransaction, SuiData, SuiEvent, SuiEventEnvelope, SuiExecutionStatus,
-    SuiGasCostSummary, SuiObject, SuiObjectInfo, SuiObjectRead, SuiObjectRef, SuiParsedData,
-    SuiPastObjectRead, SuiRawData, SuiRawMoveObject, SuiTransactionAuthSignersResponse,
-    SuiTransactionData, SuiTransactionEffects, SuiTransactionResponse, TransactionBytes,
-    TransactionsPage, TransferObjectParams,
+    Checkpoint, CheckpointId, EventPage, MoveCallParams, OwnedObjectRef,
+    RPCTransactionRequestParams, SuiCertifiedTransaction, SuiData, SuiEvent, SuiEventEnvelope,
+    SuiExecutionStatus, SuiGasCostSummary, SuiObject, SuiObjectInfo, SuiObjectRead, SuiObjectRef,
+    SuiParsedData, SuiPastObjectRead, SuiRawData, SuiRawMoveObject,
+    SuiTransactionAuthSignersResponse, SuiTransactionData, SuiTransactionEffects,
+    SuiTransactionResponse, TransactionBytes, TransactionsPage, TransferObjectParams,
 };
 use sui_open_rpc::ExamplePairing;
 use sui_types::base_types::{
@@ -39,6 +39,7 @@ use sui_types::messages::{
     CallArg, ExecuteTransactionRequestType, MoveCall, SingleTransactionKind, TransactionData,
     TransactionKind, TransferObject,
 };
+use sui_types::messages_checkpoint::CheckpointDigest;
 use sui_types::object::Owner;
 use sui_types::query::EventQuery;
 use sui_types::query::TransactionQuery;
@@ -85,6 +86,7 @@ impl RpcExampleProvider {
             self.get_events(),
             self.execute_transaction_example(),
             self.submit_transaction_example(),
+            self.get_checkpoint_example(),
         ]
         .into_iter()
         .map(|example| (example.function_name, example.examples))
@@ -269,6 +271,29 @@ impl RpcExampleProvider {
             vec![ExamplePairing::new(
                 "Get Past Object data",
                 vec![("object_id", json!(object_id)), ("version", json!(4))],
+                json!(result),
+            )],
+        )
+    }
+
+    fn get_checkpoint_example(&mut self) -> Examples {
+        let result = Checkpoint {
+            epoch: 5000,
+            sequence_number: 1000,
+            digest: CheckpointDigest::new(self.rng.gen()),
+            network_total_transactions: 792385,
+            previous_digest: Some(CheckpointDigest::new(self.rng.gen())),
+            epoch_rolling_gas_cost_summary: Default::default(),
+            timestamp_ms: 1676911928,
+            end_of_epoch_data: None,
+            transactions: vec![TransactionDigest::new(self.rng.gen())],
+        };
+
+        Examples::new(
+            "sui_getCheckpoint",
+            vec![ExamplePairing::new(
+                "Get checkpoint",
+                vec![("id", json!(CheckpointId::SequenceNumber(1000)))],
                 json!(result),
             )],
         )

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
-use sui_sdk::apis::Checkpoint;
+use sui_sdk::rpc_types::Checkpoint;
 use sui_sdk::SuiClient;
 use sui_storage::default_db_options;
 use sui_types::base_types::{EpochId, SuiAddress};
@@ -75,16 +75,12 @@ pub struct CheckpointBlockProvider {
 #[async_trait]
 impl BlockProvider for CheckpointBlockProvider {
     async fn get_block_by_index(&self, index: u64) -> Result<BlockResponse, Error> {
-        let checkpoint = self.client.read_api().get_checkpoint(index).await?;
+        let checkpoint = self.client.read_api().get_checkpoint(index.into()).await?;
         self.create_block_response(checkpoint).await
     }
 
     async fn get_block_by_hash(&self, hash: BlockHash) -> Result<BlockResponse, Error> {
-        let checkpoint = self
-            .client
-            .read_api()
-            .get_checkpoint_by_digest(hash)
-            .await?;
+        let checkpoint = self.client.read_api().get_checkpoint(hash.into()).await?;
         self.create_block_response(checkpoint).await
     }
 
@@ -147,7 +143,7 @@ impl CheckpointBlockProvider {
         spawn_monitored_task!(async move {
             if f.index_store.is_empty() {
                 info!("Index Store is empty, indexing genesis block.");
-                let checkpoint = f.client.read_api().get_checkpoint(0).await.unwrap();
+                let checkpoint = f.client.read_api().get_checkpoint(0.into()).await.unwrap();
                 let resp = f.create_block_response(checkpoint).await.unwrap();
                 f.update_balance(resp.block).await.unwrap();
             } else {
@@ -174,11 +170,11 @@ impl CheckpointBlockProvider {
             .await?;
         if last_checkpoint < head {
             for seq in last_checkpoint + 1..=head {
-                let checkpoint = self.client.read_api().get_checkpoint(seq).await?;
-                let timestamp = UNIX_EPOCH + Duration::from_millis(checkpoint.summary.timestamp_ms);
+                let checkpoint = self.client.read_api().get_checkpoint(seq.into()).await?;
+                let timestamp = UNIX_EPOCH + Duration::from_millis(checkpoint.timestamp_ms);
                 info!(
                     "indexing checkpoint {seq} with {} txs, timestamp: {}",
-                    checkpoint.content.size(),
+                    checkpoint.transactions.len(),
                     DateTime::<Utc>::from(timestamp).format("%Y-%m-%d %H:%M:%S")
                 );
                 let resp = self.create_block_response(checkpoint).await?;
@@ -225,15 +221,11 @@ impl CheckpointBlockProvider {
     }
 
     async fn create_block_response(&self, checkpoint: Checkpoint) -> Result<BlockResponse, Error> {
-        let index = checkpoint.summary.sequence_number;
-        let hash = checkpoint.summary.digest();
+        let index = checkpoint.sequence_number;
+        let hash = checkpoint.digest;
         let mut transactions = vec![];
-        for digest in checkpoint.content.iter() {
-            let tx = self
-                .client
-                .read_api()
-                .get_transaction(digest.transaction)
-                .await?;
+        for digest in checkpoint.transactions.iter() {
+            let tx = self.client.read_api().get_transaction(*digest).await?;
             transactions.push(Transaction {
                 transaction_identifier: TransactionIdentifier {
                     hash: tx.certificate.transaction_digest,
@@ -245,14 +237,13 @@ impl CheckpointBlockProvider {
         }
 
         // previous digest should only be None for genesis block.
-        if checkpoint.summary.previous_digest.is_none() && index != 0 {
+        if checkpoint.previous_digest.is_none() && index != 0 {
             return Err(Error::DataError(format!(
                 "Previous digest is None for checkpoint [{index}], digest: [{hash:?}]"
             )));
         }
 
         let parent_block_identifier = checkpoint
-            .summary
             .previous_digest
             .map(|hash| BlockIdentifier {
                 index: index - 1,
@@ -264,7 +255,7 @@ impl CheckpointBlockProvider {
             block: Block {
                 block_identifier: BlockIdentifier { index, hash },
                 parent_block_identifier,
-                timestamp: checkpoint.summary.timestamp_ms,
+                timestamp: checkpoint.timestamp_ms,
                 transactions,
                 metadata: None,
             },
@@ -276,10 +267,14 @@ impl CheckpointBlockProvider {
         &self,
         seq_number: CheckpointSequenceNumber,
     ) -> Result<BlockIdentifier, Error> {
-        let checkpoint = self.client.read_api().get_checkpoint(seq_number).await?;
+        let checkpoint = self
+            .client
+            .read_api()
+            .get_checkpoint(seq_number.into())
+            .await?;
         Ok(BlockIdentifier {
-            index: checkpoint.summary.sequence_number,
-            hash: checkpoint.summary.digest(),
+            index: checkpoint.sequence_number,
+            hash: checkpoint.digest,
         })
     }
 


### PR DESCRIPTION
Will mark other checkpoint endpoints as deprecated when https://github.com/MystenLabs/sui/pull/8334 landed

This PR combines getCheckpointSummary and getCheckpointContent into one endpoint, also use a untagged enum as input, allow either Checkpoint sequence number, or checkpoint digest as input parameter.