### PR TITLE
wallet-kit-core: update accounts when they change in the selected wallet

### DIFF
--- a/.changeset/unlucky-taxis-attend.md
+++ b/.changeset/unlucky-taxis-attend.md
@@ -1,0 +1,5 @@
+---
+"@mysten/wallet-kit-core": patch
+---
+
+Change accounts and current account when they change in the selected wallet

--- a/sdk/wallet-adapter/wallet-kit-core/src/index.ts
+++ b/sdk/wallet-adapter/wallet-kit-core/src/index.ts
@@ -188,12 +188,24 @@ export function createWalletKitCore({
         if (walletEventUnsubscribe) {
           walletEventUnsubscribe();
         }
-        walletEventUnsubscribe = currentWallet.on("change", ({ connected }) => {
-          // when undefined connected hasn't changed
-          if (connected === false) {
-            disconnected();
+        walletEventUnsubscribe = currentWallet.on(
+          "change",
+          ({ connected, accounts }) => {
+            // when undefined connected hasn't changed
+            if (connected === false) {
+              disconnected();
+            } else if (accounts) {
+              setState({
+                accounts,
+                currentAccount:
+                  internalState.currentAccount &&
+                  !accounts.includes(internalState.currentAccount)
+                    ? accounts[0]
+                    : internalState.currentAccount,
+              });
+            }
           }
-        });
+        );
         try {
           setState({ status: WalletKitCoreConnectionStatus.CONNECTING });
           await currentWallet.connect();


### PR DESCRIPTION
* update accounts when they change
* if the currentAccount is not connected anymore use the first of the new accounts

part of APPS-284