### PR TITLE
move: format tests with indentation

### DIFF
--- a/crates/sui-framework/tests/bag_tests.move
+++ b/crates/sui-framework/tests/bag_tests.move
@@ -3,167 +3,165 @@
 
 #[test_only]
 module sui::bag_tests {
+    use sui::bag::{Self, add, contains_with_type, borrow, borrow_mut, remove};
+    use sui::test_scenario as ts;
 
-use sui::bag::{Self, add, contains_with_type, borrow, borrow_mut, remove};
-use sui::test_scenario as ts;
+    #[test]
+    fun simple_all_functions() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        // add fields
+        add(&mut bag, b"hello", 0);
+        add(&mut bag, 1, 1u8);
+        // check they exist
+        assert!(contains_with_type<vector<u8>, u64>(&bag, b"hello"), 0);
+        assert!(contains_with_type<u64, u8>(&bag, 1), 0);
+        // check the values
+        assert!(*borrow(&bag, b"hello") == 0, 0);
+        assert!(*borrow(&bag, 1) == 1u8, 0);
+        // mutate them
+        *borrow_mut(&mut bag, b"hello") = *borrow(&bag, b"hello") * 2;
+        *borrow_mut(&mut bag, 1) = *borrow(&bag, 1) * 2u8;
+        // check the new value
+        assert!(*borrow(&bag, b"hello") == 0, 0);
+        assert!(*borrow(&bag, 1) == 2u8, 0);
+        // remove the value and check it
+        assert!(remove(&mut bag, b"hello") == 0, 0);
+        assert!(remove(&mut bag, 1) == 2u8, 0);
+        // verify that they are not there
+        assert!(!contains_with_type<vector<u8>, u64>(&bag, b"hello"), 0);
+        assert!(!contains_with_type<u64, u8>(&bag, 1), 0);
+        ts::end(scenario);
+        bag::destroy_empty(bag);
+    }
 
-#[test]
-fun simple_all_functions() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    // add fields
-    add(&mut bag, b"hello", 0);
-    add(&mut bag, 1, 1u8);
-    // check they exist
-    assert!(contains_with_type<vector<u8>, u64>(&bag, b"hello"), 0);
-    assert!(contains_with_type<u64, u8>(&bag, 1), 0);
-    // check the values
-    assert!(*borrow(&bag, b"hello") == 0, 0);
-    assert!(*borrow(&bag, 1) == 1u8, 0);
-    // mutate them
-    *borrow_mut(&mut bag, b"hello") = *borrow(&bag, b"hello") * 2;
-    *borrow_mut(&mut bag, 1) = *borrow(&bag, 1) * 2u8;
-    // check the new value
-    assert!(*borrow(&bag, b"hello") == 0, 0);
-    assert!(*borrow(&bag, 1) == 2u8, 0);
-    // remove the value and check it
-    assert!(remove(&mut bag, b"hello") == 0, 0);
-    assert!(remove(&mut bag, 1) == 2u8, 0);
-    // verify that they are not there
-    assert!(!contains_with_type<vector<u8>, u64>(&bag, b"hello"), 0);
-    assert!(!contains_with_type<u64, u8>(&bag, 1), 0);
-    ts::end(scenario);
-    bag::destroy_empty(bag);
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun add_duplicate() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        add(&mut bag, b"hello", 0u8);
+        add(&mut bag, b"hello", 1u8);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun add_duplicate() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    add(&mut bag, b"hello", 0u8);
-    add(&mut bag, b"hello", 1u8);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun add_duplicate_mismatched_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        add(&mut bag, b"hello", 0u128);
+        add(&mut bag, b"hello", 1u8);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun add_duplicate_mismatched_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    add(&mut bag, b"hello", 0u128);
-    add(&mut bag, b"hello", 1u8);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        borrow<u64, u64>(&bag, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    borrow<u64, u64>(&bag, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+    fun borrow_wrong_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        add(&mut bag, 0, 0);
+        borrow<u64, u8>(&mut bag, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
-fun borrow_wrong_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    add(&mut bag, 0, 0);
-    borrow<u64, u8>(&mut bag, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_mut_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        borrow_mut<u64, u64>(&mut bag, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_mut_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    borrow_mut<u64, u64>(&mut bag, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+    fun borrow_mut_wrong_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        add(&mut bag, 0, 0);
+        borrow_mut<u64, u8>(&mut bag, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
-fun borrow_mut_wrong_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    add(&mut bag, 0, 0);
-    borrow_mut<u64, u8>(&mut bag, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun remove_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        remove<u64, u64>(&mut bag, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun remove_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    remove<u64, u64>(&mut bag, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+    fun remove_wrong_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        add(&mut bag, 0, 0);
+        remove<u64, u8>(&mut bag, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
-fun remove_wrong_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    add(&mut bag, 0, 0);
-    remove<u64, u8>(&mut bag, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::bag::EBagNotEmpty)]
+    fun destroy_non_empty() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        add(&mut bag, 0, 0);
+        bag::destroy_empty(bag);
+        ts::end(scenario);
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::bag::EBagNotEmpty)]
-fun destroy_non_empty() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    add(&mut bag, 0, 0);
-    bag::destroy_empty(bag);
-    ts::end(scenario);
-}
+    #[test]
+    fun sanity_check_contains() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        assert!(!contains_with_type<u64, u64>(&mut bag, 0), 0);
+        add(&mut bag, 0, 0);
+        assert!(contains_with_type<u64, u64>(&mut bag, 0), 0);
+        assert!(!contains_with_type<u64, u64>(&mut bag, 1), 0);
+        ts::end(scenario);
+        bag::remove<u64, u64>(&mut bag, 0);
+        bag::destroy_empty(bag);
+    }
 
-#[test]
-fun sanity_check_contains() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    assert!(!contains_with_type<u64, u64>(&mut bag, 0), 0);
-    add(&mut bag, 0, 0);
-    assert!(contains_with_type<u64, u64>(&mut bag, 0), 0);
-    assert!(!contains_with_type<u64, u64>(&mut bag, 1), 0);
-    ts::end(scenario);
-    bag::remove<u64, u64>(&mut bag, 0);
-    bag::destroy_empty(bag);
-}
-
-#[test]
-fun sanity_check_size() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = bag::new(ts::ctx(&mut scenario));
-    assert!(bag::is_empty(&bag), 0);
-    assert!(bag::length(&bag) == 0, 0);
-    add(&mut bag, 0, 0);
-    assert!(!bag::is_empty(&bag), 0);
-    assert!(bag::length(&bag) == 1, 0);
-    add(&mut bag, 1, 0);
-    assert!(!bag::is_empty(&bag), 0);
-    assert!(bag::length(&bag) == 2, 0);
-    bag::remove<u64, u64>(&mut bag, 0);
-    bag::remove<u64, u64>(&mut bag, 1);
-    ts::end(scenario);
-    bag::destroy_empty(bag);
-}
-
+    #[test]
+    fun sanity_check_size() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = bag::new(ts::ctx(&mut scenario));
+        assert!(bag::is_empty(&bag), 0);
+        assert!(bag::length(&bag) == 0, 0);
+        add(&mut bag, 0, 0);
+        assert!(!bag::is_empty(&bag), 0);
+        assert!(bag::length(&bag) == 1, 0);
+        add(&mut bag, 1, 0);
+        assert!(!bag::is_empty(&bag), 0);
+        assert!(bag::length(&bag) == 2, 0);
+        bag::remove<u64, u64>(&mut bag, 0);
+        bag::remove<u64, u64>(&mut bag, 1);
+        ts::end(scenario);
+        bag::destroy_empty(bag);
+    }
 }

--- a/crates/sui-framework/tests/dynamic_field_tests.move
+++ b/crates/sui-framework/tests/dynamic_field_tests.move
@@ -3,156 +3,154 @@
 
 #[test_only]
 module sui::dynamic_field_tests {
+    use sui::dynamic_field::{add, exists_with_type, borrow, borrow_mut, remove};
+    use sui::object;
+    use sui::test_scenario as ts;
 
-use sui::dynamic_field::{add, exists_with_type, borrow, borrow_mut, remove};
-use sui::object;
-use sui::test_scenario as ts;
+    #[test]
+    fun simple_all_functions() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        // add fields
+        add<u64, u64>(&mut id, 0, 0);
+        add<vector<u8>, u64>(&mut id, b"", 1);
+        add<bool, u64>(&mut id, false, 2);
+        // check they exist
+        assert!(exists_with_type<u64, u64>(&id, 0), 0);
+        assert!(exists_with_type<vector<u8>, u64>(&id, b""), 0);
+        assert!(exists_with_type<bool, u64>(&id, false), 0);
+        // check the values
+        assert!(*borrow(&id, 0) == 0, 0);
+        assert!(*borrow(&id, b"") == 1, 0);
+        assert!(*borrow(&id, false) == 2, 0);
+        // mutate them
+        *borrow_mut(&mut id, 0) = 3 + *borrow(&id, 0);
+        *borrow_mut(&mut id, b"") = 4 + *borrow(&id, b"");
+        *borrow_mut(&mut id, false) = 5 + *borrow(&id, false);
+        // check the new value
+        assert!(*borrow(&id, 0) == 3, 0);
+        assert!(*borrow(&id, b"") == 5, 0);
+        assert!(*borrow(&id, false) == 7, 0);
+        // remove the value and check it
+        assert!(remove(&mut id, 0) == 3, 0);
+        assert!(remove(&mut id, b"") == 5, 0);
+        assert!(remove(&mut id, false) == 7, 0);
+        // verify that they are not there
+        assert!(!exists_with_type<u64, u64>(&id, 0), 0);
+        assert!(!exists_with_type<vector<u8>, u64>(&id, b""), 0);
+        assert!(!exists_with_type<bool, u64>(&id, false), 0);
+        ts::end(scenario);
+        object::delete(id);
+    }
 
-#[test]
-fun simple_all_functions() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    // add fields
-    add<u64, u64>(&mut id, 0, 0);
-    add<vector<u8>, u64>(&mut id, b"", 1);
-    add<bool, u64>(&mut id, false, 2);
-    // check they exist
-    assert!(exists_with_type<u64, u64>(&id, 0), 0);
-    assert!(exists_with_type<vector<u8>, u64>(&id, b""), 0);
-    assert!(exists_with_type<bool, u64>(&id, false), 0);
-    // check the values
-    assert!(*borrow(&id, 0) == 0, 0);
-    assert!(*borrow(&id, b"") == 1, 0);
-    assert!(*borrow(&id, false) == 2, 0);
-    // mutate them
-    *borrow_mut(&mut id, 0) = 3 + *borrow(&id, 0);
-    *borrow_mut(&mut id, b"") = 4 + *borrow(&id, b"");
-    *borrow_mut(&mut id, false) = 5 + *borrow(&id, false);
-    // check the new value
-    assert!(*borrow(&id, 0) == 3, 0);
-    assert!(*borrow(&id, b"") == 5, 0);
-    assert!(*borrow(&id, false) == 7, 0);
-    // remove the value and check it
-    assert!(remove(&mut id, 0) == 3, 0);
-    assert!(remove(&mut id, b"") == 5, 0);
-    assert!(remove(&mut id, false) == 7, 0);
-    // verify that they are not there
-    assert!(!exists_with_type<u64, u64>(&id, 0), 0);
-    assert!(!exists_with_type<vector<u8>, u64>(&id, b""), 0);
-    assert!(!exists_with_type<bool, u64>(&id, false), 0);
-    ts::end(scenario);
-    object::delete(id);
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun add_duplicate() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add<u64, u64>(&mut id, 0, 0);
+        add<u64, u64>(&mut id, 0, 1);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun add_duplicate() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add<u64, u64>(&mut id, 0, 0);
-    add<u64, u64>(&mut id, 0, 1);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun add_duplicate_mismatched_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add<u64, u64>(&mut id, 0, 0u64);
+        add<u64, u8>(&mut id, 0, 1u8);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun add_duplicate_mismatched_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add<u64, u64>(&mut id, 0, 0u64);
-    add<u64, u8>(&mut id, 0, 1u8);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        borrow<u64, u64>(&mut id, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    borrow<u64, u64>(&mut id, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+    fun borrow_wrong_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add(&mut id, 0, 0);
+        borrow<u64, u8>(&mut id, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
-fun borrow_wrong_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add(&mut id, 0, 0);
-    borrow<u64, u8>(&mut id, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_mut_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        borrow_mut<u64, u64>(&mut id, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_mut_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    borrow_mut<u64, u64>(&mut id, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+    fun borrow_mut_wrong_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add(&mut id, 0, 0);
+        borrow_mut<u64, u8>(&mut id, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
-fun borrow_mut_wrong_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add(&mut id, 0, 0);
-    borrow_mut<u64, u8>(&mut id, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun remove_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        remove<u64, u64>(&mut id, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun remove_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    remove<u64, u64>(&mut id, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+    fun remove_wrong_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add(&mut id, 0, 0);
+        remove<u64, u8>(&mut id, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
-fun remove_wrong_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add(&mut id, 0, 0);
-    remove<u64, u8>(&mut id, 0);
-    abort 42
-}
+    #[test]
+    fun sanity_check_exists() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        assert!(!exists_with_type<u64, u64>(&mut id, 0), 0);
+        add(&mut id, 0, 0);
+        assert!(exists_with_type<u64, u64>(&mut id, 0), 0);
+        assert!(!exists_with_type<u64, u8>(&mut id, 0), 0);
+        ts::end(scenario);
+        object::delete(id);
+    }
 
-#[test]
-fun sanity_check_exists() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    assert!(!exists_with_type<u64, u64>(&mut id, 0), 0);
-    add(&mut id, 0, 0);
-    assert!(exists_with_type<u64, u64>(&mut id, 0), 0);
-    assert!(!exists_with_type<u64, u8>(&mut id, 0), 0);
-    ts::end(scenario);
-    object::delete(id);
-}
-
-// should be able to do delete a UID even though it has a dynamic field
-#[test]
-fun delete_uid_with_fields() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add(&mut id, 0, 0);
-    assert!(exists_with_type<u64, u64>(&mut id, 0), 0);
-    ts::end(scenario);
-    object::delete(id);
-}
-
+    // should be able to do delete a UID even though it has a dynamic field
+    #[test]
+    fun delete_uid_with_fields() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add(&mut id, 0, 0);
+        assert!(exists_with_type<u64, u64>(&mut id, 0), 0);
+        ts::end(scenario);
+        object::delete(id);
+    }
 }

--- a/crates/sui-framework/tests/dynamic_object_field_tests.move
+++ b/crates/sui-framework/tests/dynamic_object_field_tests.move
@@ -3,241 +3,239 @@
 
 #[test_only]
 module sui::dynamic_object_field_tests {
+    use std::option;
+    use sui::dynamic_object_field::{
+        add,
+        borrow,
+        borrow_mut,
+        exists_,
+        exists_with_type,
+        remove,
+        id as field_id,
+    };
+    use sui::object::{Self, UID};
+    use sui::test_scenario as ts;
 
-use std::option;
-use sui::dynamic_object_field::{
-    add,
-    borrow,
-    borrow_mut,
-    exists_,
-    exists_with_type,
-    remove,
-    id as field_id,
-};
-use sui::object::{Self, UID};
-use sui::test_scenario as ts;
+    struct Counter has key, store {
+        id: UID,
+        count: u64,
+    }
 
-struct Counter has key, store {
-    id: UID,
-    count: u64,
-}
+    struct Fake has key, store {
+        id: UID,
+    }
 
-struct Fake has key, store {
-    id: UID,
-}
+    #[test]
+    fun simple_all_functions() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        let uid1 = ts::new_object(&mut scenario);
+        let id1 = object::uid_to_inner(&uid1);
+        let uid2 = ts::new_object(&mut scenario);
+        let id2 = object::uid_to_inner(&uid2);
+        let uid3 = ts::new_object(&mut scenario);
+        let id3 = object::uid_to_inner(&uid3);
+        // add fields
+        add(&mut id, 0, new(uid1));
+        add(&mut id, b"", new(uid2));
+        add(&mut id, false, new(uid3));
+        // check they exist
+        assert!(exists_(&id, 0), 0);
+        assert!(exists_(&id, b""), 0);
+        assert!(exists_(&id, false), 0);
+        // check the IDs
+        assert!(option::borrow(&field_id(&id, 0)) == &id1, 0);
+        assert!(option::borrow(&field_id(&id, b"")) == &id2, 0);
+        assert!(option::borrow(&field_id(&id, false)) == &id3, 0);
+        // check the values
+        assert!(count(borrow(&id, 0)) == 0, 0);
+        assert!(count(borrow(&id, b"")) == 0, 0);
+        assert!(count(borrow(&id, false)) == 0, 0);
+        // mutate them
+        bump(borrow_mut(&mut id, 0));
+        bump(bump(borrow_mut(&mut id, b"")));
+        bump(bump(bump(borrow_mut(&mut id, false))));
+        // check the new value
+        assert!(count(borrow(&id, 0)) == 1, 0);
+        assert!(count(borrow(&id, b"")) == 2, 0);
+        assert!(count(borrow(&id, false)) == 3, 0);
+        // remove the value and check it
+        assert!(destroy(remove(&mut id, 0)) == 1, 0);
+        assert!(destroy(remove(&mut id, b"")) == 2, 0);
+        assert!(destroy(remove(&mut id, false)) == 3, 0);
+        // verify that they are not there
+        assert!(!exists_(&id, 0), 0);
+        assert!(!exists_(&id, b""), 0);
+        assert!(!exists_(&id, false), 0);
+        ts::end(scenario);
+        object::delete(id);
+    }
 
-#[test]
-fun simple_all_functions() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    let uid1 = ts::new_object(&mut scenario);
-    let id1 = object::uid_to_inner(&uid1);
-    let uid2 = ts::new_object(&mut scenario);
-    let id2 = object::uid_to_inner(&uid2);
-    let uid3 = ts::new_object(&mut scenario);
-    let id3 = object::uid_to_inner(&uid3);
-    // add fields
-    add(&mut id, 0, new(uid1));
-    add(&mut id, b"", new(uid2));
-    add(&mut id, false, new(uid3));
-    // check they exist
-    assert!(exists_(&id, 0), 0);
-    assert!(exists_(&id, b""), 0);
-    assert!(exists_(&id, false), 0);
-    // check the IDs
-    assert!(option::borrow(&field_id(&id, 0)) == &id1, 0);
-    assert!(option::borrow(&field_id(&id, b"")) == &id2, 0);
-    assert!(option::borrow(&field_id(&id, false)) == &id3, 0);
-    // check the values
-    assert!(count(borrow(&id, 0)) == 0, 0);
-    assert!(count(borrow(&id, b"")) == 0, 0);
-    assert!(count(borrow(&id, false)) == 0, 0);
-    // mutate them
-    bump(borrow_mut(&mut id, 0));
-    bump(bump(borrow_mut(&mut id, b"")));
-    bump(bump(bump(borrow_mut(&mut id, false))));
-    // check the new value
-    assert!(count(borrow(&id, 0)) == 1, 0);
-    assert!(count(borrow(&id, b"")) == 2, 0);
-    assert!(count(borrow(&id, false)) == 3, 0);
-    // remove the value and check it
-    assert!(destroy(remove(&mut id, 0)) == 1, 0);
-    assert!(destroy(remove(&mut id, b"")) == 2, 0);
-    assert!(destroy(remove(&mut id, false)) == 3, 0);
-    // verify that they are not there
-    assert!(!exists_(&id, 0), 0);
-    assert!(!exists_(&id, b""), 0);
-    assert!(!exists_(&id, false), 0);
-    ts::end(scenario);
-    object::delete(id);
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun add_duplicate() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
+        add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun add_duplicate() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
-    add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun add_duplicate_mismatched_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
+        add<u64, Fake>(&mut id, 0, Fake { id: ts::new_object(&mut scenario) });
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun add_duplicate_mismatched_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add<u64, Counter>(&mut id, 0, new(ts::new_object(&mut scenario)));
-    add<u64, Fake>(&mut id, 0, Fake { id: ts::new_object(&mut scenario) });
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        borrow<u64, Counter>(&mut id, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    borrow<u64, Counter>(&mut id, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+    fun borrow_wrong_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        borrow<u64, Fake>(&mut id, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
-fun borrow_wrong_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add(&mut id, 0, new(ts::new_object(&mut scenario)));
-    borrow<u64, Fake>(&mut id, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_mut_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        borrow_mut<u64, Counter>(&mut id, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_mut_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    borrow_mut<u64, Counter>(&mut id, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+    fun borrow_mut_wrong_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        borrow_mut<u64, Fake>(&mut id, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
-fun borrow_mut_wrong_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add(&mut id, 0, new(ts::new_object(&mut scenario)));
-    borrow_mut<u64, Fake>(&mut id, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun remove_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        destroy(remove<u64, Counter>(&mut id, 0));
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun remove_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    destroy(remove<u64, Counter>(&mut id, 0));
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
+    fun remove_wrong_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        let Fake { id } = remove<u64, Fake>(&mut id, 0);
+        object::delete(id);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
-fun remove_wrong_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add(&mut id, 0, new(ts::new_object(&mut scenario)));
-    let Fake { id } = remove<u64, Fake>(&mut id, 0);
-    object::delete(id);
-    abort 42
-}
+    #[test]
+    fun sanity_check_exists() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        assert!(!exists_<u64>(&id, 0), 0);
+        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        assert!(exists_<u64>(&id, 0), 0);
+        assert!(!exists_<u8>(&id, 0), 0);
+        ts::end(scenario);
+        object::delete(id);
+    }
 
-#[test]
-fun sanity_check_exists() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    assert!(!exists_<u64>(&id, 0), 0);
-    add(&mut id, 0, new(ts::new_object(&mut scenario)));
-    assert!(exists_<u64>(&id, 0), 0);
-    assert!(!exists_<u8>(&id, 0), 0);
-    ts::end(scenario);
-    object::delete(id);
-}
+    #[test]
+    fun sanity_check_exists_with_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        assert!(!exists_with_type<u64, Counter>(&id, 0), 0);
+        assert!(!exists_with_type<u64, Fake>(&id, 0), 0);
+        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        assert!(exists_with_type<u64, Counter>(&id, 0), 0);
+        assert!(!exists_with_type<u8, Counter>(&id, 0), 0);
+        assert!(!exists_with_type<u8, Fake>(&id, 0), 0);
+        ts::end(scenario);
+        object::delete(id);
+    }
 
-#[test]
-fun sanity_check_exists_with_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    assert!(!exists_with_type<u64, Counter>(&id, 0), 0);
-    assert!(!exists_with_type<u64, Fake>(&id, 0), 0);
-    add(&mut id, 0, new(ts::new_object(&mut scenario)));
-    assert!(exists_with_type<u64, Counter>(&id, 0), 0);
-    assert!(!exists_with_type<u8, Counter>(&id, 0), 0);
-    assert!(!exists_with_type<u8, Fake>(&id, 0), 0);
-    ts::end(scenario);
-    object::delete(id);
-}
+    // should be able to do delete a UID even though it has a dynamic field
+    #[test]
+    fun delete_uid_with_fields() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id = ts::new_object(&mut scenario);
+        add(&mut id, 0, new(ts::new_object(&mut scenario)));
+        assert!(exists_<u64>(&mut id, 0), 0);
+        ts::end(scenario);
+        object::delete(id);
+    }
 
-// should be able to do delete a UID even though it has a dynamic field
-#[test]
-fun delete_uid_with_fields() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id = ts::new_object(&mut scenario);
-    add(&mut id, 0, new(ts::new_object(&mut scenario)));
-    assert!(exists_<u64>(&mut id, 0), 0);
-    ts::end(scenario);
-    object::delete(id);
-}
+    // transfer an object field from one "parent" to another
+    #[test]
+    fun transfer_object() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let id1 = ts::new_object(&mut scenario);
+        let id2 = ts::new_object(&mut scenario);
+        add(&mut id1, 0, new(ts::new_object(&mut scenario)));
+        assert!(exists_<u64>(&mut id1, 0), 0);
+        assert!(!exists_<u64>(&mut id2, 0), 0);
+        bump(borrow_mut(&mut id1, 0));
+        let c: Counter = remove(&mut id1, 0);
+        add(&mut id2, 0, c);
+        assert!(!exists_<u64>(&mut id1, 0), 0);
+        assert!(exists_<u64>(&mut id2, 0), 0);
+        bump(borrow_mut(&mut id2, 0));
+        assert!(count(borrow(&id2, 0)) == 2, 0);
+        ts::end(scenario);
+        object::delete(id1);
+        object::delete(id2);
+    }
 
-// transfer an object field from one "parent" to another
-#[test]
-fun transfer_object() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let id1 = ts::new_object(&mut scenario);
-    let id2 = ts::new_object(&mut scenario);
-    add(&mut id1, 0, new(ts::new_object(&mut scenario)));
-    assert!(exists_<u64>(&mut id1, 0), 0);
-    assert!(!exists_<u64>(&mut id2, 0), 0);
-    bump(borrow_mut(&mut id1, 0));
-    let c: Counter = remove(&mut id1, 0);
-    add(&mut id2, 0, c);
-    assert!(!exists_<u64>(&mut id1, 0), 0);
-    assert!(exists_<u64>(&mut id2, 0), 0);
-    bump(borrow_mut(&mut id2, 0));
-    assert!(count(borrow(&id2, 0)) == 2, 0);
-    ts::end(scenario);
-    object::delete(id1);
-    object::delete(id2);
-}
+    fun new(id: UID): Counter {
+        Counter { id, count: 0 }
+    }
 
-fun new(id: UID): Counter {
-    Counter { id, count: 0 }
-}
+    fun count(counter: &Counter): u64 {
+        counter.count
+    }
 
-fun count(counter: &Counter): u64 {
-    counter.count
-}
+    fun bump(counter: &mut Counter): &mut Counter {
+        counter.count = counter.count + 1;
+        counter
+    }
 
-fun bump(counter: &mut Counter): &mut Counter {
-    counter.count = counter.count + 1;
-    counter
-}
-
-fun destroy(counter: Counter): u64 {
-    let Counter { id, count } = counter;
-    object::delete(id);
-    count
-}
-
+    fun destroy(counter: Counter): u64 {
+        let Counter { id, count } = counter;
+        object::delete(id);
+        count
+    }
 }

--- a/crates/sui-framework/tests/linked_table_tests.move
+++ b/crates/sui-framework/tests/linked_table_tests.move
@@ -3,370 +3,367 @@
 
 #[test_only]
 module sui::linked_table_tests {
-
-use std::option;
-use std::vector;
-use sui::linked_table::{
-    Self,
-    LinkedTable,
-    front,
-    back,
-    push_front,
-    push_back,
-    borrow,
-    borrow_mut,
-    prev,
-    next,
-    remove,
-    pop_front,
-    pop_back,
-    contains,
-    length,
-    is_empty,
-    destroy_empty,
-    drop,
-};
-use sui::test_scenario as ts;
-use sui::tx_context::TxContext;
-
-#[test]
-fun simple_all_functions() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new(ts::ctx(&mut scenario));
-    check_ordering(&table, &vector[]);
-    // add fields
-    push_back(&mut table, b"hello", 0);
-    check_ordering(&table, &vector[b"hello"]);
-    push_back(&mut table, b"goodbye", 1);
-    // check they exist
-    assert!(contains(&table, b"hello"), 0);
-    assert!(contains(&table, b"goodbye"), 0);
-    assert!(!is_empty(&table), 0);
-    // check the values
-    assert!(*borrow(&table, b"hello") == 0, 0);
-    assert!(*borrow(&table, b"goodbye") == 1, 0);
-    // mutate them
-    *borrow_mut(&mut table, b"hello") = *borrow(&table, b"hello") * 2;
-    *borrow_mut(&mut table, b"goodbye") = *borrow(&table, b"goodbye") * 2;
-    // check the new value
-    assert!(*borrow(&table, b"hello") == 0, 0);
-    assert!(*borrow(&table, b"goodbye") == 2, 0);
-    // check the ordering
-    check_ordering(&table, &vector[b"hello", b"goodbye"]);
-    // add to the front
-    push_front(&mut table, b"!!!", 2);
-    check_ordering(&table, &vector[b"!!!", b"hello", b"goodbye"]);
-    // add to the back
-    push_back(&mut table, b"?", 3);
-    check_ordering(&table, &vector[b"!!!", b"hello", b"goodbye", b"?"]);
-    // pop front
-    let (front_k, front_v) = pop_front(&mut table);
-    assert!(front_k == b"!!!", 0);
-    assert!(front_v == 2, 0);
-    check_ordering(&table, &vector[b"hello", b"goodbye", b"?"]);
-    // remove middle
-    assert!(remove(&mut table, b"goodbye") == 2, 0);
-    check_ordering(&table, &vector[b"hello", b"?"]);
-    // pop back
-    let (back_k, back_v) = pop_back(&mut table);
-    assert!(back_k == b"?", 0);
-    assert!(back_v == 3, 0);
-    check_ordering(&table, &vector[b"hello"]);
-    // remove the value and check it
-    assert!(remove(&mut table, b"hello") == 0, 0);
-    check_ordering(&table, &vector[]);
-    // verify that they are not there
-    assert!(!contains(&table, b"!!!"), 0);
-    assert!(!contains(&table, b"goodbye"), 0);
-    assert!(!contains(&table, b"hello"), 0);
-    assert!(!contains(&table, b"?"), 0);
-    assert!(is_empty(&table), 0);
-    ts::end(scenario);
-    destroy_empty(table);
-}
-
-#[test]
-fun front_back_empty() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-    assert!(option::is_none(front(&table)), 0);
-    assert!(option::is_none(back(&table)), 0);
-    ts::end(scenario);
-    drop(table)
-}
-
-#[test]
-fun push_front_singleton() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new(ts::ctx(&mut scenario));
-    check_ordering(&table, &vector[]);
-    push_front(&mut table, b"hello", 0);
-    assert!(contains(&table, b"hello"), 0);
-    check_ordering(&table, &vector[b"hello"]);
-    ts::end(scenario);
-    drop(table)
-}
-
-#[test]
-fun push_back_singleton() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new(ts::ctx(&mut scenario));
-    check_ordering(&table, &vector[]);
-    push_back(&mut table, b"hello", 0);
-    assert!(contains(&table, b"hello"), 0);
-    check_ordering(&table, &vector[b"hello"]);
-    ts::end(scenario);
-    drop(table)
-}
-
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun push_front_duplicate() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new(ts::ctx(&mut scenario));
-    push_front(&mut table, b"hello", 0);
-    push_front(&mut table, b"hello", 0);
-    abort 42
-}
-
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun push_back_duplicate() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new(ts::ctx(&mut scenario));
-    push_back(&mut table, b"hello", 0);
-    push_back(&mut table, b"hello", 0);
-    abort 42
-}
-
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun push_mixed_duplicate() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new(ts::ctx(&mut scenario));
-    push_back(&mut table, b"hello", 0);
-    push_front(&mut table, b"hello", 0);
-    abort 42
-}
-
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-    borrow(&table, 0);
-    abort 42
-}
-
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_mut_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-    borrow_mut(&mut table, 0);
-    abort 42
-}
-
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun remove_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-    remove(&mut table, 0);
-    abort 42
-}
-
-#[test]
-#[expected_failure(abort_code = linked_table::ETableIsEmpty)]
-fun pop_front_empty() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-    pop_front(&mut table);
-    abort 42
-}
-
-#[test]
-#[expected_failure(abort_code = linked_table::ETableIsEmpty)]
-fun pop_back_empty() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-    pop_back(&mut table);
-    abort 42
-}
-
-#[test]
-#[expected_failure(abort_code = linked_table::ETableNotEmpty)]
-fun destroy_non_empty() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new(ts::ctx(&mut scenario));
-    push_back(&mut table, 0, 0);
-    destroy_empty(table);
-    ts::end(scenario);
-}
-
-#[test]
-fun sanity_check_contains() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new(ts::ctx(&mut scenario));
-    assert!(!contains(&mut table, 0), 0);
-    push_back(&mut table, 0, 0);
-    assert!(contains<u64, u64>(&mut table, 0), 0);
-    assert!(!contains<u64, u64>(&mut table, 1), 0);
-    ts::end(scenario);
-    drop(table);
-}
-
-#[test]
-fun sanity_check_drop() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new(ts::ctx(&mut scenario));
-    push_back(&mut table, 0, 0);
-    assert!(length(&table) == 1, 0);
-    ts::end(scenario);
-    drop(table);
-}
-
-#[test]
-fun sanity_check_size() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = linked_table::new(ts::ctx(&mut scenario));
-    assert!(is_empty(&table), 0);
-    assert!(length(&table) == 0, 0);
-    push_back(&mut table, 0, 0);
-    assert!(!is_empty(&table), 0);
-    assert!(length(&table) == 1, 0);
-    push_back(&mut table, 1, 0);
-    assert!(!is_empty(&table), 0);
-    assert!(length(&table) == 2, 0);
-    ts::end(scenario);
-    drop(table);
-}
-
-#[test]
-fun test_all_orderings() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let ctx = ts::ctx(&mut scenario);
-    let keys = vector[b"a", b"b", b"c"];
-    let values = vector[3, 2, 1];
-    let all_bools = vector[
-        vector[true, true, true],
-        vector[true, false, true],
-        vector[true, true, false],
-        vector[true, false, false],
-        vector[false, false, true],
-        vector[false, false, false],
-    ];
-    let i = 0;
-    let j = 0;
-    let n = vector::length(&all_bools);
-    // all_bools indicate possible orderings of accessing the front vs the back of the
-    // table
-    // test all orderings of building up and tearing down the table, while mimicing
-    // the ordering in a vector, and checking the keys have the same order in the table
-    while (i < n) {
-        let pushes = vector::borrow(&all_bools, i);
-        while (j < n) {
-            let pops = vector::borrow(&all_bools, j);
-            build_up_and_tear_down(&keys, &values, pushes, pops, ctx);
-            j = j + 1;
-        };
-        i = i + 1;
+    use std::option;
+    use std::vector;
+    use sui::linked_table::{
+        Self,
+        LinkedTable,
+        front,
+        back,
+        push_front,
+        push_back,
+        borrow,
+        borrow_mut,
+        prev,
+        next,
+        remove,
+        pop_front,
+        pop_back,
+        contains,
+        length,
+        is_empty,
+        destroy_empty,
+        drop,
     };
-    ts::end(scenario);
-}
+    use sui::test_scenario as ts;
+    use sui::tx_context::TxContext;
 
-fun build_up_and_tear_down<K: copy + drop + store, V: copy + drop + store>(
-    keys: &vector<K>,
-    values: &vector<V>,
-    // true for front, false for back
-    pushes: &vector<bool>,
-    // true for front, false for back
-    pops: &vector<bool>,
-    ctx: &mut TxContext,
-) {
-    let table = linked_table::new(ctx);
-    let n = vector::length(keys);
-    assert!(vector::length(values) == n, 0);
-    assert!(vector::length(pushes) == n, 0);
-    assert!(vector::length(pops) == n, 0);
-
-    let i = 0;
-    let order = vector[];
-    while (i < n) {
-        let k = *vector::borrow(keys, i);
-        let v = *vector::borrow(values, i);
-        if (*vector::borrow(pushes, i)) {
-            push_front(&mut table, k, v);
-            vector::insert(&mut order, k, 0);
-        } else {
-            push_front(&mut table, k, v);
-            vector::push_back(&mut order, k);
-        };
-        i = i + 1;
-    };
-
-    check_ordering(&table, &order);
-    let i = 0;
-    while (i < n) {
-        let (table_k, order_k) = if (*vector::borrow(pops, i)) {
-            let (table_k, _) = pop_front(&mut table);
-            (table_k, vector::remove(&mut order, 0))
-        } else {
-            let (table_k, _) = pop_back(&mut table);
-            (table_k, vector::pop_back(&mut order))
-        };
-        assert!(table_k == order_k, 0);
-        check_ordering(&table, &order);
-        i = i + 1;
-    };
-    destroy_empty(table)
-}
-
-fun check_ordering<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, keys: &vector<K>) {
-    let n = length(table);
-    assert!(n == vector::length(keys), 0);
-    if (n == 0) {
-        assert!(option::is_none(front(table)), 0);
-        assert!(option::is_none(back(table)), 0);
-        return
-    };
-
-    let i = 0;
-    while (i < n) {
-        let cur = *vector::borrow(keys, i);
-        if (i == 0) {
-            assert!(option::borrow(front(table)) == &cur, 0);
-            assert!(option::is_none(prev(table, cur)), 0);
-        } else {
-            assert!(option::borrow(prev(table, cur)) == vector::borrow(keys, i - 1), 0);
-        };
-        if (i + 1 == n) {
-            assert!(option::borrow(back(table)) == &cur, 0);
-            assert!(option::is_none(next(table, cur)), 0);
-        } else {
-            assert!(option::borrow(next(table, cur)) == vector::borrow(keys, i + 1), 0);
-        };
-
-        i = i + 1;
+    #[test]
+    fun simple_all_functions() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new(ts::ctx(&mut scenario));
+        check_ordering(&table, &vector[]);
+        // add fields
+        push_back(&mut table, b"hello", 0);
+        check_ordering(&table, &vector[b"hello"]);
+        push_back(&mut table, b"goodbye", 1);
+        // check they exist
+        assert!(contains(&table, b"hello"), 0);
+        assert!(contains(&table, b"goodbye"), 0);
+        assert!(!is_empty(&table), 0);
+        // check the values
+        assert!(*borrow(&table, b"hello") == 0, 0);
+        assert!(*borrow(&table, b"goodbye") == 1, 0);
+        // mutate them
+        *borrow_mut(&mut table, b"hello") = *borrow(&table, b"hello") * 2;
+        *borrow_mut(&mut table, b"goodbye") = *borrow(&table, b"goodbye") * 2;
+        // check the new value
+        assert!(*borrow(&table, b"hello") == 0, 0);
+        assert!(*borrow(&table, b"goodbye") == 2, 0);
+        // check the ordering
+        check_ordering(&table, &vector[b"hello", b"goodbye"]);
+        // add to the front
+        push_front(&mut table, b"!!!", 2);
+        check_ordering(&table, &vector[b"!!!", b"hello", b"goodbye"]);
+        // add to the back
+        push_back(&mut table, b"?", 3);
+        check_ordering(&table, &vector[b"!!!", b"hello", b"goodbye", b"?"]);
+        // pop front
+        let (front_k, front_v) = pop_front(&mut table);
+        assert!(front_k == b"!!!", 0);
+        assert!(front_v == 2, 0);
+        check_ordering(&table, &vector[b"hello", b"goodbye", b"?"]);
+        // remove middle
+        assert!(remove(&mut table, b"goodbye") == 2, 0);
+        check_ordering(&table, &vector[b"hello", b"?"]);
+        // pop back
+        let (back_k, back_v) = pop_back(&mut table);
+        assert!(back_k == b"?", 0);
+        assert!(back_v == 3, 0);
+        check_ordering(&table, &vector[b"hello"]);
+        // remove the value and check it
+        assert!(remove(&mut table, b"hello") == 0, 0);
+        check_ordering(&table, &vector[]);
+        // verify that they are not there
+        assert!(!contains(&table, b"!!!"), 0);
+        assert!(!contains(&table, b"goodbye"), 0);
+        assert!(!contains(&table, b"hello"), 0);
+        assert!(!contains(&table, b"?"), 0);
+        assert!(is_empty(&table), 0);
+        ts::end(scenario);
+        destroy_empty(table);
     }
-}
 
+    #[test]
+    fun front_back_empty() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        assert!(option::is_none(front(&table)), 0);
+        assert!(option::is_none(back(&table)), 0);
+        ts::end(scenario);
+        drop(table)
+    }
 
+    #[test]
+    fun push_front_singleton() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new(ts::ctx(&mut scenario));
+        check_ordering(&table, &vector[]);
+        push_front(&mut table, b"hello", 0);
+        assert!(contains(&table, b"hello"), 0);
+        check_ordering(&table, &vector[b"hello"]);
+        ts::end(scenario);
+        drop(table)
+    }
+
+    #[test]
+    fun push_back_singleton() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new(ts::ctx(&mut scenario));
+        check_ordering(&table, &vector[]);
+        push_back(&mut table, b"hello", 0);
+        assert!(contains(&table, b"hello"), 0);
+        check_ordering(&table, &vector[b"hello"]);
+        ts::end(scenario);
+        drop(table)
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun push_front_duplicate() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new(ts::ctx(&mut scenario));
+        push_front(&mut table, b"hello", 0);
+        push_front(&mut table, b"hello", 0);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun push_back_duplicate() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new(ts::ctx(&mut scenario));
+        push_back(&mut table, b"hello", 0);
+        push_back(&mut table, b"hello", 0);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun push_mixed_duplicate() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new(ts::ctx(&mut scenario));
+        push_back(&mut table, b"hello", 0);
+        push_front(&mut table, b"hello", 0);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        borrow(&table, 0);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_mut_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        borrow_mut(&mut table, 0);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun remove_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        remove(&mut table, 0);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = linked_table::ETableIsEmpty)]
+    fun pop_front_empty() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        pop_front(&mut table);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = linked_table::ETableIsEmpty)]
+    fun pop_back_empty() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        pop_back(&mut table);
+        abort 42
+    }
+
+    #[test]
+    #[expected_failure(abort_code = linked_table::ETableNotEmpty)]
+    fun destroy_non_empty() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new(ts::ctx(&mut scenario));
+        push_back(&mut table, 0, 0);
+        destroy_empty(table);
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun sanity_check_contains() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new(ts::ctx(&mut scenario));
+        assert!(!contains(&mut table, 0), 0);
+        push_back(&mut table, 0, 0);
+        assert!(contains<u64, u64>(&mut table, 0), 0);
+        assert!(!contains<u64, u64>(&mut table, 1), 0);
+        ts::end(scenario);
+        drop(table);
+    }
+
+    #[test]
+    fun sanity_check_drop() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new(ts::ctx(&mut scenario));
+        push_back(&mut table, 0, 0);
+        assert!(length(&table) == 1, 0);
+        ts::end(scenario);
+        drop(table);
+    }
+
+    #[test]
+    fun sanity_check_size() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = linked_table::new(ts::ctx(&mut scenario));
+        assert!(is_empty(&table), 0);
+        assert!(length(&table) == 0, 0);
+        push_back(&mut table, 0, 0);
+        assert!(!is_empty(&table), 0);
+        assert!(length(&table) == 1, 0);
+        push_back(&mut table, 1, 0);
+        assert!(!is_empty(&table), 0);
+        assert!(length(&table) == 2, 0);
+        ts::end(scenario);
+        drop(table);
+    }
+
+    #[test]
+    fun test_all_orderings() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let ctx = ts::ctx(&mut scenario);
+        let keys = vector[b"a", b"b", b"c"];
+        let values = vector[3, 2, 1];
+        let all_bools = vector[
+            vector[true, true, true],
+            vector[true, false, true],
+            vector[true, true, false],
+            vector[true, false, false],
+            vector[false, false, true],
+            vector[false, false, false],
+        ];
+        let i = 0;
+        let j = 0;
+        let n = vector::length(&all_bools);
+        // all_bools indicate possible orderings of accessing the front vs the back of the
+        // table
+        // test all orderings of building up and tearing down the table, while mimicing
+        // the ordering in a vector, and checking the keys have the same order in the table
+        while (i < n) {
+            let pushes = vector::borrow(&all_bools, i);
+            while (j < n) {
+                let pops = vector::borrow(&all_bools, j);
+                build_up_and_tear_down(&keys, &values, pushes, pops, ctx);
+                j = j + 1;
+            };
+            i = i + 1;
+        };
+        ts::end(scenario);
+    }
+
+    fun build_up_and_tear_down<K: copy + drop + store, V: copy + drop + store>(
+        keys: &vector<K>,
+        values: &vector<V>,
+        // true for front, false for back
+        pushes: &vector<bool>,
+        // true for front, false for back
+        pops: &vector<bool>,
+        ctx: &mut TxContext,
+    ) {
+        let table = linked_table::new(ctx);
+        let n = vector::length(keys);
+        assert!(vector::length(values) == n, 0);
+        assert!(vector::length(pushes) == n, 0);
+        assert!(vector::length(pops) == n, 0);
+
+        let i = 0;
+        let order = vector[];
+        while (i < n) {
+            let k = *vector::borrow(keys, i);
+            let v = *vector::borrow(values, i);
+            if (*vector::borrow(pushes, i)) {
+                push_front(&mut table, k, v);
+                vector::insert(&mut order, k, 0);
+            } else {
+                push_front(&mut table, k, v);
+                vector::push_back(&mut order, k);
+            };
+            i = i + 1;
+        };
+
+        check_ordering(&table, &order);
+        let i = 0;
+        while (i < n) {
+            let (table_k, order_k) = if (*vector::borrow(pops, i)) {
+                let (table_k, _) = pop_front(&mut table);
+                (table_k, vector::remove(&mut order, 0))
+            } else {
+                let (table_k, _) = pop_back(&mut table);
+                (table_k, vector::pop_back(&mut order))
+            };
+            assert!(table_k == order_k, 0);
+            check_ordering(&table, &order);
+            i = i + 1;
+        };
+        destroy_empty(table)
+    }
+
+    fun check_ordering<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, keys: &vector<K>) {
+        let n = length(table);
+        assert!(n == vector::length(keys), 0);
+        if (n == 0) {
+            assert!(option::is_none(front(table)), 0);
+            assert!(option::is_none(back(table)), 0);
+            return
+        };
+
+        let i = 0;
+        while (i < n) {
+            let cur = *vector::borrow(keys, i);
+            if (i == 0) {
+                assert!(option::borrow(front(table)) == &cur, 0);
+                assert!(option::is_none(prev(table, cur)), 0);
+            } else {
+                assert!(option::borrow(prev(table, cur)) == vector::borrow(keys, i - 1), 0);
+            };
+            if (i + 1 == n) {
+                assert!(option::borrow(back(table)) == &cur, 0);
+                assert!(option::is_none(next(table, cur)), 0);
+            } else {
+                assert!(option::borrow(next(table, cur)) == vector::borrow(keys, i + 1), 0);
+            };
+
+            i = i + 1;
+        }
+    }
 }

--- a/crates/sui-framework/tests/object_bag_tests.move
+++ b/crates/sui-framework/tests/object_bag_tests.move
@@ -3,218 +3,216 @@
 
 #[test_only]
 module sui::object_bag_tests {
+    use std::option;
+    use sui::object_bag::{
+        Self,
+        add,
+        contains,
+        contains_with_type,
+        borrow,
+        borrow_mut,
+        remove,
+        value_id,
+    };
+    use sui::object::{Self, UID};
+    use sui::test_scenario as ts;
 
-use std::option;
-use sui::object_bag::{
-    Self,
-    add,
-    contains,
-    contains_with_type,
-    borrow,
-    borrow_mut,
-    remove,
-    value_id,
-};
-use sui::object::{Self, UID};
-use sui::test_scenario as ts;
+    struct Counter has key, store {
+        id: UID,
+        count: u64,
+    }
 
-struct Counter has key, store {
-    id: UID,
-    count: u64,
-}
-
-struct Fake has key, store {
-    id: UID,
-}
+    struct Fake has key, store {
+        id: UID,
+    }
 
 
-#[test]
-fun simple_all_functions() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = object_bag::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    let id1 = object::uid_to_inner(&uid1);
-    let uid2 = ts::new_object(&mut scenario);
-    let id2 = object::uid_to_inner(&uid2);
-    // add fields
-    add(&mut bag, b"hello", new(uid1));
-    add(&mut bag, 1, new(uid2));
-    // check they exist
-    assert!(contains(&bag, b"hello"), 0);
-    assert!(contains(&bag, 1), 0);
-    assert!(contains_with_type<vector<u8>, Counter>(&bag, b"hello"), 0);
-    assert!(contains_with_type<u64, Counter>(&bag, 1), 0);
-    // check the IDs
-    assert!(option::borrow(&value_id(&bag, b"hello")) == &id1, 0);
-    assert!(option::borrow(&value_id(&bag, 1)) == &id2, 0);
-    // check the values
-    assert!(count(borrow(&bag, b"hello")) == 0, 0);
-    assert!(count(borrow(&bag, 1)) == 0, 0);
-    // mutate them
-    bump(borrow_mut(&mut bag, b"hello"));
-    bump(bump(borrow_mut(&mut bag, 1)));
-    // check the new value
-    assert!(count(borrow(&bag, b"hello")) == 1, 0);
-    assert!(count(borrow(&bag, 1)) == 2, 0);
-    // remove the value and check it
-    assert!(destroy(remove(&mut bag, b"hello")) == 1, 0);
-    assert!(destroy(remove(&mut bag, 1)) == 2, 0);
-    // verify that they are not there
-    assert!(!contains(&bag, b"hello"), 0);
-    assert!(!contains(&bag, 1), 0);
-    ts::end(scenario);
-    object_bag::destroy_empty(bag);
-}
+    #[test]
+    fun simple_all_functions() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = object_bag::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        let id1 = object::uid_to_inner(&uid1);
+        let uid2 = ts::new_object(&mut scenario);
+        let id2 = object::uid_to_inner(&uid2);
+        // add fields
+        add(&mut bag, b"hello", new(uid1));
+        add(&mut bag, 1, new(uid2));
+        // check they exist
+        assert!(contains(&bag, b"hello"), 0);
+        assert!(contains(&bag, 1), 0);
+        assert!(contains_with_type<vector<u8>, Counter>(&bag, b"hello"), 0);
+        assert!(contains_with_type<u64, Counter>(&bag, 1), 0);
+        // check the IDs
+        assert!(option::borrow(&value_id(&bag, b"hello")) == &id1, 0);
+        assert!(option::borrow(&value_id(&bag, 1)) == &id2, 0);
+        // check the values
+        assert!(count(borrow(&bag, b"hello")) == 0, 0);
+        assert!(count(borrow(&bag, 1)) == 0, 0);
+        // mutate them
+        bump(borrow_mut(&mut bag, b"hello"));
+        bump(bump(borrow_mut(&mut bag, 1)));
+        // check the new value
+        assert!(count(borrow(&bag, b"hello")) == 1, 0);
+        assert!(count(borrow(&bag, 1)) == 2, 0);
+        // remove the value and check it
+        assert!(destroy(remove(&mut bag, b"hello")) == 1, 0);
+        assert!(destroy(remove(&mut bag, 1)) == 2, 0);
+        // verify that they are not there
+        assert!(!contains(&bag, b"hello"), 0);
+        assert!(!contains(&bag, 1), 0);
+        ts::end(scenario);
+        object_bag::destroy_empty(bag);
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun add_duplicate() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = object_bag::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    let uid2 = ts::new_object(&mut scenario);
-    add(&mut bag, b"hello", new(uid1));
-    add(&mut bag, b"hello", new(uid2));
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun add_duplicate() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = object_bag::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        let uid2 = ts::new_object(&mut scenario);
+        add(&mut bag, b"hello", new(uid1));
+        add(&mut bag, b"hello", new(uid2));
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = object_bag::new(ts::ctx(&mut scenario));
-    borrow<u64, Counter>(&bag, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = object_bag::new(ts::ctx(&mut scenario));
+        borrow<u64, Counter>(&bag, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_mut_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = object_bag::new(ts::ctx(&mut scenario));
-    borrow_mut<u64, Counter>(&mut bag, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_mut_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = object_bag::new(ts::ctx(&mut scenario));
+        borrow_mut<u64, Counter>(&mut bag, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun remove_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = object_bag::new(ts::ctx(&mut scenario));
-    destroy(remove<u64, Counter>(&mut bag, 0));
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun remove_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = object_bag::new(ts::ctx(&mut scenario));
+        destroy(remove<u64, Counter>(&mut bag, 0));
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::object_bag::EBagNotEmpty)]
-fun destroy_non_empty() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = object_bag::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    add(&mut bag, 0, new(uid1));
-    object_bag::destroy_empty(bag);
-    ts::end(scenario);
-}
+    #[test]
+    #[expected_failure(abort_code = sui::object_bag::EBagNotEmpty)]
+    fun destroy_non_empty() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = object_bag::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        add(&mut bag, 0, new(uid1));
+        object_bag::destroy_empty(bag);
+        ts::end(scenario);
+    }
 
-#[test]
-fun sanity_check_contains() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = object_bag::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    assert!(!contains(&mut bag, 0), 0);
-    add(&mut bag, 0, new(uid1));
-    assert!(contains(&mut bag, 0), 0);
-    assert!(!contains(&mut bag, 1), 0);
-    ts::end(scenario);
-    destroy(remove(&mut bag, 0));
-    object_bag::destroy_empty(bag)
-}
+    #[test]
+    fun sanity_check_contains() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = object_bag::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        assert!(!contains(&mut bag, 0), 0);
+        add(&mut bag, 0, new(uid1));
+        assert!(contains(&mut bag, 0), 0);
+        assert!(!contains(&mut bag, 1), 0);
+        ts::end(scenario);
+        destroy(remove(&mut bag, 0));
+        object_bag::destroy_empty(bag)
+    }
 
-#[test]
-fun sanity_check_contains_with_type() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = object_bag::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    assert!(!contains_with_type<u64, Counter>(&mut bag, 0), 0);
-    assert!(!contains_with_type<u64, Fake>(&mut bag, 0), 0);
-    add(&mut bag, 0, new(uid1));
-    assert!(contains_with_type<u64, Counter>(&bag, 0), 0);
-    assert!(!contains_with_type<u8, Counter>(&bag, 0), 0);
-    assert!(!contains_with_type<u8, Fake>(&bag, 0), 0);
-    ts::end(scenario);
-    destroy(remove(&mut bag, 0));
-    object_bag::destroy_empty(bag)
-}
+    #[test]
+    fun sanity_check_contains_with_type() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = object_bag::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        assert!(!contains_with_type<u64, Counter>(&mut bag, 0), 0);
+        assert!(!contains_with_type<u64, Fake>(&mut bag, 0), 0);
+        add(&mut bag, 0, new(uid1));
+        assert!(contains_with_type<u64, Counter>(&bag, 0), 0);
+        assert!(!contains_with_type<u8, Counter>(&bag, 0), 0);
+        assert!(!contains_with_type<u8, Fake>(&bag, 0), 0);
+        ts::end(scenario);
+        destroy(remove(&mut bag, 0));
+        object_bag::destroy_empty(bag)
+    }
 
-#[test]
-fun sanity_check_size() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag = object_bag::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    let uid2 = ts::new_object(&mut scenario);
-    assert!(object_bag::is_empty(&bag), 0);
-    assert!(object_bag::length(&bag) == 0, 0);
-    add(&mut bag, 0, new(uid1));
-    assert!(!object_bag::is_empty(&bag), 0);
-    assert!(object_bag::length(&bag) == 1, 0);
-    add(&mut bag, 1, new(uid2));
-    assert!(!object_bag::is_empty(&bag), 0);
-    assert!(object_bag::length(&bag) == 2, 0);
-    ts::end(scenario);
-    destroy(remove(&mut bag, 0));
-    destroy(remove(&mut bag, 1));
-    object_bag::destroy_empty(bag);
-}
+    #[test]
+    fun sanity_check_size() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag = object_bag::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        let uid2 = ts::new_object(&mut scenario);
+        assert!(object_bag::is_empty(&bag), 0);
+        assert!(object_bag::length(&bag) == 0, 0);
+        add(&mut bag, 0, new(uid1));
+        assert!(!object_bag::is_empty(&bag), 0);
+        assert!(object_bag::length(&bag) == 1, 0);
+        add(&mut bag, 1, new(uid2));
+        assert!(!object_bag::is_empty(&bag), 0);
+        assert!(object_bag::length(&bag) == 2, 0);
+        ts::end(scenario);
+        destroy(remove(&mut bag, 0));
+        destroy(remove(&mut bag, 1));
+        object_bag::destroy_empty(bag);
+    }
 
-// transfer an object field from one "parent" to another
-#[test]
-fun transfer_object() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let bag1 = object_bag::new(ts::ctx(&mut scenario));
-    let bag2 = object_bag::new(ts::ctx(&mut scenario));
-    add(&mut bag1, 0, new(ts::new_object(&mut scenario)));
-    assert!(contains(&bag1, 0), 0);
-    assert!(!contains(&bag2, 0), 0);
-    bump(borrow_mut(&mut bag1, 0));
-    let c = remove<u64, Counter>(&mut bag1, 0);
-    add(&mut bag2, 0, c);
-    assert!(!contains(&bag1, 0), 0);
-    assert!(contains(&bag2, 0), 0);
-    bump(borrow_mut(&mut bag2, 0));
-    assert!(count(borrow(&bag2, 0)) == 2, 0);
-    ts::end(scenario);
-    destroy(remove(&mut bag2, 0));
-    object_bag::destroy_empty(bag1);
-    object_bag::destroy_empty(bag2);
-}
+    // transfer an object field from one "parent" to another
+    #[test]
+    fun transfer_object() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let bag1 = object_bag::new(ts::ctx(&mut scenario));
+        let bag2 = object_bag::new(ts::ctx(&mut scenario));
+        add(&mut bag1, 0, new(ts::new_object(&mut scenario)));
+        assert!(contains(&bag1, 0), 0);
+        assert!(!contains(&bag2, 0), 0);
+        bump(borrow_mut(&mut bag1, 0));
+        let c = remove<u64, Counter>(&mut bag1, 0);
+        add(&mut bag2, 0, c);
+        assert!(!contains(&bag1, 0), 0);
+        assert!(contains(&bag2, 0), 0);
+        bump(borrow_mut(&mut bag2, 0));
+        assert!(count(borrow(&bag2, 0)) == 2, 0);
+        ts::end(scenario);
+        destroy(remove(&mut bag2, 0));
+        object_bag::destroy_empty(bag1);
+        object_bag::destroy_empty(bag2);
+    }
 
-fun new(id: UID): Counter {
-    Counter { id, count: 0 }
-}
+    fun new(id: UID): Counter {
+        Counter { id, count: 0 }
+    }
 
-fun count(counter: &Counter): u64 {
-    counter.count
-}
+    fun count(counter: &Counter): u64 {
+        counter.count
+    }
 
-fun bump(counter: &mut Counter): &mut Counter {
-    counter.count = counter.count + 1;
-    counter
-}
+    fun bump(counter: &mut Counter): &mut Counter {
+        counter.count = counter.count + 1;
+        counter
+    }
 
-fun destroy(counter: Counter): u64 {
-    let Counter { id, count } = counter;
-    object::delete(id);
-    count
-}
-
+    fun destroy(counter: Counter): u64 {
+        let Counter { id, count } = counter;
+        object::delete(id);
+        count
+    }
 }

--- a/crates/sui-framework/tests/object_table_tests.move
+++ b/crates/sui-framework/tests/object_table_tests.move
@@ -3,185 +3,183 @@
 
 #[test_only]
 module sui::object_table_tests {
+    use std::option;
+    use sui::object_table::{Self, add, contains, borrow, borrow_mut, remove, value_id};
+    use sui::object::{Self, UID};
+    use sui::test_scenario as ts;
 
-use std::option;
-use sui::object_table::{Self, add, contains, borrow, borrow_mut, remove, value_id};
-use sui::object::{Self, UID};
-use sui::test_scenario as ts;
+    struct Counter has key, store {
+        id: UID,
+        count: u64,
+    }
 
-struct Counter has key, store {
-    id: UID,
-    count: u64,
-}
+    #[test]
+    fun simple_all_functions() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = object_table::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        let id1 = object::uid_to_inner(&uid1);
+        let uid2 = ts::new_object(&mut scenario);
+        let id2 = object::uid_to_inner(&uid2);
+        // add fields
+        add(&mut table, b"hello", new(uid1));
+        add(&mut table, b"goodbye", new(uid2));
+        // check they exist
+        assert!(contains(&table, b"hello"), 0);
+        assert!(contains(&table, b"goodbye"), 0);
+        // check the IDs
+        assert!(option::borrow(&value_id(&table, b"hello")) == &id1, 0);
+        assert!(option::borrow(&value_id(&table, b"goodbye")) == &id2, 0);
+        // check the values
+        assert!(count(borrow(&table, b"hello")) == 0, 0);
+        assert!(count(borrow(&table, b"goodbye")) == 0, 0);
+        // mutate them
+        bump(borrow_mut(&mut table, b"hello"));
+        bump(bump(borrow_mut(&mut table, b"goodbye")));
+        // check the new value
+        assert!(count(borrow(&table, b"hello")) == 1, 0);
+        assert!(count(borrow(&table, b"goodbye")) == 2, 0);
+        // remove the value and check it
+        assert!(destroy(remove(&mut table, b"hello")) == 1, 0);
+        assert!(destroy(remove(&mut table, b"goodbye")) == 2, 0);
+        // verify that they are not there
+        assert!(!contains(&table, b"hello"), 0);
+        assert!(!contains(&table, b"goodbye"), 0);
+        ts::end(scenario);
+        object_table::destroy_empty(table);
+    }
 
-#[test]
-fun simple_all_functions() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = object_table::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    let id1 = object::uid_to_inner(&uid1);
-    let uid2 = ts::new_object(&mut scenario);
-    let id2 = object::uid_to_inner(&uid2);
-    // add fields
-    add(&mut table, b"hello", new(uid1));
-    add(&mut table, b"goodbye", new(uid2));
-    // check they exist
-    assert!(contains(&table, b"hello"), 0);
-    assert!(contains(&table, b"goodbye"), 0);
-    // check the IDs
-    assert!(option::borrow(&value_id(&table, b"hello")) == &id1, 0);
-    assert!(option::borrow(&value_id(&table, b"goodbye")) == &id2, 0);
-    // check the values
-    assert!(count(borrow(&table, b"hello")) == 0, 0);
-    assert!(count(borrow(&table, b"goodbye")) == 0, 0);
-    // mutate them
-    bump(borrow_mut(&mut table, b"hello"));
-    bump(bump(borrow_mut(&mut table, b"goodbye")));
-    // check the new value
-    assert!(count(borrow(&table, b"hello")) == 1, 0);
-    assert!(count(borrow(&table, b"goodbye")) == 2, 0);
-    // remove the value and check it
-    assert!(destroy(remove(&mut table, b"hello")) == 1, 0);
-    assert!(destroy(remove(&mut table, b"goodbye")) == 2, 0);
-    // verify that they are not there
-    assert!(!contains(&table, b"hello"), 0);
-    assert!(!contains(&table, b"goodbye"), 0);
-    ts::end(scenario);
-    object_table::destroy_empty(table);
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun add_duplicate() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = object_table::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        let uid2 = ts::new_object(&mut scenario);
+        add(&mut table, b"hello", new(uid1));
+        add(&mut table, b"hello", new(uid2));
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun add_duplicate() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = object_table::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    let uid2 = ts::new_object(&mut scenario);
-    add(&mut table, b"hello", new(uid1));
-    add(&mut table, b"hello", new(uid2));
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
+        borrow(&table, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
-    borrow(&table, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_mut_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
+        borrow_mut(&mut table, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_mut_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
-    borrow_mut(&mut table, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun remove_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
+        destroy(remove(&mut table, 0));
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun remove_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
-    destroy(remove(&mut table, 0));
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::object_table::ETableNotEmpty)]
+    fun destroy_non_empty() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = object_table::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        add(&mut table, 0, new(uid1));
+        object_table::destroy_empty(table);
+        ts::end(scenario);
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::object_table::ETableNotEmpty)]
-fun destroy_non_empty() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = object_table::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    add(&mut table, 0, new(uid1));
-    object_table::destroy_empty(table);
-    ts::end(scenario);
-}
+    #[test]
+    fun sanity_check_contains() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = object_table::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        assert!(!contains(&mut table, 0), 0);
+        add(&mut table, 0, new(uid1));
+        assert!(contains(&mut table, 0), 0);
+        assert!(!contains(&mut table, 1), 0);
+        ts::end(scenario);
+        destroy(remove(&mut table, 0));
+        object_table::destroy_empty(table)
+    }
 
-#[test]
-fun sanity_check_contains() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = object_table::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    assert!(!contains(&mut table, 0), 0);
-    add(&mut table, 0, new(uid1));
-    assert!(contains(&mut table, 0), 0);
-    assert!(!contains(&mut table, 1), 0);
-    ts::end(scenario);
-    destroy(remove(&mut table, 0));
-    object_table::destroy_empty(table)
-}
+    #[test]
+    fun sanity_check_size() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = object_table::new(ts::ctx(&mut scenario));
+        let uid1 = ts::new_object(&mut scenario);
+        let uid2 = ts::new_object(&mut scenario);
+        assert!(object_table::is_empty(&table), 0);
+        assert!(object_table::length(&table) == 0, 0);
+        add(&mut table, 0, new(uid1));
+        assert!(!object_table::is_empty(&table), 0);
+        assert!(object_table::length(&table) == 1, 0);
+        add(&mut table, 1, new(uid2));
+        assert!(!object_table::is_empty(&table), 0);
+        assert!(object_table::length(&table) == 2, 0);
+        ts::end(scenario);
+        destroy(remove(&mut table, 0));
+        destroy(remove(&mut table, 1));
+        object_table::destroy_empty(table);
+    }
 
-#[test]
-fun sanity_check_size() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = object_table::new(ts::ctx(&mut scenario));
-    let uid1 = ts::new_object(&mut scenario);
-    let uid2 = ts::new_object(&mut scenario);
-    assert!(object_table::is_empty(&table), 0);
-    assert!(object_table::length(&table) == 0, 0);
-    add(&mut table, 0, new(uid1));
-    assert!(!object_table::is_empty(&table), 0);
-    assert!(object_table::length(&table) == 1, 0);
-    add(&mut table, 1, new(uid2));
-    assert!(!object_table::is_empty(&table), 0);
-    assert!(object_table::length(&table) == 2, 0);
-    ts::end(scenario);
-    destroy(remove(&mut table, 0));
-    destroy(remove(&mut table, 1));
-    object_table::destroy_empty(table);
-}
+    // transfer an object field from one "parent" to another
+    #[test]
+    fun transfer_object() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table1 = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
+        let table2 = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
+        add(&mut table1, 0, new(ts::new_object(&mut scenario)));
+        assert!(contains(&table1, 0), 0);
+        assert!(!contains(&table2, 0), 0);
+        bump(borrow_mut(&mut table1, 0));
+        let c = remove(&mut table1, 0);
+        add(&mut table2, 0, c);
+        assert!(!contains(&table1, 0), 0);
+        assert!(contains(&table2, 0), 0);
+        bump(borrow_mut(&mut table2, 0));
+        assert!(count(borrow(&table2, 0)) == 2, 0);
+        ts::end(scenario);
+        destroy(remove(&mut table2, 0));
+        object_table::destroy_empty(table1);
+        object_table::destroy_empty(table2);
+    }
 
-// transfer an object field from one "parent" to another
-#[test]
-fun transfer_object() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table1 = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
-    let table2 = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
-    add(&mut table1, 0, new(ts::new_object(&mut scenario)));
-    assert!(contains(&table1, 0), 0);
-    assert!(!contains(&table2, 0), 0);
-    bump(borrow_mut(&mut table1, 0));
-    let c = remove(&mut table1, 0);
-    add(&mut table2, 0, c);
-    assert!(!contains(&table1, 0), 0);
-    assert!(contains(&table2, 0), 0);
-    bump(borrow_mut(&mut table2, 0));
-    assert!(count(borrow(&table2, 0)) == 2, 0);
-    ts::end(scenario);
-    destroy(remove(&mut table2, 0));
-    object_table::destroy_empty(table1);
-    object_table::destroy_empty(table2);
-}
+    fun new(id: UID): Counter {
+        Counter { id, count: 0 }
+    }
 
-fun new(id: UID): Counter {
-    Counter { id, count: 0 }
-}
+    fun count(counter: &Counter): u64 {
+        counter.count
+    }
 
-fun count(counter: &Counter): u64 {
-    counter.count
-}
+    fun bump(counter: &mut Counter): &mut Counter {
+        counter.count = counter.count + 1;
+        counter
+    }
 
-fun bump(counter: &mut Counter): &mut Counter {
-    counter.count = counter.count + 1;
-    counter
-}
-
-fun destroy(counter: Counter): u64 {
-    let Counter { id, count } = counter;
-    object::delete(id);
-    count
-}
-
+    fun destroy(counter: Counter): u64 {
+        let Counter { id, count } = counter;
+        object::delete(id);
+        count
+    }
 }

--- a/crates/sui-framework/tests/table_tests.move
+++ b/crates/sui-framework/tests/table_tests.move
@@ -3,131 +3,129 @@
 
 #[test_only]
 module sui::table_tests {
+    use sui::table::{Self, add, contains, borrow, borrow_mut, remove};
+    use sui::test_scenario as ts;
 
-use sui::table::{Self, add, contains, borrow, borrow_mut, remove};
-use sui::test_scenario as ts;
+    #[test]
+    fun simple_all_functions() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = table::new(ts::ctx(&mut scenario));
+        // add fields
+        add(&mut table, b"hello", 0);
+        add(&mut table, b"goodbye", 1);
+        // check they exist
+        assert!(contains(&table, b"hello"), 0);
+        assert!(contains(&table, b"goodbye"), 0);
+        // check the values
+        assert!(*borrow(&table, b"hello") == 0, 0);
+        assert!(*borrow(&table, b"goodbye") == 1, 0);
+        // mutate them
+        *borrow_mut(&mut table, b"hello") = *borrow(&table, b"hello") * 2;
+        *borrow_mut(&mut table, b"goodbye") = *borrow(&table, b"goodbye") * 2;
+        // check the new value
+        assert!(*borrow(&table, b"hello") == 0, 0);
+        assert!(*borrow(&table, b"goodbye") == 2, 0);
+        // remove the value and check it
+        assert!(remove(&mut table, b"hello") == 0, 0);
+        assert!(remove(&mut table, b"goodbye") == 2, 0);
+        // verify that they are not there
+        assert!(!contains(&table, b"hello"), 0);
+        assert!(!contains(&table, b"goodbye"), 0);
+        ts::end(scenario);
+        table::destroy_empty(table);
+    }
 
-#[test]
-fun simple_all_functions() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = table::new(ts::ctx(&mut scenario));
-    // add fields
-    add(&mut table, b"hello", 0);
-    add(&mut table, b"goodbye", 1);
-    // check they exist
-    assert!(contains(&table, b"hello"), 0);
-    assert!(contains(&table, b"goodbye"), 0);
-    // check the values
-    assert!(*borrow(&table, b"hello") == 0, 0);
-    assert!(*borrow(&table, b"goodbye") == 1, 0);
-    // mutate them
-    *borrow_mut(&mut table, b"hello") = *borrow(&table, b"hello") * 2;
-    *borrow_mut(&mut table, b"goodbye") = *borrow(&table, b"goodbye") * 2;
-    // check the new value
-    assert!(*borrow(&table, b"hello") == 0, 0);
-    assert!(*borrow(&table, b"goodbye") == 2, 0);
-    // remove the value and check it
-    assert!(remove(&mut table, b"hello") == 0, 0);
-    assert!(remove(&mut table, b"goodbye") == 2, 0);
-    // verify that they are not there
-    assert!(!contains(&table, b"hello"), 0);
-    assert!(!contains(&table, b"goodbye"), 0);
-    ts::end(scenario);
-    table::destroy_empty(table);
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+    fun add_duplicate() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = table::new(ts::ctx(&mut scenario));
+        add(&mut table, b"hello", 0);
+        add(&mut table, b"hello", 1);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
-fun add_duplicate() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = table::new(ts::ctx(&mut scenario));
-    add(&mut table, b"hello", 0);
-    add(&mut table, b"hello", 1);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        borrow(&table, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
-    borrow(&table, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun borrow_mut_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        borrow_mut(&mut table, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun borrow_mut_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
-    borrow_mut(&mut table, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    fun remove_missing() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        remove(&mut table, 0);
+        abort 42
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
-fun remove_missing() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
-    remove(&mut table, 0);
-    abort 42
-}
+    #[test]
+    #[expected_failure(abort_code = sui::table::ETableNotEmpty)]
+    fun destroy_non_empty() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        add(&mut table, 0, 0);
+        table::destroy_empty(table);
+        ts::end(scenario);
+    }
 
-#[test]
-#[expected_failure(abort_code = sui::table::ETableNotEmpty)]
-fun destroy_non_empty() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
-    add(&mut table, 0, 0);
-    table::destroy_empty(table);
-    ts::end(scenario);
-}
+    #[test]
+    fun sanity_check_contains() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        assert!(!contains(&mut table, 0), 0);
+        add(&mut table, 0, 0);
+        assert!(contains<u64, u64>(&mut table, 0), 0);
+        assert!(!contains<u64, u64>(&mut table, 1), 0);
+        ts::end(scenario);
+        table::drop(table);
+    }
 
-#[test]
-fun sanity_check_contains() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
-    assert!(!contains(&mut table, 0), 0);
-    add(&mut table, 0, 0);
-    assert!(contains<u64, u64>(&mut table, 0), 0);
-    assert!(!contains<u64, u64>(&mut table, 1), 0);
-    ts::end(scenario);
-    table::drop(table);
-}
+    #[test]
+    fun sanity_check_drop() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        add(&mut table, 0, 0);
+        assert!(table::length(&table) == 1, 0);
+        ts::end(scenario);
+        table::drop(table);
+    }
 
-#[test]
-fun sanity_check_drop() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
-    add(&mut table, 0, 0);
-    assert!(table::length(&table) == 1, 0);
-    ts::end(scenario);
-    table::drop(table);
-}
-
-#[test]
-fun sanity_check_size() {
-    let sender = @0x0;
-    let scenario = ts::begin(sender);
-    let table = table::new<u64, u64>(ts::ctx(&mut scenario));
-    assert!(table::is_empty(&table), 0);
-    assert!(table::length(&table) == 0, 0);
-    add(&mut table, 0, 0);
-    assert!(!table::is_empty(&table), 0);
-    assert!(table::length(&table) == 1, 0);
-    add(&mut table, 1, 0);
-    assert!(!table::is_empty(&table), 0);
-    assert!(table::length(&table) == 2, 0);
-    ts::end(scenario);
-    table::drop(table);
-}
-
+    #[test]
+    fun sanity_check_size() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        assert!(table::is_empty(&table), 0);
+        assert!(table::length(&table) == 0, 0);
+        add(&mut table, 0, 0);
+        assert!(!table::is_empty(&table), 0);
+        assert!(table::length(&table) == 1, 0);
+        add(&mut table, 1, 0);
+        assert!(!table::is_empty(&table), 0);
+        assert!(table::length(&table) == 2, 0);
+        ts::end(scenario);
+        table::drop(table);
+    }
 }

--- a/crates/sui-framework/tests/test_random_tests.move
+++ b/crates/sui-framework/tests/test_random_tests.move
@@ -3,7 +3,6 @@
 
 #[test_only]
 module sui::test_random_tests {
-
     use sui::test_random::{new, next_bool, next_u8, next_u8_in_range, next_u16, next_u16_in_range, next_u32, next_u32_in_range, next_u64, next_u64_in_range, next_u128, next_u128_in_range, next_u256, next_u256_in_range};
     use std::vector;
     use sui::test_random::next_bytes;


### PR DESCRIPTION
Just a formatting change. @tzakian in https://github.com/MystenLabs/sui/pull/8434#pullrequestreview-1306257683 noticed some inconsistent indentation in tests so this PR formats 4 spaces of indentation for module blocks.

Looking forward to when we have our own Move formatter 😄 