### PR TITLE
[explorer] - fix search icon styling

### DIFF
--- a/apps/explorer/src/ui/Search.tsx
+++ b/apps/explorer/src/ui/Search.tsx
@@ -79,7 +79,7 @@ export function Search({
                 value={queryValue}
             />
 
-            <div className="absolute right-0 mr-2 hidden h-full items-center text-2xl text-white/20 sm:flex">
+            <div className="absolute bottom-0 right-0 mr-2 hidden h-full items-center text-2xl text-white/20 sm:flex">
                 <Search16 />
             </div>
 


### PR DESCRIPTION
missed a `bottom-0` classname in my previous PR 