### PR TITLE
wallet-ext: account settings import private key

### DIFF
--- a/apps/wallet/src/background/keyring/VaultStorage.test.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.test.ts
@@ -186,7 +186,7 @@ describe('VaultStorage', () => {
                     testEd25519Serialized,
                     testDataVault2.password
                 )
-            ).toBe(true);
+            ).toBeTruthy();
             expect(VaultStorage.getImportedKeys()?.length).toBe(1);
             expect(setToLocalStorage).toHaveBeenCalledOnce();
             expect(setToSessionStorage).toHaveBeenCalledTimes(2);

--- a/apps/wallet/src/background/keyring/VaultStorage.test.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.test.ts
@@ -215,7 +215,7 @@ describe('VaultStorage', () => {
                     testEd25519Serialized,
                     testDataVault1.password
                 )
-            ).toBe(false);
+            ).toBe(null);
         });
     });
 });

--- a/apps/wallet/src/background/keyring/VaultStorage.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.ts
@@ -132,7 +132,7 @@ class VaultStorageClass {
      * NOTE: make sure you verify the password before calling this method
      * @param keypair The keypair to import
      * @param password The password to be used to store the vault. Make sure to verify that it's the correct password (of the current vault) and then call this function. It doesn't verify the password see {@link VaultStorage.verifyPassword}.
-     * @returns True if the key was imported, false otherwise
+     * @returns The keyPair if the key was imported, false otherwise
      */
     public async importKeypair(keypair: ExportedKeypair, password: string) {
         if (!this.#vault) {
@@ -150,7 +150,7 @@ class VaultStorageClass {
         this.#vault.importedKeypairs.push(keypairToImport);
         await setToLocalStorage(VAULT_KEY, await this.#vault.encrypt(password));
         await this.updateSessionStorage();
-        return true;
+        return keypairToImport;
     }
 
     public getImportedKeys() {

--- a/apps/wallet/src/background/keyring/VaultStorage.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.ts
@@ -132,7 +132,7 @@ class VaultStorageClass {
      * NOTE: make sure you verify the password before calling this method
      * @param keypair The keypair to import
      * @param password The password to be used to store the vault. Make sure to verify that it's the correct password (of the current vault) and then call this function. It doesn't verify the password see {@link VaultStorage.verifyPassword}.
-     * @returns The keyPair if the key was imported, false otherwise
+     * @returns The keyPair if the key was imported, null otherwise
      */
     public async importKeypair(keypair: ExportedKeypair, password: string) {
         if (!this.#vault) {
@@ -145,7 +145,7 @@ class VaultStorageClass {
                 aKeypair.getPublicKey().toSuiAddress() === importedAddress
         );
         if (isDuplicate) {
-            return false;
+            return null;
         }
         this.#vault.importedKeypairs.push(keypairToImport);
         await setToLocalStorage(VAULT_KEY, await this.#vault.encrypt(password));

--- a/apps/wallet/src/background/keyring/index.test.ts
+++ b/apps/wallet/src/background/keyring/index.test.ts
@@ -8,6 +8,7 @@ import { getFromLocalStorage, setToLocalStorage } from '../storage-utils';
 import { VaultStorage } from './VaultStorage';
 import Alarm from '_src/background/Alarms';
 import {
+    testEd25519,
     testEd25519Serialized,
     testMnemonic,
     testSecp256k1,
@@ -139,12 +140,12 @@ describe('Keyring', () => {
                 const eventSpy = vi.fn();
                 k.on('accountsChanged', eventSpy);
                 vaultStorageMock.verifyPassword.mockResolvedValue(true);
-                vaultStorageMock.importKeypair.mockResolvedValue(true);
+                vaultStorageMock.importKeypair.mockResolvedValue(testEd25519);
                 const added = await k.importAccountKeypair(
                     testEd25519Serialized,
                     'correct password'
                 );
-                expect(added).toBe(true);
+                expect(added).toBeTruthy();
                 expect(eventSpy).toHaveBeenCalledOnce();
             });
 

--- a/apps/wallet/src/background/keyring/index.test.ts
+++ b/apps/wallet/src/background/keyring/index.test.ts
@@ -153,12 +153,12 @@ describe('Keyring', () => {
                 const eventSpy = vi.fn();
                 k.on('accountsChanged', eventSpy);
                 vaultStorageMock.verifyPassword.mockResolvedValue(true);
-                vaultStorageMock.importKeypair.mockResolvedValue(false);
+                vaultStorageMock.importKeypair.mockResolvedValue(null);
                 const added = await k.importAccountKeypair(
                     testEd25519Serialized,
                     'correct password'
                 );
-                expect(added).toBe(false);
+                expect(added).toBe(null);
                 expect(eventSpy).not.toHaveBeenCalled();
             });
 

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -175,6 +175,11 @@ export class Keyring {
         }
         const added = await VaultStorage.importKeypair(keypair, password);
         if (added) {
+            const importedAccount = new Account({
+                type: 'imported',
+                keypair: added,
+            });
+            this.#accountsMap.set(importedAccount.address, importedAccount);
             this.notifyAccountsChanged();
         }
         return added;

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -308,6 +308,18 @@ export class Keyring {
                         id
                     )
                 );
+            } else if (
+                isKeyringPayload(payload, 'importPrivateKey') &&
+                payload.args
+            ) {
+                const imported = await this.importAccountKeypair(
+                    payload.args.keyPair,
+                    payload.args.password
+                );
+                if (!imported) {
+                    throw new Error('Duplicate account not imported');
+                }
+                uiConnection.send(createMessage({ type: 'done' }, id));
             }
         } catch (e) {
             uiConnection.send(

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -69,6 +69,10 @@ type MethodToPayloads = {
         args: { password: string; accountAddress: SuiAddress };
         return: { keyPair: ExportedKeypair };
     };
+    importPrivateKey: {
+        args: { password: string; keyPair: ExportedKeypair };
+        return: void;
+    };
 };
 
 export interface KeyringPayload<Method extends keyof MethodToPayloads>

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -5,6 +5,7 @@ import {
     type SerializedSignature,
     toB64,
     type SignedTransaction,
+    type ExportedKeypair,
 } from '@mysten/sui.js';
 import { lastValueFrom, map, take } from 'rxjs';
 
@@ -309,6 +310,18 @@ export class BackgroundClient {
                     );
                 })
             )
+        );
+    }
+
+    public async importPrivateKey(password: string, keyPair: ExportedKeypair) {
+        return await lastValueFrom(
+            this.sendMessage(
+                createMessage<KeyringPayload<'importPrivateKey'>>({
+                    type: 'keyring',
+                    method: 'importPrivateKey',
+                    args: { password, keyPair },
+                })
+            ).pipe(take(1))
         );
     }
 

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -313,8 +313,8 @@ export class BackgroundClient {
         );
     }
 
-    public async importPrivateKey(password: string, keyPair: ExportedKeypair) {
-        return await lastValueFrom(
+    public importPrivateKey(password: string, keyPair: ExportedKeypair) {
+        return lastValueFrom(
             this.sendMessage(
                 createMessage<KeyringPayload<'importPrivateKey'>>({
                     type: 'keyring',

--- a/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
@@ -15,6 +15,7 @@ import { Button } from '_src/ui/app/shared/ButtonUI';
 
 export function AccountsSettings() {
     const backUrl = useNextMenuUrl(true, '/');
+    const importPrivateKeyUrl = useNextMenuUrl(true, '/import-private-key');
     const accounts = useAccounts();
     const isMultiAccountsEnabled = useFeature(
         FEATURES.WALLET_MULTI_ACCOUNTS
@@ -39,13 +40,21 @@ export function AccountsSettings() {
                     <Account address={address} key={address} />
                 ))}
                 {isMultiAccountsEnabled ? (
-                    <Button
-                        variant="outline"
-                        size="tall"
-                        text="Create New Account"
-                        loading={createAccountMutation.isLoading}
-                        onClick={() => createAccountMutation.mutate()}
-                    />
+                    <>
+                        <Button
+                            variant="outline"
+                            size="tall"
+                            text="Create New Account"
+                            loading={createAccountMutation.isLoading}
+                            onClick={() => createAccountMutation.mutate()}
+                        />
+                        <Button
+                            variant="outline"
+                            size="tall"
+                            text="Import Private Key"
+                            to={importPrivateKeyUrl}
+                        />
+                    </>
                 ) : null}
             </div>
         </MenuLayout>

--- a/apps/wallet/src/ui/app/components/menu/content/ExportAccount.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/ExportAccount.tsx
@@ -57,6 +57,7 @@ export function ExportAccount() {
     return (
         <PasswordInputDialog
             title="Export Private Key"
+            showArrowIcon
             onPasswordVerified={async (password) => {
                 await exportMutation.mutateAsync(password);
             }}

--- a/apps/wallet/src/ui/app/components/menu/content/ImportPrivateKey.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/ImportPrivateKey.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ArrowRight16 } from '@mysten/icons';
+import { type ExportedKeypair, toB64 } from '@mysten/sui.js';
+import { hexToBytes } from '@noble/hashes/utils';
+import { useMutation } from '@tanstack/react-query';
+import { ErrorMessage, Field, Form, Formik } from 'formik';
+import { useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+import { object, string as yupString } from 'yup';
+
+import Alert from '../../alert';
+import { useNextMenuUrl } from '../hooks';
+import { MenuLayout } from './MenuLayout';
+import { PasswordInputDialog } from './PasswordInputDialog';
+import { useBackgroundClient } from '_src/ui/app/hooks/useBackgroundClient';
+import { Button } from '_src/ui/app/shared/ButtonUI';
+import FieldLabel from '_src/ui/app/shared/field-label';
+
+const validation = object({
+    privateKey: yupString()
+        .ensure()
+        .trim()
+        .required()
+        .transform((value: string) => {
+            if (value.startsWith('0x')) {
+                return value.substring(2);
+            }
+            return value;
+        })
+        .test(
+            'valid-hex',
+            `\${path} must be a hex value that optionally starts with 0x`,
+            (value: string) => {
+                try {
+                    hexToBytes(value);
+                    return true;
+                } catch (e) {
+                    return false;
+                }
+            }
+        )
+        .test(
+            'valid-bytes-length',
+            `\${path} must be 32 or 64 bytes`,
+            (value: string) => {
+                try {
+                    const bytes = hexToBytes(value);
+                    return [32, 64].includes(bytes.length);
+                } catch (e) {
+                    return false;
+                }
+            }
+        )
+        .label('Private Key'),
+});
+
+export function ImportPrivateKey() {
+    const accountsUrl = useNextMenuUrl(true, `/accounts`);
+    const backgroundClient = useBackgroundClient();
+    const navigate = useNavigate();
+    const [showPasswordDialog, setShowPasswordDialog] = useState(false);
+    const [privateKey, setPrivateKey] = useState('');
+    const importMutation = useMutation({
+        mutationFn: async (password: string) => {
+            const keyPair: ExportedKeypair = {
+                schema: 'ED25519',
+                privateKey: toB64(hexToBytes(privateKey)),
+            };
+            await backgroundClient.importPrivateKey(password, keyPair);
+        },
+        onSuccess: () => {
+            toast.success('Account imported');
+            navigate(accountsUrl);
+        },
+        onError: () => setShowPasswordDialog(false),
+    });
+    return (
+        <>
+            {showPasswordDialog ? (
+                <div className="absolute inset-0 pb-8 px-2.5 flex flex-col z-10">
+                    <PasswordInputDialog
+                        title="Import Account"
+                        continueLabel="Import"
+                        finalStep
+                        onBackClicked={() => setShowPasswordDialog(false)}
+                        onPasswordVerified={async (password) => {
+                            await importMutation.mutateAsync(password);
+                        }}
+                    />
+                </div>
+            ) : null}
+            <MenuLayout title="Import Existing Account" back={accountsUrl}>
+                <Formik
+                    initialValues={{ privateKey: '' }}
+                    onSubmit={async ({ privateKey }) => {
+                        setPrivateKey(
+                            validation.cast({ privateKey }).privateKey
+                        );
+                        setShowPasswordDialog(true);
+                    }}
+                    validationSchema={validation}
+                >
+                    {({ isSubmitting, isValid }) => (
+                        <Form className="flex flex-col gap-3 pt-2.5">
+                            <FieldLabel txt="Enter Private Key">
+                                <Field
+                                    name="privateKey"
+                                    className="shadow-button text-steel-dark font-medium text-p1 resize-none rounded-xl border border-solid border-steel p-3"
+                                    component={'textarea'}
+                                    rows="3"
+                                    spellCheck="false"
+                                    autoComplete="off"
+                                />
+                                <ErrorMessage
+                                    render={(error) => <Alert>{error}</Alert>}
+                                    name="privateKey"
+                                />
+                            </FieldLabel>
+                            <Button
+                                type="submit"
+                                size="tall"
+                                variant="primary"
+                                text="Continue"
+                                after={<ArrowRight16 />}
+                                disabled={!isValid}
+                                loading={isSubmitting}
+                            />
+                        </Form>
+                    )}
+                </Formik>
+            </MenuLayout>
+        </>
+    );
+}

--- a/apps/wallet/src/ui/app/components/menu/content/ImportPrivateKey.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/ImportPrivateKey.tsx
@@ -82,7 +82,6 @@ export function ImportPrivateKey() {
             <PasswordInputDialog
                 title="Import Account"
                 continueLabel="Import"
-                finalStep
                 onBackClicked={() => setShowPasswordDialog(false)}
                 onPasswordVerified={async (password) => {
                     await importMutation.mutateAsync(password);

--- a/apps/wallet/src/ui/app/components/menu/content/ImportPrivateKey.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/ImportPrivateKey.tsx
@@ -32,7 +32,7 @@ const validation = object({
         })
         .test(
             'valid-hex',
-            `\${path} must be a hex value that optionally starts with 0x`,
+            `\${path} must be a hexadecimal value. It may optionally begin with "0x".`,
             (value: string) => {
                 try {
                     hexToBytes(value);
@@ -44,7 +44,7 @@ const validation = object({
         )
         .test(
             'valid-bytes-length',
-            `\${path} must be 32 or 64 bytes`,
+            `\${path} must be either 32 or 64 bytes.`,
             (value: string) => {
                 try {
                     const bytes = hexToBytes(value);
@@ -77,61 +77,62 @@ export function ImportPrivateKey() {
         },
         onError: () => setShowPasswordDialog(false),
     });
-    return (
-        <>
-            {showPasswordDialog ? (
-                <div className="absolute inset-0 pb-8 px-2.5 flex flex-col z-10">
-                    <PasswordInputDialog
-                        title="Import Account"
-                        continueLabel="Import"
-                        finalStep
-                        onBackClicked={() => setShowPasswordDialog(false)}
-                        onPasswordVerified={async (password) => {
-                            await importMutation.mutateAsync(password);
-                        }}
-                    />
-                </div>
-            ) : null}
-            <MenuLayout title="Import Existing Account" back={accountsUrl}>
-                <Formik
-                    initialValues={{ privateKey: '' }}
-                    onSubmit={async ({ privateKey }) => {
-                        setPrivateKey(
-                            validation.cast({ privateKey }).privateKey
-                        );
-                        setShowPasswordDialog(true);
-                    }}
-                    validationSchema={validation}
-                >
-                    {({ isSubmitting, isValid }) => (
-                        <Form className="flex flex-col gap-3 pt-2.5">
-                            <FieldLabel txt="Enter Private Key">
-                                <Field
-                                    name="privateKey"
-                                    className="shadow-button text-steel-dark font-medium text-p1 resize-none rounded-xl border border-solid border-steel p-3"
-                                    component={'textarea'}
-                                    rows="3"
-                                    spellCheck="false"
-                                    autoComplete="off"
-                                />
-                                <ErrorMessage
-                                    render={(error) => <Alert>{error}</Alert>}
-                                    name="privateKey"
-                                />
-                            </FieldLabel>
-                            <Button
-                                type="submit"
-                                size="tall"
-                                variant="primary"
-                                text="Continue"
-                                after={<ArrowRight16 />}
-                                disabled={!isValid}
-                                loading={isSubmitting}
+    return showPasswordDialog ? (
+        <div className="absolute inset-0 pb-8 px-2.5 flex flex-col z-10">
+            <PasswordInputDialog
+                title="Import Account"
+                continueLabel="Import"
+                finalStep
+                onBackClicked={() => setShowPasswordDialog(false)}
+                onPasswordVerified={async (password) => {
+                    await importMutation.mutateAsync(password);
+                }}
+            />
+        </div>
+    ) : (
+        <MenuLayout title="Import Existing Account" back={accountsUrl}>
+            <Formik
+                initialValues={{ privateKey }}
+                onSubmit={async ({ privateKey: privateKeyInput }) => {
+                    setPrivateKey(
+                        validation.cast({ privateKey: privateKeyInput })
+                            .privateKey
+                    );
+                    setShowPasswordDialog(true);
+                }}
+                validationSchema={validation}
+                validateOnMount
+                enableReinitialize
+            >
+                {({ isSubmitting, isValid }) => (
+                    <Form className="flex flex-col gap-3 pt-2.5">
+                        <FieldLabel txt="Enter Private Key">
+                            <Field
+                                name="privateKey"
+                                className="shadow-button text-steel-dark font-medium text-p1 resize-none rounded-xl border border-solid border-steel p-3"
+                                component={'textarea'}
+                                rows="3"
+                                spellCheck="false"
+                                autoComplete="off"
+                                autoFocus
                             />
-                        </Form>
-                    )}
-                </Formik>
-            </MenuLayout>
-        </>
+                            <ErrorMessage
+                                render={(error) => <Alert>{error}</Alert>}
+                                name="privateKey"
+                            />
+                        </FieldLabel>
+                        <Button
+                            type="submit"
+                            size="tall"
+                            variant="primary"
+                            text="Continue"
+                            after={<ArrowRight16 />}
+                            disabled={!isValid}
+                            loading={isSubmitting}
+                        />
+                    </Form>
+                )}
+            </Formik>
+        </MenuLayout>
     );
 }

--- a/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ArrowRight16 } from '@mysten/icons';
 import { Field, Formik, Form, ErrorMessage } from 'formik';
 import { toast } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
@@ -13,6 +14,7 @@ import { Link } from '_src/ui/app/shared/Link';
 import FieldLabel from '_src/ui/app/shared/field-label';
 import { Heading } from '_src/ui/app/shared/heading';
 import PasswordInput from '_src/ui/app/shared/input/password';
+import { Text } from '_src/ui/app/shared/text';
 
 const validation = object({
     password: YupString().ensure().required().label('Password'),
@@ -20,12 +22,18 @@ const validation = object({
 
 export type PasswordExportDialogProps = {
     title: string;
+    continueLabel?: string;
+    finalStep?: boolean;
     onPasswordVerified: (password: string) => Promise<void> | void;
+    onBackClicked?: () => void;
 };
 
 export function PasswordInputDialog({
     title,
+    continueLabel = 'Continue',
+    finalStep = false,
     onPasswordVerified,
+    onBackClicked,
 }: PasswordExportDialogProps) {
     const navigate = useNavigate();
     const backgroundService = useBackgroundClient();
@@ -63,21 +71,36 @@ export function PasswordInputDialog({
                                 name="password"
                             />
                         </FieldLabel>
+                        <div className="text-center mt-4">
+                            <Text
+                                variant="p2"
+                                color="steel-dark"
+                                weight="normal"
+                            >
+                                This is the password you currently use to lock
+                                and unlock your Sui wallet.
+                            </Text>
+                        </div>
                     </div>
                     <div className="flex flex-col flex-nowrap gap-3.75 self-stretch">
                         <Button
                             type="submit"
                             variant="primary"
                             size="tall"
-                            text="Continue"
+                            text={continueLabel}
                             loading={isSubmitting}
                             disabled={!isValid}
+                            after={finalStep ? null : <ArrowRight16 />}
                         />
                         <Link
-                            text="Cancel"
+                            text="Go Back"
                             color="heroDark"
                             onClick={() => {
-                                navigate(-1);
+                                if (typeof onBackClicked === 'function') {
+                                    onBackClicked();
+                                } else {
+                                    navigate(-1);
+                                }
                             }}
                             disabled={isSubmitting}
                         />

--- a/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
@@ -23,7 +23,7 @@ const validation = object({
 export type PasswordExportDialogProps = {
     title: string;
     continueLabel?: string;
-    finalStep?: boolean;
+    showArrowIcon?: boolean;
     onPasswordVerified: (password: string) => Promise<void> | void;
     onBackClicked?: () => void;
 };
@@ -31,7 +31,7 @@ export type PasswordExportDialogProps = {
 export function PasswordInputDialog({
     title,
     continueLabel = 'Continue',
-    finalStep = false,
+    showArrowIcon = false,
     onPasswordVerified,
     onBackClicked,
 }: PasswordExportDialogProps) {
@@ -90,7 +90,7 @@ export function PasswordInputDialog({
                             text={continueLabel}
                             loading={isSubmitting}
                             disabled={!isValid}
-                            after={finalStep ? null : <ArrowRight16 />}
+                            after={showArrowIcon ? <ArrowRight16 /> : null}
                         />
                         <Link
                             text="Go Back"

--- a/apps/wallet/src/ui/app/components/menu/content/index.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/index.tsx
@@ -14,6 +14,7 @@ import {
 import { AccountsSettings } from './AccountsSettings';
 import { AutoLockSettings } from './AutoLockSettings';
 import { ExportAccount } from './ExportAccount';
+import { ImportPrivateKey } from './ImportPrivateKey';
 import MenuList from './MenuList';
 import { NetworkSettings } from './NetworkSettings';
 import { ErrorBoundary } from '_components/error-boundary';
@@ -65,10 +66,13 @@ function MenuContent() {
                                     path="/accounts"
                                     element={<AccountsSettings />}
                                 />
-
                                 <Route
                                     path="/export/:account"
                                     element={<ExportAccount />}
+                                />
+                                <Route
+                                    path="/import-private-key"
+                                    element={<ImportPrivateKey />}
                                 />
                             </>
                         ) : null}


### PR DESCRIPTION
* PasswordInputDialog
  * make continue label configurable
  * add finalStep prop to allow show/hide the arrow of continue button
  * make back on click configurable
  * show hint about password
* show Import Private Key button in accounts setting when multi-accounts is enabled
* implement import functionality
* fixes the issue when importing a new account from it's private key the account wasn't visible until unlocking keyring again


https://user-images.githubusercontent.com/10210143/220226511-00fdaa44-dbfe-41e9-8a55-b8cf6812ddaa.mov

Updates the Password dialog for #8416 with the new design as well

<img width="375" alt="Screenshot 2023-02-21 at 12 16 12" src="https://user-images.githubusercontent.com/10210143/220342987-badd94b6-32d1-4828-b255-a5a01713b5bd.png">


closes APPS-288