### PR TITLE
[ts-sdk] Move Base58 encoding to BCS

### DIFF
--- a/.changeset/polite-clouds-cheer.md
+++ b/.changeset/polite-clouds-cheer.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Move base58 libraries to BCS

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,7 +506,6 @@ importers:
       '@scure/bip39': ^1.1.0
       '@size-limit/preset-small-lib': ^8.1.0
       '@suchipi/femver': ^1.0.0
-      bs58: ^5.0.0
       cross-fetch: ^3.1.5
       eslint: ^8.31.0
       eslint-config-prettier: ^8.6.0
@@ -537,7 +536,6 @@ importers:
       '@scure/bip32': 1.1.1
       '@scure/bip39': 1.1.0
       '@suchipi/femver': 1.0.0
-      bs58: 5.0.0
       cross-fetch: 3.1.5
       jayson: 4.0.0
       js-sha3: 0.8.0

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -93,7 +93,6 @@
     "@scure/bip32": "^1.1.1",
     "@scure/bip39": "^1.1.0",
     "@suchipi/femver": "^1.0.0",
-    "bs58": "^5.0.0",
     "cross-fetch": "^3.1.5",
     "jayson": "^4.0.0",
     "js-sha3": "^0.8.0",

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -10,10 +10,9 @@ import {
   union,
   unknown,
 } from 'superstruct';
-import bs58 from 'bs58';
 import { CallArg, TransactionData, TransactionData_v26 } from './sui-bcs';
 import { sha256Hash } from '../cryptography/hash';
-import { BCS } from '@mysten/bcs';
+import { BCS, fromB58, toB58 } from '@mysten/bcs';
 
 export const TransactionDigest = string();
 export type TransactionDigest = Infer<typeof TransactionDigest>;
@@ -64,7 +63,7 @@ export function isValidTransactionDigest(
   value: string,
 ): value is TransactionDigest {
   try {
-    const buffer = bs58.decode(value);
+    const buffer = fromB58(value);
     return buffer.length === TX_DIGEST_LENGTH;
   } catch (e) {
     return false;
@@ -130,7 +129,7 @@ export function generateTransactionDigest(
   const txBytes = bcs.ser('TransactionData', data).toBytes();
   const hash = sha256Hash('TransactionData', txBytes);
 
-  return bs58.encode(hash);
+  return toB58(hash);
 }
 
 function isHex(value: string): boolean {


### PR DESCRIPTION
Just moving the `bs58` usage to BCS, which is consistent with our other base64 and hex usage in the SDK.