### PR TITLE
[sui-metrics-proxy/ initial release]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6586,6 +6586,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-parse"
+version = "0.3.0"
+source = "git+https://github.com/suiwombat/prometheus-parse-rs?rev=daa964c#daa964cff5b83fbcf0ff08c0ab50dc7130239df3"
+dependencies = [
+ "chrono",
+ "itertools",
+ "lazy_static 1.4.0",
+ "regex",
+]
+
+[[package]]
 name = "proptest"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7683,9 +7694,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "indexmap",
  "itoa 1.0.5",
@@ -8858,6 +8869,34 @@ version = "0.7.0"
 dependencies = [
  "once_cell",
  "sui-proc-macros",
+ "workspace-hack",
+]
+
+[[package]]
+name = "sui-metrics-proxy"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "axum",
+ "axum-server",
+ "clap 3.2.23",
+ "const-str",
+ "fastcrypto",
+ "futures",
+ "git-version",
+ "hyper",
+ "mime",
+ "prometheus-parse",
+ "rand 0.8.5",
+ "reqwest",
+ "serde 1.0.152",
+ "serde_json",
+ "sui-tls",
+ "sui-types",
+ "telemetry-subscribers",
+ "tokio",
+ "tower",
+ "tracing",
  "workspace-hack",
 ]
 
@@ -11443,6 +11482,7 @@ dependencies = [
  "proc-macro2 0.4.30",
  "proc-macro2 1.0.51",
  "prometheus",
+ "prometheus-parse",
  "proptest",
  "proptest-derive",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/sui-json-rpc-types",
     "crates/sui-keys",
     "crates/sui-macros",
+    "crates/sui-metrics-proxy",
     "crates/sui-move",
     "crates/sui-network",
     "crates/sui-node",

--- a/crates/sui-metrics-proxy/Cargo.toml
+++ b/crates/sui-metrics-proxy/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "sui-metrics-proxy"
+version = "0.0.1"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+axum = "0.6.2"
+axum-server = { version = "0.4.4", default-features = false, features = ["tls-rustls"] }
+anyhow = { version = "1.0.64", features = ["backtrace"] }
+clap = { version = "3.2.17", features = ["derive"] }
+tokio = { workspace = true, features = ["full"] }
+tracing = "0.1.36"
+futures = "0.3.23"
+const-str = "0.5.3"
+serde = { version = "1.0.144", features = ["derive", "rc"] }
+serde_json = "1.0.93"
+git-version = "0.3.5"
+rand = "0.8.5"
+reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
+hyper = { version = "0.14", features = ["full"] }
+sui-tls = { path = "../sui-tls" }
+sui-types = { path = "../sui-types" }
+prometheus-parse = { git = "https://github.com/suiwombat/prometheus-parse-rs", rev = "daa964c" }
+
+
+telemetry-subscribers.workspace = true
+fastcrypto.workspace = true
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+mime = "0.3"
+serde_json = "1.0"
+tower = { version = "0.4", features = ["util"] }
+axum-server = { version = "0.4.4", default-features = false, features = ["tls-rustls"] }
+
+

--- a/crates/sui-metrics-proxy/src/admin.rs
+++ b/crates/sui-metrics-proxy/src/admin.rs
@@ -1,0 +1,158 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::channels::UpstreamConsumer;
+use crate::handlers::publish_metrics;
+use anyhow::{Context, Result};
+use axum::{routing::post as axum_post, Router};
+use fastcrypto::ed25519::Ed25519KeyPair;
+use fastcrypto::ed25519::Ed25519PublicKey;
+use fastcrypto::traits::KeyPair;
+use fastcrypto::traits::ToFromBytes;
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::Duration;
+use sui_tls::{
+    rustls::ServerConfig, SelfSignedCertificate, TlsAcceptor, ValidatorAllowlist,
+    ValidatorCertVerifier,
+};
+use sui_types::sui_system_state::ValidatorMetadata;
+use tokio::{signal, sync::mpsc};
+use tracing::{error, info};
+
+/// Configure our graceful shutdown scenarios
+pub async fn shutdown_signal(h: axum_server::Handle) {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    let grace = 30;
+    info!(
+        "signal received, starting graceful shutdown, grace period {} seconds, if needed",
+        &grace
+    );
+    h.graceful_shutdown(Some(Duration::from_secs(grace)))
+}
+
+/// App will configure our routes and create our mpsc channels.  This fn is also used to instrument
+/// our tests
+pub fn app(buffer_size: usize, network: String) -> Router {
+    // we accept data on our UpstreamConsumer up to our buffer size.
+    let (sender, receiver) = mpsc::channel(buffer_size);
+    let mut consumer = UpstreamConsumer::new(network, receiver);
+
+    tokio::spawn(async move { consumer.run().await });
+
+    // build our application with a route and our sender mpsc
+    Router::new()
+        .route("/publish/metrics", axum_post(publish_metrics))
+        .with_state(Arc::new(sender))
+}
+
+pub async fn server(
+    listener: std::net::TcpListener,
+    _acceptor: TlsAcceptor, // TODO enable for tls
+    app: Router,
+) -> std::io::Result<()> {
+    // setup our graceful shutdown
+    let handle = axum_server::Handle::new();
+    // Spawn a task to gracefully shutdown server.
+    tokio::spawn(shutdown_signal(handle.clone()));
+
+    axum_server::Server::from_tcp(listener)
+        // .acceptor(acceptor) // TODO enable for tls
+        .handle(handle)
+        .serve(app.into_make_service())
+        .await
+}
+
+pub fn create_server_cert(
+    hostname: &str,
+) -> Result<(ServerConfig, ValidatorAllowlist), sui_tls::rustls::Error> {
+    let mut rng = rand::thread_rng();
+    let server_keypair = Ed25519KeyPair::generate(&mut rng);
+    let server_certificate = SelfSignedCertificate::new(server_keypair.private(), hostname);
+
+    ValidatorCertVerifier::rustls_server_config(
+        vec![server_certificate.rustls_certificate()],
+        server_certificate.rustls_private_key(),
+    )
+}
+
+async fn get_validators(url: String) -> Result<Vec<ValidatorMetadata>> {
+    let client = reqwest::Client::builder().build().unwrap();
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method":"sui_getValidators",
+        "id":1,
+    });
+    let response = client
+        .post(url)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(request.to_string())
+        .send()
+        .await
+        .context("unable to perform rpc")?;
+
+    #[derive(Debug, Deserialize)]
+    struct ResponseBody {
+        result: Vec<ValidatorMetadata>,
+    }
+    let body = response
+        .json::<ResponseBody>()
+        .await
+        .context("unable to deserialize validator peer list")?;
+
+    Ok(body.result)
+}
+
+pub fn manage_validators(url: String, period: Duration, allowlist: ValidatorAllowlist) {
+    info!("Started polling for peers using rpc: {}", url);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(period);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            interval.tick().await;
+
+            match get_validators(url.clone()).await {
+                Ok(peers) => {
+                    // obtain rwlock; nb allowed is an raii object
+                    let mut allowed = allowlist.write().unwrap();
+                    let latest_peers = peers.iter().filter_map(|v| {
+                        info!("name: {:?} sui_address: {:?}", v.name, v.sui_address);
+                        match Ed25519PublicKey::from_bytes(&v.network_pubkey_bytes) {
+                            Ok(client_public_key) => Some(client_public_key),
+                            Err(error) => {
+                                error!(
+                                "unable to decode public key for name: {:?} sui_address: {:?} error: {error}",
+                                v.name, v.sui_address);
+                                return None;
+                            }
+                        }
+                    });
+                    allowed.clear();
+                    allowed.extend(latest_peers);
+                }
+                Err(error) => error!("unable to refresh peer list: {error}"),
+            }
+        }
+    });
+}

--- a/crates/sui-metrics-proxy/src/channels.rs
+++ b/crates/sui-metrics-proxy/src/channels.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use axum::body::Bytes;
+use prometheus_parse::Scrape;
+use tokio::sync::mpsc::Receiver;
+use tracing::error;
+/// NodeMetric is a placeholder for metric data
+/// tbd in future PR
+#[derive(Debug)]
+pub struct NodeMetric {
+    pub host: String,
+    pub data: Bytes, // raw post data from node
+}
+
+/// An UpstreamConsumer accepts bytes from calling clients and is
+/// responsible for sending them on to upstream services to store
+/// the relayed metric
+pub struct UpstreamConsumer {
+    pub network: String,
+    pub receiver: Receiver<NodeMetric>,
+}
+
+impl UpstreamConsumer {
+    pub fn new(network: String, receiver: Receiver<NodeMetric>) -> Self {
+        Self { network, receiver }
+    }
+    pub async fn run(&mut self) {
+        while let Some(nm) = self.receiver.recv().await {
+            let network = self.network.to_owned();
+            tokio::spawn(async move {
+                let Ok(data) = std::str::from_utf8(&nm.data) else {
+                    error!("unable to decode bytes from relayed metrics for host: {}", nm.host);
+                    return;
+                };
+                let lines = data.lines().map(|s| Ok(s.to_owned()));
+                let Ok(mut metrics) = Scrape::parse(lines) else {
+                    error!("unable to parse exposition data for host: {}", nm.host);
+                    return;
+                };
+
+                for s in metrics.samples.iter_mut() {
+                    s.labels.insert("host".to_string(), nm.host.to_owned());
+                    s.labels.insert("network".to_string(), network.to_owned());
+                }
+            });
+        }
+    }
+}

--- a/crates/sui-metrics-proxy/src/handlers.rs
+++ b/crates/sui-metrics-proxy/src/handlers.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use axum::{
+    body::Body,
+    extract::State,
+    http::{header, HeaderMap, HeaderValue, Request, StatusCode},
+    response::IntoResponse,
+};
+use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
+use tracing::error;
+
+use crate::channels::NodeMetric;
+
+/// Publish handler which receives metrics from nodes.  Nodes will call us at this endpoint
+/// and we relay them to the upstream tsdb
+///
+/// An mpsc is used within this handler so that we can immediately return an accept to calling nodes.
+/// Downstream processing failures may still result in metrics being dropped.
+pub async fn publish_metrics(
+    State(state): State<Arc<Sender<NodeMetric>>>,
+    headers: HeaderMap,
+    request: Request<Body>,
+) -> impl IntoResponse {
+    if let Some(reason) = validate_headers(&headers) {
+        return (
+            StatusCode::BAD_REQUEST,
+            [(header::CONNECTION, "close")],
+            reason,
+        );
+    }
+    let host = match headers.get(header::HOST).map(|x| x.to_string()) {
+        Some(host) => host,
+        None => "unknown".to_string(),
+    };
+
+    let data = match hyper::body::to_bytes(request.into_body()).await {
+        Ok(data) => data,
+        Err(_e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                [(header::CONNECTION, "close")],
+                "unable to extract post body",
+            );
+        }
+    };
+
+    let sender = state.clone();
+    if let Err(e) = sender.send(NodeMetric { host, data }).await {
+        error!("unable to queue; unable to send to consumer; {}", e);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [(header::CONNECTION, "close")],
+            "unable to queue metrics",
+        );
+    }
+    (StatusCode::OK, [(header::CONNECTION, "close")], "accepted")
+}
+
+fn validate_headers<'a>(headers: &HeaderMap) -> Option<&'a str> {
+    match headers.get(header::CONTENT_TYPE).map(|v| v.as_bytes()) {
+        Some(b"application/mysten.proxy.promexposition") => None,
+        _ => {
+            let v: &'a str = "bad content-type header";
+            Some(v)
+        }
+    }
+}
+
+/// Additional conversion methods for `HeaderValue`.
+pub trait HeaderValueExt {
+    fn to_string(&self) -> String;
+}
+
+impl HeaderValueExt for HeaderValue {
+    fn to_string(&self) -> String {
+        self.to_str().unwrap_or_default().to_string()
+    }
+}

--- a/crates/sui-metrics-proxy/src/lib.rs
+++ b/crates/sui-metrics-proxy/src/lib.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+pub mod admin;
+pub mod channels;
+pub mod handlers;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{self, Request, StatusCode},
+    };
+    use serde_json::json;
+    use tower::ServiceExt; // for `oneshot`
+
+    #[tokio::test]
+    async fn post_json() {
+        let app = admin::app(10, "unittest-network".to_string());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri("/publish/metrics")
+                    .header(
+                        http::header::CONTENT_TYPE,
+                        "application/mysten.proxy.promexposition",
+                    )
+                    .body(Body::from(
+                        serde_json::to_vec(&json!({"foo":"fooman"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        assert_eq!(body, String::from("accepted").into_bytes());
+    }
+
+    // TODO enable when tls is re-enabled
+    // #[tokio::test]
+    // async fn axum_acceptor() {
+    //     use fastcrypto::ed25519::Ed25519KeyPair;
+    //     use fastcrypto::traits::KeyPair;
+
+    //     use sui_tls::{
+    //         SelfSignedCertificate, TlsAcceptor, TlsConnectionInfo, ValidatorCertVerifier,
+    //     };
+
+    //     let mut rng = rand::thread_rng();
+    //     let client_keypair = Ed25519KeyPair::generate(&mut rng);
+    //     let client_public_key = client_keypair.public().to_owned();
+    //     // server_name param must be "sui"
+    //     let client_certificate = SelfSignedCertificate::new(client_keypair.private(), "sui");
+    //     let server_keypair = Ed25519KeyPair::generate(&mut rng);
+    //     let server_certificate = SelfSignedCertificate::new(server_keypair.private(), "localhost");
+
+    //     let client = reqwest::Client::builder()
+    //         .add_root_certificate(server_certificate.reqwest_certificate())
+    //         .identity(client_certificate.reqwest_identity())
+    //         .https_only(true)
+    //         .build()
+    //         .unwrap();
+
+    //     let (tls_config, allowlist) = ValidatorCertVerifier::rustls_server_config(
+    //         vec![server_certificate.rustls_certificate()],
+    //         server_certificate.rustls_private_key(),
+    //     )
+    //     .unwrap();
+
+    //     async fn handler(tls_info: axum::Extension<TlsConnectionInfo>) -> String {
+    //         tls_info.public_key().unwrap().to_string()
+    //     }
+
+    //     let app = admin::app(10, "unittest-network".to_string());
+    //     let listener = std::net::TcpListener::bind("localhost:0").unwrap();
+    //     let server_address = listener.local_addr().unwrap();
+    //     let acceptor = TlsAcceptor::new(tls_config);
+    //     let _server = tokio::spawn(async move {
+    //         admin::server(listener, acceptor, app).await.unwrap();
+    //     });
+    //     let server_url = format!(
+    //         "https://localhost:{}/publish/metrics",
+    //         server_address.port()
+    //     );
+    //     // Client request is rejected because it isn't in the allowlist
+    //     client.get(&server_url).send().await.unwrap_err();
+
+    //     // Insert the client's public key into the allowlist and verify the request is successful
+    //     allowlist.write().unwrap().insert(client_public_key.clone());
+
+    //     let res = client
+    //         .post(&server_url)
+    //         .body("{\"some\":\"data\"}")
+    //         .send()
+    //         .await
+    //         .unwrap();
+    //     let body = res.text().await.unwrap();
+    //     assert_eq!("accepted", body);
+    // }
+}

--- a/crates/sui-metrics-proxy/src/main.rs
+++ b/crates/sui-metrics-proxy/src/main.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use core::time::Duration;
+use std::net::SocketAddr;
+use sui_metrics_proxy::admin::{app, create_server_cert, manage_validators, server};
+use sui_tls::TlsAcceptor;
+use telemetry_subscribers::TelemetryConfig;
+use tracing::info;
+
+const GIT_REVISION: &str = {
+    if let Some(revision) = option_env!("GIT_REVISION") {
+        revision
+    } else {
+        let version = git_version::git_version!(
+            args = ["--always", "--dirty", "--exclude", "*"],
+            fallback = ""
+        );
+
+        if version.is_empty() {
+            panic!("unable to query git revision");
+        }
+        version
+    }
+};
+const VERSION: &str = const_str::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
+
+#[derive(Parser, Debug)]
+#[clap(rename_all = "kebab-case")]
+#[clap(name = env!("CARGO_BIN_NAME"))]
+#[clap(version = VERSION)]
+struct Args {
+    #[clap(
+        long,
+        short,
+        default_value = "localhost",
+        help = "Specify the tls self-signed cert hostname to use"
+    )]
+    hostname: String,
+    #[clap(long, short, help = "Specify the network name to use for labels")]
+    network: String,
+    #[clap(long, short, help = "Specify address to listen on")]
+    listen_address: SocketAddr,
+    #[clap(long, short, help = "Specify an upstream https url to send to")]
+    upstream_address: String,
+    #[clap(
+        long,
+        short,
+        default_value = "http://localhost:9000",
+        help = "Specify the rpc url to use when fetching our peer list for tls"
+    )]
+    rpc_url: String,
+    #[clap(
+        long,
+        default_value_t = 30,
+        help = "The poll interval (seconds) controls how often we verify our peer list"
+    )]
+    rpc_poll_interval: u64,
+    #[clap(
+        long,
+        default_value_t = 10000,
+        help = "mpsc buffer size - ideally set above our max rps"
+    )]
+    buffer_size: usize,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let (_guard, _handle) = TelemetryConfig::new().init();
+    let args = Args::parse();
+
+    info!(
+        "listen on {:?} send to {:?} using a buffered channel size of {}",
+        args.listen_address, args.upstream_address, args.buffer_size
+    );
+
+    let listener = std::net::TcpListener::bind(args.listen_address).unwrap();
+
+    let (tls_config, allowlist) =
+        create_server_cert(&args.hostname).expect("unable to create self-signed server cert");
+    let acceptor = TlsAcceptor::new(tls_config);
+
+    manage_validators(
+        args.rpc_url,
+        Duration::from_secs(args.rpc_poll_interval),
+        allowlist,
+    );
+
+    // create a multiple producer, single consumer channel
+    // we use this to receive data from nodes and immediately return
+    // StatusCode::OK. The http handlers will then process
+    // it and send it upstream
+    let app = app(args.buffer_size, args.network);
+    server(listener, acceptor, app).await.unwrap();
+
+    Ok(())
+}

--- a/crates/sui-node/src/metrics.rs
+++ b/crates/sui-node/src/metrics.rs
@@ -126,6 +126,10 @@ pub fn start_metrics_push_task(config: &sui_config::NodeConfig, registry: Regist
         let response = client
             .client()
             .post(url.to_owned())
+            .header(
+                reqwest::header::CONTENT_TYPE,
+                "application/mysten.proxy.promexposition",
+            )
             .body(metrics)
             .send()
             .await?;

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -436,6 +436,7 @@ primeorder = { version = "0.12", default-features = false }
 primitive-types = { version = "0.10", features = ["impl-serde"] }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["span-locations"] }
 prometheus = { version = "0.13" }
+prometheus-parse = { git = "https://github.com/suiwombat/prometheus-parse-rs", rev = "daa964c", default-features = false }
 proptest = { version = "1" }
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
@@ -1146,6 +1147,7 @@ proc-macro-hack = { version = "0.5", default-features = false }
 proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4" }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["span-locations"] }
 prometheus = { version = "0.13" }
+prometheus-parse = { git = "https://github.com/suiwombat/prometheus-parse-rs", rev = "daa964c", default-features = false }
 proptest = { version = "1" }
 proptest-derive = { version = "0.3", default-features = false }
 prost = { version = "0.11" }


### PR DESCRIPTION
# Summary:

We wish to eliminate using third party metric agents for collecting metrics from sui nodes.  This pr creates a metric proxy service that accepts post data from downstream nodes and relays it to an upstream tsdb.

The design of the proxy is intended to return a success to calling clients as early as possible.  It does this by queueing up the client data into an mpsc channel and then that will be sent upstream.  After sending on the channel, (which is buffered), the client will get an immediate "accept".  This status indicates that we have accepted the metrics and intend to relay them upstream.  Some failure modes here are restarts (we drop whatever we have queued on the floor) or if we can't relay them upstream correctly, they will be dropped.  Future work can optimize this for stateful recovery if we find it necessary.

We export the prom exposition format and add labels for the downstream node and network name within the proxy itself. We currently derive the name of the node from the http header `host`, but this needs to be replaced with the json-rpc data we collect about valid nodes.  This is retrieved in this PR, but not exposed yet.

todo in future pr:
* relay data to a tsdb data sink
* add more tests
* decide what max post data size will be (default is 2MB)
* enable tls
* expose chain data to UpstreamConsumer

# Test Plan:

cargo test and interactive testing

### interactive:

to start the server:
```
cargo run -- -l="[::1]:8080" -u="[::1]:8081" -b 100 --network joenet
```

use tests to simulate client posts.