### PR TITLE
[wallet-standard] Add signMessage support to wallet standard

### DIFF
--- a/.changeset/afraid-donuts-ring.md
+++ b/.changeset/afraid-donuts-ring.md
@@ -1,0 +1,6 @@
+---
+"@mysten/wallet-standard": minor
+"@mysten/sui.js": minor
+---
+
+Change `signMessage` to return message bytes. Add support for sui:signMessage in the wallet standard

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -98,7 +98,8 @@ export class SuiWallet implements Wallet {
 
     get features(): ConnectFeature &
         EventsFeature &
-        SuiFeatures &
+        // TODO: Support SignMessage:
+        Omit<SuiFeatures, 'sui:signMessage'> &
         SuiWalletStakeFeature {
         return {
             'standard:connect': {

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -36,6 +36,7 @@ import {
   SignableTransaction,
   UnserializedSignableTransaction,
   SignedTransaction,
+  SignedMessage,
 } from './txn-data-serializers/txn-data-serializer';
 
 ///////////////////////////////
@@ -91,10 +92,16 @@ export abstract class SignerWithProvider implements Signer {
   /**
    * Sign a message using the keypair, with the `PersonalMessage` intent.
    */
-  async signMessage(message: Uint8Array): Promise<SerializedSignature> {
-    return await this.signData(
+  async signMessage(message: Uint8Array): Promise<SignedMessage> {
+    const signature = await this.signData(
       messageWithIntent(IntentScope.PersonalMessage, message),
     );
+
+    return {
+      // TODO: Should this include the intent, or just be the raw bytes that are signed?
+      messageBytes: toB64(message),
+      signature,
+    };
   }
 
   /**

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -156,6 +156,11 @@ export type SignedTransaction = {
   signature: SerializedSignature;
 };
 
+export type SignedMessage = {
+  messageBytes: string;
+  signature: SerializedSignature;
+};
+
 /** A type that represents the possible transactions that can be signed: */
 export type SignableTransaction =
   | UnserializedSignableTransaction

--- a/sdk/typescript/test/e2e/raw-signer.test.ts
+++ b/sdk/typescript/test/e2e/raw-signer.test.ts
@@ -39,7 +39,7 @@ describe('RawSigner', () => {
     const keypair = new Ed25519Keypair();
     const signData = new TextEncoder().encode('hello world');
     const signer = new RawSigner(keypair, toolbox.provider);
-    const signature = await signer.signMessage(signData);
+    const { signature } = await signer.signMessage(signData);
     const isValid = await verifyMessage(signData, signature);
     expect(isValid).toBe(true);
   });
@@ -48,7 +48,7 @@ describe('RawSigner', () => {
     const keypair = new Ed25519Keypair();
     const signData = new TextEncoder().encode('hello world');
     const signer = new RawSigner(keypair, toolbox.provider);
-    const signature = await signer.signMessage(signData);
+    const { signature } = await signer.signMessage(signData);
     const isValid = await verifyMessage(
       new TextEncoder().encode('hello worlds'),
       signature,
@@ -73,7 +73,7 @@ describe('RawSigner', () => {
     const keypair = new Secp256k1Keypair();
     const signData = new TextEncoder().encode('hello world');
     const signer = new RawSigner(keypair, toolbox.provider);
-    const signature = await signer.signMessage(signData);
+    const { signature } = await signer.signMessage(signData);
 
     const isValid = await verifyMessage(signData, signature);
     expect(isValid).toBe(true);

--- a/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
+++ b/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
@@ -4,6 +4,7 @@
 import {
   ExecuteTransactionRequestType,
   SignableTransaction,
+  SignedMessage,
   SignedTransaction,
   SuiAddress,
   SuiTransactionResponse,
@@ -27,6 +28,7 @@ export interface WalletAdapter {
     event: E,
     callback: WalletAdapterEvents[E]
   ) => () => void;
+  signMessage(message: Uint8Array): Promise<SignedMessage>;
   signTransaction(transaction: SignableTransaction): Promise<SignedTransaction>;
   /**
    * Suggest a transaction for the user to sign. Supports all valid transaction types.

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -11,6 +11,7 @@ import {
   Network,
   RawSigner,
   SignableTransaction,
+  SignedMessage,
 } from "@mysten/sui.js";
 import {
   WalletAdapter,
@@ -47,6 +48,10 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
 
   async getAccounts() {
     return [this.#keypair.getPublicKey().toSuiAddress()];
+  }
+
+  async signMessage(message: Uint8Array) {
+    return this.#signer.signMessage(message);
   }
 
   async signTransaction(transaction: SignableTransaction) {

--- a/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
+++ b/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
@@ -89,6 +89,10 @@ export class StandardWalletAdapter implements WalletAdapter {
     }
   }
 
+  async signMessage(message: Uint8Array) {
+    return this.#wallet.features["sui:signMessage"].signMessage({ message });
+  }
+
   async signTransaction(transaction: SignableTransaction) {
     return this.#wallet.features["sui:signTransaction"].signTransaction({
       transaction,

--- a/sdk/wallet-adapter/wallet-kit-core/src/index.ts
+++ b/sdk/wallet-adapter/wallet-kit-core/src/index.ts
@@ -4,6 +4,7 @@
 import {
   ExecuteTransactionRequestType,
   SignableTransaction,
+  SignedMessage,
   SignedTransaction,
   SuiAddress,
   SuiTransactionResponse,
@@ -53,6 +54,7 @@ export interface WalletKitCore {
   subscribe(handler: SubscribeHandler): Unsubscribe;
   connect(walletName: string): Promise<void>;
   disconnect(): Promise<void>;
+  signMessage(message: Uint8Array): Promise<SignedMessage>;
   signTransaction(transaction: SignableTransaction): Promise<SignedTransaction>;
   signAndExecuteTransaction(
     transaction: SignableTransaction,
@@ -238,6 +240,16 @@ export function createWalletKitCore({
       } catch {}
       await internalState.currentWallet.disconnect();
       disconnected();
+    },
+
+    signMessage(message) {
+      if (!internalState.currentWallet) {
+        throw new Error(
+          "No wallet is currently connected, cannot call `signMessage`."
+        );
+      }
+
+      return internalState.currentWallet.signMessage(message);
     },
 
     signTransaction(transaction) {

--- a/sdk/wallet-adapter/wallet-kit/src/WalletKitContext.tsx
+++ b/sdk/wallet-adapter/wallet-kit/src/WalletKitContext.tsx
@@ -77,7 +77,11 @@ export function WalletKitProvider({
 type UseWalletKit = WalletKitCoreState &
   Pick<
     WalletKitCore,
-    "connect" | "disconnect" | "signTransaction" | "signAndExecuteTransaction"
+    | "connect"
+    | "disconnect"
+    | "signMessage"
+    | "signTransaction"
+    | "signAndExecuteTransaction"
   >;
 
 export function useWalletKit(): UseWalletKit {
@@ -95,6 +99,7 @@ export function useWalletKit(): UseWalletKit {
     () => ({
       connect: walletKit.connect,
       disconnect: walletKit.disconnect,
+      signMessage: walletKit.signMessage,
       signTransaction: walletKit.signTransaction,
       signAndExecuteTransaction: walletKit.signAndExecuteTransaction,
       ...state,

--- a/sdk/wallet-adapter/wallet-standard/src/detect.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/detect.ts
@@ -27,6 +27,8 @@ export function isStandardWalletAdapterCompatibleWallet(
     "standard:events" in wallet.features &&
     // TODO: Enable once ecosystem wallets adopt this:
     // "sui:signTransaction" in wallet.features &&
+    // TODO: Enable once ecosystem wallets adopt this
+    // "sui:signMessage" in wallet.features &&
     "sui:signAndExecuteTransaction" in wallet.features
   );
 }

--- a/sdk/wallet-adapter/wallet-standard/src/features/index.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/index.ts
@@ -4,14 +4,17 @@
 import type { WalletWithFeatures } from "@wallet-standard/core";
 import type { SuiSignTransactionFeature } from "./suiSignTransaction";
 import type { SuiSignAndExecuteTransactionFeature } from "./suiSignAndExecuteTransaction";
+import { SuiSignMessageFeature } from "./suiSignMessage";
 
 /**
  * Wallet Standard features that are unique to Sui, and that all Sui wallets are expected to implement.
  */
 export type SuiFeatures = SuiSignTransactionFeature &
-  SuiSignAndExecuteTransactionFeature;
+  SuiSignAndExecuteTransactionFeature &
+  SuiSignMessageFeature;
 
 export type WalletWithSuiFeatures = WalletWithFeatures<SuiFeatures>;
 
+export * from "./suiSignMessage";
 export * from "./suiSignTransaction";
 export * from "./suiSignAndExecuteTransaction";

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiSignMessage.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiSignMessage.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SignedMessage } from "@mysten/sui.js";
+
+/** The latest API version of the signMessage API. */
+export type SuiSignMessageVersion = "1.0.0";
+
+/**
+ * A Wallet Standard feature for signing a personal message, and returning the
+ * message bytes that were signed, and message signature.
+ */
+export type SuiSignMessageFeature = {
+  /** Namespace for the feature. */
+  "sui:signMessage": {
+    /** Version of the feature API. */
+    version: SuiSignMessageVersion;
+    signMessage: SuiSignMessageMethod;
+  };
+};
+
+export type SuiSignMessageMethod = (
+  input: SuiSignMessageInput
+) => Promise<SuiSignMessageOutput>;
+
+/** Input for signing messages. */
+export interface SuiSignMessageInput {
+  message: Uint8Array;
+  options?: SuiSignMessageOptions;
+}
+
+/** Output of signing messages. */
+export interface SuiSignMessageOutput extends SignedMessage {}
+
+/** Options for signing messages. */
+export interface SuiSignMessageOptions {}


### PR DESCRIPTION
This adds the `signMessage` feature to the wallet standard.