### PR TITLE
Reinstall cargo for TS e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,12 +87,16 @@ jobs:
       - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
         with:
           version: 7
-      - run: cargo build --bin sui-test-validator --bin sui --profile dev
+      - name: Build validator for devnet
+        run: cargo build --bin sui-test-validator --profile dev
 
-      # checkout the current branch
+      # checkout and build the current branch
       - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
         with:
           clean: false
+      - name: Build sui bin for current branch
+        run:
+          cargo build --bin sui
 
       - name: Install Nodejs
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3


### PR DESCRIPTION
This may not be needed after devnet uses the same Rust version as `main`.