### PR TITLE
[epoch_data] Pass timestamp and digest to EpochData (4/n)

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -663,11 +663,11 @@ impl Builder {
     }
 }
 
-fn get_genesis_context() -> TxContext {
+fn get_genesis_context(epoch_data: &EpochData) -> TxContext {
     TxContext::new(
         &SuiAddress::default(),
         &TransactionDigest::genesis(),
-        &EpochData::genesis(),
+        epoch_data,
     )
 }
 
@@ -677,8 +677,9 @@ fn build_unsigned_genesis_data(
     objects: &[Object],
 ) -> GenesisTuple {
     let protocol_config = ProtocolConfig::get_for_version(parameters.protocol_version);
+    let epoch_data = EpochData::new_genesis(parameters.timestamp_ms);
 
-    let mut genesis_ctx = get_genesis_context();
+    let mut genesis_ctx = get_genesis_context(&epoch_data);
 
     // Get Move and Sui Framework
     let modules = [
@@ -696,7 +697,7 @@ fn build_unsigned_genesis_data(
     );
 
     let (genesis_transaction, genesis_effects, objects) =
-        create_genesis_transaction(objects, &protocol_config);
+        create_genesis_transaction(objects, &protocol_config, &epoch_data);
     let (checkpoint, checkpoint_contents) =
         create_genesis_checkpoint(parameters, &genesis_transaction, &genesis_effects);
 
@@ -737,6 +738,7 @@ fn create_genesis_checkpoint(
 fn create_genesis_transaction(
     objects: Vec<Object>,
     protocol_config: &ProtocolConfig,
+    epoch_data: &EpochData,
 ) -> (Transaction, TransactionEffects, Vec<Object>) {
     let genesis_transaction = {
         let genesis_objects = objects
@@ -801,7 +803,7 @@ fn create_genesis_transaction(
                 &move_vm,
                 &native_functions,
                 SuiGasStatus::new_unmetered(),
-                &EpochData::genesis(),
+                epoch_data,
                 protocol_config,
             );
         assert!(inner_temp_store.objects.is_empty());
@@ -1150,7 +1152,7 @@ mod test {
                 &move_vm,
                 &native_functions,
                 SuiGasStatus::new_unmetered(),
-                &EpochData::genesis(),
+                &EpochData::new_test(),
                 &protocol_config,
             );
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -54,7 +54,7 @@ use sui_protocol_config::ProtocolConfig;
 use sui_types::epoch_data::EpochData;
 use sui_types::message_envelope::TrustedEnvelope;
 use sui_types::messages_checkpoint::{
-    CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
+    CertifiedCheckpointSummary, CheckpointContents, CheckpointDigest, CheckpointSequenceNumber,
     CheckpointSignatureMessage, CheckpointSummary, CheckpointTimestamp,
 };
 use sui_types::storage::{transaction_input_object_keys, ObjectKey, ParentSync};
@@ -258,6 +258,11 @@ pub struct AuthorityEpochTables {
 #[derive(Default, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct EpochStartConfiguration {
     pub system_state: SuiSystemState,
+    /// epoch_digest is defined as following
+    /// (1) For the genesis epoch it is set to 0
+    /// (2) For all other epochs it is a digest of the last checkpoint of a previous epoch
+    /// Note that this is in line with how epoch start timestamp is defined
+    pub epoch_digest: CheckpointDigest,
 }
 
 impl AuthorityEpochTables {
@@ -1816,7 +1821,11 @@ fn transactions_table_default_config() -> DBOptions {
 
 impl EpochStartConfiguration {
     pub fn epoch_data(&self) -> EpochData {
-        EpochData::new(self.epoch_id())
+        EpochData::new(
+            self.epoch_id(),
+            self.epoch_start_timestamp_ms(),
+            self.epoch_digest(),
+        )
     }
 
     pub fn epoch_id(&self) -> EpochId {
@@ -1825,5 +1834,9 @@ impl EpochStartConfiguration {
 
     pub fn epoch_start_timestamp_ms(&self) -> CheckpointTimestamp {
         self.system_state.epoch_start_timestamp_ms
+    }
+
+    pub fn epoch_digest(&self) -> CheckpointDigest {
+        self.epoch_digest
     }
 }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -155,6 +155,22 @@ pub async fn test_checkpoint_executor_cross_epoch() {
         &second_committee,
     );
 
+    authority_state
+        .checkpoint_store
+        .epoch_last_checkpoint_map
+        .insert(
+            &end_of_epoch_0_checkpoint.summary.epoch,
+            &end_of_epoch_0_checkpoint.sequence_number(),
+        )
+        .unwrap();
+    authority_state
+        .checkpoint_store
+        .certified_checkpoints
+        .insert(
+            &end_of_epoch_0_checkpoint.sequence_number(),
+            &end_of_epoch_0_checkpoint,
+        )
+        .unwrap();
     // sync end of epoch checkpoint
     let last_executed_checkpoint = next_epoch_checkpoints.last().cloned().unwrap();
     let (end_of_epoch_1_checkpoint, _third_committee) = sync_end_of_epoch_checkpoint(

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -350,7 +350,9 @@ impl CheckpointStore {
         &self,
         epoch_id: EpochId,
     ) -> SuiResult<Option<VerifiedCheckpoint>> {
+        println!("A");
         let seq = self.epoch_last_checkpoint_map.get(&epoch_id)?;
+        println!("B {:?}", seq);
         let checkpoint = match seq {
             Some(seq) => self.get_checkpoint_by_sequence_number(seq)?,
             None => None,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -45,6 +45,7 @@ use std::{convert::TryInto, env};
 use sui_macros::sim_test;
 use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use sui_types::dynamic_field::DynamicFieldType;
+use sui_types::epoch_data::EpochData;
 use sui_types::object::Data;
 use sui_types::{
     base_types::dbg_addr,
@@ -727,9 +728,7 @@ async fn test_dev_inspect_uses_unbound_object() {
         ))],
     }));
 
-    let result = fullnode
-        .dev_inspect_transaction(sender, kind, 1, fullnode.current_epoch_for_testing())
-        .await;
+    let result = fullnode.dev_inspect_transaction(sender, kind, 1).await;
     let Err(err) = result else { panic!() };
     assert!(err
         .to_string()
@@ -1395,7 +1394,7 @@ async fn test_publish_dependent_module_ok() {
     let transaction = to_sender_signed_transaction(data, &sender_key);
 
     let dependent_module_id =
-        TxContext::new(&sender, transaction.digest(), &EpochData::genesis()).fresh_id();
+        TxContext::new(&sender, transaction.digest(), &EpochData::new_test()).fresh_id();
 
     // Object does not exist
     assert!(authority
@@ -1436,7 +1435,7 @@ async fn test_publish_module_no_dependencies_ok() {
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
     let _module_object_id =
-        TxContext::new(&sender, transaction.digest(), &EpochData::genesis()).fresh_id();
+        TxContext::new(&sender, transaction.digest(), &EpochData::new_test()).fresh_id();
     let signed_effects = send_and_confirm_transaction(&authority, transaction)
         .await
         .unwrap()
@@ -4173,9 +4172,7 @@ pub async fn call_dev_inspect(
         type_arguments,
         arguments,
     }));
-    authority
-        .dev_inspect_transaction(*sender, kind, 1, authority.current_epoch_for_testing())
-        .await
+    authority.dev_inspect_transaction(*sender, kind, 1).await
 }
 
 #[cfg(test)]

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -167,6 +167,7 @@ impl SuiNode {
         let epoch_start_configuration = if cur_epoch == genesis.epoch() {
             Some(EpochStartConfiguration {
                 system_state: genesis.sui_system_object(),
+                epoch_digest: genesis.checkpoint().digest(),
             })
         } else {
             None

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -621,7 +621,7 @@ impl<'a> SuiTestAdapter<'a> {
             &self.native_functions,
             gas_status,
             // TODO: Support different epochs in transactional tests.
-            &EpochData::genesis(),
+            &EpochData::new_test(),
             &PROTOCOL_CONSTANTS,
         );
 

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -422,13 +422,13 @@ impl TxContext {
         Self::new(
             &SuiAddress::random_for_testing_only(),
             &TransactionDigest::random(),
-            &EpochData::genesis(),
+            &EpochData::new_test(),
         )
     }
 
     // for testing
     pub fn with_sender_for_testing_only(sender: &SuiAddress) -> Self {
-        Self::new(sender, &TransactionDigest::random(), &EpochData::genesis())
+        Self::new(sender, &TransactionDigest::random(), &EpochData::new_test())
     }
 }
 

--- a/crates/sui-types/src/epoch_data.rs
+++ b/crates/sui-types/src/epoch_data.rs
@@ -2,22 +2,61 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::base_types::EpochId;
+use crate::messages_checkpoint::{CheckpointDigest, CheckpointSummary, CheckpointTimestamp};
 
 /// The static epoch information that is accessible to move smart contracts
+#[derive(Default)]
 pub struct EpochData {
     epoch_id: EpochId,
+    epoch_start_timestamp: CheckpointTimestamp,
+    epoch_digest: CheckpointDigest,
 }
 
 impl EpochData {
-    pub fn new(epoch_id: EpochId) -> Self {
-        Self { epoch_id }
+    pub fn new(
+        epoch_id: EpochId,
+        epoch_start_timestamp: CheckpointTimestamp,
+        epoch_digest: CheckpointDigest,
+    ) -> Self {
+        Self {
+            epoch_id,
+            epoch_start_timestamp,
+            epoch_digest,
+        }
     }
 
-    pub fn genesis() -> Self {
-        Self { epoch_id: 0 }
+    pub fn new_genesis(epoch_start_timestamp: CheckpointTimestamp) -> Self {
+        Self {
+            epoch_id: 0,
+            epoch_start_timestamp,
+            epoch_digest: Default::default(),
+        }
+    }
+
+    pub fn new_from_epoch_checkpoint(
+        epoch_id: EpochId,
+        epoch_checkpoint: &CheckpointSummary,
+    ) -> Self {
+        Self {
+            epoch_id,
+            epoch_start_timestamp: epoch_checkpoint.timestamp_ms,
+            epoch_digest: epoch_checkpoint.digest(),
+        }
+    }
+
+    pub fn new_test() -> Self {
+        Default::default()
     }
 
     pub fn epoch_id(&self) -> EpochId {
         self.epoch_id
+    }
+
+    pub fn epoch_start_timestamp(&self) -> CheckpointTimestamp {
+        self.epoch_start_timestamp
+    }
+
+    pub fn epoch_digest(&self) -> CheckpointDigest {
+        self.epoch_digest
     }
 }


### PR DESCRIPTION
Those values will be used for stronger ID generation. Epoch timestamp can also be used by smart contracts when we add it to TxContext