### PR TITLE
[core] Make transaction certificate per-epoch

### DIFF
--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -55,12 +55,6 @@ pub struct EpochMetrics {
     /// This is the duration of (1) through (4) above.
     pub epoch_last_checkpoint_created_time_since_epoch_close_ms: IntGauge,
 
-    /// The total time takes to create the certificate of the last transaction of the epoch. Since
-    /// we currently this cert by querying a quorum of validators, it may take some time and we
-    /// should track how long this process is.
-    /// This should be the primary time contributor of (4) above.
-    pub epoch_last_transaction_cert_creation_time_ms: IntGauge,
-
     /// The interval from when the epoch is closed to when we finished executing the last transaction
     /// of the checkpoint (and hence triggering reconfiguration process).
     /// This is the duration of (1) through (5) above.
@@ -138,11 +132,6 @@ impl EpochMetrics {
             epoch_last_checkpoint_created_time_since_epoch_close_ms: register_int_gauge_with_registry!(
                 "epoch_last_checkpoint_created_time_since_epoch_close_ms",
                 "Time interval from when epoch was closed to when the last checkpoint of the epoch is created",
-                registry
-            ).unwrap(),
-            epoch_last_transaction_cert_creation_time_ms: register_int_gauge_with_registry!(
-                "epoch_last_transaction_cert_creation_time_ms",
-                "Time takes to create the last transaction certificate of the epoch",
                 registry
             ).unwrap(),
             epoch_reconfig_start_time_since_epoch_close_ms: register_int_gauge_with_registry!(

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -65,15 +65,19 @@ async fn test_quorum_driver_submit_transaction() {
     // Test submit_transaction
     let qd_clone = quorum_driver_handler.clone();
     let handle = tokio::task::spawn(async move {
-        let QuorumDriverResponse {
-            tx_cert,
-            effects_cert,
-        } = qd_clone
+        let (
+            tx,
+            QuorumDriverResponse {
+                tx_cert,
+                effects_cert,
+            },
+        ) = qd_clone
             .subscribe_to_effects()
             .recv()
             .await
             .unwrap()
             .unwrap();
+        assert_eq!(tx.digest(), &digest);
         assert_eq!(*tx_cert.unwrap().digest(), digest);
         assert_eq!(effects_cert.data().transaction_digest, digest);
     });
@@ -98,15 +102,19 @@ async fn test_quorum_driver_submit_transaction_no_ticket() {
     );
     let qd_clone = quorum_driver_handler.clone();
     let handle = tokio::task::spawn(async move {
-        let QuorumDriverResponse {
-            tx_cert,
-            effects_cert,
-        } = qd_clone
+        let (
+            tx,
+            QuorumDriverResponse {
+                tx_cert,
+                effects_cert,
+            },
+        ) = qd_clone
             .subscribe_to_effects()
             .recv()
             .await
             .unwrap()
             .unwrap();
+        assert_eq!(tx.digest(), &digest);
         assert_eq!(*tx_cert.unwrap().digest(), digest);
         assert_eq!(effects_cert.data().transaction_digest, digest);
     });
@@ -147,15 +155,19 @@ async fn test_quorum_driver_with_given_notify_read() {
 
     let qd_clone = quorum_driver_handler.clone();
     let handle = tokio::task::spawn(async move {
-        let QuorumDriverResponse {
-            tx_cert,
-            effects_cert,
-        } = qd_clone
+        let (
+            tx,
+            QuorumDriverResponse {
+                tx_cert,
+                effects_cert,
+            },
+        ) = qd_clone
             .subscribe_to_effects()
             .recv()
             .await
             .unwrap()
             .unwrap();
+        assert_eq!(tx.digest(), &digest);
         assert_eq!(*tx_cert.unwrap().digest(), digest);
         assert_eq!(effects_cert.data().transaction_digest, digest);
     });

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -9,7 +9,7 @@ use sui_types::committee::EpochId;
 use sui_types::digests::TransactionEffectsDigest;
 use sui_types::message_envelope::Message;
 use sui_types::messages::TransactionEffects;
-use sui_types::messages::VerifiedCertificate;
+use sui_types::messages::VerifiedTransaction;
 use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::messages_checkpoint::CheckpointContentsDigest;
 use sui_types::messages_checkpoint::CheckpointDigest;
@@ -95,21 +95,8 @@ impl ReadStore for RocksDbStore {
     fn get_transaction(
         &self,
         digest: &TransactionDigest,
-    ) -> Result<Option<VerifiedCertificate>, Self::Error> {
-        if let Some(transaction) = self.authority_store.get_certified_transaction(digest)? {
-            return Ok(Some(transaction));
-        }
-
-        if let Some(transaction) = self
-            .authority_store
-            .perpetual_tables
-            .synced_transactions
-            .get(digest)?
-        {
-            return Ok(Some(transaction.into()));
-        }
-
-        Ok(None)
+    ) -> Result<Option<VerifiedTransaction>, Self::Error> {
+        self.authority_store.get_transaction(digest)
     }
 
     fn get_transaction_effects(
@@ -160,11 +147,8 @@ impl WriteStore for RocksDbStore {
         Ok(())
     }
 
-    fn insert_transaction(&self, transaction: VerifiedCertificate) -> Result<(), Self::Error> {
-        self.authority_store
-            .perpetual_tables
-            .synced_transactions
-            .insert(transaction.digest(), transaction.serializable_ref())
+    fn insert_transaction(&self, transaction: VerifiedTransaction) -> Result<(), Self::Error> {
+        self.authority_store.insert_transaction(&transaction)
     }
 
     fn insert_transaction_effects(

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -29,8 +29,8 @@ use sui_types::committee::Committee;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    FinalizedEffects, QuorumDriverResponse, VerifiedCertificate,
-    VerifiedCertifiedTransactionEffects,
+    FinalizedEffects, QuorumDriverResponse, VerifiedCertifiedTransactionEffects,
+    VerifiedExecutableTransaction,
 };
 use sui_types::quorum_driver_types::{
     QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResult,
@@ -189,7 +189,7 @@ where
 
         let _timer_guards = self.get_timer_guards(&transaction);
 
-        let ticket = self.submit(transaction).await.map_err(|e| {
+        let ticket = self.submit(transaction.clone()).await.map_err(|e| {
             warn!(?tx_digest, "QuorumDriverInternalError: {e:?}");
             QuorumDriverError::QuorumDriverInternalError(e)
         })?;
@@ -221,24 +221,26 @@ where
                         false,
                     ))));
                 }
-                // TODO: Once we support executing transactions without a cert, we won't need this unwrap.
-                let tx_cert = tx_cert.expect("Currently we always obtain a cert");
+                let executable_tx = VerifiedExecutableTransaction::new_from_quorum_execution(
+                    transaction,
+                    effects_cert.executed_epoch,
+                );
 
                 match Self::execute_finalized_tx_locally_with_timeout(
                     &self.validator_state,
-                    &tx_cert,
+                    &executable_tx,
                     &effects_cert,
                     &self.metrics,
                 )
                 .await
                 {
                     Ok(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
-                        Some(tx_cert.into()),
+                        tx_cert.map(|cert| cert.into()),
                         FinalizedEffects::new_from_effects_cert(effects_cert.into()),
                         true,
                     )))),
                     Err(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
-                        Some(tx_cert.into()),
+                        tx_cert.map(|cert| cert.into()),
                         FinalizedEffects::new_from_effects_cert(effects_cert.into()),
                         false,
                     )))),
@@ -267,10 +269,10 @@ where
         Ok(ticket)
     }
 
-    #[instrument(name = "tx_orchestrator_execute_finalized_tx_locally_with_timeout", level = "debug", skip_all, fields(tx_digest = ?tx_cert.digest()), err)]
+    #[instrument(name = "tx_orchestrator_execute_finalized_tx_locally_with_timeout", level = "debug", skip_all, fields(tx_digest = ?transaction.digest()), err)]
     async fn execute_finalized_tx_locally_with_timeout(
         validator_state: &Arc<AuthorityState>,
-        tx_cert: &VerifiedCertificate,
+        transaction: &VerifiedExecutableTransaction,
         effects_cert: &VerifiedCertifiedTransactionEffects,
         metrics: &TransactionOrchestratorMetrics,
     ) -> SuiResult {
@@ -285,7 +287,7 @@ where
         // 2. an up-to-date fullnode should have minimal overhead to sync parents
         //      (for one extra time)
         // 3. at the end of day, the tx will be executed at most once per lock guard.
-        let tx_digest = tx_cert.digest();
+        let tx_digest = transaction.digest();
         if validator_state.is_tx_already_executed(tx_digest)? {
             return Ok(());
         }
@@ -294,7 +296,7 @@ where
                 in_flight.dec();
             });
 
-        let _guard = if tx_cert.contains_shared_object() {
+        let _guard = if transaction.contains_shared_object() {
             metrics.local_execution_latency_shared_obj.start_timer()
         } else {
             metrics.local_execution_latency_single_writer.start_timer()
@@ -302,7 +304,7 @@ where
         match timeout(
             LOCAL_EXECUTION_TIMEOUT,
             validator_state.fullnode_execute_certificate_with_effects(
-                tx_cert,
+                transaction,
                 effects_cert,
                 &epoch_store,
             ),
@@ -344,13 +346,18 @@ where
     ) {
         loop {
             match effects_receiver.recv().await {
-                Ok(Ok(QuorumDriverResponse {
-                    tx_cert,
-                    effects_cert,
-                })) => {
-                    // TODO: Once we support executing transactions without a cert, we won't need this unwrap.
-                    let tx_cert = tx_cert.expect("Currently we always obtain a cert");
-                    let tx_digest = tx_cert.digest();
+                Ok(Ok((
+                    transaction,
+                    QuorumDriverResponse {
+                        tx_cert: _,
+                        effects_cert,
+                    },
+                ))) => {
+                    let executable_tx = VerifiedExecutableTransaction::new_from_quorum_execution(
+                        transaction,
+                        effects_cert.executed_epoch,
+                    );
+                    let tx_digest = executable_tx.digest();
                     if let Err(err) = pending_transaction_log.finish_transaction(tx_digest) {
                         error!(
                             ?tx_digest,
@@ -359,7 +366,7 @@ where
                     }
                     let _ = Self::execute_finalized_tx_locally_with_timeout(
                         &validator_state,
-                        &tx_cert,
+                        &executable_tx,
                         &effects_cert,
                         &metrics,
                     )

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -118,7 +118,10 @@ impl CoinReadApi {
         object_struct_tag: StructTag,
     ) -> Result<Object, Error> {
         let publish_txn_digest = self.get_object(package_id).await?.previous_transaction;
-        let (_, effects) = self.state.get_transaction(publish_txn_digest).await?;
+        let (_, effects) = self
+            .state
+            .get_transaction_and_effects(publish_txn_digest)
+            .await?;
 
         let object_id = effects
             .events

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -147,9 +147,9 @@ impl ReadApiServer for ReadApi {
         &self,
         digest: TransactionDigest,
     ) -> RpcResult<SuiTransactionResponse> {
-        let (cert, effects) = self
+        let (transaction, effects) = self
             .state
-            .get_transaction(digest)
+            .get_transaction_and_effects(digest)
             .await
             .tap_err(|err| debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err))?;
         let checkpoint = self
@@ -158,7 +158,7 @@ impl ReadApiServer for ReadApi {
             .get_transaction_checkpoint(&digest)
             .map_err(|e| anyhow!("{e}"))?;
         Ok(SuiTransactionResponse {
-            transaction: cert.data().clone().try_into()?,
+            transaction: transaction.into_message().try_into()?,
             effects: SuiTransactionEffects::try_from(effects, self.state.module_cache.as_ref())?,
             timestamp_ms: self.state.get_timestamp_ms(&digest).await?,
             confirmed_local_execution: None,

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -140,7 +140,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .name("get_transaction_and_effects")
                 .route_name("GetTransactionAndEffects")
                 .request_type("sui_types::base_types::ExecutionDigests")
-                .response_type("Option<(sui_types::messages::CertifiedTransaction, sui_types::messages::TransactionEffects)>")
+                .response_type("Option<(sui_types::messages::Transaction, sui_types::messages::TransactionEffects)>")
                 .codec_path("anemo::rpc::codec::BincodeCodec")
                 .build(),
         )

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -1168,11 +1168,8 @@ where
                 && effects.digest() == digests.effects
                 && effects.transaction_digest == digests.transaction
             {
-                // TODO this should just be a bare Transaction type and not a TransactionCertificate
-                // since Certificates are intended to be ephemeral and thrown away at the end of an
-                // epoch
                 store
-                    .insert_transaction(sui_types::messages::VerifiedCertificate::new_unchecked(
+                    .insert_transaction(sui_types::messages::VerifiedTransaction::new_unchecked(
                         transaction,
                     ))
                     .expect("store operation should not fail");

--- a/crates/sui-network/src/state_sync/server.rs
+++ b/crates/sui-network/src/state_sync/server.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, RwLock};
 use sui_types::{
     base_types::ExecutionDigests,
     digests::{CheckpointContentsDigest, CheckpointDigest},
-    messages::{CertifiedTransaction, TransactionEffects},
+    messages::{Transaction, TransactionEffects},
     messages_checkpoint::{
         CertifiedCheckpointSummary as Checkpoint, CheckpointContents, CheckpointSequenceNumber,
         VerifiedCheckpoint,
@@ -110,32 +110,28 @@ where
     async fn get_transaction_and_effects(
         &self,
         request: Request<ExecutionDigests>,
-    ) -> Result<Response<Option<(CertifiedTransaction, TransactionEffects)>>, Status> {
+    ) -> Result<Response<Option<(Transaction, TransactionEffects)>>, Status> {
         let ExecutionDigests {
-            transaction,
-            effects,
+            transaction: tx_digest,
+            effects: effects_digest,
         } = request.into_inner();
 
-        let cert = if let Some(cert) = self
+        let Some(transaction) = self
             .store
-            .get_transaction(&transaction)
-            .map_err(|e| Status::internal(e.to_string()))?
+            .get_transaction(&tx_digest)
+            .map_err(|e| Status::internal(e.to_string()))? else
         {
-            cert
-        } else {
             return Ok(Response::new(None));
         };
 
-        let effects = if let Some(effects) = self
+        let Some(effects) = self
             .store
-            .get_transaction_effects(&effects)
-            .map_err(|e| Status::internal(e.to_string()))?
+            .get_transaction_effects(&effects_digest)
+            .map_err(|e| Status::internal(e.to_string()))? else
         {
-            effects
-        } else {
             return Ok(Response::new(None));
         };
 
-        Ok(Response::new(Some((cert.into_inner(), effects))))
+        Ok(Response::new(Some((transaction.into_inner(), effects))))
     }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_config::{ConsensusConfig, NodeConfig};
-use sui_core::authority_aggregator::{AuthorityAggregator, NetworkTransactionCertifier};
+use sui_core::authority_aggregator::AuthorityAggregator;
 use sui_core::authority_server::ValidatorService;
 use sui_core::checkpoints::checkpoint_executor;
 use sui_core::epoch::committee_store::CommitteeStore;
@@ -621,7 +621,6 @@ impl SuiNode {
             accumulator,
             checkpoint_output,
             Box::new(certified_checkpoint_output),
-            Box::<NetworkTransactionCertifier>::default(),
             checkpoint_metrics,
             max_tx_per_checkpoint,
         )

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -364,17 +364,6 @@ impl<T: Message> VerifiedEnvelope<T, CertificateProof> {
         })
     }
 
-    // TODO: All callsites will eventually be replaced with new_from_checkpoint once
-    // we are ready.
-    pub fn new_from_checkpoint_to_be_replaced(
-        certificate: VerifiedEnvelope<T, AuthorityStrongQuorumSignInfo>,
-        _epoch: EpochId,
-        _checkpoint: CheckpointSequenceNumber,
-    ) -> Self {
-        Self::new_from_certificate(certificate)
-    }
-
-    // TODO: This is currently not used, but will be soon.
     pub fn new_from_checkpoint(
         transaction: VerifiedEnvelope<T, EmptySignInfo>,
         epoch: EpochId,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -3015,6 +3015,7 @@ pub struct QuorumDriverRequest {
 
 #[derive(Debug, Clone)]
 pub struct QuorumDriverResponse {
+    // TODO: Change this to VerifiedTransaction.
     pub tx_cert: Option<VerifiedCertificate>,
     pub effects_cert: VerifiedCertifiedTransactionEffects,
 }

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use crate::base_types::{AuthorityName, ObjectRef, TransactionDigest};
 use crate::committee::StakeUnit;
 use crate::error::SuiError;
-use crate::messages::QuorumDriverResponse;
+use crate::messages::{QuorumDriverResponse, VerifiedTransaction};
 use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
 use thiserror::Error;
@@ -15,7 +15,7 @@ use thiserror::Error;
 pub type QuorumDriverResult = Result<QuorumDriverResponse, QuorumDriverError>;
 
 pub type QuorumDriverEffectsQueueResult =
-    Result<QuorumDriverResponse, (TransactionDigest, QuorumDriverError)>;
+    Result<(VerifiedTransaction, QuorumDriverResponse), (TransactionDigest, QuorumDriverError)>;
 
 /// Client facing errors regarding transaction submission via Quorum Driver.
 /// Every invariant needs detailed documents to instruct client handling.

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -964,17 +964,21 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
         .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
 
     let ExecuteTransactionResponse::EffectsCert(res) = res;
-    let QuorumDriverResponse {
-        tx_cert: certified_txn,
-        effects_cert: certified_txn_effects,
-    } = rx.recv().await.unwrap().unwrap();
+    let (
+        tx,
+        QuorumDriverResponse {
+            tx_cert: certified_txn,
+            effects_cert: certified_txn_effects,
+        },
+    ) = rx.recv().await.unwrap().unwrap();
     let (ct, cte, is_executed_locally) = *res;
+    assert_eq!(*tx.digest(), digest);
     assert_eq!(*ct.unwrap().digest(), digest);
     assert_eq!(*certified_txn.unwrap().digest(), digest);
     assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(is_executed_locally);
     // verify that the node has sequenced and executed the txn
-    node.state().get_transaction(digest).await
+    node.state().get_transaction_and_effects(digest).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {:?} that was executed with WaitForLocalExecution: {:?}", digest, e));
 
     // Test WaitForEffectsCert
@@ -989,17 +993,21 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
         .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
 
     let ExecuteTransactionResponse::EffectsCert(res) = res;
-    let QuorumDriverResponse {
-        tx_cert: certified_txn,
-        effects_cert: certified_txn_effects,
-    } = rx.recv().await.unwrap().unwrap();
+    let (
+        tx,
+        QuorumDriverResponse {
+            tx_cert: certified_txn,
+            effects_cert: certified_txn_effects,
+        },
+    ) = rx.recv().await.unwrap().unwrap();
     let (ct, cte, is_executed_locally) = *res;
+    assert_eq!(*tx.digest(), digest);
     assert_eq!(*ct.unwrap().digest(), digest);
     assert_eq!(*certified_txn.unwrap().digest(), digest);
     assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(!is_executed_locally);
     wait_for_tx(digest, node.state().clone()).await;
-    node.state().get_transaction(digest).await
+    node.state().get_transaction_and_effects(digest).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {:?} that was executed with WaitForEffectsCert: {:?}", digest, e));
 
     Ok(())

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -75,7 +75,11 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let (_, _, executed_locally) = *result;
     assert!(executed_locally);
 
-    assert!(node.state().get_transaction(digest).await.is_ok());
+    assert!(node
+        .state()
+        .get_transaction_and_effects(digest)
+        .await
+        .is_ok());
 
     Ok(())
 }


### PR DESCRIPTION
This PR moves the transaction certificate signature table to per-epoch table on validators. This means that we no longer keep transaction certificates permanently in the network. This PR also changes state sync to only download transactions instead of certificates. 