### PR TITLE
clean up check_sequenced_input_objects

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -379,15 +379,6 @@ pub enum SuiError {
         object_id: ObjectID,
         version: Option<SequenceNumber>,
     },
-    #[error(
-        "Transaction involving Shared Object {:?} at version {:?} is not ready for execution because prior transactions have yet to execute.",
-        object_id,
-        version_not_ready
-    )]
-    SharedObjectPriorVersionsPendingExecution {
-        object_id: ObjectID,
-        version_not_ready: SequenceNumber,
-    },
     #[error("Could not find the referenced object {:?} as the asked version {:?} is higher than the latest {:?}", object_id, asked_version, latest_version)]
     ObjectSequenceNumberTooHigh {
         object_id: ObjectID,


### PR DESCRIPTION
TransactionManager makes sure all depended objects are ready before invoking a tx. So during this tx's processing, we shouldn't expect an input object to be missing

This is followup of https://github.com/MystenLabs/sui/pull/8411#discussion_r1113467229