### PR TITLE
Downloading latest vesions of sui and sui-test-validator

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,15 +95,15 @@ jobs:
 
       - name: Download sui binary from latest devnet release
         run: |
-          mkdir -p target/debug
+          mkdir -p $PWD/target/debug
           wget -O target/debug/sui https://github.com/MystenLabs/sui/releases/latest/download/sui
-          chmod +x target/debug/sui
+          chmod +x $PWD/target/debug/sui
 
       - name: Download sui-test-validator binary from latest devnet release
         run: |
-          mkdir -p target/debug
+          mkdir -p $PWD/target/debug
           wget -O target/debug/sui-test-validator https://github.com/MystenLabs/sui/releases/latest/download/sui-test-validator
-          chmod +x target/debug/sui-test-validator
+          chmod +x $PWD/target/debug/sui-test-validator
 
       - name: Install Nodejs
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,16 +87,16 @@ jobs:
       - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
         with:
           version: 7
-      - name: Build validator for devnet
-        run: cargo build --bin sui-test-validator --profile dev
 
-      # checkout and build the current branch
-      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+      - name: Download sui binary from latest devnet release
+        uses: wei/wget@v1
         with:
-          clean: false
-      - name: Build sui bin for current branch
-        run:
-          cargo build --bin sui
+          args: -O $PWD/target/debug/sui https://github.com/MystenLabs/sui/releases/latest/download/sui
+
+      - name: Download sui-test-validator binary from latest devnet release
+        uses: wei/wget@v1
+        with:
+          args: -O $PWD/target/debug/sui-test-validator https://github.com/MystenLabs/sui/releases/latest/download/sui-test-validator
 
       - name: Install Nodejs
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,14 +94,10 @@ jobs:
           clean: false
 
       - name: Download sui binary from latest devnet release
-        uses: wei/wget@v1
-        with:
-          args: -O target/debug/sui https://github.com/MystenLabs/sui/releases/latest/download/sui
+        run: mkdir -p target/debug && wget -O target/debug/sui https://github.com/MystenLabs/sui/releases/latest/download/sui
 
       - name: Download sui-test-validator binary from latest devnet release
-        uses: wei/wget@v1
-        with:
-          args: -O target/debug/sui-test-validator https://github.com/MystenLabs/sui/releases/latest/download/sui-test-validator
+        run: mkdir -p target/debug && wget -O target/debug/sui-test-validator https://github.com/MystenLabs/sui/releases/latest/download/sui-test-validator
 
       - name: Install Nodejs
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           version: 7
 
-      # checkout and build the current branch
+      # checkout current branch
       - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
         with:
           clean: false
@@ -96,12 +96,12 @@ jobs:
       - name: Download sui binary from latest devnet release
         uses: wei/wget@v1
         with:
-          args: -O $PWD/target/debug/sui https://github.com/MystenLabs/sui/releases/latest/download/sui
+          args: -O target/debug/sui https://github.com/MystenLabs/sui/releases/latest/download/sui
 
       - name: Download sui-test-validator binary from latest devnet release
         uses: wei/wget@v1
         with:
-          args: -O $PWD/target/debug/sui-test-validator https://github.com/MystenLabs/sui/releases/latest/download/sui-test-validator
+          args: -O target/debug/sui-test-validator https://github.com/MystenLabs/sui/releases/latest/download/sui-test-validator
 
       - name: Install Nodejs
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,9 +87,11 @@ jobs:
       - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
         with:
           version: 7
-          
+
       # checkout and build the current branch
       - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+        with:
+          clean: false
 
       - name: Download sui binary from latest devnet release
         uses: wei/wget@v1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,10 +94,16 @@ jobs:
           clean: false
 
       - name: Download sui binary from latest devnet release
-        run: mkdir -p target/debug && wget -O target/debug/sui https://github.com/MystenLabs/sui/releases/latest/download/sui
+        run: |
+          mkdir -p target/debug
+          wget -O target/debug/sui https://github.com/MystenLabs/sui/releases/latest/download/sui
+          chmod +x target/debug/sui
 
       - name: Download sui-test-validator binary from latest devnet release
-        run: mkdir -p target/debug && wget -O target/debug/sui-test-validator https://github.com/MystenLabs/sui/releases/latest/download/sui-test-validator
+        run: |
+          mkdir -p target/debug
+          wget -O target/debug/sui-test-validator https://github.com/MystenLabs/sui/releases/latest/download/sui-test-validator
+          chmod +x target/debug/sui-test-validator
 
       - name: Install Nodejs
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,6 +87,9 @@ jobs:
       - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
         with:
           version: 7
+          
+      # checkout and build the current branch
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
 
       - name: Download sui binary from latest devnet release
         uses: wei/wget@v1

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -72,7 +72,6 @@ import { LocalTxnDataSerializer } from '../signers/txn-data-serializers/local-tx
 import { toB64 } from '@mysten/bcs';
 import { SerializedSignature } from '../cryptography/signature';
 import { pkgVersion } from '../pkg-version';
-
 import { Connection, devnetConnection } from '../rpc/connection';
 
 export const TARGETED_RPC_VERSION = '0.27.0';

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -65,8 +65,6 @@ import {
   WebsocketClient,
   WebsocketClientOptions,
 } from '../rpc/websocket-client';
-import { ApiEndpoints, Network, NETWORK_TO_API } from '../utils/api-endpoints';
-
 import { requestSuiFromFaucet } from '../rpc/faucet-client';
 import { any, is, number, array } from 'superstruct';
 import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
@@ -74,6 +72,7 @@ import { LocalTxnDataSerializer } from '../signers/txn-data-serializers/local-tx
 import { toB64 } from '@mysten/bcs';
 import { SerializedSignature } from '../cryptography/signature';
 import { pkgVersion } from '../pkg-version';
+
 import { Connection, devnetConnection } from '../rpc/connection';
 
 export const TARGETED_RPC_VERSION = '0.27.0';

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -65,6 +65,8 @@ import {
   WebsocketClient,
   WebsocketClientOptions,
 } from '../rpc/websocket-client';
+import { ApiEndpoints, Network, NETWORK_TO_API } from '../utils/api-endpoints';
+
 import { requestSuiFromFaucet } from '../rpc/faucet-client';
 import { any, is, number, array } from 'superstruct';
 import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';


### PR DESCRIPTION
**Description**
Instead of running builds to produce binaries that were shipped with the current devnet release, we are instead going to pull the binaries directly from the GitHub Release page.

**Test**
Verified that tests still pass https://github.com/MystenLabs/sui/actions/runs/4248045135/jobs/7386762594#logs