### PR TITLE
Use same VM for publishing and execution. Instantiate a new VM for dry run and devinspect

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -365,7 +365,6 @@ pub fn publish<
 >(
     state_view: &mut S,
     vm: &MoveVM,
-    natives: NativeFunctionTable,
     module_bytes: Vec<Vec<u8>>,
     ctx: &mut TxContext,
     gas_status: &mut GasStatus,
@@ -385,15 +384,15 @@ pub fn publish<
     }
 
     let package_id = generate_package_id(&mut modules, ctx)?;
-    let vm = verify_and_link(
+    verify_and_link(
+        vm,
         state_view,
         &modules,
         package_id,
-        natives,
         gas_status,
         protocol_config,
     )?;
-    store_package_and_init_modules(state_view, &vm, modules, ctx, gas_status, protocol_config)
+    store_package_and_init_modules(state_view, vm, modules, ctx, gas_status, protocol_config)
 }
 
 /// Store package in state_view and call module initializers
@@ -520,20 +519,18 @@ pub fn verify_and_link<
     E: Debug,
     S: ResourceResolver<Error = E> + ModuleResolver<Error = E> + Storage + ChildObjectResolver,
 >(
+    vm: &MoveVM,
     state_view: &S,
     modules: &[CompiledModule],
     package_id: ObjectID,
-    natives: NativeFunctionTable,
     gas_status: &mut GasStatus,
     protocol_config: &ProtocolConfig,
-) -> Result<MoveVM, ExecutionError> {
+) -> Result<(), ExecutionError> {
     // Run the Move bytecode verifier and linker.
     // It is important to do this before running the Sui verifier, since the sui
     // verifier may assume well-formedness conditions enforced by the Move verifier hold
-    let vm = MoveVM::new(natives)
-        .expect("VM creation only fails if natives are invalid, and we created the natives");
     let mut session = new_session(
-        &vm,
+        vm,
         state_view,
         BTreeMap::new(),
         gas_status.is_metered(),
@@ -556,14 +553,14 @@ pub fn verify_and_link<
             // Do we want to charge there?
             gas_status,
         )
-        .map_err(|e| convert_vm_error(e, &vm, state_view))?;
+        .map_err(|e| convert_vm_error(e, vm, state_view))?;
 
     // run the Sui verifier
     for module in modules.iter() {
         // Run Sui bytecode verifier, which runs some additional checks that assume the Move bytecode verifier has passed.
         verifier::verify_module(module, &BTreeMap::new())?;
     }
-    Ok(vm)
+    Ok(())
 }
 
 /// Given a list of `modules`, use `ctx` to generate a fresh ID for the new packages.

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use crate::execution_mode::{self, ExecutionMode};
 use move_core_types::language_storage::{ModuleId, StructTag};
-use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
+use move_vm_runtime::move_vm::MoveVM;
 use sui_types::base_types::SequenceNumber;
 use tracing::{debug, instrument};
 
@@ -65,7 +65,6 @@ pub fn execute_transaction_to_effects<
     transaction_digest: TransactionDigest,
     mut transaction_dependencies: BTreeSet<TransactionDigest>,
     move_vm: &Arc<MoveVM>,
-    native_functions: &NativeFunctionTable,
     gas_status: SuiGasStatus,
     epoch_data: &EpochData,
     protocol_config: &ProtocolConfig,
@@ -82,7 +81,6 @@ pub fn execute_transaction_to_effects<
         gas_object_ref.0,
         &mut tx_ctx,
         move_vm,
-        native_functions,
         gas_status,
         protocol_config,
     );
@@ -144,7 +142,6 @@ fn execute_transaction<
     gas_object_id: ObjectID,
     tx_ctx: &mut TxContext,
     move_vm: &Arc<MoveVM>,
-    native_functions: &NativeFunctionTable,
     mut gas_status: SuiGasStatus,
     protocol_config: &ProtocolConfig,
 ) -> (
@@ -161,7 +158,6 @@ fn execute_transaction<
             gas_object_id,
             tx_ctx,
             move_vm,
-            native_functions,
             &mut gas_status,
             protocol_config,
         );
@@ -194,7 +190,6 @@ fn execution_loop<
     gas_object_id: ObjectID,
     tx_ctx: &mut TxContext,
     move_vm: &Arc<MoveVM>,
-    native_functions: &NativeFunctionTable,
     gas_status: &mut SuiGasStatus,
     protocol_config: &ProtocolConfig,
 ) -> Result<Mode::ExecutionResults, ExecutionError> {
@@ -291,7 +286,6 @@ fn execution_loop<
                 adapter::publish(
                     temporary_store,
                     move_vm,
-                    native_functions.clone(),
                     modules,
                     tx_ctx,
                     gas_status.create_move_gas_status(),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -972,7 +972,6 @@ impl AuthorityState {
                 *certificate.digest(),
                 transaction_dependencies,
                 &self.move_vm,
-                &self._native_functions,
                 gas_status,
                 &epoch_store.epoch_start_configuration().epoch_data(),
                 epoch_store.protocol_config(),
@@ -1021,6 +1020,13 @@ impl AuthorityState {
         );
         let signer = transaction.sender();
         let gas = transaction.gas();
+        let move_vm = Arc::new(
+            adapter::new_move_vm(
+                self._native_functions.clone(),
+                epoch_store.protocol_config(),
+            )
+            .expect("We defined natives to not fail here"),
+        );
         let (_inner_temp_store, effects, _execution_error) =
             execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
                 shared_object_refs,
@@ -1030,8 +1036,7 @@ impl AuthorityState {
                 gas,
                 transaction_digest,
                 transaction_dependencies,
-                &self.move_vm,
-                &self._native_functions,
+                &move_vm,
                 gas_status,
                 &epoch_store.epoch_start_configuration().epoch_data(),
                 epoch_store.protocol_config(),
@@ -1097,6 +1102,13 @@ impl AuthorityState {
             SuiCostTable::new(protocol_config),
         );
         gas_status.charge_min_tx_gas()?;
+        let move_vm = Arc::new(
+            adapter::new_move_vm(
+                self._native_functions.clone(),
+                epoch_store.protocol_config(),
+            )
+            .expect("We defined natives to not fail here"),
+        );
         let (_inner_temp_store, effects, execution_result) =
             execution_engine::execute_transaction_to_effects::<execution_mode::DevInspect, _>(
                 shared_object_refs,
@@ -1106,8 +1118,7 @@ impl AuthorityState {
                 gas_object_ref,
                 transaction_digest,
                 transaction_dependencies,
-                &self.move_vm,
-                &self._native_functions,
+                &move_vm,
                 gas_status,
                 &EpochData::new(epoch), /* TODO(epoch_data): this needs to be figured out */
                 protocol_config,

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -25,9 +25,7 @@ use move_transactional_test_runner::{
     framework::{CompiledState, MoveTestAdapter},
     tasks::{InitCommand, SyntaxChoice, TaskInput},
 };
-use move_vm_runtime::{
-    move_vm::MoveVM, native_functions::NativeFunctionTable, session::SerializedReturnValues,
-};
+use move_vm_runtime::{move_vm::MoveVM, session::SerializedReturnValues};
 use once_cell::sync::Lazy;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::fmt::Write;
@@ -74,7 +72,6 @@ const RNG_SEED: [u8; 32] = [
 pub struct SuiTestAdapter<'a> {
     vm: Arc<MoveVM>,
     pub(crate) storage: Arc<InMemoryStorage>,
-    native_functions: NativeFunctionTable,
     pub(crate) compiled_state: CompiledState<'a>,
     accounts: BTreeMap<String, (SuiAddress, AccountKeyPair)>,
     default_syntax: SyntaxChoice,
@@ -250,9 +247,8 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         }
 
         let mut test_adapter = Self {
-            vm: Arc::new(new_move_vm(native_functions.clone(), &PROTOCOL_CONSTANTS).unwrap()),
+            vm: Arc::new(new_move_vm(native_functions, &PROTOCOL_CONSTANTS).unwrap()),
             storage: Arc::new(InMemoryStorage::new(objects)),
-            native_functions,
             compiled_state: CompiledState::new(
                 named_address_mapping,
                 pre_compiled_deps,
@@ -618,7 +614,6 @@ impl<'a> SuiTestAdapter<'a> {
             transaction_digest,
             transaction_dependencies,
             &self.vm,
-            &self.native_functions,
             gas_status,
             // TODO: Support different epochs in transactional tests.
             &EpochData::genesis(),


### PR DESCRIPTION
With this PR we are now using the same VM for execution and publishing. That solves the problem of running the same verifier on loading and publishing, which is vital. 
The VM may get polluted with published packages but that should be fine and we will also have a way to restart the VM if we have too much pressure on the code cache.

Dry run and Dev Inspect are instead running in their own instance of a VM. That makes the 2 operations heavier but it also keeps the execution VM cleaner. Dry run and Dev Inspect run on a full node and not a validator, in that respect consistency of a VM is less critical, but it seems reasonable to have those 2 modes run on a scratchpad (so to speak).

Move VM people please raise concerns if you have any (@tnowacki @sblackshear @oxade @amnn @awelc @tzakian and whomever else may have feelings on the subject) 