### PR TITLE
[TransactionManager] reduce time spent while holding lock in `enqueue()`

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -863,7 +863,7 @@ impl AuthorityState {
         // REQUIRED: this must be called before tx_guard.commit_tx() (below), to ensure
         // TransactionManager can get the notifications after the node crashes and restarts.
         self.transaction_manager
-            .objects_committed(output_keys, epoch_store);
+            .objects_available(output_keys, epoch_store);
 
         // commit_certificate finished, the tx is fully committed to the store.
         tx_guard.commit_tx();

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -288,17 +288,6 @@ impl AuthorityStore {
             .get(&ObjectKey(*object_id, version))?)
     }
 
-    pub fn object_version_exists(
-        &self,
-        object_id: &ObjectID,
-        version: VersionNumber,
-    ) -> Result<bool, SuiError> {
-        Ok(self
-            .perpetual_tables
-            .objects
-            .contains_key(&ObjectKey(*object_id, version))?)
-    }
-
     /// Read an object and return it, or Ok(None) if the object was not found.
     pub fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         self.perpetual_tables.as_ref().get_object(object_id)
@@ -333,56 +322,60 @@ impl AuthorityStore {
         Ok(result)
     }
 
+    /// Gets the input object keys from input object kinds, by determining the versions of owned,
+    /// shared and package objects.
     /// When making changes, please see if check_sequenced_input_objects() below needs
     /// similar changes as well.
-    pub fn get_missing_input_objects(
+    pub fn get_input_object_keys(
         &self,
         digest: &TransactionDigest,
         objects: &[InputObjectKind],
         epoch_store: &AuthorityPerEpochStore,
-    ) -> Result<Vec<InputKey>, SuiError> {
-        let shared_locks_cell: OnceCell<HashMap<_, _>> = OnceCell::new();
+    ) -> Vec<InputKey> {
+        let mut shared_locks = HashMap::<ObjectID, SequenceNumber>::new();
+        objects
+            .iter()
+            .map(|kind| {
+                match kind {
+                    InputObjectKind::SharedMoveObject { id, .. } => {
+                        if shared_locks.is_empty() {
+                            shared_locks = epoch_store
+                                .get_shared_locks(digest)
+                                .expect("Read from storage should not fail!")
+                                .into_iter()
+                                .collect();
+                        }
+                        // If we can't find the locked version, it means
+                        // 1. either we have a bug that skips shared object version assignment
+                        // 2. or we have some DB corruption
+                        let Some(version) = shared_locks.get(id) else {
+                            panic!(
+                                "Shared object locks should have been set. tx_digset: {digest:?}, obj \
+                                id: {id:?}",
+                            )
+                        };
+                        InputKey(*id, Some(*version))
+                    }
+                    InputObjectKind::MovePackage(id) => InputKey(*id, None),
+                    InputObjectKind::ImmOrOwnedMoveObject(objref) => InputKey(objref.0, Some(objref.1))
+                }
+            })
+            .collect()
+    }
 
-        let mut missing = Vec::new();
-        for kind in objects {
-            match kind {
-                InputObjectKind::SharedMoveObject { id, .. } => {
-                    let shared_locks = shared_locks_cell.get_or_try_init(|| {
-                        Ok::<HashMap<ObjectID, SequenceNumber>, SuiError>(
-                            epoch_store.get_shared_locks(digest)?.into_iter().collect(),
-                        )
-                    })?;
-                    // If we can't find the locked version, it means
-                    // 1. either we have a bug that skips shared object version assignment
-                    // 2. or we have some DB corruption
-                    let Some(version) = shared_locks.get(id) else {
-                        panic!(
-                            "Shared object locks should have been set. tx_digset: {digest:?}, obj \
-                             id: {id:?}",
-                        )
-                    };
-
-                    if !self.object_version_exists(id, *version)? {
-                        // When this happens, other transactions that use smaller versions of this
-                        // shared object haven't finished execution.
-                        missing.push(InputKey(*id, Some(*version)));
-                    }
-                }
-                InputObjectKind::MovePackage(id) => {
-                    if !self.object_exists(*id)? {
-                        // The cert cannot have been formed if the package was missing.
-                        missing.push(InputKey(*id, None));
-                    }
-                }
-                InputObjectKind::ImmOrOwnedMoveObject(objref) => {
-                    if self.get_object_by_key(&objref.0, objref.1)?.is_none() {
-                        missing.push(InputKey(objref.0, Some(objref.1)));
-                    }
-                }
-            };
+    /// Checks if the input object identified by the InputKey exists, with support for non-system
+    /// packages i.e. when version is None.
+    pub fn input_object_exists(&self, key: &InputKey) -> Result<bool, SuiError> {
+        match key.1 {
+            Some(version) => Ok(self
+                .perpetual_tables
+                .objects
+                .contains_key(&ObjectKey(key.0, version))?),
+            None => match self.get_latest_parent_entry(key.0)? {
+                None => Ok(false),
+                Some(entry) => Ok(entry.0 .2.is_alive()),
+            },
         }
-
-        Ok(missing)
     }
 
     /// Attempts to acquire execution lock for an executable transaction.
@@ -407,7 +400,7 @@ impl AuthorityStore {
         self.execution_lock.write().await
     }
 
-    /// When making changes, please see if get_missing_input_objects() above needs
+    /// When making changes, please see if get_input_object_keys() above needs
     /// similar changes as well.
     ///
     /// Before this function is invoked, TransactionManager must ensure all depended
@@ -1100,13 +1093,6 @@ impl AuthorityStore {
         object_id: ObjectID,
     ) -> Result<Option<(ObjectRef, TransactionDigest)>, SuiError> {
         self.perpetual_tables.get_latest_parent_entry(object_id)
-    }
-
-    pub fn object_exists(&self, object_id: ObjectID) -> SuiResult<bool> {
-        match self.get_latest_parent_entry(object_id)? {
-            None => Ok(false),
-            Some(entry) => Ok(entry.0 .2.is_alive()),
-        }
     }
 
     pub fn insert_transaction_and_effects(


### PR DESCRIPTION
Although `TransactionManager` may not be the immediate bottleneck during Sui node catchup / checkpoint execution, it seems worthwhile to make sure the contention is as low as possible.

This PR updates `TransactionManager::enqueue()` to only hold the internal lock while updating internal in-memory state. The high level logic is:
1. Without lock: Get versions for all input objects, reading them from shared locks table if necessary. Then find input objects that are still unavailable.
2. With lock: update internal state for pending certificates and missing input objects.
3. Without lock: Re-check missing input objects to see if any of them exists now.
4. With lock: call `objects_available()` with newly available objects.

In the ideal and likely common case, steps 3 and 4 are skipped because no missing input object is found at step 1. The worst case scenario is that an object's existence is checked twice: at steps 1 and 3.

Also, `TransactionManager` no longer takes tx lock in `enqueue()`, because it seems unnecessary:
- Transactions may have multiple executions after crash recovery, when they are recovered from both the recovery log and `pending_execution` table. But this seems benign.
- Missing input objects table does not need this lock to ensure available objects do not remain in the table forever.

