### PR TITLE
[explorer] Add sentry instrumentation for network requests

### DIFF
--- a/.changeset/bright-pants-thank.md
+++ b/.changeset/bright-pants-thank.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Expose rpcClient and websocketClient options

--- a/apps/explorer/src/utils/api/DefaultRpcClient.ts
+++ b/apps/explorer/src/utils/api/DefaultRpcClient.ts
@@ -6,7 +6,11 @@ import {
     Connection,
     devnetConnection,
     localnetConnection,
+    JsonRpcClient,
+    type RpcParams,
 } from '@mysten/sui.js';
+import * as Sentry from '@sentry/react';
+import { type SpanStatusType } from '@sentry/tracing';
 
 export enum Network {
     LOCAL = 'LOCAL',
@@ -22,6 +26,56 @@ const CONNECTIONS: Record<Network, Connection> = {
     }),
 };
 
+class SentryRPCClient extends JsonRpcClient {
+    #url: string;
+    constructor(url: string) {
+        super(url);
+        this.#url = url;
+    }
+
+    async request(method: string, args: any[]) {
+        const transaction = Sentry.startTransaction({
+            name: method,
+            op: 'http.rpc-request',
+            data: { url: this.#url, args },
+        });
+
+        try {
+            const res = await super.request(method, args);
+            const status: SpanStatusType = 'ok';
+            transaction.setStatus(status);
+            return res;
+        } catch (e) {
+            const status: SpanStatusType = 'internal_error';
+            transaction.setStatus(status);
+            throw e;
+        } finally {
+            transaction.finish();
+        }
+    }
+
+    async batchRequest(requests: RpcParams[]) {
+        const transaction = Sentry.startTransaction({
+            name: 'batch',
+            op: 'http.rpc-request',
+            data: { url: this.#url, requests },
+        });
+
+        try {
+            const res = await super.batchRequest(requests);
+            const status: SpanStatusType = 'ok';
+            transaction.setStatus(status);
+            return res;
+        } catch (e) {
+            const status: SpanStatusType = 'internal_error';
+            transaction.setStatus(status);
+            throw e;
+        } finally {
+            transaction.finish();
+        }
+    }
+}
+
 const defaultRpcMap: Map<Network | string, JsonRpcProvider> = new Map();
 /** @deprecated This shouldn't be directly used, and instead should be used through `useRpc()`. */
 export const DefaultRpcClient = (network: Network | string) => {
@@ -33,7 +87,13 @@ export const DefaultRpcClient = (network: Network | string) => {
             ? CONNECTIONS[network as Network]
             : new Connection({ fullnode: network });
 
-    const provider = new JsonRpcProvider(connection);
+    const provider = new JsonRpcProvider(connection, {
+        rpcClient:
+            // If the network is a known network, then attach the sentry RPC client for instrumentation:
+            network in Network
+                ? new SentryRPCClient(connection.fullnode)
+                : undefined,
+    });
     defaultRpcMap.set(network, provider);
     return provider;
 };

--- a/apps/explorer/src/utils/sentry.ts
+++ b/apps/explorer/src/utils/sentry.ts
@@ -11,11 +11,14 @@ import {
     useNavigationType,
 } from 'react-router-dom';
 
-import { featuresPromise, growthbook } from './growthbook';
+const SENTRY_ENABLED = import.meta.env.PROD;
+const SENTRY_SAMPLE_RATE = 0.02;
 
 Sentry.init({
-    enabled: import.meta.env.PROD,
-    dsn: 'https://e4251274d1b141d7ba272103fa0f8d83@o1314142.ingest.sentry.io/6564988',
+    enabled: SENTRY_ENABLED,
+    dsn: import.meta.env.PROD
+        ? 'https://e4251274d1b141d7ba272103fa0f8d83@o1314142.ingest.sentry.io/6564988'
+        : 'https://5455656fe14848c0944fb4216dd5c483@o1314142.ingest.sentry.io/4504362510188544',
     environment: import.meta.env.VITE_VERCEL_ENV,
     integrations: [
         new BrowserTracing({
@@ -28,22 +31,7 @@ Sentry.init({
             ),
         }),
     ],
-    // NOTE: Even though this is set to 1, we actually will properly sample the event in `beforeSendTransaction`.
-    // We don't do sampling here or in `tracesSampler` because those can't be async, so we can't wait for
-    // the features from growthbook to load before applying sampling.
-    tracesSampleRate: 1,
-    async beforeSendTransaction(event) {
-        await featuresPromise;
-        const sampleRate = growthbook.getFeatureValue(
-            'explorer-sentry-tracing',
-            0
-        );
-        if (sampleRate > Math.random()) {
-            return event;
-        } else {
-            return null;
-        }
-    },
+    tracesSampleRate: import.meta.env.PROD ? SENTRY_SAMPLE_RATE : 1,
     beforeSend(event) {
         try {
             // Filter out any code from unknown sources:

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -13,6 +13,11 @@ export * from './providers/provider';
 export * from './providers/json-rpc-provider';
 export * from './providers/json-rpc-provider-with-cache';
 
+export * from './rpc/client';
+export * from './rpc/faucet-client';
+export * from './rpc/websocket-client';
+export * from './rpc/connection';
+
 export * from './signers/txn-data-serializers/rpc-txn-data-serializer';
 export * from './signers/txn-data-serializers/txn-data-serializer';
 export * from './signers/txn-data-serializers/local-txn-data-serializer';
@@ -26,7 +31,6 @@ export * from './types';
 export * from './utils/format';
 export * from './utils/intent';
 export * from './utils/verify';
-export * from './rpc/connection';
 
 export * from './framework';
 

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -97,12 +97,19 @@ export type RpcProviderOptions = {
   skipDataValidation?: boolean;
   /**
    * Configuration options for the websocket connection
+   * TODO: Move to connection.
    */
   socketOptions?: WebsocketClientOptions;
   /**
    * Cache timeout in seconds for the RPC API Version
    */
   versionCacheTimeoutInSeconds?: number;
+
+  /** Allow defining a custom RPC client to use */
+  rpcClient?: JsonRpcClient;
+
+  /** Allow defining a custom websocket client to use */
+  websocketClient?: WebsocketClient;
 };
 
 const DEFAULT_OPTIONS: RpcProviderOptions = {
@@ -146,12 +153,15 @@ export class JsonRpcProvider extends Provider {
     //   'Client-Target-Api-Version': TARGETED_RPC_VERSION,
     // });
     // TODO: add header for websocket request
-    this.client = new JsonRpcClient(this.connection.fullnode);
-    this.wsClient = new WebsocketClient(
-      this.connection.websocket,
-      opts.skipDataValidation!,
-      opts.socketOptions,
-    );
+    this.client = opts.rpcClient ?? new JsonRpcClient(this.connection.fullnode);
+
+    this.wsClient =
+      opts.websocketClient ??
+      new WebsocketClient(
+        this.connection.websocket,
+        opts.skipDataValidation!,
+        opts.socketOptions,
+      );
   }
 
   async getRpcApiVersion(): Promise<RpcApiVersion | undefined> {

--- a/sdk/typescript/src/rpc/client.ts
+++ b/sdk/typescript/src/rpc/client.ts
@@ -53,11 +53,7 @@ export class JsonRpcClient {
   private rpcClient: RpcClient;
 
   constructor(url: string, httpHeaders?: HttpHeaders) {
-    this.rpcClient = this.createRpcClient(url, httpHeaders);
-  }
-
-  private createRpcClient(url: string, httpHeaders?: HttpHeaders): RpcClient {
-    const client = new RpcClient(
+    this.rpcClient = new RpcClient(
       async (
         request: any,
         callback: (arg0: Error | null, arg1?: string | undefined) => void,
@@ -65,12 +61,18 @@ export class JsonRpcClient {
         const options = {
           method: 'POST',
           body: request,
-          headers: Object.assign(
-            {
-              'Content-Type': 'application/json',
-            },
-            httpHeaders || {},
-          ),
+          headers: {
+            'Content-Type': 'application/json',
+            ...httpHeaders,
+            // TODO: uncomment this when 0.27.0 is released. We cannot do this now because
+            // the current Devnet(0.26.0) does not support the header. And we need to make
+            // a request to RPC to know which version it is running. Therefore, we do not
+            // add headers here, instead we add headers in the first call of the `getRpcApiVersion`
+            // method
+            //   'Client-Sdk-Type': 'typescript',
+            //   'Client-Sdk-Version': pkgVersion,
+            //   'Client-Target-Api-Version': TARGETED_RPC_VERSION,
+          },
         };
 
         try {
@@ -92,8 +94,6 @@ export class JsonRpcClient {
       },
       {},
     );
-
-    return client;
   }
 
   async requestWithType<T>(


### PR DESCRIPTION
- Adds a new `SentryRPCClient` that creates Sentry transactions around requests, so that we can observe latencies for HTTP requests, and get an idea of error rates. This should let us add error rate alerting as well.
- Allow custom rpc client to be provided when constructing the provider.
- Exposes all clients from the SDK so that they can be extended.
- Move sentry sample rate to a static value (and raise to 5%). This gives us better control over sampling, and given we can instantly deploy the explorer, should be fine.