### PR TITLE
[checkpoint] Use notify_one for builder->aggregator notification

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -539,7 +539,7 @@ impl CheckpointBuilder {
             )?;
         }
         batch.write()?;
-        self.notify_aggregator.notify_waiters();
+        self.notify_aggregator.notify_one();
         self.epoch_store
             .process_pending_checkpoint(height, &new_checkpoint)?;
         Ok(())


### PR DESCRIPTION
We used to have `notify_waiters` when sending notification from checkpoint builder, because both CheckpointAggregator and CheckpointTailer were listening to those notifications.

However, now that Tailer is removed, notify_one should be used.