### PR TITLE
[ts-sdk] - add support for combined `sui_getCheckpoint` endpoint

### DIFF
--- a/.changeset/thin-candles-march.md
+++ b/.changeset/thin-candles-march.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+added combined `getCheckpoint` endpoint for retrieving information about a checkpoint

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -54,6 +54,7 @@ import {
   CheckpointSummary,
   CheckpointContents,
   CheckpointDigest,
+  Checkpoint,
   CheckPointContentsDigest,
   CommitteeInfo,
   versionToString,
@@ -1008,6 +1009,22 @@ export class JsonRpcProvider extends Provider {
     } catch (err) {
       throw new Error(
         `Error getting checkpoint summary with request type: ${err} for digest: ${digest}.`,
+      );
+    }
+  }
+
+  async getCheckpoint(id: CheckpointDigest | number): Promise<Checkpoint> {
+    try {
+      const resp = await this.client.requestWithType(
+        'sui_getCheckpoint',
+        [id],
+        Checkpoint,
+        this.options.skipDataValidation,
+      );
+      return resp;
+    } catch (err) {
+      throw new Error(
+        `Error getting checkpoint with request type: ${err} for id: ${id}.`,
       );
     }
   }

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -388,6 +388,7 @@ export abstract class Provider {
   /**
    * Returns checkpoint summary based on a checkpoint sequence number
    * @param sequence_number - The sequence number of the desired checkpoint summary
+   * @deprecated - Prefer `getCheckpoint` instead
    */
   abstract getCheckpointSummary(
     sequenceNumber: number,

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -44,6 +44,7 @@ import {
   CheckpointContents,
   CheckpointDigest,
   CheckPointContentsDigest,
+  Checkpoint,
   CommitteeInfo,
 } from '../types';
 
@@ -395,6 +396,7 @@ export abstract class Provider {
   /**
    * Returns checkpoint summary based on a checkpoint digest
    * @param digest - The checkpoint digest
+   * @deprecated - Use `getCheckpoint` instead
    */
   abstract getCheckpointSummaryByDigest(
     digest: CheckpointDigest,
@@ -403,6 +405,7 @@ export abstract class Provider {
   /**
    * Return contents of a checkpoint, namely a list of execution digests
    * @param sequence_number - The sequence number of the desired checkpoint contents
+   * @deprecated - Use `getCheckpoint` instead
    */
   abstract getCheckpointContents(
     sequenceNumber: number,
@@ -415,6 +418,12 @@ export abstract class Provider {
   abstract getCheckpointContentsByDigest(
     digest: CheckPointContentsDigest,
   ): Promise<CheckpointContents>;
+
+  /**
+   * Returns information about a given checkpoint
+   * @param id - The checkpoint digest or sequence number
+   */
+  abstract getCheckpoint(id: CheckpointDigest | number): Promise<Checkpoint>;
 
   /**
    * Return the committee information for the asked epoch

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -396,7 +396,7 @@ export abstract class Provider {
   /**
    * Returns checkpoint summary based on a checkpoint digest
    * @param digest - The checkpoint digest
-   * @deprecated - Use `getCheckpoint` instead
+   * @deprecated - Prefer `getCheckpoint` instead
    */
   abstract getCheckpointSummaryByDigest(
     digest: CheckpointDigest,
@@ -405,7 +405,7 @@ export abstract class Provider {
   /**
    * Return contents of a checkpoint, namely a list of execution digests
    * @param sequence_number - The sequence number of the desired checkpoint contents
-   * @deprecated - Use `getCheckpoint` instead
+   * @deprecated - Prefer `getCheckpoint` instead
    */
   abstract getCheckpointContents(
     sequenceNumber: number,

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -45,6 +45,7 @@ import {
   CheckpointDigest,
   CheckPointContentsDigest,
   CommitteeInfo,
+  Checkpoint,
 } from '../types';
 import { Provider } from './provider';
 
@@ -314,6 +315,10 @@ export class VoidProvider extends Provider {
     _digest: CheckpointDigest,
   ): Promise<CheckpointSummary> {
     throw this.newError('getCheckpointSummaryByDigest');
+  }
+
+  async getCheckpoint(_id: CheckpointDigest | number): Promise<Checkpoint> {
+    throw this.newError('getCheckpoint');
   }
 
   async getCheckpointContents(

--- a/sdk/typescript/src/types/checkpoints.ts
+++ b/sdk/typescript/src/types/checkpoints.ts
@@ -58,4 +58,18 @@ export const CheckpointContents = object({
   transactions: array(ExecutionDigests),
   user_signatures: array(string()),
 });
+
+export const Checkpoint = object({
+  epoch: number(),
+  sequenceNumber: number(),
+  digest: CheckpointDigest,
+  networkTotalTransactions: number(),
+  previousDigest: union([CheckpointDigest, literal(null)]),
+  epochRollingGasCostSummary: GasCostSummary,
+  timestampMs: union([number(), literal(null)]),
+  endOfEpochData: union([EndOfEpochData, literal(null)]),
+  transactions: array(TransactionDigest),
+});
+export type Checkpoint = Infer<typeof Checkpoint>;
+
 export type CheckpointContents = Infer<typeof CheckpointContents>;

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -18,4 +18,5 @@ export {
   CheckpointContents,
   CheckpointDigest,
   CheckPointContentsDigest,
+  Checkpoint,
 } from './checkpoints';

--- a/sdk/typescript/test/e2e/checkpoint.test.ts
+++ b/sdk/typescript/test/e2e/checkpoint.test.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { lt } from '@suchipi/femver';
 import { describe, it, expect, beforeAll } from 'vitest';
+import { versionToString } from '../../src';
 import { setup, TestToolbox } from './utils/setup';
 
 describe('Checkpoints Reading API', () => {
@@ -48,10 +50,9 @@ describe('Checkpoints Reading API', () => {
   it('gets checkpoint by id', async () => {
     const version = await toolbox.provider.getRpcApiVersion();
     // todo: remove this once 0.28.0 is released
-    if (version?.major === 0 && version?.minor > 27) {
-      const resp = await toolbox.provider.getCheckpoint(0);
-      expect(resp.digest.length).greaterThan(0);
-    }
+    if (version && lt(versionToString(version), '0.28.0')) return;
+    const resp = await toolbox.provider.getCheckpoint(0);
+    expect(resp.digest.length).greaterThan(0);
   });
 
   it('get checkpoint contents by digest', async () => {

--- a/sdk/typescript/test/e2e/checkpoint.test.ts
+++ b/sdk/typescript/test/e2e/checkpoint.test.ts
@@ -46,8 +46,12 @@ describe('Checkpoints Reading API', () => {
   });
 
   it('gets checkpoint by id', async () => {
-    const resp = await toolbox.provider.getCheckpoint(0);
-    expect(resp.digest.length).greaterThan(0);
+    const version = await toolbox.provider.getRpcApiVersion();
+    // todo: remove this once 0.28.0 is released
+    if (version?.major === 0 && version?.minor > 27) {
+      const resp = await toolbox.provider.getCheckpoint(0);
+      expect(resp.digest.length).greaterThan(0);
+    }
   });
 
   it('get checkpoint contents by digest', async () => {

--- a/sdk/typescript/test/e2e/checkpoint.test.ts
+++ b/sdk/typescript/test/e2e/checkpoint.test.ts
@@ -47,7 +47,7 @@ describe('Checkpoints Reading API', () => {
 
   it('gets checkpoint by id', async () => {
     const resp = await toolbox.provider.getCheckpoint(0);
-    // todo: finish this test
+    expect(resp.digest.length).greaterThan(0);
   });
 
   it('get checkpoint contents by digest', async () => {

--- a/sdk/typescript/test/e2e/checkpoint.test.ts
+++ b/sdk/typescript/test/e2e/checkpoint.test.ts
@@ -45,6 +45,11 @@ describe('Checkpoints Reading API', () => {
     expect(resp.transactions.length).greaterThan(0);
   });
 
+  it('gets checkpoint by id', async () => {
+    const resp = await toolbox.provider.getCheckpoint(0);
+    // todo: finish this test
+  });
+
   it('get checkpoint contents by digest', async () => {
     const checkpoint_resp = await toolbox.provider.getCheckpointSummary(0);
     const digest = checkpoint_resp.content_digest;


### PR DESCRIPTION
- adds support in the ts-sdk for combined `getCheckpoint` endpoint that was added [here](https://github.com/MystenLabs/sui/pull/8440/files)
- marked `getCheckpointSummary` `getCheckpointSummaryByDigest` and `getCheckpointContents` as deprecated in favor of the combined endpoint


