### PR TITLE
[consensus] Store VerifiedExecutableTransaction instead of certificates for pending execution

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1650,7 +1650,13 @@ impl AuthorityState {
         certs: Vec<VerifiedCertificate>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<()> {
-        epoch_store.insert_pending_certificates(&certs)?;
+        let executable_txns: Vec<_> = certs
+            .clone()
+            .into_iter()
+            .map(VerifiedExecutableTransaction::new_from_certificate)
+            .map(VerifiedExecutableTransaction::serializable)
+            .collect();
+        epoch_store.insert_pending_execution(&executable_txns)?;
         self.transaction_manager
             .enqueue_certificates(certs, epoch_store)
     }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -90,7 +90,7 @@ impl TransactionManager {
             tx_ready_certificates,
         };
         transaction_manager
-            .enqueue_certificates(epoch_store.all_pending_certificates().unwrap(), epoch_store)
+            .enqueue(epoch_store.all_pending_execution().unwrap(), epoch_store)
             .expect("Initialize TransactionManager with pending certificates failed.");
         transaction_manager
     }
@@ -153,7 +153,7 @@ impl TransactionManager {
             // skip already executed txes
             if self.authority_store.is_tx_already_executed(&digest)? {
                 // also ensure the transaction will not be retried after restart.
-                let _ = epoch_store.remove_pending_certificate(&digest);
+                let _ = epoch_store.remove_pending_execution(&digest);
                 self.metrics
                     .transaction_manager_num_enqueued_certificates
                     .with_label_values(&["already_executed"])
@@ -310,7 +310,7 @@ impl TransactionManager {
                 .transaction_manager_num_executing_certificates
                 .set(inner.executing_certificates.len() as i64);
         }
-        let _ = epoch_store.remove_pending_certificate(digest);
+        let _ = epoch_store.remove_pending_execution(digest);
     }
 
     /// Sends the ready certificate for execution.


### PR DESCRIPTION
We used to store transaction certificates in pending certificates, so that transaction manager can pick them up on restart.

This change modifies this table to store `VerifiedExecutableTransaction`, rather than certificates - this is needed to uniformly handle system transaction to update time that won't have a certificate.