### PR TITLE
[TypeScript SDK] Fix backward-compatibility for expiration field

### DIFF
--- a/.changeset/cuddly-donuts-compete.md
+++ b/.changeset/cuddly-donuts-compete.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Add TransactionExpiration to TransactionData

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -16,7 +16,6 @@ import {
   SuiEventEnvelope,
   SuiEventFilter,
   SuiExecuteTransactionResponse,
-  SuiExecuteTransactionResponse_v26,
   SuiMoveFunctionArgTypes,
   SuiMoveNormalizedFunction,
   SuiMoveNormalizedModule,
@@ -38,7 +37,6 @@ import {
   TransactionEffects,
   DevInspectResults,
   CoinMetadata,
-  toSuiTransactionData,
   isValidTransactionDigest,
   isValidSuiAddress,
   isValidSuiObjectId,
@@ -689,38 +687,6 @@ export class JsonRpcProvider extends Provider {
     signature: SerializedSignature,
     requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert',
   ): Promise<SuiExecuteTransactionResponse> {
-    const version = await this.getRpcApiVersion();
-    if (version?.major === 0 && version?.minor <= 26) {
-      try {
-        let resp = await this.client.requestWithType(
-          'sui_executeTransactionSerializedSig',
-          [
-            typeof txnBytes === 'string' ? txnBytes : toB64(txnBytes),
-            signature,
-            requestType,
-          ],
-          SuiExecuteTransactionResponse_v26,
-          this.options.skipDataValidation,
-        );
-        let certificate = resp.certificate
-          ? {
-              transactionDigest: resp.certificate!.transactionDigest,
-              data: toSuiTransactionData(resp.certificate!.data),
-              txSignatures: [resp.certificate!.txSignature],
-              authSignInfo: resp.certificate!.authSignInfo,
-            }
-          : undefined;
-        return {
-          certificate: certificate,
-          effects: resp.effects,
-          confirmed_local_execution: resp.confirmed_local_execution,
-        };
-      } catch (err) {
-        throw new Error(
-          `Error executing transaction with request type: ${err}`,
-        );
-      }
-    }
     try {
       return await this.client.requestWithType(
         'sui_executeTransactionSerializedSig',

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -18,9 +18,7 @@ import {
   normalizeSuiObjectId,
   bcsForVersion,
   GasData,
-  TransactionData_v26,
   RpcApiVersion,
-  toTransactionData,
 } from '../../types';
 import {
   MoveCallTransaction,
@@ -247,7 +245,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
   async constructTransactionData(
     signerAddress: string,
     unserializedTxn: UnserializedSignableTransaction,
-  ): Promise<TransactionData | TransactionData_v26> {
+  ): Promise<TransactionData> {
     const [tx, gasPayment] = await this.constructTransactionKindAndPayment(
       signerAddress,
       unserializedTxn,
@@ -337,7 +335,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     originalTx: UnserializedSignableTransaction,
     gasObjectId: ObjectId | undefined,
     signerAddress: SuiAddress,
-  ): Promise<TransactionData | TransactionData_v26> {
+  ): Promise<TransactionData> {
     // TODO: Allow people to add tip to the reference gas price by using originalTx.data.gasPrice
     originalTx.data.gasPrice = await this.provider.getReferenceGasPrice();
     if (gasObjectId === undefined) {
@@ -357,16 +355,6 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
         'Must provide a valid gas budget for contructing TransactionData',
       );
     }
-    let version = await this.provider.getRpcApiVersion();
-    if (version?.major === 0 && version?.minor <= 26) {
-      return {
-        kind: tx,
-        sender: signerAddress,
-        gasPayment: gasPayment!,
-        gasPrice: originalTx.data.gasPrice!,
-        gasBudget: originalTx.data.gasBudget!,
-      };
-    }
     return {
       kind: tx,
       sender: signerAddress,
@@ -384,7 +372,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
    * Serialize `TransactionData` into BCS encoded bytes
    */
   public async serializeTransactionData(
-    tx: TransactionData | TransactionData_v26,
+    tx: TransactionData,
     // TODO: derive the buffer size automatically
     size: number = 8192,
   ): Promise<Uint8Array> {
@@ -427,11 +415,10 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
    * Deserialize `TransactionData` to `SignableTransaction`
    */
   public async transformTransactionDataToSignableTransaction(
-    tx: TransactionData | TransactionData_v26,
+    tx_data: TransactionData,
   ): Promise<
     UnserializedSignableTransaction | UnserializedSignableTransaction[]
   > {
-    let tx_data = toTransactionData(tx);
     if ('Single' in tx_data.kind) {
       return this.transformTransactionToSignableTransaction(
         tx_data.kind.Single,

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -10,7 +10,7 @@ import {
   union,
   unknown,
 } from 'superstruct';
-import { CallArg, TransactionData, TransactionData_v26 } from './sui-bcs';
+import { CallArg, TransactionData } from './sui-bcs';
 import { sha256Hash } from '../cryptography/hash';
 import { BCS, fromB58, toB58 } from '@mysten/bcs';
 
@@ -123,7 +123,7 @@ export function normalizeSuiObjectId(
  * @param publicKey public key
  */
 export function generateTransactionDigest(
-  data: TransactionData | TransactionData_v26,
+  data: TransactionData,
   bcs: BCS,
 ): string {
   const txBytes = bcs.ser('TransactionData', data).toBytes();

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -264,43 +264,9 @@ export const TRANSACTION_DATA_TYPE_TAG = Array.from('TransactionData::').map(
 export function deserializeTransactionBytesToTransactionData(
   bcs: BCS,
   bytes: Uint8Array,
-): TransactionData | TransactionData_v26 {
+): TransactionData {
   return bcs.de('TransactionData', bytes);
 }
-
-export function toTransactionData(
-  tx_data: TransactionData_v26 | TransactionData,
-): TransactionData {
-  if ('gasData' in tx_data) {
-    return tx_data;
-  }
-  return {
-    sender: tx_data.sender,
-    kind: tx_data.kind,
-    gasData: {
-      payment: tx_data.gasPayment,
-      owner: tx_data.sender!,
-      budget: tx_data.gasBudget,
-      price: tx_data.gasPrice,
-    },
-    expiration: { None: null },
-  };
-}
-
-/* TransactionData <= v26 */
-/**
- * The TransactionData to be signed and sent to the RPC service.
- *
- * Field `sender` is made optional as it can be added during the signing
- * process and there's no need to define it sooner.
- */
-export type TransactionData_v26 = {
-  sender?: string; //
-  gasBudget: number;
-  gasPrice: number;
-  kind: TransactionKind;
-  gasPayment: SuiObjectRef;
-};
 
 const BCS_SPEC = {
   enums: {
@@ -420,16 +386,14 @@ const BCS_SPEC = {
   },
 };
 
-// for version <= 0.26.0
-const BCS_0_26_SPEC = {
+// for version <= 0.27.0
+const BCS_0_27_SPEC = {
   structs: {
     ...BCS_SPEC.structs,
     TransactionData: {
       kind: 'TransactionKind',
       sender: BCS.ADDRESS,
-      gasPayment: 'SuiObjectRef',
-      gasPrice: BCS.U64,
-      gasBudget: BCS.U64,
+      gasData: 'GasData',
     },
     SenderSignedData: {
       data: 'TransactionData',
@@ -446,12 +410,12 @@ const bcs = new BCS({ ...getSuiMoveConfig(), types: BCS_SPEC });
 registerUTF8String(bcs);
 
 // ========== Backward Compatibility (remove after v0.24 deploys) ===========
-const bcs_0_26 = new BCS({ ...getSuiMoveConfig(), types: BCS_0_26_SPEC });
-registerUTF8String(bcs_0_26);
+const bcs_0_27 = new BCS({ ...getSuiMoveConfig(), types: BCS_0_27_SPEC });
+registerUTF8String(bcs_0_27);
 
 export function bcsForVersion(v?: RpcApiVersion) {
-  if (v?.major === 0 && v?.minor <= 26) {
-    return bcs_0_26;
+  if (v?.major === 0 && v?.minor <= 27) {
+    return bcs_0_27;
   }
 
   return bcs;

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -21,7 +21,6 @@ import {
   getObjectId,
   PayAllSuiTx,
   PayAllSuiTransaction,
-  TransactionData_v26,
 } from '../../src';
 import { CallArgSerializer } from '../../src/signers/txn-data-serializers/call-arg-serializer';
 import {
@@ -222,27 +221,17 @@ describe('Transaction Serialization and deserialization', () => {
       },
     } as PaySuiTx;
 
-    const version = await localSerializer.getRpcApiVersion();
-    const tx_data =
-      version?.major === 0 && version?.minor <= 26
-        ? ({
-            sender: DEFAULT_RECIPIENT_2,
-            gasBudget: gasBudget,
-            gasPrice: 100,
-            kind: { Single: paySuiTx } as TransactionKind,
-            gasPayment: getObjectReference(coins[1]),
-          } as TransactionData_v26)
-        : ({
-            sender: DEFAULT_RECIPIENT_2,
-            kind: { Single: paySuiTx } as TransactionKind,
-            gasData: {
-              owner: DEFAULT_RECIPIENT_2,
-              budget: gasBudget,
-              price: 100,
-              payment: getObjectReference(coins[1]),
-            },
-            expiration: { None: null },
-          } as TransactionData);
+    const tx_data = {
+      sender: DEFAULT_RECIPIENT_2,
+      kind: { Single: paySuiTx } as TransactionKind,
+      gasData: {
+        owner: DEFAULT_RECIPIENT_2,
+        budget: gasBudget,
+        price: 100,
+        payment: getObjectReference(coins[1]),
+      },
+      expiration: { None: null },
+    } as TransactionData;
 
     const serializedData = await localSerializer.serializeTransactionData(
       tx_data,
@@ -278,28 +267,17 @@ describe('Transaction Serialization and deserialization', () => {
         recipient: DEFAULT_RECIPIENT,
       },
     } as PayAllSuiTx;
-
-    const version = await localSerializer.getRpcApiVersion();
-    const tx_data =
-      version?.major === 0 && version?.minor <= 26
-        ? ({
-            sender: DEFAULT_RECIPIENT_2,
-            gasBudget: gasBudget,
-            gasPrice: 100,
-            kind: { Single: payAllSui } as TransactionKind,
-            gasPayment: getObjectReference(coins[1]),
-          } as TransactionData_v26)
-        : ({
-            sender: DEFAULT_RECIPIENT_2,
-            kind: { Single: payAllSui } as TransactionKind,
-            gasData: {
-              owner: DEFAULT_RECIPIENT_2,
-              budget: gasBudget,
-              price: 100,
-              payment: getObjectReference(coins[1]),
-            },
-            expiration: { None: null },
-          } as TransactionData);
+    const tx_data = {
+      sender: DEFAULT_RECIPIENT_2,
+      kind: { Single: payAllSui } as TransactionKind,
+      gasData: {
+        owner: DEFAULT_RECIPIENT_2,
+        budget: gasBudget,
+        price: 100,
+        payment: getObjectReference(coins[1]),
+      },
+      expiration: { None: null },
+    } as TransactionData;
 
     const serializedData = await localSerializer.serializeTransactionData(
       tx_data,


### PR DESCRIPTION
The TS e2e test is broken due to change in https://github.com/MystenLabs/sui/pull/8499 . The e2e test failed to catch the error before merging because the devnet was still at 0.26.0 at the time but the culrprit PR did not go into 0.27.0