### PR TITLE
[storage] Make tx and effects insertion atomic

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2022,7 +2022,7 @@ impl AuthorityState {
         self.get_indexes()?.get_recent_transactions(count)
     }
 
-    pub async fn get_transaction_and_effects(
+    pub async fn get_executed_transaction_and_effects(
         &self,
         digest: TransactionDigest,
     ) -> Result<(VerifiedTransaction, TransactionEffects), anyhow::Error> {
@@ -2573,9 +2573,8 @@ impl AuthorityState {
         // We must write tx and effects to the state sync tables so that state sync is able to
         // deliver to the transaction to CheckpointExecutor after it is included in a certified
         // checkpoint.
-        let effects_digest = signed_effects.digest();
         self.database
-            .insert_transaction_and_effects(&tx, &signed_effects, effects_digest)
+            .insert_transaction_and_effects(&tx, signed_effects.data())
             .map_err(|err| {
                 let err: anyhow::Error = err.into();
                 err

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -7,7 +7,6 @@ use sui_types::base_types::TransactionDigest;
 use sui_types::committee::Committee;
 use sui_types::committee::EpochId;
 use sui_types::digests::TransactionEffectsDigest;
-use sui_types::message_envelope::Message;
 use sui_types::messages::TransactionEffects;
 use sui_types::messages::VerifiedTransaction;
 use sui_types::messages_checkpoint::CheckpointContents;
@@ -147,17 +146,12 @@ impl WriteStore for RocksDbStore {
         Ok(())
     }
 
-    fn insert_transaction(&self, transaction: VerifiedTransaction) -> Result<(), Self::Error> {
-        self.authority_store.insert_transaction(&transaction)
-    }
-
-    fn insert_transaction_effects(
+    fn insert_transaction_and_effects(
         &self,
+        transaction: VerifiedTransaction,
         transaction_effects: TransactionEffects,
     ) -> Result<(), Self::Error> {
         self.authority_store
-            .perpetual_tables
-            .effects
-            .insert(&transaction_effects.digest(), &transaction_effects)
+            .insert_transaction_and_effects(&transaction, &transaction_effects)
     }
 }

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -120,7 +120,7 @@ impl CoinReadApi {
         let publish_txn_digest = self.get_object(package_id).await?.previous_transaction;
         let (_, effects) = self
             .state
-            .get_transaction_and_effects(publish_txn_digest)
+            .get_executed_transaction_and_effects(publish_txn_digest)
             .await?;
 
         let object_id = effects

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -149,7 +149,7 @@ impl ReadApiServer for ReadApi {
     ) -> RpcResult<SuiTransactionResponse> {
         let (transaction, effects) = self
             .state
-            .get_transaction_and_effects(digest)
+            .get_executed_transaction_and_effects(digest)
             .await
             .tap_err(|err| debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err))?;
         let checkpoint = self

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -1169,12 +1169,10 @@ where
                 && effects.transaction_digest == digests.transaction
             {
                 store
-                    .insert_transaction(sui_types::messages::VerifiedTransaction::new_unchecked(
-                        transaction,
-                    ))
-                    .expect("store operation should not fail");
-                store
-                    .insert_transaction_effects(effects)
+                    .insert_transaction_and_effects(
+                        sui_types::messages::VerifiedTransaction::new_unchecked(transaction),
+                        effects,
+                    )
                     .expect("store operation should not fail");
                 // TODO: If the transaction has already been executed, we should check that the executed
                 // effects match. If they don't, it's a bug and we should panic.

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -978,7 +978,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(is_executed_locally);
     // verify that the node has sequenced and executed the txn
-    node.state().get_transaction_and_effects(digest).await
+    node.state().get_executed_transaction_and_effects(digest).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {:?} that was executed with WaitForLocalExecution: {:?}", digest, e));
 
     // Test WaitForEffectsCert
@@ -1007,7 +1007,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(!is_executed_locally);
     wait_for_tx(digest, node.state().clone()).await;
-    node.state().get_transaction_and_effects(digest).await
+    node.state().get_executed_transaction_and_effects(digest).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {:?} that was executed with WaitForEffectsCert: {:?}", digest, e));
 
     Ok(())

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -77,7 +77,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
 
     assert!(node
         .state()
-        .get_transaction_and_effects(digest)
+        .get_executed_transaction_and_effects(digest)
         .await
         .is_ok());
 


### PR DESCRIPTION
Nothing fundamentally wrong with the separate APIs, but we always insert them together and it's easier to reason about if they happen atomically. One less thing to worry about.