### PR TITLE
[core] Introduce root state hash verification

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use either::Either;
+use fastcrypto::hash::{Digest, MultisetHash};
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::resolver::ModuleResolver;
 use once_cell::sync::OnceCell;
@@ -183,6 +184,15 @@ impl AuthorityStore {
         }
 
         Ok(store)
+    }
+
+    pub fn get_root_state_hash(&self, epoch: EpochId) -> SuiResult<Digest<32>> {
+        let acc = self
+            .perpetual_tables
+            .root_state_hash_by_epoch
+            .get(&epoch)?
+            .expect("Root state hash for this epoch does not exist");
+        Ok(acc.1.digest())
     }
 
     pub fn get_recovery_epoch_at_restart(&self) -> SuiResult<EpochId> {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -15,6 +15,7 @@ pub struct CheckpointExecutorMetrics {
     pub checkpoint_exec_epoch: IntGauge,
     pub checkpoint_transaction_count: Histogram,
     pub checkpoint_contents_age_ms: Histogram,
+    pub accumulator_inconsistent_state: IntGauge,
 }
 
 impl CheckpointExecutorMetrics {
@@ -54,6 +55,12 @@ impl CheckpointExecutorMetrics {
                 "Age of checkpoints when they arrive for execution",
                 registry,
             ),
+            accumulator_inconsistent_state: register_int_gauge_with_registry!(
+                "accumulator_inconsistent_state",
+                "1 if accumulated live object set differs from StateAccumulator root state hash for the previous epoch",
+                registry,
+            )
+            .unwrap(),
         };
         Arc::new(this)
     }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -215,6 +215,12 @@ impl CheckpointExecutor {
         }
     }
 
+    pub fn set_inconsistent_state(&self, is_inconsistent_state: bool) {
+        self.metrics
+            .accumulator_inconsistent_state
+            .set(is_inconsistent_state as i64);
+    }
+
     /// Post processing and plumbing after we executed a checkpoint. This function is guaranteed
     /// to be called in the order of checkpoint sequence number.
     fn process_executed_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -850,8 +850,8 @@ impl SuiNode {
             .ok_or_else(|| anyhow::anyhow!("Transaction Orchestrator is not enabled in this node."))
     }
 
-    /// This function waits for a signal from the checkpoint executor to indicate that on-chain
-    /// epoch has changed. Upon receiving such signal, we reconfigure the entire system.
+    /// This function awaits the completion of checkpoint execution of the current epoch,
+    /// after which it iniitiates reconfiguration of the entire system.
     pub async fn monitor_reconfiguration(self: Arc<Self>) -> Result<()> {
         let mut checkpoint_executor = CheckpointExecutor::new(
             self.state_sync.subscribe_to_synced_checkpoints(),
@@ -1007,6 +1007,26 @@ impl SuiNode {
                         .await?,
                     )
                 } else {
+                    // was a fullnode, still a fullnode
+                    let live_object_set = self
+                        .state
+                        .database
+                        .iter_live_object_set()
+                        .map(|oref| oref.2);
+                    let mut acc = sui_types::accumulator::Accumulator::default();
+                    fastcrypto::hash::MultisetHash::insert_all(&mut acc, live_object_set);
+
+                    let live_object_set_hash = fastcrypto::hash::MultisetHash::digest(&acc);
+
+                    let root_state_hash = self
+                        .state
+                        .database
+                        .get_root_state_hash(cur_epoch_store.epoch())
+                        .expect("Retrieving root state hash cannot fail");
+
+                    let is_inconsistent = root_state_hash != live_object_set_hash;
+                    checkpoint_executor.set_inconsistent_state(is_inconsistent);
+
                     None
                 }
             };


### PR DESCRIPTION
Check root state hash against live object set on all fullnodes (past epoch and current epoch), and bump metric on inconsistency. 

Later may panic in this case, as (if the root state hash can be trusted, this would indicate a fork), but currently we are unsure of the reliability  of the implementation, so need to gain some confidence.

This also contains some fixes with how we are processing effects, as well as how/where we are accumulating.