### PR TITLE
Add ProtocolConfig limits for various attributes of input transactions.

### DIFF
--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -42,7 +42,7 @@ pub struct Opts {
     pub primary_gas_id: String,
     #[clap(long, default_value = "5000", global = true)]
     pub primary_gas_objects: u64,
-    #[clap(long, default_value = "1000", global = true)]
+    #[clap(long, default_value = "500", global = true)]
     pub gas_request_chunk_size: u64,
     /// Whether to run local or remote benchmark
     /// NOTE: For running remote benchmark we must have the following

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1040,6 +1040,7 @@ impl AuthorityState {
         );
         let (gas_object_ref, input_objects) = transaction_input_checker::check_dev_inspect_input(
             &self.database,
+            protocol_config,
             &transaction_kind,
             gas_object,
         )

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -55,9 +55,10 @@ impl AuthorityAPI for LocalAuthorityClient {
         if self.fault_config.fail_before_handle_transaction {
             return Err(SuiError::from("Mock error before handle_transaction"));
         }
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
         let state = self.state.clone();
         let transaction = transaction.verify()?;
-        let result = state.handle_transaction(transaction).await;
+        let result = state.handle_transaction(&epoch_store, transaction).await;
         if self.fault_config.fail_after_handle_transaction {
             return Err(SuiError::GenericAuthorityError {
                 error: "Mock error after handle_transaction".to_owned(),

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1511,7 +1511,8 @@ async fn test_package_size_limit() {
     while package_size <= max_move_package_size {
         let mut module = file_format::empty_module();
         // generate unique name
-        module.identifiers[0] = Identifier::new(format!("TestModule{:?}", package_size)).unwrap();
+        module.identifiers[0] =
+            Identifier::new(format!("TestModule{:0>21000?}", package_size)).unwrap();
         let module_bytes = {
             let mut bytes = Vec::new();
             module.serialize(&mut bytes).unwrap();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -876,6 +876,7 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
         (sender, gas_object_id, SequenceNumber::new()),
     ])
     .await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -894,7 +895,7 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
         gas_object.compute_object_reference(),
     );
     let res = authority_state
-        .handle_transaction(transfer_transaction)
+        .handle_transaction(&epoch_store, transfer_transaction)
         .await;
 
     assert_eq!(
@@ -907,8 +908,11 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
 async fn test_handle_shared_object_with_max_sequence_number() {
     let (authority, _fullnode, transaction, _, _) =
         construct_shared_object_transaction_with_sequence_number(Some(SequenceNumber::MAX)).await;
+    let epoch_store = authority.load_epoch_store_one_call_per_task();
     // Submit the transaction and assemble a certificate.
-    let response = authority.handle_transaction(transaction.clone()).await;
+    let response = authority
+        .handle_transaction(&epoch_store, transaction.clone())
+        .await;
     assert_eq!(
         UserInputError::try_from(response.unwrap_err()).unwrap(),
         UserInputError::InvalidSequenceNumber,
@@ -924,6 +928,7 @@ async fn test_handle_transfer_transaction_unknown_sender() {
     let recipient = dbg_addr(2);
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -944,7 +949,7 @@ async fn test_handle_transfer_transaction_unknown_sender() {
     );
 
     assert!(authority_state
-        .handle_transaction(unknown_sender_transfer_transaction)
+        .handle_transaction(&epoch_store, unknown_sender_transfer_transaction)
         .await
         .is_err());
 
@@ -1008,6 +1013,7 @@ async fn test_handle_transfer_transaction_ok() {
     let gas_object_id = ObjectID::random();
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
 
     let object = authority_state
         .get_object(&object_id)
@@ -1052,7 +1058,7 @@ async fn test_handle_transfer_transaction_ok() {
         .is_err());
 
     let account_info = authority_state
-        .handle_transaction(transfer_transaction.clone())
+        .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await
         .unwrap();
 
@@ -1093,6 +1099,7 @@ async fn test_handle_sponsored_transaction() {
     let gas_object_id = ObjectID::random();
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sponsor, gas_object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
 
     let object = authority_state
         .get_object(&object_id)
@@ -1124,7 +1131,7 @@ async fn test_handle_sponsored_transaction() {
         to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &sponsor_key]);
 
     authority_state
-        .handle_transaction(dual_signed_tx.clone())
+        .handle_transaction(&epoch_store, dual_signed_tx.clone())
         .await
         .unwrap();
 
@@ -1143,7 +1150,7 @@ async fn test_handle_sponsored_transaction() {
         to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &sponsor_key]);
 
     let error = authority_state
-        .handle_transaction(dual_signed_tx.clone())
+        .handle_transaction(&epoch_store, dual_signed_tx.clone())
         .await
         .unwrap_err();
 
@@ -1170,7 +1177,7 @@ async fn test_handle_sponsored_transaction() {
     let dual_signed_tx =
         to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &sponsor_key]);
     let error = authority_state
-        .handle_transaction(dual_signed_tx.clone())
+        .handle_transaction(&epoch_store, dual_signed_tx.clone())
         .await
         .unwrap_err();
 
@@ -1198,7 +1205,7 @@ async fn test_handle_sponsored_transaction() {
     let dual_signed_tx =
         to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &third_party_key]);
     let error = authority_state
-        .handle_transaction(dual_signed_tx.clone())
+        .handle_transaction(&epoch_store, dual_signed_tx.clone())
         .await
         .unwrap_err();
 
@@ -1218,6 +1225,7 @@ async fn test_transfer_package() {
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
     let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let gas_object = authority_state
         .get_object(&object_id)
         .await
@@ -1233,7 +1241,7 @@ async fn test_transfer_package() {
         gas_object.compute_object_reference(),
     );
     authority_state
-        .handle_transaction(transfer_transaction.clone())
+        .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await
         .unwrap_err();
 }
@@ -1246,6 +1254,7 @@ async fn test_immutable_gas() {
     let recipient = dbg_addr(2);
     let mut_object_id = ObjectID::random();
     let authority_state = init_state_with_ids(vec![(sender, mut_object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let imm_object_id = ObjectID::random();
     let imm_object = Object::immutable_with_id_for_testing(imm_object_id);
     authority_state
@@ -1264,7 +1273,7 @@ async fn test_immutable_gas() {
         imm_object.compute_object_reference(),
     );
     let result = authority_state
-        .handle_transaction(transfer_transaction.clone())
+        .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await;
     assert!(matches!(
         UserInputError::try_from(result.unwrap_err()).unwrap(),
@@ -1280,6 +1289,7 @@ async fn test_objected_owned_gas() {
     let recipient = dbg_addr(2);
     let parent_object_id = ObjectID::random();
     let authority_state = init_state_with_ids(vec![(sender, parent_object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let child_object_id = ObjectID::random();
     let child_object = Object::with_object_owner_for_testing(child_object_id, parent_object_id);
     authority_state
@@ -1294,7 +1304,9 @@ async fn test_objected_owned_gas() {
     );
 
     let transaction = to_sender_signed_transaction(data, &sender_key);
-    let result = authority_state.handle_transaction(transaction).await;
+    let result = authority_state
+        .handle_transaction(&epoch_store, transaction)
+        .await;
     assert!(matches!(
         UserInputError::try_from(result.unwrap_err()).unwrap(),
         UserInputError::GasObjectNotOwnedObject { .. }
@@ -1321,7 +1333,10 @@ pub async fn send_and_confirm_transaction_(
     with_shared: bool, // transaction includes shared objects
 ) -> Result<(CertifiedTransaction, SignedTransactionEffects), SuiError> {
     // Make the initial request
-    let response = authority.handle_transaction(transaction.clone()).await?;
+    let epoch_store = authority.load_epoch_store_one_call_per_task();
+    let response = authority
+        .handle_transaction(&epoch_store, transaction.clone())
+        .await?;
     let vote = response.status.into_signed_for_testing();
 
     // Collect signatures from a quorum of authorities
@@ -1473,6 +1488,7 @@ async fn test_publish_non_existing_dependent_module() {
         bytes
     };
     let authority = init_state_with_objects(vec![gas_payment_object]).await;
+    let epoch_store = authority.load_epoch_store_one_call_per_task();
 
     let data = TransactionData::new_module_with_dummy_gas_price(
         sender,
@@ -1481,7 +1497,9 @@ async fn test_publish_non_existing_dependent_module() {
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
-    let response = authority.handle_transaction(transaction).await;
+    let response = authority
+        .handle_transaction(&epoch_store, transaction)
+        .await;
     assert!(std::string::ToString::to_string(&response.unwrap_err())
         .contains("DependentPackageNotFound"));
     // Check that gas was not charged.
@@ -1586,6 +1604,7 @@ async fn test_conflicting_transactions() {
     let gas_object_id = ObjectID::random();
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -1620,8 +1639,8 @@ async fn test_conflicting_transactions() {
     // acquire_transaction_locks() and then add a sleep after we read the locks.
     for _ in 0..100 {
         let mut futures = FuturesUnordered::new();
-        futures.push(authority_state.handle_transaction(tx1.clone()));
-        futures.push(authority_state.handle_transaction(tx2.clone()));
+        futures.push(authority_state.handle_transaction(&epoch_store, tx1.clone()));
+        futures.push(authority_state.handle_transaction(&epoch_store, tx2.clone()));
 
         let first = futures.next().await.unwrap();
         let second = futures.next().await.unwrap();
@@ -1688,6 +1707,7 @@ async fn test_handle_transfer_transaction_double_spend() {
     let gas_object_id = ObjectID::random();
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -1707,12 +1727,12 @@ async fn test_handle_transfer_transaction_double_spend() {
     );
 
     let signed_transaction = authority_state
-        .handle_transaction(transfer_transaction.clone())
+        .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await
         .unwrap();
     // calls to handlers are idempotent -- returns the same.
     let double_spend_signed_transaction = authority_state
-        .handle_transaction(transfer_transaction)
+        .handle_transaction(&epoch_store, transfer_transaction)
         .await
         .unwrap();
     // this is valid because our test authority should not change its certified transaction
@@ -1725,6 +1745,7 @@ async fn test_handle_transfer_sui_with_amount_insufficient_gas() {
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
     let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -1738,7 +1759,9 @@ async fn test_handle_transfer_sui_with_amount_insufficient_gas() {
         200,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
-    let result = authority_state.handle_transaction(transaction).await;
+    let result = authority_state
+        .handle_transaction(&epoch_store, transaction)
+        .await;
 
     assert!(matches!(
         UserInputError::try_from(result.unwrap_err()).unwrap(),
@@ -1790,11 +1813,12 @@ async fn test_transaction_expiration() {
     );
 
     // Expired transaction returns an error
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let mut expired_data = data.clone();
     expired_data.expiration = TransactionExpiration::Epoch(0);
     let expired_transaction = to_sender_signed_transaction(expired_data, &sender_key);
     let result = authority_state
-        .handle_transaction(expired_transaction)
+        .handle_transaction(&epoch_store, expired_transaction)
         .await;
 
     assert!(matches!(result.unwrap_err(), SuiError::TransactionExpired));
@@ -1803,7 +1827,7 @@ async fn test_transaction_expiration() {
     data.expiration = TransactionExpiration::Epoch(10);
     let transaction = to_sender_signed_transaction(data, &sender_key);
     authority_state
-        .handle_transaction(transaction)
+        .handle_transaction(&epoch_store, transaction)
         .await
         .unwrap();
 }
@@ -1814,6 +1838,7 @@ async fn test_missing_package() {
     let gas_object_id = ObjectID::random();
     let (authority_state, _object_basics) =
         init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let gas_object = authority_state
         .get_object(&gas_object_id)
         .await
@@ -1832,7 +1857,9 @@ async fn test_missing_package() {
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
-    let result = authority_state.handle_transaction(transaction).await;
+    let result = authority_state
+        .handle_transaction(&epoch_store, transaction)
+        .await;
     assert!(matches!(
         UserInputError::try_from(result.unwrap_err()).unwrap(),
         UserInputError::DependentPackageNotFound { .. }
@@ -1849,6 +1876,7 @@ async fn test_type_argument_dependencies() {
     let gas3 = ObjectID::random();
     let (authority_state, (object_basics, _, _)) =
         init_state_with_ids_and_object_basics(vec![(s1, gas1), (s2, gas2), (s3, gas3)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let gas1 = {
         let o = authority_state.get_object(&gas1).await.unwrap().unwrap();
         o.compute_object_reference()
@@ -1874,7 +1902,7 @@ async fn test_type_argument_dependencies() {
     );
     let transaction = to_sender_signed_transaction(data, &s1_key);
     authority_state
-        .handle_transaction(transaction)
+        .handle_transaction(&epoch_store, transaction)
         .await
         .unwrap()
         .status
@@ -1897,7 +1925,7 @@ async fn test_type_argument_dependencies() {
     );
     let transaction = to_sender_signed_transaction(data, &s2_key);
     authority_state
-        .handle_transaction(transaction)
+        .handle_transaction(&epoch_store, transaction)
         .await
         .unwrap()
         .status
@@ -1919,7 +1947,9 @@ async fn test_type_argument_dependencies() {
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &s3_key);
-    let result = authority_state.handle_transaction(transaction).await;
+    let result = authority_state
+        .handle_transaction(&epoch_store, transaction)
+        .await;
 
     assert!(matches!(
         UserInputError::try_from(result.unwrap_err()).unwrap(),
@@ -2802,6 +2832,7 @@ async fn test_idempotent_reversed_confirmation() {
     let gas_object = Object::with_owner_for_testing(sender);
     let gas_object_ref = gas_object.compute_object_reference();
     let authority_state = init_state_with_objects([object, gas_object]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
 
     let certified_transfer_transaction = init_certified_transfer_transaction(
         sender,
@@ -2819,7 +2850,7 @@ async fn test_idempotent_reversed_confirmation() {
         .await;
     assert!(result1.is_ok());
     let result2 = authority_state
-        .handle_transaction(certified_transfer_transaction.into_unsigned())
+        .handle_transaction(&epoch_store, certified_transfer_transaction.into_unsigned())
         .await;
     assert!(result2.is_ok());
     assert_eq!(
@@ -2839,6 +2870,7 @@ async fn test_refusal_to_sign_consensus_commit_prologue() {
     let gas_object_id = ObjectID::random();
     let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
     let authority_state = init_state_with_objects(vec![gas_object.clone()]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
 
     let gas_ref = gas_object.compute_object_reference();
     let tx_data = TransactionData::new_with_dummy_gas_price(
@@ -2859,7 +2891,9 @@ async fn test_refusal_to_sign_consensus_commit_prologue() {
 
     // But the authority should refuse to handle it.
     assert!(matches!(
-        authority_state.handle_transaction(transaction).await,
+        authority_state
+            .handle_transaction(&epoch_store, transaction)
+            .await,
         Err(SuiError::InvalidSystemTransaction),
     ));
 }
@@ -2872,6 +2906,7 @@ async fn test_invalid_mutable_clock_parameter() {
     let gas_object_id = ObjectID::random();
     let (authority_state, package_object_ref) =
         init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
     let gas_ref = gas_object.compute_object_reference();
 
@@ -2892,7 +2927,7 @@ async fn test_invalid_mutable_clock_parameter() {
 
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
 
-    let Err(e) = authority_state.handle_transaction(transaction).await else {
+    let Err(e) = authority_state.handle_transaction(&epoch_store, transaction).await else {
         panic!("Expected handling transaction to fail");
     };
 
@@ -2911,6 +2946,7 @@ async fn test_valid_immutable_clock_parameter() {
     let gas_object_id = ObjectID::random();
     let (authority_state, package_object_ref) =
         init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
     let gas_ref = gas_object.compute_object_reference();
 
@@ -2931,7 +2967,7 @@ async fn test_valid_immutable_clock_parameter() {
 
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
     authority_state
-        .handle_transaction(transaction)
+        .handle_transaction(&epoch_store, transaction)
         .await
         .unwrap();
 }
@@ -2969,6 +3005,7 @@ async fn test_transfer_sui_no_amount() {
     let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
     let init_balance = sui_types::gas::get_gas_balance(&gas_object).unwrap();
     let authority_state = init_state_with_objects(vec![gas_object.clone()]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
 
     let gas_ref = gas_object.compute_object_reference();
     let tx_data = TransactionData::new_transfer_sui_with_dummy_gas_price(
@@ -2978,7 +3015,7 @@ async fn test_transfer_sui_no_amount() {
     // Make sure transaction handling works as usual.
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
     authority_state
-        .handle_transaction(transaction.clone())
+        .handle_transaction(&epoch_store, transaction.clone())
         .await
         .unwrap();
 
@@ -4285,8 +4322,9 @@ async fn make_test_transaction(
     let mut sigs = vec![];
 
     for authority in authorities {
+        let epoch_store = authority.load_epoch_store_one_call_per_task();
         let response = authority
-            .handle_transaction(transaction.clone())
+            .handle_transaction(&epoch_store, transaction.clone())
             .await
             .unwrap();
         let vote = response.status.into_signed_for_testing();

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -17,10 +17,10 @@ use sui_types::{
 #[tokio::test]
 async fn test_batch_transaction_ok() -> anyhow::Result<()> {
     // This test tests a sucecssful normal batch transaction.
-    // This batch transaction contains 100 transfers, and 100 Move calls.
+    // This batch transaction contains 5 transfers, and 5 Move calls.
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let (recipient, _): (_, AccountKeyPair) = get_key_pair();
-    const N: usize = 10;
+    const N: usize = 5;
     const TOTAL: usize = N + 1;
     let all_ids = (0..TOTAL).map(|_| ObjectID::random()).collect::<Vec<_>>();
     let (authority_state, package) = init_state_with_ids_and_object_basics(
@@ -89,7 +89,7 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
     // We make sure that the entire batch is rolled back, and only gas is charged.
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let (recipient, _): (_, AccountKeyPair) = get_key_pair();
-    const N: usize = 100;
+    const N: usize = 5;
     const TOTAL: usize = N + 1;
     let all_ids = (0..TOTAL).map(|_| ObjectID::random()).collect::<Vec<_>>();
     let (authority_state, package) = init_state_with_ids_and_object_basics(
@@ -199,7 +199,7 @@ async fn test_batch_contains_transfer_sui() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
-    // This test creates 100 Move call transactions batch, each with a budget of 5000.
+    // This test creates 10 Move call transactions batch, each with a budget of 5000.
     // However we provide a gas coin with only 49999 balance.
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let (authority_state, package) = init_state_with_ids_and_object_basics([]).await;
@@ -213,7 +213,7 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
         .insert_genesis_object(gas_object.clone())
         .await;
 
-    const N: usize = 100;
+    const N: usize = 10;
     let mut transactions = vec![];
     for _ in 0..N {
         transactions.push(SingleTransactionKind::Call(MoveCall {

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -39,6 +39,7 @@ pub fn test_gas_objects() -> Vec<Object> {
 
 /// Fixture: a few test certificates containing a shared object.
 pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTransaction> {
+    let epoch_store = authority.load_epoch_store_one_call_per_task();
     let (sender, keypair) = deterministic_random_account_key();
 
     let mut certificates = Vec::new();
@@ -73,7 +74,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
 
         // Submit the transaction and assemble a certificate.
         let response = authority
-            .handle_transaction(transaction.clone())
+            .handle_transaction(&epoch_store, transaction.clone())
             .await
             .unwrap();
         let vote = response.status.into_signed_for_testing();

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -594,6 +594,7 @@ async fn execute_transfer_with_price(
     let object_id: ObjectID = ObjectID::random();
     let recipient = dbg_addr(2);
     let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let gas_object_id = ObjectID::random();
     let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, gas_balance);
     let gas_object_ref = gas_object.compute_object_reference();
@@ -623,7 +624,7 @@ async fn execute_transfer_with_price(
             })
     } else {
         authority_state
-            .handle_transaction(tx)
+            .handle_transaction(&epoch_store, tx)
             .await
             .map(|r| r.status)
     };

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -105,6 +105,9 @@ impl SupportedProtocolVersions {
 #[derive(Clone)]
 pub struct ProtocolConfig {
     // ==== Transaction input limits ====
+    /// Maximum serialized size of a transaction (in bytes).
+    max_tx_size: Option<usize>,
+
     /// Maximum number of individual transactions in a Batch transaction.
     max_tx_in_batch: Option<u32>,
 
@@ -136,9 +139,6 @@ pub struct ProtocolConfig {
 
     /// Maximum number of Commands in a ProgrammableTransaction.
     max_programmable_tx_commands: Option<u32>,
-
-    /// Maximum number of Publish Commands in a ProgrammableTransaction.
-    max_programmable_tx_publish_commands: Option<u32>,
 
     // ==== Move VM, Move bytecode verifier, and execution limits ===
     /// Maximum Move bytecode version the VM understands. All older versions are accepted.
@@ -283,6 +283,9 @@ const CONSTANT_ERR_MSG: &str = "protocol constant not present in current protoco
 
 // getters
 impl ProtocolConfig {
+    pub fn max_tx_size(&self) -> usize {
+        self.max_tx_size.expect(CONSTANT_ERR_MSG)
+    }
     pub fn max_tx_in_batch(&self) -> u32 {
         self.max_tx_in_batch.expect(CONSTANT_ERR_MSG)
     }
@@ -312,10 +315,6 @@ impl ProtocolConfig {
     }
     pub fn max_programmable_tx_commands(&self) -> u32 {
         self.max_programmable_tx_commands.expect(CONSTANT_ERR_MSG)
-    }
-    pub fn max_programmable_tx_publish_commands(&self) -> u32 {
-        self.max_programmable_tx_publish_commands
-            .expect(CONSTANT_ERR_MSG)
     }
     pub fn move_binary_format_version(&self) -> u32 {
         self.move_binary_format_version.expect(CONSTANT_ERR_MSG)
@@ -527,17 +526,17 @@ impl ProtocolConfig {
         // To change the values here you must create a new protocol version with the new values!
         match version.0 {
             1 => Self {
+                max_tx_size: Some(64 * 1024),
                 max_tx_in_batch: Some(10),
-                max_modules_in_publish: Some(8),
-                max_arguments: Some(16),
+                max_modules_in_publish: Some(128),
+                max_arguments: Some(128),
                 max_type_arguments: Some(16),
                 max_type_argument_depth: Some(16),
-                max_pure_argument_size: Some(10 * 1024),
+                max_pure_argument_size: Some(16 * 1024),
                 max_object_vec_argument_size: Some(128),
                 max_coins: Some(1024),
                 max_pay_recipients: Some(1024),
-                max_programmable_tx_commands: Some(16),
-                max_programmable_tx_publish_commands: Some(1),
+                max_programmable_tx_commands: Some(128),
                 move_binary_format_version: Some(6),
                 max_move_object_size: Some(250 * 1024),
                 max_move_package_size: Some(100 * 1024),

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -104,6 +104,42 @@ impl SupportedProtocolVersions {
 /// result in forking if not prevented here).
 #[derive(Clone)]
 pub struct ProtocolConfig {
+    // ==== Transaction input limits ====
+    /// Maximum number of individual transactions in a Batch transaction.
+    max_tx_in_batch: Option<u32>,
+
+    /// Maximum number of modules in a Publish transaction.
+    max_modules_in_publish: Option<u32>,
+
+    /// Maximum number of arguments in a move call or a ProgrammableTransaction's
+    /// TransferObjects command.
+    max_arguments: Option<u32>,
+
+    /// Maximum number of total type arguments, computed recursively.
+    max_type_arguments: Option<u32>,
+
+    /// Maximum depth of an individual type argument.
+    max_type_argument_depth: Option<u32>,
+
+    /// Maximum size of a Pure CallArg.
+    max_pure_argument_size: Option<u32>,
+
+    /// Maximum size of an ObjVec CallArg.
+    max_object_vec_argument_size: Option<u32>,
+
+    /// Maximum number of coins in Pay* transactions, or a ProgrammableTransaction's
+    /// MergeCoins command.
+    max_coins: Option<u32>,
+
+    /// Maximum number of recipients in Pay* transactions.
+    max_pay_recipients: Option<u32>,
+
+    /// Maximum number of Commands in a ProgrammableTransaction.
+    max_programmable_tx_commands: Option<u32>,
+
+    /// Maximum number of Publish Commands in a ProgrammableTransaction.
+    max_programmable_tx_publish_commands: Option<u32>,
+
     // ==== Move VM, Move bytecode verifier, and execution limits ===
     /// Maximum Move bytecode version the VM understands. All older versions are accepted.
     move_binary_format_version: Option<u32>,
@@ -247,6 +283,40 @@ const CONSTANT_ERR_MSG: &str = "protocol constant not present in current protoco
 
 // getters
 impl ProtocolConfig {
+    pub fn max_tx_in_batch(&self) -> u32 {
+        self.max_tx_in_batch.expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_modules_in_publish(&self) -> u32 {
+        self.max_modules_in_publish.expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_arguments(&self) -> u32 {
+        self.max_arguments.expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_type_arguments(&self) -> u32 {
+        self.max_type_arguments.expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_type_argument_depth(&self) -> u32 {
+        self.max_type_argument_depth.expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_pure_argument_size(&self) -> u32 {
+        self.max_pure_argument_size.expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_object_vec_argument_size(&self) -> u32 {
+        self.max_object_vec_argument_size.expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_coins(&self) -> u32 {
+        self.max_coins.expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_pay_recipients(&self) -> u32 {
+        self.max_pay_recipients.expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_programmable_tx_commands(&self) -> u32 {
+        self.max_programmable_tx_commands.expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_programmable_tx_publish_commands(&self) -> u32 {
+        self.max_programmable_tx_publish_commands
+            .expect(CONSTANT_ERR_MSG)
+    }
     pub fn move_binary_format_version(&self) -> u32 {
         self.move_binary_format_version.expect(CONSTANT_ERR_MSG)
     }
@@ -395,7 +465,7 @@ impl ProtocolConfig {
         CONFIG_OVERRIDE.with(|ovr| {
             if let Some(override_fn) = &*ovr.borrow() {
                 warn!(
-                    "overriding ProtocolConfig settings with custom settings (you should not see this log outside of tests"
+                    "overriding ProtocolConfig settings with custom settings (you should not see this log outside of tests)"
                 );
                 override_fn(version, ret)
             } else {
@@ -457,6 +527,17 @@ impl ProtocolConfig {
         // To change the values here you must create a new protocol version with the new values!
         match version.0 {
             1 => Self {
+                max_tx_in_batch: Some(10),
+                max_modules_in_publish: Some(8),
+                max_arguments: Some(16),
+                max_type_arguments: Some(16),
+                max_type_argument_depth: Some(16),
+                max_pure_argument_size: Some(10 * 1024),
+                max_object_vec_argument_size: Some(128),
+                max_coins: Some(1024),
+                max_pay_recipients: Some(1024),
+                max_programmable_tx_commands: Some(16),
+                max_programmable_tx_publish_commands: Some(1),
                 move_binary_format_version: Some(6),
                 max_move_object_size: Some(250 * 1024),
                 max_move_package_size: Some(100 * 1024),

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -85,6 +85,8 @@ pub enum UserInputError {
     DependentPackageNotFound { package_id: ObjectID },
     #[error("Mutable parameter provided, immutable parameter expected.")]
     ImmutableParameterExpectedError { object_id: ObjectID },
+    #[error("Size limit exceeded: {limit} is {value}")]
+    SizeLimitExceeded { limit: String, value: String },
     #[error(
         "Object {child_id:?} is owned by object {parent_id:?}. \
         Objects owned by other objects cannot be used as input arguments."

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -787,7 +787,7 @@ fn test_sponsored_transaction_validity_check() {
         sender,
         gas_data.clone(),
     )
-    .validity_check()
+    .validity_check(&ProtocolConfig::get_for_max_version())
     .unwrap();
 
     TransactionData::new_with_gas_data(
@@ -803,7 +803,7 @@ fn test_sponsored_transaction_validity_check() {
         sender,
         gas_data.clone(),
     )
-    .validity_check()
+    .validity_check(&ProtocolConfig::get_for_max_version())
     .unwrap();
 
     TransactionData::new_with_gas_data(
@@ -813,7 +813,7 @@ fn test_sponsored_transaction_validity_check() {
         sender,
         gas_data.clone(),
     )
-    .validity_check()
+    .validity_check(&ProtocolConfig::get_for_max_version())
     .unwrap();
 
     TransactionData::new_with_gas_data(
@@ -825,7 +825,7 @@ fn test_sponsored_transaction_validity_check() {
         sender,
         gas_data.clone(),
     )
-    .validity_check()
+    .validity_check(&ProtocolConfig::get_for_max_version())
     .unwrap();
 
     // TransferSui cannot be sponsored
@@ -838,7 +838,7 @@ fn test_sponsored_transaction_validity_check() {
             sender,
             gas_data.clone(),
         )
-        .validity_check()
+        .validity_check(&ProtocolConfig::get_for_max_version())
         .unwrap_err(),
         UserInputError::UnsupportedSponsoredTransactionKind
     );
@@ -854,7 +854,7 @@ fn test_sponsored_transaction_validity_check() {
             sender,
             gas_data.clone(),
         )
-        .validity_check()
+        .validity_check(&ProtocolConfig::get_for_max_version())
         .unwrap_err(),
         UserInputError::UnsupportedSponsoredTransactionKind
     );
@@ -869,7 +869,7 @@ fn test_sponsored_transaction_validity_check() {
             sender,
             gas_data.clone(),
         )
-        .validity_check()
+        .validity_check(&ProtocolConfig::get_for_max_version())
         .unwrap_err(),
         UserInputError::UnsupportedSponsoredTransactionKind
     );
@@ -885,7 +885,7 @@ fn test_sponsored_transaction_validity_check() {
             sender,
             gas_data,
         )
-        .validity_check()
+        .validity_check(&ProtocolConfig::get_for_max_version())
         .unwrap_err(),
         UserInputError::UnsupportedSponsoredTransactionKind
     );


### PR DESCRIPTION
## Description 

Adds various size limits for components of input transaction.

## Test Plan 

Updated unit tests, which did fail with old impls by hitting the new limits.