### PR TITLE
indexer: read txn digests in checkpoint

### DIFF
--- a/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
@@ -2,6 +2,7 @@ CREATE TABLE transactions (
     id BIGSERIAL PRIMARY KEY,
     transaction_digest VARCHAR(255) NOT NULL,
     sender VARCHAR(255) NOT NULL,
+    checkpoint_sequence_number BIGINT,
     transaction_time TIMESTAMP,
     transaction_kinds TEXT[] NOT NULL,
     -- object related
@@ -32,3 +33,4 @@ CREATE INDEX transactions_transaction_digest ON transactions (transaction_digest
 CREATE INDEX transactions_transaction_time ON transactions (transaction_time);
 CREATE INDEX transactions_sender ON transactions (sender);
 CREATE INDEX transactions_gas_object_id ON transactions (gas_object_id);
+CREATE INDEX transactions_checkpoint_sequence_number ON transactions (checkpoint_sequence_number);

--- a/crates/sui-indexer/migrations/2022-11-22-235415_logs/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-22-235415_logs/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE transaction_logs (
     id SERIAL PRIMARY KEY,
-    next_cursor_tx_digest TEXT
+    next_checkpoint_sequence_number BIGINT NOT NULL
 );
 
-INSERT INTO transaction_logs (id, next_cursor_tx_digest) VALUES
-(1, NULL);
+INSERT INTO transaction_logs (id, next_checkpoint_sequence_number) 
+VALUES (1, 0);

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -10,7 +10,7 @@ use sui_indexer::errors::IndexerError;
 use sui_indexer::metrics::IndexerCheckpointHandlerMetrics;
 use sui_indexer::models::checkpoint_logs::{commit_checkpoint_log, read_checkpoint_log};
 use sui_indexer::models::checkpoints::{
-    commit_checkpoint, create_checkpoint, get_previous_checkpoint, Checkpoint,
+    commit_checkpoint, create_checkpoint, get_checkpoint, Checkpoint,
 };
 use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
 use sui_json_rpc_types::CheckpointId;
@@ -40,13 +40,13 @@ impl CheckpointHandler {
 
         let checkpoint_log = read_checkpoint_log(&mut pg_pool_conn)?;
         let mut next_cursor_sequence_number = checkpoint_log.next_cursor_sequence_number;
-        let mut previous_checkpoint_commit = Checkpoint::default();
 
-        if next_cursor_sequence_number != 0 {
+        let mut previous_checkpoint = Checkpoint::default();
+        if next_cursor_sequence_number > 0 {
             let temp_checkpoint =
-                get_previous_checkpoint(&mut pg_pool_conn, next_cursor_sequence_number - 1);
+                get_checkpoint(&mut pg_pool_conn, next_cursor_sequence_number - 1);
             match temp_checkpoint {
-                Ok(checkpoint) => previous_checkpoint_commit = checkpoint,
+                Ok(checkpoint) => previous_checkpoint = checkpoint,
                 Err(err) => {
                     error!("{}", err)
                 }
@@ -92,14 +92,14 @@ impl CheckpointHandler {
                 .db_write_request_latency
                 .start_timer();
             // unwrap here is safe because we checked for error above
-            let new_checkpoint = create_checkpoint(checkpoint.unwrap(), previous_checkpoint_commit);
+            let new_checkpoint = create_checkpoint(checkpoint.unwrap(), previous_checkpoint);
             commit_checkpoint(&mut pg_pool_conn, new_checkpoint.clone())?;
             info!("Checkpoint {} committed", next_cursor_sequence_number);
             self.checkpoint_handler_metrics
                 .total_checkpoint_processed
                 .inc();
             db_guard.stop_and_record();
-            previous_checkpoint_commit = Checkpoint::from(new_checkpoint.clone());
+            previous_checkpoint = Checkpoint::from(new_checkpoint.clone());
             next_cursor_sequence_number += 1;
             commit_checkpoint_log(&mut pg_pool_conn, next_cursor_sequence_number)?;
         }

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -18,15 +18,12 @@ const LATENCY_SEC_BUCKETS: &[f64] = &[
 pub struct IndexerTransactionHandlerMetrics {
     pub total_transactions_received: IntCounter,
     pub total_transactions_processed: IntCounter,
-
-    pub total_transaction_page_fetch_attempt: IntCounter,
-    pub total_transaction_page_received: IntCounter,
-    pub total_transaction_page_committed: IntCounter,
-
+    pub total_transaction_checkpoint_processed: IntCounter,
     pub total_transaction_handler_error: IntCounter,
 
     pub db_write_request_latency: Histogram,
     pub full_node_read_request_latency: Histogram,
+    pub checkpoint_db_read_request_latency: Histogram,
 }
 
 impl IndexerTransactionHandlerMetrics {
@@ -44,21 +41,9 @@ impl IndexerTransactionHandlerMetrics {
                 registry,
             )
             .unwrap(),
-            total_transaction_page_fetch_attempt: register_int_counter_with_registry!(
-                "total_transaction_page_fetch_attempt",
-                "Total number of transaction page fetch attempt",
-                registry,
-            )
-            .unwrap(),
-            total_transaction_page_received: register_int_counter_with_registry!(
-                "total_transaction_page_received",
-                "Total number of transaction page received",
-                registry,
-            )
-            .unwrap(),
-            total_transaction_page_committed: register_int_counter_with_registry!(
-                "total_transaction_page_committed",
-                "Total number of transaction page committed",
+            total_transaction_checkpoint_processed: register_int_counter_with_registry!(
+                "total_transaction_checkpoint_processed",
+                "Total number of transactions processed",
                 registry,
             )
             .unwrap(),
@@ -78,6 +63,13 @@ impl IndexerTransactionHandlerMetrics {
             full_node_read_request_latency: register_histogram_with_registry!(
                 "transaction_full_node_read_request_latency",
                 "Time spent in waiting for a new transaction from the Full Node",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            checkpoint_db_read_request_latency: register_histogram_with_registry!(
+                "transaction_checkpoint_db_read_request_latency",
+                "Time spent in reading a transaction from the checkpoint db",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -201,16 +201,16 @@ fn commit_checkpoint_impl(
     })
 }
 
-pub fn get_previous_checkpoint(
+pub fn get_checkpoint(
     pg_pool_conn: &mut PgPoolConnection,
-    currency_checkpoint_sequence_number: i64,
+    checkpoint_sequence_number: i64,
 ) -> Result<Checkpoint, IndexerError> {
     let checkpoint_read_result = pg_pool_conn
         .build_transaction()
         .read_only()
         .run::<_, Error, _>(|conn| {
             checkpoints_table
-                .filter(sequence_number.eq(currency_checkpoint_sequence_number - 1))
+                .filter(sequence_number.eq(checkpoint_sequence_number))
                 .limit(1)
                 .first::<Checkpoint>(conn)
         });

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -19,6 +19,7 @@ pub struct Transaction {
     pub id: i64,
     pub transaction_digest: String,
     pub sender: String,
+    pub checkpoint_sequence_number: Option<i64>,
     pub transaction_time: Option<NaiveDateTime>,
     pub transaction_kinds: Vec<Option<String>>,
     pub created: Vec<Option<String>>,
@@ -43,6 +44,7 @@ pub struct Transaction {
 pub struct NewTransaction {
     pub transaction_digest: String,
     pub sender: String,
+    pub checkpoint_sequence_number: Option<i64>,
     pub transaction_time: Option<NaiveDateTime>,
     pub transaction_kinds: Vec<Option<String>>,
     pub created: Vec<Option<String>>,
@@ -132,6 +134,7 @@ pub fn transaction_response_to_new_transaction(
     let gas_budget = tx_resp.transaction.data.gas_data.budget;
     let gas_price = tx_resp.transaction.data.gas_data.price;
     let sender = tx_resp.transaction.data.sender.to_string();
+    let checkpoint_seq_number = tx_resp.checkpoint.map(|c| c as i64);
     let txn_kind_iter = tx_resp
         .transaction
         .data
@@ -195,6 +198,7 @@ pub fn transaction_response_to_new_transaction(
     Ok(NewTransaction {
         transaction_digest: tx_digest,
         sender,
+        checkpoint_sequence_number: checkpoint_seq_number,
         transaction_kinds: txn_kind_iter.map(Some).collect::<Vec<Option<String>>>(),
         transaction_time: timestamp,
         created: vec_string_to_vec_opt_string(created),

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -163,7 +163,7 @@ diesel::table! {
 diesel::table! {
     transaction_logs (id) {
         id -> Int4,
-        next_cursor_tx_digest -> Nullable<Text>,
+        next_checkpoint_sequence_number -> Int8,
     }
 }
 
@@ -172,6 +172,7 @@ diesel::table! {
         id -> Int8,
         transaction_digest -> Varchar,
         sender -> Varchar,
+        checkpoint_sequence_number -> Nullable<Int8>,
         transaction_time -> Nullable<Timestamp>,
         transaction_kinds -> Array<Nullable<Text>>,
         created -> Array<Nullable<Text>>,


### PR DESCRIPTION
## Description 

Before this PR, indexer uses txn pagination to read txn digests, this PR changes it to use checkpoint instead, which also unblocks removal of txn pagination on FN.

## Test Plan 

tested locally with validator, FN and indexer as some new APIs are not in devnet yet, verify that checkpoints table and txns table can still be properly populated:

![Screenshot 2023-02-22 at 7 30 07 PM](https://user-images.githubusercontent.com/106119108/220796411-5314ecc5-2aca-4132-b575-0f8d20f0b314.png)



---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
