### PR TITLE
Fix two small issues with protocol upgrades

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2553,7 +2553,7 @@ impl AuthorityState {
         let current_protocol_version = committee.protocol_version;
         let next_protocol_version = current_protocol_version + 1;
 
-        let mut stake_aggregator: StakeAggregator<bool, true> =
+        let mut stake_aggregator: StakeAggregator<(), true> =
             StakeAggregator::new(Arc::new(committee.clone()));
 
         for cap in epoch_store.get_capabilities().into_iter() {
@@ -2568,7 +2568,7 @@ impl AuthorityState {
                     authority.concise(),
                     next_protocol_version
                 );
-                stake_aggregator.insert_generic(authority, true);
+                stake_aggregator.insert_generic(authority, ());
             } else {
                 info!(
                     "validator {:?} does not support {:?}",

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -239,6 +239,12 @@ pub struct ProtocolConfig {
     /// Max number of transactions per checkpoint.
     /// Note that this is constant and not a config as validators must have this set to the same value, otherwise they *will* fork
     max_transactions_per_checkpoint: Option<usize>,
+
+    /// A protocol upgrade always requires 2f+1 stake to agree. We support a buffer of additional
+    /// stake (as a fraction of f, expressed in basis points) that is required before an upgrade
+    /// can happen automatically. 10000bps would indicate that complete unanimity is required (all
+    /// 3f+1 must vote), while 0bps would indicate that 2f+1 is sufficient.
+    buffer_stake_for_protocol_upgrade_bps: Option<u64>,
 }
 
 const CONSTANT_ERR_MSG: &str = "protocol constant not present in current protocol version";
@@ -359,6 +365,10 @@ impl ProtocolConfig {
     }
     pub fn max_transactions_per_checkpoint(&self) -> usize {
         self.max_transactions_per_checkpoint
+            .expect(CONSTANT_ERR_MSG)
+    }
+    pub fn buffer_stake_for_protocol_upgrade_bps(&self) -> u64 {
+        self.buffer_stake_for_protocol_upgrade_bps
             .expect(CONSTANT_ERR_MSG)
     }
 
@@ -490,6 +500,8 @@ impl ProtocolConfig {
                 stake_subsidy_rate: Some(1),
                 storage_gas_price: Some(1),
                 max_transactions_per_checkpoint: Some(1000),
+                // require 2f+1 + 0.75 * f stake for automatic protocol upgrades.
+                buffer_stake_for_protocol_upgrade_bps: Some(7500),
                 // When adding a new constant, set it to None in the earliest version, like this:
                 // new_constant: None,
             },

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -501,6 +501,7 @@ impl ProtocolConfig {
                 storage_gas_price: Some(1),
                 max_transactions_per_checkpoint: Some(1000),
                 // require 2f+1 + 0.75 * f stake for automatic protocol upgrades.
+                // TODO: tune based on experience in testnet
                 buffer_stake_for_protocol_upgrade_bps: Some(7500),
                 // When adding a new constant, set it to None in the earliest version, like this:
                 // new_constant: None,


### PR DESCRIPTION
Change the upgrade threshold to be purely stake based, make the additional stake configurable as a fraction of f, so that upgrades proceed if 2f+1 + B*f vote, where B is configured in ProtocolConfig.