### PR TITLE
[Wallet] Ability to change current page via progress bar

### DIFF
--- a/apps/wallet/src/ui/app/components/progress-bar/index.tsx
+++ b/apps/wallet/src/ui/app/components/progress-bar/index.tsx
@@ -9,14 +9,20 @@ import st from './ProgressBar.module.scss';
 type Props = {
     currentStep: number;
     stepsName: string[];
+    changeStep: (step: number) => void;
 };
 
-function ProgressBar({ currentStep, stepsName }: Props) {
+function ProgressBar({ currentStep, stepsName, changeStep }: Props) {
     const activeStep = currentStep - 1;
     return (
         <div className={st.progressBar}>
             {stepsName.map((step, index) => (
                 <div
+                    onClick={(_) => {
+                        if (index !== activeStep) {
+                            changeStep(index + 1);
+                        }
+                    }}
                     className={cl(
                         st.step,
                         index === activeStep && st.currentStep,

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -225,6 +225,9 @@ function TransferCoinPage() {
                     <ProgressBar
                         currentStep={currentStep}
                         stepsName={['Amount', 'Address']}
+                        changeStep={(step) =>
+                            step < currentStep ? setCurrentStep(step) : {}
+                        }
                     />
                     {steps[currentStep - 1]}
                 </Loading>


### PR DESCRIPTION
## Description 

When a user creates new transaction in the wallet and wants to go to the previous screen to change amount, he must use back button which is small and is not convenient to press. Also the user can think that pressing on the back button will drop him to the balance page. I think it would be better to allow pressing on a progress bar at the top.

So, for example, when you entered a transaction amount and pressed `Continue`, you may press on the `Amount` tab at the top which will show the first page with amount selection.

Pressing on the next pages in the progress bar will do nothing since data on pages should be verified first.

## Test Plan 

I cloned the repo, made changes while viewing the results in Chrome browser as an unpacked extension.

---
### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- Ability to change an active page in creating transaction screen by clicking on a top progress bar (that shows all pages in one line). If the previous page was selected, it will be opened. Otherwise, nothing will happen (next pages have no reaction)
![sui-wallet](https://user-images.githubusercontent.com/7953703/220814856-0eff418b-8f6b-4da6-be78-181ac12cc96b.png)