### PR TITLE
[CI] Avoid rebuilding sui binaries

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -116,7 +116,9 @@ jobs:
         run: pnpm explorer playwright install --with-deps chromium
 
       - name: Set env
-        run: echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG=\"consensus=off\" $(echo $PWD/target/debug/sui-test-validator))" >> $GITHUB_ENV
+        run: |
+          echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG=\"consensus=off\" $(echo $PWD/target/debug/sui-test-validator))" >> $GITHUB_ENV
+          echo "VITE_SUI_BIN=$PWD/target/debug/sui" >> $GITHUB_ENV
 
       - name: Run TS SDK e2e tests
         if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' }}


### PR DESCRIPTION
## Description 

We are not leveraging the downloaded binary for `sui` in https://github.com/MystenLabs/sui/blob/main/sdk/typescript/test/e2e/utils/setup.ts#L28, therefore the code was still trying to rebuild the binary. This PR fixes this by specifying the path for the downloaded binary

## Test Plan 

1. Updated any ts file to trigger the e2e test
2. verify the test run is successful: https://github.com/MystenLabs/sui/actions/runs/4249465886/jobs/7389651316

Before: it took 15min to run
<img width="411" alt="CleanShot 2023-02-22 at 23 40 43@2x" src="https://user-images.githubusercontent.com/76067158/220822786-e1633a5a-c80c-44df-8c93-c769d8179c00.png">

After: it takes 2min to run
<img width="516" alt="CleanShot 2023-02-22 at 23 40 09@2x" src="https://user-images.githubusercontent.com/76067158/220822791-b59b218d-5868-46cf-be3e-2f5fed5cf03c.png">
