### PR TITLE
[narwhal] calculate consensus reputation scores

### DIFF
--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -53,7 +53,7 @@ pub struct Bullshark {
     pub max_inserted_certificate_round: Round,
     /// The number of committed subdags that will trigger the schedule change and reputation
     /// score reset.
-    pub change_schedule_every_committed_sub_dags: u64,
+    pub num_sub_dags_per_schedule: u64,
 }
 
 impl ConsensusProtocol for Bullshark {
@@ -249,7 +249,7 @@ impl Bullshark {
         store: Arc<ConsensusStore>,
         gc_depth: Round,
         metrics: Arc<ConsensusMetrics>,
-        change_schedule_every_committed_sub_dags: u64,
+        num_sub_dags_per_schedule: u64,
     ) -> Self {
         Self {
             committee,
@@ -259,7 +259,7 @@ impl Bullshark {
             last_leader_election: LastRound::default(),
             max_inserted_certificate_round: 0,
             metrics,
-            change_schedule_every_committed_sub_dags,
+            num_sub_dags_per_schedule,
         }
     }
 
@@ -341,7 +341,7 @@ impl Bullshark {
         // we reset the scores for every schedule change window.
         // TODO: when schedule change is implemented we should probably change a little bit
         // this logic here.
-        if sub_dag_index % self.change_schedule_every_committed_sub_dags == 0 {
+        if sub_dag_index % self.num_sub_dags_per_schedule == 0 {
             state.last_consensus_reputation_score = ReputationScores::default()
         }
 
@@ -367,7 +367,7 @@ impl Bullshark {
         // scores as final_of_schedule = true so any downstream user can now that those are the last
         // ones calculated for the current schedule.
         state.last_consensus_reputation_score.final_of_schedule =
-            (sub_dag_index + 1) % self.change_schedule_every_committed_sub_dags == 0;
+            (sub_dag_index + 1) % self.num_sub_dags_per_schedule == 0;
 
         state.last_consensus_reputation_score.clone()
     }

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -13,7 +13,7 @@ use fastcrypto::traits::EncodeDecodeBase64;
 use std::{collections::BTreeSet, sync::Arc};
 use tokio::time::Instant;
 use tracing::{debug, trace};
-use types::{Certificate, CertificateDigest, CommittedSubDag, ConsensusStore, Round, StoreResult};
+use types::{Certificate, CertificateDigest, CommittedSubDag, ConsensusStore, Round};
 
 #[cfg(test)]
 #[path = "tests/bullshark_tests.rs"]

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -12,7 +12,7 @@ use fastcrypto::traits::EncodeDecodeBase64;
 use std::{collections::BTreeSet, sync::Arc};
 use tokio::time::Instant;
 use tracing::{debug, trace};
-use types::{Certificate, CertificateDigest, CommittedSubDag, ConsensusStore, Round};
+use types::{Certificate, CertificateDigest, CommittedSubDag, ConsensusReputationScore, ConsensusStore, Round, StoreResult};
 
 #[cfg(test)]
 #[path = "tests/bullshark_tests.rs"]
@@ -48,6 +48,11 @@ pub struct Bullshark {
     pub last_leader_election: LastRound,
     /// The most recent round of inserted certificate
     pub max_inserted_certificate_round: Round,
+    /// The number of committed subdags that will trigger the schedule change and reputation
+    /// score reset.
+    pub change_schedule_every_committed_subdags: u64,
+    /// The last calculated consensus reputation score
+    pub last_consensus_reputation_score: ConsensusReputationScore
 }
 
 impl ConsensusProtocol for Bullshark {

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -79,14 +79,15 @@ impl ConsensusState {
             .expect("error when recovering DAG from store");
         metrics.recovered_consensus_state.inc();
 
-        let (latest_sub_dag_index, last_committed_leader) = latest_sub_dag
-            .map(|s| (s.sub_dag_index, Some(s.leader)))
-            .unwrap_or_default();
+        let (latest_sub_dag_index, last_consensus_reputation_score, last_committed_leader) =
+            latest_sub_dag
+                .map(|s| (s.sub_dag_index, s.reputation_score, Some(s.leader)))
+                .unwrap_or_default();
 
         Self {
             last_committed_round,
             last_committed: recover_last_committed,
-            last_consensus_reputation_score: Default::default(),
+            last_consensus_reputation_score,
             latest_sub_dag_index,
             last_committed_leader,
             dag,

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -19,8 +19,7 @@ use tokio::{sync::watch, task::JoinHandle};
 use tracing::{debug, info, instrument};
 use types::{
     metered_channel, Certificate, CertificateDigest, CommittedSubDag, CommittedSubDagShell,
-    ConditionalBroadcastReceiver, ConsensusReputationScore, ConsensusStore, Round, StoreResult,
-    Timestamp,
+    ConditionalBroadcastReceiver, ConsensusReputationScore, ConsensusStore, Round, Timestamp,
 };
 
 #[cfg(test)]

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -266,7 +266,7 @@ where
             tx_sequence,
             protocol,
             metrics,
-            state,
+            state
         };
 
         spawn_logged_monitored_task!(s.run(), "Consensus", INFO)

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -19,7 +19,7 @@ use tokio::{sync::watch, task::JoinHandle};
 use tracing::{debug, info, instrument};
 use types::{
     metered_channel, Certificate, CertificateDigest, CommittedSubDag, CommittedSubDagShell,
-    ConditionalBroadcastReceiver, ConsensusReputationScore, ConsensusStore, Round, Timestamp,
+    ConditionalBroadcastReceiver, ConsensusStore, ReputationScores, Round, Timestamp,
 };
 
 #[cfg(test)]
@@ -39,7 +39,7 @@ pub struct ConsensusState {
     /// Used to populate the index in the sub-dag construction.
     pub latest_sub_dag_index: SequenceNumber,
     /// The last calculated consensus reputation score
-    pub last_consensus_reputation_score: ConsensusReputationScore,
+    pub last_consensus_reputation_score: ReputationScores,
     /// The last committed sub dag leader. This allow us to calculate the reputation score of the nodes
     /// that vote for the last leader.
     pub last_committed_leader: Option<CertificateDigest>,
@@ -57,7 +57,7 @@ impl ConsensusState {
             last_committed: Default::default(),
             latest_sub_dag_index: 0,
             dag: Default::default(),
-            last_consensus_reputation_score: ConsensusReputationScore::default(),
+            last_consensus_reputation_score: ReputationScores::default(),
             last_committed_leader: None,
             metrics,
         }

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -691,10 +691,10 @@ async fn reset_consensus_scores_on_every_schedule_change() {
     // ensure the leaders of rounds 2 and 4 have been committed
     let mut current_score = 0;
     for sub_dag in all_subdags {
-        // The first commit has not scores
+        // The first commit has no scores
         if sub_dag.sub_dag_index == 1 {
             assert_eq!(sub_dag.reputation_score.total_authorities(), 0);
-        } else if sub_dag.sub_dag_index % 5 == 0 {
+        } else if sub_dag.sub_dag_index % CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS == 0 {
             // On every 5th commit we reset the scores and count from the beginning with
             // scores updated to 1, as we expect now every node to have voted for the previous leader.
             for score in sub_dag.reputation_score.scores_per_authority.values() {
@@ -708,6 +708,14 @@ async fn reset_consensus_scores_on_every_schedule_change() {
 
             for score in sub_dag.reputation_score.scores_per_authority.values() {
                 assert_eq!(*score, current_score);
+            }
+
+            if (sub_dag.sub_dag_index + 1) % CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS == 0 {
+                // if this is going to be the last score update for the current schedule, then
+                // make sure that the `fina_of_schedule` will be true
+                assert!(sub_dag.reputation_score.final_of_schedule);
+            } else {
+                assert!(!sub_dag.reputation_score.final_of_schedule);
             }
         }
     }

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -22,7 +22,7 @@ use types::PreSubscribedBroadcastSender;
 // the leader of round 2.
 #[tokio::test]
 async fn commit_one() {
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
@@ -60,7 +60,7 @@ async fn commit_one() {
         store.clone(),
         gc_depth,
         metrics.clone(),
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     let _consensus_handle = Consensus::spawn(
@@ -102,7 +102,7 @@ async fn commit_one() {
 // rounds 2, 4, and 6.
 #[tokio::test]
 async fn dead_node() {
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     // Make the certificates.
     let fixture = CommitteeFixture::builder().build();
@@ -136,7 +136,7 @@ async fn dead_node() {
         store.clone(),
         gc_depth,
         metrics.clone(),
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     let _consensus_handle = Consensus::spawn(
@@ -197,7 +197,7 @@ async fn dead_node() {
 // round 4 does. The leader of rounds 2 and 4 should thus be committed (because they are linked).
 #[tokio::test]
 async fn not_enough_support() {
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     let mut keys: Vec<_> = fixture.authorities().map(|a| a.public_key()).collect();
@@ -279,7 +279,7 @@ async fn not_enough_support() {
         store.clone(),
         gc_depth,
         metrics.clone(),
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     let _consensus_handle = Consensus::spawn(
@@ -346,7 +346,7 @@ async fn not_enough_support() {
 // and reappears from round 3.
 #[tokio::test]
 async fn missing_leader() {
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     let mut keys: Vec<_> = fixture.authorities().map(|a| a.public_key()).collect();
@@ -392,7 +392,7 @@ async fn missing_leader() {
         store.clone(),
         gc_depth,
         metrics.clone(),
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     let _consensus_handle = Consensus::spawn(
@@ -445,7 +445,7 @@ async fn committed_round_after_restart() {
     let committee = fixture.committee();
     let keys: Vec<_> = fixture.authorities().map(|a| a.public_key()).collect();
     let epoch = committee.epoch();
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     // Make certificates for rounds 1 to 11.
     let genesis = Certificate::genesis(&committee)
@@ -473,7 +473,7 @@ async fn committed_round_after_restart() {
             store.clone(),
             gc_depth,
             metrics.clone(),
-            CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+            NUM_SUB_DAGS_PER_SCHEDULE,
         );
 
         let handle = Consensus::spawn(
@@ -537,7 +537,7 @@ async fn committed_round_after_restart() {
 /// from round 2. Certificate 2 should not get committed.
 #[tokio::test]
 async fn delayed_certificates_are_rejected() {
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
@@ -561,7 +561,7 @@ async fn delayed_certificates_are_rejected() {
         store,
         gc_depth,
         metrics,
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     // Populate DAG with the rounds up to round 5 so we trigger commits
@@ -589,7 +589,7 @@ async fn delayed_certificates_are_rejected() {
 
 #[tokio::test]
 async fn submitting_equivocating_certificate_should_error() {
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
@@ -613,7 +613,7 @@ async fn submitting_equivocating_certificate_should_error() {
         store,
         gc_depth,
         metrics,
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     // Populate DAG with all the certificates
@@ -652,7 +652,7 @@ async fn submitting_equivocating_certificate_should_error() {
 /// Advance the DAG for 50 rounds, while we change "schedule" for every 5 subdag commits.
 #[tokio::test]
 async fn reset_consensus_scores_on_every_schedule_change() {
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 5;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 5;
 
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
@@ -676,7 +676,7 @@ async fn reset_consensus_scores_on_every_schedule_change() {
         store,
         gc_depth,
         metrics,
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     // Populate DAG with the rounds up to round 50 so we trigger commits
@@ -694,7 +694,7 @@ async fn reset_consensus_scores_on_every_schedule_change() {
         // The first commit has no scores
         if sub_dag.sub_dag_index == 1 {
             assert_eq!(sub_dag.reputation_score.total_authorities(), 0);
-        } else if sub_dag.sub_dag_index % CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS == 0 {
+        } else if sub_dag.sub_dag_index % NUM_SUB_DAGS_PER_SCHEDULE == 0 {
             // On every 5th commit we reset the scores and count from the beginning with
             // scores updated to 1, as we expect now every node to have voted for the previous leader.
             for score in sub_dag.reputation_score.scores_per_authority.values() {
@@ -710,7 +710,7 @@ async fn reset_consensus_scores_on_every_schedule_change() {
                 assert_eq!(*score, current_score);
             }
 
-            if (sub_dag.sub_dag_index + 1) % CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS == 0 {
+            if (sub_dag.sub_dag_index + 1) % NUM_SUB_DAGS_PER_SCHEDULE == 0 {
                 // if this is going to be the last score update for the current schedule, then
                 // make sure that the `fina_of_schedule` will be true
                 assert!(sub_dag.reputation_score.final_of_schedule);
@@ -728,7 +728,7 @@ async fn restart_with_new_committee() {
     let fixture = CommitteeFixture::builder().build();
     let mut committee = fixture.committee();
     let keys: Vec<_> = fixture.authorities().map(|a| a.public_key()).collect();
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     // Run for a few epochs.
     for epoch in 0..5 {
@@ -748,7 +748,7 @@ async fn restart_with_new_committee() {
             store.clone(),
             gc_depth,
             metrics.clone(),
-            CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+            NUM_SUB_DAGS_PER_SCHEDULE,
         );
 
         let handle = Consensus::spawn(

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -22,6 +22,8 @@ use types::PreSubscribedBroadcastSender;
 // the leader of round 2.
 #[tokio::test]
 async fn commit_one() {
+    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     // Make certificates for rounds 1 and 2.
@@ -53,7 +55,13 @@ async fn commit_one() {
     let cert_store = make_certificate_store(&test_utils::temp_dir());
     let gc_depth = 50;
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth, metrics.clone());
+    let bullshark = Bullshark::new(
+        committee.clone(),
+        store.clone(),
+        gc_depth,
+        metrics.clone(),
+        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+    );
 
     let _consensus_handle = Consensus::spawn(
         committee,
@@ -91,6 +99,8 @@ async fn commit_one() {
 // rounds 2, 4, and 6.
 #[tokio::test]
 async fn dead_node() {
+    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+
     // Make the certificates.
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
@@ -118,7 +128,13 @@ async fn dead_node() {
     let cert_store = make_certificate_store(&test_utils::temp_dir());
     let gc_depth = 50;
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth, metrics.clone());
+    let bullshark = Bullshark::new(
+        committee.clone(),
+        store.clone(),
+        gc_depth,
+        metrics.clone(),
+        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+    );
 
     let _consensus_handle = Consensus::spawn(
         committee,
@@ -162,6 +178,7 @@ async fn dead_node() {
 // round 4 does. The leader of rounds 2 and 4 should thus be committed (because they are linked).
 #[tokio::test]
 async fn not_enough_support() {
+    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     let mut keys: Vec<_> = fixture.authorities().map(|a| a.public_key()).collect();
@@ -238,7 +255,13 @@ async fn not_enough_support() {
     let cert_store = make_certificate_store(&test_utils::temp_dir());
     let gc_depth = 50;
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth, metrics.clone());
+    let bullshark = Bullshark::new(
+        committee.clone(),
+        store.clone(),
+        gc_depth,
+        metrics.clone(),
+        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+    );
 
     let _consensus_handle = Consensus::spawn(
         committee,
@@ -288,6 +311,7 @@ async fn not_enough_support() {
 // and reappears from round 3.
 #[tokio::test]
 async fn missing_leader() {
+    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     let mut keys: Vec<_> = fixture.authorities().map(|a| a.public_key()).collect();
@@ -328,7 +352,13 @@ async fn missing_leader() {
     let cert_store = make_certificate_store(&test_utils::temp_dir());
     let gc_depth = 50;
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth, metrics.clone());
+    let bullshark = Bullshark::new(
+        committee.clone(),
+        store.clone(),
+        gc_depth,
+        metrics.clone(),
+        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+    );
 
     let _consensus_handle = Consensus::spawn(
         committee,
@@ -377,6 +407,7 @@ async fn committed_round_after_restart() {
     let committee = fixture.committee();
     let keys: Vec<_> = fixture.authorities().map(|a| a.public_key()).collect();
     let epoch = committee.epoch();
+    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
 
     // Make certificates for rounds 1 to 11.
     let genesis = Certificate::genesis(&committee)
@@ -399,7 +430,13 @@ async fn committed_round_after_restart() {
         let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
         let gc_depth = 50;
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-        let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth, metrics.clone());
+        let bullshark = Bullshark::new(
+            committee.clone(),
+            store.clone(),
+            gc_depth,
+            metrics.clone(),
+            CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        );
 
         let handle = Consensus::spawn(
             committee.clone(),
@@ -565,6 +602,7 @@ async fn restart_with_new_committee() {
     let fixture = CommitteeFixture::builder().build();
     let mut committee = fixture.committee();
     let keys: Vec<_> = fixture.authorities().map(|a| a.public_key()).collect();
+    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
 
     // Run for a few epochs.
     for epoch in 0..5 {
@@ -579,7 +617,13 @@ async fn restart_with_new_committee() {
         let cert_store = make_certificate_store(&test_utils::temp_dir());
         let gc_depth = 50;
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-        let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth, metrics.clone());
+        let bullshark = Bullshark::new(
+            committee.clone(),
+            store.clone(),
+            gc_depth,
+            metrics.clone(),
+            CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        );
 
         let handle = Consensus::spawn(
             committee.clone(),

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -85,7 +85,7 @@ async fn commit_one() {
 
     // Ensure the first 4 ordered certificates are from round 1 (they are the parents of the committed
     // leader); then the leader's certificate should be committed.
-    let committed_sub_dag = rx_output.recv().await.unwrap();
+    let committed_sub_dag: CommittedSubDag = rx_output.recv().await.unwrap();
     let mut sequence = committed_sub_dag.certificates.into_iter();
     for _ in 1..=4 {
         let output = sequence.next().unwrap();
@@ -93,6 +93,9 @@ async fn commit_one() {
     }
     let output = sequence.next().unwrap();
     assert_eq!(output.round(), 2);
+
+    // AND the reputation scores have not been updated
+    assert_eq!(committed_sub_dag.reputation_score.total_authorities(), 0);
 }
 
 // Run for 8 dag rounds with one dead node node (that is not a leader). We should commit the leaders of

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -37,7 +37,7 @@ async fn test_consensus_recovery_with_bullshark() {
 
     let consensus_store = storage.consensus_store;
     let certificate_store = storage.certificate_store;
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     // AND Setup consensus
     let fixture = CommitteeFixture::builder().build();
@@ -67,7 +67,7 @@ async fn test_consensus_recovery_with_bullshark() {
         consensus_store.clone(),
         gc_depth,
         metrics.clone(),
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     let consensus_handle = Consensus::spawn(
@@ -161,7 +161,7 @@ async fn test_consensus_recovery_with_bullshark() {
         consensus_store.clone(),
         gc_depth,
         metrics.clone(),
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     let consensus_handle = Consensus::spawn(
@@ -229,7 +229,7 @@ async fn test_consensus_recovery_with_bullshark() {
         consensus_store.clone(),
         gc_depth,
         metrics.clone(),
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     let _consensus_handle = Consensus::spawn(

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -37,6 +37,7 @@ async fn test_consensus_recovery_with_bullshark() {
 
     let consensus_store = storage.consensus_store;
     let certificate_store = storage.certificate_store;
+    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
 
     // AND Setup consensus
     let fixture = CommitteeFixture::builder().build();
@@ -66,6 +67,7 @@ async fn test_consensus_recovery_with_bullshark() {
         consensus_store.clone(),
         gc_depth,
         metrics.clone(),
+        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
     );
 
     let consensus_handle = Consensus::spawn(
@@ -155,6 +157,7 @@ async fn test_consensus_recovery_with_bullshark() {
         consensus_store.clone(),
         gc_depth,
         metrics.clone(),
+        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
     );
 
     let consensus_handle = Consensus::spawn(
@@ -222,6 +225,7 @@ async fn test_consensus_recovery_with_bullshark() {
         consensus_store.clone(),
         gc_depth,
         metrics.clone(),
+        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
     );
 
     let _consensus_handle = Consensus::spawn(

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -16,7 +16,7 @@ use crate::bullshark::Bullshark;
 use crate::metrics::ConsensusMetrics;
 use crate::Consensus;
 use crate::NUM_SHUTDOWN_RECEIVERS;
-use types::{Certificate, PreSubscribedBroadcastSender};
+use types::{Certificate, PreSubscribedBroadcastSender, ReputationScores};
 
 /// This test is trying to compare the output of the Consensus algorithm when:
 /// (1) running without any crash for certificates processed from round 1 to 5 (inclusive)
@@ -43,14 +43,14 @@ async fn test_consensus_recovery_with_bullshark() {
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
 
-    // AND make certificates for rounds 1 to 5 (inclusive)
+    // AND make certificates for rounds 1 to 7 (inclusive)
     let keys: Vec<_> = fixture.authorities().map(|a| a.public_key()).collect();
     let genesis = Certificate::genesis(&committee)
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
     let (certificates, _next_parents) =
-        test_utils::make_optimal_certificates(&committee, 1..=5, &genesis, &keys);
+        test_utils::make_optimal_certificates(&committee, 1..=7, &genesis, &keys);
 
     // AND Spawn the consensus engine.
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(100);
@@ -96,25 +96,29 @@ async fn test_consensus_recovery_with_bullshark() {
     // * 4 certificates from round 1
     // * 4 certificates from round 2
     // * 4 certificates from round 3
-    // * 1 certificate from round 4 (the leader of last round)
+    // * 4 certificates from round 4
+    // * 4 certificates from round 5
+    // * 1 certificates from round 6 (the leader of last round)
     //
-    // In total we should see 13 certificates committed
+    // In total we should see 21 certificates committed
     let mut consensus_index_counter = 1;
 
     // hold all the certificates that get committed when consensus runs
     // without any crash.
     let mut committed_output_no_crash: Vec<Certificate> = Vec::new();
+    let mut score_no_crash: ReputationScores = ReputationScores::default();
 
     'main: while let Some(sub_dag) = rx_output.recv().await {
+        score_no_crash = sub_dag.reputation_score.clone();
         assert_eq!(sub_dag.sub_dag_index, consensus_index_counter);
         for output in sub_dag.certificates {
-            assert!(output.round() <= 4);
+            assert!(output.round() <= 6);
 
             committed_output_no_crash.push(output.clone());
 
-            // we received the leader of round 4, now stop as we don't expect to see any other
+            // we received the leader of round 6, now stop as we don't expect to see any other
             // certificate from that or higher round.
-            if output.round() == 4 {
+            if output.round() == 6 {
                 break 'main;
             }
         }
@@ -127,12 +131,12 @@ async fn test_consensus_recovery_with_bullshark() {
     for key in keys.clone() {
         let last_round = *last_committed.get(&key).unwrap();
 
-        // For the leader of round 4 we expect to have last committed round of 4.
-        if key == Bullshark::leader_authority(&committee, 4) {
-            assert_eq!(last_round, 4);
+        // For the leader of round 6 we expect to have last committed round of 6.
+        if key == Bullshark::leader_authority(&committee, 6) {
+            assert_eq!(last_round, 6);
         } else {
-            // For the others should be 3.
-            assert_eq!(last_round, 3);
+            // For the others should be 5.
+            assert_eq!(last_round, 5);
         }
     }
 
@@ -174,15 +178,15 @@ async fn test_consensus_recovery_with_bullshark() {
     );
 
     // WHEN we send same certificates but up to round 3 (inclusive)
-    // Then we store all the certificates up to round 4 so we can let the recovery algorithm
+    // Then we store all the certificates up to round 6 so we can let the recovery algorithm
     // restore the consensus.
-    // We omit round 5 so we can feed those later after "crash" to trigger a new leader
+    // We omit round 7 so we can feed those later after "crash" to trigger a new leader
     // election round and commit.
     for certificate in certificates.iter() {
         if certificate.header.round <= 3 {
             tx_waiter.send(certificate.clone()).await.unwrap();
         }
-        if certificate.header.round <= 4 {
+        if certificate.header.round <= 6 {
             certificate_store.write(certificate.clone()).unwrap();
         }
     }
@@ -251,16 +255,18 @@ async fn test_consensus_recovery_with_bullshark() {
 
     // AND capture the committed output
     let mut committed_output_after_crash: Vec<Certificate> = Vec::new();
+    let mut score_with_crash: ReputationScores = ReputationScores::default();
 
     'main: while let Some(sub_dag) = rx_output.recv().await {
+        score_with_crash = sub_dag.reputation_score.clone();
         for output in sub_dag.certificates {
             assert!(output.round() >= 2);
 
             committed_output_after_crash.push(output.clone());
 
-            // we received the leader of round 4, now stop as we don't expect to see any other
+            // we received the leader of round 6, now stop as we don't expect to see any other
             // certificate from that or higher round.
-            if output.round() == 4 {
+            if output.round() == 6 {
                 break 'main;
             }
         }
@@ -276,6 +282,18 @@ async fn test_consensus_recovery_with_bullshark() {
     let all_output_with_crash = committed_output_before_crash;
 
     assert_eq!(committed_output_no_crash, all_output_with_crash);
+
+    // AND ensure that scores are exactly the same
+    assert_eq!(score_with_crash.scores_per_authority.len(), 4);
+    assert_eq!(score_with_crash, score_no_crash);
+    assert_eq!(
+        score_with_crash
+            .scores_per_authority
+            .into_iter()
+            .filter(|(_, score)| *score == 2)
+            .count(),
+        4
+    );
 }
 
 fn setup_tracing() -> TelemetryGuards {

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -9,7 +9,10 @@ use config::{Committee, Stake};
 use fastcrypto::{hash::Hash, traits::EncodeDecodeBase64};
 use std::{collections::HashMap, sync::Arc};
 use tracing::debug;
-use types::{Certificate, CertificateDigest, CommittedSubDag, ConsensusReputationScore, ConsensusStore, Round, StoreResult};
+use types::{
+    Certificate, CertificateDigest, CommittedSubDag, ConsensusReputationScore, ConsensusStore,
+    Round,
+};
 
 #[cfg(any(test))]
 #[path = "tests/tusk_tests.rs"]
@@ -103,7 +106,7 @@ impl ConsensusProtocol for Tusk {
                 certificates: sequence,
                 leader: leader.clone(),
                 sub_dag_index: next_sub_dag_index,
-                reputation_score: ConsensusReputationScore::default() // TODO compute the scores for Tusk as well
+                reputation_score: ConsensusReputationScore::default(), // TODO compute the scores for Tusk as well
             };
 
             // Persist the update.

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -9,7 +9,7 @@ use config::{Committee, Stake};
 use fastcrypto::{hash::Hash, traits::EncodeDecodeBase64};
 use std::{collections::HashMap, sync::Arc};
 use tracing::debug;
-use types::{Certificate, CertificateDigest, CommittedSubDag, ConsensusStore, Round};
+use types::{Certificate, CertificateDigest, CommittedSubDag, ConsensusReputationScore, ConsensusStore, Round, StoreResult};
 
 #[cfg(any(test))]
 #[path = "tests/tusk_tests.rs"]
@@ -103,6 +103,7 @@ impl ConsensusProtocol for Tusk {
                 certificates: sequence,
                 leader: leader.clone(),
                 sub_dag_index: next_sub_dag_index,
+                reputation_score: ConsensusReputationScore::default() // TODO compute the scores for Tusk as well
             };
 
             // Persist the update.

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -10,8 +10,7 @@ use fastcrypto::{hash::Hash, traits::EncodeDecodeBase64};
 use std::{collections::HashMap, sync::Arc};
 use tracing::debug;
 use types::{
-    Certificate, CertificateDigest, CommittedSubDag, ConsensusReputationScore, ConsensusStore,
-    Round,
+    Certificate, CertificateDigest, CommittedSubDag, ConsensusStore, ReputationScores, Round,
 };
 
 #[cfg(any(test))]
@@ -106,7 +105,7 @@ impl ConsensusProtocol for Tusk {
                 certificates: sequence,
                 leader: leader.clone(),
                 sub_dag_index: next_sub_dag_index,
-                reputation_score: ConsensusReputationScore::default(), // TODO compute the scores for Tusk as well
+                reputation_score: ReputationScores::default(), // TODO compute the scores for Tusk as well
             };
 
             // Persist the update.

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -121,6 +121,7 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
             certificates,
             leader,
             sub_dag_index,
+            reputation_score: compressed_sub_dag.reputation_score
         });
     }
 

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -121,7 +121,7 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
             certificates,
             leader,
             sub_dag_index,
-            reputation_score: compressed_sub_dag.reputation_score
+            reputation_score: compressed_sub_dag.reputation_score,
         });
     }
 

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -16,7 +16,7 @@ use telemetry_subscribers::TelemetryGuards;
 use test_utils::{cluster::Cluster, temp_dir, CommitteeFixture};
 use tokio::sync::watch;
 
-use types::{Certificate, PreSubscribedBroadcastSender, TransactionProto};
+use types::{Certificate, PreSubscribedBroadcastSender, Round, TransactionProto};
 
 #[tokio::test]
 async fn test_recovery() {
@@ -55,13 +55,15 @@ async fn test_recovery() {
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
-    let gc_depth = 50;
+    const GC_DEPTH: Round = 50;
+    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
-        gc_depth,
+        GC_DEPTH,
         metrics.clone(),
+        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
     );
 
     let _consensus_handle = Consensus::spawn(

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -56,14 +56,14 @@ async fn test_recovery() {
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
     const GC_DEPTH: Round = 50;
-    const CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS: u64 = 100;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
         GC_DEPTH,
         metrics.clone(),
-        CHANGE_SCHEDULE_EVERY_COMMITTED_SUB_DAGS,
+        NUM_SUB_DAGS_PER_SCHEDULE,
     );
 
     let _consensus_handle = Consensus::spawn(

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -45,6 +45,10 @@ struct PrimaryNodeInner {
 impl PrimaryNodeInner {
     /// The default channel capacity.
     pub const CHANNEL_CAPACITY: usize = 1_000;
+    /// The window where the schedule change takes place in consensus. It represents number
+    /// of committed sub dags.
+    /// TODO: move this to node properties
+    const CONSENSUS_SCHEDULE_CHANGE_SUB_DAGS: u64 = 10_000;
 
     // Starts the primary node with the provided info. If the node is already running then this
     // method will return an error instead.
@@ -325,7 +329,7 @@ impl PrimaryNodeInner {
             store.consensus_store.clone(),
             parameters.gc_depth,
             consensus_metrics.clone(),
-            100,
+            Self::CONSENSUS_SCHEDULE_CHANGE_SUB_DAGS,
         );
         let consensus_handles = Consensus::spawn(
             committee.clone(),

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -325,6 +325,7 @@ impl PrimaryNodeInner {
             store.consensus_store.clone(),
             parameters.gc_depth,
             consensus_metrics.clone(),
+            100,
         );
         let consensus_handles = Consensus::spawn(
             committee.clone(),

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -80,12 +80,10 @@ pub struct ReputationScores {
 impl ReputationScores {
     /// Adds the provided `score` to the existing score for the provided `authority`
     pub fn add_score(&mut self, authority: PublicKey, score: u64) {
-        let total_score = self
-            .scores_per_authority
-            .get(&authority)
-            .map(|value| value + score)
-            .unwrap_or(score);
-        self.scores_per_authority.insert(authority, total_score);
+        self.scores_per_authority
+            .entry(authority)
+            .and_modify(|value| *value += score)
+            .or_insert(score);
     }
 
     pub fn total_authorities(&self) -> u64 {

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -65,7 +65,7 @@ impl CommittedSubDag {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct ReputationScores {
     /// Holds the score for every authority. If an authority is not amongst
     /// the records of the map then we assume that its score is zero.

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -33,6 +33,8 @@ pub struct CommittedSubDag {
     pub leader: Certificate,
     /// The index associated with this CommittedSubDag
     pub sub_dag_index: SequenceNumber,
+    /// The so far calculated reputation score for nodes
+    pub reputation_score: ConsensusReputationScore,
 }
 
 impl CommittedSubDag {
@@ -63,7 +65,7 @@ impl CommittedSubDag {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct ConsensusReputationScore {
     pub scores_per_authority: HashMap<PublicKey, u64>,
 }
@@ -93,6 +95,8 @@ pub struct CommittedSubDagShell {
     pub leader: CertificateDigest,
     /// Sequence number of the CommittedSubDag
     pub sub_dag_index: SequenceNumber,
+    /// The so far calculated reputation score for nodes
+    pub reputation_score: ConsensusReputationScore,
 }
 
 impl CommittedSubDagShell {
@@ -101,6 +105,7 @@ impl CommittedSubDagShell {
             certificates: sub_dag.certificates.iter().map(|x| x.digest()).collect(),
             leader: sub_dag.leader.digest(),
             sub_dag_index: sub_dag.sub_dag_index,
+            reputation_score: sub_dag.reputation_score.clone(),
         }
     }
 }

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -81,6 +81,10 @@ impl ConsensusReputationScore {
         self.scores_per_authority.insert(authority, total_score);
     }
 
+    pub fn total_authorities(&self) -> u64 {
+        self.scores_per_authority.len() as u64
+    }
+
     /// Clear the scores for all authorities
     fn clear(&mut self) {
         self.scores_per_authority.clear();

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -34,7 +34,7 @@ pub struct CommittedSubDag {
     /// The index associated with this CommittedSubDag
     pub sub_dag_index: SequenceNumber,
     /// The so far calculated reputation score for nodes
-    pub reputation_score: ConsensusReputationScore,
+    pub reputation_score: ReputationScores,
 }
 
 impl CommittedSubDag {
@@ -66,11 +66,13 @@ impl CommittedSubDag {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
-pub struct ConsensusReputationScore {
+pub struct ReputationScores {
+    /// Holds the score for every authority. If an authority is not amongst
+    /// the records of the map then we assume that its score is zero.
     pub scores_per_authority: HashMap<PublicKey, u64>,
 }
 
-impl ConsensusReputationScore {
+impl ReputationScores {
     /// Adds the provided `score` to the existing score for the provided `authority`
     pub fn add_score(&mut self, authority: PublicKey, score: u64) {
         let total_score = self
@@ -100,7 +102,7 @@ pub struct CommittedSubDagShell {
     /// Sequence number of the CommittedSubDag
     pub sub_dag_index: SequenceNumber,
     /// The so far calculated reputation score for nodes
-    pub reputation_score: ConsensusReputationScore,
+    pub reputation_score: ReputationScores,
 }
 
 impl CommittedSubDagShell {

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -86,7 +86,7 @@ impl ConsensusReputationScore {
     }
 
     /// Clear the scores for all authorities
-    fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.scores_per_authority.clear();
     }
 }

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -63,6 +63,11 @@ impl CommittedSubDag {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct ConsensusReputationScore {
+    pub scores_per_authority: HashMap<PublicKey, u64>,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CommittedSubDagShell {
     /// The sequence of committed certificates' digests.

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -70,6 +70,11 @@ pub struct ReputationScores {
     /// Holds the score for every authority. If an authority is not amongst
     /// the records of the map then we assume that its score is zero.
     pub scores_per_authority: HashMap<PublicKey, u64>,
+    /// When true it notifies us that those scores will be the last updated scores of the
+    /// current schedule before they get reset for the next schedule and start
+    /// scoring from the beginning. In practice we can leverage this information to
+    /// use the scores during the next schedule until the next final ones are calculated.
+    pub final_of_schedule: bool,
 }
 
 impl ReputationScores {
@@ -85,11 +90,6 @@ impl ReputationScores {
 
     pub fn total_authorities(&self) -> u64 {
         self.scores_per_authority.len() as u64
-    }
-
-    /// Clear the scores for all authorities
-    pub fn clear(&mut self) {
-        self.scores_per_authority.clear();
     }
 }
 
@@ -191,18 +191,6 @@ impl ConsensusStore {
             .skip_to_last()
             .next()
             .map(|(_, subdag)| subdag)
-    }
-
-    /// Returns the subdag by the specified index. If found Some is returned with the result,
-    /// otherwise None is returned instead.
-    pub fn get_sub_dag_by_index(
-        &self,
-        index: &SequenceNumber,
-    ) -> StoreResult<Option<CommittedSubDagShell>> {
-        match self.committed_sub_dags_by_index.get(index)? {
-            None => Ok(None),
-            Some(sub_dag) => Ok(Some(sub_dag)),
-        }
     }
 
     /// Load all the sub dags committed with sequence number of at least `from`.


### PR DESCRIPTION
## Description 

Introduces the authority score calculation as this is [described here](https://www.notion.so/mystenlabs/2023-04-Leader-Reputation-c9204dd9e91249d5a68175e7076f9e91?pvs=4#84e2b6aac24241a1bec8b8fd51ea51ab). The `change_schedule_every_committed_sub_dags` has been introduced to accommodate the score reset for every `K` commit rounds which will be later needed once we implement the schedule change. Also, the crash recovery path has been considered to ensure that we keep counting scores from where we left off. Additional testing has been introduced.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
