### PR TITLE
[ts-sdk] Remove old transaction interfaces

### DIFF
--- a/.changeset/yellow-ants-smoke.md
+++ b/.changeset/yellow-ants-smoke.md
@@ -1,0 +1,6 @@
+---
+"@mysten/wallet-adapter-unsafe-burner": minor
+"@mysten/sui.js": minor
+---
+
+Remove old `SuiExecuteTransactionResponse` interface, and `CertifiedTransaction` interface in favor of the new unified `SuiTransactionResponse` interfaces.

--- a/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
@@ -212,7 +212,7 @@ export const getDataOnTxDigests = (
                     coinType: transfer?.coinType || null,
                     kind: txKind,
                     From: getTransactionSender(txEff),
-                    timestamp_ms: txEff.timestamp_ms || txEff.timestampMs,
+                    timestamp_ms: txEff.timestampMs,
                     ...(recipient
                         ? {
                               To: recipient,

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -441,7 +441,7 @@ function TransactionView({
         ? getSignatureFromAddress(deserializedTransactionSignatures, gasOwner)
         : null;
 
-    const timestamp = transaction.timestamp_ms || transaction.timestampMs;
+    const timestamp = transaction.timestampMs;
 
     return (
         <div className={clsx(styles.txdetailsbg)}>

--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -10,9 +10,9 @@ import {
     RawSigner,
     LocalTxnDataSerializer,
     type Keypair,
-    SuiExecuteTransactionResponse,
     assert,
     localnetConnection,
+    SuiTransactionResponse,
 } from '@mysten/sui.js';
 
 const addressToKeypair = new Map<string, Keypair>();
@@ -49,7 +49,7 @@ export async function mint(address: string) {
         gasBudget: 30000,
     });
 
-    assert(tx, SuiExecuteTransactionResponse);
+    assert(tx, SuiTransactionResponse);
     return tx;
 }
 

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -43,7 +43,7 @@ type ReceiptCardProps = {
 
 function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
     const { effects, events } = txn;
-    const timestamp = txn.timestamp_ms || txn.timestampMs;
+    const timestamp = txn.timestampMs;
     const executionStatus = getExecutionStatusType(txn);
     const error = useMemo(() => getExecutionStatusError(txn), [txn]);
     const isSuccessful = executionStatus === 'success';

--- a/apps/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -150,7 +150,7 @@ export function TransactionCard({
             />
         );
 
-    const timestamp = txn.timestamp_ms || txn.timestampMs;
+    const timestamp = txn.timestampMs;
 
     return (
         <Link

--- a/apps/wallet/src/ui/app/hooks/useGetTransactionsByAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetTransactionsByAddress.ts
@@ -28,9 +28,7 @@ export function useGetTransactionsByAddress(address: SuiAddress | null) {
 
             return resp.sort(
                 // timestamp could be null, so we need to handle
-                (a, b) =>
-                    (b.timestamp_ms || b.timestampMs || 0) -
-                    (a.timestamp_ms || b.timestampMs || 0)
+                (a, b) => (b.timestampMs || 0) - (a.timestampMs || 0)
             );
         },
         { enabled: !!address, staleTime: 10 * 1000 }

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -14,7 +14,7 @@ import type {
     SuiObject,
     SuiAddress,
     SuiMoveObject,
-    SuiExecuteTransactionResponse,
+    SuiTransactionResponse,
     SignerWithProvider,
 } from '@mysten/sui.js';
 
@@ -93,7 +93,7 @@ export class Coin {
         amount: bigint,
         validator: SuiAddress,
         gasPrice: number
-    ): Promise<SuiExecuteTransactionResponse> {
+    ): Promise<SuiTransactionResponse> {
         const transaction = Sentry.startTransaction({ name: 'stake' });
         const stakeCoin = await this.coinManageForStake(
             signer,
@@ -132,7 +132,7 @@ export class Coin {
         signer: SignerWithProvider,
         delegation: ObjectId,
         stakedSuiId: ObjectId
-    ): Promise<SuiExecuteTransactionResponse> {
+    ): Promise<SuiTransactionResponse> {
         const transaction = Sentry.startTransaction({ name: 'unstake' });
         try {
             return await signer.executeMoveCall({

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
@@ -3,7 +3,7 @@
 
 import type {
     SignerWithProvider,
-    SuiExecuteTransactionResponse,
+    SuiTransactionResponse,
 } from '@mysten/sui.js';
 
 const DEFAULT_NFT_IMAGE =
@@ -21,7 +21,7 @@ export class ExampleNFT {
         name?: string,
         description?: string,
         imageUrl?: string
-    ): Promise<SuiExecuteTransactionResponse> {
+    ): Promise<SuiTransactionResponse> {
         return await signer.executeMoveCall({
             packageObjectId: '0x2',
             module: 'devnet_nft',

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -3,9 +3,6 @@
 
 import {
     fromB64,
-    getCertifiedTransaction,
-    getEvents,
-    getTransactionEffects,
     LocalTxnDataSerializer,
     type SignedTransaction,
     type SuiAddress,
@@ -20,7 +17,6 @@ import type {
     SuiMoveNormalizedFunction,
     SuiTransactionResponse,
     SignableTransaction,
-    SuiExecuteTransactionResponse,
     MoveCallTransaction,
     UnserializedSignableTransaction,
 } from '@mysten/sui.js';
@@ -158,7 +154,7 @@ export const respondToTransactionRequest = createAsyncThunk<
                     // Just a signing request, do not submit
                     txSigned = await signer.signTransaction(txRequest.tx.data);
                 } else {
-                    let response: SuiExecuteTransactionResponse;
+                    let response: SuiTransactionResponse;
                     if (
                         txRequest.tx.type === 'v2' ||
                         txRequest.tx.type === 'move-call'
@@ -188,13 +184,7 @@ export const respondToTransactionRequest = createAsyncThunk<
                         );
                     }
 
-                    txResult = {
-                        certificate: getCertifiedTransaction(response)!,
-                        effects: getTransactionEffects(response)!,
-                        events: getEvents(response)!,
-                        timestamp_ms: null,
-                        parsed_data: null,
-                    };
+                    txResult = response;
                 }
             } catch (e) {
                 tsResultError = (e as Error).message;

--- a/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
@@ -9,8 +9,8 @@ import {
   TransactionEffects,
   normalizeSuiObjectId,
   ExecuteTransactionRequestType,
-  SuiExecuteTransactionResponse,
   getTransactionEffects,
+  SuiTransactionResponse,
 } from '../types';
 import { JsonRpcProvider } from './json-rpc-provider';
 import { is } from 'superstruct';
@@ -67,7 +67,7 @@ export class JsonRpcProviderWithCache extends JsonRpcProvider {
     txnBytes: Uint8Array | string,
     signature: SerializedSignature,
     requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     if (requestType !== 'WaitForEffectsCert') {
       console.warn(
         `It's not recommended to use JsonRpcProviderWithCache with the request ` +

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -15,7 +15,6 @@ import {
   SuiAddress,
   SuiEventEnvelope,
   SuiEventFilter,
-  SuiExecuteTransactionResponse,
   SuiMoveFunctionArgTypes,
   SuiMoveNormalizedFunction,
   SuiMoveNormalizedModule,
@@ -669,7 +668,7 @@ export class JsonRpcProvider extends Provider {
     txnBytes: Uint8Array | string,
     signature: SerializedSignature,
     requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     try {
       return await this.client.requestWithType(
         'sui_executeTransactionSerializedSig',
@@ -678,7 +677,7 @@ export class JsonRpcProvider extends Provider {
           signature,
           requestType,
         ],
-        SuiExecuteTransactionResponse,
+        SuiTransactionResponse,
         this.options.skipDataValidation,
       );
     } catch (err) {

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -19,7 +19,6 @@ import {
   SuiEventEnvelope,
   SubscriptionId,
   ExecuteTransactionRequestType,
-  SuiExecuteTransactionResponse,
   TransactionDigest,
   ObjectId,
   SuiAddress,
@@ -46,6 +45,7 @@ import {
   Checkpoint,
   CommitteeInfo,
   DryRunTransactionResponse,
+  SuiTransactionResponse,
 } from '../types';
 
 import { DynamicFieldName, DynamicFieldPage } from '../types/dynamic_fields';
@@ -242,7 +242,7 @@ export abstract class Provider {
     txnBytes: Uint8Array | string,
     signature: SerializedSignature,
     requestType: ExecuteTransactionRequestType,
-  ): Promise<SuiExecuteTransactionResponse>;
+  ): Promise<SuiTransactionResponse>;
 
   // Move info
   /**

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -4,7 +4,6 @@
 import { HttpHeaders } from '../rpc/client';
 import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
 import {
-  CertifiedTransaction,
   TransactionDigest,
   GetTxnDigestsResponse,
   GatewayTxSeqNumber,
@@ -20,7 +19,7 @@ import {
   SuiEventEnvelope,
   SubscriptionId,
   ExecuteTransactionRequestType,
-  SuiExecuteTransactionResponse,
+  SuiTransactionResponse,
   SuiAddress,
   ObjectId,
   TransactionQuery,
@@ -178,7 +177,7 @@ export class VoidProvider extends Provider {
   // Transactions
   async getTransaction(
     _digest: TransactionDigest,
-  ): Promise<CertifiedTransaction> {
+  ): Promise<SuiTransactionResponse> {
     throw this.newError('getTransaction');
   }
 
@@ -186,7 +185,7 @@ export class VoidProvider extends Provider {
     _txnBytes: Uint8Array,
     _signature: SerializedSignature,
     _requestType: ExecuteTransactionRequestType,
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     throw this.newError('executeTransaction with request Type');
   }
 

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -14,7 +14,7 @@ import {
   generateTransactionDigest,
   getTotalGasUsedUpperBound,
   SuiAddress,
-  SuiExecuteTransactionResponse,
+  SuiTransactionResponse,
   DevInspectResults,
   bcsForVersion,
   DryRunTransactionResponse,
@@ -140,7 +140,7 @@ export abstract class SignerWithProvider implements Signer {
   async signAndExecuteTransaction(
     transaction: Uint8Array | SignableTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     const { transactionBytes, signature } = await this.signTransaction(
       transaction,
     );
@@ -230,7 +230,7 @@ export abstract class SignerWithProvider implements Signer {
   async transferObject(
     transaction: TransferObjectTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     return this.signAndExecuteTransaction(
       { kind: 'transferObject', data: transaction },
       requestType,
@@ -245,7 +245,7 @@ export abstract class SignerWithProvider implements Signer {
   async transferSui(
     transaction: TransferSuiTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     return this.signAndExecuteTransaction(
       { kind: 'transferSui', data: transaction },
       requestType,
@@ -259,7 +259,7 @@ export abstract class SignerWithProvider implements Signer {
   async pay(
     transaction: PayTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     return this.signAndExecuteTransaction(
       { kind: 'pay', data: transaction },
       requestType,
@@ -272,7 +272,7 @@ export abstract class SignerWithProvider implements Signer {
   async paySui(
     transaction: PaySuiTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     return this.signAndExecuteTransaction(
       { kind: 'paySui', data: transaction },
       requestType,
@@ -285,7 +285,7 @@ export abstract class SignerWithProvider implements Signer {
   async payAllSui(
     transaction: PayAllSuiTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     return this.signAndExecuteTransaction(
       { kind: 'payAllSui', data: transaction },
       requestType,
@@ -300,7 +300,7 @@ export abstract class SignerWithProvider implements Signer {
   async mergeCoin(
     transaction: MergeCoinTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     return this.signAndExecuteTransaction(
       { kind: 'mergeCoin', data: transaction },
       requestType,
@@ -315,7 +315,7 @@ export abstract class SignerWithProvider implements Signer {
   async splitCoin(
     transaction: SplitCoinTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     return this.signAndExecuteTransaction(
       { kind: 'splitCoin', data: transaction },
       requestType,
@@ -329,7 +329,7 @@ export abstract class SignerWithProvider implements Signer {
   async executeMoveCall(
     transaction: MoveCallTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     return this.signAndExecuteTransaction(
       { kind: 'moveCall', data: transaction },
       requestType,
@@ -344,7 +344,7 @@ export abstract class SignerWithProvider implements Signer {
   async publish(
     transaction: PublishTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiExecuteTransactionResponse> {
+  ): Promise<SuiTransactionResponse> {
     return this.signAndExecuteTransaction(
       { kind: 'publish', data: transaction },
       requestType,
@@ -361,7 +361,7 @@ export abstract class SignerWithProvider implements Signer {
     ...args: Parameters<SignerWithProvider['dryRunTransaction']>
   ) {
     const txEffects = await this.dryRunTransaction(...args);
-    const gasEstimation = getTotalGasUsedUpperBound(txEffects);
+    const gasEstimation = getTotalGasUsedUpperBound(txEffects.effects);
     if (typeof gasEstimation === 'undefined') {
       throw new Error('Failed to estimate the gas cost from transaction');
     }

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -144,14 +144,6 @@ export const AuthorityQuorumSignInfo = object({
 });
 export type AuthorityQuorumSignInfo = Infer<typeof AuthorityQuorumSignInfo>;
 
-export const CertifiedTransaction = object({
-  transactionDigest: TransactionDigest,
-  data: SuiTransactionData,
-  txSignatures: array(string()),
-  authSignInfo: AuthorityQuorumSignInfo,
-});
-export type CertifiedTransaction = Infer<typeof CertifiedTransaction>;
-
 export const GasCostSummary = object({
   computationCost: number(),
   storageCost: number(),
@@ -247,13 +239,6 @@ export const DevInspectResults = object({
   results: DevInspectResultsType,
 });
 export type DevInspectResults = Infer<typeof DevInspectResults>;
-
-// TODO: this is likely to go away after https://github.com/MystenLabs/sui/issues/4207
-export const SuiCertifiedTransactionEffects = object({
-  transactionEffectsDigest: string(),
-  authSignInfo: AuthorityQuorumSignInfo,
-  effects: TransactionEffects,
-});
 
 export const SuiEffectsFinalityInfo = union([
   object({ certified: AuthorityQuorumSignInfo }),
@@ -354,135 +339,51 @@ export const SuiTransaction = object({
 export type SuiTransaction = Infer<typeof SuiTransaction>;
 
 export const SuiTransactionResponse = object({
-  // TODO: Remove optional after devnet 0.28.0
-  transaction: optional(SuiTransaction),
-  // TODO: Remove after devnet 0.28.0
-  certificate: optional(CertifiedTransaction),
+  transaction: SuiTransaction,
   effects: TransactionEffects,
   events: TransactionEvents,
-  // TODO: Remove after devnet 0.28.0
-  timestamp_ms: optional(union([number(), literal(null)])),
-  // TODO: Remove optional after devnet 0.28.0
   timestampMs: optional(union([number(), literal(null)])),
-  // TODO: remove optional after 0.27.0 is released
-  checkpoint: optional(union([number(), literal(null)])),
-  // TODO: Remove optional after devnet 0.28.0
+  checkpoint: union([number(), literal(null)]),
   confirmedLocalExecution: optional(boolean()),
-  // TODO: Remove after devnet 0.28.0
-  parsed_data: optional(union([SuiParsedTransactionResponse, literal(null)])),
 });
 export type SuiTransactionResponse = Infer<typeof SuiTransactionResponse>;
-
-// TODO: Remove after devnet 0.28.0
-export const SuiExecuteTransactionResponse = union([
-  object({
-    EffectsCert: object({
-      certificate: CertifiedTransaction,
-      effects: SuiCertifiedTransactionEffects,
-      confirmed_local_execution: boolean(),
-    }),
-  }),
-  object({
-    certificate: optional(CertifiedTransaction),
-    effects: SuiFinalizedEffects,
-    confirmed_local_execution: boolean(),
-  }),
-  SuiTransactionResponse,
-]);
-export type SuiExecuteTransactionResponse = Infer<
-  typeof SuiExecuteTransactionResponse
->;
 
 /* -------------------------------------------------------------------------- */
 /*                              Helper functions                              */
 /* -------------------------------------------------------------------------- */
 
-/* ---------------------------------- CertifiedTransaction --------------------------------- */
-
-export function getCertifiedTransaction(
-  tx: SuiTransactionResponse | SuiExecuteTransactionResponse,
-): CertifiedTransaction | undefined {
-  if ('certificate' in tx) {
-    return tx.certificate;
-  } else if ('EffectsCert' in tx) {
-    return tx.EffectsCert.certificate;
-  }
-  return undefined;
-}
-
 export function getTransactionDigest(
-  tx:
-    | CertifiedTransaction
-    | SuiTransactionResponse
-    | SuiExecuteTransactionResponse,
+  tx: SuiTransactionResponse,
 ): TransactionDigest {
-  if ('transactionDigest' in tx) {
-    return tx.transactionDigest;
-  }
   const effects = getTransactionEffects(tx)!;
   return effects.transactionDigest;
 }
 
-export function getTransactionSignature(
-  tx: SuiTransactionResponse | CertifiedTransaction,
-): string[] {
-  const certificateOrTx =
-    'certificate' in tx
-      ? tx.certificate!
-      : 'transaction' in tx
-      ? tx.transaction!
-      : tx;
-
-  if ('txSignatures' in certificateOrTx) {
-    return certificateOrTx.txSignatures;
-  }
-
-  return [];
-}
-
-export function getTransactionData(
-  tx: CertifiedTransaction,
-): SuiTransactionData {
-  return tx.data;
+export function getTransactionSignature(tx: SuiTransactionResponse): string[] {
+  return tx.transaction.txSignatures;
 }
 
 /* ----------------------------- TransactionData ---------------------------- */
 
 export function getTransactionSender(tx: SuiTransactionResponse): SuiAddress {
-  return tx.certificate
-    ? tx.certificate.data.sender
-    : tx.transaction!.data.sender;
+  return tx.transaction.data.sender;
 }
 
-export function getGasData(
-  tx: CertifiedTransaction | SuiTransactionResponse,
-): SuiGasData {
-  if ('data' in tx) {
-    return tx.data.gasData;
-  }
-
-  if ('certificate' in tx) {
-    return tx.certificate!.data.gasData;
-  }
-
-  return tx.transaction!.data.gasData;
+export function getGasData(tx: SuiTransactionResponse): SuiGasData {
+  return tx.transaction.data.gasData;
 }
 
 export function getTransactionGasObject(
-  tx: SuiTransactionResponse | CertifiedTransaction,
+  tx: SuiTransactionResponse,
 ): SuiObjectRef {
   return getGasData(tx).payment;
 }
 
-export function getTransactionGasPrice(
-  tx: SuiTransactionResponse | CertifiedTransaction,
-) {
+export function getTransactionGasPrice(tx: SuiTransactionResponse) {
   return getGasData(tx).price;
 }
 
-export function getTransactionGasBudget(
-  tx: SuiTransactionResponse | CertifiedTransaction,
-): number {
+export function getTransactionGasBudget(tx: SuiTransactionResponse): number {
   return getGasData(tx).budget;
 }
 
@@ -543,9 +444,7 @@ export function getConsensusCommitPrologueTransaction(
 export function getTransactions(
   data: SuiTransactionResponse,
 ): SuiTransactionKind[] {
-  return data.certificate
-    ? data.certificate.data.transactions
-    : data.transaction!.data.transactions;
+  return data.transaction.data.transactions;
 }
 
 export function getTransferSuiAmount(data: SuiTransactionKind): bigint | null {
@@ -563,28 +462,25 @@ export function getTransactionKindName(
 /* ----------------------------- ExecutionStatus ---------------------------- */
 
 export function getExecutionStatusType(
-  data: SuiTransactionResponse | SuiExecuteTransactionResponse,
+  data: SuiTransactionResponse,
 ): ExecutionStatusType | undefined {
   return getExecutionStatus(data)?.status;
 }
 
 export function getExecutionStatus(
-  data: SuiTransactionResponse | SuiExecuteTransactionResponse,
+  data: SuiTransactionResponse,
 ): ExecutionStatus | undefined {
   return getTransactionEffects(data)?.status;
 }
 
 export function getExecutionStatusError(
-  data: SuiTransactionResponse | SuiExecuteTransactionResponse,
+  data: SuiTransactionResponse,
 ): string | undefined {
   return getExecutionStatus(data)?.error;
 }
 
 export function getExecutionStatusGasSummary(
-  data:
-    | SuiTransactionResponse
-    | SuiExecuteTransactionResponse
-    | TransactionEffects,
+  data: SuiTransactionResponse | TransactionEffects,
 ): GasCostSummary | undefined {
   if (is(data, TransactionEffects)) {
     return data.gasUsed;
@@ -593,10 +489,7 @@ export function getExecutionStatusGasSummary(
 }
 
 export function getTotalGasUsed(
-  data:
-    | SuiTransactionResponse
-    | SuiExecuteTransactionResponse
-    | TransactionEffects,
+  data: SuiTransactionResponse | TransactionEffects,
 ): number | undefined {
   const gasSummary = getExecutionStatusGasSummary(data);
   return gasSummary
@@ -607,10 +500,7 @@ export function getTotalGasUsed(
 }
 
 export function getTotalGasUsedUpperBound(
-  data:
-    | SuiTransactionResponse
-    | SuiExecuteTransactionResponse
-    | TransactionEffects,
+  data: SuiTransactionResponse | TransactionEffects,
 ): number | undefined {
   const gasSummary = getExecutionStatusGasSummary(data);
   return gasSummary
@@ -619,18 +509,15 @@ export function getTotalGasUsedUpperBound(
 }
 
 export function getTransactionEffects(
-  data: SuiExecuteTransactionResponse | SuiTransactionResponse,
+  data: SuiTransactionResponse,
 ): TransactionEffects | undefined {
-  if ('effects' in data) {
-    return `effects` in data.effects ? data.effects.effects : data.effects;
-  }
-  return 'EffectsCert' in data ? data.EffectsCert.effects.effects : undefined;
+  return data.effects;
 }
 
 /* ---------------------------- Transaction Effects --------------------------- */
 
 export function getEvents(
-  data: SuiExecuteTransactionResponse | SuiTransactionResponse,
+  data: SuiTransactionResponse,
 ): SuiEvent[] | undefined {
   if ('events' in data) {
     return data.events;
@@ -639,7 +526,7 @@ export function getEvents(
 }
 
 export function getCreatedObjects(
-  data: SuiExecuteTransactionResponse | SuiTransactionResponse,
+  data: SuiTransactionResponse,
 ): OwnedObjectRef[] | undefined {
   return getTransactionEffects(data)?.created;
 }
@@ -647,81 +534,16 @@ export function getCreatedObjects(
 /* --------------------------- TransactionResponse -------------------------- */
 
 export function getTimestampFromTransactionResponse(
-  data: SuiExecuteTransactionResponse | SuiTransactionResponse,
+  data: SuiTransactionResponse,
 ): number | undefined {
-  return 'timestamp_ms' in data || 'timestampMs' in data
-    ? (data.timestamp_ms || data.timestampMs) ?? undefined
-    : undefined;
-}
-
-export function getParsedSplitCoinResponse(
-  data: SuiTransactionResponse,
-): SuiParsedSplitCoinResponse | undefined {
-  const parsed = data.parsed_data;
-  return parsed && 'SplitCoin' in parsed ? parsed.SplitCoin : undefined;
-}
-
-export function getParsedMergeCoinResponse(
-  data: SuiTransactionResponse,
-): SuiParsedMergeCoinResponse | undefined {
-  const parsed = data.parsed_data;
-  return parsed && 'MergeCoin' in parsed ? parsed.MergeCoin : undefined;
-}
-
-export function getParsedPublishResponse(
-  data: SuiTransactionResponse,
-): SuiParsedPublishResponse | undefined {
-  const parsed = data.parsed_data;
-  return parsed && 'Publish' in parsed ? parsed.Publish : undefined;
-}
-
-/**
- * Get the updated coin after a merge.
- * @param data the response for executing a merge coin transaction
- * @returns the updated state of the primary coin after the merge
- */
-export function getCoinAfterMerge(
-  data: SuiTransactionResponse,
-): SuiObject | undefined {
-  return getParsedMergeCoinResponse(data)?.updatedCoin;
-}
-
-/**
- * Get the updated coin after a split.
- * @param data the response for executing a Split coin transaction
- * @returns the updated state of the original coin object used for the split
- */
-export function getCoinAfterSplit(
-  data: SuiTransactionResponse,
-): SuiObject | undefined {
-  return getParsedSplitCoinResponse(data)?.updatedCoin;
-}
-
-/**
- * Get the newly created coin after a split.
- * @param data the response for executing a Split coin transaction
- * @returns the updated state of the original coin object used for the split
- */
-export function getNewlyCreatedCoinsAfterSplit(
-  data: SuiTransactionResponse,
-): SuiObject[] | undefined {
-  return getParsedSplitCoinResponse(data)?.newCoins;
+  return data.timestampMs ?? undefined;
 }
 
 /**
  * Get the newly created coin refs after a split.
  */
 export function getNewlyCreatedCoinRefsAfterSplit(
-  data: SuiTransactionResponse | SuiExecuteTransactionResponse,
+  data: SuiTransactionResponse,
 ): SuiObjectRef[] | undefined {
-  if ('EffectsCert' in data) {
-    const effects = data.EffectsCert.effects.effects;
-    return effects.created?.map((c) => c.reference);
-  }
-  if ('effects' in data) {
-    const effects =
-      'effects' in data.effects ? data.effects.effects : data.effects;
-    return effects.created?.map((c) => c.reference);
-  }
-  return undefined;
+  return data.effects.created?.map((c) => c.reference);
 }

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -3,13 +3,13 @@
 
 import {
   Ed25519Keypair,
-  getCertifiedTransaction,
   getTransactionEffects,
   JsonRpcProvider,
   LocalTxnDataSerializer,
   RawSigner,
   Connection,
-  devnetConnection, getEvents,
+  devnetConnection,
+  getEvents,
 } from "@mysten/sui.js";
 import {
   WalletAdapter,
@@ -68,18 +68,10 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
 
   signAndExecuteTransaction: WalletAdapter["signAndExecuteTransaction"] =
     async (transactionInput) => {
-      const response = await this.#signer.signAndExecuteTransaction(
+      return await this.#signer.signAndExecuteTransaction(
         transactionInput.transaction,
         transactionInput.options?.requestType
       );
-
-      return {
-        certificate: getCertifiedTransaction(response)!,
-        effects: getTransactionEffects(response)!,
-        events: getEvents(response)!,
-        timestamp_ms: null,
-        parsed_data: null,
-      };
     };
 
   async connect() {


### PR DESCRIPTION
## Description 

Remove the old `SuiExecuteTransaction` and `CertifiedTransaction` interfaces in favor of the new unified `SuiTransactionResponse` interface. I removed all APIs that worked with the previous interfaces as well. 

## Test Plan 

Localnet e2e tests

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes