### PR TITLE
[core] Audit all reads to system state object

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -540,7 +540,7 @@ impl AuthorityState {
             return Err(SuiError::ValidatorHaltedAtEpochEnd);
         }
 
-        // Checks to see if the transaciton has expired
+        // Checks to see if the transactions has expired
         if match &transaction.inner().data().transaction_data().expiration {
             TransactionExpiration::None => false,
             TransactionExpiration::Epoch(epoch) => *epoch < epoch_store.epoch(),
@@ -1029,12 +1029,13 @@ impl AuthorityState {
         &self,
         sender: SuiAddress,
         transaction_kind: TransactionKind,
-        gas_price: u64,
+        gas_price: Option<u64>,
     ) -> Result<DevInspectResults, anyhow::Error> {
         let epoch_store = self.load_epoch_store_one_call_per_task();
         if !self.is_fullnode(&epoch_store) {
             return Err(anyhow!("dev-inspect is only supported on fullnodes"));
         }
+        let gas_price = gas_price.unwrap_or_else(|| epoch_store.reference_gas_price());
 
         let protocol_config = epoch_store.protocol_config();
 
@@ -1825,8 +1826,14 @@ impl AuthorityState {
             .compute_object_reference())
     }
 
-    // TODO: Audit every call to this function to make sure there are no data races during reconfig.
-    pub fn get_sui_system_state_object(&self) -> SuiResult<SuiSystemState> {
+    /// This function should be called once and exactly once during reconfiguration.
+    pub fn get_sui_system_state_object_during_reconfig(&self) -> SuiResult<SuiSystemState> {
+        self.database.get_sui_system_state_object()
+    }
+
+    // This function is only used for testing.
+    #[cfg(test)]
+    pub fn get_sui_system_state_object_for_testing(&self) -> SuiResult<SuiSystemState> {
         self.database.get_sui_system_state_object()
     }
 
@@ -2608,8 +2615,7 @@ impl AuthorityState {
             "Effects summary of the change epoch transaction: {:?}",
             signed_effects.summary_for_debug()
         );
-        epoch_store
-            .record_is_safe_mode_metric(self.get_sui_system_state_object().unwrap().safe_mode);
+        epoch_store.record_is_safe_mode_metric(system_obj.safe_mode);
         // The change epoch transaction cannot fail to execute.
         assert!(signed_effects.status.is_ok());
         Ok((system_obj, signed_effects.into_message()))

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -461,10 +461,12 @@ impl AuthorityPerEpochStore {
             .insert(checkpoint, accumulator)?)
     }
 
+    pub fn system_state_object(&self) -> &SuiSystemState {
+        &self.epoch_start_configuration.system_state
+    }
+
     pub fn reference_gas_price(&self) -> u64 {
-        self.epoch_start_configuration
-            .system_state
-            .reference_gas_price
+        self.system_state_object().reference_gas_price
     }
 
     pub async fn acquire_tx_guard(

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1158,6 +1158,7 @@ impl AuthorityStore {
             .map(|v| v.map(|v| v.into()))
     }
 
+    // TODO: Transaction Orchestrator also calls this, which is not ideal.
     pub fn get_sui_system_state_object(&self) -> SuiResult<SuiSystemState> {
         self.perpetual_tables.get_sui_system_state_object()
     }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -729,7 +729,9 @@ async fn test_dev_inspect_uses_unbound_object() {
         ))],
     }));
 
-    let result = fullnode.dev_inspect_transaction(sender, kind, 1).await;
+    let result = fullnode
+        .dev_inspect_transaction(sender, kind, Some(1))
+        .await;
     let Err(err) = result else { panic!() };
     assert!(err
         .to_string()
@@ -4234,7 +4236,9 @@ pub async fn call_dev_inspect(
         type_arguments,
         arguments,
     }));
-    authority.dev_inspect_transaction(*sender, kind, 1).await
+    authority
+        .dev_inspect_transaction(*sender, kind, Some(1))
+        .await
 }
 
 #[cfg(test)]

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -98,7 +98,7 @@ async fn test_narwhal_manager() {
             AuthorityState::new_for_testing(genesis_committee, &secret, None, genesis).await;
 
         let system_state = state
-            .get_sui_system_state_object()
+            .get_sui_system_state_object_for_testing()
             .expect("Reading Sui system state object cannot fail");
 
         let transactions_addr = &config.consensus_config.as_ref().unwrap().address;
@@ -174,7 +174,7 @@ async fn test_narwhal_manager() {
             .is_empty());
 
         let system_state = state
-            .get_sui_system_state_object()
+            .get_sui_system_state_object_for_testing()
             .expect("Reading Sui system state object cannot fail");
 
         let mut narwhal_committee = system_state.get_current_epoch_narwhal_committee();

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -274,13 +274,11 @@ impl CoinReadApiServer for CoinReadApi {
     }
 
     async fn get_total_supply(&self, coin_type: String) -> RpcResult<Supply> {
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
         let coin_struct = parse_sui_struct_tag(&coin_type)?;
 
         Ok(if GAS::is_gas(&coin_struct) {
-            self.state
-                .get_sui_system_state_object()
-                .map_err(Error::from)?
-                .treasury_cap
+            epoch_store.system_state_object().treasury_cap.clone()
         } else {
             let treasury_cap_object = self
                 .find_package_object(&coin_struct.address.into(), TreasuryCap::type_(coin_struct))

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -88,10 +88,8 @@ impl GovernanceReadApiServer for GovernanceReadApi {
     }
 
     async fn get_sui_system_state(&self) -> RpcResult<SuiSystemState> {
-        Ok(self
-            .state
-            .get_sui_system_state_object()
-            .map_err(Error::from)?)
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        Ok(epoch_store.system_state_object().clone())
     }
 
     async fn get_reference_gas_price(&self) -> RpcResult<u64> {

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -72,7 +72,8 @@ impl DataReader for AuthorityStateDataReader {
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, anyhow::Error> {
-        Ok(self.0.get_sui_system_state_object()?.reference_gas_price)
+        let epoch_store = self.0.load_epoch_store_one_call_per_task();
+        Ok(epoch_store.reference_gas_price())
     }
 }
 


### PR DESCRIPTION
Now that we cache the system state object in the epoch store, we should read from it as much as possible.
There are only 3 places now that reads the system state object from the database:
1. During reconfiguration. This is the only legit place in prod code.
2. In testing. We don't really care.
3. We also read it in the reconfg observer that's currently used by the transaction orchestrator. We need to look into this and see if there is a better way. But at least this is fullnode and there isn't really an inconsistency issue.