### PR TITLE
wallet-ext: confirmation modal size update

### DIFF
--- a/apps/wallet/src/ui/app/shared/ModalDialog.tsx
+++ b/apps/wallet/src/ui/app/shared/ModalDialog.tsx
@@ -60,7 +60,7 @@ export function ModalDialog({
                     leaveTo="opacity-0 scale-95"
                 >
                     <div className="fixed inset-0 flex flex-col items-center justify-center z-50">
-                        <Dialog.Panel className="shadow-wallet-modal bg-white py-6 rounded-xl max-w-[80vw] max-h-[60vh] overflow-hidden flex flex-col flex-nowrap items-stretch gap-1.5">
+                        <Dialog.Panel className="shadow-wallet-modal bg-white py-6 rounded-xl w-80 max-w-[85vw] max-h-[60vh] overflow-hidden flex flex-col flex-nowrap items-stretch gap-1.5">
                             {title ? (
                                 <div className="px-6 text-center">
                                     <Dialog.Title


### PR DESCRIPTION
* same modal width for logout confirmation between full screen and pop-up


<img width="1792" alt="Screenshot 2023-02-23 at 17 53 04" src="https://user-images.githubusercontent.com/10210143/220999280-0b2f68f2-4aae-401f-9d74-a81587ec8197.png">

addresses [this](https://github.com/MystenLabs/sui/pull/8489#issuecomment-1441919401) and [this](https://github.com/MystenLabs/sui/pull/8489#issuecomment-1441920667)

closes APPS-501