### PR TITLE
Introduce UserInputError

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -63,11 +63,11 @@ created: object(128)
 written: object(127)
 
 task 16 'run'. lines 163-166:
-Error: Error checking transaction input objects: [DuplicateObjectRefInput]
+Error: The transaction inputs contain duplicated ObjectRef's
 
 task 17 'run'. lines 168-168:
 created: object(131)
 written: object(130)
 
 task 18 'run'. lines 170-170:
-Error: Error checking transaction input objects: [DuplicateObjectRefInput]
+Error: The transaction inputs contain duplicated ObjectRef's

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
@@ -60,11 +60,11 @@ created: object(127)
 written: object(126)
 
 task 15 'run'. lines 160-163:
-Error: Error checking transaction input objects: [DuplicateObjectRefInput]
+Error: The transaction inputs contain duplicated ObjectRef's
 
 task 16 'run'. lines 165-165:
 created: object(130)
 written: object(129)
 
 task 17 'run'. lines 167-167:
-Error: Error checking transaction input objects: [DuplicateObjectRefInput]
+Error: The transaction inputs contain duplicated ObjectRef's

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{collections::HashMap, pin::Pin};
 use sui_config::node::AuthorityStorePruningConfig;
+use sui_types::error::UserInputError;
 use sui_types::message_envelope::Message;
 use sui_types::parse_sui_struct_tag;
 use tap::TapFallible;
@@ -465,7 +466,7 @@ impl AuthorityState {
         &self,
         transaction: VerifiedTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> Result<VerifiedSignedTransaction, SuiError> {
+    ) -> SuiResult<VerifiedSignedTransaction> {
         let (_gas_status, input_objects) = transaction_input_checker::check_transaction_input(
             &self.database,
             epoch_store.as_ref(),
@@ -724,9 +725,9 @@ impl AuthorityState {
             .expect("notify_read_effects should return exactly 1 element"))
     }
 
-    #[instrument(level = "trace", skip_all)]
     async fn check_owned_locks(&self, owned_object_refs: &[ObjectRef]) -> SuiResult {
-        self.database.check_locks_exist(owned_object_refs)
+        self.database
+            .check_owned_object_locks_exist(owned_object_refs)
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -1279,10 +1280,10 @@ impl AuthorityState {
             DynamicFieldType::DynamicObject => {
                 // Find the actual object from storage using the object id obtained from the wrapper.
                 let Some(object) = self.database.find_object_lt_or_eq_version(object_id, o.version()) else{
-                    return Err(SuiError::ObjectNotFound {
+                    return Err(UserInputError::ObjectNotFound {
                         object_id,
                         version: Some(o.version()),
-                    })
+                    }.into())
                 };
                 let version = object.version();
                 let digest = object.digest();
@@ -1392,9 +1393,11 @@ impl AuthorityState {
                 let (_, seq, _) = self
                     .get_latest_parent_entry(request.object_id)
                     .await?
-                    .ok_or(SuiError::ObjectNotFound {
-                        object_id: request.object_id,
-                        version: None,
+                    .ok_or_else(|| {
+                        SuiError::from(UserInputError::ObjectNotFound {
+                            object_id: request.object_id,
+                            version: None,
+                        })
                     })?
                     .0;
                 seq
@@ -1405,9 +1408,11 @@ impl AuthorityState {
         let object = self
             .database
             .get_object_by_key(&request.object_id, requested_object_seq)?
-            .ok_or(SuiError::ObjectNotFound {
-                object_id: request.object_id,
-                version: Some(requested_object_seq),
+            .ok_or_else(|| {
+                SuiError::from(UserInputError::ObjectNotFound {
+                    object_id: request.object_id,
+                    version: Some(requested_object_seq),
+                })
             })?;
 
         let layout = match request.object_format_options {
@@ -1852,10 +1857,11 @@ impl AuthorityState {
                     match self.database.get_object_by_key(object_id, obj_ref.1)? {
                         None => {
                             error!("Object with in parent_entry is missing from object store, datastore is inconsistent");
-                            Err(SuiError::ObjectNotFound {
+                            Err(UserInputError::ObjectNotFound {
                                 object_id: *object_id,
                                 version: Some(obj_ref.1),
-                            })
+                            }
+                            .into())
                         }
                         Some(object) => {
                             let layout = object.get_layout(
@@ -1930,10 +1936,11 @@ impl AuthorityState {
                     match self.database.get_object_by_key(object_id, obj_ref.1)? {
                         None => {
                             error!("Object with in parent_entry is missing from object store, datastore is inconsistent");
-                            Err(SuiError::ObjectNotFound {
+                            Err(UserInputError::ObjectNotFound {
                                 object_id: *object_id,
                                 version: Some(obj_ref.1),
-                            })
+                            }
+                            .into())
                         }
                         Some(object) => {
                             let layout = object.get_layout(
@@ -1957,9 +1964,11 @@ impl AuthorityState {
     ) -> Result<Owner, SuiError> {
         self.database
             .get_object_by_key(object_id, version)?
-            .ok_or(SuiError::ObjectNotFound {
-                object_id: *object_id,
-                version: Some(version),
+            .ok_or_else(|| {
+                SuiError::from(UserInputError::ObjectNotFound {
+                    object_id: *object_id,
+                    version: Some(version),
+                })
             })
             .map(|o| o.owner)
     }
@@ -2479,8 +2488,8 @@ impl AuthorityState {
 
     /// Get the TransactionEnvelope that currently locks the given object, if any.
     /// Since object locks are only valid for one epoch, we also need the epoch_id in the query.
-    /// Returns SuiError::ObjectNotFound if no lock records for the given object can be found.
-    /// Returns SuiError::ObjectVersionUnavailableForConsumption if the object record is at a different version.
+    /// Returns UserInputError::ObjectNotFound if no lock records for the given object can be found.
+    /// Returns UserInputError::ObjectVersionUnavailableForConsumption if the object record is at a different version.
     /// Returns Some(VerifiedEnvelope) if the given ObjectRef is locked by a certain transaction.
     /// Returns None if the a lock record is initialized for the given ObjectRef but not yet locked by any transaction,
     ///     or cannot find the transaction in transaction table, because of data race etc.
@@ -2489,13 +2498,17 @@ impl AuthorityState {
         object_ref: &ObjectRef,
         epoch_store: &AuthorityPerEpochStore,
     ) -> Result<Option<VerifiedSignedTransaction>, SuiError> {
-        let lock_info = self.database.get_lock(*object_ref, epoch_store.epoch())?;
+        let lock_info = self
+            .database
+            .get_lock(*object_ref, epoch_store.epoch())
+            .map_err(SuiError::from)?;
         let lock_info = match lock_info {
             ObjectLockStatus::LockedAtDifferentVersion { locked_ref } => {
-                return Err(SuiError::ObjectVersionUnavailableForConsumption {
+                return Err(UserInputError::ObjectVersionUnavailableForConsumption {
                     provided_obj_ref: *object_ref,
                     current_version: locked_ref.1,
-                })
+                }
+                .into());
             }
             ObjectLockStatus::Initialized => {
                 return Ok(None);

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -18,6 +18,7 @@ use sui_network::{
     default_mysten_network_config, DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_REQUEST_TIMEOUT_SEC,
 };
 use sui_types::crypto::{AuthorityPublicKeyBytes, AuthoritySignInfo};
+use sui_types::error::UserInputError;
 use sui_types::message_envelope::Message;
 use sui_types::object::Object;
 use sui_types::sui_system_state::SuiSystemState;
@@ -820,10 +821,10 @@ where
                 // A long timeout before we hear back from a quorum
                 self.timeouts.pre_quorum_timeout,
             )
-            .await.map_err(|_state| SuiError::ObjectNotFound {
+            .await.map_err(|_state| UserInputError::ObjectNotFound {
                 object_id,
                 version: None,
-            })
+            }.into())
     }
 
     /// Get the latest system state object from the authorities.
@@ -839,7 +840,7 @@ where
             object
                 .data
                 .try_as_move()
-                .ok_or(SuiError::MovePackageAsObject {
+                .ok_or(UserInputError::MovePackageAsObject {
                     object_id: object.id(),
                 })?
                 .contents(),

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -317,7 +317,8 @@ impl ValidatorService {
                 .intent_message
                 .value
                 .kind
-                .input_objects()?
+                .input_objects()
+                .map_err(SuiError::from)?
                 .into_iter()
                 .map(|r| r.object_id())
                 .collect(),

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -5,11 +5,12 @@ use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::AuthorityStore;
 use std::collections::HashSet;
 use sui_types::base_types::ObjectRef;
+use sui_types::error::{SuiError, UserInputError, UserInputResult};
 use sui_types::gas::SuiCostTable;
 use sui_types::messages::{TransactionKind, VerifiedExecutableTransaction};
 use sui_types::{
     base_types::{SequenceNumber, SuiAddress},
-    error::{SuiError, SuiResult},
+    error::SuiResult,
     fp_ensure,
     gas::{self, SuiGasStatus},
     messages::{InputObjectKind, InputObjects, SingleTransactionKind, TransactionData},
@@ -42,20 +43,15 @@ async fn get_gas_status(
         extra_gas_object_refs,
     )
     .await
-    .map_err(SuiError::into_transaction_input_error)
 }
 
-// Note: Transaction Input related errors returned from this function
-// should be aggregated into Sui::TransactionInputObjectsErrors
 #[instrument(level = "trace", skip_all)]
 pub async fn check_transaction_input(
     store: &AuthorityStore,
     epoch_store: &AuthorityPerEpochStore,
     transaction: &TransactionData,
 ) -> SuiResult<(SuiGasStatus<'static>, InputObjects)> {
-    transaction
-        .validity_check()
-        .map_err(SuiError::into_transaction_input_error)?;
+    transaction.validity_check()?;
     let gas_status = get_gas_status(store, epoch_store, transaction).await?;
     let input_objects = transaction.input_objects()?;
     let objects = store.check_input_objects(&input_objects)?;
@@ -96,12 +92,8 @@ pub(crate) async fn check_dev_inspect_input(
         if !object.is_immutable() {
             fp_ensure!(
                 used_objects.insert(object.id().into()),
-                SuiError::InvalidBatchTransaction {
-                    error: format!(
-                        "Mutable object {} cannot appear in more than one single \
-                        transactions in a batch",
-                        object.id()
-                    ),
+                UserInputError::MutableObjectUsedMoreThanOnce {
+                    object_id: object.id()
                 }
                 .into()
             );
@@ -150,9 +142,11 @@ async fn check_gas(
         Ok(SuiGasStatus::new_unmetered())
     } else {
         let gas_object = store.get_object_by_key(&gas_payment.0, gas_payment.1)?;
-        let gas_object = gas_object.ok_or(SuiError::ObjectNotFound {
-            object_id: gas_payment.0,
-            version: Some(gas_payment.1),
+        let gas_object = gas_object.ok_or_else(|| {
+            SuiError::from(UserInputError::ObjectNotFound {
+                object_id: gas_payment.0,
+                version: Some(gas_payment.1),
+            })
         })?;
 
         // If the transaction is TransferSui, we ensure that the gas balance is enough to cover
@@ -166,10 +160,11 @@ async fn check_gas(
         };
         let reference_gas_price = epoch_store.reference_gas_price();
         if computation_gas_price < reference_gas_price {
-            return Err(SuiError::GasPriceUnderRGP {
+            return Err(UserInputError::GasPriceUnderRGP {
                 gas_price: computation_gas_price,
                 reference_gas_price,
-            });
+            }
+            .into());
         }
         let protocol_config = epoch_store.protocol_config();
         let cost_table = SuiCostTable::new(protocol_config);
@@ -182,7 +177,7 @@ async fn check_gas(
             let mut additional_objs = vec![];
             for obj_ref in additional_objects_for_gas_payment.iter() {
                 let obj = store.get_object_by_key(&obj_ref.0, obj_ref.1)?;
-                let obj = obj.ok_or(SuiError::ObjectNotFound {
+                let obj = obj.ok_or(UserInputError::ObjectNotFound {
                     object_id: obj_ref.0,
                     version: Some(obj_ref.1),
                 })?;
@@ -213,18 +208,18 @@ async fn check_gas(
             storage_gas_price,
             cost_table,
         )
+        .map_err(|e| e.into())
     }
 }
 
 /// Check all the objects used in the transaction against the database, and ensure
 /// that they are all the correct version and number.
-// Transaction input errors should be aggregated in TransactionInputObjectsErrors
 #[instrument(level = "trace", skip_all)]
 async fn check_objects(
     transaction: &TransactionData,
     input_objects: Vec<InputObjectKind>,
     objects: Vec<Object>,
-) -> Result<InputObjects, SuiError> {
+) -> UserInputResult<InputObjects> {
     // We require that mutable objects cannot show up more than once.
     // In [`SingleTransactionKind::input_objects`] we checked that there is no
     // duplicate objects in the same SingleTransactionKind. However for a Batch
@@ -238,10 +233,8 @@ async fn check_objects(
         if !object.is_immutable() {
             fp_ensure!(
                 used_objects.insert(object.id().into()),
-                SuiError::TransactionInputObjectsErrors { errors: vec![
-                    SuiError::InvalidBatchTransaction {
-                        error: format!("Mutable object {} cannot appear in more than one single transactions in a batch", object.id()),
-                    }]
+                UserInputError::MutableObjectUsedMoreThanOnce {
+                    object_id: object.id()
                 }
             );
         }
@@ -249,7 +242,6 @@ async fn check_objects(
 
     // Gather all objects and errors.
     let mut all_objects = Vec::with_capacity(input_objects.len());
-    let mut errors = Vec::new();
     let transfer_object_ids: HashSet<_> = transaction
         .kind
         .single_transactions()
@@ -264,7 +256,11 @@ async fn check_objects(
 
     for (object_kind, object) in input_objects.into_iter().zip(objects) {
         if transfer_object_ids.contains(&object.id()) {
-            object.ensure_public_transfer_eligible()?;
+            object.ensure_public_transfer_eligible().map_err(|_e| {
+                UserInputError::TransferObjectWithoutPublicTransferError {
+                    object_id: object.id(),
+                }
+            })?;
         }
         // For Gas Object, we check the object is owned by gas owner
         let owner_address = if object.id() == transaction.gas_payment_object_ref().0 {
@@ -274,39 +270,27 @@ async fn check_objects(
         };
         // Check if the object contents match the type of lock we need for
         // this object.
-        match check_one_object(&owner_address, object_kind, &object) {
-            Ok(()) => all_objects.push((object_kind, object)),
-            Err(e) => {
-                errors.push(e);
-            }
-        }
-    }
-    // If any errors with the locks were detected, we return all errors to give the client
-    // a chance to update the authority if possible.
-    if !errors.is_empty() {
-        return Err(SuiError::TransactionInputObjectsErrors { errors });
+        check_one_object(&owner_address, object_kind, &object)?;
+        all_objects.push((object_kind, object));
     }
     if !transaction.kind.is_genesis_tx() && all_objects.is_empty() {
-        return Err(SuiError::TransactionInputObjectsErrors {
-            errors: vec![SuiError::ObjectInputArityViolation],
-        });
+        return Err(UserInputError::ObjectInputArityViolation);
     }
 
     Ok(InputObjects::new(all_objects))
 }
 
-/// The logic to check one object against a reference, and return the object if all is well
-/// or an error if not.
+/// Check one object against a reference
 fn check_one_object(
     owner: &SuiAddress,
     object_kind: InputObjectKind,
     object: &Object,
-) -> SuiResult {
+) -> UserInputResult {
     match object_kind {
         InputObjectKind::MovePackage(package_id) => {
             fp_ensure!(
                 object.data.try_as_package().is_some(),
-                SuiError::MoveObjectAsPackage {
+                UserInputError::MoveObjectAsPackage {
                     object_id: package_id
                 }
             );
@@ -314,11 +298,11 @@ fn check_one_object(
         InputObjectKind::ImmOrOwnedMoveObject((object_id, sequence_number, object_digest)) => {
             fp_ensure!(
                 !object.is_package(),
-                SuiError::MovePackageAsObject { object_id }
+                UserInputError::MovePackageAsObject { object_id }
             );
             fp_ensure!(
                 sequence_number < SequenceNumber::MAX,
-                SuiError::InvalidSequenceNumber
+                UserInputError::InvalidSequenceNumber
             );
 
             // This is an invariant - we just load the object with the given ID and version.
@@ -331,11 +315,11 @@ fn check_one_object(
                 object.id(),
             );
 
-            // Check the digest matches - uesr could give a mismatched ObjectDigest
+            // Check the digest matches - user could give a mismatched ObjectDigest
             let expected_digest = object.digest();
             fp_ensure!(
                 expected_digest == object_digest,
-                SuiError::InvalidObjectDigest {
+                UserInputError::InvalidObjectDigest {
                     object_id,
                     expected_digest
                 }
@@ -349,13 +333,13 @@ fn check_one_object(
                     // Check the owner is correct.
                     fp_ensure!(
                         owner == &actual_owner,
-                        SuiError::IncorrectSigner {
+                        UserInputError::IncorrectUserSignature {
                             error: format!("Object {:?} is owned by account address {:?}, but given owner/signer address is {:?}", object_id, actual_owner, owner),
                         }
                     );
                 }
                 Owner::ObjectOwner(owner) => {
-                    return Err(SuiError::InvalidChildObjectArgument {
+                    return Err(UserInputError::InvalidChildObjectArgument {
                         child_id: object.id(),
                         parent_id: owner.into(),
                     });
@@ -363,7 +347,7 @@ fn check_one_object(
                 Owner::Shared { .. } => {
                     // This object is a mutable shared object. However the transaction
                     // specifies it as an owned object. This is inconsistent.
-                    return Err(SuiError::NotSharedObjectError);
+                    return Err(UserInputError::NotSharedObjectError);
                 }
             };
         }
@@ -374,7 +358,9 @@ fn check_one_object(
         } => {
             // Only system transactions (which don't perform input checks) can accept the Clock
             // object as a mutable parameter.
-            return Err(SuiError::ImmutableParameterExpectedError);
+            return Err(UserInputError::ImmutableParameterExpectedError {
+                object_id: SUI_CLOCK_OBJECT_ID,
+            });
         }
         InputObjectKind::SharedMoveObject {
             initial_shared_version: input_initial_shared_version,
@@ -382,20 +368,20 @@ fn check_one_object(
         } => {
             fp_ensure!(
                 object.version() < SequenceNumber::MAX,
-                SuiError::InvalidSequenceNumber
+                UserInputError::InvalidSequenceNumber
             );
 
             match object.owner {
                 Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
                     // When someone locks an object as shared it must be shared already.
-                    return Err(SuiError::NotSharedObjectError);
+                    return Err(UserInputError::NotSharedObjectError);
                 }
                 Owner::Shared {
                     initial_shared_version: actual_initial_shared_version,
                 } => {
                     fp_ensure!(
                         input_initial_shared_version == actual_initial_shared_version,
-                        SuiError::SharedObjectStartingVersionMismatch
+                        UserInputError::SharedObjectStartingVersionMismatch
                     )
                 }
             }

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -161,11 +161,8 @@ async fn test_batch_contains_publish() -> anyhow::Result<()> {
     let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
-        *response
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        SuiError::InvalidBatchTransaction { .. }
+        UserInputError::try_from(response.unwrap_err()).unwrap(),
+        UserInputError::InvalidBatchTransaction { .. }
     ));
     Ok(())
 }
@@ -194,11 +191,8 @@ async fn test_batch_contains_transfer_sui() -> anyhow::Result<()> {
     let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
-        *response
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        SuiError::InvalidBatchTransaction { .. }
+        UserInputError::try_from(response.unwrap_err()).unwrap(),
+        UserInputError::InvalidBatchTransaction { .. }
     ));
     Ok(())
 }
@@ -244,11 +238,8 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
     let response = send_and_confirm_transaction(&authority_state, tx).await;
 
     assert!(matches!(
-        *response
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        SuiError::GasBalanceTooLowToCoverGasBudget { .. }
+        UserInputError::try_from(response.unwrap_err()).unwrap(),
+        UserInputError::GasBalanceTooLowToCoverGasBudget { .. }
     ));
 
     Ok(())

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -31,12 +31,8 @@ async fn test_tx_less_than_minimum_gas_budget() {
     let result = execute_transfer(*MAX_GAS_BUDGET, budget, false).await;
 
     assert_eq!(
-        result
-            .response
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasBudgetTooLow {
+        UserInputError::try_from(result.response.unwrap_err()).unwrap(),
+        UserInputError::GasBudgetTooLow {
             gas_budget: budget,
             min_budget: *MIN_GAS_BUDGET
         }
@@ -52,12 +48,8 @@ async fn test_tx_more_than_maximum_gas_budget() {
     let result = execute_transfer(*MAX_GAS_BUDGET, budget, false).await;
 
     assert_eq!(
-        result
-            .response
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasBudgetTooHigh {
+        UserInputError::try_from(result.response.unwrap_err()).unwrap(),
+        UserInputError::GasBudgetTooHigh {
             gas_budget: budget,
             max_budget: *MAX_GAS_BUDGET
         }
@@ -74,12 +66,8 @@ async fn test_tx_gas_balance_less_than_budget() {
     let gas_price = 1;
     let result = execute_transfer_with_price(gas_balance, budget, gas_price, false).await;
     assert_eq!(
-        result
-            .response
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::try_from(result.response.unwrap_err()).unwrap(),
+        UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: gas_balance as u128,
             gas_budget: (gas_price * budget) as u128,
             gas_price
@@ -171,12 +159,8 @@ async fn test_native_transfer_gas_price_is_used() {
     let gas_price = u64::MAX;
     let result = execute_transfer_with_price(gas_balance, gas_budget, gas_price, true).await;
     assert_eq!(
-        result
-            .response
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::try_from(result.response.unwrap_err()).unwrap(),
+        UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: (gas_balance as u128),
             gas_budget: (gas_budget as u128) * (gas_price as u128),
             gas_price
@@ -583,12 +567,8 @@ async fn test_tx_gas_price_less_than_reference_gas_price() {
     let gas_price = 0;
     let result = execute_transfer_with_price(gas_balance, budget, gas_price, false).await;
     assert_eq!(
-        result
-            .response
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasPriceUnderRGP {
+        UserInputError::try_from(result.response.unwrap_err()).unwrap(),
+        UserInputError::GasPriceUnderRGP {
             gas_price: 0,
             reference_gas_price: 1
         }

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -424,8 +424,7 @@ async fn test_object_owning_another_object() {
     )
     .await;
     assert!(effects.is_err());
-    assert!(format!("{effects:?}")
-        .contains("TransactionInputObjectsErrors { errors: [InvalidChildObjectArgument"));
+    assert!(format!("{effects:?}").contains("InvalidChildObjectArgument"));
 
     // Create another parent.
     let effects = call_move(
@@ -985,8 +984,7 @@ async fn test_entry_point_vector() {
     )
     .await;
     assert!(effects.is_err());
-    assert!(format!("{effects:?}")
-        .contains("TransactionInputObjectsErrors { errors: [InvalidChildObjectArgument"));
+    assert!(format!("{effects:?}").contains("InvalidChildObjectArgument"));
 }
 
 #[tokio::test]
@@ -1188,11 +1186,8 @@ async fn test_entry_point_vector_error() {
     .await;
     // should fail as we have the same object passed in vector and as a separate by-value argument
     assert!(matches!(
-        result
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::DuplicateObjectRefInput { .. }
+        UserInputError::try_from(result.unwrap_err()).unwrap(),
+        UserInputError::DuplicateObjectRefInput { .. }
     ));
 
     // mint an owned object
@@ -1234,11 +1229,8 @@ async fn test_entry_point_vector_error() {
     .await;
     // should fail as we have the same object passed in vector and as a separate by-reference argument
     assert!(matches!(
-        result
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::DuplicateObjectRefInput { .. }
+        UserInputError::try_from(result.unwrap_err()).unwrap(),
+        UserInputError::DuplicateObjectRefInput { .. }
     ));
 }
 
@@ -1362,8 +1354,7 @@ async fn test_entry_point_vector_any() {
     )
     .await;
     assert!(effects.is_err());
-    assert!(format!("{effects:?}")
-        .contains("TransactionInputObjectsErrors { errors: [InvalidChildObjectArgument"));
+    assert!(format!("{effects:?}").contains("InvalidChildObjectArgument"));
 }
 
 #[tokio::test]
@@ -1568,11 +1559,8 @@ async fn test_entry_point_vector_any_error() {
     .await;
     // should fail as we have the same object passed in vector and as a separate by-value argument
     assert!(matches!(
-        result
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::DuplicateObjectRefInput { .. }
+        UserInputError::try_from(result.unwrap_err()).unwrap(),
+        UserInputError::DuplicateObjectRefInput { .. }
     ));
 
     // mint an owned object
@@ -1613,11 +1601,8 @@ async fn test_entry_point_vector_any_error() {
     )
     .await;
     assert!(matches!(
-        result
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::DuplicateObjectRefInput { .. }
+        UserInputError::try_from(result.unwrap_err()).unwrap(),
+        UserInputError::DuplicateObjectRefInput { .. }
     ));
 }
 
@@ -1995,7 +1980,10 @@ async fn check_latest_object_ref(
         })
         .await;
     if expect_not_found {
-        assert!(matches!(response, Err(SuiError::ObjectNotFound { .. })));
+        assert!(matches!(
+            UserInputError::try_from(response.unwrap_err()).unwrap(),
+            UserInputError::ObjectNotFound { .. },
+        ));
     } else {
         assert_eq!(
             &response.unwrap().object.compute_object_reference(),

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::crypto::AccountKeyPair;
+use sui_types::error::UserInputError;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
     ExecutionFailureStatus, ExecutionStatus, PayAllSui, PaySui, SignedTransactionEffects,
@@ -77,11 +78,8 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
     .await;
 
     assert_eq!(
-        res.txn_result
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
+        UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 1200,
             gas_price: 1
@@ -107,11 +105,8 @@ async fn test_pay_sui_failure_insufficient_total_balance_one_input_coin() {
     .await;
 
     assert_eq!(
-        res.txn_result
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
+        UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 100 + 100 + 900,
             gas_price: 1
@@ -138,11 +133,8 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
     .await;
 
     assert_eq!(
-        res.txn_result
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
+        UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 400,
             gas_budget: 801,
             gas_price: 1
@@ -168,11 +160,8 @@ async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() 
     )
     .await;
     assert_eq!(
-        res.txn_result
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
+        UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 400 + 600,
             gas_budget: 400 + 400 + 201,
             gas_price: 1
@@ -335,11 +324,8 @@ async fn test_pay_all_sui_failure_insufficient_gas_one_input_coin() {
     let res = execute_pay_all_sui(vec![&coin1], recipient, sender, sender_key, 2000).await;
 
     assert_eq!(
-        res.txn_result
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
+        UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 2000,
             gas_price: 1
@@ -356,11 +342,8 @@ async fn test_pay_all_sui_failure_insufficient_gas_budget_multiple_input_coins()
     let res = execute_pay_all_sui(vec![&coin1, &coin2], recipient, sender, sender_key, 2500).await;
 
     assert_eq!(
-        res.txn_result
-            .unwrap_err()
-            .collapse_if_single_transaction_input_error()
-            .unwrap(),
-        &SuiError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
+        UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 2500,
             gas_price: 1

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -38,7 +38,7 @@ use sui_types::coin::CoinMetadata;
 use sui_types::committee::EpochId;
 use sui_types::crypto::SuiAuthorityStrongQuorumSignInfo;
 use sui_types::dynamic_field::DynamicFieldInfo;
-use sui_types::error::{ExecutionError, SuiError};
+use sui_types::error::{ExecutionError, SuiError, UserInputError, UserInputResult};
 use sui_types::event::{BalanceChangeType, Event, EventID};
 use sui_types::event::{EventEnvelope, EventType};
 use sui_types::filter::EventFilter;
@@ -1025,12 +1025,12 @@ pub enum SuiObjectRead<T: SuiData> {
 impl<T: SuiData> SuiObjectRead<T> {
     /// Returns a reference to the object if there is any, otherwise an Err if
     /// the object does not exist or is deleted.
-    pub fn object(&self) -> Result<&SuiObject<T>, SuiError> {
+    pub fn object(&self) -> UserInputResult<&SuiObject<T>> {
         match &self {
-            Self::Deleted(oref) => Err(SuiError::ObjectDeleted {
+            Self::Deleted(oref) => Err(UserInputError::ObjectDeleted {
                 object_ref: oref.to_object_ref(),
             }),
-            Self::NotExists(id) => Err(SuiError::ObjectNotFound {
+            Self::NotExists(id) => Err(UserInputError::ObjectNotFound {
                 object_id: *id,
                 version: None,
             }),
@@ -1040,12 +1040,12 @@ impl<T: SuiData> SuiObjectRead<T> {
 
     /// Returns the object value if there is any, otherwise an Err if
     /// the object does not exist or is deleted.
-    pub fn into_object(self) -> Result<SuiObject<T>, SuiError> {
+    pub fn into_object(self) -> UserInputResult<SuiObject<T>> {
         match self {
-            Self::Deleted(oref) => Err(SuiError::ObjectDeleted {
+            Self::Deleted(oref) => Err(UserInputError::ObjectDeleted {
                 object_ref: oref.to_object_ref(),
             }),
-            Self::NotExists(id) => Err(SuiError::ObjectNotFound {
+            Self::NotExists(id) => Err(UserInputError::ObjectNotFound {
                 object_id: id,
                 version: None,
             }),
@@ -1091,17 +1091,17 @@ pub enum SuiPastObjectRead<T: SuiData> {
 
 impl<T: SuiData> SuiPastObjectRead<T> {
     /// Returns a reference to the object if there is any, otherwise an Err
-    pub fn object(&self) -> Result<&SuiObject<T>, SuiError> {
+    pub fn object(&self) -> UserInputResult<&SuiObject<T>> {
         match &self {
-            Self::ObjectDeleted(oref) => Err(SuiError::ObjectDeleted {
+            Self::ObjectDeleted(oref) => Err(UserInputError::ObjectDeleted {
                 object_ref: oref.to_object_ref(),
             }),
-            Self::ObjectNotExists(id) => Err(SuiError::ObjectNotFound {
+            Self::ObjectNotExists(id) => Err(UserInputError::ObjectNotFound {
                 object_id: *id,
                 version: None,
             }),
             Self::VersionFound(o) => Ok(o),
-            Self::VersionNotFound(id, seq_num) => Err(SuiError::ObjectNotFound {
+            Self::VersionNotFound(id, seq_num) => Err(UserInputError::ObjectNotFound {
                 object_id: *id,
                 version: Some(*seq_num),
             }),
@@ -1109,7 +1109,7 @@ impl<T: SuiData> SuiPastObjectRead<T> {
                 object_id,
                 asked_version,
                 latest_version,
-            } => Err(SuiError::ObjectSequenceNumberTooHigh {
+            } => Err(UserInputError::ObjectSequenceNumberTooHigh {
                 object_id: *object_id,
                 asked_version: *asked_version,
                 latest_version: *latest_version,
@@ -1118,17 +1118,17 @@ impl<T: SuiData> SuiPastObjectRead<T> {
     }
 
     /// Returns the object value if there is any, otherwise an Err
-    pub fn into_object(self) -> Result<SuiObject<T>, SuiError> {
+    pub fn into_object(self) -> UserInputResult<SuiObject<T>> {
         match self {
-            Self::ObjectDeleted(oref) => Err(SuiError::ObjectDeleted {
+            Self::ObjectDeleted(oref) => Err(UserInputError::ObjectDeleted {
                 object_ref: oref.to_object_ref(),
             }),
-            Self::ObjectNotExists(id) => Err(SuiError::ObjectNotFound {
+            Self::ObjectNotExists(id) => Err(UserInputError::ObjectNotFound {
                 object_id: id,
                 version: None,
             }),
             Self::VersionFound(o) => Ok(o),
-            Self::VersionNotFound(object_id, version) => Err(SuiError::ObjectNotFound {
+            Self::VersionNotFound(object_id, version) => Err(UserInputError::ObjectNotFound {
                 object_id,
                 version: Some(version),
             }),
@@ -1136,7 +1136,7 @@ impl<T: SuiData> SuiPastObjectRead<T> {
                 object_id,
                 asked_version,
                 latest_version,
-            } => Err(SuiError::ObjectSequenceNumberTooHigh {
+            } => Err(UserInputError::ObjectSequenceNumberTooHigh {
                 object_id,
                 asked_version,
                 latest_version,

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -38,7 +38,12 @@ impl CoinReadApi {
     }
 
     async fn get_object(&self, object_id: &ObjectID) -> Result<Object, Error> {
-        Ok(self.state.get_object_read(object_id).await?.into_object()?)
+        Ok(self
+            .state
+            .get_object_read(object_id)
+            .await?
+            .into_object()
+            .map_err(SuiError::from)?)
     }
 
     async fn get_coin(&self, coin_id: &ObjectID) -> Result<SuiCoin, Error> {

--- a/crates/sui-json-rpc/src/threshold_bls_api.rs
+++ b/crates/sui-json-rpc/src/threshold_bls_api.rs
@@ -21,7 +21,7 @@ use sui_json_rpc_types::{
 use sui_open_rpc::Module;
 use sui_types::base_types::ObjectID;
 use sui_types::crypto::construct_tbls_randomness_object_message;
-use sui_types::error::SuiError;
+use sui_types::error::{SuiError, UserInputError};
 use sui_types::object::{Object, ObjectRead};
 
 pub struct ThresholdBlsApi {
@@ -44,7 +44,7 @@ impl ThresholdBlsApi {
     async fn get_randomness_object(&self, object_id: ObjectID) -> Result<Object, Error> {
         let obj_read = self.state.get_object_read(&object_id).await?;
         let ObjectRead::Exists(_obj_ref, obj, layout) = obj_read else {
-            Err(Error::SuiError(SuiError::ObjectNotFound{ object_id, version: None }))? };
+            Err(Error::SuiError(UserInputError::ObjectNotFound{ object_id, version: None }.into()))? };
         let Some(layout) = layout else {
             Err(Error::InternalError(anyhow!("Object does not have a layout")))?};
         if !Self::is_randomness_object(&layout) {

--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -6,6 +6,7 @@ use futures::future;
 use move_binary_format::access::ModuleAccess;
 use move_binary_format::CompiledModule;
 use std::{collections::HashMap, fmt::Debug};
+use sui_types::error::UserInputError;
 use thiserror::Error;
 
 use move_compiler::compiled_unit::{CompiledUnitEnum, NamedCompiledModule};
@@ -16,7 +17,7 @@ use sui_sdk::apis::ReadApi;
 use sui_sdk::error::Error;
 
 use sui_sdk::rpc_types::{SuiRawData, SuiRawMoveObject, SuiRawMovePackage};
-use sui_types::{base_types::ObjectID, error::SuiError};
+use sui_types::base_types::ObjectID;
 
 #[cfg(test)]
 mod tests;
@@ -27,7 +28,7 @@ pub enum SourceVerificationError {
     DependencyObjectReadFailure(Error),
 
     #[error("Dependency object does not exist or was deleted: {0:?}")]
-    SuiObjectRefFailure(SuiError),
+    SuiObjectRefFailure(UserInputError),
 
     #[error("Dependency ID contains a Sui object, not a Move package: {0}")]
     ObjectFoundWhenPackageExpected(ObjectID, SuiRawMoveObject),

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -22,7 +22,7 @@ use sui_json_rpc_types::{RPCTransactionRequestParams, SuiData, SuiTypeTag};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::{ObjectID, ObjectRef, ObjectType, SuiAddress};
 use sui_types::coin::{Coin, LockedCoin};
-use sui_types::error::SuiError;
+use sui_types::error::UserInputError;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
     CallArg, InputObjectKind, MoveCall, ObjectArg, SingleTransactionKind, TransactionData,
@@ -194,7 +194,10 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         amounts: Vec<u64>,
         gas_budget: u64,
     ) -> anyhow::Result<TransactionData> {
-        fp_ensure!(!input_coins.is_empty(), SuiError::EmptyInputCoins.into());
+        fp_ensure!(
+            !input_coins.is_empty(),
+            UserInputError::EmptyInputCoins.into()
+        );
 
         let handles: Vec<_> = input_coins
             .into_iter()
@@ -225,7 +228,10 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         recipient: SuiAddress,
         gas_budget: u64,
     ) -> anyhow::Result<TransactionData> {
-        fp_ensure!(!input_coins.is_empty(), SuiError::EmptyInputCoins.into());
+        fp_ensure!(
+            !input_coins.is_empty(),
+            UserInputError::EmptyInputCoins.into()
+        );
 
         let handles: Vec<_> = input_coins
             .into_iter()
@@ -539,7 +545,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
     ) -> anyhow::Result<TransactionData> {
         fp_ensure!(
             !single_transaction_params.is_empty(),
-            SuiError::InvalidBatchTransaction {
+            UserInputError::InvalidBatchTransaction {
                 error: "Batch Transaction cannot be empty".to_owned(),
             }
             .into()

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -18,7 +18,7 @@ use serde_with::Bytes;
 
 use crate::base_types::ObjectIDParseError;
 use crate::crypto::{deterministic_random_account_key, sha3_hash};
-use crate::error::{ExecutionError, ExecutionErrorKind};
+use crate::error::{ExecutionError, ExecutionErrorKind, UserInputError, UserInputResult};
 use crate::error::{SuiError, SuiResult};
 use crate::move_package::MovePackage;
 use crate::{
@@ -761,10 +761,10 @@ pub enum ObjectRead {
 impl ObjectRead {
     /// Returns the object value if there is any, otherwise an Err if
     /// the object does not exist or is deleted.
-    pub fn into_object(self) -> Result<Object, SuiError> {
+    pub fn into_object(self) -> UserInputResult<Object> {
         match self {
-            Self::Deleted(oref) => Err(SuiError::ObjectDeleted { object_ref: oref }),
-            Self::NotExists(id) => Err(SuiError::ObjectNotFound {
+            Self::Deleted(oref) => Err(UserInputError::ObjectDeleted { object_ref: oref }),
+            Self::NotExists(id) => Err(UserInputError::ObjectNotFound {
                 object_id: id,
                 version: None,
             }),
@@ -819,15 +819,15 @@ pub enum PastObjectRead {
 
 impl PastObjectRead {
     /// Returns the object value if there is any, otherwise an Err
-    pub fn into_object(self) -> Result<Object, SuiError> {
+    pub fn into_object(self) -> UserInputResult<Object> {
         match self {
-            Self::ObjectDeleted(oref) => Err(SuiError::ObjectDeleted { object_ref: oref }),
-            Self::ObjectNotExists(id) => Err(SuiError::ObjectNotFound {
+            Self::ObjectDeleted(oref) => Err(UserInputError::ObjectDeleted { object_ref: oref }),
+            Self::ObjectNotExists(id) => Err(UserInputError::ObjectNotFound {
                 object_id: id,
                 version: None,
             }),
             Self::VersionFound(_, o, _) => Ok(o),
-            Self::VersionNotFound(object_id, version) => Err(SuiError::ObjectNotFound {
+            Self::VersionNotFound(object_id, version) => Err(UserInputError::ObjectNotFound {
                 object_id,
                 version: Some(version),
             }),
@@ -835,7 +835,7 @@ impl PastObjectRead {
                 object_id,
                 asked_version,
                 latest_version,
-            } => Err(SuiError::ObjectSequenceNumberTooHigh {
+            } => Err(UserInputError::ObjectSequenceNumberTooHigh {
                 object_id,
                 asked_version,
                 latest_version,

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -811,7 +811,7 @@ fn test_sponsored_transaction_validity_check() {
         )
         .validity_check()
         .unwrap_err(),
-        SuiError::UnsupportedSponsoredTransactionKind
+        UserInputError::UnsupportedSponsoredTransactionKind
     );
 
     // PaySui cannot be sponsored
@@ -827,7 +827,7 @@ fn test_sponsored_transaction_validity_check() {
         )
         .validity_check()
         .unwrap_err(),
-        SuiError::UnsupportedSponsoredTransactionKind
+        UserInputError::UnsupportedSponsoredTransactionKind
     );
 
     // PayAllSui cannot be sponsored
@@ -842,7 +842,7 @@ fn test_sponsored_transaction_validity_check() {
         )
         .validity_check()
         .unwrap_err(),
-        SuiError::UnsupportedSponsoredTransactionKind
+        UserInputError::UnsupportedSponsoredTransactionKind
     );
 
     // Batch is non-sponsorable
@@ -858,7 +858,7 @@ fn test_sponsored_transaction_validity_check() {
         )
         .validity_check()
         .unwrap_err(),
-        SuiError::UnsupportedSponsoredTransactionKind
+        UserInputError::UnsupportedSponsoredTransactionKind
     );
 }
 


### PR DESCRIPTION
## Description 

This PR is part of the `SuiError` cleanup work. 
1. Here we introduce `UserInputError` as a new enum under `SuiError` to represent errors from user inputs such as transactions or reads. `UserInputError` itself is an enum and we move a bunch of user input errors from `SuiError` as its variants.
2. Largely, `UserInputError` replaces `TransactionInputObjectsErrors` which contains a list of object errors. This de-vector makes error handling more convenient.

For reviewers, the meat is in non-test files.

## Test Plan 

unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Introduce `UserInputError` as a new enum under `SuiError` to represent errors from user inputs such as transactions or reads. `UserInputError` itself is an enum and we move a bunch of user input errors from `SuiError` as its variants. Largely, `UserInputError` replaces `TransactionInputObjectsErrors` which contains a list of object errors. This de-vector makes error handling more convenient.