### PR TITLE
Add vercel config to ignore gh-pages

### DIFF
--- a/apps/explorer/vercel.json
+++ b/apps/explorer/vercel.json
@@ -1,6 +1,11 @@
 {
     "$schema": "https://openapi.vercel.sh/vercel.json",
     "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+    "git": {
+        "deploymentEnabled": {
+            "gh-pages": false
+        }
+    },
     "headers": [
         {
             "source": "/assets/(.*)",

--- a/dapps/frenemies/vercel.json
+++ b/dapps/frenemies/vercel.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "git": {
+    "deploymentEnabled": {
+      "gh-pages": false
+    }
+  },
   "headers": [
     {
       "source": "/assets/(.*)",

--- a/sdk/wallet-adapter/example/vercel.json
+++ b/sdk/wallet-adapter/example/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "gh-pages": false
+    }
+  }
+}


### PR DESCRIPTION
This removes the deployments from `gh-pages` so that we have less build failures in the dash.