### PR TITLE
[wallet][APPS-443] refactor the main page header and do some style tweaking

### DIFF
--- a/apps/wallet/src/ui/app/components/menu/button/MenuButton.module.scss
+++ b/apps/wallet/src/ui/app/components/menu/button/MenuButton.module.scss
@@ -5,6 +5,7 @@ $btn-height: 14px;
 $line-height: 2px;
 
 .button {
+    display: block;
     background: none;
     outline: none;
     border: none;

--- a/apps/wallet/src/ui/app/pages/home/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/index.tsx
@@ -71,7 +71,6 @@ const HomePage = ({ disableNavigation, limitToPopUpSize = true }: Props) => {
                     bottomNavEnabled={!disableNavigation}
                     dappStatusEnabled={!disableNavigation}
                     topNavMenuEnabled={!disableNavigation}
-                    centerLogo={true}
                 >
                     <Outlet />
                 </PageMainLayout>

--- a/apps/wallet/src/ui/app/shared/header/Header.stories.tsx
+++ b/apps/wallet/src/ui/app/shared/header/Header.stories.tsx
@@ -11,29 +11,29 @@ export default {
 
 export const Default: StoryObj<typeof Header> = {};
 
-export const WithMiddleContent: StoryObj<typeof Header> = {
+export const Full: StoryObj<typeof Header> = {
     args: {
         middleContent: (
             <div className="text-ellipsis whitespace-nowrap overflow-hidden">
                 Connected to some dapp
             </div>
         ),
-    },
-};
-
-export const WithRightContent: StoryObj<typeof Header> = {
-    args: {
         rightContent: <div>Menu</div>,
     },
 };
 
-export const WithAll: StoryObj<typeof Header> = {
+export const WithMiddleContentOnly: StoryObj<typeof Header> = {
     args: {
         middleContent: (
             <div className="text-ellipsis whitespace-nowrap overflow-hidden">
                 Connected to some dapp
             </div>
         ),
+    },
+};
+
+export const WithRightContentOnly: StoryObj<typeof Header> = {
+    args: {
         rightContent: <div>Menu</div>,
     },
 };

--- a/apps/wallet/src/ui/app/shared/header/Header.stories.tsx
+++ b/apps/wallet/src/ui/app/shared/header/Header.stories.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type Meta, type StoryObj } from '@storybook/react';
+
+import { Header } from './Header';
+
+export default {
+    component: Header,
+} as Meta<typeof Header>;
+
+export const Default: StoryObj<typeof Header> = {};
+
+export const WithMiddleContent: StoryObj<typeof Header> = {
+    args: {
+        middleContent: (
+            <div className="text-ellipsis whitespace-nowrap overflow-hidden">
+                Connected to some dapp
+            </div>
+        ),
+    },
+};
+
+export const WithRightContent: StoryObj<typeof Header> = {
+    args: {
+        rightContent: <div>Menu</div>,
+    },
+};
+
+export const WithAll: StoryObj<typeof Header> = {
+    args: {
+        middleContent: (
+            <div className="text-ellipsis whitespace-nowrap overflow-hidden">
+                Connected to some dapp
+            </div>
+        ),
+        rightContent: <div>Menu</div>,
+    },
+};

--- a/apps/wallet/src/ui/app/shared/header/Header.tsx
+++ b/apps/wallet/src/ui/app/shared/header/Header.tsx
@@ -24,9 +24,11 @@ export function Header({
 }: HeaderProps) {
     return (
         <header className="grid grid-cols-header items-center gap-3 px-3 py-1">
-            <Link to="/tokens" className="no-underline text-gray-90">
-                <Logo networkName={networkName} />
-            </Link>
+            <div>
+                <Link to="/tokens" className="no-underline text-gray-90">
+                    <Logo networkName={networkName} />
+                </Link>
+            </div>
             {middleContent && (
                 <div className="col-start-2 overflow-hidden">
                     {middleContent}

--- a/apps/wallet/src/ui/app/shared/header/Header.tsx
+++ b/apps/wallet/src/ui/app/shared/header/Header.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+import Logo from '../../components/logo';
+import { type API_ENV } from '_src/shared/api-env';
+
+type HeaderProps = {
+    networkName: API_ENV;
+    middleContent?: ReactNode;
+    rightContent?: ReactNode;
+};
+
+/**
+ * General page header that can render arbitrary content where the content
+ * located in the middle of the header is centered and has a capped width
+ */
+export function Header({
+    networkName,
+    middleContent,
+    rightContent,
+}: HeaderProps) {
+    return (
+        <header className="grid grid-cols-header items-center gap-3 px-3 py-1">
+            <Link to="/tokens" className="no-underline text-gray-90">
+                <Logo networkName={networkName} />
+            </Link>
+            {middleContent && (
+                <div className="col-start-2 overflow-hidden">
+                    {middleContent}
+                </div>
+            )}
+            {rightContent && (
+                <div className="col-start-3 justify-self-end">
+                    {rightContent}
+                </div>
+            )}
+        </header>
+    );
+}

--- a/apps/wallet/src/ui/app/shared/header/Header.tsx
+++ b/apps/wallet/src/ui/app/shared/header/Header.tsx
@@ -25,7 +25,7 @@ export function Header({
     return (
         <header className="grid grid-cols-header items-center gap-3 px-3 py-1">
             <div>
-                <Link to="/tokens" className="no-underline text-gray-90">
+                <Link to="/" className="no-underline text-gray-90">
                     <Logo networkName={networkName} />
                 </Link>
             </div>

--- a/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayout.module.scss
+++ b/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayout.module.scss
@@ -9,24 +9,7 @@
     flex-grow: 1;
     width: 100%;
     max-height: 100%;
-    background-color: colors.$gray-40;
-}
-
-.header {
-    display: flex;
-    flex-flow: row nowrap;
-    align-items: center;
-    padding: 0 12px;
-    min-height: 52px;
-    gap: 20px;
-
-    &.center {
-        justify-content: center;
-    }
-}
-
-.menu-button {
-    justify-self: flex-end;
+    background-color: v.use(v.$colors-background-color);
 }
 
 .content {
@@ -53,25 +36,4 @@
 .with-nav {
     padding: 25px sizing.$main-sides-space;
     @include utils.main-extra-space-for-nav;
-}
-
-.dapp-status-container {
-    display: flex;
-    align-items: center;
-    overflow: hidden;
-}
-
-.logo-container,
-.menu-container {
-    display: flex;
-    flex: 1 0;
-    align-items: center;
-}
-
-.logo-container {
-    justify-content: flex-start;
-}
-
-.menu-container {
-    justify-content: flex-end;
 }

--- a/apps/wallet/src/ui/app/shared/page-main-layout/index.tsx
+++ b/apps/wallet/src/ui/app/shared/page-main-layout/index.tsx
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
-import { type ReactNode, useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { type ReactNode } from 'react';
 
 import { useAppSelector } from '../../hooks';
+import DappStatus from '../dapp-status';
+import { Header } from '../header/Header';
 import { Toaster } from '../toaster';
-import DappStatus from '_app/shared/dapp-status';
 import { ErrorBoundary } from '_components/error-boundary';
-import Logo from '_components/logo';
 import { MenuButton, MenuContent } from '_components/menu';
 import Navigation from '_components/navigation';
 
@@ -20,7 +19,6 @@ export type PageMainLayoutProps = {
     bottomNavEnabled?: boolean;
     topNavMenuEnabled?: boolean;
     dappStatusEnabled?: boolean;
-    centerLogo?: boolean;
     className?: string;
 };
 
@@ -29,55 +27,17 @@ export default function PageMainLayout({
     bottomNavEnabled = false,
     topNavMenuEnabled = false,
     dappStatusEnabled = false,
-    centerLogo = false,
     className,
 }: PageMainLayoutProps) {
     const networkName = useAppSelector(({ app: { apiEnv } }) => apiEnv);
-    const [logoWidth, setLogoWidth] = useState<number>();
-    const logoRef = useRef<HTMLAnchorElement>(null);
-    useEffect(() => {
-        const observer = new ResizeObserver(([entry]) => {
-            setLogoWidth(entry?.borderBoxSize[0]?.inlineSize);
-        });
-        if (logoRef.current) {
-            observer.observe(logoRef.current);
-        }
-        return () => observer.disconnect();
-    }, []);
+
     return (
         <div className={st.container}>
-            <div
-                className={cl(st.header, {
-                    [st.center]:
-                        centerLogo && !topNavMenuEnabled && !dappStatusEnabled,
-                })}
-            >
-                <div
-                    className={st.logoContainer}
-                    style={{ flexBasis: logoWidth }}
-                >
-                    <Link
-                        ref={logoRef}
-                        to="/tokens"
-                        className="no-underline text-gray-90"
-                    >
-                        <Logo networkName={networkName} />
-                    </Link>
-                </div>
-                {dappStatusEnabled ? (
-                    <div className={st.dappStatusContainer}>
-                        <DappStatus />
-                    </div>
-                ) : null}
-                {topNavMenuEnabled ? (
-                    <div
-                        className={st.menuContainer}
-                        style={{ flexBasis: logoWidth }}
-                    >
-                        <MenuButton className={st.menuButton} />
-                    </div>
-                ) : null}
-            </div>
+            <Header
+                networkName={networkName}
+                middleContent={dappStatusEnabled ? <DappStatus /> : undefined}
+                rightContent={topNavMenuEnabled ? <MenuButton /> : undefined}
+            />
             <div className={st.content}>
                 <main
                     className={cl(

--- a/apps/wallet/src/ui/styles/themes/light.scss
+++ b/apps/wallet/src/ui/styles/themes/light.scss
@@ -3,8 +3,8 @@
 @use '_values/colors' as c-val;
 
 $values: (
-    c-var.$background: #f1f8fd,
-    c-var.$background-color: #f1f8fd,
+    c-var.$background: c-val.$sui-alice-blue,
+    c-var.$background-color: c-val.$sui-alice-blue,
     c-var.$text-on-background: c-val.$gray-95,
     c-var.$main-content-background: c-val.$white,
     c-var.$text-on-main-content-background: c-val.$gray-100,

--- a/apps/wallet/src/ui/styles/themes/light.scss
+++ b/apps/wallet/src/ui/styles/themes/light.scss
@@ -3,16 +3,12 @@
 @use '_values/colors' as c-val;
 
 $values: (
-    c-var.$background: c-val.$gray-40,
-    c-var.$background-color: c-val.$gray-40,
+    c-var.$background: #f1f8fd,
+    c-var.$background-color: #f1f8fd,
     c-var.$text-on-background: c-val.$gray-95,
     c-var.$main-content-background: c-val.$white,
     c-var.$text-on-main-content-background: c-val.$gray-100,
-    shadows.$main-content: (
-        0 0 29px rgb(0 0 0 / 10%),
-        0 0 44px rgb(0 0 0 / 5%),
-        0 0 6px rgb(0 0 0 / 2%),
-    ),
+    shadows.$main-content: 0 -5px 20px 5px rgb(111 188 240 / 11%),
     c-var.$nav-background-color: #f0f9ffb0,
     c-var.$nav-background-filter: blur(40px),
     c-var.$nav-item-color: c-val.$gray-60,

--- a/apps/wallet/src/ui/styles/values/colors.scss
+++ b/apps/wallet/src/ui/styles/values/colors.scss
@@ -13,6 +13,7 @@ $gray-90: #3d444d;
 $gray-95: #2a3645;
 $gray-100: #182435;
 $sui-blue: #6fbcf0;
+$sui-alice-blue: #f1f8fd;
 $sui-dark-blue: #1f6493;
 $sui-steel-blue: #a0b6c3;
 $sui-steel-darker: #566873;

--- a/apps/wallet/tailwind.config.js
+++ b/apps/wallet/tailwind.config.js
@@ -41,6 +41,9 @@ module.exports = {
                 15: '0.9375rem',
                 '2lg': '0.625rem',
             },
+            gridTemplateColumns: {
+                header: '1fr fit-content(160px) 1fr',
+            },
             height: {
                 header: '4.25rem',
                 'nav-height': '76px',


### PR DESCRIPTION
## Description 

This change re-factors the header component for the main page layout into a more generic `Header` component that uses Tailwind, has Storybook entries, and no longer relies on manual calculations for centering the dApp status button. Instead of using the width of the logo container to get the dApp status button evenly centered, we can do some grid magic 😄. For the visual changes here, we're just changing the background color and updating the box shadow around the main page content that borders the header.

There's some other work for this ticket like showing the dApp status button even when not connected that I'll do in a follow-up PR!

Before:
<img width="364" alt="image" src="https://user-images.githubusercontent.com/7453188/221020593-2657e706-0d8a-49cc-a553-91611167a790.png">
<img width="369" alt="image" src="https://user-images.githubusercontent.com/7453188/221020681-45b67f96-e548-4c75-9ef9-4e2accbe6b5f.png">

After:
<img width="363" alt="image" src="https://user-images.githubusercontent.com/7453188/221020735-bc7329f1-b82e-4e7e-8a17-6a80c547a0fb.png">
<img width="362" alt="image" src="https://user-images.githubusercontent.com/7453188/221021048-332f94a5-f012-4b05-a308-eac8edaaed42.png">

## Test Plan 
- Manual testing (welcome page, not connected to dApp, connected to dApp with a really long name, etc.)
- Storybook