### PR TITLE
Fix or remove tests in #[tokio::test] context

### DIFF
--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -3,17 +3,10 @@
 
 use mysten_metrics::RegistryService;
 use prometheus::Registry;
-use std::sync::Arc;
-use sui_macros::*;
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion, SupportedProtocolVersions};
-use test_utils::{
-    authority::start_node,
-    network::{TestCluster, TestClusterBuilder},
-};
-use tokio::time::{timeout, Duration};
-use tracing::info;
+use test_utils::authority::start_node;
 
-#[sim_test]
+#[tokio::test]
 #[should_panic]
 async fn test_validator_panics_on_unsupported_protocol_version() {
     let dir = tempfile::TempDir::new().unwrap();
@@ -58,92 +51,103 @@ fn test_protocol_overrides_2() {
     );
 }
 
-#[sim_test]
-async fn test_protocol_version_upgrade() {
-    telemetry_subscribers::init_for_testing();
-    sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+#[cfg(msim)]
+mod sim_only_tests {
 
-    let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(10000)
-        .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(1, 2))
-        .build()
-        .await
-        .unwrap();
+    use std::sync::Arc;
+    use sui_macros::*;
+    use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
+    use test_utils::network::{TestCluster, TestClusterBuilder};
+    use tokio::time::{timeout, Duration};
+    use tracing::info;
 
-    monitor_version_change(&test_cluster, 2 /* expected proto version */).await;
-}
+    #[sim_test]
+    async fn test_protocol_version_upgrade() {
+        telemetry_subscribers::init_for_testing();
+        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
 
-// TODO: should_panic should be removed - however we need to add the ability to model intentional
-// shutdown to the simulator first. Currently in this test the network proceeds to version 2 just
-// fine, but the validator that doesn't support it panics.
-#[sim_test]
-#[should_panic]
-async fn test_protocol_version_upgrade_one_laggard() {
-    telemetry_subscribers::init_for_testing();
-    sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+        let test_cluster = TestClusterBuilder::new()
+            .with_epoch_duration_ms(10000)
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(1, 2))
+            .build()
+            .await
+            .unwrap();
 
-    let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(10000)
-        .with_supported_protocol_version_callback(Arc::new(|idx, name| {
-            if name.is_some() && idx == 0 {
-                // first validator only does not support version 2.
-                SupportedProtocolVersions::new_for_testing(1, 1)
-            } else {
-                SupportedProtocolVersions::new_for_testing(1, 2)
+        monitor_version_change(&test_cluster, 2 /* expected proto version */).await;
+    }
+
+    // TODO: should_panic should be removed - however we need to add the ability to model intentional
+    // shutdown to the simulator first. Currently in this test the network proceeds to version 2 just
+    // fine, but the validator that doesn't support it panics.
+    #[sim_test]
+    #[should_panic]
+    async fn test_protocol_version_upgrade_one_laggard() {
+        telemetry_subscribers::init_for_testing();
+        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+
+        let test_cluster = TestClusterBuilder::new()
+            .with_epoch_duration_ms(10000)
+            .with_supported_protocol_version_callback(Arc::new(|idx, name| {
+                if name.is_some() && idx == 0 {
+                    // first validator only does not support version 2.
+                    SupportedProtocolVersions::new_for_testing(1, 1)
+                } else {
+                    SupportedProtocolVersions::new_for_testing(1, 2)
+                }
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        monitor_version_change(&test_cluster, 2 /* expected proto version */).await;
+    }
+
+    #[sim_test]
+    async fn test_protocol_version_upgrade_no_quorum() {
+        telemetry_subscribers::init_for_testing();
+        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+
+        let test_cluster = TestClusterBuilder::new()
+            .with_epoch_duration_ms(10000)
+            .with_supported_protocol_version_callback(Arc::new(|idx, name| {
+                if name.is_some() && idx <= 1 {
+                    // two validators don't support version 2, so we never advance to 2.
+                    SupportedProtocolVersions::new_for_testing(1, 1)
+                } else {
+                    SupportedProtocolVersions::new_for_testing(1, 2)
+                }
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        monitor_version_change(&test_cluster, 1 /* expected proto version */).await;
+    }
+
+    async fn monitor_version_change(test_cluster: &TestCluster, final_version: u64) {
+        let mut epoch_rx = test_cluster
+            .fullnode_handle
+            .sui_node
+            .subscribe_to_epoch_change();
+
+        timeout(Duration::from_secs(60), async move {
+            while let Ok(committee) = epoch_rx.recv().await {
+                info!(
+                    "received epoch {} {:?}",
+                    committee.epoch, committee.protocol_version
+                );
+                match committee.epoch {
+                    0 => assert_eq!(committee.protocol_version, ProtocolVersion::new(1)),
+                    1 => assert_eq!(
+                        committee.protocol_version,
+                        ProtocolVersion::new(final_version)
+                    ),
+                    2 => break,
+                    _ => unreachable!(),
+                }
             }
-        }))
-        .build()
+        })
         .await
-        .unwrap();
-
-    monitor_version_change(&test_cluster, 2 /* expected proto version */).await;
-}
-
-#[sim_test]
-async fn test_protocol_version_upgrade_no_quorum() {
-    telemetry_subscribers::init_for_testing();
-    sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-
-    let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(10000)
-        .with_supported_protocol_version_callback(Arc::new(|idx, name| {
-            if name.is_some() && idx <= 1 {
-                // two validators don't support version 2, so we never advance to 2.
-                SupportedProtocolVersions::new_for_testing(1, 1)
-            } else {
-                SupportedProtocolVersions::new_for_testing(1, 2)
-            }
-        }))
-        .build()
-        .await
-        .unwrap();
-
-    monitor_version_change(&test_cluster, 1 /* expected proto version */).await;
-}
-
-async fn monitor_version_change(test_cluster: &TestCluster, final_version: u64) {
-    let mut epoch_rx = test_cluster
-        .fullnode_handle
-        .sui_node
-        .subscribe_to_epoch_change();
-
-    timeout(Duration::from_secs(60), async move {
-        while let Ok(committee) = epoch_rx.recv().await {
-            info!(
-                "received epoch {} {:?}",
-                committee.epoch, committee.protocol_version
-            );
-            match committee.epoch {
-                0 => assert_eq!(committee.protocol_version, ProtocolVersion::new(1)),
-                1 => assert_eq!(
-                    committee.protocol_version,
-                    ProtocolVersion::new(final_version)
-                ),
-                2 => break,
-                _ => unreachable!(),
-            }
-        }
-    })
-    .await
-    .expect("Timed out waiting for cluster to target epoch");
+        .expect("Timed out waiting for cluster to target epoch");
+    }
 }


### PR DESCRIPTION
Moved one test to `#[tokio::test]` to avoid problem with `should_panic` in tokio test mode.

Restrict several tests to `#[cfg(msim)]` because they cannot meaningfully run via `#[tokio::test]`.