### PR TITLE
move framework: camel case error code constants

### DIFF
--- a/crates/sui-framework/docs/safe.md
+++ b/crates/sui-framework/docs/safe.md
@@ -163,20 +163,38 @@ Allows the owner of the capability to take <code>amount</code> of coins from the
 ## Constants
 
 
-<a name="0x2_safe_INVALID_OWNER_CAPABILITY"></a>
+<a name="0x2_safe_EInvalidOwnerCapability"></a>
 
 
 
-<pre><code><b>const</b> <a href="safe.md#0x2_safe_INVALID_OWNER_CAPABILITY">INVALID_OWNER_CAPABILITY</a>: u64 = 1;
+<pre><code><b>const</b> <a href="safe.md#0x2_safe_EInvalidOwnerCapability">EInvalidOwnerCapability</a>: u64 = 1;
 </code></pre>
 
 
 
-<a name="0x2_safe_INVALID_TRANSFER_CAPABILITY"></a>
+<a name="0x2_safe_EInvalidTransferCapability"></a>
 
 
 
-<pre><code><b>const</b> <a href="safe.md#0x2_safe_INVALID_TRANSFER_CAPABILITY">INVALID_TRANSFER_CAPABILITY</a>: u64 = 0;
+<pre><code><b>const</b> <a href="safe.md#0x2_safe_EInvalidTransferCapability">EInvalidTransferCapability</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_safe_EOverdrawn"></a>
+
+
+
+<pre><code><b>const</b> <a href="safe.md#0x2_safe_EOverdrawn">EOverdrawn</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_safe_ETransferCapabilityRevoked"></a>
+
+
+
+<pre><code><b>const</b> <a href="safe.md#0x2_safe_ETransferCapabilityRevoked">ETransferCapabilityRevoked</a>: u64 = 2;
 </code></pre>
 
 
@@ -186,24 +204,6 @@ Allows the owner of the capability to take <code>amount</code> of coins from the
 
 
 <pre><code><b>const</b> <a href="safe.md#0x2_safe_MAX_CAPABILITY_ISSUABLE">MAX_CAPABILITY_ISSUABLE</a>: u64 = 1000;
-</code></pre>
-
-
-
-<a name="0x2_safe_OVERDRAWN"></a>
-
-
-
-<pre><code><b>const</b> <a href="safe.md#0x2_safe_OVERDRAWN">OVERDRAWN</a>: u64 = 3;
-</code></pre>
-
-
-
-<a name="0x2_safe_TRANSFER_CAPABILITY_REVOKED"></a>
-
-
-
-<pre><code><b>const</b> <a href="safe.md#0x2_safe_TRANSFER_CAPABILITY_REVOKED">TRANSFER_CAPABILITY_REVOKED</a>: u64 = 2;
 </code></pre>
 
 
@@ -227,9 +227,9 @@ Check that the capability has not yet been revoked by the owner.
 
 <pre><code><b>fun</b> <a href="safe.md#0x2_safe_check_capability_validity">check_capability_validity</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_TransferCapability">TransferCapability</a>&lt;T&gt;) {
     // Check that the ids match
-    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(<a href="safe.md#0x2_safe">safe</a>) == capability.safe_id, <a href="safe.md#0x2_safe_INVALID_TRANSFER_CAPABILITY">INVALID_TRANSFER_CAPABILITY</a>);
+    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(<a href="safe.md#0x2_safe">safe</a>) == capability.safe_id, <a href="safe.md#0x2_safe_EInvalidTransferCapability">EInvalidTransferCapability</a>);
     // Check that it <b>has</b> not been cancelled
-    <b>assert</b>!(<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(&<a href="safe.md#0x2_safe">safe</a>.allowed_safes, &<a href="object.md#0x2_object_id">object::id</a>(capability)), <a href="safe.md#0x2_safe_TRANSFER_CAPABILITY_REVOKED">TRANSFER_CAPABILITY_REVOKED</a>);
+    <b>assert</b>!(<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(&<a href="safe.md#0x2_safe">safe</a>.allowed_safes, &<a href="object.md#0x2_object_id">object::id</a>(capability)), <a href="safe.md#0x2_safe_ETransferCapabilityRevoked">ETransferCapabilityRevoked</a>);
 }
 </code></pre>
 
@@ -253,7 +253,7 @@ Check that the capability has not yet been revoked by the owner.
 
 
 <pre><code><b>fun</b> <a href="safe.md#0x2_safe_check_owner_capability_validity">check_owner_capability_validity</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a>&lt;T&gt;) {
-    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(<a href="safe.md#0x2_safe">safe</a>) == capability.safe_id, <a href="safe.md#0x2_safe_INVALID_OWNER_CAPABILITY">INVALID_OWNER_CAPABILITY</a>);
+    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(<a href="safe.md#0x2_safe">safe</a>) == capability.safe_id, <a href="safe.md#0x2_safe_EInvalidOwnerCapability">EInvalidOwnerCapability</a>);
 }
 </code></pre>
 
@@ -534,7 +534,7 @@ Withdraw coins from the safe as a <code><a href="safe.md#0x2_safe_TransferCapabi
     <a href="safe.md#0x2_safe_check_capability_validity">check_capability_validity</a>(<a href="safe.md#0x2_safe">safe</a>, capability);
 
     // Withdraw funds
-    <b>assert</b>!(capability.amount &gt;= withdraw_amount, <a href="safe.md#0x2_safe_OVERDRAWN">OVERDRAWN</a>);
+    <b>assert</b>!(capability.amount &gt;= withdraw_amount, <a href="safe.md#0x2_safe_EOverdrawn">EOverdrawn</a>);
     capability.amount = capability.amount - withdraw_amount;
     <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> <a href="safe.md#0x2_safe">safe</a>.<a href="balance.md#0x2_balance">balance</a>, withdraw_amount)
 }

--- a/crates/sui-framework/docs/stake.md
+++ b/crates/sui-framework/docs/stake.md
@@ -84,12 +84,12 @@ TODO: this is a placehodler number and may be changed.
 
 
 
-<a name="0x2_stake_ENONZERO_BALANCE"></a>
+<a name="0x2_stake_ENonzeroBalance"></a>
 
 Error number for when a Stake with nonzero balance is burnt.
 
 
-<pre><code><b>const</b> <a href="stake.md#0x2_stake_ENONZERO_BALANCE">ENONZERO_BALANCE</a>: u64 = 0;
+<pre><code><b>const</b> <a href="stake.md#0x2_stake_ENonzeroBalance">ENonzeroBalance</a>: u64 = 0;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -408,83 +408,83 @@ A self-custodial object holding the staked SUI tokens.
 ## Constants
 
 
-<a name="0x2_staking_pool_EDESTROY_NON_ZERO_BALANCE"></a>
+<a name="0x2_staking_pool_EDestroyNonzeroBalance"></a>
 
 
 
-<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EDESTROY_NON_ZERO_BALANCE">EDESTROY_NON_ZERO_BALANCE</a>: u64 = 5;
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EDestroyNonzeroBalance">EDestroyNonzeroBalance</a>: u64 = 5;
 </code></pre>
 
 
 
-<a name="0x2_staking_pool_EINSUFFICIENT_POOL_TOKEN_BALANCE"></a>
+<a name="0x2_staking_pool_EInsufficientPoolTokenBalance"></a>
 
 
 
-<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EINSUFFICIENT_POOL_TOKEN_BALANCE">EINSUFFICIENT_POOL_TOKEN_BALANCE</a>: u64 = 0;
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EInsufficientPoolTokenBalance">EInsufficientPoolTokenBalance</a>: u64 = 0;
 </code></pre>
 
 
 
-<a name="0x2_staking_pool_EINSUFFICIENT_REWARDS_POOL_BALANCE"></a>
+<a name="0x2_staking_pool_EInsufficientRewardsPoolBalance"></a>
 
 
 
-<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EINSUFFICIENT_REWARDS_POOL_BALANCE">EINSUFFICIENT_REWARDS_POOL_BALANCE</a>: u64 = 4;
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EInsufficientRewardsPoolBalance">EInsufficientRewardsPoolBalance</a>: u64 = 4;
 </code></pre>
 
 
 
-<a name="0x2_staking_pool_EINSUFFICIENT_SUI_TOKEN_BALANCE"></a>
+<a name="0x2_staking_pool_EInsufficientSuiTokenBalance"></a>
 
 
 
-<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EINSUFFICIENT_SUI_TOKEN_BALANCE">EINSUFFICIENT_SUI_TOKEN_BALANCE</a>: u64 = 3;
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EInsufficientSuiTokenBalance">EInsufficientSuiTokenBalance</a>: u64 = 3;
 </code></pre>
 
 
 
-<a name="0x2_staking_pool_EPENDING_DELEGATION_DOES_NOT_EXIST"></a>
+<a name="0x2_staking_pool_EPendingDelegationDoesNotExist"></a>
 
 
 
-<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EPENDING_DELEGATION_DOES_NOT_EXIST">EPENDING_DELEGATION_DOES_NOT_EXIST</a>: u64 = 8;
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EPendingDelegationDoesNotExist">EPendingDelegationDoesNotExist</a>: u64 = 8;
 </code></pre>
 
 
 
-<a name="0x2_staking_pool_ETOKEN_TIME_LOCK_IS_SOME"></a>
+<a name="0x2_staking_pool_ETokenTimeLockIsSome"></a>
 
 
 
-<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_ETOKEN_TIME_LOCK_IS_SOME">ETOKEN_TIME_LOCK_IS_SOME</a>: u64 = 6;
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_ETokenTimeLockIsSome">ETokenTimeLockIsSome</a>: u64 = 6;
 </code></pre>
 
 
 
-<a name="0x2_staking_pool_EWITHDRAW_AMOUNT_CANNOT_BE_ZERO"></a>
+<a name="0x2_staking_pool_EWithdrawAmountCannotBeZero"></a>
 
 
 
-<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWITHDRAW_AMOUNT_CANNOT_BE_ZERO">EWITHDRAW_AMOUNT_CANNOT_BE_ZERO</a>: u64 = 2;
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWithdrawAmountCannotBeZero">EWithdrawAmountCannotBeZero</a>: u64 = 2;
 </code></pre>
 
 
 
-<a name="0x2_staking_pool_EWRONG_DELEGATION"></a>
+<a name="0x2_staking_pool_EWrongDelegation"></a>
 
 
 
-<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWRONG_DELEGATION">EWRONG_DELEGATION</a>: u64 = 7;
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWrongDelegation">EWrongDelegation</a>: u64 = 7;
 </code></pre>
 
 
 
-<a name="0x2_staking_pool_EWRONG_POOL"></a>
+<a name="0x2_staking_pool_EWrongPool"></a>
 
 
 
-<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWRONG_POOL">EWRONG_POOL</a>: u64 = 1;
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWrongPool">EWrongPool</a>: u64 = 1;
 </code></pre>
 
 
@@ -647,16 +647,16 @@ time lock if applicable.
     staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>,
 ) : (Balance&lt;<a href="staking_pool.md#0x2_staking_pool_DelegationToken">DelegationToken</a>&gt;, Balance&lt;SUI&gt;, Option&lt;EpochTimeLock&gt;) {
     // Check that the delegation and staked <a href="sui.md#0x2_sui">sui</a> objects match.
-    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(&staked_sui) == delegation.staked_sui_id, <a href="staking_pool.md#0x2_staking_pool_EWRONG_DELEGATION">EWRONG_DELEGATION</a>);
+    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(&staked_sui) == delegation.staked_sui_id, <a href="staking_pool.md#0x2_staking_pool_EWrongDelegation">EWrongDelegation</a>);
 
     // Check that the delegation information matches the pool.
     <b>assert</b>!(
         staked_sui.validator_address == pool.validator_address &&
         staked_sui.pool_starting_epoch == pool.starting_epoch,
-        <a href="staking_pool.md#0x2_staking_pool_EWRONG_POOL">EWRONG_POOL</a>
+        <a href="staking_pool.md#0x2_staking_pool_EWrongPool">EWrongPool</a>
     );
 
-    <b>assert</b>!(delegation.principal_sui_amount == <a href="balance.md#0x2_balance_value">balance::value</a>(&staked_sui.principal), <a href="staking_pool.md#0x2_staking_pool_EINSUFFICIENT_SUI_TOKEN_BALANCE">EINSUFFICIENT_SUI_TOKEN_BALANCE</a>);
+    <b>assert</b>!(delegation.principal_sui_amount == <a href="balance.md#0x2_balance_value">balance::value</a>(&staked_sui.principal), <a href="staking_pool.md#0x2_staking_pool_EInsufficientSuiTokenBalance">EInsufficientSuiTokenBalance</a>);
 
     <b>let</b> pool_tokens = <a href="staking_pool.md#0x2_staking_pool_destroy_delegation_and_return_pool_tokens">destroy_delegation_and_return_pool_tokens</a>(delegation);
     <b>let</b> (principal_withdraw, time_lock) = <a href="staking_pool.md#0x2_staking_pool_unwrap_staked_sui">unwrap_staked_sui</a>(staked_sui);
@@ -1022,8 +1022,8 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
         principal_sui_amount,
     } = delegation;
     <a href="object.md#0x2_object_delete">object::delete</a>(id);
-    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&pool_tokens) == 0, <a href="staking_pool.md#0x2_staking_pool_EDESTROY_NON_ZERO_BALANCE">EDESTROY_NON_ZERO_BALANCE</a>);
-    <b>assert</b>!(principal_sui_amount == 0, <a href="staking_pool.md#0x2_staking_pool_EDESTROY_NON_ZERO_BALANCE">EDESTROY_NON_ZERO_BALANCE</a>);
+    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&pool_tokens) == 0, <a href="staking_pool.md#0x2_staking_pool_EDestroyNonzeroBalance">EDestroyNonzeroBalance</a>);
+    <b>assert</b>!(principal_sui_amount == 0, <a href="staking_pool.md#0x2_staking_pool_EDestroyNonzeroBalance">EDestroyNonzeroBalance</a>);
     <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(pool_tokens);
 }
 </code></pre>
@@ -1058,9 +1058,9 @@ Destroy an empty delegation that no longer contains any SUI or pool tokens.
         sui_token_lock
     } = staked_sui;
     <a href="object.md#0x2_object_delete">object::delete</a>(id);
-    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&principal) == 0, <a href="staking_pool.md#0x2_staking_pool_EDESTROY_NON_ZERO_BALANCE">EDESTROY_NON_ZERO_BALANCE</a>);
+    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&principal) == 0, <a href="staking_pool.md#0x2_staking_pool_EDestroyNonzeroBalance">EDestroyNonzeroBalance</a>);
     <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(principal);
-    <b>assert</b>!(<a href="_is_none">option::is_none</a>(&sui_token_lock), <a href="staking_pool.md#0x2_staking_pool_ETOKEN_TIME_LOCK_IS_SOME">ETOKEN_TIME_LOCK_IS_SOME</a>);
+    <b>assert</b>!(<a href="_is_none">option::is_none</a>(&sui_token_lock), <a href="staking_pool.md#0x2_staking_pool_ETokenTimeLockIsSome">ETokenTimeLockIsSome</a>);
     <a href="_destroy_none">option::destroy_none</a>(sui_token_lock);
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -294,65 +294,65 @@ the epoch advancement transaction.
 
 
 
-<a name="0x2_sui_system_EBPS_TOO_LARGE"></a>
+<a name="0x2_sui_system_EBpsTooLarge"></a>
 
 
 
-<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EBPS_TOO_LARGE">EBPS_TOO_LARGE</a>: u64 = 5;
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EBpsTooLarge">EBpsTooLarge</a>: u64 = 5;
 </code></pre>
 
 
 
-<a name="0x2_sui_system_ECANNOT_REPORT_ONESELF"></a>
+<a name="0x2_sui_system_ECannotReportOneself"></a>
 
 
 
-<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ECANNOT_REPORT_ONESELF">ECANNOT_REPORT_ONESELF</a>: u64 = 3;
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ECannotReportOneself">ECannotReportOneself</a>: u64 = 3;
 </code></pre>
 
 
 
-<a name="0x2_sui_system_EEPOCH_NUMBER_MISMATCH"></a>
+<a name="0x2_sui_system_EEpochNumberMismatch"></a>
 
 
 
-<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EEPOCH_NUMBER_MISMATCH">EEPOCH_NUMBER_MISMATCH</a>: u64 = 2;
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EEpochNumberMismatch">EEpochNumberMismatch</a>: u64 = 2;
 </code></pre>
 
 
 
-<a name="0x2_sui_system_ELIMIT_EXCEEDED"></a>
+<a name="0x2_sui_system_ELimitExceeded"></a>
 
 
 
-<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ELIMIT_EXCEEDED">ELIMIT_EXCEEDED</a>: u64 = 1;
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ELimitExceeded">ELimitExceeded</a>: u64 = 1;
 </code></pre>
 
 
 
-<a name="0x2_sui_system_ENOT_VALIDATOR"></a>
+<a name="0x2_sui_system_ENotValidator"></a>
 
 
 
-<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ENOT_VALIDATOR">ENOT_VALIDATOR</a>: u64 = 0;
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ENotValidator">ENotValidator</a>: u64 = 0;
 </code></pre>
 
 
 
-<a name="0x2_sui_system_EREPORT_RECORD_NOT_FOUND"></a>
+<a name="0x2_sui_system_EReportRecordNotFound"></a>
 
 
 
-<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EREPORT_RECORD_NOT_FOUND">EREPORT_RECORD_NOT_FOUND</a>: u64 = 4;
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EReportRecordNotFound">EReportRecordNotFound</a>: u64 = 4;
 </code></pre>
 
 
 
-<a name="0x2_sui_system_ESTAKED_SUI_FROM_WRONG_EPOCH"></a>
+<a name="0x2_sui_system_EStakedSuiFromWrongEpoch"></a>
 
 
 
-<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ESTAKED_SUI_FROM_WRONG_EPOCH">ESTAKED_SUI_FROM_WRONG_EPOCH</a>: u64 = 6;
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_EStakedSuiFromWrongEpoch">EStakedSuiFromWrongEpoch</a>: u64 = 6;
 </code></pre>
 
 
@@ -450,12 +450,12 @@ The amount of stake in the <code><a href="validator.md#0x2_validator">validator<
 ) {
     <b>assert</b>!(
         <a href="validator_set.md#0x2_validator_set_next_epoch_validator_count">validator_set::next_epoch_validator_count</a>(&self.validators) &lt; self.parameters.max_validator_candidate_count,
-        <a href="sui_system.md#0x2_sui_system_ELIMIT_EXCEEDED">ELIMIT_EXCEEDED</a>,
+        <a href="sui_system.md#0x2_sui_system_ELimitExceeded">ELimitExceeded</a>,
     );
     <b>let</b> stake_amount = <a href="coin.md#0x2_coin_value">coin::value</a>(&<a href="stake.md#0x2_stake">stake</a>);
     <b>assert</b>!(
         stake_amount &gt;= self.parameters.min_validator_stake,
-        <a href="sui_system.md#0x2_sui_system_ELIMIT_EXCEEDED">ELIMIT_EXCEEDED</a>,
+        <a href="sui_system.md#0x2_sui_system_ELimitExceeded">ELimitExceeded</a>,
     );
     <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator.md#0x2_validator_new">validator::new</a>(
         <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx),
@@ -896,9 +896,9 @@ and they are not the same address. This function is idempotent within an epoch.
 ) {
     <b>let</b> sender = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
     // Both the reporter and the reported have <b>to</b> be validators.
-    <b>assert</b>!(<a href="validator_set.md#0x2_validator_set_is_active_validator">validator_set::is_active_validator</a>(&self.validators, sender), <a href="sui_system.md#0x2_sui_system_ENOT_VALIDATOR">ENOT_VALIDATOR</a>);
-    <b>assert</b>!(<a href="validator_set.md#0x2_validator_set_is_active_validator">validator_set::is_active_validator</a>(&self.validators, validator_addr), <a href="sui_system.md#0x2_sui_system_ENOT_VALIDATOR">ENOT_VALIDATOR</a>);
-    <b>assert</b>!(sender != validator_addr, <a href="sui_system.md#0x2_sui_system_ECANNOT_REPORT_ONESELF">ECANNOT_REPORT_ONESELF</a>);
+    <b>assert</b>!(<a href="validator_set.md#0x2_validator_set_is_active_validator">validator_set::is_active_validator</a>(&self.validators, sender), <a href="sui_system.md#0x2_sui_system_ENotValidator">ENotValidator</a>);
+    <b>assert</b>!(<a href="validator_set.md#0x2_validator_set_is_active_validator">validator_set::is_active_validator</a>(&self.validators, validator_addr), <a href="sui_system.md#0x2_sui_system_ENotValidator">ENotValidator</a>);
+    <b>assert</b>!(sender != validator_addr, <a href="sui_system.md#0x2_sui_system_ECannotReportOneself">ECannotReportOneself</a>);
 
     <b>if</b> (!<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.validator_report_records, &validator_addr)) {
         <a href="vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(&<b>mut</b> self.validator_report_records, validator_addr, <a href="vec_set.md#0x2_vec_set_singleton">vec_set::singleton</a>(sender));
@@ -939,9 +939,9 @@ Undo a <code>report_validator</code> action. Aborts if the sender has not report
 ) {
     <b>let</b> sender = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
 
-    <b>assert</b>!(<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.validator_report_records, &validator_addr), <a href="sui_system.md#0x2_sui_system_EREPORT_RECORD_NOT_FOUND">EREPORT_RECORD_NOT_FOUND</a>);
+    <b>assert</b>!(<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.validator_report_records, &validator_addr), <a href="sui_system.md#0x2_sui_system_EReportRecordNotFound">EReportRecordNotFound</a>);
     <b>let</b> reporters = <a href="vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(&<b>mut</b> self.validator_report_records, &validator_addr);
-    <b>assert</b>!(<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &sender), <a href="sui_system.md#0x2_sui_system_EREPORT_RECORD_NOT_FOUND">EREPORT_RECORD_NOT_FOUND</a>);
+    <b>assert</b>!(<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &sender), <a href="sui_system.md#0x2_sui_system_EReportRecordNotFound">EReportRecordNotFound</a>);
     <a href="vec_set.md#0x2_vec_set_remove">vec_set::remove</a>(reporters, &sender);
 }
 </code></pre>
@@ -996,7 +996,7 @@ gas coins.
     <b>assert</b>!(
         storage_fund_reinvest_rate &lt;= bps_denominator_u64
         && reward_slashing_rate &lt;= bps_denominator_u64,
-        <a href="sui_system.md#0x2_sui_system_EBPS_TOO_LARGE">EBPS_TOO_LARGE</a>,
+        <a href="sui_system.md#0x2_sui_system_EBpsTooLarge">EBpsTooLarge</a>,
     );
 
     <b>let</b> delegation_stake = <a href="validator_set.md#0x2_validator_set_total_delegation_stake">validator_set::total_delegation_stake</a>(&self.validators);

--- a/crates/sui-framework/docs/table_vec.md
+++ b/crates/sui-framework/docs/table_vec.md
@@ -57,20 +57,20 @@ A basic scalable vector library implemented using <code>Table</code>.
 ## Constants
 
 
-<a name="0x2_table_vec_EINDEX_OUT_OF_BOUND"></a>
+<a name="0x2_table_vec_EIndexOutOfBound"></a>
 
 
 
-<pre><code><b>const</b> <a href="table_vec.md#0x2_table_vec_EINDEX_OUT_OF_BOUND">EINDEX_OUT_OF_BOUND</a>: u64 = 0;
+<pre><code><b>const</b> <a href="table_vec.md#0x2_table_vec_EIndexOutOfBound">EIndexOutOfBound</a>: u64 = 0;
 </code></pre>
 
 
 
-<a name="0x2_table_vec_ETABLE_NONEMPTY"></a>
+<a name="0x2_table_vec_ETableNonEmpty"></a>
 
 
 
-<pre><code><b>const</b> <a href="table_vec.md#0x2_table_vec_ETABLE_NONEMPTY">ETABLE_NONEMPTY</a>: u64 = 1;
+<pre><code><b>const</b> <a href="table_vec.md#0x2_table_vec_ETableNonEmpty">ETableNonEmpty</a>: u64 = 1;
 </code></pre>
 
 
@@ -197,7 +197,7 @@ Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_borrow">borrow</a>&lt;Element: store&gt;(t: &<a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;, i: u64): &Element {
-    <b>assert</b>!(<a href="table_vec.md#0x2_table_vec_length">length</a>(t) &gt; i, <a href="table_vec.md#0x2_table_vec_EINDEX_OUT_OF_BOUND">EINDEX_OUT_OF_BOUND</a>);
+    <b>assert</b>!(<a href="table_vec.md#0x2_table_vec_length">length</a>(t) &gt; i, <a href="table_vec.md#0x2_table_vec_EIndexOutOfBound">EIndexOutOfBound</a>);
     <a href="table.md#0x2_table_borrow">table::borrow</a>(&t.contents, i)
 }
 </code></pre>
@@ -250,7 +250,7 @@ Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_borrow_mut">borrow_mut</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element {
-    <b>assert</b>!(<a href="table_vec.md#0x2_table_vec_length">length</a>(t) &gt; i, <a href="table_vec.md#0x2_table_vec_EINDEX_OUT_OF_BOUND">EINDEX_OUT_OF_BOUND</a>);
+    <b>assert</b>!(<a href="table_vec.md#0x2_table_vec_length">length</a>(t) &gt; i, <a href="table_vec.md#0x2_table_vec_EIndexOutOfBound">EIndexOutOfBound</a>);
     <a href="table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> t.contents, i)
 }
 </code></pre>
@@ -278,7 +278,7 @@ Aborts if <code>t</code> is empty.
 
 <pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_pop_back">pop_back</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;): Element {
     <b>let</b> length = <a href="table_vec.md#0x2_table_vec_length">length</a>(t);
-    <b>assert</b>!(length &gt; 0, <a href="table_vec.md#0x2_table_vec_EINDEX_OUT_OF_BOUND">EINDEX_OUT_OF_BOUND</a>);
+    <b>assert</b>!(length &gt; 0, <a href="table_vec.md#0x2_table_vec_EIndexOutOfBound">EIndexOutOfBound</a>);
     <a href="table.md#0x2_table_remove">table::remove</a>(&<b>mut</b> t.contents, length - 1)
 }
 </code></pre>
@@ -305,7 +305,7 @@ Aborts if <code>t</code> is not empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="table_vec.md#0x2_table_vec_destroy_empty">destroy_empty</a>&lt;Element: store&gt;(t: <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;) {
-    <b>assert</b>!(<a href="table_vec.md#0x2_table_vec_length">length</a>(&t) == 0, <a href="table_vec.md#0x2_table_vec_ETABLE_NONEMPTY">ETABLE_NONEMPTY</a>);
+    <b>assert</b>!(<a href="table_vec.md#0x2_table_vec_length">length</a>(&t) == 0, <a href="table_vec.md#0x2_table_vec_ETableNonEmpty">ETableNonEmpty</a>);
     <b>let</b> <a href="table_vec.md#0x2_table_vec_TableVec">TableVec</a> { contents } = t;
     <a href="table.md#0x2_table_destroy_empty">table::destroy_empty</a>(contents);
 }

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -272,20 +272,20 @@ each validator, emitted during epoch advancement.
 
 
 
-<a name="0x2_validator_set_EINVALID_STAKE_ADJUSTMENT_AMOUNT"></a>
+<a name="0x2_validator_set_EInvalidStakeAdjustmentAmount"></a>
 
 
 
-<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_EINVALID_STAKE_ADJUSTMENT_AMOUNT">EINVALID_STAKE_ADJUSTMENT_AMOUNT</a>: u64 = 1;
+<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_EInvalidStakeAdjustmentAmount">EInvalidStakeAdjustmentAmount</a>: u64 = 1;
 </code></pre>
 
 
 
-<a name="0x2_validator_set_ENON_VALIDATOR_IN_REPORT_RECORDS"></a>
+<a name="0x2_validator_set_ENonValidatorInReportRecords"></a>
 
 
 
-<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_ENON_VALIDATOR_IN_REPORT_RECORDS">ENON_VALIDATOR_IN_REPORT_RECORDS</a>: u64 = 0;
+<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_ENonValidatorInReportRecords">ENonValidatorInReportRecords</a>: u64 = 0;
 </code></pre>
 
 
@@ -1417,7 +1417,7 @@ non-performant validators according to the input threshold.
         <b>let</b> (validator_address, reporters) = <a href="vec_map.md#0x2_vec_map_pop">vec_map::pop</a>(&<b>mut</b> validator_report_records);
         <b>assert</b>!(
             <a href="validator_set.md#0x2_validator_set_is_active_validator">is_active_validator</a>(self, validator_address),
-            <a href="validator_set.md#0x2_validator_set_ENON_VALIDATOR_IN_REPORT_RECORDS">ENON_VALIDATOR_IN_REPORT_RECORDS</a>
+            <a href="validator_set.md#0x2_validator_set_ENonValidatorInReportRecords">ENonValidatorInReportRecords</a>,
         );
         // Sum up the voting power of validators that have reported this <a href="validator.md#0x2_validator">validator</a> and check <b>if</b> it <b>has</b>
         // passed the slashing threshold.

--- a/crates/sui-framework/sources/governance/stake.move
+++ b/crates/sui-framework/sources/governance/stake.move
@@ -33,7 +33,7 @@ module sui::stake {
     const BONDING_PERIOD: u64 = 1;
 
     /// Error number for when a Stake with nonzero balance is burnt.
-    const ENONZERO_BALANCE: u64 = 0;
+    const ENonzeroBalance: u64 = 0;
 
     /// Create a stake object from a SUI balance. If the balance comes from a
     /// `LockedCoin`, an EpochTimeLock is passed in to keep track of locking period.

--- a/crates/sui-framework/sources/governance/staking_pool.move
+++ b/crates/sui-framework/sources/governance/staking_pool.move
@@ -18,15 +18,15 @@ module sui::staking_pool {
     friend sui::validator;
     friend sui::validator_set;
     
-    const EINSUFFICIENT_POOL_TOKEN_BALANCE: u64 = 0;
-    const EWRONG_POOL: u64 = 1;
-    const EWITHDRAW_AMOUNT_CANNOT_BE_ZERO: u64 = 2;
-    const EINSUFFICIENT_SUI_TOKEN_BALANCE: u64 = 3;
-    const EINSUFFICIENT_REWARDS_POOL_BALANCE: u64 = 4;
-    const EDESTROY_NON_ZERO_BALANCE: u64 = 5;
-    const ETOKEN_TIME_LOCK_IS_SOME: u64 = 6;
-    const EWRONG_DELEGATION: u64 = 7;
-    const EPENDING_DELEGATION_DOES_NOT_EXIST: u64 = 8;
+    const EInsufficientPoolTokenBalance: u64 = 0;
+    const EWrongPool: u64 = 1;
+    const EWithdrawAmountCannotBeZero: u64 = 2;
+    const EInsufficientSuiTokenBalance: u64 = 3;
+    const EInsufficientRewardsPoolBalance: u64 = 4;
+    const EDestroyNonzeroBalance: u64 = 5;
+    const ETokenTimeLockIsSome: u64 = 6;
+    const EWrongDelegation: u64 = 7;
+    const EPendingDelegationDoesNotExist: u64 = 8;
 
     /// A staking pool embedded in each validator struct in the system state object.
     struct StakingPool has store {
@@ -198,16 +198,16 @@ module sui::staking_pool {
         staked_sui: StakedSui,
     ) : (Balance<DelegationToken>, Balance<SUI>, Option<EpochTimeLock>) {
         // Check that the delegation and staked sui objects match.
-        assert!(object::id(&staked_sui) == delegation.staked_sui_id, EWRONG_DELEGATION);
+        assert!(object::id(&staked_sui) == delegation.staked_sui_id, EWrongDelegation);
 
         // Check that the delegation information matches the pool. 
         assert!(
             staked_sui.validator_address == pool.validator_address &&
             staked_sui.pool_starting_epoch == pool.starting_epoch,
-            EWRONG_POOL
+            EWrongPool
         );
 
-        assert!(delegation.principal_sui_amount == balance::value(&staked_sui.principal), EINSUFFICIENT_SUI_TOKEN_BALANCE);
+        assert!(delegation.principal_sui_amount == balance::value(&staked_sui.principal), EInsufficientSuiTokenBalance);
 
         let pool_tokens = destroy_delegation_and_return_pool_tokens(delegation);
         let (principal_withdraw, time_lock) = unwrap_staked_sui(staked_sui);
@@ -381,8 +381,8 @@ module sui::staking_pool {
             principal_sui_amount,
         } = delegation;
         object::delete(id);
-        assert!(balance::value(&pool_tokens) == 0, EDESTROY_NON_ZERO_BALANCE);
-        assert!(principal_sui_amount == 0, EDESTROY_NON_ZERO_BALANCE);
+        assert!(balance::value(&pool_tokens) == 0, EDestroyNonzeroBalance);
+        assert!(principal_sui_amount == 0, EDestroyNonzeroBalance);
         balance::destroy_zero(pool_tokens);
     }
 
@@ -397,9 +397,9 @@ module sui::staking_pool {
             sui_token_lock
         } = staked_sui;
         object::delete(id);
-        assert!(balance::value(&principal) == 0, EDESTROY_NON_ZERO_BALANCE);
+        assert!(balance::value(&principal) == 0, EDestroyNonzeroBalance);
         balance::destroy_zero(principal);
-        assert!(option::is_none(&sui_token_lock), ETOKEN_TIME_LOCK_IS_SOME);
+        assert!(option::is_none(&sui_token_lock), ETokenTimeLockIsSome);
         option::destroy_none(sui_token_lock);
     }
 

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -95,13 +95,13 @@ module sui::sui_system {
     }
 
     // Errors
-    const ENOT_VALIDATOR: u64 = 0;
-    const ELIMIT_EXCEEDED: u64 = 1;
-    const EEPOCH_NUMBER_MISMATCH: u64 = 2;
-    const ECANNOT_REPORT_ONESELF: u64 = 3;
-    const EREPORT_RECORD_NOT_FOUND: u64 = 4;
-    const EBPS_TOO_LARGE: u64 = 5;
-    const ESTAKED_SUI_FROM_WRONG_EPOCH: u64 = 6;
+    const ENotValidator: u64 = 0;
+    const ELimitExceeded: u64 = 1;
+    const EEpochNumberMismatch: u64 = 2;
+    const ECannotReportOneself: u64 = 3;
+    const EReportRecordNotFound: u64 = 4;
+    const EBpsTooLarge: u64 = 5;
+    const EStakedSuiFromWrongEpoch: u64 = 6;
 
     const BASIS_POINT_DENOMINATOR: u128 = 10000;
 
@@ -169,12 +169,12 @@ module sui::sui_system {
     ) {
         assert!(
             validator_set::next_epoch_validator_count(&self.validators) < self.parameters.max_validator_candidate_count,
-            ELIMIT_EXCEEDED,
+            ELimitExceeded,
         );
         let stake_amount = coin::value(&stake);
         assert!(
             stake_amount >= self.parameters.min_validator_stake,
-            ELIMIT_EXCEEDED,
+            ELimitExceeded,
         );
         let validator = validator::new(
             tx_context::sender(ctx),
@@ -375,9 +375,9 @@ module sui::sui_system {
     ) {
         let sender = tx_context::sender(ctx);
         // Both the reporter and the reported have to be validators.
-        assert!(validator_set::is_active_validator(&self.validators, sender), ENOT_VALIDATOR);
-        assert!(validator_set::is_active_validator(&self.validators, validator_addr), ENOT_VALIDATOR);
-        assert!(sender != validator_addr, ECANNOT_REPORT_ONESELF);
+        assert!(validator_set::is_active_validator(&self.validators, sender), ENotValidator);
+        assert!(validator_set::is_active_validator(&self.validators, validator_addr), ENotValidator);
+        assert!(sender != validator_addr, ECannotReportOneself);
 
         if (!vec_map::contains(&self.validator_report_records, &validator_addr)) {
             vec_map::insert(&mut self.validator_report_records, validator_addr, vec_set::singleton(sender));
@@ -398,9 +398,9 @@ module sui::sui_system {
     ) {
         let sender = tx_context::sender(ctx);
 
-        assert!(vec_map::contains(&self.validator_report_records, &validator_addr), EREPORT_RECORD_NOT_FOUND);
+        assert!(vec_map::contains(&self.validator_report_records, &validator_addr), EReportRecordNotFound);
         let reporters = vec_map::get_mut(&mut self.validator_report_records, &validator_addr);
-        assert!(vec_set::contains(reporters, &sender), EREPORT_RECORD_NOT_FOUND);
+        assert!(vec_set::contains(reporters, &sender), EReportRecordNotFound);
         vec_set::remove(reporters, &sender);
     }
 
@@ -435,7 +435,7 @@ module sui::sui_system {
         assert!(
             storage_fund_reinvest_rate <= bps_denominator_u64
             && reward_slashing_rate <= bps_denominator_u64,
-            EBPS_TOO_LARGE,
+            EBpsTooLarge,
         );
 
         let delegation_stake = validator_set::total_delegation_stake(&self.validators);

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -74,8 +74,8 @@ module sui::validator_set {
     const BASIS_POINT_DENOMINATOR: u128 = 10000;
 
     // Errors
-    const ENON_VALIDATOR_IN_REPORT_RECORDS: u64 = 0;
-    const EINVALID_STAKE_ADJUSTMENT_AMOUNT: u64 = 1;
+    const ENonValidatorInReportRecords: u64 = 0;
+    const EInvalidStakeAdjustmentAmount: u64 = 1;
 
     // ==== initialization at genesis ====
 
@@ -607,7 +607,7 @@ module sui::validator_set {
             let (validator_address, reporters) = vec_map::pop(&mut validator_report_records);
             assert!(
                 is_active_validator(self, validator_address),
-                ENON_VALIDATOR_IN_REPORT_RECORDS
+                ENonValidatorInReportRecords,
             );
             // Sum up the voting power of validators that have reported this validator and check if it has
             // passed the slashing threshold.

--- a/crates/sui-framework/sources/safe.move
+++ b/crates/sui-framework/sources/safe.move
@@ -14,10 +14,10 @@ module sui::safe {
     const MAX_CAPABILITY_ISSUABLE: u64 = 1000;
 
     // Errors
-    const INVALID_TRANSFER_CAPABILITY: u64 = 0;
-    const INVALID_OWNER_CAPABILITY: u64 = 1;
-    const TRANSFER_CAPABILITY_REVOKED: u64 = 2;
-    const OVERDRAWN: u64 = 3;
+    const EInvalidTransferCapability: u64 = 0;
+    const EInvalidOwnerCapability: u64 = 1;
+    const ETransferCapabilityRevoked: u64 = 2;
+    const EOverdrawn: u64 = 3;
 
     //
     /// Allows any holder of a capability to transfer a fixed amount of assets from the safe.
@@ -55,13 +55,13 @@ module sui::safe {
     /// Check that the capability has not yet been revoked by the owner.
     fun check_capability_validity<T>(safe: &Safe<T>, capability: &TransferCapability<T>) {
         // Check that the ids match
-        assert!(object::id(safe) == capability.safe_id, INVALID_TRANSFER_CAPABILITY);
+        assert!(object::id(safe) == capability.safe_id, EInvalidTransferCapability);
         // Check that it has not been cancelled
-        assert!(vec_set::contains(&safe.allowed_safes, &object::id(capability)), TRANSFER_CAPABILITY_REVOKED);
+        assert!(vec_set::contains(&safe.allowed_safes, &object::id(capability)), ETransferCapabilityRevoked);
     }
 
     fun check_owner_capability_validity<T>(safe: &Safe<T>, capability: &OwnerCapability<T>) {
-        assert!(object::id(safe) == capability.safe_id, INVALID_OWNER_CAPABILITY);
+        assert!(object::id(safe) == capability.safe_id, EInvalidOwnerCapability);
     }
 
     /// Helper function to create a capability.
@@ -145,7 +145,7 @@ module sui::safe {
         check_capability_validity(safe, capability);
 
         // Withdraw funds
-        assert!(capability.amount >= withdraw_amount, OVERDRAWN);
+        assert!(capability.amount >= withdraw_amount, EOverdrawn);
         capability.amount = capability.amount - withdraw_amount;
         balance::split(&mut safe.balance, withdraw_amount)
     }

--- a/crates/sui-framework/sources/table_vec.move
+++ b/crates/sui-framework/sources/table_vec.move
@@ -11,8 +11,8 @@ module sui::table_vec {
         contents: Table<u64, Element>,
     }
 
-    const EINDEX_OUT_OF_BOUND: u64 = 0;
-    const ETABLE_NONEMPTY: u64 = 1;
+    const EIndexOutOfBound: u64 = 0;
+    const ETableNonEmpty: u64 = 1;
 
     /// Create an empty TableVec.
     public fun empty<Element: store>(ctx: &mut TxContext): TableVec<Element> {
@@ -41,7 +41,7 @@ module sui::table_vec {
     /// Acquire an immutable reference to the `i`th element of the TableVec `t`.
     /// Aborts if `i` is out of bounds.
     public fun borrow<Element: store>(t: &TableVec<Element>, i: u64): &Element {
-        assert!(length(t) > i, EINDEX_OUT_OF_BOUND);
+        assert!(length(t) > i, EIndexOutOfBound);
         table::borrow(&t.contents, i)
     }
 
@@ -54,7 +54,7 @@ module sui::table_vec {
     /// Return a mutable reference to the `i`th element in the TableVec `t`.
     /// Aborts if `i` is out of bounds.
     public fun borrow_mut<Element: store>(t: &mut TableVec<Element>, i: u64): &mut Element {
-        assert!(length(t) > i, EINDEX_OUT_OF_BOUND);
+        assert!(length(t) > i, EIndexOutOfBound);
         table::borrow_mut(&mut t.contents, i)
     }
 
@@ -62,14 +62,14 @@ module sui::table_vec {
     /// Aborts if `t` is empty.
     public fun pop_back<Element: store>(t: &mut TableVec<Element>): Element {
         let length = length(t);
-        assert!(length > 0, EINDEX_OUT_OF_BOUND);
+        assert!(length > 0, EIndexOutOfBound);
         table::remove(&mut t.contents, length - 1)
     }
 
     /// Destroy the TableVec `t`.
     /// Aborts if `t` is not empty.
     public fun destroy_empty<Element: store>(t: TableVec<Element>) {
-        assert!(length(&t) == 0, ETABLE_NONEMPTY);
+        assert!(length(&t) == 0, ETableNonEmpty);
         let TableVec { contents } = t;
         table::destroy_empty(contents);
     }

--- a/crates/sui-framework/tests/digest_tests.move
+++ b/crates/sui-framework/tests/digest_tests.move
@@ -5,7 +5,7 @@
 module sui::digest_tests {
     use sui::digest::{sha3_256_digest_from_bytes, sha3_256_digest_to_bytes};
 
-    const EHASH_LENGTH_MISMATCH: u64 = 0;
+    const EHashLengthMismatch: u64 = 0;
 
     #[test]
     #[expected_failure(abort_code = sui::digest::EHashLengthMismatch)]
@@ -25,6 +25,6 @@ module sui::digest_tests {
     fun test_good_hash() {
         let hash = x"1234567890123456789012345678901234567890abcdefabcdefabcdefabcdef";
         let digest = sha3_256_digest_from_bytes(hash);
-        assert!(sha3_256_digest_to_bytes(&digest) == hash, EHASH_LENGTH_MISMATCH);
+        assert!(sha3_256_digest_to_bytes(&digest) == hash, EHashLengthMismatch);
     }
 }

--- a/crates/sui-framework/tests/id_tests.move
+++ b/crates/sui-framework/tests/id_tests.move
@@ -6,7 +6,7 @@ module sui::id_tests {
     use sui::object;
     use sui::tx_context;
 
-    const ID_BYTES_MISMATCH: u64 = 0;
+    const EIdBytesMismatch: u64 = 0;
 
     struct Object has key {
         id: object::UID,
@@ -18,7 +18,7 @@ module sui::id_tests {
         let id = object::new(&mut ctx);
         let obj_id = object::uid_to_inner(&id);
         let obj = Object { id };
-        assert!(object::id(&obj) == obj_id, ID_BYTES_MISMATCH);
+        assert!(object::id(&obj) == obj_id, EIdBytesMismatch);
         let Object { id } = obj;
         object::delete(id);
     }

--- a/crates/sui-framework/tests/immutable_external_resource_tests.move
+++ b/crates/sui-framework/tests/immutable_external_resource_tests.move
@@ -8,8 +8,8 @@ module sui::immutable_external_resource_tests {
     use std::ascii::Self;
     use sui::digest;
 
-    const EHASH_LENGTH_MISMATCH: u64 = 0;
-    const URL_STRING_MISMATCH: u64 = 1;
+    const EHashLengthMisMatch: u64 = 0;
+    const EUrlStringMisMatch: u64 = 1;
 
     #[test]
     fun test_init() {

--- a/crates/sui-framework/tests/safe_tests.move
+++ b/crates/sui-framework/tests/safe_tests.move
@@ -103,7 +103,7 @@ module sui::safe_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = safe::OVERDRAWN)]
+    #[expected_failure(abort_code = safe::EOverdrawn)]
     /// Ensure that funds cannot be over withdrawn
     fun test_safe_attempt_to_over_withdraw() {
         let owner = TEST_OWNER_ADDR;
@@ -126,7 +126,7 @@ module sui::safe_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = safe::TRANSFER_CAPABILITY_REVOKED)]
+    #[expected_failure(abort_code = safe::ETransferCapabilityRevoked)]
     /// Ensure that funds cannot be over withdrawn
     fun test_safe_withdraw_revoked() {
         let owner = TEST_OWNER_ADDR;
@@ -149,7 +149,7 @@ module sui::safe_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = safe::TRANSFER_CAPABILITY_REVOKED)]
+    #[expected_failure(abort_code = safe::ETransferCapabilityRevoked)]
     /// Ensure owner cannot withdraw funds after revoking itself.
     fun test_safe_withdraw_self_revoked() {
         let owner = TEST_OWNER_ADDR;

--- a/crates/sui-framework/tests/sui_system_tests.move
+++ b/crates/sui-framework/tests/sui_system_tests.move
@@ -41,7 +41,7 @@ module sui::sui_system_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = sui_system::ENOT_VALIDATOR)]
+    #[expected_failure(abort_code = sui_system::ENotValidator)]
     fun test_report_non_validator_failure() {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
@@ -52,7 +52,7 @@ module sui::sui_system_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = sui_system::ECANNOT_REPORT_ONESELF)]
+    #[expected_failure(abort_code = sui_system::ECannotReportOneself)]
     fun test_report_self_failure() {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
@@ -63,7 +63,7 @@ module sui::sui_system_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = sui_system::EREPORT_RECORD_NOT_FOUND)]
+    #[expected_failure(abort_code = sui_system::EReportRecordNotFound)]
     fun test_undo_report_failure() {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;

--- a/crates/sui-framework/tests/table_vec_tests.move
+++ b/crates/sui-framework/tests/table_vec_tests.move
@@ -27,7 +27,7 @@ module sui::table_vec_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = sui::table_vec::ETABLE_NONEMPTY)]
+    #[expected_failure(abort_code = sui::table_vec::ETableNonEmpty)]
     fun destroy_non_empty_aborts() {
         let scenario = ts::begin(TEST_SENDER_ADDR);
         let table_vec = table_vec::singleton(1, ts::ctx(&mut scenario));
@@ -36,7 +36,7 @@ module sui::table_vec_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = sui::table_vec::EINDEX_OUT_OF_BOUND)]
+    #[expected_failure(abort_code = sui::table_vec::EIndexOutOfBound)]
     fun pop_back_empty_aborts() {
         let scenario = ts::begin(TEST_SENDER_ADDR);
         let table_vec = table_vec::empty<u64>(ts::ctx(&mut scenario));
@@ -46,7 +46,7 @@ module sui::table_vec_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = sui::table_vec::EINDEX_OUT_OF_BOUND)]
+    #[expected_failure(abort_code = sui::table_vec::EIndexOutOfBound)]
     fun borrow_out_of_bounds_aborts() {
         let scenario = ts::begin(TEST_SENDER_ADDR);
         let table_vec = table_vec::singleton(1, ts::ctx(&mut scenario));
@@ -56,7 +56,7 @@ module sui::table_vec_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = sui::table_vec::EINDEX_OUT_OF_BOUND)]
+    #[expected_failure(abort_code = sui::table_vec::EIndexOutOfBound)]
     fun borrow_mut_out_of_bounds_aborts() {
         let scenario = ts::begin(TEST_SENDER_ADDR);
         let table_vec = table_vec::singleton(1, ts::ctx(&mut scenario));

--- a/crates/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/tests/test_scenario_tests.move
@@ -8,9 +8,9 @@ module sui::test_scenarioTests {
     use sui::transfer;
     use sui::tx_context;
 
-    const ID_BYTES_MISMATCH: u64 = 0;
-    const VALUE_MISMATCH: u64 = 1;
-    const OBJECT_ID_NOT_FOUND: u64 = 2;
+    const EIdBytesMismatch: u64 = 0;
+    const EValueMismatch: u64 = 1;
+    const EObjectIdNotFound: u64 = 2;
 
     struct Object has key, store {
         id: object::UID,
@@ -211,8 +211,8 @@ module sui::test_scenarioTests {
             assert!(ts::has_most_recent_for_sender<Object>(&scenario), 1);
             let received_obj = ts::take_from_sender<Object>(&mut scenario);
             let Object { id: received_id, value } = received_obj;
-            assert!(object::uid_to_inner(&received_id) == id_bytes, ID_BYTES_MISMATCH);
-            assert!(value == 100, VALUE_MISMATCH);
+            assert!(object::uid_to_inner(&received_id) == id_bytes, EIdBytesMismatch);
+            assert!(value == 100, EValueMismatch);
             object::delete(received_id);
         };
         // check that the object is no longer accessible after deletion
@@ -243,7 +243,7 @@ module sui::test_scenarioTests {
         };
         ts::next_tx(&mut scenario, sender);
         let ids = ts::ids_for_sender<Object>(&scenario);
-        assert!(ids == vector[id1, id2, id3], VALUE_MISMATCH);
+        assert!(ids == vector[id1, id2, id3], EValueMismatch);
         ts::end(scenario);
     }
 
@@ -270,9 +270,9 @@ module sui::test_scenarioTests {
             let obj1 = ts::take_from_sender_by_id<Object>(&mut scenario, id1);
             let obj3 = ts::take_from_sender_by_id<Object>(&mut scenario, id3);
             let obj2 = ts::take_from_sender_by_id<Object>(&mut scenario, id2);
-            assert!(obj1.value == 10, VALUE_MISMATCH);
-            assert!(obj2.value == 20, VALUE_MISMATCH);
-            assert!(obj3.value == 30, VALUE_MISMATCH);
+            assert!(obj1.value == 10, EValueMismatch);
+            assert!(obj2.value == 20, EValueMismatch);
+            assert!(obj3.value == 30, EValueMismatch);
             ts::return_to_sender(&mut scenario, obj1);
             ts::return_to_sender(&mut scenario, obj2);
             ts::return_to_sender(&mut scenario, obj3);
@@ -318,9 +318,9 @@ module sui::test_scenarioTests {
             let obj1 = ts::take_shared_by_id<Object>(&scenario, id1);
             let obj3 = ts::take_shared_by_id<Object>(&scenario, id3);
             let obj2 = ts::take_shared_by_id<Object>(&scenario, id2);
-            assert!(obj1.value == 10, VALUE_MISMATCH);
-            assert!(obj2.value == 20, VALUE_MISMATCH);
-            assert!(obj3.value == 30, VALUE_MISMATCH);
+            assert!(obj1.value == 10, EValueMismatch);
+            assert!(obj2.value == 20, EValueMismatch);
+            assert!(obj3.value == 30, EValueMismatch);
             ts::return_shared(obj1);
             ts::return_shared(obj2);
             ts::return_shared(obj3);
@@ -341,7 +341,7 @@ module sui::test_scenarioTests {
         {
             assert!(ts::has_most_recent_shared<Object>(), 1);
             let obj1 = ts::take_shared<Object>(&mut scenario);
-            assert!(obj1.value == 10, VALUE_MISMATCH);
+            assert!(obj1.value == 10, EValueMismatch);
             ts::return_shared(obj1);
         };
         ts::end(scenario);
@@ -370,9 +370,9 @@ module sui::test_scenarioTests {
             let obj1 = ts::take_immutable_by_id<Object>(&scenario, id1);
             let obj3 = ts::take_immutable_by_id<Object>(&scenario, id3);
             let obj2 = ts::take_immutable_by_id<Object>(&scenario, id2);
-            assert!(obj1.value == 10, VALUE_MISMATCH);
-            assert!(obj2.value == 20, VALUE_MISMATCH);
-            assert!(obj3.value == 30, VALUE_MISMATCH);
+            assert!(obj1.value == 10, EValueMismatch);
+            assert!(obj2.value == 20, EValueMismatch);
+            assert!(obj3.value == 30, EValueMismatch);
             ts::return_immutable(obj1);
             ts::return_immutable(obj2);
             ts::return_immutable(obj3);
@@ -393,7 +393,7 @@ module sui::test_scenarioTests {
         {
             assert!(ts::has_most_recent_immutable<Object>(), 1);
             let obj1 = ts::take_immutable<Object>(&mut scenario);
-            assert!(obj1.value == 10, VALUE_MISMATCH);
+            assert!(obj1.value == 10, EValueMismatch);
             ts::return_immutable(obj1);
         };
         ts::end(scenario);

--- a/crates/sui-framework/tests/url_tests.move
+++ b/crates/sui-framework/tests/url_tests.move
@@ -6,7 +6,7 @@ module sui::url_tests {
     use sui::url;
     use std::ascii::Self;
 
-    const URL_STRING_MISMATCH: u64 = 1;
+    const EUrlStringMismatch: u64 = 1;
 
     #[test]
     fun test_basic_url() {
@@ -14,6 +14,6 @@ module sui::url_tests {
         let url_str = ascii::string(x"414243454647");
 
         let url = url::new_unsafe(url_str);
-        assert!(url::inner_url(&url) == url_str, URL_STRING_MISMATCH);
+        assert!(url::inner_url(&url) == url_str, EUrlStringMismatch);
     }
 }


### PR DESCRIPTION
## Description 

Camel cases error code constants in framework [as per recommended style
](https://move-language.github.io/move/coding-conventions.html#naming)

## Test Plan 

`cargo test` / `move test` (semantics-preserving functionality, this is a rename)

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

Constants, like errors, are internal to Move modules _except_ when a Move test explicitly references it. In the rare or uncommon case where an external Move packages that users wrote contain tests that reference previous errors in upper case format (like `INVALID_OWNER_CAPABILITY`) they need to update the reference to the error-style camel case variant (like `EInvalidOwnerCapability`). So, this has an expected _low_ user-visible impact.

### Release notes

Framework error code constants now consistently follow [naming conventions](https://move-language.github.io/move/coding-conventions.html#naming): they are upper camel case and begin with an `E`. Constants are module-internal and typically not accessed by external modules, except when those constants are referenced in tests. In the rare event that your Move code references error code constants in SUI framework code like `INVALID_OWNER_CAPABILITY` you'll need to update the reference to the new name, like `EInvalidOwnerCapability`. The complete set of affected Move modules are: `sui::{stake, staking_pool, sui_system, validator_set, safe, table_vec}`.
