### PR TITLE
Improve validator shutdown test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4997,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=d9f001161fb8c8362c8644013bb7dc1572bbeb45#d9f001161fb8c8362c8644013bb7dc1572bbeb45"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=888a9dc4331b0ed944bd6e37bac982bbcf0625d5#888a9dc4331b0ed944bd6e37bac982bbcf0625d5"
 dependencies = [
  "ahash 0.7.6",
  "async-task",
@@ -5027,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=d9f001161fb8c8362c8644013bb7dc1572bbeb45#d9f001161fb8c8362c8644013bb7dc1572bbeb45"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=888a9dc4331b0ed944bd6e37bac982bbcf0625d5#888a9dc4331b0ed944bd6e37bac982bbcf0625d5"
 dependencies = [
  "darling",
  "proc-macro2 1.0.51",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1470,10 +1470,19 @@ impl AuthorityState {
         info!("current protocol version is now {:?}", current_version);
         info!("supported versions are: {:?}", supported_protocol_versions);
         if !supported_protocol_versions.is_version_supported(current_version) {
-            panic!(
-                "Unsupported protocol version. The network is at {:?}, but this SuiNode only supports: {:?}",
+            let msg = format!(
+                "Unsupported protocol version. The network is at {:?}, but this SuiNode only supports: {:?}. Shutting down.",
                 current_version, supported_protocol_versions,
             );
+
+            error!("{}", msg);
+            eprintln!("{}", msg);
+
+            #[cfg(not(msim))]
+            std::process::exit(1);
+
+            #[cfg(msim)]
+            sui_simulator::task::shutdown_current_node();
         }
     }
     // TODO: This function takes both committee and genesis as parameter.

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -38,7 +38,7 @@ use sui_types::{
 use tokio::time::timeout;
 use tracing::{info, warn};
 
-const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(10);
+const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(15);
 /// The maximum gas per transaction.
 pub const MAX_GAS: u64 = 2_000;
 

--- a/crates/sui-proc-macros/Cargo.toml
+++ b/crates/sui-proc-macros/Cargo.toml
@@ -16,4 +16,4 @@ syn = "1.0.104"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d9f001161fb8c8362c8644013bb7dc1572bbeb45", package = "msim-macros" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "888a9dc4331b0ed944bd6e37bac982bbcf0625d5", package = "msim-macros" }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -547,6 +547,9 @@ impl ProtocolConfig {
     pub fn set_max_function_definitions_for_testing(&mut self, m: usize) {
         self.max_function_definitions = Some(m)
     }
+    pub fn set_buffer_stake_for_protocol_upgrade_bps_for_testing(&mut self, b: u64) {
+        self.buffer_stake_for_protocol_upgrade_bps = Some(b)
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send;

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -21,4 +21,4 @@ telemetry-subscribers.workspace = true
 tower = "0.4.13"
 
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d9f001161fb8c8362c8644013bb7dc1572bbeb45", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "888a9dc4331b0ed944bd6e37bac982bbcf0625d5", package = "msim" }

--- a/crates/sui-swarm/src/memory/container-sim.rs
+++ b/crates/sui-swarm/src/memory/container-sim.rs
@@ -88,7 +88,10 @@ impl Container {
     ///
     pub fn is_alive(&self) -> bool {
         if let Some(cancel_sender) = &self.cancel_sender {
-            cancel_sender.receiver_count() > 0
+            // unless the node is deleted, it keeps a reference to its start up function, which
+            // keeps 1 receiver alive. If the node is actually running, the cloned receiver will
+            // also be alive, and receiver count will be 2.
+            cancel_sender.receiver_count() > 1
         } else {
             false
         }

--- a/crates/sui-swarm/src/memory/node.rs
+++ b/crates/sui-swarm/src/memory/node.rs
@@ -73,8 +73,7 @@ impl Node {
             .lock()
             .unwrap()
             .as_ref()
-            .map(|c| c.is_alive())
-            .unwrap_or(false)
+            .map_or(false, |c| c.is_alive())
     }
 
     /// Perform a health check on this Node by:

--- a/crates/sui-swarm/src/memory/node.rs
+++ b/crates/sui-swarm/src/memory/node.rs
@@ -20,7 +20,7 @@ use super::container::Container;
 #[derive(Debug)]
 pub struct Node {
     container: Mutex<Option<Container>>,
-    config: NodeConfig,
+    pub config: NodeConfig,
     runtime_type: RuntimeType,
 }
 
@@ -69,7 +69,12 @@ impl Node {
 
     /// If this Node is currently running
     pub fn is_running(&self) -> bool {
-        self.container.lock().unwrap().is_some()
+        self.container
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|c| c.is_alive())
+            .unwrap_or(false)
     }
 
     /// Perform a health check on this Node by:

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -54,6 +54,7 @@ fn test_protocol_overrides_2() {
 #[cfg(msim)]
 mod sim_only_tests {
 
+    use super::*;
     use std::sync::Arc;
     use sui_macros::*;
     use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
@@ -63,8 +64,7 @@ mod sim_only_tests {
 
     #[sim_test]
     async fn test_protocol_version_upgrade() {
-        telemetry_subscribers::init_for_testing();
-        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+        ProtocolConfig::poison_get_for_min_version();
 
         let test_cluster = TestClusterBuilder::new()
             .with_epoch_duration_ms(10000)
@@ -78,8 +78,12 @@ mod sim_only_tests {
 
     #[sim_test]
     async fn test_protocol_version_upgrade_one_laggard() {
-        telemetry_subscribers::init_for_testing();
-        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_buffer_stake_for_protocol_upgrade_bps_for_testing(0);
+            config
+        });
+
+        ProtocolConfig::poison_get_for_min_version();
 
         let test_cluster = TestClusterBuilder::new()
             .with_epoch_duration_ms(10000)
@@ -114,8 +118,7 @@ mod sim_only_tests {
 
     #[sim_test]
     async fn test_protocol_version_upgrade_no_quorum() {
-        telemetry_subscribers::init_for_testing();
-        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+        ProtocolConfig::poison_get_for_min_version();
 
         let test_cluster = TestClusterBuilder::new()
             .with_epoch_duration_ms(10000)

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -105,9 +105,9 @@ mod sim_only_tests {
                 .unwrap()
                 .is_version_supported(ProtocolVersion::new(2))
             {
-                assert!(!v.is_running());
+                assert!(!v.is_running(), "{:?}", v.name().concise());
             } else {
-                assert!(v.is_running());
+                assert!(v.is_running(), "{:?}", v.name().concise());
             }
         }
     }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -43,4 +43,4 @@ typed-store-derive = {path = "../typed-store-derive"}
 # Most packages should depend on sui-simulator instead of directly on msim, but for typed-store
 # that creates a circular dependency.
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d9f001161fb8c8362c8644013bb7dc1572bbeb45", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "888a9dc4331b0ed944bd6e37bac982bbcf0625d5", package = "msim" }

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -54,9 +54,9 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "d9f001161fb8c8362c8644013bb7dc1572bbeb45"'
+    --config 'patch.crates-io.tokio.rev = "888a9dc4331b0ed944bd6e37bac982bbcf0625d5"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "d9f001161fb8c8362c8644013bb7dc1572bbeb45"'
+    --config 'patch.crates-io.futures-timer.rev = "888a9dc4331b0ed944bd6e37bac982bbcf0625d5"'
   )
 fi
 


### PR DESCRIPTION
Instead of expecting a simple panic, we check that a validator that no longer supports the current protocol version shuts itself down.