### PR TITLE
[6/x][programmable transactions] Calculate effects

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -307,7 +307,7 @@ fn execute_internal<
         deletions,
         user_events,
         loaded_child_objects,
-    } = object_runtime.finish(by_value_objects)?;
+    } = object_runtime.finish(by_value_objects, BTreeSet::new())?;
     let session = new_session(
         vm,
         &*state_view,
@@ -1456,7 +1456,7 @@ fn struct_tag_equals_struct_inst(
         )
 }
 
-fn missing_unwrapped_msg(id: &ObjectID) -> String {
+pub fn missing_unwrapped_msg(id: &ObjectID) -> String {
     format!(
         "Unable to unwrap object {}. Was unable to retrieve last known version in the parent sync",
         id

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -3,23 +3,28 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
-    fmt,
+    fmt::{self},
     marker::PhantomData,
 };
 
-use move_binary_format::{errors::VMError, file_format::LocalIndex};
+use move_binary_format::{
+    errors::{Location, VMError},
+    file_format::LocalIndex,
+};
+use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use sui_cost_tables::bytecode_tables::GasStatus;
+use sui_framework::natives::object_runtime::{max_event_error, ObjectRuntime, RuntimeResults};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
-    base_types::{ObjectID, SuiAddress, TxContext},
+    base_types::{ObjectID, SequenceNumber, SuiAddress, TxContext},
     error::{ExecutionError, ExecutionErrorKind},
     messages::{Argument, CallArg, EntryArgumentErrorKind, ObjectArg},
-    object::{Object, Owner},
-    storage::Storage,
+    object::{MoveObject, Object, Owner},
+    storage::{ObjectChange, SingleTxContext, Storage, WriteKind},
 };
 
-use crate::adapter::new_session;
+use crate::adapter::{missing_unwrapped_msg, new_session};
 
 use super::types::*;
 
@@ -36,26 +41,34 @@ pub struct ExecutionContext<'vm, 'state, 'a, 'b, E: fmt::Debug, S: StorageView<E
     pub gas_status: &'a mut GasStatus<'b>,
     /// The session used for interacting with Move types and calls
     pub session: Session<'state, 'vm, S>,
-    /// Owner meta data for input objects,
-    _object_owner_map: BTreeMap<ObjectID, Owner>,
     /// Additional transfers not from the Move runtime
     additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
     /// Newly published packages
     new_packages: Vec<Object>,
+    /// User events are claimed after each Move call
+    user_events: Vec<(ModuleId, StructTag, Vec<u8>)>,
     // runtime data
     /// The runtime value for the Gas coin, None if it has been taken/moved
-    gas: Option<Value>,
+    gas: InputValue,
     /// The runtime value for the inputs/call args, None if it has been taken/moved
-    inputs: Vec<Option<Value>>,
+    inputs: Vec<InputValue>,
     /// The results of a given command. For most commands, the inner vector will have length 1.
     /// It will only not be 1 for Move calls with multiple return values.
     /// Inner values are None if taken/moved by-value
-    results: Vec<Vec<Option<Value>>>,
+    results: Vec<Vec<ResultValue>>,
     /// Map of arguments that are currently borrowed in this command, true if the borrow is mutable
     /// This gets cleared out when new results are pushed, i.e. the end of a command
     borrowed: HashMap<Argument, /* mut */ bool>,
     _e: PhantomData<E>,
 }
+
+pub type AdditionalWrite = (
+    /* recipient */ Owner,
+    StructTag,
+    /* has public transfer */ bool,
+    Vec<u8>,
+);
+
 impl<'vm, 'state, 'a, 'b, E, S> ExecutionContext<'vm, 'state, 'a, 'b, E, S>
 where
     E: fmt::Debug,
@@ -70,27 +83,21 @@ where
         gas_coin: ObjectID,
         inputs: Vec<CallArg>,
     ) -> Result<Self, ExecutionError> {
-        let mut _object_owner_map = BTreeMap::new();
+        let mut object_owner_map = BTreeMap::new();
         let inputs = inputs
             .into_iter()
-            .map(|call_arg| {
-                Ok(Some(load_call_arg(
-                    state_view,
-                    &mut _object_owner_map,
-                    call_arg,
-                )?))
-            })
+            .map(|call_arg| load_call_arg(state_view, &mut object_owner_map, call_arg))
             .collect::<Result<_, ExecutionError>>()?;
-        let gas = Some(Value::Object(load_object(
+        let gas = load_object(
             state_view,
-            &mut _object_owner_map,
-            None,
+            &mut object_owner_map,
+            /* imm override */ false,
             gas_coin,
-        )?));
+        )?;
         let session = new_session(
             vm,
             state_view,
-            _object_owner_map.clone(),
+            object_owner_map,
             gas_status.is_metered(),
             protocol_config,
         );
@@ -101,12 +108,12 @@ where
             tx_context,
             gas_status,
             session,
-            _object_owner_map,
             gas,
             inputs,
             results: vec![],
             additional_transfers: vec![],
             new_packages: vec![],
+            user_events: vec![],
             borrowed: HashMap::new(),
             _e: PhantomData,
         })
@@ -114,22 +121,50 @@ where
 
     /// Create a new ID and update the state
     pub fn fresh_id(&mut self) -> Result<ObjectID, ExecutionError> {
-        if true {
-            todo!("update native context set")
-        }
-        Ok(self.tx_context.fresh_id())
+        let object_id = self.tx_context.fresh_id();
+        let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+        object_runtime
+            .new_id(object_id)
+            .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))?;
+        Ok(object_id)
     }
 
     /// Delete an ID and update the state
-    pub fn delete_id(&mut self, _object_id: ObjectID) -> Result<(), ExecutionError> {
-        if true {
-            todo!("update native context set")
+    pub fn delete_id(&mut self, object_id: ObjectID) -> Result<(), ExecutionError> {
+        let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+        object_runtime
+            .delete_id(object_id)
+            .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
+    }
+
+    /// Takes the user events from the runtime and tags them with the Move module of function that
+    /// was invoked for the command
+    pub fn take_user_events(&mut self, module_id: &ModuleId) -> Result<(), ExecutionError> {
+        let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+        let events = object_runtime.take_user_events();
+        let num_events = self.user_events.len() + events.len();
+        let max_events = self.protocol_config.max_num_event_emit();
+        if num_events as u64 >= max_events {
+            let err = max_event_error(max_events).finish(Location::Module(module_id.clone()));
+            return Err(self.convert_vm_error(err));
         }
+        let new_events = events
+            .into_iter()
+            .map(|(tag, value)| {
+                let layout = self
+                    .session
+                    .get_type_layout(&TypeTag::Struct(Box::new(tag.clone())))?;
+                let bytes = value.simple_serialize(&layout).unwrap();
+                Ok((module_id.clone(), tag, bytes))
+            })
+            .collect::<Result<Vec<_>, VMError>>()
+            .map_err(|e| self.convert_vm_error(e))?;
+        self.user_events.extend(new_events);
         Ok(())
     }
 
     pub fn gas_is_taken(&self) -> bool {
-        self.gas.is_none()
+        self.gas.inner.value.is_none()
     }
 
     pub fn take_arg<V: TryFromValue>(
@@ -145,28 +180,31 @@ where
         if self.arg_is_borrowed(&arg) {
             panic!("taken borrowed value")
         }
-        let val_opt = self.borrow_mut(arg)?;
+        let (input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::Take)?;
         if val_opt.is_none() {
             panic!("taken value")
         }
-        let val = val_opt.take().unwrap();
-        if let Value::Object(obj) = &val {
-            if let Some(Owner::Shared { .. } | Owner::Immutable) = obj.owner {
-                let error = format!(
-                    "Immutable and shared objects cannot be passed by-value, \
+        if matches!(
+            input_metadata_opt,
+            Some(InputObjectMetadata {
+                owner: Owner::Immutable | Owner::Shared { .. },
+                ..
+            })
+        ) {
+            let error = format!(
+                "Immutable and shared objects cannot be passed by-value, \
                                 violation found in argument {}",
-                    arg_idx
-                );
-                return Err(ExecutionError::new_with_source(
-                    ExecutionErrorKind::entry_argument_error(
-                        arg_idx as LocalIndex,
-                        EntryArgumentErrorKind::InvalidObjectByValue,
-                    ),
-                    error,
-                ));
-            }
+                arg_idx
+            );
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::entry_argument_error(
+                    arg_idx as LocalIndex,
+                    EntryArgumentErrorKind::InvalidObjectByValue,
+                ),
+                error,
+            ));
         }
-        V::try_from_value(val)
+        V::try_from_value(val_opt.take().unwrap())
     }
 
     pub fn borrow_arg_mut<V: TryFromValue>(
@@ -178,27 +216,30 @@ where
             panic!("mutable args can only be used once in a given command")
         }
         self.borrowed.insert(arg, /* is_mut */ true);
-        let val_opt = self.borrow_mut(arg)?;
+        let (input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::BorrowMut)?;
         if val_opt.is_none() {
             panic!("taken value")
         }
-        let val = val_opt.take().unwrap();
-        if let Value::Object(obj) = &val {
-            if let Some(Owner::Immutable) = obj.owner {
-                let error = format!(
-                    "Argument {} is expected to be mutable, immutable object found",
-                    arg_idx
-                );
-                return Err(ExecutionError::new_with_source(
-                    ExecutionErrorKind::entry_argument_error(
-                        arg_idx as LocalIndex,
-                        EntryArgumentErrorKind::InvalidObjectByMuteRef,
-                    ),
-                    error,
-                ));
-            }
+        if matches!(
+            input_metadata_opt,
+            Some(InputObjectMetadata {
+                owner: Owner::Immutable,
+                ..
+            })
+        ) {
+            let error = format!(
+                "Argument {} is expected to be mutable, immutable object found",
+                arg_idx
+            );
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::entry_argument_error(
+                    arg_idx as LocalIndex,
+                    EntryArgumentErrorKind::InvalidObjectByMuteRef,
+                ),
+                error,
+            ));
         }
-        V::try_from_value(val)
+        V::try_from_value(val_opt.take().unwrap())
     }
 
     pub fn clone_arg<V: TryFromValue>(
@@ -209,7 +250,7 @@ where
         if self.arg_is_mut_borrowed(&arg) {
             panic!("mutable args can only be used once in a given command")
         }
-        let val_opt = self.borrow_mut(arg)?;
+        let (_input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::Clone)?;
         if val_opt.is_none() {
             panic!("taken value")
         }
@@ -226,7 +267,7 @@ where
             panic!("mutable args can only be used once in a given command")
         }
         self.borrowed.insert(arg, /* is_mut */ false);
-        let val_opt = self.borrow_mut(arg)?;
+        let (_input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::BorrowImm)?;
         if val_opt.is_none() {
             panic!("taken value")
         }
@@ -239,7 +280,9 @@ where
             "Should never restore a non-mut borrowed value. \
             The take+restore is an implementation detail of mutable references"
         );
-        let old_value = self.borrow_mut(arg)?.replace(value);
+        // restore is exclusively used for mut
+        let (_, value_opt) = self.borrow_mut(arg, UsageKind::BorrowMut)?;
+        let old_value = value_opt.replace(value);
         assert_invariant!(
             old_value.is_none(),
             "Should never restore a non-taken value. \
@@ -249,7 +292,7 @@ where
     }
 
     pub fn mark_used_in_non_entry_move_call(&mut self, arg: Argument) {
-        if let Ok(Some(val)) = self.borrow_mut(arg) {
+        if let Ok((_, Some(val))) = self.borrow_mut_impl(arg, /* do not update usage */ None) {
             match val {
                 Value::Object(obj) => obj.used_in_non_entry_move_call = true,
                 // nothing to do for raw, either it is pure bytes from input and there is nothing
@@ -259,66 +302,13 @@ where
         }
     }
 
-    pub fn push_command_results(&mut self, results: Vec<Value>) -> Result<(), ExecutionError> {
-        assert_invariant!(
-            self.borrowed.values().all(|is_mut| !is_mut),
-            "all mut borrows should be restored"
-        );
-        // clear borrow state
-        self.borrowed = HashMap::new();
-        self.results.push(results.into_iter().map(Some).collect());
-        Ok(())
-    }
-
-    fn arg_is_borrowed(&self, arg: &Argument) -> bool {
-        self.borrowed.contains_key(arg)
-    }
-
-    fn arg_is_mut_borrowed(&self, arg: &Argument) -> bool {
-        matches!(self.borrowed.get(arg), Some(/* mut */ true))
-    }
-
-    fn borrow_mut(&mut self, arg: Argument) -> Result<&mut Option<Value>, ExecutionError> {
-        Ok(match arg {
-            Argument::GasCoin => &mut self.gas,
-            Argument::Input(i) => {
-                let Some(inner_opt) = self.inputs.get_mut(i as usize) else {
-                    panic!("out of bounds")
-                };
-                inner_opt
-            }
-            Argument::Result(i) => {
-                let Some(command_result) = self.results.get_mut(i as usize) else {
-                    panic!("out of bounds")
-                };
-                if command_result.len() != 1 {
-                    panic!("expected a single result")
-                }
-                &mut command_result[0]
-            }
-            Argument::NestedResult(i, j) => {
-                let Some(command_result) = self.results.get_mut(i as usize) else {
-                    panic!("out of bounds")
-                };
-                let Some(inner_opt) = command_result.get_mut(j as usize) else {
-                    panic!("out of bounds")
-                };
-                inner_opt
-            }
-        })
-    }
-
     pub fn transfer_object(
         &mut self,
         obj: ObjectValue,
-        arg: SuiAddress,
+        addr: SuiAddress,
     ) -> Result<(), ExecutionError> {
-        self.additional_transfers.push((arg, obj));
+        self.additional_transfers.push((addr, obj));
         Ok(())
-    }
-
-    pub fn convert_vm_error(&self, error: VMError) -> ExecutionError {
-        sui_types::error::convert_vm_error(error, self.vm, self.state_view)
     }
 
     pub fn new_package(
@@ -334,40 +324,325 @@ where
         self.new_packages.push(package_object);
         Ok(())
     }
+
+    pub fn push_command_results(&mut self, results: Vec<Value>) -> Result<(), ExecutionError> {
+        assert_invariant!(
+            self.borrowed.values().all(|is_mut| !is_mut),
+            "all mut borrows should be restored"
+        );
+        // clear borrow state
+        self.borrowed = HashMap::new();
+        self.results
+            .push(results.into_iter().map(ResultValue::new).collect());
+        Ok(())
+    }
+
+    /// Determine the object changes and collect all user events
+    pub fn finish(self) -> Result<ExecutionResults, ExecutionError> {
+        use sui_types::error::convert_vm_error;
+        let Self {
+            protocol_config,
+            vm,
+            state_view,
+            tx_context,
+            gas_status,
+            session,
+            additional_transfers,
+            new_packages,
+            gas,
+            mut inputs,
+            results,
+            user_events,
+            ..
+        } = self;
+        let tx_digest = tx_context.digest();
+        let sender = tx_context.sender();
+        let mut additional_writes = BTreeMap::new();
+        let mut input_object_metadata = BTreeMap::new();
+        // check for unused inputs
+        // track by-ref input objects as being written
+        inputs.push(gas);
+        for input in inputs {
+            let InputValue {
+                object_metadata: object_metadata_opt,
+                inner:
+                    ResultValue {
+                        last_usage_kind,
+                        value,
+                    },
+            } = input;
+            if last_usage_kind.is_none() {
+                panic!("unused input")
+            }
+            let Some(object_metadata) = object_metadata_opt else { continue };
+            let Some(Value::Object(object_value)) = value else { continue };
+            if object_metadata.is_mutable_input {
+                add_additional_write(&mut additional_writes, object_metadata.owner, object_value);
+            }
+            input_object_metadata.insert(object_metadata.id, object_metadata);
+        }
+        // check for unused values
+        for (i, command_result) in results.iter().enumerate() {
+            for (j, result_value) in command_result.iter().enumerate() {
+                let ResultValue {
+                    last_usage_kind,
+                    value,
+                } = result_value;
+                match value {
+                    None => (),
+                    Some(Value::Object(_)) => panic!("unused value without drop {i} {j}"),
+                    Some(Value::Raw(ValueType::Any, _)) => (),
+                    Some(Value::Raw(ValueType::Loaded { abilities, .. }, _)) => {
+                        // - nothing to check for drop
+                        // - if it does not have drop, but has copy,
+                        //   the last usage must be a take/clone in order to "lie" and say that the
+                        //   last usage is actually a take instead of a clone
+                        // - Otherwise, an error
+                        if abilities.has_drop() {
+                        } else if abilities.has_copy()
+                            && !matches!(last_usage_kind, Some(UsageKind::Take | UsageKind::Clone))
+                        {
+                            panic!("unused value without drop {i} {j}")
+                        }
+                    }
+                }
+            }
+        }
+        // add transfers from TransferObjects command
+        for (recipient, object_value) in additional_transfers {
+            let owner = Owner::AddressOwner(recipient);
+            add_additional_write(&mut additional_writes, owner, object_value)
+        }
+
+        let (change_set, events, mut native_context_extensions) = session
+            .finish_with_extensions()
+            .map_err(|e| convert_vm_error(e, vm, state_view))?;
+        // Sui Move programs should never touch global state, so ChangeSet should be empty
+        assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
+        // Sui Move no longer uses Move's internal event system
+        assert_invariant!(events.is_empty(), "Events must be empty");
+        let object_runtime: ObjectRuntime = native_context_extensions.remove();
+        let new_ids = object_runtime.new_ids().clone();
+        // tell the object runtime what input objects were taken and which were transferred
+        let by_value_inputs = input_object_metadata
+            .keys()
+            .copied()
+            .filter(|id| !additional_writes.contains_key(id))
+            .collect();
+        let external_transfers = additional_writes.keys().copied().collect();
+        let RuntimeResults {
+            writes,
+            deletions,
+            user_events: remaining_events,
+            loaded_child_objects,
+        } = object_runtime.finish(by_value_inputs, external_transfers)?;
+        assert_invariant!(
+            remaining_events.is_empty(),
+            "Events should be taken after every Move call"
+        );
+        // todo remove this when system events are removed
+        let dummy_event_ctx = SingleTxContext::unused_input(sender);
+        let mut object_changes = BTreeMap::new();
+        for package in new_packages {
+            let id = package.id();
+            let change =
+                ObjectChange::Write(SingleTxContext::publish(sender), package, WriteKind::Create);
+            object_changes.insert(id, change);
+        }
+        for (id, (recipient, tag, has_public_transfer, contents)) in additional_writes {
+            let write_kind = if input_object_metadata.contains_key(&id)
+                || loaded_child_objects.contains_key(&id)
+            {
+                assert_invariant!(
+                    !new_ids.contains_key(&id),
+                    "new id should not be in mutations"
+                );
+                WriteKind::Mutate
+            } else if new_ids.contains_key(&id) {
+                WriteKind::Create
+            } else {
+                WriteKind::Unwrap
+            };
+            let move_object = create_written_object(
+                protocol_config,
+                &input_object_metadata,
+                &loaded_child_objects,
+                id,
+                tag,
+                has_public_transfer,
+                contents,
+                write_kind,
+            )?;
+            let object = Object::new_move(move_object, recipient, tx_digest);
+            let change = ObjectChange::Write(dummy_event_ctx.clone(), object, write_kind);
+            object_changes.insert(id, change);
+        }
+
+        // we need a new session just for deserializing and fetching abilities. Which is sad
+        let tmp_session = new_session(
+            vm,
+            state_view,
+            BTreeMap::new(),
+            gas_status.is_metered(),
+            protocol_config,
+        );
+        for (id, (write_kind, recipient, ty, tag, value)) in writes {
+            let abilities = tmp_session
+                .get_type_abilities(&ty)
+                .map_err(|e| convert_vm_error(e, vm, state_view))?;
+            let has_public_transfer = abilities.has_store();
+            let layout = tmp_session
+                .get_type_layout(&TypeTag::Struct(Box::new(tag.clone())))
+                .map_err(|e| convert_vm_error(e, vm, state_view))?;
+            let bytes = value.simple_serialize(&layout).unwrap();
+            let move_object = create_written_object(
+                protocol_config,
+                &input_object_metadata,
+                &loaded_child_objects,
+                id,
+                tag,
+                has_public_transfer,
+                bytes,
+                write_kind,
+            )?;
+            let object = Object::new_move(move_object, recipient, tx_digest);
+            let change = ObjectChange::Write(dummy_event_ctx.clone(), object, write_kind);
+            object_changes.insert(id, change);
+        }
+        for (id, delete_kind) in deletions {
+            let version = match input_object_metadata.get(&id) {
+                Some(metadata) => metadata.version,
+                None => match state_view.get_latest_parent_entry_ref(id) {
+                    Ok(Some((_, previous_version, _))) => previous_version,
+                    // This object was not created this transaction but has never existed in
+                    // storage, skip it.
+                    Ok(None) => continue,
+                    Err(_) => invariant_violation!(missing_unwrapped_msg(&id)),
+                },
+            };
+            object_changes.insert(
+                id,
+                ObjectChange::Delete(dummy_event_ctx.clone(), version, delete_kind),
+            );
+        }
+        let (change_set, move_events) = tmp_session
+            .finish()
+            .map_err(|e| convert_vm_error(e, vm, state_view))?;
+        // the session was just used for ability and layout metadata fetching, no changes should
+        // exist. Plus, Sui Move does not use these changes or events
+        assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
+        assert_invariant!(move_events.is_empty(), "Events must be empty");
+
+        Ok(ExecutionResults {
+            object_changes,
+            user_events,
+        })
+    }
+
+    pub fn convert_vm_error(&self, error: VMError) -> ExecutionError {
+        sui_types::error::convert_vm_error(error, self.vm, self.state_view)
+    }
+
+    fn arg_is_borrowed(&self, arg: &Argument) -> bool {
+        self.borrowed.contains_key(arg)
+    }
+
+    fn arg_is_mut_borrowed(&self, arg: &Argument) -> bool {
+        matches!(self.borrowed.get(arg), Some(/* mut */ true))
+    }
+
+    fn borrow_mut(
+        &mut self,
+        arg: Argument,
+        usage: UsageKind,
+    ) -> Result<(Option<&InputObjectMetadata>, &mut Option<Value>), ExecutionError> {
+        self.borrow_mut_impl(arg, Some(usage))
+    }
+
+    fn borrow_mut_impl(
+        &mut self,
+        arg: Argument,
+        update_last_usage: Option<UsageKind>,
+    ) -> Result<(Option<&InputObjectMetadata>, &mut Option<Value>), ExecutionError> {
+        let (metadata, result_value) = match arg {
+            Argument::GasCoin => (self.gas.object_metadata.as_ref(), &mut self.gas.inner),
+            Argument::Input(i) => {
+                let Some(input_value) = self.inputs.get_mut(i as usize) else {
+                    panic!("out of bounds")
+                };
+                (input_value.object_metadata.as_ref(), &mut input_value.inner)
+            }
+            Argument::Result(i) => {
+                let Some(command_result) = self.results.get_mut(i as usize) else {
+                    panic!("out of bounds")
+                };
+                if command_result.len() != 1 {
+                    panic!("expected a single result")
+                }
+                (None, &mut command_result[0])
+            }
+            Argument::NestedResult(i, j) => {
+                let Some(command_result) = self.results.get_mut(i as usize) else {
+                    panic!("out of bounds")
+                };
+                let Some(result_value) = command_result.get_mut(j as usize) else {
+                    panic!("out of bounds")
+                };
+                (None, result_value)
+            }
+        };
+        if let Some(usage) = update_last_usage {
+            result_value.last_usage_kind = Some(usage);
+        }
+        Ok((metadata, &mut result_value.value))
+    }
 }
 
 fn load_object<S: Storage>(
     state_view: &S,
     object_owner_map: &mut BTreeMap<ObjectID, Owner>,
-    // used for masking the owner, specifically in the case where a shared object is read-only and
-    // acts like an immutable object
-    owner_override: Option<Owner>,
+    override_as_immutable: bool,
     id: ObjectID,
-) -> Result<ObjectValue, ExecutionError> {
+) -> Result<InputValue, ExecutionError> {
     let Some(obj) = state_view.read_object(&id) else {
         // protected by transaction input checker
         invariant_violation!(format!("Object {} does not exist yet", id));
     };
-    let owner = owner_override.unwrap_or(obj.owner);
-    let prev = object_owner_map.insert(id, owner);
+    // override_as_immutable ==> Owner::Shared
+    assert_invariant!(
+        !override_as_immutable || matches!(obj.owner, Owner::Shared { .. }),
+        "override_as_immutable should only be set for shared objects"
+    );
+    let is_mutable_input = match obj.owner {
+        Owner::AddressOwner(_) => true,
+        Owner::Shared { .. } => !override_as_immutable,
+        Owner::Immutable => false,
+        Owner::ObjectOwner(_) => {
+            // protected by transaction input checker
+            invariant_violation!("ObjectOwner objects cannot be input")
+        }
+    };
+    let object_metadata = InputObjectMetadata {
+        id,
+        is_mutable_input,
+        owner: obj.owner,
+        version: obj.version(),
+    };
+    let prev = object_owner_map.insert(id, obj.owner);
     // protected by transaction input checker
     assert_invariant!(prev.is_none(), format!("Duplicate input object {}", id));
-    let mut obj_value = ObjectValue::from_object(obj)?;
-    // propagate override
-    obj_value.owner = Some(owner);
-    Ok(obj_value)
+    let obj_value = ObjectValue::from_object(obj)?;
+    Ok(InputValue::new_object(object_metadata, obj_value))
 }
 
 fn load_call_arg<S: Storage>(
     state_view: &S,
     object_owner_map: &mut BTreeMap<ObjectID, Owner>,
     call_arg: CallArg,
-) -> Result<Value, ExecutionError> {
+) -> Result<InputValue, ExecutionError> {
     Ok(match call_arg {
-        CallArg::Pure(bytes) => Value::Raw(ValueType::Any, bytes),
-        CallArg::Object(obj_arg) => {
-            Value::Object(load_object_arg(state_view, object_owner_map, obj_arg)?)
-        }
+        CallArg::Pure(bytes) => InputValue::new_raw(ValueType::Any, bytes),
+        CallArg::Object(obj_arg) => load_object_arg(state_view, object_owner_map, obj_arg)?,
         CallArg::ObjVec(_) => {
             // protected by transaction input checker
             invariant_violation!("ObjVec is not supported in programmable transactions")
@@ -379,14 +654,82 @@ fn load_object_arg<S: Storage>(
     state_view: &S,
     object_owner_map: &mut BTreeMap<ObjectID, Owner>,
     obj_arg: ObjectArg,
-) -> Result<ObjectValue, ExecutionError> {
+) -> Result<InputValue, ExecutionError> {
     match obj_arg {
         ObjectArg::ImmOrOwnedObject((id, _, _))
         | ObjectArg::SharedObject {
             id, mutable: true, ..
-        } => load_object(state_view, object_owner_map, None, id),
+        } => load_object(
+            state_view,
+            object_owner_map,
+            /* imm override */ false,
+            id,
+        ),
         ObjectArg::SharedObject {
             id, mutable: false, ..
-        } => load_object(state_view, object_owner_map, Some(Owner::Immutable), id),
+        } => load_object(
+            state_view,
+            object_owner_map,
+            /* imm override */ true,
+            id,
+        ),
+    }
+}
+
+fn add_additional_write(
+    additional_writes: &mut BTreeMap<ObjectID, AdditionalWrite>,
+    owner: Owner,
+    object_value: ObjectValue,
+) {
+    let ObjectValue {
+        type_,
+        has_public_transfer,
+        contents,
+        ..
+    } = object_value;
+    let bytes = match contents {
+        ObjectContents::Coin(coin) => coin.to_bcs_bytes(),
+        ObjectContents::Raw(bytes) => bytes,
+    };
+    let object_id = MoveObject::id_opt(&bytes).unwrap();
+    additional_writes.insert(object_id, (owner, type_, has_public_transfer, bytes));
+}
+
+fn create_written_object(
+    protocol_config: &ProtocolConfig,
+    input_object_metadata: &BTreeMap<ObjectID, InputObjectMetadata>,
+    loaded_child_objects: &BTreeMap<ObjectID, SequenceNumber>,
+    id: ObjectID,
+    tag: StructTag,
+    has_public_transfer: bool,
+    contents: Vec<u8>,
+    write_kind: WriteKind,
+) -> Result<MoveObject, ExecutionError> {
+    debug_assert_eq!(
+        id,
+        MoveObject::id_opt(&contents).expect("object contents should start with an id")
+    );
+    let metadata_opt = input_object_metadata.get(&id);
+    let loaded_child_version_opt = loaded_child_objects.get(&id);
+    assert_invariant!(
+        metadata_opt.is_none() || loaded_child_version_opt.is_none(),
+        format!("Loaded {id} as a child, but that object was an input object")
+    );
+
+    let old_obj_ver = metadata_opt
+        .map(|metadata| metadata.version)
+        .or_else(|| loaded_child_version_opt.copied());
+
+    debug_assert!((write_kind == WriteKind::Mutate) == old_obj_ver.is_some());
+
+    // safe because `has_public_transfer` was properly determined from the abilities
+    unsafe {
+        MoveObject::new_from_execution(
+            tag,
+            has_public_transfer,
+            old_obj_ver.unwrap_or_else(SequenceNumber::new),
+            contents,
+            protocol_config,
+        )
     }
 }

--- a/crates/sui-framework/src/natives/test_scenario.rs
+++ b/crates/sui-framework/src/natives/test_scenario.rs
@@ -70,7 +70,7 @@ pub fn end_transaction(
     let object_runtime_state = object_runtime_ref.take_state();
     // Determine writes and deletes
     // We pass an empty map as we do not expose dynamic field objects in the system
-    let results = object_runtime_state.finish(BTreeSet::new(), BTreeMap::new());
+    let results = object_runtime_state.finish(BTreeSet::new(), BTreeSet::new(), BTreeMap::new());
     let RuntimeResults {
         writes,
         deletions,


### PR DESCRIPTION
- Adds the final bit of execution for determining the object changes and collecting the user events

## Description 

This replicates the work currently done by the Move adapter, but will apply to _all_ commands. Which in the future might call for a cleanup of the TemporaryAuthorityStore 

## Test Plan 

Not yet visible or usable

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
