### PR TITLE
[TypeScript SDK] Fix TS definition for MoveCall

### DIFF
--- a/.changeset/tender-hairs-drum.md
+++ b/.changeset/tender-hairs-drum.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Make arguments field optional for MoveCall to match Rust definition. This fixes a bug where the Explorer page does not load for transactions with no argument.

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -10,7 +10,6 @@ import {
     getTransferObjectTransaction,
     getTransactionSignature,
     getMovePackageContent,
-    getObjectId,
     SUI_TYPE_ARG,
     getExecutionStatusType,
     getTotalGasUsed,
@@ -118,12 +117,7 @@ function formatByTransactionKind(
                     category: 'address',
                 },
                 package: {
-                    // TODO: Simplify after v0.24.0 launched everywhere, when
-                    // moveCall.package is always an ObjectID (a string)
-                    value:
-                        typeof moveCall.package === 'string'
-                            ? moveCall.package
-                            : getObjectId(moveCall.package),
+                    value: moveCall.package,
                     link: true,
                     category: 'object',
                 },
@@ -394,7 +388,9 @@ function TransactionView({
                       {
                           label: 'Argument',
                           monotypeClass: true,
-                          value: JSON.stringify(txKindData.arguments.value),
+                          value: JSON.stringify(
+                              txKindData.arguments.value ?? []
+                          ),
                       },
                   ],
               }

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -450,15 +450,10 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
         },
       };
     } else if ('Call' in tx) {
-      const packageObjectId =
-        typeof tx.Call.package === 'string'
-          ? tx.Call.package
-          : tx.Call.package.objectId;
-
       return {
         kind: 'moveCall',
         data: {
-          packageObjectId,
+          packageObjectId: tx.Call.package,
           module: tx.Call.module,
           function: tx.Call.function,
           typeArguments: tx.Call.typeArguments,

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -194,9 +194,7 @@ export type TypeTag =
  */
 export type MoveCallTx = {
   Call: {
-    // TODO: restrict to just `string` once 0.24.0 is deployed in
-    // devnet and testnet
-    package: string | SuiObjectRef;
+    package: string;
     module: string;
     function: string;
     typeArguments: TypeTag[];

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -78,12 +78,11 @@ export const PayAllSui = object({
 export type PayAllSui = Infer<typeof PayAllSui>;
 
 export const MoveCall = object({
-  // TODO: Simplify once 0.24.0 lands
-  package: union([string(), SuiObjectRef]),
+  package: string(),
   module: string(),
   function: string(),
   typeArguments: optional(array(string())),
-  arguments: array(SuiJsonValue),
+  arguments: optional(array(SuiJsonValue)),
 });
 export type MoveCall = Infer<typeof MoveCall>;
 


### PR DESCRIPTION
## Description 

We received a user reported bug that https://explorer.sui.io/transaction/BRL4LcY8hHytehMBPkNezXHQP2VNyG8pcWwzAGb16J9b is not loading correctly.

This is because there's some mismatch between rust types and ts definition:
- in rust, the arguments field can be optional if the vector is empty: https://github.com/MystenLabs/sui/blame/main/crates/sui-json-rpc-types/src/lib.rs#L1809-L1810
- in TS, the argument field is not optional: https://github.com/MystenLabs/sui/blob/main/sdk/typescript/src/types/transactions.ts#L86

## Test Plan 

Verify that the transaction is loading correctly in preview: https://explorer-git-fix-movecall-def-mysten-labs.vercel.app/transaction/BRL4LcY8hHytehMBPkNezXHQP2VNyG8pcWwzAGb16J9b

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Make `arguments` field optional for MoveCall to match Rust definition. This fixes a bug where the Explorer page does not load for transactions with no argument.
