### PR TITLE
[ts-sdk] - JsonRpcProvider assign options in constructor

### DIFF
--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -135,6 +135,7 @@ export class JsonRpcProvider extends Provider {
     this.connection = connection;
 
     const opts = { ...DEFAULT_OPTIONS, ...options };
+    this.options = opts;
     // TODO: add header for websocket request
     this.client = opts.rpcClient ?? new JsonRpcClient(this.connection.fullnode);
 


### PR DESCRIPTION
## Description 

Related to: https://github.com/MystenLabs/sui/pull/8605

While looking into issues with explorer transactions, I noticed we never re-assign merged options in the `JsonRpcProvider` constructor. 

So with latest Sentry changes, we override the default options to pass in a custom RPC client and lose the default `skipDataValidation = true` settings, which causes `undefined` to be passed into `requestWithType`, which falls back to `skipDataValidation = false`. This causes an error to be thrown instead of the previous behavior of printing a warning

## Test Plan 

The previous behavior was to print a warning to the console instead of throwing an error in the case of a Rust/TS type mismatch. You can verify this by going to a problematic transaction and confirming that the transaction loads with a warning in the console. 

https://explorer-git-mamos-explorer-broken-transaction-mysten-labs.vercel.app/transaction/BRL4LcY8hHytehMBPkNezXHQP2VNyG8pcWwzAGb16J9b

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
