### PR TITLE
Update default config values for timestamp and narwhal params

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -283,6 +283,7 @@ pub struct GenesisValidatorInfo {
 /// Initial set of parameters for a chain.
 #[derive(Serialize, Deserialize)]
 pub struct GenesisChainParameters {
+    #[serde(default = "GenesisChainParameters::default_timestamp_ms")]
     pub timestamp_ms: u64,
 
     /// protocol version that the chain starts at.
@@ -294,12 +295,16 @@ pub struct GenesisChainParameters {
 impl GenesisChainParameters {
     pub fn new() -> Self {
         Self {
-            timestamp_ms: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64,
+            timestamp_ms: Self::default_timestamp_ms(),
             protocol_version: ProtocolVersion::MAX,
         }
+    }
+
+    fn default_timestamp_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
     }
 }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -350,6 +350,10 @@ impl AuthorityPerEpochStore {
         let epoch_start_configuration =
             if let Some(epoch_start_configuration) = epoch_start_configuration {
                 assert_eq!(epoch_start_configuration.epoch_id(), epoch_id);
+                debug!(
+                    "Epoch start configuration provided for epoch {}",
+                    epoch_start_configuration.epoch_id()
+                );
                 tables
                     .epoch_start_configuration
                     .insert(&(), &epoch_start_configuration)
@@ -359,6 +363,10 @@ impl AuthorityPerEpochStore {
                 assert!(
                     epoch_id > 0,
                     "epoch_start_configuration should be provided for epoch 0"
+                );
+                debug!(
+                    "Epoch start configuration not provided for epoch {}",
+                    epoch_id
                 );
                 tables
                     .epoch_start_configuration

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -67,7 +67,9 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         let checkpoint_seq = summary.sequence_number;
         let checkpoint_timestamp = summary.timestamp_ms;
         debug!(
-            "Sending checkpoint signature at sequence {checkpoint_seq} to consensus, timestamp {checkpoint_timestamp}"
+            "Sending checkpoint signature at sequence {checkpoint_seq} to consensus, timestamp {checkpoint_timestamp}. 
+            {}ms left till end of epoch at timestamp {}",
+            self.next_reconfiguration_timestamp_ms - checkpoint_timestamp, self.next_reconfiguration_timestamp_ms 
         );
         LogCheckpointOutput
             .checkpoint_created(summary, contents, epoch_store)

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -69,7 +69,7 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         debug!(
             "Sending checkpoint signature at sequence {checkpoint_seq} to consensus, timestamp {checkpoint_timestamp}. 
             {}ms left till end of epoch at timestamp {}",
-            self.next_reconfiguration_timestamp_ms - checkpoint_timestamp, self.next_reconfiguration_timestamp_ms 
+            self.next_reconfiguration_timestamp_ms - checkpoint_timestamp, self.next_reconfiguration_timestamp_ms
         );
         LogCheckpointOutput
             .checkpoint_created(summary, contents, epoch_store)

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -39,6 +39,7 @@ use sui_json_rpc::{JsonRpcServerBuilder, ServerHandle};
 use sui_network::api::ValidatorServer;
 use sui_network::discovery;
 use sui_network::{state_sync, DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_HTTP2_KEEPALIVE_SEC};
+use tracing::debug;
 
 use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 
@@ -601,6 +602,15 @@ impl SuiNode {
         accumulator: Arc<StateAccumulator>,
         checkpoint_metrics: Arc<CheckpointMetrics>,
     ) -> (Arc<CheckpointService>, watch::Sender<()>) {
+        debug!(
+            "Starting checkpoint service with epoch start timestamp {}
+            and epoch duration {}",
+            epoch_store
+                .epoch_start_configuration()
+                .epoch_start_timestamp_ms(),
+            config.epoch_duration_ms
+        );
+
         let checkpoint_output = Box::new(SubmitCheckpointToConsensus {
             sender: consensus_adapter,
             signer: state.secret.clone(),

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -135,29 +135,43 @@ pub struct Parameters {
     pub min_header_delay: Duration,
 
     /// The depth of the garbage collection (Denominated in number of rounds).
+    #[serde(default = "Parameters::default_gc_depth")]
     pub gc_depth: u64,
     /// The delay after which the synchronizer retries to send sync requests. Denominated in ms.
-    #[serde(with = "duration_format")]
+    #[serde(
+        with = "duration_format",
+        default = "Parameters::default_sync_retry_delay"
+    )]
     pub sync_retry_delay: Duration,
     /// Determine with how many nodes to sync when re-trying to send sync-request. These nodes
     /// are picked at random from the committee.
+    #[serde(default = "Parameters::default_sync_retry_nodes")]
     pub sync_retry_nodes: usize,
     /// The preferred batch size. The workers seal a batch of transactions when it reaches this size.
     /// Denominated in bytes.
+    #[serde(default = "Parameters::default_batch_size")]
     pub batch_size: usize,
     /// The delay after which the workers seal a batch of transactions, even if `max_batch_size`
     /// is not reached.
-    #[serde(with = "duration_format")]
+    #[serde(
+        with = "duration_format",
+        default = "Parameters::default_max_batch_delay"
+    )]
     pub max_batch_delay: Duration,
     /// The parameters for the block synchronizer
+    #[serde(default = "BlockSynchronizerParameters::default")]
     pub block_synchronizer: BlockSynchronizerParameters,
     /// The parameters for the Consensus API gRPC server
+    #[serde(default = "ConsensusAPIGrpcParameters::default")]
     pub consensus_api_grpc: ConsensusAPIGrpcParameters,
     /// The maximum number of concurrent requests for messages accepted from an un-trusted entity
+    #[serde(default = "Parameters::default_max_concurrent_requests")]
     pub max_concurrent_requests: usize,
     /// Properties for the prometheus metrics
+    #[serde(default = "PrometheusMetricsParameters::default")]
     pub prometheus_metrics: PrometheusMetricsParameters,
     /// Network admin server ports for primary & worker.
+    #[serde(default = "NetworkAdminServerParameters::default")]
     pub network_admin_server: NetworkAdminServerParameters,
     /// Anemo network settings.
     #[serde(default = "AnemoParameters::default")]


### PR DESCRIPTION
## Description 

Added additional logging for epoch duration/timestamp. And providing a default value for `timestamp_ms` and updated defaults for nw params. This will fix our deployments that were setting this value to 0 in configs and triggering an instant epoch change from 0 -> 1. Will follow up with an update to sui-ops repo to remove setting of `timestamp_ms` value in configs.

## Test Plan 

Confirmed epoch 0 duration in deployment in [labnet](https://mysten.grafana.net/d/H9fvUo24z/sui-epoch-metrics?orgId=1&var-Environment=mysten-metrics-internal&var-network=labnet&from=now-1h&to=now)
