### PR TITLE
[Narwhal] suspend certificates with missing parents

### DIFF
--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -436,7 +436,7 @@ async fn process_certificates_helper(
         let certificates = task.await.map_err(|_| DagError::Canceled)??;
         for cert in certificates {
             match synchronizer
-                .try_accept_sanitized_certificate(cert, network)
+                .try_accept_fetched_certificate(cert, network)
                 .await
             {
                 Ok(()) => continue,

--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -435,16 +435,14 @@ async fn process_certificates_helper(
     for task in verify_tasks {
         let certificates = task.await.map_err(|_| DagError::Canceled)??;
         for cert in certificates {
-            match synchronizer
+            if let Err(e) = synchronizer
                 .try_accept_fetched_certificate(cert, network)
                 .await
             {
-                Ok(()) => continue,
-                // It is possible that subsequent certificates are above GC round,
+                // It is possible that subsequent certificates are useful,
                 // so not stopping early.
-                Err(DagError::TooOld(_, _, _)) => continue,
-                result => return result,
-            };
+                warn!("Failed to accept fetched certificate: {e}");
+            }
         }
     }
 

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -300,6 +300,8 @@ pub struct PrimaryMetrics {
     pub certificates_processed: IntCounterVec,
     /// count number of certificates that the node suspended their processing
     pub certificates_suspended: IntCounterVec,
+    /// number of certificates that are currently suspended.
+    pub certificates_currently_suspended: IntGauge,
     /// count number of duplicate certificates that the node processed (others + own)
     pub duplicate_certificates_processed: IntCounter,
     /// Latency to perform a garbage collection in core module
@@ -391,6 +393,12 @@ impl PrimaryMetrics {
                 "certificates_suspended",
                 "Number of certificates that node suspended processing of",
                 &["reason"],
+                registry
+            )
+            .unwrap(),
+            certificates_currently_suspended: register_int_gauge_with_registry!(
+                "certificates_currently_suspended",
+                "Number of certificates that are suspended in memory",
                 registry
             )
             .unwrap(),

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -259,9 +259,10 @@ async fn fetch_certificates_basic() {
     // Send a primary message for a certificate with parents that do not exist locally, to trigger fetching.
     let target_index = 123;
     assert!(!synchronizer
-        .check_parents(&certificates[target_index].clone())
+        .get_missing_parents(&certificates[target_index].clone())
         .await
-        .unwrap());
+        .unwrap()
+        .is_empty());
 
     // Verify the fetch request.
     let mut req = rx_fetch_req.recv().await.unwrap();

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -352,7 +352,6 @@ async fn test_request_vote_send_missing_parents() {
     let (certificates, _next_parents) =
         make_optimal_signed_certificates(1..=3, &genesis, &committee, keys.as_slice());
     let all_certificates = certificates.into_iter().collect_vec();
-    let _round_1_certs = all_certificates[..NUM_PARENTS].to_vec();
     let round_2_certs = all_certificates[NUM_PARENTS..(NUM_PARENTS * 2)].to_vec();
     let round_2_parents = round_2_certs[..(NUM_PARENTS / 2)].to_vec();
     let round_2_missing = round_2_certs[(NUM_PARENTS / 2)..].to_vec();
@@ -368,9 +367,8 @@ async fn test_request_vote_send_missing_parents() {
         .unwrap();
 
     // Write some certificates from round 2 into the store, and leave out the rest to test
-    // headers with some parents but not all available. All round 1 certificates should be written
-    // into the storage as well as parents of round 2 certificates. But to test phase 2 they are
-    // left out for now.
+    // headers with some parents but not all available. Round 1 certificates should be written
+    // into the storage as parents of round 2 certificates. But to test phase 2 they are left out.
     for cert in round_2_parents {
         for (digest, (worker_id, _)) in &cert.header.payload {
             payload_store.async_write((*digest, *worker_id), 1).await;

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -289,7 +289,152 @@ async fn get_network_peers_from_admin_server() {
 }
 
 #[tokio::test]
-async fn test_request_vote_missing_parents() {
+async fn test_request_vote_send_missing_parents() {
+    telemetry_subscribers::init_for_testing();
+    const NUM_PARENTS: usize = 10;
+    let fixture = CommitteeFixture::builder()
+        .randomize_ports(true)
+        .committee_size(NonZeroUsize::new(NUM_PARENTS).unwrap())
+        .build();
+    let target = fixture.authorities().next().unwrap();
+    let author = fixture.authorities().nth(2).unwrap();
+    let target_name = target.public_key();
+    let author_name = author.public_key();
+    let worker_cache = fixture.shared_worker_cache();
+    let signature_service = SignatureService::new(target.keypair().copy());
+    let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
+    let network = test_utils::test_network(target.network_keypair(), target.address());
+
+    let (header_store, certificate_store, payload_store) = create_db_stores();
+    let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
+    let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
+    let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
+    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
+
+    let synchronizer = Arc::new(Synchronizer::new(
+        target_name.clone(),
+        fixture.committee(),
+        worker_cache.clone(),
+        /* gc_depth */ 50,
+        certificate_store.clone(),
+        payload_store.clone(),
+        tx_certificate_fetcher,
+        tx_new_certificates,
+        tx_parents,
+        rx_consensus_round_updates,
+        rx_synchronizer_network,
+        None,
+        metrics.clone(),
+    ));
+    let handler = PrimaryReceiverHandler {
+        name: target_name.clone(),
+        committee: fixture.committee(),
+        worker_cache: worker_cache.clone(),
+        synchronizer: synchronizer.clone(),
+        signature_service,
+        header_store: header_store.clone(),
+        certificate_store: certificate_store.clone(),
+        payload_store: payload_store.clone(),
+        vote_digest_store: crate::common::create_test_vote_store(),
+        rx_narwhal_round_updates,
+        metrics: metrics.clone(),
+    };
+
+    // Make some mock certificates that are parents of our new header.
+    let committee: Committee = fixture.committee();
+    let genesis = Certificate::genesis(&committee)
+        .iter()
+        .map(|x| x.digest())
+        .collect::<BTreeSet<_>>();
+    let keys: Vec<_> = fixture.authorities().map(|a| a.keypair().copy()).collect();
+    let (certificates, _next_parents) =
+        make_optimal_signed_certificates(1..=3, &genesis, &committee, keys.as_slice());
+    let all_certificates = certificates.into_iter().collect_vec();
+    let _round_1_certs = all_certificates[..NUM_PARENTS].to_vec();
+    let round_2_certs = all_certificates[NUM_PARENTS..(NUM_PARENTS * 2)].to_vec();
+    let round_2_parents = round_2_certs[..(NUM_PARENTS / 2)].to_vec();
+    let round_2_missing = round_2_certs[(NUM_PARENTS / 2)..].to_vec();
+
+    // Create a test header.
+    let test_header = author
+        .header_builder(&fixture.committee())
+        .author(author_name)
+        .round(3)
+        .parents(round_2_certs.iter().map(|c| c.digest()).collect())
+        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0, 0)
+        .build(author.keypair())
+        .unwrap();
+
+    // Write some certificates from round 2 into the store, and leave out the rest to test
+    // headers with some parents but not all available. All round 1 certificates should be written
+    // into the storage as well as parents of round 2 certificates. But to test phase 2 they are
+    // left out for now.
+    for cert in round_2_parents {
+        for (digest, (worker_id, _)) in &cert.header.payload {
+            payload_store.async_write((*digest, *worker_id), 1).await;
+        }
+        certificate_store.write(cert.clone()).unwrap();
+    }
+
+    // TEST PHASE 1: Handler should report missing parent certificates to caller.
+    let mut request = anemo::Request::new(RequestVoteRequest {
+        header: test_header.clone(),
+        parents: Vec::new(),
+    });
+    assert!(request
+        .extensions_mut()
+        .insert(network.downgrade())
+        .is_none());
+    assert!(request
+        .extensions_mut()
+        .insert(anemo::PeerId(author.network_public_key().0.to_bytes()))
+        .is_none());
+    let result = handler.request_vote(request).await;
+
+    let expected_missing: HashSet<_> = round_2_missing.iter().map(|c| c.digest()).collect();
+    let received_missing: HashSet<_> = result.unwrap().into_body().missing.into_iter().collect();
+    assert_eq!(expected_missing, received_missing);
+
+    // TEST PHASE 2: Handler should abort if round advances too much while awaiting processing
+    // of certs.
+    let tx_narwhal_round_updates = Arc::new(tx_narwhal_round_updates);
+    {
+        let tx_narwhal_round_updates = tx_narwhal_round_updates.clone();
+        tokio::task::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let _ = tx_narwhal_round_updates.send(100);
+        });
+    }
+    let mut request = anemo::Request::new(RequestVoteRequest {
+        header: test_header.clone(),
+        parents: round_2_missing.clone(),
+    });
+    assert!(request
+        .extensions_mut()
+        .insert(network.downgrade())
+        .is_none());
+    assert!(request
+        .extensions_mut()
+        .insert(anemo::PeerId(author.network_public_key().0.to_bytes()))
+        .is_none());
+    // Because round 1 certificates are not in store, the missing parents will not be accepted yet.
+    let result = timeout(Duration::from_secs(5), handler.request_vote(request))
+        .await
+        .unwrap();
+    assert!(result.is_err(), "{:?}", result);
+    assert_eq!(
+        // Returned error should be unretriable.
+        anemo::types::response::StatusCode::BadRequest,
+        result.err().unwrap().status()
+    );
+
+    // TODO: inject error for handling parents.
+}
+
+#[tokio::test]
+async fn test_request_vote_accept_missing_parents() {
     telemetry_subscribers::init_for_testing();
     const NUM_PARENTS: usize = 10;
     let fixture = CommitteeFixture::builder()
@@ -357,18 +502,7 @@ async fn test_request_vote_missing_parents() {
     let round_2_parents = round_2_certs[..(NUM_PARENTS / 2)].to_vec();
     let round_2_missing = round_2_certs[(NUM_PARENTS / 2)..].to_vec();
 
-    // Write some certificates from round 2 into the store, and leave out the rest to test
-    // headers with some parents but not all available. All round 1 certificates should be written
-    // into the storage as well as parents of round 2 certificates. But to test phase 2 they are
-    // left out for now.
-    for cert in round_2_parents {
-        certificate_store.write(cert.clone()).unwrap();
-        for (digest, (worker_id, _)) in cert.header.payload {
-            payload_store.async_write((digest, worker_id), 1).await;
-        }
-    }
-
-    // TEST PHASE 1: Handler should report missing parent certificates to caller.
+    // Create a test header.
     let test_header = author
         .header_builder(&fixture.committee())
         .author(author_name)
@@ -377,6 +511,28 @@ async fn test_request_vote_missing_parents() {
         .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0, 0)
         .build(author.keypair())
         .unwrap();
+
+    // Populate all round 1 certificates and some round 2 certificates into the storage.
+    // The new header will have some round 2 certificates missing as parents, but these parents
+    // should be able to get accepted.
+    for cert in round_1_certs {
+        for (digest, (worker_id, _)) in &cert.header.payload {
+            payload_store.async_write((*digest, *worker_id), 1).await;
+        }
+        certificate_store.write(cert.clone()).unwrap();
+    }
+    for cert in round_2_parents {
+        for (digest, (worker_id, _)) in &cert.header.payload {
+            payload_store.async_write((*digest, *worker_id), 1).await;
+        }
+        certificate_store.write(cert.clone()).unwrap();
+    }
+    // Populate new header payload so they don't have to be retrieved.
+    for (digest, (worker_id, _)) in &test_header.payload {
+        payload_store.async_write((*digest, *worker_id), 1).await;
+    }
+
+    // TEST PHASE 1: Handler should report missing parent certificates to caller.
     let mut request = anemo::Request::new(RequestVoteRequest {
         header: test_header.clone(),
         parents: Vec::new(),
@@ -395,55 +551,8 @@ async fn test_request_vote_missing_parents() {
     let received_missing: HashSet<_> = result.unwrap().into_body().missing.into_iter().collect();
     assert_eq!(expected_missing, received_missing);
 
-    // TEST PHASE 2: Handler should abort if round advances too much while awaiting processing
-    // of certs.
-    let tx_narwhal_round_updates = Arc::new(tx_narwhal_round_updates);
-    {
-        let tx_narwhal_round_updates = tx_narwhal_round_updates.clone();
-        tokio::task::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            let _ = tx_narwhal_round_updates.send(100);
-        });
-    }
-    let mut request = anemo::Request::new(RequestVoteRequest {
-        header: test_header.clone(),
-        parents: round_2_missing.clone(),
-    });
-    assert!(request
-        .extensions_mut()
-        .insert(network.downgrade())
-        .is_none());
-    assert!(request
-        .extensions_mut()
-        .insert(anemo::PeerId(author.network_public_key().0.to_bytes()))
-        .is_none());
-    // Because round 1 certificates are not in store, the missing parents will not be accepted yet.
-    let result = timeout(Duration::from_secs(5), handler.request_vote(request))
-        .await
-        .unwrap();
-    assert!(result.is_err(), "{:?}", result);
-    assert_eq!(
-        // Returned error should be unretriable.
-        anemo::types::response::StatusCode::BadRequest,
-        result.err().unwrap().status()
-    );
-
-    // TODO: inject error for handling parents.
-
-    // TEST PHASE 3: Handler should process missing certificates and succeed.
-    // Reset narwhal round.
+    // TEST PHASE 2: Handler should process missing parent certificates and succeed.
     let _ = tx_narwhal_round_updates.send(1);
-    // Populate round 1 certificates so the missing round 2 parents can be accepted.
-    for cert in round_1_certs {
-        certificate_store.write(cert.clone()).unwrap();
-        for (digest, (worker_id, _)) in cert.header.payload {
-            payload_store.async_write((digest, worker_id), 1).await;
-        }
-    }
-    // Populate header payload so they don't have to be retrieved.
-    for (digest, (worker_id, _)) in &test_header.payload {
-        payload_store.async_write((*digest, *worker_id), 1).await;
-    }
     let mut request = anemo::Request::new(RequestVoteRequest {
         header: test_header,
         parents: round_2_missing.clone(),

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use fastcrypto::{hash::Hash, traits::KeyPair};
+use futures::{stream::FuturesUnordered, StreamExt};
+use itertools::Itertools;
 use prometheus::Registry;
 use std::{
     collections::{BTreeSet, HashMap},
@@ -108,6 +110,97 @@ async fn accept_certificates() {
             .get(),
         3
     );
+}
+
+#[tokio::test]
+async fn accept_suspended_certificates() {
+    const NUM_AUTHORITIES: usize = 4;
+    telemetry_subscribers::init_for_testing();
+    let fixture = CommitteeFixture::builder()
+        .randomize_ports(true)
+        .committee_size(NonZeroUsize::new(NUM_AUTHORITIES).unwrap())
+        .build();
+    let worker_cache = fixture.shared_worker_cache();
+    let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
+    let primary = fixture.authorities().next().unwrap();
+    let name = primary.public_key();
+    let network = test_utils::test_network(primary.network_keypair(), primary.address());
+
+    let (_header_store, certificate_store, payload_store) = create_db_stores();
+    let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(100);
+    let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
+    let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
+
+    let synchronizer = Arc::new(Synchronizer::new(
+        name.clone(),
+        fixture.committee(),
+        worker_cache.clone(),
+        /* gc_depth */ 50,
+        certificate_store.clone(),
+        payload_store.clone(),
+        tx_certificate_fetcher,
+        tx_new_certificates,
+        tx_parents,
+        rx_consensus_round_updates.clone(),
+        rx_synchronizer_network,
+        None,
+        metrics.clone(),
+    ));
+
+    // Make fake certificates.
+    let committee = fixture.committee();
+    let genesis = Certificate::genesis(&committee)
+        .iter()
+        .map(|x| x.digest())
+        .collect::<BTreeSet<_>>();
+    let keys: Vec<_> = fixture.authorities().map(|a| a.keypair().copy()).collect();
+    let (certificates, _next_parents) =
+        make_optimal_signed_certificates(1..=5, &genesis, &committee, keys.as_slice());
+    let certificates = certificates.into_iter().collect_vec();
+
+    // Try to aceept certificates from round 2 and above. All of them should be suspended.
+    let accept = FuturesUnordered::new();
+    for cert in &certificates[NUM_AUTHORITIES..] {
+        match synchronizer
+            .try_accept_certificate(cert.clone(), &network)
+            .await
+        {
+            Ok(()) => panic!("Unexpected acceptance of {cert:?}"),
+            Err(DagError::Suspended(notify)) => {
+                let notify = notify.lock().unwrap().take();
+                accept.push(async move { notify.unwrap().recv().await.unwrap() });
+                continue;
+            }
+            Err(e) => panic!("Unexpected error {e}"),
+        }
+    }
+
+    // Try to aceept certificates from round 1. All of them should be accepted.
+    for cert in &certificates[..NUM_AUTHORITIES] {
+        match synchronizer
+            .try_accept_certificate(cert.clone(), &network)
+            .await
+        {
+            Ok(()) => continue,
+            Err(e) => panic!("Unexpected error {e}"),
+        }
+    }
+
+    // Wait for all notifications to arrive.
+    accept.collect::<Vec<()>>().await;
+
+    // Try to aceept certificates from round 2 and above again. All of them should be accepted.
+    for cert in &certificates[NUM_AUTHORITIES..] {
+        match synchronizer
+            .try_accept_certificate(cert.clone(), &network)
+            .await
+        {
+            Ok(()) => continue,
+            Err(e) => panic!("Unexpected error {e}"),
+        }
+    }
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -509,7 +602,11 @@ async fn deliver_certificate_using_dag() {
     let test_certificate = certificates.pop_back().unwrap();
 
     // ensure that the certificate parents are found
-    let parents_available = synchronizer.check_parents(&test_certificate).await.unwrap();
+    let parents_available = synchronizer
+        .get_missing_parents(&test_certificate)
+        .await
+        .unwrap()
+        .is_empty();
     assert!(parents_available);
 }
 
@@ -568,7 +665,11 @@ async fn deliver_certificate_using_store() {
     let test_certificate = certificates.pop_back().unwrap();
 
     // ensure that the certificate parents are found
-    let parents_available = synchronizer.check_parents(&test_certificate).await.unwrap();
+    let parents_available = synchronizer
+        .get_missing_parents(&test_certificate)
+        .await
+        .unwrap()
+        .is_empty();
     assert!(parents_available);
 }
 
@@ -622,7 +723,11 @@ async fn deliver_certificate_not_found_parents() {
     let test_certificate = certificates.pop_back().unwrap();
 
     // we try to find the certificate's parents
-    let parents_available = synchronizer.check_parents(&test_certificate).await.unwrap();
+    let parents_available = synchronizer
+        .get_missing_parents(&test_certificate)
+        .await
+        .unwrap()
+        .is_empty();
 
     // and we should fail
     assert!(!parents_available);
@@ -705,4 +810,87 @@ async fn sync_batches_drops_old() {
         Err(DagError::TooOld(_, _, _)) => (),
         result => panic!("unexpected result {result:?}"),
     }
+}
+
+#[tokio::test]
+async fn gc_suspended_certificates() {
+    const NUM_AUTHORITIES: usize = 4;
+    telemetry_subscribers::init_for_testing();
+    let fixture = CommitteeFixture::builder()
+        .randomize_ports(true)
+        .committee_size(NonZeroUsize::new(NUM_AUTHORITIES).unwrap())
+        .build();
+    let worker_cache = fixture.shared_worker_cache();
+    let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
+    let primary = fixture.authorities().next().unwrap();
+    let name = primary.public_key();
+    let network = test_utils::test_network(primary.network_keypair(), primary.address());
+
+    let (_header_store, certificate_store, payload_store) = create_db_stores();
+    let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(100);
+    let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(100);
+    let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
+    let (tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
+
+    let synchronizer = Arc::new(Synchronizer::new(
+        name.clone(),
+        fixture.committee(),
+        worker_cache.clone(),
+        /* gc_depth */ 5,
+        certificate_store.clone(),
+        payload_store.clone(),
+        tx_certificate_fetcher,
+        tx_new_certificates,
+        tx_parents,
+        rx_consensus_round_updates.clone(),
+        rx_synchronizer_network,
+        None,
+        metrics.clone(),
+    ));
+
+    // Make fake certificates.
+    let committee = fixture.committee();
+    let genesis = Certificate::genesis(&committee)
+        .iter()
+        .map(|x| x.digest())
+        .collect::<BTreeSet<_>>();
+    let keys: Vec<_> = fixture.authorities().map(|a| a.keypair().copy()).collect();
+    let (certificates, _next_parents) =
+        make_optimal_signed_certificates(1..=5, &genesis, &committee, keys.as_slice());
+    let certificates = certificates.into_iter().collect_vec();
+    // Try to aceept certificates from round 2 and above. All of them should be suspended.
+    let accept = FuturesUnordered::new();
+    for cert in &certificates[NUM_AUTHORITIES..] {
+        match synchronizer
+            .try_accept_certificate(cert.clone(), &network)
+            .await
+        {
+            Ok(()) => panic!("Unexpected acceptance of {cert:?}"),
+            Err(DagError::Suspended(notify)) => {
+                let mut notify = notify.lock().unwrap().take().unwrap();
+                accept.push(async move { notify.recv().await.unwrap() });
+                continue;
+            }
+            Err(e) => panic!("Unexpected error {e}"),
+        }
+    }
+
+    // At commit round 8, round 3 becomes the GC round. Round 4 and 5 will be accepted.
+    let _ = tx_consensus_round_updates.send(8);
+
+    // Wait for all notifications to arrive.
+    accept.collect::<Vec<()>>().await;
+
+    // Compare received and expected certificates.
+    let mut received_certificates = HashMap::new();
+    for _ in 0..NUM_AUTHORITIES * 2 {
+        let cert = rx_new_certificates.try_recv().unwrap();
+        received_certificates.insert(cert.digest(), cert);
+    }
+    let expected_certificates: HashMap<_, _> = certificates[NUM_AUTHORITIES * 3..]
+        .iter()
+        .map(|cert| (cert.digest(), cert.clone()))
+        .collect();
+    assert_eq!(received_certificates, expected_certificates);
 }

--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -31,7 +31,8 @@ macro_rules! ensure {
 
 pub type DagResult<T> = Result<T, DagError>;
 
-/// Notification for certificate accepted.
+// Notification for certificate accepted.
+// TODO: use a lighter weight alternative to broadcast::channel.
 pub type AcceptNotification = Arc<Mutex<Option<broadcast::Receiver<()>>>>;
 
 #[derive(Clone, Debug, Error)]
@@ -134,4 +135,8 @@ impl<T> From<tokio::sync::mpsc::error::TrySendError<T>> for DagError {
             tokio::sync::mpsc::error::TrySendError::Closed(_) => DagError::ShuttingDown,
         }
     }
+}
+
+pub fn new_accept_notification(receiver: broadcast::Receiver<()>) -> AcceptNotification {
+    Arc::new(std::sync::Mutex::new(Some(receiver)))
 }

--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::{HeaderDigest, Round, TimestampMs, VoteDigest};
+use crate::{CertificateDigest, HeaderDigest, Round, TimestampMs, VoteDigest};
 use config::Epoch;
 use fastcrypto::hash::Digest;
 use std::sync::{Arc, Mutex};
@@ -105,6 +105,9 @@ pub enum DagError {
         created_time: TimestampMs,
         local_time: TimestampMs,
     },
+
+    #[error("Invalid parent {0} (not found in genesis)")]
+    InvalidGenesisParent(CertificateDigest),
 
     #[error("No peer can be reached for fetching certificates! Check if network is healthy.")]
     NoCertificateFetched,


### PR DESCRIPTION
## Description 

Narwhal used to have `HeaderWaiter` that suspends Headers and Certificates, and commits a certificate when it has no missing parent. The active requests for parent certificates were a bit problematic, and the idea of suspending received certificates is useful. As Narwhal decreases its round intervals, more nodes may start to receive certificates out of their causal order. It is useful to temporarily buffer the certificates to smooth out disruptions from network or slower nodes.

## Test Plan 
unit tests
deployed to private testnet

#8288