### PR TITLE
wallet-ext: check all accounts before importing a private key

### DIFF
--- a/apps/wallet/src/background/keyring/Account.ts
+++ b/apps/wallet/src/background/keyring/Account.ts
@@ -59,4 +59,8 @@ export class Account {
             derivationPath: this.derivationPath,
         };
     }
+
+    get publicKey() {
+        return this.#keypair.getPublicKey();
+    }
 }

--- a/apps/wallet/src/background/keyring/VaultStorage.test.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.test.ts
@@ -10,6 +10,7 @@ import {
     setToSessionStorage,
     isSessionStorageSupported,
 } from '../storage-utils';
+import { Account } from './Account';
 import {
     EPHEMERAL_PASSWORD_KEY,
     EPHEMERAL_VAULT_KEY,
@@ -21,6 +22,7 @@ import {
     testDataVault2,
     testEntropySerialized,
     testMnemonic,
+    testEd25519,
 } from '_src/test-utils/vault';
 
 vi.mock('../storage-utils');
@@ -170,7 +172,7 @@ describe('VaultStorage', () => {
     describe('importKeypair', () => {
         it('throws when vault is locked', async () => {
             await expect(
-                VaultStorage.importKeypair(testEd25519Serialized, '12345')
+                VaultStorage.importKeypair(testEd25519Serialized, '12345', [])
             ).rejects.toThrow();
         });
 
@@ -184,7 +186,8 @@ describe('VaultStorage', () => {
             expect(
                 await VaultStorage.importKeypair(
                     testEd25519Serialized,
-                    testDataVault2.password
+                    testDataVault2.password,
+                    []
                 )
             ).toBeTruthy();
             expect(VaultStorage.getImportedKeys()?.length).toBe(1);
@@ -213,7 +216,8 @@ describe('VaultStorage', () => {
             expect(
                 await VaultStorage.importKeypair(
                     testEd25519Serialized,
-                    testDataVault1.password
+                    testDataVault1.password,
+                    [new Account({ type: 'imported', keypair: testEd25519 })]
                 )
             ).toBe(null);
         });

--- a/apps/wallet/src/background/keyring/VaultStorage.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.ts
@@ -133,7 +133,7 @@ class VaultStorageClass {
      * NOTE: make sure you verify the password before calling this method
      * @param keypair The keypair to import
      * @param password The password to be used to store the vault. Make sure to verify that it's the correct password (of the current vault) and then call this function. It doesn't verify the password see {@link VaultStorage.verifyPassword}.
-     * @param existingAccounts All the current account of the wallet derived and imported
+     * @param existingAccounts The wallet's derived and imported accounts
      * @returns The keyPair if the key was imported, null otherwise
      */
     public async importKeypair(

--- a/apps/wallet/src/background/keyring/VaultStorage.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.ts
@@ -11,6 +11,7 @@ import {
     setToLocalStorage,
     setToSessionStorage,
 } from '../storage-utils';
+import { type Account } from './Account';
 import { Vault } from './Vault';
 import { getRandomEntropy, toEntropy } from '_shared/utils/bip39';
 
@@ -132,17 +133,22 @@ class VaultStorageClass {
      * NOTE: make sure you verify the password before calling this method
      * @param keypair The keypair to import
      * @param password The password to be used to store the vault. Make sure to verify that it's the correct password (of the current vault) and then call this function. It doesn't verify the password see {@link VaultStorage.verifyPassword}.
+     * @param existingAccounts All the current account of the wallet derived and imported
      * @returns The keyPair if the key was imported, null otherwise
      */
-    public async importKeypair(keypair: ExportedKeypair, password: string) {
+    public async importKeypair(
+        keypair: ExportedKeypair,
+        password: string,
+        existingAccounts: Account[]
+    ) {
         if (!this.#vault) {
             throw new Error('Error, vault is locked. Unlock the vault first.');
         }
         const keypairToImport = fromExportedKeypair(keypair);
         const importedAddress = keypairToImport.getPublicKey().toSuiAddress();
-        const isDuplicate = this.#vault.importedKeypairs.some(
-            (aKeypair) =>
-                aKeypair.getPublicKey().toSuiAddress() === importedAddress
+        const isDuplicate = existingAccounts.some(
+            (anAccount) =>
+                anAccount.publicKey.toSuiAddress() === importedAddress
         );
         if (isDuplicate) {
             return null;


### PR DESCRIPTION
## Description 
* avoid importing an account that already exists in the wallet and is already derived from the mnemonic
* for the case we import a keyPair and then derive an account from the mnemonic that is the same handle the account as a derived one


https://user-images.githubusercontent.com/10210143/221228772-3e1bb7d4-b68a-41f8-ac32-0845efff3cae.mov



## Test Plan 

* export an existing derived account
* try to import it

closes APPS-534