### PR TITLE
fix explorer showing NFT owned by two addresses

### DIFF
--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -78,7 +78,7 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                 setResults(
                     results
                         .filter((data) => {
-                            // show only objects owned by address
+                            // show only objects/nfts owned by address
                             if (
                                 byAddress &&
                                 getObjectType(data) === 'moveObject'

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -83,12 +83,14 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                                 byAddress &&
                                 getObjectType(data) === 'moveObject'
                             ) {
-                                const owner = getObjectOwner(data) as {
+                                const { AddressOwner } = getObjectOwner(
+                                    data
+                                ) as {
                                     AddressOwner: string;
                                 };
                                 return (
                                     data.status === 'Exists' &&
-                                    owner.AddressOwner === id
+                                    AddressOwner === id
                                 );
                             }
 

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -1,7 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Coin, getObjectFields, getObjectId } from '@mysten/sui.js';
+import {
+    Coin,
+    getObjectFields,
+    getObjectId,
+    getObjectOwner,
+    getObjectType,
+} from '@mysten/sui.js';
 import {
     useCallback,
     useEffect,
@@ -71,7 +77,23 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
             return rpc.getObjectBatch(ids).then((results) => {
                 setResults(
                     results
-                        .filter(({ status }) => status === 'Exists')
+                        .filter((data) => {
+                            // show only objects owned by address
+                            if (
+                                byAddress &&
+                                getObjectType(data) === 'moveObject'
+                            ) {
+                                const owner = getObjectOwner(data) as {
+                                    AddressOwner: string;
+                                };
+                                return (
+                                    data.status === 'Exists' &&
+                                    owner.AddressOwner === id
+                                );
+                            }
+
+                            return data.status === 'Exists';
+                        })
                         .map(
                             (resp) => {
                                 const contents = getObjectFields(resp);

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -78,7 +78,7 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                 setResults(
                     results
                         .filter((data) => {
-                            // show only objects or nfts owned by address
+                            // show only objects owned by address
                             if (
                                 byAddress &&
                                 getObjectType(data) === 'moveObject'

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -78,7 +78,7 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                 setResults(
                     results
                         .filter((data) => {
-                            // show only objects owned by address
+                            // show only objects/nft owned by address
                             if (
                                 byAddress &&
                                 getObjectType(data) === 'moveObject'

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -78,7 +78,7 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                 setResults(
                     results
                         .filter((data) => {
-                            // show only objects/nft owned by address
+                            // show only objects owned by address
                             if (
                                 byAddress &&
                                 getObjectType(data) === 'moveObject'

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -78,7 +78,7 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                 setResults(
                     results
                         .filter((data) => {
-                            // show only objects/nfts owned by address
+                            // show only objects or nfts owned by address
                             if (
                                 byAddress &&
                                 getObjectType(data) === 'moveObject'


### PR DESCRIPTION
## Description 

Under the address 0xbbf6e1a24a7b71a33699d08de47e5e41da879512  appears the NFT with object id 0x93e5265cf2439a19fe13e57035eb3b3cd420cc13  but the owner of that NFT is 0x81209693a0c393cdcefd548e891107aaeb024eb9 . The same NFT with the exact object id appears also under the address 0x81209693a0c393cdcefd548e891107aaeb024eb9  which is the original owner.

issue [531](https://mysten.atlassian.net/browse/APPS-531)

## Test Plan 

0x93e5265cf2439a19fe13e57035eb3b3cd420cc13 NFT no longer appears under 0xbbf6e1a24a7b71a33699d08de47e5e41da879512 see [Link](https://explorer-o0eq4i0i3-mysten-labs.vercel.app/address/0xbbf6e1a24a7b71a33699d08de47e5e41da879512)



---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
