### PR TITLE
wallet-ext: dapp status disconnect only the active account

### DIFF
--- a/apps/wallet/src/ui/app/shared/dapp-status/actions/index.ts
+++ b/apps/wallet/src/ui/app/shared/dapp-status/actions/index.ts
@@ -1,18 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { type SuiAddress } from '@mysten/sui.js';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import type { AppThunkConfig } from '_redux/store/thunk-extras';
 
 export const appDisconnect = createAsyncThunk<
     void,
-    { origin: string },
+    { origin: string; accounts: SuiAddress[] },
     AppThunkConfig
 >(
     'dapp-status-app-disconnect',
-    async ({ origin }, { extra: { background } }) => {
-        await background.disconnectApp(origin);
+    async ({ origin, accounts }, { extra: { background } }) => {
+        await background.disconnectApp(origin, accounts);
         await background.sendGetPermissionRequests();
     }
 );

--- a/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
+++ b/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
@@ -13,6 +13,7 @@ import { ChevronDown12, Dot12 } from '@mysten/icons';
 import { motion, AnimatePresence } from 'framer-motion';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
+import { useActiveAddress } from '../../hooks/useActiveAddress';
 import { ButtonConnectedTo } from '../ButtonConnectedTo';
 import { appDisconnect } from './actions';
 import Loading from '_components/loading';
@@ -42,6 +43,7 @@ function DappStatus() {
         [activeOriginUrl]
     );
     const isConnected = useAppSelector(dappStatusSelector);
+    const activeAddress = useActiveAddress();
     const [disconnecting, setDisconnecting] = useState(false);
     const [visible, setVisible] = useState(false);
     const onHandleClick = useCallback(
@@ -74,14 +76,17 @@ function DappStatus() {
         }),
     ]);
     const onHandleDisconnect = useCallback(async () => {
-        if (!disconnecting && isConnected && activeOriginUrl) {
+        if (!disconnecting && isConnected && activeOriginUrl && activeAddress) {
             trackEvent('AppDisconnect', {
                 props: { source: 'Header' },
             });
             setDisconnecting(true);
             try {
                 await dispatch(
-                    appDisconnect({ origin: activeOriginUrl })
+                    appDisconnect({
+                        origin: activeOriginUrl,
+                        accounts: [activeAddress],
+                    })
                 ).unwrap();
                 setVisible(false);
             } catch (e) {
@@ -90,7 +95,7 @@ function DappStatus() {
                 setDisconnecting(false);
             }
         }
-    }, [disconnecting, isConnected, activeOriginUrl, dispatch]);
+    }, [disconnecting, isConnected, activeOriginUrl, activeAddress, dispatch]);
     if (!isConnected) {
         return null;
     }


### PR DESCRIPTION
## Description 

When disconnecting a dapp  from the status popup disconnect only the active account. Wont have any effect for singe account wallets but when we enable multi accounts this will make the functionality consistent with the UI that only shows one account.


https://user-images.githubusercontent.com/10210143/221234066-bc21db35-e949-4163-b966-24d452e3c676.mov



## Test Plan 
manual testing, only when multi-accounts enabled
* connect to a dapp with multiple accounts
* use the status popup to disconnect
* one the active account should have been disconnected

closes APPS-536