### PR TITLE
wallet-ext: fix dapp info card icon

### DIFF
--- a/apps/wallet/src/ui/app/components/DAppInfoCard.tsx
+++ b/apps/wallet/src/ui/app/components/DAppInfoCard.tsx
@@ -29,7 +29,7 @@ export function DAppInfoCard({ name, url, iconUrl }: DAppInfoCardProps) {
             body={
                 <>
                     <div className="flex flex-row flex-nowrap items-center gap-3.75 pb-3">
-                        <div className="flex items-stretch h-15 w-15 rounded-full overflow-hidden bg-steel/20">
+                        <div className="flex items-stretch h-15 w-15 rounded-full overflow-hidden bg-steel/20 shrink-0 grow-0">
                             {iconUrl ? (
                                 <img
                                     className="flex-1"


### PR DESCRIPTION
## Description 

* when dapp name/hostname is long stop the icon from shrinking

| before | after |
| - | - |
| <img width="365" alt="Screenshot 2023-02-24 at 18 41 02" src="https://user-images.githubusercontent.com/10210143/221263939-888633d4-7d9f-40cb-8956-550bcb0ba75a.png"> | <img width="365" alt="Screenshot 2023-02-24 at 18 13 04" src="https://user-images.githubusercontent.com/10210143/221263975-a532e280-2381-4b62-b2e2-e4c26947a2f1.png"> |


## Test Plan 

manual testing, in active connections view select an app
change the name or link using debugger if not log enough


closes APPS-537