### PR TITLE
[core] Fullnodes should not sign transaction effects

### DIFF
--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -18,7 +18,7 @@ use sui_types::{
     messages::{
         CertifiedTransaction, CommitteeInfoRequest, CommitteeInfoResponse,
         HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, Transaction,
-        TransactionInfoRequest, TransactionInfoResponse, VerifiedExecutableTransaction,
+        TransactionInfoRequest, TransactionInfoResponse,
     },
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
 };
@@ -145,12 +145,8 @@ impl LocalAuthorityClient {
             match state.get_signed_effects_and_maybe_resign(&tx_digest, &epoch_store) {
                 Ok(Some(effects)) => effects,
                 _ => {
-                    let certificate = { certificate.verify(epoch_store.committee())? };
-                    let executable_tx =
-                        VerifiedExecutableTransaction::new_from_certificate(certificate);
-                    state
-                        .try_execute_immediately(&executable_tx, &epoch_store)
-                        .await?
+                    let certificate = certificate.verify(epoch_store.committee())?;
+                    state.try_execute_for_test(&certificate).await?
                 }
             }
             .into_inner();


### PR DESCRIPTION
This PR makes sure that only validators would be signing transaction effects, and fullnode won't.
It will be a decent win for fulnode sync because signing every effects takes cpu resource.
It also allows a fullnode to operate without a private protocol key.
In order to do this, we make the wal to only store effects, and all interfaces to only return effects. We only generate the effects signature when we are about to commit it to the db.