### PR TITLE
[explorer] Move transaction timestamp to the end of the table

### DIFF
--- a/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
+++ b/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
@@ -254,12 +254,12 @@ export function LatestTxCard({
                                 rowCount={15}
                                 rowHeight="16px"
                                 colHeadings={[
-                                    'Time',
                                     'Type',
                                     'Transaction ID',
                                     'Addresses',
                                     'Amount',
                                     'Gas',
+                                    'Time',
                                 ]}
                                 colWidths={[
                                     '85px',

--- a/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
@@ -141,10 +141,6 @@ export const genTableDataFromTxData = (
     })),
     columns: [
         {
-            header: 'Time',
-            accessorKey: 'date',
-        },
-        {
             header: 'Type',
             accessorKey: 'txTypes',
         },
@@ -165,6 +161,10 @@ export const genTableDataFromTxData = (
         {
             header: 'Gas',
             accessorKey: 'gas',
+        },
+        {
+            header: 'Time',
+            accessorKey: 'date',
         },
     ],
 });


### PR DESCRIPTION
## Description 

This moves the transaction time to the end of the table.

## Test Plan 

With my eyes.