### PR TITLE
[7/x][programmable transaction] Integrate into execution engine

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -9,7 +9,7 @@ use move_vm_runtime::move_vm::MoveVM;
 use sui_types::base_types::SequenceNumber;
 use tracing::{debug, instrument};
 
-use crate::adapter;
+use crate::{adapter, programmable_transactions};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::coin::{transfer_coin, update_input_coins, Coin};
 use sui_types::epoch_data::EpochData;
@@ -345,8 +345,17 @@ fn execution_loop<
                 gas_status,
                 protocol_config,
             )?,
-            SingleTransactionKind::ProgrammableTransaction(_) => {
-                unreachable!("programmable transactions are not yet supported")
+            SingleTransactionKind::ProgrammableTransaction(pt) => {
+                // TODO use Mode
+                programmable_transactions::execution::execute(
+                    protocol_config,
+                    move_vm,
+                    temporary_store,
+                    tx_ctx,
+                    gas_status,
+                    gas_object_id,
+                    pt,
+                )?
             }
         };
     }

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -282,6 +282,12 @@ impl<'a> SuiGasStatus<'a> {
         !self.charge
     }
 
+    pub fn max_gax_budget_in_balance(&self) -> u64 {
+        let max_gas_unit_price =
+            std::cmp::max(self.computation_gas_unit_price, self.storage_gas_unit_price);
+        self.init_budget.mul(max_gas_unit_price).into()
+    }
+
     pub fn create_move_gas_status(&mut self) -> &mut GasStatus<'a> {
         &mut self.gas_status
     }


### PR DESCRIPTION
## Description 

- Massaged some code to make it easier to integrate into the execution engine
- Added the gas budget removal/refund logic
 - We remove the max gas budget when we start executing, and put it back at the end. This mimics setting that amount as "off limits" in the course of the transaction. Without doing this, we might not have enough to pay for gas at the end. 
 
## Test Plan 

Nothing yet 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
