### PR TITLE
[upgrade] Consolidate system state object read

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -18,7 +18,10 @@ use sui_types::accumulator::Accumulator;
 use sui_types::error::UserInputError;
 use sui_types::message_envelope::Message;
 use sui_types::object::Owner;
-use sui_types::storage::{BackingPackageStore, ChildObjectResolver, DeleteKind, ObjectKey};
+use sui_types::storage::{
+    BackingPackageStore, ChildObjectResolver, DeleteKind, ObjectKey, ObjectStore,
+};
+use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::{debug, info, trace};
@@ -298,7 +301,7 @@ impl AuthorityStore {
 
     /// Read an object and return it, or Ok(None) if the object was not found.
     pub fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
-        self.perpetual_tables.get_object(object_id)
+        self.perpetual_tables.as_ref().get_object(object_id)
     }
 
     /// Get many objects
@@ -1149,7 +1152,7 @@ impl AuthorityStore {
 
     // TODO: Transaction Orchestrator also calls this, which is not ideal.
     pub fn get_sui_system_state_object(&self) -> SuiResult<SuiSystemState> {
-        self.perpetual_tables.get_sui_system_state_object()
+        get_sui_system_state(self.perpetual_tables.as_ref())
     }
 
     pub fn iter_live_object_set(&self) -> impl Iterator<Item = ObjectRef> + '_ {

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -568,6 +568,9 @@ pub enum SuiError {
     #[error("Index store not available on this Fullnode.")]
     IndexStoreNotAvailable,
 
+    #[error("Failed to get the system state object content")]
+    SuiSystemStateNotFound,
+
     #[error("unknown error: {0}")]
     Unknown(String),
 }

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -17,8 +17,7 @@ use crate::coin::Coin;
 use crate::committee::EpochId;
 use crate::event::BalanceChangeType;
 use crate::storage::SingleTxContext;
-use crate::sui_system_state::SuiSystemState;
-use crate::SUI_SYSTEM_STATE_OBJECT_ID;
+use crate::sui_system_state::{get_sui_system_state, SuiSystemState};
 use crate::{
     base_types::{
         ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
@@ -82,14 +81,7 @@ impl InnerTemporaryStore {
     }
 
     pub fn get_sui_system_state_object(&self) -> Option<SuiSystemState> {
-        let sui_system_object = self.get_written_object(&SUI_SYSTEM_STATE_OBJECT_ID)?;
-        let move_object = sui_system_object
-            .data
-            .try_as_move()
-            .expect("Sui System State object must be a Move object");
-        let result = bcs::from_bytes::<SuiSystemState>(move_object.contents())
-            .expect("Sui System State object deserialization cannot fail");
-        Some(result)
+        get_sui_system_state(&self.written).ok()
     }
 }
 


### PR DESCRIPTION
Add a unified method to read system state object from an ObjectStore trait.
This will allow us easily change how we read system state under versioning.
We had 3 places where we use the same code to read the system state object: genesis, temp memory store, and perpetual store.