### PR TITLE
[examples]fix: sui test failed since ColorObjects on demo missing `store` ability

### DIFF
--- a/sui_programmability/examples/objects_tutorial/sources/color_object.move
+++ b/sui_programmability/examples/objects_tutorial/sources/color_object.move
@@ -6,7 +6,7 @@ module tutorial::color_object {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct ColorObject has key {
+    struct ColorObject has key, store {
         id: UID,
         red: u8,
         green: u8,


### PR DESCRIPTION
## Description 

In current repo, running shell below
```
cd sui_programmability/examples/objects_tutorial/
sui move build
sui move test
```
caused error 
```
Error executing ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("0000000000000000000000000000000000000000::color_objectTests::test_transfer. Invalid call to '0000000000000000000000000000000000000002::transfer::transfer' on an object of type '0x0::color_object::ColorObject'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
```

## Solution

add `store` ability for `ColorObject` on `sui/sui_programmability/examples/objects_tutorial/sources/color_object.move`

## Test Plan 

```
cd sui_programmability/examples/objects_tutorial/
sui move build && sui move test
```

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

