### PR TITLE
crypto: match export keypair privkey to 32 bytes

### DIFF
--- a/.changeset/silly-ears-appear.md
+++ b/.changeset/silly-ears-appear.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Make Ed25519 ExportedKeyPair only use 32 bytes seed.

--- a/sdk/typescript/src/cryptography/ed25519-keypair.ts
+++ b/sdk/typescript/src/cryptography/ed25519-keypair.ts
@@ -12,7 +12,9 @@ import { SignatureScheme } from './signature';
 export const DEFAULT_ED25519_DERIVATION_PATH = "m/44'/784'/0'/0'/0'";
 
 /**
- * Ed25519 Keypair data
+ * Ed25519 Keypair data. The publickey is the 32-byte public key and
+ * the secretkey is 64-byte, where the first 32 bytes is the secret
+ * key and the last 32 bytes is the public key.
  */
 export interface Ed25519KeypairData {
   publicKey: Uint8Array;
@@ -130,10 +132,13 @@ export class Ed25519Keypair implements Keypair {
     return Ed25519Keypair.fromSecretKey(key);
   }
 
+  /**
+   * This returns an exported keypair object, the private key field is the pure 32-byte seed.
+   */
   export(): ExportedKeypair {
     return {
       schema: 'ED25519',
-      privateKey: toB64(this.keypair.secretKey),
+      privateKey: toB64(this.keypair.secretKey.slice(0, PRIVATE_KEY_SIZE)),
     };
   }
 }

--- a/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fromB64 } from '@mysten/bcs';
+import { fromB64, toB64 } from '@mysten/bcs';
 import nacl from 'tweetnacl';
 import { describe, it, expect } from 'vitest';
 import { Ed25519Keypair, PRIVATE_KEY_SIZE } from '../../../src';
@@ -58,6 +58,10 @@ describe('ed25519-keypair', () => {
       }
       const imported = Ed25519Keypair.fromSecretKey(raw.slice(1));
       expect(imported.getPublicKey().toSuiAddress()).toEqual(t[2]);
+
+      // Exported secret key matches the 32-byte secret key.
+      const exported = imported.export();
+      expect(exported.privateKey).toEqual(toB64(raw.slice(1)));
     }
   });
 


### PR DESCRIPTION
## Description 

This makes the exported private key to be 32 bytes as the pure secret key. This can be imported again with Ed25519.fromSecretKey. A follow up fix for https://github.com/MystenLabs/sui/pull/6798

## Test Plan 

Unit test ed25519-keypair.test.ts
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
