### PR TITLE
[8/x][programmable transactions] Added MakeMoveVec

### DIFF
--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -85,6 +85,13 @@ Command:
         NEWTYPE:
           SEQ:
             SEQ: U8
+    5:
+      MakeMoveVec:
+        TUPLE:
+          - OPTION:
+              TYPENAME: TypeTag
+          - SEQ:
+              TYPENAME: Argument
 ConsensusCommitPrologue:
   STRUCT:
     - epoch: U64

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -169,6 +169,9 @@ pub enum UserInputError {
     #[error("Attempt to transfer object {object_id} that does not have public transfer. Object transfer must be done instead using a distinct Move function call.")]
     TransferObjectWithoutPublicTransferError { object_id: ObjectID },
 
+    #[error("TransferObjects, MergeCoin, and Publish cannot have empty arguments")]
+    EmptyCommandInput,
+
     #[error("Feature is not yet supported: {0}")]
     Unsupported(String),
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -169,7 +169,10 @@ pub enum UserInputError {
     #[error("Attempt to transfer object {object_id} that does not have public transfer. Object transfer must be done instead using a distinct Move function call.")]
     TransferObjectWithoutPublicTransferError { object_id: ObjectID },
 
-    #[error("TransferObjects, MergeCoin, and Publish cannot have empty arguments")]
+    #[error(
+        "TransferObjects, MergeCoin, and Publish cannot have empty arguments. \
+        If MakeMoveVec has empty arguments, it must have a type specified"
+    )]
     EmptyCommandInput,
 
     #[error("Feature is not yet supported: {0}")]

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -694,6 +694,16 @@ impl Command {
                     ty_opt.is_some() || !args.is_empty(),
                     UserInputError::EmptyCommandInput
                 );
+                if let Some(ty) = ty_opt {
+                    let type_arguments_count = type_tag_validity_check(ty, config, 1, 0)?;
+                    fp_ensure!(
+                        type_arguments_count < config.max_type_arguments() as usize,
+                        UserInputError::SizeLimitExceeded {
+                            limit: "maximum type arguments in a call transaction".to_string(),
+                            value: config.max_type_arguments().to_string()
+                        }
+                    );
+                }
                 fp_ensure!(!args.is_empty(), UserInputError::EmptyCommandInput);
                 fp_ensure!(
                     args.len() < config.max_arguments() as usize,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -540,10 +540,6 @@ pub struct ProgrammableTransaction {
 pub enum Command {
     /// A call to either an entry or a public Move function
     MoveCall(Box<ProgrammableMoveCall>),
-    /// `forall T: Vec<T> -> vector<T>`
-    /// Given n-values of the same type, it constructs a vector. For non objects or an empty vector,
-    /// the type tag must be specified.
-    MakeMoveVec(Option<TypeTag>, Vec<Argument>),
     /// `(Vec<forall T:key+store. T>, address)`
     /// It sends n-objects to the specified address. These objects must have store
     /// (public transfer) and either the previous owner must be an address or the object must
@@ -557,6 +553,10 @@ pub enum Command {
     MergeCoins(Argument, Vec<Argument>),
     /// Publishes a Move package
     Publish(Vec<Vec<u8>>),
+    /// `forall T: Vec<T> -> vector<T>`
+    /// Given n-values of the same type, it constructs a vector. For non objects or an empty vector,
+    /// the type tag must be specified.
+    MakeMoveVec(Option<TypeTag>, Vec<Argument>),
 }
 
 /// An argument to a programmable transaction command


### PR DESCRIPTION
## Description 

- MakeMoveVec is the more general alternative to CallArg::ObjVec
- Built on #8633 

## Test Plan 

No tests yet

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
