### PR TITLE
TPS Metric for node sync

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -9,6 +9,7 @@ use prometheus::{
 use std::sync::Arc;
 
 pub struct CheckpointExecutorMetrics {
+    pub checkpoint_exec_sync_tps: IntGauge,
     pub last_executed_checkpoint: IntGauge,
     pub checkpoint_exec_errors: IntCounter,
     pub checkpoint_exec_epoch: IntGauge,
@@ -19,6 +20,12 @@ pub struct CheckpointExecutorMetrics {
 impl CheckpointExecutorMetrics {
     pub fn new(registry: &Registry) -> Arc<Self> {
         let this = Self {
+            checkpoint_exec_sync_tps: register_int_gauge_with_registry!(
+                "checkpoint_exec_sync_tps",
+                "Checkpoint sync estimated transactions per second",
+                registry
+            )
+            .unwrap(),
             last_executed_checkpoint: register_int_gauge_with_registry!(
                 "last_executed_checkpoint",
                 "Last executed checkpoint",

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -21,7 +21,7 @@
 use std::{
     collections::HashMap,
     sync::Arc,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 
 use futures::stream::FuturesOrdered;
@@ -150,6 +150,13 @@ impl CheckpointExecutor {
                 0
             });
         let mut pending: CheckpointExecutionBuffer = FuturesOrdered::new();
+
+        let mut now_time = Instant::now();
+        let mut now_transaction_num = highest_executed
+            .as_ref()
+            .map(|c| c.summary.network_total_transactions)
+            .unwrap_or(0);
+
         loop {
             // If we have executed the last checkpoint of the current epoch, stop.
             if let Some(next_epoch_committee) =
@@ -177,6 +184,17 @@ impl CheckpointExecutor {
                 Some(Ok((checkpoint, checkpoint_execution_state))) = pending.next() => {
                     self.process_executed_checkpoint(&checkpoint, checkpoint_execution_state).await;
                     highest_executed = Some(checkpoint);
+
+                    // Estimate TPS every 10k transactions or 30 sec
+                    let elapsed = now_time.elapsed().as_millis();
+                    let current_transaction_num =  highest_executed.as_ref().map(|c| c.summary.network_total_transactions).unwrap_or(0);
+                    if current_transaction_num - now_transaction_num > 10_000 || elapsed > 30_000{
+                        let tps = (1000.0 * (current_transaction_num - now_transaction_num) as f64 / elapsed as f64) as i32;
+                        self.metrics.checkpoint_exec_sync_tps.set(tps as i64);
+                        now_time = Instant::now();
+                        now_transaction_num = current_transaction_num;
+                    }
+
                 }
                 // Check for newly synced checkpoints from StateSync.
                 received = self.mailbox.recv() => match received {


### PR DESCRIPTION
## Description 

This PR add a `checkpoint_exec_sync_tps` metric that allows an operator to monitor the estimated tps rate for checkpoint sync for validator or full node.

## Test Plan 

Ran CI and validated the metric is present using a web request.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- Added the metric `checkpoint_exec_sync_tps` to monitor checkpoint sync performance
