### PR TITLE
unblock request_set_commission_rate function

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -56,7 +56,7 @@ use sui_types::{
     messages::VerifiedTransaction,
     object::{Owner, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION},
     sui_system_state::SuiSystemState,
-    SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+    SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use tracing::info;
 
@@ -4490,44 +4490,6 @@ async fn test_consensus_message_processed() {
         authority2
             .epoch_store_for_testing()
             .get_next_object_version(&shared_object_id),
-    );
-}
-
-#[tokio::test]
-async fn test_blocked_move_calls() {
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let gas_object_id = ObjectID::random();
-    let authority_state = init_state_with_ids(vec![(sender, gas_object_id)]).await;
-
-    let tx = to_sender_signed_transaction(
-        TransactionData::new_move_call_with_dummy_gas_price(
-            sender,
-            SUI_FRAMEWORK_OBJECT_ID,
-            ident_str!("sui_system").to_owned(),
-            ident_str!("request_set_commission_rate").to_owned(),
-            vec![],
-            authority_state
-                .get_object(&gas_object_id)
-                .await
-                .unwrap()
-                .unwrap()
-                .compute_object_reference(),
-            vec![
-                CallArg::Object(ObjectArg::SharedObject {
-                    id: SUI_SYSTEM_STATE_OBJECT_ID,
-                    initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
-                    mutable: true,
-                }),
-                CallArg::Pure(bcs::to_bytes(&0u64).unwrap()),
-            ],
-            MAX_GAS,
-        ),
-        &sender_key,
-    );
-    let response = authority_state.handle_transaction(tx).await;
-    assert_eq!(
-        UserInputError::try_from(response.unwrap_err()).unwrap(),
-        UserInputError::BlockedMoveFunction
     );
 }
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -18,8 +18,8 @@ use crate::object::{MoveObject, Object, ObjectFormatOptions, Owner};
 use crate::signature::{AuthenticatorTrait, GenericSignature};
 use crate::storage::{DeleteKind, WriteKind};
 use crate::{
-    SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_FRAMEWORK_OBJECT_ID,
-    SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+    SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_SYSTEM_STATE_OBJECT_ID,
+    SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 use byteorder::{BigEndian, ReadBytesExt};
 use fastcrypto::encoding::Base64;
@@ -51,11 +51,7 @@ use tracing::debug;
 
 pub const DUMMY_GAS_PRICE: u64 = 1;
 
-const BLOCKED_MOVE_FUNCTIONS: [(ObjectID, &str, &str); 1] = [(
-    SUI_FRAMEWORK_OBJECT_ID,
-    "sui_system",
-    "request_set_commission_rate",
-)];
+const BLOCKED_MOVE_FUNCTIONS: [(ObjectID, &str, &str); 0] = [];
 
 #[cfg(test)]
 #[path = "unit_tests/messages_tests.rs"]


### PR DESCRIPTION
## Description 

We blocked calls to `request_set_commission_rate` only for testnet wave 2. Now we should unblock it. After this removal there is no more blocked functions but the logic is kept there in case we want to use it again in the future.

## Test Plan 

How did you test the new or updated feature?

cargo test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
