### PR TITLE
wallet-ext: clear permissions and active account

### DIFF
--- a/apps/wallet/src/background/index.ts
+++ b/apps/wallet/src/background/index.ts
@@ -24,8 +24,10 @@ Browser.runtime.onInstalled.addListener(async ({ reason, previousVersion }) => {
     // TODO: Our versions don't use semver, and instead are date-based. Instead of using the semver
     // library, we can use some combination of parsing into a date + inspecting patch.
     const previousVersionSemver = coerce(previousVersion)?.version;
-
     if (reason === 'install') {
+        await Browser.storage.local.set({
+            v: -1,
+        });
         openInNewTab();
     } else if (
         reason === 'update' &&
@@ -36,6 +38,20 @@ Browser.runtime.onInstalled.addListener(async ({ reason, previousVersion }) => {
         // mainly done to clear the mnemonic that was stored
         // as plain text
         await Browser.storage.local.clear();
+        await Browser.storage.local.set({
+            v: -1,
+        });
+    } else if (reason === 'update') {
+        const storageVersion = (await Browser.storage.local.get({ v: null })).v;
+        // handle address size update and include storage version
+        if (storageVersion === null) {
+            //clear permissions and active_account because currently they are using the previous address size
+            await Browser.storage.local.set({
+                permissions: {},
+                active_account: null,
+                v: -1,
+            });
+        }
     }
 });
 

--- a/apps/wallet/src/ui/app/redux/slices/account/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/account/index.ts
@@ -49,6 +49,9 @@ export const logout = createAsyncThunk<void, void, AppThunkConfig>(
     'account/logout',
     async (_, { extra: { background } }): Promise<void> => {
         await Browser.storage.local.clear();
+        await Browser.storage.local.set({
+            v: -1,
+        });
         await background.clearWallet();
     }
 );


### PR DESCRIPTION
## Description 

* permissions have the connected account using the previous address size
* to avoid any errors clear them and let users reconnect to dapps
* active account wont create any issues if it remains in previous format but we can clear it to avoid any confusion

## Test Plan 

manual testing 
* use a previous version connect to a dapp, update the wallet and check storage
* when updating to a newer version from one that contains this change, make sure it does't remove permissions/active address

---
### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Clears the existing permissions in the wallet extension (disconnects all connected sites) to migrate to new account address format.