### PR TITLE
[Display] RPC support for fetching and rendering Display object

### DIFF
--- a/.changeset/silver-geckos-look.md
+++ b/.changeset/silver-geckos-look.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Add optional parameter for filtering object by type in getOwnedObjectsByAddress

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -213,6 +213,13 @@ impl ReadApiServer for ReadApi {
     async fn get_raw_object(&self, object_id: ObjectID) -> RpcResult<GetRawObjectDataResponse> {
         self.fullnode.get_raw_object(object_id).await
     }
+
+    async fn get_display_deprecated(
+        &self,
+        object_id: ObjectID,
+    ) -> RpcResult<BTreeMap<String, String>> {
+        self.fullnode.get_display_deprecated(object_id).await
+    }
 }
 
 impl SuiRpcModule for ReadApi {

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -201,4 +201,13 @@ pub trait ReadApi {
         /// the id of the object
         object_id: ObjectID,
     ) -> RpcResult<GetRawObjectDataResponse>;
+
+    // TODO: this will be replaced by the new queryObjects API
+    /// Return the Display string of a object
+    #[method(name = "getDisplayDeprecated")]
+    async fn get_display_deprecated(
+        &self,
+        /// the id of the object
+        object_id: ObjectID,
+    ) -> RpcResult<BTreeMap<String, String>>;
 }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -620,7 +620,7 @@ fn get_value_from_move_struct(move_struct: &SuiMoveStruct, var_name: &str) -> Rp
     match current_value {
         SuiMoveValue::Option(move_option) => match move_option.as_ref() {
             Some(move_value) => Ok(move_value.to_string()),
-            None => Ok("None".to_string()),
+            None => Ok("".to_string()),
         },
         SuiMoveValue::Vector(_) => Err(anyhow!(
             "Vector is not supported as a Display value {}",

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -824,6 +824,35 @@
       }
     },
     {
+      "name": "sui_getDisplayDeprecated",
+      "tags": [
+        {
+          "name": "Read API"
+        }
+      ],
+      "description": "Return the Display string of a object",
+      "params": [
+        {
+          "name": "object_id",
+          "description": "the id of the object",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        }
+      ],
+      "result": {
+        "name": "BTreeMap<String,String>",
+        "required": true,
+        "schema": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
       "name": "sui_getDynamicFieldObject",
       "tags": [
         {

--- a/crates/sui-types/src/collection_types.rs
+++ b/crates/sui-types/src/collection_types.rs
@@ -13,8 +13,8 @@ pub struct VecMap<K, V> {
 /// Rust version of the Move sui::vec_map::Entry type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct Entry<K, V> {
-    key: K,
-    value: V,
+    pub key: K,
+    pub value: V,
 }
 
 /// Rust version of the Move sui::vec_set::VecSet type

--- a/crates/sui-types/src/display.rs
+++ b/crates/sui-types/src/display.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::collection_types::VecMap;
+use crate::id::{ID, UID};
+use crate::SUI_FRAMEWORK_ADDRESS;
+use move_core_types::ident_str;
+use move_core_types::identifier::IdentStr;
+use move_core_types::language_storage::StructTag;
+use serde::Deserialize;
+
+pub const DISPLAY_MODULE_NAME: &IdentStr = ident_str!("display");
+pub const DISPLAY_CREATED_EVENT_NAME: &IdentStr = ident_str!("DisplayCreated");
+
+// TODO: add tests to keep in sync
+/// Rust version of the Move sui::display::Display type
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct DisplayObject {
+    pub id: UID,
+    pub fields: VecMap<String, String>,
+    pub version: u16,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct DisplayCreatedEvent {
+    // The Object ID of Display Object
+    pub id: ID,
+}
+
+impl DisplayCreatedEvent {
+    pub fn type_(inner: &StructTag) -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            name: DISPLAY_CREATED_EVENT_NAME.to_owned(),
+            module: DISPLAY_MODULE_NAME.to_owned(),
+            type_params: vec![inner.clone().into()],
+        }
+    }
+}

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -29,6 +29,7 @@ pub mod collection_types;
 pub mod committee;
 pub mod crypto;
 pub mod digests;
+pub mod display;
 pub mod dynamic_field;
 pub mod event;
 pub mod filter;

--- a/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  GetObjectDataResponse,
+  SuiObjectInfo,
+  SuiObjectRef,
+  getObjectReference,
+  TransactionEffects,
+  normalizeSuiObjectId,
+  ExecuteTransactionRequestType,
+  SuiExecuteTransactionResponse,
+  getTransactionEffects,
+} from '../types';
+import { JsonRpcProvider } from './json-rpc-provider';
+import { is } from 'superstruct';
+import { SerializedSignature } from '../cryptography/signature';
+
+export class JsonRpcProviderWithCache extends JsonRpcProvider {
+  /**
+   * A list of object references which are being tracked.
+   *
+   * Whenever an object is fetched or updated within the transaction,
+   * its record gets updated.
+   */
+  private objectRefs: Map<string, SuiObjectRef> = new Map();
+
+  // Objects
+  async getObjectsOwnedByAddress(
+    address: string,
+    typefilter?: string,
+  ): Promise<SuiObjectInfo[]> {
+    const resp = await super.getObjectsOwnedByAddress(address, typefilter);
+    resp.forEach((r) => this.updateObjectRefCache(r));
+    return resp;
+  }
+
+  async getObject(objectId: string): Promise<GetObjectDataResponse> {
+    const resp = await super.getObject(objectId);
+    this.updateObjectRefCache(resp);
+    return resp;
+  }
+
+  async getObjectRef(
+    objectId: string,
+    skipCache = false,
+  ): Promise<SuiObjectRef | undefined> {
+    const normalizedId = normalizeSuiObjectId(objectId);
+    if (!skipCache && this.objectRefs.has(normalizedId)) {
+      return this.objectRefs.get(normalizedId);
+    }
+
+    const ref = await super.getObjectRef(objectId);
+    this.updateObjectRefCache(ref);
+    return ref;
+  }
+
+  async getObjectBatch(objectIds: string[]): Promise<GetObjectDataResponse[]> {
+    const resp = await super.getObjectBatch(objectIds);
+    resp.forEach((r) => this.updateObjectRefCache(r));
+    return resp;
+  }
+
+  // Transactions
+
+  async executeTransaction(
+    txnBytes: Uint8Array | string,
+    signature: SerializedSignature,
+    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert',
+  ): Promise<SuiExecuteTransactionResponse> {
+    if (requestType !== 'WaitForEffectsCert') {
+      console.warn(
+        `It's not recommended to use JsonRpcProviderWithCache with the request ` +
+          `type other than 'WaitForEffectsCert' for executeTransaction. Using ` +
+          `the '${requestType}' may result in stale cache and a failure in subsequent transactions.`,
+      );
+    }
+    const resp = await super.executeTransaction(
+      txnBytes,
+      signature,
+      requestType,
+    );
+    const effects = getTransactionEffects(resp);
+    if (effects != null) {
+      this.updateObjectRefCacheFromTransactionEffects(effects);
+    }
+    return resp;
+  }
+
+  private updateObjectRefCache(
+    newData: GetObjectDataResponse | SuiObjectRef | undefined,
+  ) {
+    if (newData == null) {
+      return;
+    }
+    const ref = is(newData, SuiObjectRef)
+      ? newData
+      : getObjectReference(newData);
+    if (ref != null) {
+      this.objectRefs.set(ref.objectId, ref);
+    }
+  }
+
+  private updateObjectRefCacheFromTransactionEffects(
+    effects: TransactionEffects,
+  ) {
+    effects.created?.forEach((r) => this.updateObjectRefCache(r.reference));
+    effects.mutated?.forEach((r) => this.updateObjectRefCache(r.reference));
+    effects.unwrapped?.forEach((r) => this.updateObjectRefCache(r.reference));
+    effects.wrapped?.forEach((r) => this.updateObjectRefCache(r));
+    effects.deleted?.forEach((r) => this.objectRefs.delete(r.objectId));
+  }
+}

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -404,17 +404,26 @@ export class JsonRpcProvider extends Provider {
   // Objects
   async getObjectsOwnedByAddress(
     address: SuiAddress,
+    typefilter?: string,
   ): Promise<SuiObjectInfo[]> {
     try {
       if (!address || !isValidSuiAddress(normalizeSuiAddress(address))) {
         throw new Error('Invalid Sui address');
       }
-      return await this.client.requestWithType(
+      const objects = await this.client.requestWithType(
         'sui_getObjectsOwnedByAddress',
         [address],
         GetOwnedObjectsResponse,
         this.options.skipDataValidation,
       );
+      // TODO: remove this once we migrated to the new queryObject API
+      if (typefilter) {
+        return objects.filter(
+          (obj: SuiObjectInfo) =>
+            obj.type === typefilter || obj.type.startsWith(typefilter + '<'),
+        );
+      }
+      return objects;
     } catch (err) {
       throw new Error(
         `Error fetching owned object: ${err} for address ${address}`,

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -404,7 +404,7 @@ export class JsonRpcProvider extends Provider {
   // Objects
   async getObjectsOwnedByAddress(
     address: SuiAddress,
-    typefilter?: string,
+    typeFilter?: string,
   ): Promise<SuiObjectInfo[]> {
     try {
       if (!address || !isValidSuiAddress(normalizeSuiAddress(address))) {
@@ -417,10 +417,10 @@ export class JsonRpcProvider extends Provider {
         this.options.skipDataValidation,
       );
       // TODO: remove this once we migrated to the new queryObject API
-      if (typefilter) {
+      if (typeFilter) {
         return objects.filter(
           (obj: SuiObjectInfo) =>
-            obj.type === typefilter || obj.type.startsWith(typefilter + '<'),
+            obj.type === typeFilter || obj.type.startsWith(typeFilter + '<'),
         );
       }
       return objects;

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -138,8 +138,14 @@ export abstract class Provider {
   /**
    * Get all objects owned by an address
    */
+  /**
+   * @param addressOrObjectId owner address or object id
+   * @param typefilter? a fully qualified type name for the object(e.g., 0x2::coin::Coin<0x2::sui::SUI>)
+   * or type name without generics (e.g., 0x2::coin::Coin will match all 0x2::coin::Coin<T>)
+   */
   abstract getObjectsOwnedByAddress(
     addressOrObjectId: string,
+    typefilter?: string,
   ): Promise<SuiObjectInfo[]>;
 
   /**

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -140,12 +140,12 @@ export abstract class Provider {
    */
   /**
    * @param addressOrObjectId owner address or object id
-   * @param typefilter? a fully qualified type name for the object(e.g., 0x2::coin::Coin<0x2::sui::SUI>)
+   * @param typeFilter? a fully qualified type name for the object(e.g., 0x2::coin::Coin<0x2::sui::SUI>)
    * or type name without generics (e.g., 0x2::coin::Coin will match all 0x2::coin::Coin<T>)
    */
   abstract getObjectsOwnedByAddress(
     addressOrObjectId: string,
-    typefilter?: string,
+    typeFilter?: string,
   ): Promise<SuiObjectInfo[]>;
 
   /**

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -126,7 +126,10 @@ export class VoidProvider extends Provider {
   }
 
   // Objects
-  async getObjectsOwnedByAddress(_address: string): Promise<SuiObjectInfo[]> {
+  async getObjectsOwnedByAddress(
+    _address: string,
+    _typefilter?: string,
+  ): Promise<SuiObjectInfo[]> {
     throw this.newError('getObjectsOwnedByAddress');
   }
 

--- a/sdk/typescript/test/e2e/data/display_test/Move.toml
+++ b/sdk/typescript/test/e2e/data/display_test/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "display_test"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../../crates/sui-framework" }
+# Using a local dep for the Move stdlib instead of a git dep to avoid the overhead of fetching the git dep in
+# CI. The local dep is an unmodified version of the upstream stdlib
+MoveStdlib = { local = "../../../../../../crates/sui-framework/deps/move-stdlib" }
+
+[addresses]
+display_test =  "0x0"

--- a/sdk/typescript/test/e2e/data/display_test/sources/display_test.move
+++ b/sdk/typescript/test/e2e/data/display_test/sources/display_test.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module display_test::boars {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{TxContext, sender};
+    use sui::transfer::transfer;
+    use sui::publisher;
+    use sui::display;
+    use std::string::{utf8, String};
+
+    /// For when a witness type passed is not an OTW.
+    const ENotOneTimeWitness: u64 = 0;
+
+    /// An OTW to use when creating a Publisher
+    struct BOARS has drop {}
+
+    struct Boar has key, store {
+        id: UID,
+        img_url: String,
+        name: String,
+        description: String,
+        creator: String,
+    }
+
+    fun init(otw: BOARS, ctx: &mut TxContext) {
+        assert!(sui::types::is_one_time_witness(&otw), ENotOneTimeWitness);
+
+        let pub = publisher::claim(otw, ctx);
+        let display = display::new<Boar>(&pub, ctx);
+
+        display::add_multiple(&pub, &mut display, vector[
+            utf8(b"name"),
+            utf8(b"description"),
+            utf8(b"img_url"),
+            utf8(b"creator"),
+            utf8(b"project_url")
+        ], vector[
+            utf8(b"{name}"),
+            utf8(b"Unique Boar from the Boars collection!"),
+            utf8(b"https://get-a-boar.com/{img_url}"),
+            utf8(b"Boarcognito"),
+            utf8(b"https://get-a-boar.com/")
+        ]);
+
+        display::update_version(&pub, &mut display);
+        display::transfer(display, sender(ctx));
+        transfer(pub, sender(ctx));
+
+        let boar = Boar {
+            id: object::new(ctx),
+            img_url: utf8(b"first.png"),
+            name: utf8(b"First Boar"),
+            description: utf8(b"First Boar from the Boars collection!"),
+            creator: utf8(b"Chris"),
+        };
+        transfer(boar, sender(ctx))
+    }
+}

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -32,11 +32,16 @@ describe('Test Object Display Standard', () => {
       boarId,
     ]);
     expect(display).toEqual({
-      description: 'Unique Boar from the Boars collection!',
-      creator: 'Boarcognito',
-      img_url: 'https://get-a-boar.com/{img_url}',
-      name: '{name}',
+      age: '10',
+      buyer: `0x${toolbox.address()}`,
+      creator: 'Chris',
+      description: `Unique Boar from the Boars collection with First Boar and ${boarId}`,
+      img_url: 'https://get-a-boar.com/first.png',
+      name: 'First Boar',
+      price: 'None',
       project_url: 'https://get-a-boar.com/',
+      full_url: 'https://get-a-boar.fullurl.com/',
+      escape_syntax: '{name}',
     });
   });
 });

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -38,7 +38,7 @@ describe('Test Object Display Standard', () => {
       description: `Unique Boar from the Boars collection with First Boar and ${boarId}`,
       img_url: 'https://get-a-boar.com/first.png',
       name: 'First Boar',
-      price: 'None',
+      price: '',
       project_url: 'https://get-a-boar.com/',
       full_url: 'https://get-a-boar.fullurl.com/',
       escape_syntax: '{name}',

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { LocalTxnDataSerializer, ObjectId, RawSigner } from '../../src';
+import { publishPackage, setup, TestToolbox } from './utils/setup';
+
+describe('Test Object Display Standard', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+  let packageId: ObjectId;
+
+  beforeAll(async () => {
+    toolbox = await setup();
+    signer = new RawSigner(
+      toolbox.keypair,
+      toolbox.provider,
+      new LocalTxnDataSerializer(toolbox.provider),
+    );
+    const packagePath = __dirname + '/./data/display_test';
+    packageId = await publishPackage(signer, true, packagePath);
+  });
+
+  it('Test getting Display Object', async () => {
+    const boarId = (
+      await toolbox.provider.getObjectsOwnedByAddress(
+        toolbox.address(),
+        `${packageId}::boars::Boar`,
+      )
+    )[0].objectId;
+    const display = await toolbox.provider.call('sui_getDisplayDeprecated', [
+      boarId,
+    ]);
+    expect(display).toEqual({
+      description: 'Unique Boar from the Boars collection!',
+      creator: 'Boarcognito',
+      img_url: 'https://get-a-boar.com/{img_url}',
+      name: '{name}',
+      project_url: 'https://get-a-boar.com/',
+    });
+  });
+});

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -93,5 +93,9 @@ export async function publishPackage(
   const publishEvent = getEvents(publishTxn)?.find((e) => 'publish' in e);
 
   // @ts-ignore: Publish not narrowed:
-  return publishEvent?.publish.packageId.replace(/^(0x)(0+)/, '0x');
+  const packageId = publishEvent?.publish.packageId.replace(/^(0x)(0+)/, '0x');
+  console.info(
+    `Published package ${packageId} from address ${await signer.getAddress()}}`,
+  );
+  return packageId;
 }


### PR DESCRIPTION
## Description 

This PR adds the RPC support for https://github.com/MystenLabs/sui/pull/7668 and added e2e TS tests

Todos(in separate PRs)

- [ ] merge the display endpoint into the[ new queryObjects API](https://www.notion.so/mystenlabs/RFC-GetObjects-API-Refactoring-27ff6b8d6ffc42c8b492c1efa368b70a?pvs=4)
- [ ] Handle struct that has no Display defined `Overall display should be treated as Debug and Display traits in Rust. If we don’t have Display defined, we show default debug (on the FE/Apps), if there’s Display, we show things nicely.` I'll implement this when we implement the new queryObjects API
- [ ] Add rust based tests


## Test Plan 

How did you test the new or updated feature?

Added e2e TS tests to cover the following test cases
- Escape syntax (e.g., `\{name\}` should return `{name}` instead of `Alice` even if there's a field called Alice)
- Nested fields
- multiple fields
- option::some and option::none
- no template value
- sui address
- UID
- `sui::url::Url` type



---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
