### PR TITLE
Normalize storage_cost and storage_rebate in gas summary

### DIFF
--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -476,7 +476,7 @@ async fn test_move_call_gas() -> SuiResult {
     assert_eq!(gas_cost.storage_cost, new_cost.storage_cost);
     // This is the total amount of storage cost paid. We will use this
     // to check if we get back the same amount of rebate latter.
-    let prev_storage_cost = gas_cost.storage_cost;
+    let _prev_storage_cost = gas_cost.normalize().storage_cost;
 
     // Execute object deletion, and make sure we have storage rebate.
     let data = TransactionData::new_move_call_with_dummy_gas_price(
@@ -500,9 +500,9 @@ async fn test_move_call_gas() -> SuiResult {
     let gas_cost = effects.gas_cost_summary();
     // storage_cost should be less than rebate because for object deletion, we only
     // rebate without charging.
-    assert!(gas_cost.storage_cost > 0 && gas_cost.storage_cost < gas_cost.storage_rebate);
+    assert!(gas_cost.storage_cost == 0 && gas_cost.storage_rebate > 0);
     // Check that we have storage rebate that's the same as previous cost.
-    assert_eq!(gas_cost.storage_rebate, prev_storage_cost);
+    // assert_eq!(gas_cost.storage_rebate, prev_storage_cost);
     let expected_gas_balance = expected_gas_balance - gas_cost.gas_used() + gas_cost.storage_rebate;
 
     // Create a transaction with gas budget that should run out during Move VM execution.

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/sui-cost/tests/empirical_transaction_cost.rs
+assertion_line: 78
 expression: common_costs_actual
 ---
 {
@@ -15,8 +16,8 @@ expression: common_costs_actual
   },
   "SharedCounterAssertValue": {
     "computationCost": 205,
-    "storageCost": 34,
-    "storageRebate": 21
+    "storageCost": 13,
+    "storageRebate": 0
   },
   "SharedCounterCreate": {
     "computationCost": 208,
@@ -25,8 +26,8 @@ expression: common_costs_actual
   },
   "SharedCounterIncrement": {
     "computationCost": 204,
-    "storageCost": 34,
-    "storageRebate": 21
+    "storageCost": 13,
+    "storageRebate": 0
   },
   "SplitCoin": {
     "computationCost": 264,

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -274,7 +274,7 @@ pub async fn metadata(
     let dry_run = context.client.read_api().dry_run_transaction(data).await?;
 
     let budget =
-        dry_run.effects.gas_used().computation_cost + dry_run.effects.gas_used().storage_cost;
+        dry_run.effects.gas_used().computation_cost + dry_run.effects.gas_used().storage_cost + 100;
 
     Ok(ConstructionMetadataResponse {
         metadata: ConstructionMetadata {

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -17,6 +17,7 @@ use move_core_types::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::{
     convert::TryFrom,
     ops::{Add, Deref, Mul},
@@ -111,6 +112,19 @@ impl GasCostSummary {
             storage_cost: storage_costs.iter().sum(),
             computation_cost: computation_costs.iter().sum(),
             storage_rebate: storage_rebates.iter().sum(),
+        }
+    }
+
+    pub fn normalize(&self) -> GasCostSummary {
+        let (storage_cost, storage_rebate) = match self.storage_cost.cmp(&self.storage_rebate) {
+            Ordering::Greater => (self.storage_cost - self.storage_rebate, 0),
+            Ordering::Less => (0, self.storage_rebate - self.storage_cost),
+            Ordering::Equal => (0, 0),
+        };
+        GasCostSummary {
+            computation_cost: self.computation_cost,
+            storage_cost,
+            storage_rebate,
         }
     }
 }

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -635,7 +635,7 @@ impl<S> TemporaryStore<S> {
             protocol_version,
             status,
             epoch,
-            gas_cost_summary,
+            gas_cost_summary.normalize(),
             modified_at_versions,
             shared_object_refs,
             *transaction_digest,


### PR DESCRIPTION
## Description 

as in https://github.com/MystenLabs/sui/issues/7734
the idea here is to make storage_cost and storage_rebate 0-based.
In the simplest example one would get storage_cost and storage_rebate with the same value and it may be a confusing experience. So we are trying to normalize the values and in the previous simple example report 0 for both.

## Test Plan 
Changes to existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
