### PR TITLE
fix total coin balance overflow

### DIFF
--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -249,7 +249,9 @@ ExecutionFailureStatus:
     34:
       VMInvariantViolation: UNIT
     35:
-      TotalAmountOverflow: UNIT
+      TotalPaymentAmountOverflow: UNIT
+    36:
+      TotalCoinBalanceOverflow: UNIT
 ExecutionStatus:
   ENUM:
     0:

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1996,7 +1996,9 @@ pub enum ExecutionFailureStatus {
     VMInvariantViolation,
 
     /// The total amount of coins to be paid is larger than the maximum value of u64.
-    TotalAmountOverflow,
+    TotalPaymentAmountOverflow,
+    /// The total balance of coins is larger than the maximum value of u64.
+    TotalCoinBalanceOverflow,
     // NOTE: if you want to add a new enum,
     // please add it at the end for Rust SDK backward compatibility.
 }
@@ -2093,12 +2095,6 @@ impl Display for ExecutionFailureStatus {
                 write!(
                     f,
                     "Coin exceeds maximum value for a single coin"
-                )
-            },
-            ExecutionFailureStatus::TotalAmountOverflow => {
-                write!(
-                    f,
-                    "The total amount of coins to be paid is larger than the maximum value of u64"
                 )
             },
             ExecutionFailureStatus::EmptyInputCoins => {
@@ -2238,7 +2234,19 @@ impl Display for ExecutionFailureStatus {
             ),
             ExecutionFailureStatus::VMInvariantViolation => {
                 write!(f, "MOVE VM INVARIANT VIOLATION.")
-            }
+            },
+            ExecutionFailureStatus::TotalPaymentAmountOverflow => {
+                write!(
+                    f,
+                    "The total amount of coins to be paid overflows of u64"
+                )
+            },
+            ExecutionFailureStatus::TotalCoinBalanceOverflow => {
+                write!(
+                    f,
+                    "The total balance of coins overflows u64"
+                )
+            },
         }
     }
 }


### PR DESCRIPTION
## Description 

Even though SUI coin has total supply of 10B, which means it will not overflow u64::MAX, but overflow might happen for other coins, this PR fixes that.

## Test Plan 

Added a unit test and `cargo test`
