### PR TITLE
Gas budget in SUI

### DIFF
--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -70,7 +70,6 @@ async fn test_tx_gas_balance_less_than_budget() {
         UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: gas_balance as u128,
             gas_budget: (gas_price * budget) as u128,
-            gas_price
         }
     );
 }
@@ -154,16 +153,15 @@ async fn test_native_transfer_gas_price_is_used() {
     );
 
     // test overflow with insufficient gas
-    let gas_balance = *MAX_GAS_BUDGET;
+    let gas_balance = *MAX_GAS_BUDGET - 1;
     let gas_budget = *MAX_GAS_BUDGET;
-    let gas_price = u64::MAX;
+    let gas_price = 10;
     let result = execute_transfer_with_price(gas_balance, gas_budget, gas_price, true).await;
     assert_eq!(
         UserInputError::try_from(result.response.unwrap_err()).unwrap(),
         UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: (gas_balance as u128),
-            gas_budget: (gas_budget as u128) * (gas_price as u128),
-            gas_price
+            gas_budget: (gas_budget as u128),
         }
     );
 }

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -82,7 +82,6 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
         UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 1200,
-            gas_price: 1
         }
     );
 }
@@ -109,7 +108,6 @@ async fn test_pay_sui_failure_insufficient_total_balance_one_input_coin() {
         UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 100 + 100 + 900,
-            gas_price: 1
         }
     );
 }
@@ -137,7 +135,6 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
         UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 400,
             gas_budget: 801,
-            gas_price: 1
         }
     );
 }
@@ -164,7 +161,6 @@ async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() 
         UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 400 + 600,
             gas_budget: 400 + 400 + 201,
-            gas_price: 1
         }
     );
 }
@@ -328,7 +324,6 @@ async fn test_pay_all_sui_failure_insufficient_gas_one_input_coin() {
         UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 2000,
-            gas_price: 1
         }
     );
 }
@@ -346,7 +341,6 @@ async fn test_pay_all_sui_failure_insufficient_gas_budget_multiple_input_coins()
         UserInputError::GasBalanceTooLowToCoverGasBudget {
             gas_balance: 1000,
             gas_budget: 2500,
-            gas_price: 1
         }
     );
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -121,16 +121,11 @@ pub enum UserInputError {
     #[error("Gas budget: {:?} is lower than min: {:?}.", gas_budget, min_budget)]
     GasBudgetTooLow { gas_budget: u64, min_budget: u64 },
     #[error(
-        "Balance of gas object {:?} is lower than gas budget: {:?}, with gas price: {:?}.",
+        "Balance of gas object {:?} is lower than gas budget: {:?}.",
         gas_balance,
-        gas_budget,
-        gas_price
+        gas_budget
     )]
-    GasBalanceTooLowToCoverGasBudget {
-        gas_balance: u128,
-        gas_budget: u128,
-        gas_price: u64,
-    },
+    GasBalanceTooLowToCoverGasBudget { gas_balance: u128, gas_budget: u128 },
     #[error("Transaction kind does not support Sponsored Transaction")]
     UnsupportedSponsoredTransactionKind,
     #[error(

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -147,7 +147,7 @@ async fn test_sponsored_transaction() -> Result<(), anyhow::Error> {
             payment: gas_obj,
             owner: sponsor,
             price: 100,
-            budget: 10000,
+            budget: 1000000,
         },
     );
 


### PR DESCRIPTION
## Description 

Change Gas Budget to be in sui rather then gas units, that removes the concept of gas units from any user related API.
Internally we move to gas units as soon as we make `SuiGasStatus` so the change is very minimal.

The format of the `TransactionData` is not changed (`u64`), so effectively this is not a breaking change as a format but it requires clients to think about how they use gas budget.

Most of our codebase (tests) use a gas price of 1 (DUMMY_GAS_PRICE), so GAS UNITS or MIST are the same, which explains why almost nothing broke.
Locally I changed the DUMMY_GAS_PRICE to be 2 and some tests broke, however I verified that they were all using constants that had to be changed. So this seems to be really the only change needed.
Tests pass so we are good.

I need to produce documentation about this change - and others I have - but given we are not going out with this in devnet, that can wait a day or two (doing it as soon as I move all blockers from my plate).

@Jordan-Mysten @gegaowp @patrickkuo @666lcz please let me know if you see issues or we can move this forward

## Test Plan 

Existing test 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
