### PR TITLE
[fix] consensus integrity hash message

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -75,8 +75,8 @@ fn update_hash(
     previous_hash.hash(&mut hasher);
     v.hash(&mut hasher);
     let hash = hasher.finish();
-    // Log hash for every sub dag
-    if index.sub_dag_index == 1 && last_seen_guard.index.sub_dag_index == 1 {
+    // Log hash every 100th transaction of the subdag
+    if index.transaction_index % 100 == 0 {
         debug!(
             "Integrity hash for consensus output at subdag {} is {:016x}",
             index.sub_dag_index, hash


### PR DESCRIPTION
## Description 

This PR is fixing the broken consensus integrity hash message.  Now we'll simply print for every 100th transaction of a committed subdag (we guarantee that we'll always print it for the first transaction).

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
