### PR TITLE
subsidies: draw down a balance instead of minting

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -392,7 +392,6 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
             CallArg::Pure(bcs::to_bytes(&change_epoch.storage_rebate).unwrap()),
             CallArg::Pure(bcs::to_bytes(&protocol_config.storage_fund_reinvest_rate()).unwrap()),
             CallArg::Pure(bcs::to_bytes(&protocol_config.reward_slashing_rate()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&protocol_config.stake_subsidy_rate()).unwrap()),
             CallArg::Pure(bcs::to_bytes(&change_epoch.epoch_start_timestamp_ms).unwrap()),
         ],
         gas_status.create_move_gas_status(),

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -492,8 +492,6 @@ validators:
   staking_pool_mappings:
     id: "0x628ffd0e51e9a6ea32c13c2739a31a8f344b557d"
     size: 1
-treasury_cap:
-  value: 2
 storage_fund:
   value: 1
 parameters:
@@ -505,7 +503,7 @@ validator_report_records:
 stake_subsidy:
   epoch_counter: 0
   balance:
-    value: 0
+    value: 1000000000000000000
   current_epoch_amount: 1000000
 safe_mode: false
 epoch_start_timestamp_ms: 10

--- a/crates/sui-framework/docs/balance.md
+++ b/crates/sui-framework/docs/balance.md
@@ -22,6 +22,7 @@ custom coins with <code><a href="balance.md#0x2_balance_Supply">Supply</a></code
 -  [Function `destroy_zero`](#0x2_balance_destroy_zero)
 -  [Function `create_staking_rewards`](#0x2_balance_create_staking_rewards)
 -  [Function `destroy_storage_rebates`](#0x2_balance_destroy_storage_rebates)
+-  [Function `destroy_supply`](#0x2_balance_destroy_supply)
 
 
 <pre><code></code></pre>
@@ -455,6 +456,32 @@ and nowhere else.
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_destroy_storage_rebates">destroy_storage_rebates</a>&lt;T&gt;(self: <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;) {
     <b>let</b> <a href="balance.md#0x2_balance_Balance">Balance</a> { value: _ } = self;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_balance_destroy_supply"></a>
+
+## Function `destroy_supply`
+
+Destroy a <code><a href="balance.md#0x2_balance_Supply">Supply</a></code> preventing any further minting and burning.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_destroy_supply">destroy_supply</a>&lt;T&gt;(self: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_destroy_supply">destroy_supply</a>&lt;T&gt;(self: <a href="balance.md#0x2_balance_Supply">Supply</a>&lt;T&gt;): u64 {
+    <b>let</b> <a href="balance.md#0x2_balance_Supply">Supply</a> { value } = self;
+    value
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -12,6 +12,7 @@
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="clock.md#0x2_clock">0x2::clock</a>;
+<b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
 <b>use</b> <a href="sui_system.md#0x2_sui_system">0x2::sui_system</a>;
@@ -53,6 +54,16 @@ Stake subisidy to be given out in the very first epoch. Placeholder value.
 
 
 <pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_STAKE_SUBSIDY_AMOUNT">INIT_STAKE_SUBSIDY_AMOUNT</a>: u64 = 1000000;
+</code></pre>
+
+
+
+<a name="0x2_genesis_INIT_STAKE_SUBSIDY_FUND_BALANCE"></a>
+
+The initial balance of the Subsidy fund in Mist (1 Billion * 10^9)
+
+
+<pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_STAKE_SUBSIDY_FUND_BALANCE">INIT_STAKE_SUBSIDY_FUND_BALANCE</a>: u64 = 1000000000000000000;
 </code></pre>
 
 
@@ -107,6 +118,7 @@ all the information we need in the system.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> sui_supply = <a href="sui.md#0x2_sui_new">sui::new</a>(ctx);
+    <b>let</b> subsidy_fund = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> sui_supply, <a href="genesis.md#0x2_genesis_INIT_STAKE_SUBSIDY_FUND_BALANCE">INIT_STAKE_SUBSIDY_FUND_BALANCE</a>);
     <b>let</b> storage_fund = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> sui_supply, <a href="genesis.md#0x2_genesis_INIT_STORAGE_FUND">INIT_STORAGE_FUND</a>);
     <b>let</b> validators = <a href="_empty">vector::empty</a>();
     <b>let</b> count = <a href="_length">vector::length</a>(&validator_pubkeys);
@@ -168,7 +180,7 @@ all the information we need in the system.
 
     <a href="sui_system.md#0x2_sui_system_create">sui_system::create</a>(
         validators,
-        sui_supply,
+        subsidy_fund,
         storage_fund,
         <a href="genesis.md#0x2_genesis_INIT_MAX_VALIDATOR_COUNT">INIT_MAX_VALIDATOR_COUNT</a>,
         <a href="genesis.md#0x2_genesis_INIT_MIN_VALIDATOR_STAKE">INIT_MIN_VALIDATOR_STAKE</a>,
@@ -179,6 +191,11 @@ all the information we need in the system.
     );
 
     <a href="clock.md#0x2_clock_create">clock::create</a>();
+
+    // Transfer the remaining <a href="balance.md#0x2_balance">balance</a> of <a href="sui.md#0x2_sui">sui</a>'s supply <b>to</b> the initial account
+    // TODO pass in the account that should recieve the initial
+    // distribution of Sui instead of sending it <b>to</b> <b>address</b> 0x0
+    <a href="sui.md#0x2_sui_transfer">sui::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(sui_supply, ctx), @0x0);
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -107,7 +107,7 @@ all the information we need in the system.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> sui_supply = <a href="sui.md#0x2_sui_new">sui::new</a>(ctx);
-    <b>let</b> storage_fund = <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(&<b>mut</b> sui_supply, <a href="genesis.md#0x2_genesis_INIT_STORAGE_FUND">INIT_STORAGE_FUND</a>);
+    <b>let</b> storage_fund = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> sui_supply, <a href="genesis.md#0x2_genesis_INIT_STORAGE_FUND">INIT_STORAGE_FUND</a>);
     <b>let</b> validators = <a href="_empty">vector::empty</a>();
     <b>let</b> count = <a href="_length">vector::length</a>(&validator_pubkeys);
     <b>assert</b>!(
@@ -157,7 +157,7 @@ all the information we need in the system.
             p2p_address,
             consensus_address,
             worker_address,
-            <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(&<b>mut</b> sui_supply, <a href="stake.md#0x2_stake">stake</a>),
+            <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> sui_supply, <a href="stake.md#0x2_stake">stake</a>),
             <a href="_none">option::none</a>(),
             gas_price,
             commission_rate,

--- a/crates/sui-framework/docs/stake_subsidy.md
+++ b/crates/sui-framework/docs/stake_subsidy.md
@@ -8,13 +8,12 @@
 -  [Struct `StakeSubsidy`](#0x2_stake_subsidy_StakeSubsidy)
 -  [Constants](#@Constants_0)
 -  [Function `create`](#0x2_stake_subsidy_create)
--  [Function `mint_stake_subsidy_proportional_to_total_stake_testnet`](#0x2_stake_subsidy_mint_stake_subsidy_proportional_to_total_stake_testnet)
 -  [Function `advance_epoch`](#0x2_stake_subsidy_advance_epoch)
--  [Function `withdraw_all`](#0x2_stake_subsidy_withdraw_all)
 -  [Function `current_epoch_subsidy_amount`](#0x2_stake_subsidy_current_epoch_subsidy_amount)
 
 
 <pre><code><b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="math.md#0x2_math">0x2::math</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
 </code></pre>
 
@@ -47,13 +46,14 @@
 <code><a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
 </dt>
 <dd>
- Balance storing the accumulated stake subsidy.
+ Balance of Sui set asside for Staking subsidies that will be drawn down over time.
 </dd>
 <dt>
 <code>current_epoch_amount: u64</code>
 </dt>
 <dd>
- The amount of stake subsidy to be minted this epoch.
+ The amount of stake subsidy to be drawn down per epoch.
+ This amount decays and decreases over time.
 </dd>
 </dl>
 
@@ -120,44 +120,14 @@
 
 </details>
 
-<a name="0x2_stake_subsidy_mint_stake_subsidy_proportional_to_total_stake_testnet"></a>
-
-## Function `mint_stake_subsidy_proportional_to_total_stake_testnet`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_mint_stake_subsidy_proportional_to_total_stake_testnet">mint_stake_subsidy_proportional_to_total_stake_testnet</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>, supply: &<b>mut</b> <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, stake_subsidy_rate: u64, total_stake: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_mint_stake_subsidy_proportional_to_total_stake_testnet">mint_stake_subsidy_proportional_to_total_stake_testnet</a>(
-    subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a>, supply: &<b>mut</b> Supply&lt;SUI&gt;, stake_subsidy_rate: u64, total_stake: u64
-) {
-    <b>let</b> amount_to_mint = ((total_stake <b>as</b> u128) * (stake_subsidy_rate <b>as</b> u128)) / <a href="stake_subsidy.md#0x2_stake_subsidy_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
-    <a href="balance.md#0x2_balance_join">balance::join</a>(
-        &<b>mut</b> subsidy.<a href="balance.md#0x2_balance">balance</a>,
-        <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(supply, (amount_to_mint <b>as</b> u64))
-    );
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x2_stake_subsidy_advance_epoch"></a>
 
 ## Function `advance_epoch`
 
-Advance the epoch counter and mint new subsidy for the epoch.
+Advance the epoch counter and draw down the subsidy for the epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_advance_epoch">advance_epoch</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>, supply: &<b>mut</b> <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_advance_epoch">advance_epoch</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
 </code></pre>
 
 
@@ -166,45 +136,25 @@ Advance the epoch counter and mint new subsidy for the epoch.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_advance_epoch">advance_epoch</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a>, supply: &<b>mut</b> Supply&lt;SUI&gt;) {
-    // Mint new subsidy for this epoch.
-    <a href="balance.md#0x2_balance_join">balance::join</a>(
-        &<b>mut</b> subsidy.<a href="balance.md#0x2_balance">balance</a>,
-        <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(supply, subsidy.current_epoch_amount)
-    );
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_advance_epoch">advance_epoch</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a>): Balance&lt;SUI&gt; {
+    // Take the minimum of the reward amount and the remaining <a href="balance.md#0x2_balance">balance</a> in
+    // order <b>to</b> ensure we don't overdraft the remaining <a href="stake.md#0x2_stake">stake</a> subsidy
+    // <a href="balance.md#0x2_balance">balance</a>
+    <b>let</b> to_withdrawl = <a href="math.md#0x2_math_min">math::min</a>(subsidy.current_epoch_amount, <a href="balance.md#0x2_balance_value">balance::value</a>(&subsidy.<a href="balance.md#0x2_balance">balance</a>));
+
+    // Drawn down the subsidy for this epoch.
+    <b>let</b> <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a> = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> subsidy.<a href="balance.md#0x2_balance">balance</a>, to_withdrawl);
+
     subsidy.epoch_counter = subsidy.epoch_counter + 1;
+
     // Decrease the subsidy amount only when the current period ends.
     <b>if</b> (subsidy.epoch_counter % <a href="stake_subsidy.md#0x2_stake_subsidy_STAKE_SUBSIDY_PERIOD_LENGTH">STAKE_SUBSIDY_PERIOD_LENGTH</a> == 0) {
         <b>let</b> decrease_amount = (subsidy.current_epoch_amount <b>as</b> u128)
             * <a href="stake_subsidy.md#0x2_stake_subsidy_STAKE_SUBSIDY_DECREASE_RATE">STAKE_SUBSIDY_DECREASE_RATE</a> / <a href="stake_subsidy.md#0x2_stake_subsidy_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
         subsidy.current_epoch_amount = subsidy.current_epoch_amount - (decrease_amount <b>as</b> u64)
     };
-}
-</code></pre>
 
-
-
-</details>
-
-<a name="0x2_stake_subsidy_withdraw_all"></a>
-
-## Function `withdraw_all`
-
-Withdraw all the minted stake subsidy.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_withdraw_all">withdraw_all</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_withdraw_all">withdraw_all</a>(subsidy: &<b>mut</b> <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a>): Balance&lt;SUI&gt; {
-    <b>let</b> amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&subsidy.<a href="balance.md#0x2_balance">balance</a>);
-    <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> subsidy.<a href="balance.md#0x2_balance">balance</a>, amount)
+    <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/stake_subsidy.md
+++ b/crates/sui-framework/docs/stake_subsidy.md
@@ -46,7 +46,7 @@
 <code><a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
 </dt>
 <dd>
- Balance of Sui set asside for Staking subsidies that will be drawn down over time.
+ Balance of SUI set aside for stake subsidies that will be drawn down over time.
 </dd>
 <dt>
 <code>current_epoch_amount: u64</code>
@@ -98,7 +98,7 @@
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_create">create</a>(initial_stake_subsidy_amount: u64): <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_create">create</a>(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, initial_stake_subsidy_amount: u64): <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>
 </code></pre>
 
 
@@ -107,10 +107,10 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_create">create</a>(initial_stake_subsidy_amount: u64): <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_create">create</a>(<a href="balance.md#0x2_balance">balance</a>: Balance&lt;SUI&gt;, initial_stake_subsidy_amount: u64): <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a> {
     <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a> {
         epoch_counter: 0,
-        <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_zero">balance::zero</a>(),
+        <a href="balance.md#0x2_balance">balance</a>,
         current_epoch_amount: initial_stake_subsidy_amount,
     }
 }

--- a/crates/sui-framework/docs/sui.md
+++ b/crates/sui-framework/docs/sui.md
@@ -56,6 +56,15 @@ Name of the coin
 ## Constants
 
 
+<a name="0x2_sui_EAlreadyMinted"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui.md#0x2_sui_EAlreadyMinted">EAlreadyMinted</a>: u64 = 0;
+</code></pre>
+
+
+
 <a name="0x2_sui_MIST_PER_SUI"></a>
 
 The amount of Mist per Sui token based on the the fact that mist is
@@ -95,7 +104,7 @@ Register the <code><a href="sui.md#0x2_sui_SUI">SUI</a></code> Coin to acquire i
 This should be called only once during genesis creation.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
 </code></pre>
 
 
@@ -104,7 +113,9 @@ This should be called only once during genesis creation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> TxContext): Supply&lt;<a href="sui.md#0x2_sui_SUI">SUI</a>&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> TxContext): Balance&lt;<a href="sui.md#0x2_sui_SUI">SUI</a>&gt; {
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) == 0, <a href="sui.md#0x2_sui_EAlreadyMinted">EAlreadyMinted</a>);
+
     <b>let</b> (treasury, metadata) = <a href="coin.md#0x2_coin_create_currency">coin::create_currency</a>(
         <a href="sui.md#0x2_sui_SUI">SUI</a> {},
         9,
@@ -116,7 +127,10 @@ This should be called only once during genesis creation.
         ctx
     );
     <a href="transfer.md#0x2_transfer_freeze_object">transfer::freeze_object</a>(metadata);
-    <a href="coin.md#0x2_coin_treasury_into_supply">coin::treasury_into_supply</a>(treasury)
+    <b>let</b> supply = <a href="coin.md#0x2_coin_treasury_into_supply">coin::treasury_into_supply</a>(treasury);
+    <b>let</b> total_sui = <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(&<b>mut</b> supply, <a href="sui.md#0x2_sui_TOTAL_SUPPLY_MIST">TOTAL_SUPPLY_MIST</a>);
+    <a href="balance.md#0x2_balance_destroy_supply">balance::destroy_supply</a>(supply);
+    total_sui
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui.md
+++ b/crates/sui-framework/docs/sui.md
@@ -8,6 +8,7 @@ It has 9 decimals, and the smallest unit (10^-9) is called "mist".
 
 
 -  [Struct `SUI`](#0x2_sui_SUI)
+-  [Constants](#@Constants_0)
 -  [Function `new`](#0x2_sui_new)
 -  [Function `transfer`](#0x2_sui_transfer)
 
@@ -49,6 +50,42 @@ Name of the coin
 
 
 </details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_sui_MIST_PER_SUI"></a>
+
+The amount of Mist per Sui token based on the the fact that mist is
+10^-9 of a Sui token
+
+
+<pre><code><b>const</b> <a href="sui.md#0x2_sui_MIST_PER_SUI">MIST_PER_SUI</a>: u64 = 1000000000;
+</code></pre>
+
+
+
+<a name="0x2_sui_TOTAL_SUPPLY_MIST"></a>
+
+The total supply of Sui denominated in Mist (10 Billion * 10^9)
+
+
+<pre><code><b>const</b> <a href="sui.md#0x2_sui_TOTAL_SUPPLY_MIST">TOTAL_SUPPLY_MIST</a>: u64 = 10000000000000000000;
+</code></pre>
+
+
+
+<a name="0x2_sui_TOTAL_SUPPLY_SUI"></a>
+
+The total supply of Sui denominated in whole Sui tokens (10 Billion)
+
+
+<pre><code><b>const</b> <a href="sui.md#0x2_sui_TOTAL_SUPPLY_SUI">TOTAL_SUPPLY_SUI</a>: u64 = 10000000000;
+</code></pre>
+
+
 
 <a name="0x2_sui_new"></a>
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -969,7 +969,7 @@ gas coins.
 4. Update all validators.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_epoch: u64, next_protocol_version: u64, storage_charge: u64, computation_charge: u64, storage_rebate: u64, storage_fund_reinvest_rate: u64, reward_slashing_rate: u64, stake_subsidy_rate: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_epoch: u64, next_protocol_version: u64, storage_charge: u64, computation_charge: u64, storage_rebate: u64, storage_fund_reinvest_rate: u64, reward_slashing_rate: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -988,7 +988,6 @@ gas coins.
     storage_fund_reinvest_rate: u64, // share of storage fund's rewards that's reinvested
                                      // into storage fund, in basis point.
     reward_slashing_rate: u64, // how much rewards are slashed <b>to</b> punish a <a href="validator.md#0x2_validator">validator</a>, in bps.
-    stake_subsidy_rate: u64, // what percentage of the total <a href="stake.md#0x2_stake">stake</a> do we mint <b>as</b> <a href="stake.md#0x2_stake">stake</a> subsidy.
     epoch_start_timestamp_ms: u64, // Timestamp of the epoch start
     ctx: &<b>mut</b> TxContext,
 ) {
@@ -1014,9 +1013,7 @@ gas coins.
     <b>let</b> computation_reward = <a href="balance.md#0x2_balance_create_staking_rewards">balance::create_staking_rewards</a>(computation_charge);
 
     // Include <a href="stake.md#0x2_stake">stake</a> subsidy in the rewards given out <b>to</b> validators and delegators.
-    <a href="stake_subsidy.md#0x2_stake_subsidy_mint_stake_subsidy_proportional_to_total_stake_testnet">stake_subsidy::mint_stake_subsidy_proportional_to_total_stake_testnet</a>(
-        &<b>mut</b> self.<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>, &<b>mut</b> self.sui_supply, stake_subsidy_rate, delegation_stake + validator_stake);
-    <b>let</b> <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a> = <a href="stake_subsidy.md#0x2_stake_subsidy_withdraw_all">stake_subsidy::withdraw_all</a>(&<b>mut</b> self.<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>);
+    <b>let</b> <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a> = <a href="stake_subsidy.md#0x2_stake_subsidy_advance_epoch">stake_subsidy::advance_epoch</a>(&<b>mut</b> self.<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>);
     <b>let</b> stake_subsidy_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>);
     <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> computation_reward, <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>);
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -140,12 +140,6 @@ The top-level object containing all information of the Sui system.
  Contains all information about the validators.
 </dd>
 <dt>
-<code>sui_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
-</dt>
-<dd>
- The SUI treasury capability needed to mint SUI.
-</dd>
-<dt>
 <code>storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
 </dt>
 <dd>
@@ -368,7 +362,7 @@ Create a new SuiSystemState object and make it shared.
 This function will be called only once in genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, sui_supply: <a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_candidate_count: u64, min_validator_stake: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_candidate_count: u64, min_validator_stake: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -379,7 +373,7 @@ This function will be called only once in genesis.
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(
     validators: <a href="">vector</a>&lt;Validator&gt;,
-    sui_supply: Supply&lt;SUI&gt;,
+    stake_subsidy_fund: Balance&lt;SUI&gt;,
     storage_fund: Balance&lt;SUI&gt;,
     max_validator_candidate_count: u64,
     min_validator_stake: u64,
@@ -396,7 +390,6 @@ This function will be called only once in genesis.
         epoch: 0,
         protocol_version,
         validators,
-        sui_supply,
         storage_fund,
         parameters: <a href="sui_system.md#0x2_sui_system_SystemParameters">SystemParameters</a> {
             min_validator_stake,
@@ -404,7 +397,7 @@ This function will be called only once in genesis.
         },
         reference_gas_price,
         validator_report_records: <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>(),
-        <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>: <a href="stake_subsidy.md#0x2_stake_subsidy_create">stake_subsidy::create</a>(initial_stake_subsidy_amount),
+        <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>: <a href="stake_subsidy.md#0x2_stake_subsidy_create">stake_subsidy::create</a>(stake_subsidy_fund, initial_stake_subsidy_amount),
         safe_mode: <b>false</b>,
         epoch_start_timestamp_ms,
     };

--- a/crates/sui-framework/sources/balance.move
+++ b/crates/sui-framework/sources/balance.move
@@ -6,6 +6,7 @@
 /// custom coins with `Supply` and `Balance`s.
 module sui::balance {
     friend sui::sui_system;
+    friend sui::sui;
 
     /// For when trying to destroy a non-zero balance.
     const ENonZero: u64 = 0;
@@ -117,6 +118,12 @@ module sui::balance {
         let Balance { value: _ } = self;
     }
 
+    /// Destroy a `Supply` preventing any further minting and burning.
+    public(friend) fun destroy_supply<T>(self: Supply<T>): u64 {
+        let Supply { value } = self;
+        value
+    }
+
     #[test_only]
     /// Create a `Balance` of any coin for testing purposes.
     public fun create_for_testing<T>(value: u64): Balance<T> {
@@ -135,12 +142,6 @@ module sui::balance {
     public fun destroy_supply_for_testing<T>(self: Supply<T>): u64 {
         let Supply { value } = self;
         value
-    }
-
-    #[test_only]
-    /// Create a `Supply` of any coin for testing purposes.
-    public fun create_supply_for_testing<T>(value: u64): Supply<T> {
-        Supply { value }
     }
 }
 

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -50,7 +50,7 @@ module sui::genesis {
         ctx: &mut TxContext,
     ) {
         let sui_supply = sui::new(ctx);
-        let storage_fund = balance::increase_supply(&mut sui_supply, INIT_STORAGE_FUND);
+        let storage_fund = balance::split(&mut sui_supply, INIT_STORAGE_FUND);
         let validators = vector::empty();
         let count = vector::length(&validator_pubkeys);
         assert!(
@@ -100,7 +100,7 @@ module sui::genesis {
                 p2p_address,
                 consensus_address,
                 worker_address,
-                balance::increase_supply(&mut sui_supply, stake),
+                balance::split(&mut sui_supply, stake),
                 option::none(),
                 gas_price,
                 commission_rate,

--- a/crates/sui-framework/sources/governance/stake_subsidy.move
+++ b/crates/sui-framework/sources/governance/stake_subsidy.move
@@ -12,7 +12,7 @@ module sui::stake_subsidy {
         /// This counter may be different from the current epoch number if
         /// in some epochs we decide to skip the subsidy. 
         epoch_counter: u64,
-        /// Balance of Sui set asside for Staking subsidies that will be drawn down over time.
+        /// Balance of SUI set aside for stake subsidies that will be drawn down over time.
         balance: Balance<SUI>,
         /// The amount of stake subsidy to be drawn down per epoch.
         /// This amount decays and decreases over time.
@@ -25,10 +25,10 @@ module sui::stake_subsidy {
     const STAKE_SUBSIDY_DECREASE_RATE: u128 = 1000; // in basis point
     const STAKE_SUBSIDY_PERIOD_LENGTH: u64 = 30; // in number of epochs
 
-    public(friend) fun create(initial_stake_subsidy_amount: u64): StakeSubsidy {
+    public(friend) fun create(balance: Balance<SUI>, initial_stake_subsidy_amount: u64): StakeSubsidy {
         StakeSubsidy {
             epoch_counter: 0,
-            balance: balance::zero(),
+            balance,
             current_epoch_amount: initial_stake_subsidy_amount,
         }
     }

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui::sui_system {
-    use sui::balance::{Self, Balance, Supply};
+    use sui::balance::{Self, Balance};
     use sui::clock::{Self, Clock};
     use sui::coin::{Self, Coin};
     use sui::staking_pool::{Delegation, StakedSui};
@@ -53,8 +53,6 @@ module sui::sui_system {
         protocol_version: u64,
         /// Contains all information about the validators.
         validators: ValidatorSet,
-        /// The SUI treasury capability needed to mint SUI.
-        sui_supply: Supply<SUI>,
         /// The storage fund.
         storage_fund: Balance<SUI>,
         /// A list of system config parameters.
@@ -112,7 +110,7 @@ module sui::sui_system {
     /// This function will be called only once in genesis.
     public(friend) fun create(
         validators: vector<Validator>,
-        sui_supply: Supply<SUI>,
+        stake_subsidy_fund: Balance<SUI>,
         storage_fund: Balance<SUI>,
         max_validator_candidate_count: u64,
         min_validator_stake: u64,
@@ -129,7 +127,6 @@ module sui::sui_system {
             epoch: 0,
             protocol_version,
             validators,
-            sui_supply,
             storage_fund,
             parameters: SystemParameters {
                 min_validator_stake,
@@ -137,7 +134,7 @@ module sui::sui_system {
             },
             reference_gas_price,
             validator_report_records: vec_map::empty(),
-            stake_subsidy: stake_subsidy::create(initial_stake_subsidy_amount),
+            stake_subsidy: stake_subsidy::create(stake_subsidy_fund, initial_stake_subsidy_amount),
             safe_mode: false,
             epoch_start_timestamp_ms,
         };

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -425,7 +425,6 @@ module sui::sui_system {
         storage_fund_reinvest_rate: u64, // share of storage fund's rewards that's reinvested
                                          // into storage fund, in basis point.
         reward_slashing_rate: u64, // how much rewards are slashed to punish a validator, in bps.
-        stake_subsidy_rate: u64, // what percentage of the total stake do we mint as stake subsidy.
         epoch_start_timestamp_ms: u64, // Timestamp of the epoch start
         ctx: &mut TxContext,
     ) {
@@ -451,9 +450,7 @@ module sui::sui_system {
         let computation_reward = balance::create_staking_rewards(computation_charge);
 
         // Include stake subsidy in the rewards given out to validators and delegators.
-        stake_subsidy::mint_stake_subsidy_proportional_to_total_stake_testnet(
-            &mut self.stake_subsidy, &mut self.sui_supply, stake_subsidy_rate, delegation_stake + validator_stake);
-        let stake_subsidy = stake_subsidy::withdraw_all(&mut self.stake_subsidy);
+        let stake_subsidy = stake_subsidy::advance_epoch(&mut self.stake_subsidy);
         let stake_subsidy_amount = balance::value(&stake_subsidy);
         balance::join(&mut computation_reward, stake_subsidy);
 

--- a/crates/sui-framework/sources/sui.move
+++ b/crates/sui-framework/sources/sui.move
@@ -5,19 +5,33 @@
 /// It has 9 decimals, and the smallest unit (10^-9) is called "mist".
 module sui::sui {
     use std::option;
-    use sui::tx_context::TxContext;
-    use sui::balance::Supply;
+    use sui::tx_context::{Self, TxContext};
+    use sui::balance::{Self, Balance};
     use sui::transfer;
     use sui::coin;
 
     friend sui::genesis;
+
+    const EAlreadyMinted: u64 = 0;
+
+    /// The amount of Mist per Sui token based on the the fact that mist is
+    /// 10^-9 of a Sui token
+    const MIST_PER_SUI: u64 = 1_000_000_000;
+
+    /// The total supply of Sui denominated in whole Sui tokens (10 Billion)
+    const TOTAL_SUPPLY_SUI: u64 = 10_000_000_000;
+
+    /// The total supply of Sui denominated in Mist (10 Billion * 10^9)
+    const TOTAL_SUPPLY_MIST: u64 = 10_000_000_000_000_000_000;
 
     /// Name of the coin
     struct SUI has drop {}
 
     /// Register the `SUI` Coin to acquire its `Supply`.
     /// This should be called only once during genesis creation.
-    public(friend) fun new(ctx: &mut TxContext): Supply<SUI> {
+    public(friend) fun new(ctx: &mut TxContext): Balance<SUI> {
+        assert!(tx_context::epoch(ctx) == 0, EAlreadyMinted);
+
         let (treasury, metadata) = coin::create_currency(
             SUI {}, 
             9,
@@ -29,7 +43,10 @@ module sui::sui {
             ctx
         );
         transfer::freeze_object(metadata);
-        coin::treasury_into_supply(treasury)
+        let supply = coin::treasury_into_supply(treasury);
+        let total_sui = balance::increase_supply(&mut supply, TOTAL_SUPPLY_MIST);
+        balance::destroy_supply(supply);
+        total_sui
     }
 
     public entry fun transfer(c: coin::Coin<SUI>, recipient: address) {

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -58,7 +58,7 @@ module sui::governance_test_utils {
     ) {
         sui_system::create(
             validators,
-            balance::create_supply_for_testing(sui_supply_amount), // sui_supply
+            balance::create_for_testing<SUI>(sui_supply_amount), // sui_supply
             balance::create_for_testing<SUI>(storage_fund_amount), // storage_fund
             1024, // max_validator_candidate_count
             0, // min_validator_stake

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -96,20 +96,7 @@ module sui::governance_test_utils {
 
         let ctx = test_scenario::ctx(scenario);
 
-        sui_system::advance_epoch(&mut system_state, new_epoch, 1, storage_charge, computation_charge, 0, 0, 0, 0, 0, ctx);
-        test_scenario::return_shared(system_state);
-    }
-
-    public fun advance_epoch_with_reward_amounts_and_subsidy_rate(
-        storage_charge: u64, computation_charge: u64, stake_subsidy_rate: u64, scenario: &mut Scenario
-    ) {
-        test_scenario::next_epoch(scenario, @0x0);
-        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario));
-        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-
-        let ctx = test_scenario::ctx(scenario);
-
-        sui_system::advance_epoch(&mut system_state, new_epoch, 1, storage_charge, computation_charge, 0, 0, 0, stake_subsidy_rate, 0, ctx);
+        sui_system::advance_epoch(&mut system_state, new_epoch, 1, storage_charge, computation_charge, 0, 0, 0, 0,  ctx);
         test_scenario::return_shared(system_state);
     }
 
@@ -126,7 +113,7 @@ module sui::governance_test_utils {
         let ctx = test_scenario::ctx(scenario);
 
         sui_system::advance_epoch(
-            &mut system_state, new_epoch, 1, storage_charge, computation_charge, 0, 0, reward_slashing_rate, 0, 0, ctx
+            &mut system_state, new_epoch, 1, storage_charge, computation_charge, 0, 0, reward_slashing_rate, 0, ctx
         );
         test_scenario::return_shared(system_state);
     }

--- a/crates/sui-framework/tests/rewards_distribution_tests.move
+++ b/crates/sui-framework/tests/rewards_distribution_tests.move
@@ -11,7 +11,6 @@ module sui::rewards_distribution_tests {
         Self,
         advance_epoch,
         advance_epoch_with_reward_amounts,
-        advance_epoch_with_reward_amounts_and_subsidy_rate,
         advance_epoch_with_reward_amounts_and_slashing_rates,
         assert_validator_delegate_amounts,
         assert_validator_stake_amounts,
@@ -68,8 +67,8 @@ module sui::rewards_distribution_tests {
         // need to advance epoch so validator's staking starts counting
         governance_test_utils::advance_epoch(scenario);
 
-        advance_epoch_with_reward_amounts_and_subsidy_rate(0, 100, 1, scenario);
-        assert_validator_stake_amounts(validator_addrs(), vector[100_010_010, 200_020_020, 300_030_030, 400_040_040], scenario);
+        advance_epoch_with_reward_amounts(0, 100, scenario);
+        assert_validator_stake_amounts(validator_addrs(), vector[100_000_010, 200_000_020, 300_000_030, 400_000_040], scenario);
         test_scenario::end(scenario_val);
     }
 

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -279,11 +279,10 @@ impl CoinReadApiServer for CoinReadApi {
     }
 
     async fn get_total_supply(&self, coin_type: String) -> RpcResult<Supply> {
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
         let coin_struct = parse_sui_struct_tag(&coin_type)?;
 
         Ok(if GAS::is_gas(&coin_struct) {
-            epoch_store.system_state_object().treasury_cap.clone()
+            Supply { value: 0 }
         } else {
             let treasury_cap_object = self
                 .find_package_object(&coin_struct.address.into(), TreasuryCap::type_(coin_struct))

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -849,8 +849,8 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
         )
         .await
         .unwrap();
-    // 17 events created by this test + 38 Genesis event
-    assert_eq!(55, page2.data.len());
+    // 17 events created by this test + 39 Genesis event
+    assert_eq!(56, page2.data.len());
     assert_eq!(None, page2.next_cursor);
 
     // test get sender events

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6055,7 +6055,6 @@
           "safe_mode",
           "stake_subsidy",
           "storage_fund",
-          "treasury_cap",
           "validator_report_records",
           "validators"
         ],
@@ -6094,9 +6093,6 @@
           },
           "storage_fund": {
             "$ref": "#/components/schemas/Balance"
-          },
-          "treasury_cap": {
-            "$ref": "#/components/schemas/Supply"
           },
           "validator_report_records": {
             "$ref": "#/components/schemas/VecMap_for_SuiAddress_and_VecSet_for_SuiAddress"

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -227,10 +227,6 @@ pub struct ProtocolConfig {
     /// In basis point.
     reward_slashing_rate: Option<u64>,
 
-    /// The stake subsidy we mint each epoch is 0.01% of the total stake.
-    /// In basis point.
-    stake_subsidy_rate: Option<u64>,
-
     /// Unit gas price, Mist per internal gas unit.
     storage_gas_price: Option<u64>,
 
@@ -356,9 +352,6 @@ impl ProtocolConfig {
     }
     pub fn reward_slashing_rate(&self) -> u64 {
         self.reward_slashing_rate.expect(CONSTANT_ERR_MSG)
-    }
-    pub fn stake_subsidy_rate(&self) -> u64 {
-        self.stake_subsidy_rate.expect(CONSTANT_ERR_MSG)
     }
     pub fn storage_gas_price(&self) -> u64 {
         self.storage_gas_price.expect(CONSTANT_ERR_MSG)
@@ -497,7 +490,6 @@ impl ProtocolConfig {
                 storage_rebate_rate: Some(9900),
                 storage_fund_reinvest_rate: Some(500),
                 reward_slashing_rate: Some(5000),
-                stake_subsidy_rate: Some(1),
                 storage_gas_price: Some(1),
                 max_transactions_per_checkpoint: Some(1000),
                 // require 2f+1 + 0.75 * f stake for automatic protocol upgrades.

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -210,7 +210,6 @@ pub struct SuiSystemState {
     pub epoch: u64,
     pub protocol_version: u64,
     pub validators: ValidatorSet,
-    pub treasury_cap: Supply,
     pub storage_fund: Balance,
     pub parameters: SystemParameters,
     pub reference_gas_price: u64,
@@ -345,7 +344,6 @@ impl Default for SuiSystemState {
             epoch: 0,
             protocol_version: ProtocolVersion::MIN.as_u64(),
             validators: validator_set,
-            treasury_cap: Supply { value: 0 },
             storage_fund: Balance::new(0),
             parameters: SystemParameters {
                 min_validator_stake: 1,

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -89,7 +89,6 @@ pub fn test_sui_system_state(epoch: EpochId, validators: Vec<Validator>) -> SuiS
         epoch,
         protocol_version: ProtocolVersion::MAX.as_u64(),
         validators: validator_set,
-        treasury_cap: Supply { value: 0 },
         storage_fund: Balance::new(0),
         parameters: SystemParameters {
             min_validator_stake: 1,

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -194,7 +194,6 @@ export const SuiSystemState = object({
   // TODO(cleanup): remove optional after TestNet Wave 2(0.22.0)
   protocol_version: optional(number()),
   validators: ValidatorSet,
-  treasury_cap: SuiSupplyFields,
   storage_fund: Balance,
   parameters: SystemParameters,
   reference_gas_price: number(),


### PR DESCRIPTION
In an effort to eliminate the ability to mint arbitrary amounts of Sui, we'll have the StakeSubsidy structure custody the total balance of tokens set asside for subsidies and drawn down that balance over time instead of minting tokens.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
