### PR TITLE
fix: Issue with struct layouts not being generated

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -80,6 +80,7 @@ impl Build {
             layout_filename.push(pkg.package.compiled_package_info.package_name.as_str());
             layout_filename.push(LAYOUTS_DIR);
             layout_filename.push(STRUCT_LAYOUTS_FILENAME);
+            fs::create_dir_all(layout_filename.parent().unwrap()).unwrap();
             fs::write(layout_filename, layout_str)?
         }
 


### PR DESCRIPTION
## Description 

This is bugfix.

Fixed a problem that caused an error when executing `sui move build --generate-struct-layouts`, as the struct_layouts.yaml file was not created.
