### PR TITLE
[move] A few fields don't belong to ValidatorMetadata

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -236,10 +236,6 @@ system_state:
           p2p_address: []
           consensus_address: []
           worker_address: []
-          next_epoch_stake: 1
-          next_epoch_delegation: 0
-          next_epoch_gas_price: 1
-          next_epoch_commission_rate: 0
         voting_power: 10000
         stake_amount: 1
         pending_stake: 0
@@ -265,6 +261,10 @@ system_state:
               id: "0x18b8140c8a6ea340142f128061016fc4bd8220ec"
               size: 0
         commission_rate: 0
+        next_epoch_stake: 1
+        next_epoch_delegation: 0
+        next_epoch_gas_price: 1
+        next_epoch_commission_rate: 0
     pending_validators: []
     pending_removals: []
     next_epoch_validators:
@@ -489,10 +489,6 @@ system_state:
         p2p_address: []
         consensus_address: []
         worker_address: []
-        next_epoch_stake: 1
-        next_epoch_delegation: 0
-        next_epoch_gas_price: 1
-        next_epoch_commission_rate: 0
     staking_pool_mappings:
       id: "0x628ffd0e51e9a6ea32c13c2739a31a8f344b557d"
       size: 1

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -232,10 +232,6 @@ validators:
         p2p_address: []
         consensus_address: []
         worker_address: []
-        next_epoch_stake: 1
-        next_epoch_delegation: 0
-        next_epoch_gas_price: 1
-        next_epoch_commission_rate: 0
       voting_power: 10000
       stake_amount: 1
       pending_stake: 0
@@ -261,6 +257,10 @@ validators:
             id: "0x18b8140c8a6ea340142f128061016fc4bd8220ec"
             size: 0
       commission_rate: 0
+      next_epoch_stake: 1
+      next_epoch_delegation: 0
+      next_epoch_gas_price: 1
+      next_epoch_commission_rate: 0
   pending_validators: []
   pending_removals: []
   next_epoch_validators:
@@ -485,10 +485,6 @@ validators:
       p2p_address: []
       consensus_address: []
       worker_address: []
-      next_epoch_stake: 1
-      next_epoch_delegation: 0
-      next_epoch_gas_price: 1
-      next_epoch_commission_rate: 0
   staking_pool_mappings:
     id: "0x628ffd0e51e9a6ea32c13c2739a31a8f344b557d"
     size: 1

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6730,6 +6730,10 @@
           "delegation_staking_pool",
           "gas_price",
           "metadata",
+          "next_epoch_commission_rate",
+          "next_epoch_delegation",
+          "next_epoch_gas_price",
+          "next_epoch_stake",
           "pending_stake",
           "pending_withdraw",
           "stake_amount",
@@ -6751,6 +6755,26 @@
           },
           "metadata": {
             "$ref": "#/components/schemas/ValidatorMetadata"
+          },
+          "next_epoch_commission_rate": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "next_epoch_delegation": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "next_epoch_gas_price": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "next_epoch_stake": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "pending_stake": {
             "type": "integer",
@@ -6783,10 +6807,6 @@
           "name",
           "net_address",
           "network_pubkey_bytes",
-          "next_epoch_commission_rate",
-          "next_epoch_delegation",
-          "next_epoch_gas_price",
-          "next_epoch_stake",
           "p2p_address",
           "project_url",
           "proof_of_possession_bytes",
@@ -6828,26 +6848,6 @@
               "format": "uint8",
               "minimum": 0.0
             }
-          },
-          "next_epoch_commission_rate": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "next_epoch_delegation": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "next_epoch_gas_price": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "next_epoch_stake": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
           },
           "p2p_address": {
             "type": "array",

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -56,21 +56,6 @@ pub struct ValidatorMetadata {
     pub p2p_address: Vec<u8>,
     pub consensus_address: Vec<u8>,
     pub worker_address: Vec<u8>,
-    pub next_epoch_stake: u64,
-    pub next_epoch_delegation: u64,
-    pub next_epoch_gas_price: u64,
-    pub next_epoch_commission_rate: u64,
-}
-
-impl ValidatorMetadata {
-    pub fn to_next_epoch_validator_and_stake_pair(&self) -> (AuthorityName, StakeUnit) {
-        (
-            // TODO: Make sure we are actually verifying this on-chain.
-            AuthorityPublicKeyBytes::from_bytes(self.pubkey_bytes.as_ref())
-                .expect("Validity of public key bytes should be verified on-chain"),
-            self.next_epoch_stake + self.next_epoch_delegation,
-        )
-    }
 }
 
 /// Rust version of the Move sui::validator::Validator type
@@ -84,6 +69,10 @@ pub struct Validator {
     pub gas_price: u64,
     pub delegation_staking_pool: StakingPool,
     pub commission_rate: u64,
+    pub next_epoch_stake: u64,
+    pub next_epoch_delegation: u64,
+    pub next_epoch_gas_price: u64,
+    pub next_epoch_commission_rate: u64,
 }
 
 impl Validator {

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -36,10 +36,6 @@ pub fn test_validatdor_metadata(
         p2p_address: vec![],
         consensus_address: vec![],
         worker_address: vec![],
-        next_epoch_stake: 1,
-        next_epoch_delegation: 1,
-        next_epoch_gas_price: 1,
-        next_epoch_commission_rate: 0,
     }
 }
 
@@ -71,6 +67,10 @@ pub fn test_validator(
         gas_price: 1,
         delegation_staking_pool: test_staking_pool(delegated_amount),
         commission_rate: 0,
+        next_epoch_stake: 1,
+        next_epoch_delegation: 1,
+        next_epoch_gas_price: 1,
+        next_epoch_commission_rate: 0,
     }
 }
 

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -32,10 +32,6 @@ export const ValidatorMetaData = object({
   net_address: array(number()),
   consensus_address: array(number()),
   worker_address: array(number()),
-  next_epoch_stake: number(),
-  next_epoch_delegation: number(),
-  next_epoch_gas_price: number(),
-  next_epoch_commission_rate: number(),
 });
 
 export type DelegatedStake = Infer<typeof DelegatedStake>;
@@ -162,6 +158,10 @@ export const Validator = object({
   gas_price: number(),
   delegation_staking_pool: DelegationStakingPoolFields,
   commission_rate: number(),
+  next_epoch_stake: number(),
+  next_epoch_delegation: number(),
+  next_epoch_gas_price: number(),
+  next_epoch_commission_rate: number(),
 });
 export type Validator = Infer<typeof Validator>;
 


### PR DESCRIPTION
## Description 

These fields are for tracking some of the next epoch values, and they are not considered as metadata of the validator.
Moving them to validator fields.

## Test Plan 

All tests pass

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ x] breaking change for a client SDKs
- [ x] breaking change for FNs (FN binary must upgrade)
- [ x] breaking change for validators or node operators (must upgrade binaries)
- [ x] breaking change for on-chain data layout
- [ x] necessitate either a data wipe or data migration

### Release notes
