### PR TITLE
allow validator to update metadata

### DIFF
--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -18,7 +18,7 @@ type ValidatorMetaProps = {
 
 export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
     const validatorPublicKey = toB64(
-        new Uint8Array(validatorData.metadata.pubkey_bytes)
+        new Uint8Array(validatorData.metadata.protocol_pubkey_bytes)
     );
 
     const validatorName = validatorData.metadata.name;

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -529,7 +529,7 @@ impl Builder {
             );
             assert_eq!(
                 validator.protocol_key().as_ref().to_vec(),
-                onchain_validator.metadata.pubkey_bytes,
+                onchain_validator.metadata.protocol_pubkey_bytes,
             );
             assert_eq!(validator.name(), onchain_validator.metadata.name);
             assert_eq!(

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -9,7 +9,7 @@ validators:
   active_validators:
     - metadata:
         sui_address: "0x21b60aa9a8cb189ccbe20461dbfad2202fdef55b9418f30ac2c5fe632f6e1cb7"
-        pubkey_bytes:
+        protocol_pubkey_bytes:
           - 153
           - 242
           - 94
@@ -229,6 +229,14 @@ validators:
         p2p_address: []
         consensus_address: []
         worker_address: []
+        next_epoch_protocol_pubkey_bytes: ~
+        next_epoch_proof_of_possession: ~
+        next_epoch_network_pubkey_bytes: ~
+        next_epoch_worker_pubkey_bytes: ~
+        next_epoch_net_address: ~
+        next_epoch_p2p_address: ~
+        next_epoch_consensus_address: ~
+        next_epoch_worker_address: ~
       voting_power: 10000
       gas_price: 1
       staking_pool:

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -190,7 +190,7 @@ pub fn make_network_authority_client_sets_from_system_state(
             .connect_lazy(&address)
             .map_err(|err| anyhow!(err.to_string()))?;
         let client = NetworkAuthorityClient::new(channel);
-        let name: &[u8] = &validator.metadata.pubkey_bytes;
+        let name: &[u8] = &validator.metadata.protocol_pubkey_bytes;
         let public_key_bytes = AuthorityName::from_bytes(name)?;
         authority_clients.insert(public_key_bytes, client);
     }

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -493,6 +493,10 @@ The amount of stake in the <code><a href="validator.md#0x2_validator">validator<
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
+    <b>assert</b>!(
+        <a href="validator_set.md#0x2_validator_set_next_epoch_validator_count">validator_set::next_epoch_validator_count</a>(&self.validators) &lt; self.parameters.max_validator_candidate_count,
+        <a href="sui_system.md#0x2_sui_system_ELimitExceeded">ELimitExceeded</a>,
+    );
     <b>let</b> stake_amount = <a href="coin.md#0x2_coin_value">coin::value</a>(&stake);
     <b>assert</b>!(
         stake_amount &gt;= self.parameters.min_validator_stake,

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -22,6 +22,26 @@
 -  [Function `get_staking_pool_mut_ref`](#0x2_validator_get_staking_pool_mut_ref)
 -  [Function `metadata`](#0x2_validator_metadata)
 -  [Function `sui_address`](#0x2_validator_sui_address)
+-  [Function `name`](#0x2_validator_name)
+-  [Function `description`](#0x2_validator_description)
+-  [Function `image_url`](#0x2_validator_image_url)
+-  [Function `project_url`](#0x2_validator_project_url)
+-  [Function `network_address`](#0x2_validator_network_address)
+-  [Function `p2p_address`](#0x2_validator_p2p_address)
+-  [Function `consensus_address`](#0x2_validator_consensus_address)
+-  [Function `worker_address`](#0x2_validator_worker_address)
+-  [Function `protocol_pubkey_bytes`](#0x2_validator_protocol_pubkey_bytes)
+-  [Function `proof_of_possession`](#0x2_validator_proof_of_possession)
+-  [Function `network_pubkey_bytes`](#0x2_validator_network_pubkey_bytes)
+-  [Function `worker_pubkey_bytes`](#0x2_validator_worker_pubkey_bytes)
+-  [Function `next_epoch_network_address`](#0x2_validator_next_epoch_network_address)
+-  [Function `next_epoch_p2p_address`](#0x2_validator_next_epoch_p2p_address)
+-  [Function `next_epoch_consensus_address`](#0x2_validator_next_epoch_consensus_address)
+-  [Function `next_epoch_worker_address`](#0x2_validator_next_epoch_worker_address)
+-  [Function `next_epoch_protocol_pubkey_bytes`](#0x2_validator_next_epoch_protocol_pubkey_bytes)
+-  [Function `next_epoch_proof_of_possession`](#0x2_validator_next_epoch_proof_of_possession)
+-  [Function `next_epoch_network_pubkey_bytes`](#0x2_validator_next_epoch_network_pubkey_bytes)
+-  [Function `next_epoch_worker_pubkey_bytes`](#0x2_validator_next_epoch_worker_pubkey_bytes)
 -  [Function `total_stake_amount`](#0x2_validator_total_stake_amount)
 -  [Function `delegate_amount`](#0x2_validator_delegate_amount)
 -  [Function `total_stake`](#0x2_validator_total_stake)
@@ -34,6 +54,18 @@
 -  [Function `pool_token_exchange_rate_at_epoch`](#0x2_validator_pool_token_exchange_rate_at_epoch)
 -  [Function `staking_pool_id`](#0x2_validator_staking_pool_id)
 -  [Function `is_duplicate`](#0x2_validator_is_duplicate)
+-  [Function `update_name`](#0x2_validator_update_name)
+-  [Function `update_description`](#0x2_validator_update_description)
+-  [Function `update_image_url`](#0x2_validator_update_image_url)
+-  [Function `update_project_url`](#0x2_validator_update_project_url)
+-  [Function `update_next_epoch_network_address`](#0x2_validator_update_next_epoch_network_address)
+-  [Function `update_next_epoch_p2p_address`](#0x2_validator_update_next_epoch_p2p_address)
+-  [Function `update_next_epoch_consensus_address`](#0x2_validator_update_next_epoch_consensus_address)
+-  [Function `update_next_epoch_worker_address`](#0x2_validator_update_next_epoch_worker_address)
+-  [Function `update_next_epoch_protocol_pubkey`](#0x2_validator_update_next_epoch_protocol_pubkey)
+-  [Function `update_next_epoch_network_pubkey`](#0x2_validator_update_next_epoch_network_pubkey)
+-  [Function `update_next_epoch_worker_pubkey`](#0x2_validator_update_next_epoch_worker_pubkey)
+-  [Function `effectuate_staged_metadata`](#0x2_validator_effectuate_staged_metadata)
 -  [Function `validate_metadata`](#0x2_validator_validate_metadata)
 -  [Function `validate_metadata_bcs`](#0x2_validator_validate_metadata_bcs)
 
@@ -80,7 +112,7 @@
  and also the address to send validator/coins to during withdraws.
 </dd>
 <dt>
-<code>pubkey_bytes: <a href="">vector</a>&lt;u8&gt;</code>
+<code>protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;</code>
 </dt>
 <dd>
  The public key bytes corresponding to the private key that the validator
@@ -152,6 +184,55 @@
 </dt>
 <dd>
  The address of the narwhal worker
+</dd>
+<dt>
+<code>next_epoch_protocol_pubkey_bytes: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+ "next_epoch" metadata only takes effects in the next epoch.
+ If none, current value will stay unchanged.
+</dd>
+<dt>
+<code>next_epoch_proof_of_possession: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>next_epoch_network_pubkey_bytes: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>next_epoch_worker_pubkey_bytes: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>next_epoch_net_address: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>next_epoch_p2p_address: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>next_epoch_consensus_address: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>next_epoch_worker_address: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
 </dd>
 </dl>
 
@@ -231,6 +312,15 @@
 <a name="@Constants_0"></a>
 
 ## Constants
+
+
+<a name="0x2_validator_EInvalidProofOfPossession"></a>
+
+
+
+<pre><code><b>const</b> <a href="validator.md#0x2_validator_EInvalidProofOfPossession">EInvalidProofOfPossession</a>: u64 = 0;
+</code></pre>
+
 
 
 <a name="0x2_validator_EMetadataInvalidConsensusAddr"></a>
@@ -318,7 +408,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 
 
 
-<pre><code><b>fun</b> <a href="validator.md#0x2_validator_verify_proof_of_possession">verify_proof_of_possession</a>(proof_of_possession: <a href="">vector</a>&lt;u8&gt;, sui_address: <b>address</b>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;)
+<pre><code><b>fun</b> <a href="validator.md#0x2_validator_verify_proof_of_possession">verify_proof_of_possession</a>(proof_of_possession: <a href="">vector</a>&lt;u8&gt;, sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -330,17 +420,17 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 <pre><code><b>fun</b> <a href="validator.md#0x2_validator_verify_proof_of_possession">verify_proof_of_possession</a>(
     proof_of_possession: <a href="">vector</a>&lt;u8&gt;,
     sui_address: <b>address</b>,
-    pubkey_bytes: <a href="">vector</a>&lt;u8&gt;
+    protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;
 ) {
     // The proof of possession is the signature over ValidatorPK || AccountAddress.
     // This proves that the account <b>address</b> is owned by the holder of ValidatorPK, and <b>ensures</b>
     // that PK <b>exists</b>.
-    <b>let</b> signed_bytes = pubkey_bytes;
+    <b>let</b> signed_bytes = protocol_pubkey_bytes;
     <b>let</b> address_bytes = to_bytes(&sui_address);
     <a href="_append">vector::append</a>(&<b>mut</b> signed_bytes, address_bytes);
     <b>assert</b>!(
-        bls12381_min_sig_verify_with_domain(&proof_of_possession, &pubkey_bytes, signed_bytes, <a href="validator.md#0x2_validator_PROOF_OF_POSSESSION_DOMAIN">PROOF_OF_POSSESSION_DOMAIN</a>) == <b>true</b>,
-        0
+        bls12381_min_sig_verify_with_domain(&proof_of_possession, &protocol_pubkey_bytes, signed_bytes, <a href="validator.md#0x2_validator_PROOF_OF_POSSESSION_DOMAIN">PROOF_OF_POSSESSION_DOMAIN</a>) == <b>true</b>,
+        <a href="validator.md#0x2_validator_EInvalidProofOfPossession">EInvalidProofOfPossession</a>
     );
 }
 </code></pre>
@@ -355,7 +445,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new_metadata">new_metadata</a>(sui_address: <b>address</b>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="_String">string::String</a>, description: <a href="_String">string::String</a>, image_url: <a href="url.md#0x2_url_Url">url::Url</a>, project_url: <a href="url.md#0x2_url_Url">url::Url</a>, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, consensus_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;): <a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new_metadata">new_metadata</a>(sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="_String">string::String</a>, description: <a href="_String">string::String</a>, image_url: <a href="url.md#0x2_url_Url">url::Url</a>, project_url: <a href="url.md#0x2_url_Url">url::Url</a>, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, consensus_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;): <a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>
 </code></pre>
 
 
@@ -366,7 +456,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new_metadata">new_metadata</a>(
     sui_address: <b>address</b>,
-    pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
+    protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
     network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
     worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
     proof_of_possession: <a href="">vector</a>&lt;u8&gt;,
@@ -381,7 +471,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 ): <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> {
     <b>let</b> metadata = <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> {
         sui_address,
-        pubkey_bytes,
+        protocol_pubkey_bytes,
         network_pubkey_bytes,
         worker_pubkey_bytes,
         proof_of_possession,
@@ -393,6 +483,14 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
         p2p_address,
         consensus_address,
         worker_address,
+        next_epoch_protocol_pubkey_bytes: <a href="_none">option::none</a>(),
+        next_epoch_network_pubkey_bytes: <a href="_none">option::none</a>(),
+        next_epoch_worker_pubkey_bytes: <a href="_none">option::none</a>(),
+        next_epoch_proof_of_possession: <a href="_none">option::none</a>(),
+        next_epoch_net_address: <a href="_none">option::none</a>(),
+        next_epoch_p2p_address: <a href="_none">option::none</a>(),
+        next_epoch_consensus_address: <a href="_none">option::none</a>(),
+        next_epoch_worker_address: <a href="_none">option::none</a>(),
     };
     metadata
 }
@@ -408,7 +506,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new">new</a>(sui_address: <b>address</b>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, consensus_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, gas_price: u64, commission_rate: u64, starting_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new">new</a>(sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, consensus_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, gas_price: u64, commission_rate: u64, starting_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
 </code></pre>
 
 
@@ -419,7 +517,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new">new</a>(
     sui_address: <b>address</b>,
-    pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
+    protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
     network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
     worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
     proof_of_possession: <a href="">vector</a>&lt;u8&gt;,
@@ -444,18 +542,19 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
             && <a href="_length">vector::length</a>(&p2p_address) &lt;= 128
             && <a href="_length">vector::length</a>(&name) &lt;= 128
             && <a href="_length">vector::length</a>(&description) &lt;= 150
-            && <a href="_length">vector::length</a>(&pubkey_bytes) &lt;= 128,
+            && <a href="_length">vector::length</a>(&protocol_pubkey_bytes) &lt;= 128,
         0
     );
     <a href="validator.md#0x2_validator_verify_proof_of_possession">verify_proof_of_possession</a>(
         proof_of_possession,
         sui_address,
-        pubkey_bytes
+        protocol_pubkey_bytes
     );
     <b>let</b> stake_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&stake);
-    <b>let</b> metadata =  <a href="validator.md#0x2_validator_new_metadata">new_metadata</a>(
+
+    <b>let</b> metadata = <a href="validator.md#0x2_validator_new_metadata">new_metadata</a>(
         sui_address,
-        pubkey_bytes,
+        protocol_pubkey_bytes,
         network_pubkey_bytes,
         worker_pubkey_bytes,
         proof_of_possession,
@@ -797,6 +896,486 @@ Called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></
 
 </details>
 
+<a name="0x2_validator_name"></a>
+
+## Function `name`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_name">name</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_name">name</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &String {
+    &self.metadata.name
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_description"></a>
+
+## Function `description`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_description">description</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_description">description</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &String {
+    &self.metadata.description
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_image_url"></a>
+
+## Function `image_url`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_image_url">image_url</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="url.md#0x2_url_Url">url::Url</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_image_url">image_url</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Url {
+    &self.metadata.image_url
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_project_url"></a>
+
+## Function `project_url`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_project_url">project_url</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="url.md#0x2_url_Url">url::Url</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_project_url">project_url</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Url {
+    &self.metadata.project_url
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_network_address"></a>
+
+## Function `network_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_network_address">network_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_network_address">network_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="">vector</a>&lt;u8&gt; {
+    &self.metadata.net_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_p2p_address"></a>
+
+## Function `p2p_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_p2p_address">p2p_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_p2p_address">p2p_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="">vector</a>&lt;u8&gt; {
+    &self.metadata.p2p_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_consensus_address"></a>
+
+## Function `consensus_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_consensus_address">consensus_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_consensus_address">consensus_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="">vector</a>&lt;u8&gt; {
+    &self.metadata.consensus_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_worker_address"></a>
+
+## Function `worker_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_worker_address">worker_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_worker_address">worker_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="">vector</a>&lt;u8&gt; {
+    &self.metadata.worker_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_protocol_pubkey_bytes"></a>
+
+## Function `protocol_pubkey_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_protocol_pubkey_bytes">protocol_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_protocol_pubkey_bytes">protocol_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="">vector</a>&lt;u8&gt; {
+    &self.metadata.protocol_pubkey_bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_proof_of_possession"></a>
+
+## Function `proof_of_possession`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_proof_of_possession">proof_of_possession</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_proof_of_possession">proof_of_possession</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="">vector</a>&lt;u8&gt; {
+    &self.metadata.proof_of_possession
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_network_pubkey_bytes"></a>
+
+## Function `network_pubkey_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_network_pubkey_bytes">network_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_network_pubkey_bytes">network_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="">vector</a>&lt;u8&gt; {
+    &self.metadata.network_pubkey_bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_worker_pubkey_bytes"></a>
+
+## Function `worker_pubkey_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_worker_pubkey_bytes">worker_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_worker_pubkey_bytes">worker_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="">vector</a>&lt;u8&gt; {
+    &self.metadata.worker_pubkey_bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_next_epoch_network_address"></a>
+
+## Function `next_epoch_network_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_network_address">next_epoch_network_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_network_address">next_epoch_network_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    &self.metadata.next_epoch_net_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_next_epoch_p2p_address"></a>
+
+## Function `next_epoch_p2p_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_p2p_address">next_epoch_p2p_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_p2p_address">next_epoch_p2p_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    &self.metadata.next_epoch_p2p_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_next_epoch_consensus_address"></a>
+
+## Function `next_epoch_consensus_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_consensus_address">next_epoch_consensus_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_consensus_address">next_epoch_consensus_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    &self.metadata.next_epoch_consensus_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_next_epoch_worker_address"></a>
+
+## Function `next_epoch_worker_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_worker_address">next_epoch_worker_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_worker_address">next_epoch_worker_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    &self.metadata.next_epoch_worker_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_next_epoch_protocol_pubkey_bytes"></a>
+
+## Function `next_epoch_protocol_pubkey_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_protocol_pubkey_bytes">next_epoch_protocol_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_protocol_pubkey_bytes">next_epoch_protocol_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    &self.metadata.next_epoch_protocol_pubkey_bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_next_epoch_proof_of_possession"></a>
+
+## Function `next_epoch_proof_of_possession`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_proof_of_possession">next_epoch_proof_of_possession</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_proof_of_possession">next_epoch_proof_of_possession</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    &self.metadata.next_epoch_proof_of_possession
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_next_epoch_network_pubkey_bytes"></a>
+
+## Function `next_epoch_network_pubkey_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_network_pubkey_bytes">next_epoch_network_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_network_pubkey_bytes">next_epoch_network_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    &self.metadata.next_epoch_network_pubkey_bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_next_epoch_worker_pubkey_bytes"></a>
+
+## Function `next_epoch_worker_pubkey_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_worker_pubkey_bytes">next_epoch_worker_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_worker_pubkey_bytes">next_epoch_worker_pubkey_bytes</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    &self.metadata.next_epoch_worker_pubkey_bytes
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_validator_total_stake_amount"></a>
 
 ## Function `total_stake_amount`
@@ -1100,7 +1679,354 @@ Set the voting power of this validator, called only from validator_set.
         || self.metadata.name == other.metadata.name
         || self.metadata.net_address == other.metadata.net_address
         || self.metadata.p2p_address == other.metadata.p2p_address
-        || self.metadata.pubkey_bytes == other.metadata.pubkey_bytes
+        || self.metadata.protocol_pubkey_bytes == other.metadata.protocol_pubkey_bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_name"></a>
+
+## Function `update_name`
+
+Update name of the validator.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_name">update_name</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, name: <a href="_String">string::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_name">update_name</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, name: String) {
+    self.metadata.name = name;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_description"></a>
+
+## Function `update_description`
+
+Update description of the validator.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_description">update_description</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, description: <a href="_String">string::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_description">update_description</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, description: String) {
+    self.metadata.description = description;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_image_url"></a>
+
+## Function `update_image_url`
+
+Update image url of the validator.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_image_url">update_image_url</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, image_url: <a href="url.md#0x2_url_Url">url::Url</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_image_url">update_image_url</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, image_url: Url) {
+    self.metadata.image_url = image_url;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_project_url"></a>
+
+## Function `update_project_url`
+
+Update project url of the validator.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_project_url">update_project_url</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, project_url: <a href="url.md#0x2_url_Url">url::Url</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_project_url">update_project_url</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, project_url: Url) {
+    self.metadata.project_url = project_url;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_next_epoch_network_address"></a>
+
+## Function `update_next_epoch_network_address`
+
+Update network address of this validator, taking effects from next epoch
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_network_address">update_next_epoch_network_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, net_address: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_network_address">update_next_epoch_network_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, net_address: <a href="">vector</a>&lt;u8&gt;) {
+    self.metadata.next_epoch_net_address = <a href="_some">option::some</a>(net_address);
+    <a href="validator.md#0x2_validator_validate_metadata">validate_metadata</a>(&self.metadata);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_next_epoch_p2p_address"></a>
+
+## Function `update_next_epoch_p2p_address`
+
+Update p2p address of this validator, taking effects from next epoch
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_p2p_address">update_next_epoch_p2p_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, p2p_address: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_p2p_address">update_next_epoch_p2p_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, p2p_address: <a href="">vector</a>&lt;u8&gt;) {
+    self.metadata.next_epoch_p2p_address = <a href="_some">option::some</a>(p2p_address);
+    <a href="validator.md#0x2_validator_validate_metadata">validate_metadata</a>(&self.metadata);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_next_epoch_consensus_address"></a>
+
+## Function `update_next_epoch_consensus_address`
+
+Update consensus address of this validator, taking effects from next epoch
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_consensus_address">update_next_epoch_consensus_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, consensus_address: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_consensus_address">update_next_epoch_consensus_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, consensus_address: <a href="">vector</a>&lt;u8&gt;) {
+    self.metadata.next_epoch_consensus_address = <a href="_some">option::some</a>(consensus_address);
+    <a href="validator.md#0x2_validator_validate_metadata">validate_metadata</a>(&self.metadata);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_next_epoch_worker_address"></a>
+
+## Function `update_next_epoch_worker_address`
+
+Update worker address of this validator, taking effects from next epoch
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_worker_address">update_next_epoch_worker_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, worker_address: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_worker_address">update_next_epoch_worker_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, worker_address: <a href="">vector</a>&lt;u8&gt;) {
+    self.metadata.next_epoch_worker_address = <a href="_some">option::some</a>(worker_address);
+    <a href="validator.md#0x2_validator_validate_metadata">validate_metadata</a>(&self.metadata);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_next_epoch_protocol_pubkey"></a>
+
+## Function `update_next_epoch_protocol_pubkey`
+
+Update protocol public key of this validator, taking effects from next epoch
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_protocol_pubkey">update_next_epoch_protocol_pubkey</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, protocol_pubkey: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_protocol_pubkey">update_next_epoch_protocol_pubkey</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, protocol_pubkey: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;) {
+    // TODO <b>move</b> proof of possession verification <b>to</b> the <b>native</b> function
+    <a href="validator.md#0x2_validator_verify_proof_of_possession">verify_proof_of_possession</a>(proof_of_possession, self.metadata.sui_address, protocol_pubkey);
+    self.metadata.next_epoch_protocol_pubkey_bytes = <a href="_some">option::some</a>(protocol_pubkey);
+    self.metadata.next_epoch_proof_of_possession = <a href="_some">option::some</a>(proof_of_possession);
+    <a href="validator.md#0x2_validator_validate_metadata">validate_metadata</a>(&self.metadata);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_next_epoch_network_pubkey"></a>
+
+## Function `update_next_epoch_network_pubkey`
+
+Update network public key of this validator, taking effects from next epoch
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_network_pubkey">update_next_epoch_network_pubkey</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, network_pubkey: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_network_pubkey">update_next_epoch_network_pubkey</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, network_pubkey: <a href="">vector</a>&lt;u8&gt;) {
+    self.metadata.next_epoch_network_pubkey_bytes = <a href="_some">option::some</a>(network_pubkey);
+    <a href="validator.md#0x2_validator_validate_metadata">validate_metadata</a>(&self.metadata);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_update_next_epoch_worker_pubkey"></a>
+
+## Function `update_next_epoch_worker_pubkey`
+
+Update Narwhal worker public key of this validator, taking effects from next epoch
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_worker_pubkey">update_next_epoch_worker_pubkey</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, worker_pubkey: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_worker_pubkey">update_next_epoch_worker_pubkey</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, worker_pubkey: <a href="">vector</a>&lt;u8&gt;) {
+    self.metadata.next_epoch_worker_pubkey_bytes = <a href="_some">option::some</a>(worker_pubkey);
+    <a href="validator.md#0x2_validator_validate_metadata">validate_metadata</a>(&self.metadata);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_effectuate_staged_metadata"></a>
+
+## Function `effectuate_staged_metadata`
+
+Effectutate all staged next epoch metadata for this validator.
+NOTE: this function SHOULD ONLY be called by validator_set when
+advancing an epoch.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_effectuate_staged_metadata">effectuate_staged_metadata</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_effectuate_staged_metadata">effectuate_staged_metadata</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>) {
+    <b>if</b> (<a href="_is_some">option::is_some</a>(<a href="validator.md#0x2_validator_next_epoch_network_address">next_epoch_network_address</a>(self))) {
+        self.metadata.net_address = <a href="_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_net_address);
+        self.metadata.next_epoch_net_address = <a href="_none">option::none</a>();
+    };
+
+    <b>if</b> (<a href="_is_some">option::is_some</a>(<a href="validator.md#0x2_validator_next_epoch_p2p_address">next_epoch_p2p_address</a>(self))) {
+        self.metadata.p2p_address = <a href="_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_p2p_address);
+        self.metadata.next_epoch_p2p_address = <a href="_none">option::none</a>();
+    };
+
+    <b>if</b> (<a href="_is_some">option::is_some</a>(<a href="validator.md#0x2_validator_next_epoch_consensus_address">next_epoch_consensus_address</a>(self))) {
+        self.metadata.consensus_address = <a href="_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_consensus_address);
+        self.metadata.next_epoch_consensus_address = <a href="_none">option::none</a>();
+    };
+
+    <b>if</b> (<a href="_is_some">option::is_some</a>(<a href="validator.md#0x2_validator_next_epoch_worker_address">next_epoch_worker_address</a>(self))) {
+        self.metadata.worker_address = <a href="_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_worker_address);
+        self.metadata.next_epoch_worker_address = <a href="_none">option::none</a>();
+    };
+
+    <b>if</b> (<a href="_is_some">option::is_some</a>(<a href="validator.md#0x2_validator_next_epoch_protocol_pubkey_bytes">next_epoch_protocol_pubkey_bytes</a>(self))) {
+        self.metadata.protocol_pubkey_bytes = <a href="_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_protocol_pubkey_bytes);
+        self.metadata.next_epoch_protocol_pubkey_bytes = <a href="_none">option::none</a>();
+        self.metadata.proof_of_possession = <a href="_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_proof_of_possession);
+        self.metadata.next_epoch_proof_of_possession = <a href="_none">option::none</a>();
+    };
+
+    <b>if</b> (<a href="_is_some">option::is_some</a>(<a href="validator.md#0x2_validator_next_epoch_network_pubkey_bytes">next_epoch_network_pubkey_bytes</a>(self))) {
+        self.metadata.network_pubkey_bytes = <a href="_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_network_pubkey_bytes);
+        self.metadata.next_epoch_network_pubkey_bytes = <a href="_none">option::none</a>();
+    };
+
+    <b>if</b> (<a href="_is_some">option::is_some</a>(<a href="validator.md#0x2_validator_next_epoch_worker_pubkey_bytes">next_epoch_worker_pubkey_bytes</a>(self))) {
+        self.metadata.worker_pubkey_bytes = <a href="_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_worker_pubkey_bytes);
+        self.metadata.next_epoch_worker_pubkey_bytes = <a href="_none">option::none</a>();
+    };
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -26,8 +26,8 @@
 -  [Function `staking_pool_mappings`](#0x2_validator_set_staking_pool_mappings)
 -  [Function `next_epoch_validator_count`](#0x2_validator_set_next_epoch_validator_count)
 -  [Function `is_active_validator_by_sui_address`](#0x2_validator_set_is_active_validator_by_sui_address)
--  [Function `is_currently_active_validator`](#0x2_validator_set_is_currently_active_validator)
--  [Function `is_currently_pending_validator`](#0x2_validator_set_is_currently_pending_validator)
+-  [Function `is_duplicate_with_active_validator`](#0x2_validator_set_is_duplicate_with_active_validator)
+-  [Function `is_duplicate_with_pending_validator`](#0x2_validator_set_is_duplicate_with_pending_validator)
 -  [Function `find_validator`](#0x2_validator_set_find_validator)
 -  [Function `find_validator_from_table_vec`](#0x2_validator_set_find_validator_from_table_vec)
 -  [Function `get_validator_indices`](#0x2_validator_set_get_validator_indices)
@@ -349,8 +349,8 @@ processed at the end of epoch.
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, <a href="validator.md#0x2_validator">validator</a>: Validator) {
     <b>assert</b>!(
-        !<a href="validator_set.md#0x2_validator_set_is_currently_active_validator">is_currently_active_validator</a>(self, &<a href="validator.md#0x2_validator">validator</a>)
-            && !<a href="validator_set.md#0x2_validator_set_is_currently_pending_validator">is_currently_pending_validator</a>(self, &<a href="validator.md#0x2_validator">validator</a>),
+        !<a href="validator_set.md#0x2_validator_set_is_duplicate_with_active_validator">is_duplicate_with_active_validator</a>(self, &<a href="validator.md#0x2_validator">validator</a>)
+            && !<a href="validator_set.md#0x2_validator_set_is_duplicate_with_pending_validator">is_duplicate_with_pending_validator</a>(self, &<a href="validator.md#0x2_validator">validator</a>),
         <a href="validator_set.md#0x2_validator_set_EDuplicateValidator">EDuplicateValidator</a>
     );
     <a href="table_vec.md#0x2_table_vec_push_back">table_vec::push_back</a>(&<b>mut</b> self.pending_validators, <a href="validator.md#0x2_validator">validator</a>);
@@ -916,16 +916,16 @@ Returns true iff the address exists in active validators.
 
 </details>
 
-<a name="0x2_validator_set_is_currently_active_validator"></a>
+<a name="0x2_validator_set_is_duplicate_with_active_validator"></a>
 
-## Function `is_currently_active_validator`
+## Function `is_duplicate_with_active_validator`
 
-Checks whether <code>new_validator</code> is already in currently active validator list.
+Checks whether <code>new_validator</code> is duplicate with any currently active validators.
 It differs from <code>is_active_validator_by_sui_address</code> in that the former checks
 only the sui address but this function looks at more metadata.
 
 
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_currently_active_validator">is_currently_active_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, new_validator: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): bool
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_duplicate_with_active_validator">is_duplicate_with_active_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, new_validator: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): bool
 </code></pre>
 
 
@@ -934,7 +934,7 @@ only the sui address but this function looks at more metadata.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_currently_active_validator">is_currently_active_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, new_validator: &Validator): bool {
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_duplicate_with_active_validator">is_duplicate_with_active_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, new_validator: &Validator): bool {
     <b>let</b> len = <a href="_length">vector::length</a>(&self.active_validators);
     <b>let</b> i = 0;
     <b>while</b> (i &lt; len) {
@@ -952,14 +952,14 @@ only the sui address but this function looks at more metadata.
 
 </details>
 
-<a name="0x2_validator_set_is_currently_pending_validator"></a>
+<a name="0x2_validator_set_is_duplicate_with_pending_validator"></a>
 
-## Function `is_currently_pending_validator`
+## Function `is_duplicate_with_pending_validator`
 
-Checks whether <code>new_validator</code> is already in currently pending validator list.
+Checks whether <code>new_validator</code> is duplicate with any currently pending validators.
 
 
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_currently_pending_validator">is_currently_pending_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, new_validator: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): bool
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_duplicate_with_pending_validator">is_duplicate_with_pending_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, new_validator: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): bool
 </code></pre>
 
 
@@ -968,7 +968,7 @@ Checks whether <code>new_validator</code> is already in currently pending valida
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_currently_pending_validator">is_currently_pending_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, new_validator: &Validator): bool {
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_duplicate_with_pending_validator">is_duplicate_with_pending_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, new_validator: &Validator): bool {
     <b>let</b> len = <a href="table_vec.md#0x2_table_vec_length">table_vec::length</a>(&self.pending_validators);
     <b>let</b> i = 0;
     <b>while</b> (i &lt; len) {

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -17,6 +17,7 @@
 -  [Function `request_set_gas_price`](#0x2_validator_set_request_set_gas_price)
 -  [Function `request_set_commission_rate`](#0x2_validator_set_request_set_commission_rate)
 -  [Function `advance_epoch`](#0x2_validator_set_advance_epoch)
+-  [Function `effectuate_staged_metadata`](#0x2_validator_set_effectuate_staged_metadata)
 -  [Function `derive_reference_gas_price`](#0x2_validator_set_derive_reference_gas_price)
 -  [Function `total_stake`](#0x2_validator_set_total_stake)
 -  [Function `validator_total_stake_amount`](#0x2_validator_set_validator_total_stake_amount)
@@ -24,13 +25,17 @@
 -  [Function `validator_staking_pool_id`](#0x2_validator_set_validator_staking_pool_id)
 -  [Function `staking_pool_mappings`](#0x2_validator_set_staking_pool_mappings)
 -  [Function `next_epoch_validator_count`](#0x2_validator_set_next_epoch_validator_count)
--  [Function `is_active_validator`](#0x2_validator_set_is_active_validator)
+-  [Function `is_active_validator_by_sui_address`](#0x2_validator_set_is_active_validator_by_sui_address)
 -  [Function `is_currently_active_validator`](#0x2_validator_set_is_currently_active_validator)
 -  [Function `is_currently_pending_validator`](#0x2_validator_set_is_currently_pending_validator)
 -  [Function `find_validator`](#0x2_validator_set_find_validator)
+-  [Function `find_validator_from_table_vec`](#0x2_validator_set_find_validator_from_table_vec)
 -  [Function `get_validator_indices`](#0x2_validator_set_get_validator_indices)
 -  [Function `get_validator_mut`](#0x2_validator_set_get_validator_mut)
+-  [Function `get_active_or_pending_validator_mut`](#0x2_validator_set_get_active_or_pending_validator_mut)
 -  [Function `get_validator_ref`](#0x2_validator_set_get_validator_ref)
+-  [Function `get_active_validator_ref`](#0x2_validator_set_get_active_validator_ref)
+-  [Function `get_pending_validator_ref`](#0x2_validator_set_get_pending_validator_ref)
 -  [Function `process_pending_removals`](#0x2_validator_set_process_pending_removals)
 -  [Function `process_pending_validators`](#0x2_validator_set_process_pending_validators)
 -  [Function `sort_removal_list`](#0x2_validator_set_sort_removal_list)
@@ -641,6 +646,43 @@ It does the following things:
     self.total_stake = <a href="validator_set.md#0x2_validator_set_calculate_total_stakes">calculate_total_stakes</a>(&self.active_validators);
 
     <a href="voting_power.md#0x2_voting_power_set_voting_power">voting_power::set_voting_power</a>(&<b>mut</b> self.active_validators);
+
+    // At this point, self.active_validators are updated for next epoch.
+    // Now we process the staged <a href="validator.md#0x2_validator">validator</a> metadata.
+    <a href="validator_set.md#0x2_validator_set_effectuate_staged_metadata">effectuate_staged_metadata</a>(self);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_effectuate_staged_metadata"></a>
+
+## Function `effectuate_staged_metadata`
+
+Effectutate pending next epoch metadata if they are staged.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_effectuate_staged_metadata">effectuate_staged_metadata</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_effectuate_staged_metadata">effectuate_staged_metadata</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+) {
+    <b>let</b> num_validators = <a href="_length">vector::length</a>(&self.active_validators);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; num_validators) {
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.active_validators, i);
+        <a href="validator.md#0x2_validator_effectuate_staged_metadata">validator::effectuate_staged_metadata</a>(<a href="validator.md#0x2_validator">validator</a>);
+        i = i + 1;
+    }
 }
 </code></pre>
 
@@ -846,14 +888,14 @@ Get the total number of validators in the next epoch.
 
 </details>
 
-<a name="0x2_validator_set_is_active_validator"></a>
+<a name="0x2_validator_set_is_active_validator_by_sui_address"></a>
 
-## Function `is_active_validator`
+## Function `is_active_validator_by_sui_address`
 
-Returns true iff <code>validator_address</code> is a member of the active validators.
+Returns true iff the address exists in active validators.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_is_active_validator">is_active_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>): bool
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_is_active_validator_by_sui_address">is_active_validator_by_sui_address</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>): bool
 </code></pre>
 
 
@@ -862,7 +904,7 @@ Returns true iff <code>validator_address</code> is a member of the active valida
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_is_active_validator">is_active_validator</a>(
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_is_active_validator_by_sui_address">is_active_validator_by_sui_address</a>(
     self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
     validator_address: <b>address</b>,
 ): bool {
@@ -879,7 +921,8 @@ Returns true iff <code>validator_address</code> is a member of the active valida
 ## Function `is_currently_active_validator`
 
 Checks whether <code>new_validator</code> is already in currently active validator list.
-Two validators are identical if they share the same sui_address or same IP or same name.
+It differs from <code>is_active_validator_by_sui_address</code> in that the former checks
+only the sui address but this function looks at more metadata.
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_currently_active_validator">is_currently_active_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, new_validator: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): bool
@@ -914,7 +957,6 @@ Two validators are identical if they share the same sui_address or same IP or sa
 ## Function `is_currently_pending_validator`
 
 Checks whether <code>new_validator</code> is already in currently pending validator list.
-Two validators are identical if they share the same sui_address or same IP or same name.
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_currently_pending_validator">is_currently_pending_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, new_validator: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): bool
@@ -967,6 +1009,42 @@ If not found, returns (false, 0).
     <b>let</b> i = 0;
     <b>while</b> (i &lt; length) {
         <b>let</b> v = <a href="_borrow">vector::borrow</a>(validators, i);
+        <b>if</b> (<a href="validator.md#0x2_validator_sui_address">validator::sui_address</a>(v) == validator_address) {
+            <b>return</b> <a href="_some">option::some</a>(i)
+        };
+        i = i + 1;
+    };
+    <a href="_none">option::none</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_find_validator_from_table_vec"></a>
+
+## Function `find_validator_from_table_vec`
+
+Find validator by <code>validator_address</code>, in <code>validators</code>.
+Returns (true, index) if the validator is found, and the index is its index in the list.
+If not found, returns (false, 0).
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(validators: &<a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, validator_address: <b>address</b>): <a href="_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(validators: &TableVec&lt;Validator&gt;, validator_address: <b>address</b>): Option&lt;u64&gt; {
+    <b>let</b> length = <a href="table_vec.md#0x2_table_vec_length">table_vec::length</a>(validators);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; length) {
+        <b>let</b> v = <a href="table_vec.md#0x2_table_vec_borrow">table_vec::borrow</a>(validators, i);
         <b>if</b> (<a href="validator.md#0x2_validator_sui_address">validator::sui_address</a>(v) == validator_address) {
             <b>return</b> <a href="_some">option::some</a>(i)
         };
@@ -1046,6 +1124,42 @@ Aborts if any address isn't in the given validator set.
 
 </details>
 
+<a name="0x2_validator_set_get_active_or_pending_validator_mut"></a>
+
+## Function `get_active_or_pending_validator_mut`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">get_active_or_pending_validator_mut</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">get_active_or_pending_validator_mut</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    ctx: &TxContext,
+): &<b>mut</b> Validator {
+    <b>let</b> validator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+
+    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address);
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&validator_index_opt)) {
+        <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
+        <b>return</b> <a href="_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.active_validators, validator_index)
+    };
+    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(&self.pending_validators, validator_address);
+    <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
+    <b>return</b> <a href="table_vec.md#0x2_table_vec_borrow_mut">table_vec::borrow_mut</a>(&<b>mut</b> self.pending_validators, validator_index)
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_validator_set_get_validator_ref"></a>
 
 ## Function `get_validator_ref`
@@ -1069,6 +1183,66 @@ Aborts if any address isn't in the given validator set.
     <b>assert</b>!(<a href="_is_some">option::is_some</a>(&validator_index_opt), 0);
     <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
     <a href="_borrow">vector::borrow</a>(validators, validator_index)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_get_active_validator_ref"></a>
+
+## Function `get_active_validator_ref`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_get_active_validator_ref">get_active_validator_ref</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>): &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_get_active_validator_ref">get_active_validator_ref</a>(
+    self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    validator_address: <b>address</b>,
+): &Validator {
+    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address);
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&validator_index_opt), 0);
+    <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
+    <a href="_borrow">vector::borrow</a>(&self.active_validators, validator_index)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_get_pending_validator_ref"></a>
+
+## Function `get_pending_validator_ref`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_get_pending_validator_ref">get_pending_validator_ref</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>): &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x2_validator_set_get_pending_validator_ref">get_pending_validator_ref</a>(
+    self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    validator_address: <b>address</b>,
+): &Validator {
+    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(&self.pending_validators, validator_address);
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&validator_index_opt), 0);
+    <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
+    <a href="table_vec.md#0x2_table_vec_borrow">table_vec::borrow</a>(&self.pending_validators, validator_index)
 }
 </code></pre>
 
@@ -1371,7 +1545,7 @@ non-performant validators according to the input threshold.
     <b>while</b> (!<a href="vec_map.md#0x2_vec_map_is_empty">vec_map::is_empty</a>(&validator_report_records)) {
         <b>let</b> (validator_address, reporters) = <a href="vec_map.md#0x2_vec_map_pop">vec_map::pop</a>(&<b>mut</b> validator_report_records);
         <b>assert</b>!(
-            <a href="validator_set.md#0x2_validator_set_is_active_validator">is_active_validator</a>(self, validator_address),
+            <a href="validator_set.md#0x2_validator_set_is_active_validator_by_sui_address">is_active_validator_by_sui_address</a>(self, validator_address),
             <a href="validator_set.md#0x2_validator_set_ENonValidatorInReportRecords">ENonValidatorInReportRecords</a>,
         );
         // Sum up the voting power of validators that have reported this <a href="validator.md#0x2_validator">validator</a> and check <b>if</b> it <b>has</b>

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -179,6 +179,10 @@ module sui::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
+        assert!(
+            validator_set::next_epoch_validator_count(&self.validators) < self.parameters.max_validator_candidate_count,
+            ELimitExceeded,
+        );
         let stake_amount = coin::value(&stake);
         assert!(
             stake_amount >= self.parameters.min_validator_stake,

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -12,7 +12,7 @@ module sui::validator {
     use sui::tx_context::{Self, TxContext};
     use sui::epoch_time_lock::EpochTimeLock;
     use sui::object::{Self, ID};
-    use std::option::Option;
+    use std::option::{Option, Self};
     use sui::bls12381::bls12381_min_sig_verify_with_domain;
     use sui::staking_pool::{Self, PoolTokenExchangeRate, StakedSui, StakingPool};
     use std::string::{Self, String};
@@ -27,6 +27,8 @@ module sui::validator {
     friend sui::validator_tests;
     #[test_only]
     friend sui::validator_set_tests;
+    #[test_only]
+    friend sui::sui_system_tests;
     #[test_only]
     friend sui::governance_test_utils;
 
@@ -51,6 +53,7 @@ module sui::validator {
     /// Invalidworker_address field in ValidatorMetadata
     const EMetadataInvalidWorkerAddr: u64 = 7;
 
+    const EInvalidProofOfPossession: u64 = 0;
 
     struct ValidatorMetadata has store, drop, copy {
         /// The Sui Address of the validator. This is the sender that created the Validator object,
@@ -58,7 +61,7 @@ module sui::validator {
         sui_address: address,
         /// The public key bytes corresponding to the private key that the validator
         /// holds to sign transactions. For now, this is the same as AuthorityName.
-        pubkey_bytes: vector<u8>,
+        protocol_pubkey_bytes: vector<u8>,
         /// The public key bytes corresponding to the private key that the validator
         /// uses to establish TLS connections
         network_pubkey_bytes: vector<u8>,
@@ -79,6 +82,17 @@ module sui::validator {
         consensus_address: vector<u8>,
         /// The address of the narwhal worker
         worker_address: vector<u8>,
+
+        /// "next_epoch" metadata only takes effects in the next epoch.
+        /// If none, current value will stay unchanged.
+        next_epoch_protocol_pubkey_bytes: Option<vector<u8>>,
+        next_epoch_proof_of_possession: Option<vector<u8>>,
+        next_epoch_network_pubkey_bytes: Option<vector<u8>>,
+        next_epoch_worker_pubkey_bytes: Option<vector<u8>>,
+        next_epoch_net_address: Option<vector<u8>>,
+        next_epoch_p2p_address: Option<vector<u8>>,
+        next_epoch_consensus_address: Option<vector<u8>>,
+        next_epoch_worker_address: Option<vector<u8>>,
     }
 
     struct Validator has store {
@@ -106,22 +120,23 @@ module sui::validator {
     fun verify_proof_of_possession(
         proof_of_possession: vector<u8>,
         sui_address: address,
-        pubkey_bytes: vector<u8>
+        protocol_pubkey_bytes: vector<u8>
     ) {
         // The proof of possession is the signature over ValidatorPK || AccountAddress.
         // This proves that the account address is owned by the holder of ValidatorPK, and ensures
         // that PK exists.
-        let signed_bytes = pubkey_bytes;
+        let signed_bytes = protocol_pubkey_bytes;
         let address_bytes = to_bytes(&sui_address);
         vector::append(&mut signed_bytes, address_bytes);
         assert!(
-            bls12381_min_sig_verify_with_domain(&proof_of_possession, &pubkey_bytes, signed_bytes, PROOF_OF_POSSESSION_DOMAIN) == true,
-            0
+            bls12381_min_sig_verify_with_domain(&proof_of_possession, &protocol_pubkey_bytes, signed_bytes, PROOF_OF_POSSESSION_DOMAIN) == true,
+            EInvalidProofOfPossession
         );
     }
+
     public(friend) fun new_metadata(
         sui_address: address,
-        pubkey_bytes: vector<u8>,
+        protocol_pubkey_bytes: vector<u8>,
         network_pubkey_bytes: vector<u8>,
         worker_pubkey_bytes: vector<u8>,
         proof_of_possession: vector<u8>,
@@ -136,7 +151,7 @@ module sui::validator {
     ): ValidatorMetadata {
         let metadata = ValidatorMetadata {
             sui_address,
-            pubkey_bytes,
+            protocol_pubkey_bytes,
             network_pubkey_bytes,
             worker_pubkey_bytes,
             proof_of_possession,
@@ -148,13 +163,21 @@ module sui::validator {
             p2p_address,
             consensus_address,
             worker_address,
+            next_epoch_protocol_pubkey_bytes: option::none(),
+            next_epoch_network_pubkey_bytes: option::none(),
+            next_epoch_worker_pubkey_bytes: option::none(),
+            next_epoch_proof_of_possession: option::none(),
+            next_epoch_net_address: option::none(),
+            next_epoch_p2p_address: option::none(),
+            next_epoch_consensus_address: option::none(),
+            next_epoch_worker_address: option::none(),
         };
         metadata
     }
 
     public(friend) fun new(
         sui_address: address,
-        pubkey_bytes: vector<u8>,
+        protocol_pubkey_bytes: vector<u8>,
         network_pubkey_bytes: vector<u8>,
         worker_pubkey_bytes: vector<u8>,
         proof_of_possession: vector<u8>,
@@ -179,18 +202,19 @@ module sui::validator {
                 && vector::length(&p2p_address) <= 128
                 && vector::length(&name) <= 128
                 && vector::length(&description) <= 150
-                && vector::length(&pubkey_bytes) <= 128,
+                && vector::length(&protocol_pubkey_bytes) <= 128,
             0
         );
         verify_proof_of_possession(
             proof_of_possession,
             sui_address,
-            pubkey_bytes
+            protocol_pubkey_bytes
         );
         let stake_amount = balance::value(&stake);
-        let metadata =  new_metadata(
+
+        let metadata = new_metadata(
             sui_address,
-            pubkey_bytes,
+            protocol_pubkey_bytes,
             network_pubkey_bytes,
             worker_pubkey_bytes,
             proof_of_possession,
@@ -307,6 +331,86 @@ module sui::validator {
         self.metadata.sui_address
     }
 
+    public fun name(self: &Validator): &String {
+        &self.metadata.name
+    }
+
+    public fun description(self: &Validator): &String {
+        &self.metadata.description
+    }
+
+    public fun image_url(self: &Validator): &Url {
+        &self.metadata.image_url
+    }
+
+    public fun project_url(self: &Validator): &Url {
+        &self.metadata.project_url
+    }
+
+    public fun network_address(self: &Validator): &vector<u8> {
+        &self.metadata.net_address
+    }
+
+    public fun p2p_address(self: &Validator): &vector<u8> {
+        &self.metadata.p2p_address
+    }
+
+    public fun consensus_address(self: &Validator): &vector<u8> {
+        &self.metadata.consensus_address
+    }
+
+    public fun worker_address(self: &Validator): &vector<u8> {
+        &self.metadata.worker_address
+    }
+
+    public fun protocol_pubkey_bytes(self: &Validator): &vector<u8> {
+        &self.metadata.protocol_pubkey_bytes
+    }
+
+    public fun proof_of_possession(self: &Validator): &vector<u8> {
+        &self.metadata.proof_of_possession
+    }
+
+    public fun network_pubkey_bytes(self: &Validator): &vector<u8> {
+        &self.metadata.network_pubkey_bytes
+    }
+
+    public fun worker_pubkey_bytes(self: &Validator): &vector<u8> {
+        &self.metadata.worker_pubkey_bytes
+    }
+
+    public fun next_epoch_network_address(self: &Validator): &Option<vector<u8>> {
+        &self.metadata.next_epoch_net_address
+    }
+
+    public fun next_epoch_p2p_address(self: &Validator): &Option<vector<u8>> {
+        &self.metadata.next_epoch_p2p_address
+    }
+
+    public fun next_epoch_consensus_address(self: &Validator): &Option<vector<u8>> {
+        &self.metadata.next_epoch_consensus_address
+    }
+
+    public fun next_epoch_worker_address(self: &Validator): &Option<vector<u8>> {
+        &self.metadata.next_epoch_worker_address
+    }
+
+    public fun next_epoch_protocol_pubkey_bytes(self: &Validator): &Option<vector<u8>> {
+        &self.metadata.next_epoch_protocol_pubkey_bytes
+    }
+
+    public fun next_epoch_proof_of_possession(self: &Validator): &Option<vector<u8>> {
+        &self.metadata.next_epoch_proof_of_possession
+    }
+
+    public fun next_epoch_network_pubkey_bytes(self: &Validator): &Option<vector<u8>> {
+        &self.metadata.next_epoch_network_pubkey_bytes
+    }
+
+    public fun next_epoch_worker_pubkey_bytes(self: &Validator): &Option<vector<u8>> {
+        &self.metadata.next_epoch_worker_pubkey_bytes
+    }
+
     public fun total_stake_amount(self: &Validator): u64 {
         spec {
             // TODO: this should be provable rather than assumed
@@ -367,7 +471,116 @@ module sui::validator {
             || self.metadata.name == other.metadata.name
             || self.metadata.net_address == other.metadata.net_address
             || self.metadata.p2p_address == other.metadata.p2p_address
-            || self.metadata.pubkey_bytes == other.metadata.pubkey_bytes
+            || self.metadata.protocol_pubkey_bytes == other.metadata.protocol_pubkey_bytes
+    }
+
+    // ==== Validator Metadata Management Functions ====
+
+    /// Update name of the validator.
+    public(friend) fun update_name(self: &mut Validator, name: String) {
+        self.metadata.name = name;
+    }
+
+    /// Update description of the validator.
+    public(friend) fun update_description(self: &mut Validator, description: String) {
+        self.metadata.description = description;
+    }
+
+    /// Update image url of the validator.
+    public(friend) fun update_image_url(self: &mut Validator, image_url: Url) {
+        self.metadata.image_url = image_url;
+    }
+
+    /// Update project url of the validator.
+    public(friend) fun update_project_url(self: &mut Validator, project_url: Url) {
+        self.metadata.project_url = project_url;
+    }
+
+    /// Update network address of this validator, taking effects from next epoch
+    public(friend) fun update_next_epoch_network_address(self: &mut Validator, net_address: vector<u8>) {
+        self.metadata.next_epoch_net_address = option::some(net_address);
+        validate_metadata(&self.metadata);
+    }
+
+    /// Update p2p address of this validator, taking effects from next epoch
+    public(friend) fun update_next_epoch_p2p_address(self: &mut Validator, p2p_address: vector<u8>) {
+        self.metadata.next_epoch_p2p_address = option::some(p2p_address);
+        validate_metadata(&self.metadata);
+    }
+
+    /// Update consensus address of this validator, taking effects from next epoch
+    public(friend) fun update_next_epoch_consensus_address(self: &mut Validator, consensus_address: vector<u8>) {
+        self.metadata.next_epoch_consensus_address = option::some(consensus_address);
+        validate_metadata(&self.metadata);
+    }
+
+    /// Update worker address of this validator, taking effects from next epoch
+    public(friend) fun update_next_epoch_worker_address(self: &mut Validator, worker_address: vector<u8>) {
+        self.metadata.next_epoch_worker_address = option::some(worker_address);
+        validate_metadata(&self.metadata);
+    }
+
+    /// Update protocol public key of this validator, taking effects from next epoch
+    public(friend) fun update_next_epoch_protocol_pubkey(self: &mut Validator, protocol_pubkey: vector<u8>, proof_of_possession: vector<u8>) {
+        // TODO move proof of possession verification to the native function
+        verify_proof_of_possession(proof_of_possession, self.metadata.sui_address, protocol_pubkey);
+        self.metadata.next_epoch_protocol_pubkey_bytes = option::some(protocol_pubkey);
+        self.metadata.next_epoch_proof_of_possession = option::some(proof_of_possession);
+        validate_metadata(&self.metadata);
+    } 
+
+    /// Update network public key of this validator, taking effects from next epoch
+    public(friend) fun update_next_epoch_network_pubkey(self: &mut Validator, network_pubkey: vector<u8>) {
+        self.metadata.next_epoch_network_pubkey_bytes = option::some(network_pubkey);
+        validate_metadata(&self.metadata);
+    }
+
+    /// Update Narwhal worker public key of this validator, taking effects from next epoch
+    public(friend) fun update_next_epoch_worker_pubkey(self: &mut Validator, worker_pubkey: vector<u8>) {
+        self.metadata.next_epoch_worker_pubkey_bytes = option::some(worker_pubkey);
+        validate_metadata(&self.metadata);
+    }
+
+    /// Effectutate all staged next epoch metadata for this validator.
+    /// NOTE: this function SHOULD ONLY be called by validator_set when
+    /// advancing an epoch.
+    public(friend) fun effectuate_staged_metadata(self: &mut Validator) {
+        if (option::is_some(next_epoch_network_address(self))) {
+            self.metadata.net_address = option::extract(&mut self.metadata.next_epoch_net_address);
+            self.metadata.next_epoch_net_address = option::none();
+        };
+
+        if (option::is_some(next_epoch_p2p_address(self))) {
+            self.metadata.p2p_address = option::extract(&mut self.metadata.next_epoch_p2p_address);
+            self.metadata.next_epoch_p2p_address = option::none();
+        };
+
+        if (option::is_some(next_epoch_consensus_address(self))) {
+            self.metadata.consensus_address = option::extract(&mut self.metadata.next_epoch_consensus_address);
+            self.metadata.next_epoch_consensus_address = option::none();
+        };
+
+        if (option::is_some(next_epoch_worker_address(self))) {
+            self.metadata.worker_address = option::extract(&mut self.metadata.next_epoch_worker_address);
+            self.metadata.next_epoch_worker_address = option::none();
+        };
+
+        if (option::is_some(next_epoch_protocol_pubkey_bytes(self))) {
+            self.metadata.protocol_pubkey_bytes = option::extract(&mut self.metadata.next_epoch_protocol_pubkey_bytes);
+            self.metadata.next_epoch_protocol_pubkey_bytes = option::none();
+            self.metadata.proof_of_possession = option::extract(&mut self.metadata.next_epoch_proof_of_possession);
+            self.metadata.next_epoch_proof_of_possession = option::none();
+        };
+
+        if (option::is_some(next_epoch_network_pubkey_bytes(self))) {
+            self.metadata.network_pubkey_bytes = option::extract(&mut self.metadata.next_epoch_network_pubkey_bytes);
+            self.metadata.next_epoch_network_pubkey_bytes = option::none();
+        };
+
+        if (option::is_some(next_epoch_worker_pubkey_bytes(self))) {
+            self.metadata.worker_pubkey_bytes = option::extract(&mut self.metadata.next_epoch_worker_pubkey_bytes);
+            self.metadata.next_epoch_worker_pubkey_bytes = option::none();
+        };
     }
 
     /// Aborts if validator metadata is valid
@@ -395,7 +608,7 @@ module sui::validator {
     #[test_only]
     public(friend) fun new_for_testing(
         sui_address: address,
-        pubkey_bytes: vector<u8>,
+        protocol_pubkey_bytes: vector<u8>,
         network_pubkey_bytes: vector<u8>,
         worker_pubkey_bytes: vector<u8>,
         proof_of_possession: vector<u8>,
@@ -420,7 +633,7 @@ module sui::validator {
                 && vector::length(&p2p_address) <= 128
                 && vector::length(&name) <= 128
                 && vector::length(&description) <= 150
-                && vector::length(&pubkey_bytes) <= 128,
+                && vector::length(&protocol_pubkey_bytes) <= 128,
             0
         );
         let stake_amount = balance::value(&stake);
@@ -432,7 +645,7 @@ module sui::validator {
         Validator {
             metadata: new_metadata(
                 sui_address,
-                pubkey_bytes,
+                protocol_pubkey_bytes,
                 network_pubkey_bytes,
                 worker_pubkey_bytes,
                 proof_of_possession,

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -103,8 +103,8 @@ module sui::validator_set {
     /// processed at the end of epoch.
     public(friend) fun request_add_validator(self: &mut ValidatorSet, validator: Validator) {
         assert!(
-            !is_currently_active_validator(self, &validator)
-                && !is_currently_pending_validator(self, &validator),
+            !is_duplicate_with_active_validator(self, &validator)
+                && !is_duplicate_with_pending_validator(self, &validator),
             EDuplicateValidator
         );
         table_vec::push_back(&mut self.pending_validators, validator);
@@ -377,10 +377,10 @@ module sui::validator_set {
 
     // ==== private helpers ====
 
-    /// Checks whether `new_validator` is already in currently active validator list.
+    /// Checks whether `new_validator` is duplicate with any currently active validators.
     /// It differs from `is_active_validator_by_sui_address` in that the former checks
     /// only the sui address but this function looks at more metadata.
-    fun is_currently_active_validator(self: &ValidatorSet, new_validator: &Validator): bool {
+    fun is_duplicate_with_active_validator(self: &ValidatorSet, new_validator: &Validator): bool {
         let len = vector::length(&self.active_validators);
         let i = 0;
         while (i < len) {
@@ -393,8 +393,8 @@ module sui::validator_set {
         false
     }
 
-    /// Checks whether `new_validator` is already in currently pending validator list.
-    fun is_currently_pending_validator(self: &ValidatorSet, new_validator: &Validator): bool {
+    /// Checks whether `new_validator` is duplicate with any currently pending validators.
+    fun is_duplicate_with_pending_validator(self: &ValidatorSet, new_validator: &Validator): bool {
         let len = table_vec::length(&self.pending_validators);
         let i = 0;
         while (i < len) {

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -236,7 +236,7 @@ module sui::governance_test_utils {
 
     /// Return the rewards for the validator at `addr` in terms of SUI.
     public fun stake_plus_current_rewards_for_validator(addr: address, system_state: &SuiSystemState, scenario: &mut Scenario): u64 {
-        let validator_ref = validator_set::get_validator_ref_test(sui_system::validators(system_state), addr);
+        let validator_ref = validator_set::get_active_validator_ref(sui_system::validators(system_state), addr);
         let amount = stake_plus_current_rewards(addr, validator::get_staking_pool_ref(validator_ref), scenario);
         amount
     }

--- a/crates/sui-framework/tests/sui_system_tests.move
+++ b/crates/sui-framework/tests/sui_system_tests.move
@@ -8,11 +8,21 @@
 #[test_only]
 module sui::sui_system_tests {
     use sui::test_scenario::{Self, Scenario};
-    use sui::governance_test_utils::{add_validator, advance_epoch, remove_validator, set_up_sui_system_state};
+    use sui::sui::SUI;
+    use sui::governance_test_utils::{add_validator, advance_epoch, remove_validator, set_up_sui_system_state, create_sui_system_state_for_testing};
     use sui::sui_system::{Self, SuiSystemState};
+    use sui::validator::Self;
     use sui::vec_set;
     use sui::table;
+    use std::vector;
+    use sui::coin;
+    use sui::balance;
+    use sui::validator::Validator;
     use sui::test_utils::assert_eq;
+    use std::option::Self;
+    use sui::url;
+    use std::string;
+    use std::ascii;
 
     #[test]
     fun test_report_validator() {
@@ -153,4 +163,272 @@ module sui::sui_system_tests {
         res
     }
 
+    fun update_metadata(
+        scenario: &mut Scenario,
+        system_state: &mut SuiSystemState,
+        name: vector<u8>,
+        protocol_pub_key: vector<u8>,
+        pop: vector<u8>,
+        network_address: vector<u8>,
+        p2p_address: vector<u8>
+    ) {
+        let ctx = test_scenario::ctx(scenario);
+        sui_system::update_validator_name(system_state, name, ctx);
+        sui_system::update_validator_description(system_state, b"new_desc", ctx);
+        sui_system::update_validator_image_url(system_state, b"new_image_url", ctx);
+        sui_system::update_validator_project_url(system_state, b"new_project_url", ctx);
+        sui_system::update_validator_next_epoch_network_address(system_state, network_address, ctx);
+        sui_system::update_validator_next_epoch_p2p_address(system_state, p2p_address, ctx);
+        sui_system::update_validator_next_epoch_consensus_address(system_state, vector[4, 168, 168, 168, 168], ctx);
+        sui_system::update_validator_next_epoch_worker_address(system_state, vector[4, 168, 168, 168, 168], ctx);
+        sui_system::update_validator_next_epoch_protocol_pubkey(
+            system_state,
+            protocol_pub_key,
+            pop,
+            ctx
+        );
+        sui_system::update_validator_next_epoch_worker_pubkey(system_state, vector[215, 64, 85, 185, 231, 116, 69, 151, 97, 79, 4, 183, 20, 70, 84, 51, 211, 162, 115, 221, 73, 241, 240, 171, 192, 25, 232, 106, 175, 162, 176, 43], ctx);
+        sui_system::update_validator_next_epoch_network_pubkey(system_state, vector[148, 117, 212, 171, 44, 104, 167, 11, 177, 100, 4, 55, 17, 235, 117, 45, 117, 84, 159, 49, 14, 159, 239, 246, 237, 21, 83, 166, 112, 53, 62, 199], ctx);
+    }
+
+    fun verify_metadata(
+        validator: &Validator,
+        name: vector<u8>,
+        protocol_pub_key: vector<u8>,
+        pop: vector<u8>,
+        network_address: vector<u8>,
+        p2p_address: vector<u8>,
+        new_protocol_pub_key: vector<u8>,
+        new_pop: vector<u8>,
+        new_network_address: vector<u8>,
+        new_p2p_address: vector<u8>,
+    ) {
+        // Current epoch
+        assert!(validator::name(validator) == &string::from_ascii(ascii::string(name)), 0);
+        assert!(validator::description(validator) == &string::from_ascii(ascii::string(b"new_desc")), 0);
+        assert!(validator::image_url(validator) == &url::new_unsafe_from_bytes(b"new_image_url"), 0);
+        assert!(validator::project_url(validator) == &url::new_unsafe_from_bytes(b"new_project_url"), 0);
+        assert!(validator::network_address(validator) == &network_address, 0);
+        assert!(validator::p2p_address(validator) == &p2p_address, 0);
+        assert!(validator::consensus_address(validator) == &vector[4, 127, 0, 0, 1], 0);
+        assert!(validator::worker_address(validator) == &vector[4, 127, 0, 0, 1], 0);
+        assert!(validator::protocol_pubkey_bytes(validator) == &protocol_pub_key, 0);
+        assert!(validator::proof_of_possession(validator) == &pop, 0);
+        assert!(validator::network_pubkey_bytes(validator) == &vector[32, 219, 38, 23, 242, 109, 116, 235, 225, 192, 219, 45, 40, 124, 162, 25, 33, 68, 52, 41, 123, 9, 98, 11, 184, 150, 214, 62, 60, 210, 121, 62], 0);
+        assert!(validator::worker_pubkey_bytes(validator) == &vector[68, 55, 206, 25, 199, 14, 169, 53, 68, 92, 142, 136, 174, 149, 54, 215, 101, 63, 249, 206, 197, 98, 233, 80, 60, 12, 183, 32, 216, 88, 103, 25], 0);
+
+        // Next epoch
+        assert!(validator::next_epoch_network_address(validator) == &option::some(new_network_address), 0);
+        assert!(validator::next_epoch_p2p_address(validator) == &option::some(new_p2p_address), 0);
+        assert!(validator::next_epoch_consensus_address(validator) == &option::some(vector[4, 168, 168, 168, 168]), 0);
+        assert!(validator::next_epoch_worker_address(validator) == &option::some(vector[4, 168, 168, 168, 168]), 0);
+        assert!(
+            validator::next_epoch_protocol_pubkey_bytes(validator) == &option::some(new_protocol_pub_key),
+            0
+        );
+        assert!(
+            validator::next_epoch_proof_of_possession(validator) == &option::some(new_pop),
+            0
+        );
+        assert!(
+            validator::next_epoch_worker_pubkey_bytes(validator) == &option::some(vector[215, 64, 85, 185, 231, 116, 69, 151, 97, 79, 4, 183, 20, 70, 84, 51, 211, 162, 115, 221, 73, 241, 240, 171, 192, 25, 232, 106, 175, 162, 176, 43]),
+            0
+        );
+        assert!(
+            validator::next_epoch_network_pubkey_bytes(validator) == &option::some(vector[148, 117, 212, 171, 44, 104, 167, 11, 177, 100, 4, 55, 17, 235, 117, 45, 117, 84, 159, 49, 14, 159, 239, 246, 237, 21, 83, 166, 112, 53, 62, 199]),
+            0
+        );
+    }
+
+    fun verify_metadata_after_advancing_epoch(
+        validator: &Validator,
+        name: vector<u8>,
+        protocol_pub_key: vector<u8>,
+        pop: vector<u8>,
+        network_address: vector<u8>,
+        p2p_address: vector<u8>,
+    ) {
+        // Current epoch
+        assert!(validator::name(validator) == &string::from_ascii(ascii::string(name)), 0);
+        assert!(validator::description(validator) == &string::from_ascii(ascii::string(b"new_desc")), 0);
+        assert!(validator::image_url(validator) == &url::new_unsafe_from_bytes(b"new_image_url"), 0);
+        assert!(validator::project_url(validator) == &url::new_unsafe_from_bytes(b"new_project_url"), 0);
+        assert!(validator::network_address(validator) == &network_address, 0);
+        assert!(validator::p2p_address(validator) == &p2p_address, 0);
+        assert!(validator::consensus_address(validator) == &vector[4, 168, 168, 168, 168], 0);
+        assert!(validator::worker_address(validator) == &vector[4, 168, 168, 168, 168], 0);
+        assert!(validator::protocol_pubkey_bytes(validator) == &protocol_pub_key, 0);
+        assert!(validator::proof_of_possession(validator) == &pop, 0);
+        assert!(validator::worker_pubkey_bytes(validator) == &vector[215, 64, 85, 185, 231, 116, 69, 151, 97, 79, 4, 183, 20, 70, 84, 51, 211, 162, 115, 221, 73, 241, 240, 171, 192, 25, 232, 106, 175, 162, 176, 43], 0);
+        assert!(validator::network_pubkey_bytes(validator) == &vector[148, 117, 212, 171, 44, 104, 167, 11, 177, 100, 4, 55, 17, 235, 117, 45, 117, 84, 159, 49, 14, 159, 239, 246, 237, 21, 83, 166, 112, 53, 62, 199], 0);
+
+        // Next epoch
+        assert!(option::is_none(validator::next_epoch_network_address(validator)), 0);
+        assert!(option::is_none(validator::next_epoch_p2p_address(validator)), 0);
+        assert!(option::is_none(validator::next_epoch_consensus_address(validator)), 0);
+        assert!(option::is_none(validator::next_epoch_worker_address(validator)), 0);
+        assert!(option::is_none(validator::next_epoch_protocol_pubkey_bytes(validator)), 0);
+        assert!(option::is_none(validator::next_epoch_proof_of_possession(validator)), 0);
+        assert!(option::is_none(validator::next_epoch_worker_pubkey_bytes(validator)), 0);
+        assert!(option::is_none(validator::next_epoch_network_pubkey_bytes(validator)), 0);
+    }
+
+    #[test]
+    fun test_active_validator_update_metadata() {
+        let validator_addr = @0xaf76afe6f866d8426d2be85d6ef0b11f871a251d043b2f11e15563bf418f5a5a;
+        let scenario_val = test_scenario::begin(validator_addr);
+        let scenario = &mut scenario_val;
+
+        // Set up SuiSystemState with an active validator
+        let validators = vector::empty();
+        let ctx = test_scenario::ctx(scenario);
+        let validator = validator::new_for_testing(
+            validator_addr,
+            vector[153, 242, 94, 246, 31, 128, 50, 185, 20, 99, 100, 96, 152, 44, 92, 198, 241, 52, 239, 29, 218, 231, 102, 87, 242, 203, 254, 193, 235, 252, 141, 9, 115, 116, 8, 13, 246, 252, 240, 220, 184, 188, 75, 13, 142, 10, 245, 216, 14, 187, 255, 43, 76, 89, 159, 84, 244, 45, 99, 18, 223, 195, 20, 39, 96, 120, 193, 204, 52, 126, 187, 190, 197, 25, 139, 226, 88, 81, 63, 56, 107, 147, 13, 2, 194, 116, 154, 128, 62, 35, 48, 149, 94, 189, 26, 16],
+            vector[32, 219, 38, 23, 242, 109, 116, 235, 225, 192, 219, 45, 40, 124, 162, 25, 33, 68, 52, 41, 123, 9, 98, 11, 184, 150, 214, 62, 60, 210, 121, 62],
+            vector[68, 55, 206, 25, 199, 14, 169, 53, 68, 92, 142, 136, 174, 149, 54, 215, 101, 63, 249, 206, 197, 98, 233, 80, 60, 12, 183, 32, 216, 88, 103, 25],
+            vector[170, 123, 102, 14, 115, 218, 115, 118, 170, 89, 192, 247, 101, 58, 60, 31, 48, 30, 9, 47, 0, 59, 54, 9, 136, 148, 14, 159, 198, 205, 109, 33, 189, 144, 195, 122, 18, 111, 137, 207, 112, 77, 204, 241, 187, 152, 88, 238],
+            b"ValidatorName",
+            b"description",
+            b"image_url",
+            b"project_url",
+            vector[4, 127, 0, 0, 1],
+            vector[4, 127, 0, 0, 1],
+            vector[4, 127, 0, 0, 1],
+            vector[4, 127, 0, 0, 1],
+            balance::create_for_testing<SUI>(100),
+            option::none(),
+            1,
+            0,
+            0,
+            ctx
+        );
+        vector::push_back(&mut validators, validator);
+        create_sui_system_state_for_testing(validators, 1000, 0, ctx);
+
+        test_scenario::next_tx(scenario, validator_addr);
+
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+        // Test active validator metadata changes
+        test_scenario::next_tx(scenario, validator_addr); 
+        {
+            update_metadata(
+                scenario,
+                &mut system_state,
+                b"validator_new_name",
+                vector[143, 97, 231, 116, 194, 3, 239, 10, 180, 80, 18, 78, 135, 46, 201, 7, 72, 33, 52, 183, 108, 35, 55, 55, 38, 187, 187, 150, 233, 146, 117, 165, 157, 219, 220, 157, 150, 19, 224, 131, 23, 206, 189, 221, 55, 134, 90, 140, 21, 159, 246, 179, 108, 104, 152, 249, 176, 243, 55, 27, 154, 78, 142, 169, 64, 77, 159, 227, 43, 123, 35, 252, 28, 205, 209, 160, 249, 40, 110, 101, 55, 16, 176, 56, 56, 177, 123, 185, 58, 61, 63, 88, 239, 241, 95, 99],
+                vector[161, 130, 28, 216, 188, 134, 52, 4, 25, 167, 187, 251, 207, 203, 145, 37, 30, 135, 202, 189, 170, 87, 115, 250, 82, 59, 216, 9, 150, 110, 52, 167, 225, 17, 132, 192, 32, 41, 20, 124, 115, 54, 158, 228, 55, 75, 98, 36],
+                vector[4, 42, 42, 42, 42],
+                vector[4, 43, 43, 43, 43],
+            );
+        };
+
+        test_scenario::next_tx(scenario, validator_addr);
+        let validator = sui_system::active_validator_by_address(&system_state, validator_addr);
+        verify_metadata(
+            validator,
+            b"validator_new_name",
+            vector[153, 242, 94, 246, 31, 128, 50, 185, 20, 99, 100, 96, 152, 44, 92, 198, 241, 52, 239, 29, 218, 231, 102, 87, 242, 203, 254, 193, 235, 252, 141, 9, 115, 116, 8, 13, 246, 252, 240, 220, 184, 188, 75, 13, 142, 10, 245, 216, 14, 187, 255, 43, 76, 89, 159, 84, 244, 45, 99, 18, 223, 195, 20, 39, 96, 120, 193, 204, 52, 126, 187, 190, 197, 25, 139, 226, 88, 81, 63, 56, 107, 147, 13, 2, 194, 116, 154, 128, 62, 35, 48, 149, 94, 189, 26, 16],
+            vector[170, 123, 102, 14, 115, 218, 115, 118, 170, 89, 192, 247, 101, 58, 60, 31, 48, 30, 9, 47, 0, 59, 54, 9, 136, 148, 14, 159, 198, 205, 109, 33, 189, 144, 195, 122, 18, 111, 137, 207, 112, 77, 204, 241, 187, 152, 88, 238],
+            vector[4, 127, 0, 0, 1],
+            vector[4, 127, 0, 0, 1],
+            vector[143, 97, 231, 116, 194, 3, 239, 10, 180, 80, 18, 78, 135, 46, 201, 7, 72, 33, 52, 183, 108, 35, 55, 55, 38, 187, 187, 150, 233, 146, 117, 165, 157, 219, 220, 157, 150, 19, 224, 131, 23, 206, 189, 221, 55, 134, 90, 140, 21, 159, 246, 179, 108, 104, 152, 249, 176, 243, 55, 27, 154, 78, 142, 169, 64, 77, 159, 227, 43, 123, 35, 252, 28, 205, 209, 160, 249, 40, 110, 101, 55, 16, 176, 56, 56, 177, 123, 185, 58, 61, 63, 88, 239, 241, 95, 99],
+            vector[161, 130, 28, 216, 188, 134, 52, 4, 25, 167, 187, 251, 207, 203, 145, 37, 30, 135, 202, 189, 170, 87, 115, 250, 82, 59, 216, 9, 150, 110, 52, 167, 225, 17, 132, 192, 32, 41, 20, 124, 115, 54, 158, 228, 55, 75, 98, 36],
+            vector[4 ,42, 42, 42, 42],
+            vector[4, 43, 43, 43, 43],
+        );
+
+        test_scenario::return_shared(system_state);
+        test_scenario::end(scenario_val);
+
+        // Test pending validator metadata changes
+        let new_validator_addr = @0x8e3446145b0c7768839d71840df389ffa3b9742d0baaff326a3d453b595f87d7;
+        let scenario_val = test_scenario::begin(new_validator_addr);
+        let scenario = &mut scenario_val;
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        test_scenario::next_tx(scenario, new_validator_addr);
+        {
+            let ctx = test_scenario::ctx(scenario);
+            sui_system::request_add_validator(
+                &mut system_state,
+                vector[153, 21, 95, 72, 205, 126, 148, 249, 194, 129, 121, 224, 137, 171, 173, 206, 207, 69, 3, 142, 106, 91, 158, 244, 0, 234, 14, 134, 130, 255, 173, 137, 125, 109, 44, 193, 187, 107, 78, 227, 84, 147, 66, 54, 92, 53, 208, 76, 10, 110, 217, 188, 125, 75, 58, 1, 143, 160, 113, 62, 239, 45, 154, 163, 105, 227, 253, 87, 44, 156, 5, 211, 41, 8, 35, 13, 197, 240, 203, 104, 222, 70, 62, 189, 63, 228, 214, 32, 82, 119, 148, 170, 155, 82, 223, 127],
+                vector[32, 219, 38, 23, 242, 109, 116, 235, 225, 192, 219, 45, 40, 124, 162, 25, 33, 68, 52, 41, 123, 9, 98, 11, 184, 150, 214, 62, 60, 210, 121, 62],
+                vector[68, 55, 206, 25, 199, 14, 169, 53, 68, 92, 142, 136, 174, 149, 54, 215, 101, 63, 249, 206, 197, 98, 233, 80, 60, 12, 183, 32, 216, 88, 103, 25],
+                vector[131, 170, 51, 121, 46, 85, 50, 42, 110, 180, 220, 186, 24, 12, 168, 180, 66, 63, 129, 111, 6, 94, 250, 52, 137, 174, 6, 184, 181, 148, 15, 5, 129, 14, 8, 206, 163, 32, 239, 20, 141, 242, 195, 80, 179, 142, 35, 13],
+                b"ValidatorName2",
+                b"description2",
+                b"image_url2",
+                b"project_url2",
+                vector[4, 127, 0, 0, 2],
+                vector[4, 127, 0, 0, 2],
+                vector[4, 127, 0, 0, 1],
+                vector[4, 127, 0, 0, 1],
+                coin::mint_for_testing(100, ctx),
+                1,
+                0,
+                ctx,
+            );
+        };
+
+        test_scenario::next_tx(scenario, new_validator_addr); 
+        {
+            update_metadata(
+                scenario,
+                &mut system_state,
+                b"new_validator_new_name",
+                vector[183, 97, 159, 105, 112, 198, 200, 131, 106, 12, 121, 10, 13, 215, 126, 169, 100, 14, 36, 38, 62, 247, 25, 195, 136, 153, 95, 72, 35, 138, 154, 215, 92, 221, 78, 232, 48, 200, 86, 101, 12, 48, 67, 190, 41, 198, 188, 88, 20, 209, 164, 224, 162, 239, 20, 222, 216, 229, 31, 200, 168, 65, 198, 231, 26, 26, 128, 29, 83, 103, 124, 130, 202, 100, 167, 34, 172, 124, 60, 74, 223, 77, 61, 171, 226, 24, 81, 221, 56, 157, 217, 170, 63, 153, 56, 166],
+                vector[144, 93, 160, 14, 152, 139, 5, 150, 41, 172, 63, 158, 49, 33, 86, 5, 189, 115, 168, 91, 111, 159, 77, 32, 172, 15, 170, 71, 201, 212, 59, 149, 199, 17, 16, 46, 210, 1, 221, 171, 35, 11, 249, 128, 220, 111, 64, 64],
+                vector[4, 66, 66, 66, 66],
+                vector[4, 77, 77, 77, 77],
+            );
+        };
+
+        test_scenario::next_tx(scenario, new_validator_addr);
+        let validator = sui_system::pending_validator_by_address(&system_state, new_validator_addr);
+        verify_metadata(
+            validator,
+            b"new_validator_new_name",
+            vector[153, 21, 95, 72, 205, 126, 148, 249, 194, 129, 121, 224, 137, 171, 173, 206, 207, 69, 3, 142, 106, 91, 158, 244, 0, 234, 14, 134, 130, 255, 173, 137, 125, 109, 44, 193, 187, 107, 78, 227, 84, 147, 66, 54, 92, 53, 208, 76, 10, 110, 217, 188, 125, 75, 58, 1, 143, 160, 113, 62, 239, 45, 154, 163, 105, 227, 253, 87, 44, 156, 5, 211, 41, 8, 35, 13, 197, 240, 203, 104, 222, 70, 62, 189, 63, 228, 214, 32, 82, 119, 148, 170, 155, 82, 223, 127],
+            vector[131, 170, 51, 121, 46, 85, 50, 42, 110, 180, 220, 186, 24, 12, 168, 180, 66, 63, 129, 111, 6, 94, 250, 52, 137, 174, 6, 184, 181, 148, 15, 5, 129, 14, 8, 206, 163, 32, 239, 20, 141, 242, 195, 80, 179, 142, 35, 13],
+            vector[4, 127, 0, 0, 2],
+            vector[4, 127, 0, 0, 2],
+            vector[183, 97, 159, 105, 112, 198, 200, 131, 106, 12, 121, 10, 13, 215, 126, 169, 100, 14, 36, 38, 62, 247, 25, 195, 136, 153, 95, 72, 35, 138, 154, 215, 92, 221, 78, 232, 48, 200, 86, 101, 12, 48, 67, 190, 41, 198, 188, 88, 20, 209, 164, 224, 162, 239, 20, 222, 216, 229, 31, 200, 168, 65, 198, 231, 26, 26, 128, 29, 83, 103, 124, 130, 202, 100, 167, 34, 172, 124, 60, 74, 223, 77, 61, 171, 226, 24, 81, 221, 56, 157, 217, 170, 63, 153, 56, 166],
+            vector[144, 93, 160, 14, 152, 139, 5, 150, 41, 172, 63, 158, 49, 33, 86, 5, 189, 115, 168, 91, 111, 159, 77, 32, 172, 15, 170, 71, 201, 212, 59, 149, 199, 17, 16, 46, 210, 1, 221, 171, 35, 11, 249, 128, 220, 111, 64, 64],
+            vector[4, 66, 66, 66, 66],
+            vector[4, 77, 77, 77, 77],
+        );
+
+        test_scenario::return_shared(system_state);
+
+        // Advance epoch to effectuate the metadata changes.
+        test_scenario::next_tx(scenario, new_validator_addr);
+        advance_epoch(scenario);
+
+        // Now both validators are active, verify their metadata.
+        test_scenario::next_tx(scenario, new_validator_addr);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let validator = sui_system::active_validator_by_address(&system_state, validator_addr);
+        verify_metadata_after_advancing_epoch(
+            validator,
+            b"validator_new_name",
+            vector[143, 97, 231, 116, 194, 3, 239, 10, 180, 80, 18, 78, 135, 46, 201, 7, 72, 33, 52, 183, 108, 35, 55, 55, 38, 187, 187, 150, 233, 146, 117, 165, 157, 219, 220, 157, 150, 19, 224, 131, 23, 206, 189, 221, 55, 134, 90, 140, 21, 159, 246, 179, 108, 104, 152, 249, 176, 243, 55, 27, 154, 78, 142, 169, 64, 77, 159, 227, 43, 123, 35, 252, 28, 205, 209, 160, 249, 40, 110, 101, 55, 16, 176, 56, 56, 177, 123, 185, 58, 61, 63, 88, 239, 241, 95, 99],
+            vector[161, 130, 28, 216, 188, 134, 52, 4, 25, 167, 187, 251, 207, 203, 145, 37, 30, 135, 202, 189, 170, 87, 115, 250, 82, 59, 216, 9, 150, 110, 52, 167, 225, 17, 132, 192, 32, 41, 20, 124, 115, 54, 158, 228, 55, 75, 98, 36],
+            vector[4, 42, 42, 42, 42],
+            vector[4, 43, 43, 43, 43],
+        );
+
+        let validator = sui_system::active_validator_by_address(&system_state, new_validator_addr);
+        verify_metadata_after_advancing_epoch(
+            validator,
+            b"new_validator_new_name",
+            vector[183, 97, 159, 105, 112, 198, 200, 131, 106, 12, 121, 10, 13, 215, 126, 169, 100, 14, 36, 38, 62, 247, 25, 195, 136, 153, 95, 72, 35, 138, 154, 215, 92, 221, 78, 232, 48, 200, 86, 101, 12, 48, 67, 190, 41, 198, 188, 88, 20, 209, 164, 224, 162, 239, 20, 222, 216, 229, 31, 200, 168, 65, 198, 231, 26, 26, 128, 29, 83, 103, 124, 130, 202, 100, 167, 34, 172, 124, 60, 74, 223, 77, 61, 171, 226, 24, 81, 221, 56, 157, 217, 170, 63, 153, 56, 166],
+            vector[144, 93, 160, 14, 152, 139, 5, 150, 41, 172, 63, 158, 49, 33, 86, 5, 189, 115, 168, 91, 111, 159, 77, 32, 172, 15, 170, 71, 201, 212, 59, 149, 199, 17, 16, 46, 210, 1, 221, 171, 35, 11, 249, 128, 220, 111, 64, 64],
+            vector[4, 66, 66, 66, 66],
+            vector[4, 77, 77, 77, 77],
+        );
+
+        test_scenario::return_shared(system_state);
+        test_scenario::end(scenario_val);
+    }
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6850,7 +6850,7 @@
           "p2p_address",
           "project_url",
           "proof_of_possession_bytes",
-          "pubkey_bytes",
+          "protocol_pubkey_bytes",
           "sui_address",
           "worker_address",
           "worker_pubkey_bytes"
@@ -6889,6 +6889,94 @@
               "minimum": 0.0
             }
           },
+          "next_epoch_consensus_address": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_net_address": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_network_pubkey_bytes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_p2p_address": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_proof_of_possession": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_protocol_pubkey_bytes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_worker_address": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_worker_pubkey_bytes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
           "p2p_address": {
             "type": "array",
             "items": {
@@ -6908,7 +6996,7 @@
               "minimum": 0.0
             }
           },
-          "pubkey_bytes": {
+          "protocol_pubkey_bytes": {
             "type": "array",
             "items": {
               "type": "integer",

--- a/crates/sui-rosetta/src/network.rs
+++ b/crates/sui-rosetta/src/network.rs
@@ -50,7 +50,7 @@ pub async fn status(
         .map(|v| Peer {
             peer_id: ObjectID::from(v.metadata.sui_address).into(),
             metadata: Some(json!({
-                "public_key": Hex::from_bytes(&v.metadata.pubkey_bytes),
+                "public_key": Hex::from_bytes(&v.metadata.protocol_pubkey_bytes),
                 "stake_amount": v.staking_pool.sui_balance,
             })),
         })

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -16,13 +16,13 @@ use sui_types::sui_system_state::{
 
 pub fn test_validatdor_metadata(
     sui_address: SuiAddress,
-    pubkey_bytes: AuthorityPublicKeyBytes,
+    protocol_pubkey_bytes: AuthorityPublicKeyBytes,
     net_address: Vec<u8>,
 ) -> ValidatorMetadata {
     let network_keypair: NetworkKeyPair = get_key_pair().1;
     ValidatorMetadata {
         sui_address,
-        pubkey_bytes: pubkey_bytes.as_bytes().to_vec(),
+        protocol_pubkey_bytes: protocol_pubkey_bytes.as_bytes().to_vec(),
         network_pubkey_bytes: network_keypair.public().as_bytes().to_vec(),
         worker_pubkey_bytes: vec![],
         proof_of_possession_bytes: vec![],
@@ -34,6 +34,14 @@ pub fn test_validatdor_metadata(
         p2p_address: vec![],
         consensus_address: vec![],
         worker_address: vec![],
+        next_epoch_protocol_pubkey_bytes: None,
+        next_epoch_proof_of_possession: None,
+        next_epoch_network_pubkey_bytes: None,
+        next_epoch_worker_pubkey_bytes: None,
+        next_epoch_net_address: None,
+        next_epoch_p2p_address: None,
+        next_epoch_consensus_address: None,
+        next_epoch_worker_address: None,
     }
 }
 
@@ -52,14 +60,14 @@ pub fn test_staking_pool(sui_balance: u64) -> StakingPool {
 }
 
 pub fn test_validator(
-    pubkey_bytes: AuthorityPublicKeyBytes,
+    protocol_pubkey_bytes: AuthorityPublicKeyBytes,
     net_address: Vec<u8>,
     stake_amount: u64,
     delegated_amount: u64,
 ) -> Validator {
-    let sui_address = SuiAddress::from(&pubkey_bytes);
+    let sui_address = SuiAddress::from(&protocol_pubkey_bytes);
     Validator {
-        metadata: test_validatdor_metadata(sui_address, pubkey_bytes, net_address),
+        metadata: test_validatdor_metadata(sui_address, protocol_pubkey_bytes, net_address),
         voting_power: stake_amount + delegated_amount,
         gas_price: 1,
         staking_pool: test_staking_pool(delegated_amount + stake_amount),

--- a/dapps/frenemies/src/network/bcs.ts
+++ b/dapps/frenemies/src/network/bcs.ts
@@ -181,6 +181,22 @@ export const bcs = suiBcs
     nextEpochGasPrice: "u64",
     /** The commission rate of the validator starting the next epoch, in basis point.  */
     nextEpochCommissionRate: "u64",
+    /** Next epoch's protocol public key of the validator */
+    nextEpochProtocolPubkeyBytes: "Option<vector<u8>>",
+    /** Next epoch's protocol key proof of posesssion of the validator */
+    nextEpochProofOfPossession: "Option<vector<u8>>",
+    /** Next epoch's network public key of the validator */
+    nextEpochNetworkPubkeyBytes: "Option<vector<u8>>",
+    /** Next epoch's worker public key of the validator */
+    nextEpochWorkerPubkeyBytes: "Option<vector<u8>>",
+    /** Next epoch's network address of the validator */
+    nextEpochNetAddress: "Option<vector<u8>>",
+    /** Next epoch's p2p address of the validator*/
+    nextEpochP2pAddress: "Option<vector<u8>>",
+    /** Next epoch's consensus address of the validator*/
+    nextEpochConsensusAddress: "Option<vector<u8>>",
+    /** Next epoch's worker address of the validator*/
+    nextEpochWorkerAddress: "Option<vector<u8>>",
   })
 
   .registerEnumType("Option<T>", {

--- a/dapps/frenemies/src/network/types.ts
+++ b/dapps/frenemies/src/network/types.ts
@@ -235,6 +235,23 @@ export type ValidatorMetadata = {
   nextEpochGasPrice: bigint;
   /** The commission rate of the validator starting the next epoch, in basis point.  */
   nextEpochCommissionRate: bigint;
+
+  /** Next epoch's protocol public key of the validator */
+  nextEpochProtocolPubkeyBytes: number[];
+  /** Next epoch's protocol key proof of posesssion of the validator */
+  nextEpochProofOfPossession: number[];
+  /** Next epoch's network public key of the validator */
+  nextEpochNetworkPubkeyBytes: number[];
+  /** Next epoch's worker public key of the validator */
+  nextEpochWorkerPubkeyBytes: number[];
+  /** Next epoch's network address of the validator */
+  nextEpochNetAddress: number[];
+  /** Next epoch's p2p address of the validator*/
+  nextEpochP2pAddress: number[];
+  /** Next epoch's consensus address of the validator*/
+  nextEpochConsensusAddress: number[];
+  /** Next epoch's worker address of the validator*/
+  nextEpochWorkerAddress: number[];
 };
 
 export type StakingPool = {

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -10,6 +10,7 @@ import {
   string,
   union,
   Infer,
+  nullable,
   tuple,
   optional,
 } from 'superstruct';
@@ -20,7 +21,7 @@ import { AuthorityName } from './transactions';
 
 export const ValidatorMetaData = object({
   sui_address: SuiAddress,
-  pubkey_bytes: array(number()),
+  protocol_pubkey_bytes: array(number()),
   network_pubkey_bytes: array(number()),
   worker_pubkey_bytes: array(number()),
   proof_of_possession_bytes: array(number()),
@@ -32,6 +33,14 @@ export const ValidatorMetaData = object({
   net_address: array(number()),
   consensus_address: array(number()),
   worker_address: array(number()),
+  next_epoch_protocol_pubkey_bytes: nullable(array(number())),
+  next_epoch_proof_of_possession: nullable(array(number())),
+  next_epoch_network_pubkey_bytes: nullable(array(number())),
+  next_epoch_worker_pubkey_bytes: nullable(array(number())),
+  next_epoch_net_address: nullable(array(number())),
+  next_epoch_p2p_address: nullable(array(number())),
+  next_epoch_consensus_address: nullable(array(number())),
+  next_epoch_worker_address: nullable(array(number())),
 });
 
 export type DelegatedStake = Infer<typeof DelegatedStake>;


### PR DESCRIPTION
## Description 

This PR adds the necessary entry functions for validator to update their onchain metadata.
1. "functional" metadata including address and keys only take effects starting from the next epoch, so we stage them in `next_epoch_xyz` variables, and promote them during `advance_epoch` call. 
2. "non functional"metadata including name, description, image url, project url etc can be updated in real time.
3. Both active validators and pending validators can update their metadata
4. also rename `pubkey_bytes` to `protocol_pubkey_bytes` for explicitness 

## Test Plan 

uni tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
Allow validators to update their onchain metadata. "functional" metadata including address and keys only take effects starting from the next epoch, so we stage them in `next_epoch_xyz` variables, and promote them during `advance_epoch` call. "non functional"metadata including name, description, image url, project url etc can be updated in real time.
