### PR TITLE
[upgrade] Add EpochStaticInfo

### DIFF
--- a/apps/explorer/src/components/HomeMetrics/index.tsx
+++ b/apps/explorer/src/components/HomeMetrics/index.tsx
@@ -8,7 +8,7 @@ import { MetricGroup } from './MetricGroup';
 
 import { useNetwork } from '~/context';
 import { useAppsBackend } from '~/hooks/useAppsBackend';
-import { useGetSystemObject } from '~/hooks/useGetObject';
+import { useGetCurrentEpochStaticInfo } from '~/hooks/useGetObject';
 import { useRpc } from '~/hooks/useRpc';
 import { Card } from '~/ui/Card';
 import { Heading } from '~/ui/Heading';
@@ -46,7 +46,7 @@ export function HomeMetrics() {
     const enabled = useFeature(GROWTHBOOK_FEATURES.EXPLORER_METRICS).on;
 
     const request = useAppsBackend();
-    const { data: systemData } = useGetSystemObject();
+    const { data: systemData } = useGetCurrentEpochStaticInfo();
 
     const rpc = useRpc();
     const { data: gasData } = useQuery(['reference-gas-price'], () =>

--- a/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -7,7 +7,7 @@ import { useMemo } from 'react';
 import { ReactComponent as ArrowRight } from '../../assets/SVGIcons/12px/ArrowRight.svg';
 import { StakeColumn } from './StakeColumn';
 
-import { useGetSystemObject } from '~/hooks/useGetObject';
+import { useGetCurrentEpochStaticInfo } from '~/hooks/useGetObject';
 import { Banner } from '~/ui/Banner';
 import { ImageIcon } from '~/ui/ImageIcon';
 import { ValidatorLink } from '~/ui/InternalLink';
@@ -93,7 +93,8 @@ type TopValidatorsCardProps = {
 };
 
 export function TopValidatorsCard({ limit, showIcon }: TopValidatorsCardProps) {
-    const { data, isLoading, isSuccess, isError } = useGetSystemObject();
+    const { data, isLoading, isSuccess, isError } =
+        useGetCurrentEpochStaticInfo();
 
     const tableData = useMemo(
         () =>

--- a/apps/explorer/src/hooks/useGetObject.ts
+++ b/apps/explorer/src/hooks/useGetObject.ts
@@ -14,9 +14,9 @@ export function useGetValidators() {
     return useQuery(['system', 'validators'], () => rpc.getValidators());
 }
 
-export function useGetSystemObject() {
+export function useGetCurrentEpochStaticInfo() {
     const rpc = useRpc();
-    return useQuery(['system', 'state'], () => rpc.getSuiSystemState());
+    return useQuery(['system', 'state'], () => rpc.getCurrentEpochStaticInfo());
 }
 
 export function useGetObject(

--- a/apps/explorer/src/pages/validator/ValidatorDetails.tsx
+++ b/apps/explorer/src/pages/validator/ValidatorDetails.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom';
 
 import { ValidatorMeta } from '~/components/validator/ValidatorMeta';
 import { ValidatorStats } from '~/components/validator/ValidatorStats';
-import { useGetSystemObject } from '~/hooks/useGetObject';
+import { useGetCurrentEpochStaticInfo } from '~/hooks/useGetObject';
 import { useGetValidatorsEvents } from '~/hooks/useGetValidatorsEvents';
 import { Banner } from '~/ui/Banner';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
@@ -15,7 +15,7 @@ import { getValidatorMoveEvent } from '~/utils/getValidatorMoveEvent';
 function ValidatorDetails() {
     const { id } = useParams();
     // TODO: Use `getValidators` once that API returns more data:
-    const { data, isLoading } = useGetSystemObject();
+    const { data, isLoading } = useGetCurrentEpochStaticInfo();
 
     const validatorData = useMemo(() => {
         if (!data) return null;

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -8,7 +8,7 @@ import { ErrorBoundary } from '~/components/error-boundary/ErrorBoundary';
 import { StakeColumn } from '~/components/top-validators-card/StakeColumn';
 import { DelegationAmount } from '~/components/validator/DelegationAmount';
 import { calculateAPY } from '~/components/validator/calculateAPY';
-import { useGetSystemObject } from '~/hooks/useGetObject';
+import { useGetCurrentEpochStaticInfo } from '~/hooks/useGetObject';
 import { useGetValidatorsEvents } from '~/hooks/useGetValidatorsEvents';
 import { Banner } from '~/ui/Banner';
 import { Card } from '~/ui/Card';
@@ -158,7 +158,8 @@ function validatorsTableData(
 }
 
 function ValidatorPageResult() {
-    const { data, isLoading, isSuccess, isError } = useGetSystemObject();
+    const { data, isLoading, isSuccess, isError } =
+        useGetCurrentEpochStaticInfo();
 
     const numberOfValidators = useMemo(
         () => data?.validators.active_validators.length || null,

--- a/apps/wallet/src/ui/app/staking/useSystemState.tsx
+++ b/apps/wallet/src/ui/app/staking/useSystemState.tsx
@@ -7,5 +7,5 @@ import { useRpc } from '../hooks';
 
 export function useSystemState() {
     const rpc = useRpc();
-    return useQuery(['system', 'state'], () => rpc.getSuiSystemState());
+    return useQuery(['system', 'state'], () => rpc.getCurrentEpochStaticInfo());
 }

--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -61,7 +61,12 @@ impl ReconfigObserver<NetworkAuthorityClient> for FullNodeReconfigObserver {
     async fn run(&mut self, quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>) {
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-            match self.fullnode_client.read_api().get_sui_system_state().await {
+            match self
+                .fullnode_client
+                .read_api()
+                .get_current_epoch_static_info()
+                .await
+            {
                 Ok(sui_system_state) => {
                     let epoch_id = sui_system_state.epoch;
                     if epoch_id > quorum_driver.current_epoch() {

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -494,7 +494,11 @@ impl ValidatorProxy for FullNodeProxy {
     }
 
     async fn get_latest_system_state_object(&self) -> Result<SuiSystemState, anyhow::Error> {
-        Ok(self.sui_client.read_api().get_sui_system_state().await?)
+        Ok(self
+            .sui_client
+            .read_api()
+            .get_current_epoch_static_info()
+            .await?)
     }
 
     async fn execute_transaction(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects> {

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -57,9 +57,9 @@ pub trait AuthorityAPI {
         request: CommitteeInfoRequest,
     ) -> Result<CommitteeInfoResponse, SuiError>;
 
-    async fn handle_system_state_object(
+    async fn handle_current_epoch_static_info(
         &self,
-        request: SystemStateRequest,
+        request: CurrentEpochStaticInfoRequest,
     ) -> Result<SuiSystemState, SuiError>;
 }
 
@@ -165,12 +165,12 @@ impl AuthorityAPI for NetworkAuthorityClient {
             .map_err(Into::into)
     }
 
-    async fn handle_system_state_object(
+    async fn handle_current_epoch_static_info(
         &self,
-        request: SystemStateRequest,
+        request: CurrentEpochStaticInfoRequest,
     ) -> Result<SuiSystemState, SuiError> {
         self.client()
-            .get_system_state_object(request)
+            .current_epoch_static_info(request)
             .await
             .map(tonic::Response::into_inner)
             .map_err(Into::into)

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -471,9 +471,9 @@ impl Validator for ValidatorService {
         return Ok(tonic::Response::new(response));
     }
 
-    async fn get_system_state_object(
+    async fn current_epoch_static_info(
         &self,
-        _request: tonic::Request<SystemStateRequest>,
+        _request: tonic::Request<CurrentEpochStaticInfoRequest>,
     ) -> Result<tonic::Response<SuiSystemState>, tonic::Status> {
         let epoch_store = self.state.load_epoch_store_one_call_per_task();
         let response = epoch_store.system_state_object().clone();

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -487,7 +487,7 @@ where
 
     pub async fn handle_system_state_object(&self) -> Result<SuiSystemState, SuiError> {
         self.authority_client
-            .handle_system_state_object(SystemStateRequest { _unused: false })
+            .handle_current_epoch_static_info(CurrentEpochStaticInfoRequest { _unused: false })
             .await
     }
 }

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -17,8 +17,8 @@ use sui_types::{
     error::SuiError,
     messages::{
         CertifiedTransaction, CommitteeInfoRequest, CommitteeInfoResponse,
-        HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, SystemStateRequest,
-        Transaction, TransactionInfoRequest, TransactionInfoResponse,
+        CurrentEpochStaticInfoRequest, HandleTransactionResponse, ObjectInfoRequest,
+        ObjectInfoResponse, Transaction, TransactionInfoRequest, TransactionInfoResponse,
     },
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     sui_system_state::SuiSystemState,
@@ -111,9 +111,9 @@ impl AuthorityAPI for LocalAuthorityClient {
         state.handle_committee_info_request(&request)
     }
 
-    async fn handle_system_state_object(
+    async fn handle_current_epoch_static_info(
         &self,
-        _request: SystemStateRequest,
+        _request: CurrentEpochStaticInfoRequest,
     ) -> Result<SuiSystemState, SuiError> {
         let epoch_store = self.state.load_epoch_store_one_call_per_task();
         Ok(epoch_store.system_state_object().clone())
@@ -258,9 +258,9 @@ impl AuthorityAPI for MockAuthorityApi {
         self.handle_committee_info_request_result.clone().unwrap()
     }
 
-    async fn handle_system_state_object(
+    async fn handle_current_epoch_static_info(
         &self,
-        _request: SystemStateRequest,
+        _request: CurrentEpochStaticInfoRequest,
     ) -> Result<SuiSystemState, SuiError> {
         unimplemented!();
     }
@@ -315,9 +315,9 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
         unimplemented!()
     }
 
-    async fn handle_system_state_object(
+    async fn handle_current_epoch_static_info(
         &self,
-        _request: SystemStateRequest,
+        _request: CurrentEpochStaticInfoRequest,
     ) -> Result<SuiSystemState, SuiError> {
         unimplemented!()
     }

--- a/crates/sui-indexer/src/apis/governance_api.rs
+++ b/crates/sui-indexer/src/apis/governance_api.rs
@@ -39,8 +39,8 @@ impl GovernanceReadApiServer for GovernanceReadApi {
         self.fullnode.get_committee_info(epoch).await
     }
 
-    async fn get_sui_system_state(&self) -> RpcResult<SuiSystemState> {
-        self.fullnode.get_sui_system_state().await
+    async fn get_current_epoch_static_info(&self) -> RpcResult<SuiSystemState> {
+        self.fullnode.get_current_epoch_static_info().await
     }
 
     async fn get_reference_gas_price(&self) -> RpcResult<u64> {

--- a/crates/sui-json-rpc/src/api/governance.rs
+++ b/crates/sui-json-rpc/src/api/governance.rs
@@ -33,8 +33,8 @@ pub trait GovernanceReadApi {
     ) -> RpcResult<CommitteeInfoResponse>;
 
     /// Return [SuiSystemState]
-    #[method(name = "getSuiSystemState")]
-    async fn get_sui_system_state(&self) -> RpcResult<SuiSystemState>;
+    #[method(name = "getCurrentEpochStaticInfo")]
+    async fn get_current_epoch_static_info(&self) -> RpcResult<SuiSystemState>;
 
     /// Return the reference gas price for the network
     #[method(name = "getReferenceGasPrice")]

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -69,9 +69,8 @@ impl GovernanceReadApiServer for GovernanceReadApi {
     }
 
     async fn get_validators(&self) -> RpcResult<Vec<ValidatorMetadata>> {
-        // TODO: include pending validators as well when the necessary changes are made in move.
         Ok(self
-            .get_sui_system_state()
+            .get_current_epoch_static_info()
             .await?
             .validators
             .active_validators
@@ -87,13 +86,16 @@ impl GovernanceReadApiServer for GovernanceReadApi {
             .map_err(Error::from)?)
     }
 
-    async fn get_sui_system_state(&self) -> RpcResult<SuiSystemState> {
+    async fn get_current_epoch_static_info(&self) -> RpcResult<SuiSystemState> {
         let epoch_store = self.state.load_epoch_store_one_call_per_task();
         Ok(epoch_store.system_state_object().clone())
     }
 
     async fn get_reference_gas_price(&self) -> RpcResult<u64> {
-        Ok(self.get_sui_system_state().await?.reference_gas_price)
+        Ok(self
+            .get_current_epoch_static_info()
+            .await?
+            .reference_gas_price)
     }
 }
 

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -78,9 +78,9 @@ fn main() -> Result<()> {
         )
         .method(
             Method::builder()
-                .name("get_system_state_object")
-                .route_name("GetSystemStateObject")
-                .input_type("sui_types::messages::SystemStateRequest")
+                .name("current_epoch_static_info")
+                .route_name("CurrentEpochStaticInfo")
+                .input_type("sui_types::messages::CurrentEpochStaticInfoRequest")
                 .output_type("sui_types::sui_system_state::SuiSystemState")
                 .codec_path(codec_path)
                 .build(),

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -796,6 +796,23 @@
       }
     },
     {
+      "name": "sui_getCurrentEpochStaticInfo",
+      "tags": [
+        {
+          "name": "Governance Read API"
+        }
+      ],
+      "description": "Return [SuiSystemState]",
+      "params": [],
+      "result": {
+        "name": "SuiSystemState",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/SuiSystemState"
+        }
+      }
+    },
+    {
       "name": "sui_getDelegatedStakes",
       "tags": [
         {
@@ -1436,23 +1453,6 @@
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
-        }
-      }
-    },
-    {
-      "name": "sui_getSuiSystemState",
-      "tags": [
-        {
-          "name": "Governance Read API"
-        }
-      ],
-      "description": "Return [SuiSystemState]",
-      "params": [],
-      "result": {
-        "name": "SuiSystemState",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/SuiSystemState"
         }
       }
     },

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -193,7 +193,7 @@ pub async fn metadata(
     let gas_price = context
         .client
         .governance_api()
-        .get_sui_system_state()
+        .get_current_epoch_static_info()
         .await?
         .reference_gas_price;
 

--- a/crates/sui-rosetta/src/network.rs
+++ b/crates/sui-rosetta/src/network.rs
@@ -41,7 +41,11 @@ pub async fn status(
 ) -> Result<NetworkStatusResponse, Error> {
     env.check_network_identifier(&request.network_identifier)?;
 
-    let system_state = context.client.read_api().get_sui_system_state().await?;
+    let system_state = context
+        .client
+        .read_api()
+        .get_current_epoch_static_info()
+        .await?;
 
     let peers = system_state
         .validators

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -191,8 +191,8 @@ impl ReadApi {
             .await?)
     }
 
-    pub async fn get_sui_system_state(&self) -> SuiRpcResult<SuiSystemState> {
-        Ok(self.api.http.get_sui_system_state().await?)
+    pub async fn get_current_epoch_static_info(&self) -> SuiRpcResult<SuiSystemState> {
+        Ok(self.api.http.get_current_epoch_static_info().await?)
     }
 
     pub async fn get_reference_gas_price(&self) -> SuiRpcResult<u64> {
@@ -499,7 +499,7 @@ impl GovernanceApi {
     }
 
     /// Return [SuiSystemState]
-    pub async fn get_sui_system_state(&self) -> SuiRpcResult<SuiSystemState> {
-        Ok(self.api.http.get_sui_system_state().await?)
+    pub async fn get_current_epoch_static_info(&self) -> SuiRpcResult<SuiSystemState> {
+        Ok(self.api.http.get_current_epoch_static_info().await?)
     }
 }

--- a/crates/sui-types/src/epoch_static_info.rs
+++ b/crates/sui-types/src/epoch_static_info.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::sui_system_state::{SuiSystemState, ValidatorMetadata};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+pub struct EpochStaticInfo {
+    pub epoch: u64,
+    pub protocol_version: u64,
+    pub safe_mode: bool,
+
+    pub reference_gas_price: u64,
+    pub epoch_start_timestamp_ms: u64,
+
+    pub storage_fund_balance: u64,
+
+    pub stake_subsidy_epoch_counter: u64,
+    pub stake_subsidy_balance: u64,
+    pub stake_subsidy_current_epoch_amount: u64,
+
+    pub total_validator_self_stake: u64,
+    pub total_delegation_stake: u64,
+
+    pub validators: Vec<EpochValidator>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+pub struct EpochValidator {
+    pub metadata: ValidatorMetadata,
+
+    pub voting_power: u64,
+    pub stake_amount: u64,
+
+    pub gas_price: u64,
+    pub commission_rate: u64,
+}
+
+impl From<SuiSystemState> for EpochStaticInfo {
+    fn from(state: SuiSystemState) -> Self {
+        Self {
+            epoch: state.epoch,
+            protocol_version: state.protocol_version,
+            safe_mode: state.safe_mode,
+            reference_gas_price: state.reference_gas_price,
+            epoch_start_timestamp_ms: state.epoch_start_timestamp_ms,
+            storage_fund_balance: state.storage_fund.value(),
+            stake_subsidy_epoch_counter: state.stake_subsidy.epoch_counter,
+            stake_subsidy_balance: state.stake_subsidy.balance.value(),
+            stake_subsidy_current_epoch_amount: state.stake_subsidy.current_epoch_amount,
+            total_validator_self_stake: state.validators.validator_stake,
+            total_delegation_stake: state.validators.delegation_stake,
+            validators: state
+                .validators
+                .active_validators
+                .iter()
+                .map(|v| EpochValidator {
+                    metadata: v.metadata.clone(),
+                    voting_power: v.voting_power,
+                    stake_amount: v.stake_amount,
+                    gas_price: v.gas_price,
+                    commission_rate: v.commission_rate,
+                })
+                .collect(),
+        }
+    }
+}

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -30,6 +30,7 @@ pub mod committee;
 pub mod crypto;
 pub mod digests;
 pub mod dynamic_field;
+pub mod epoch_static_info;
 pub mod event;
 pub mod filter;
 pub mod gas;

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -3136,7 +3136,7 @@ pub struct CommitteeInfo {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct SystemStateRequest {
+pub struct CurrentEpochStaticInfoRequest {
     // This is needed to make gRPC happy.
     pub _unused: bool,
 }

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -754,17 +754,17 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async getSuiSystemState(): Promise<SuiSystemState> {
+  async getCurrentEpochStaticInfo(): Promise<SuiSystemState> {
     try {
       const resp = await this.client.requestWithType(
-        'sui_getSuiSystemState',
+        'sui_getCurrentEpochStaticInfo',
         [],
         SuiSystemState,
         this.options.skipDataValidation,
       );
       return resp;
     } catch (err) {
-      throw new Error(`Error in getSuiSystemState: ${err}`);
+      throw new Error(`Error in getCurrentEpochStaticInfo: ${err}`);
     }
   }
 

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -313,7 +313,7 @@ export abstract class Provider {
   abstract unsubscribeEvent(id: SubscriptionId): Promise<boolean>;
 
   /**
-   * Runs the transaction in dev-inpsect mode. Which allows for nearly any
+   * Runs the transaction in dev-inspect mode. Which allows for nearly any
    * transaction (or Move call) with any arguments. Detailed results are
    * provided, including both the transaction effects and any return values.
    *
@@ -376,9 +376,10 @@ export abstract class Provider {
   abstract getValidators(): Promise<ValidatorMetaData[]>;
 
   /**
-   * Return the content of `0x5` object
+   * Return the static validator network information of the current epoch.
+   * Such information remain the same during the epoch.
    */
-  abstract getSuiSystemState(): Promise<SuiSystemState>;
+  abstract getCurrentEpochStaticInfo(): Promise<SuiSystemState>;
 
   /**
    * Get the sequence number of the latest checkpoint that has been executed

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -63,8 +63,8 @@ export class VoidProvider extends Provider {
     throw this.newError('getReferenceGasPrice');
   }
 
-  async getSuiSystemState(): Promise<SuiSystemState> {
-    throw this.newError('getSuiSystemState');
+  async getCurrentEpochStaticInfo(): Promise<SuiSystemState> {
+    throw this.newError('getCurrentEpochStaticInfo');
   }
 
   async getDelegatedStakes(_address: SuiAddress): Promise<DelegatedStake[]> {

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -54,13 +54,13 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       expect(validators.length).greaterThan(0);
     });
 
-    it('test getCommiteeInfo', async () => {
-      const commiteeInfo = await toolbox.provider.getCommitteeInfo(0);
-      expect(commiteeInfo.committee_info?.length).greaterThan(0);
+    it('test getCommitteeInfo', async () => {
+      const committeeInfo = await toolbox.provider.getCommitteeInfo(0);
+      expect(committeeInfo.committee_info?.length).greaterThan(0);
     });
 
-    it('test getSuiSystemState', async () => {
-      await toolbox.provider.getSuiSystemState();
+    it('test getCurrentEpochStaticInfo', async () => {
+      await toolbox.provider.getCurrentEpochStaticInfo();
     });
   },
 );


### PR DESCRIPTION
## Description 

Currently we expose SuiSystemState object directly both in the epoch store cache as well as return to RPC calls (get_suiSystemState). This has two problems:
It confuses between the static epoch information that doesn't actually change during the epoch (which is what we intended to cache), and the actual dynamic system state. We are bound to make mistakes when these two are mixed in use.
It couples the on-chain state data type and the RPC data type (as well as implementation type inside epoch store). This will make it very difficult to evolve the system state data structure down the road.
I am introducing a new type called EpochStaticInfo which captures all the epoch static information from SuiSystemState, and making it as flat as possible (fields are at top-level as possible) so that it has almost no structural dependencies. This will make it much much easier to evolve and we no longer care about the specific changes to SuiSystemState. We can convert any version of SuiSystemState into this type. The epoch store will cache an instance of such static info, instead of the system state directly. RPC interfaces will also return the epoch static info (we can introduce a separate RPC API to return the latest system state object from the database). 

This PR does two things:
1. Introduce a new type called EpochStaticInfo, which captures all the epoch static information from SuiSystemState. It's currently not used (otherwise this PR will grow out of control). Currently ValidatorMetadata is used, but I also plan to flatten that.
2. Rename all API (gRPC, jsonRPC) names to reflect that they will be returning epoch static info instead of system state.

## Test Plan 

build
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ x] breaking change for a client SDKs
- [ x] breaking change for FNs (FN binary must upgrade)
- [ x] breaking change for validators or node operators (must upgrade binaries)
- [ x] breaking change for on-chain data layout
- [ x] necessitate either a data wipe or data migration

### Release notes
