### PR TITLE
wallet-ext: WalletListSelect hide select all

### DIFF
--- a/apps/wallet/src/ui/app/components/WalletListSelect.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelect.tsx
@@ -86,19 +86,21 @@ export function WalletListSelect({
                 mode === 'select' ? (
                     <div className="flex flex-row flex-nowrap self-stretch justify-between">
                         <div>
-                            <Link
-                                color="heroDark"
-                                weight="medium"
-                                text="Select all"
-                                disabled={disabled}
-                                onClick={() =>
-                                    onChange(
-                                        filteredAccounts.map(
-                                            ({ address }) => address
+                            {filteredAccounts.length > 1 ? (
+                                <Link
+                                    color="heroDark"
+                                    weight="medium"
+                                    text="Select all"
+                                    disabled={disabled}
+                                    onClick={() =>
+                                        onChange(
+                                            filteredAccounts.map(
+                                                ({ address }) => address
+                                            )
                                         )
-                                    )
-                                }
-                            />
+                                    }
+                                />
+                            ) : null}
                         </div>
                         <div>
                             <Link


### PR DESCRIPTION
## Description 

WalletListSelect hide select all

* when only one account is available hide select all button


https://user-images.githubusercontent.com/10210143/221866225-0bad1d02-19ec-4fdd-b003-9414c61442c0.mov


https://user-images.githubusercontent.com/10210143/221866246-d76ca313-7d90-4a1e-bddb-1abc7c5b5087.mov



## Test Plan 

manual testing - while connecting to a dapp and having only one account in the wallet see select all is hidden (multi-account has to be enabled)

closes APPS-538