### PR TITLE
wallet-ext: WalletListSelect display new for created account and auto select

### DIFF
--- a/apps/wallet/src/background/keyring/index.test.ts
+++ b/apps/wallet/src/background/keyring/index.test.ts
@@ -72,16 +72,10 @@ describe('Keyring', () => {
             it('creates the account with index 1 and emits a change event', async () => {
                 const eventSpy = vi.fn();
                 k.on('accountsChanged', eventSpy);
-                const result = await k.deriveNextAccount();
-                expect(result).toBe(true);
+                const account = await k.deriveNextAccount();
+                expect(account!.derivationPath).toBe("m/44'/784'/1'/0'/0'");
                 const accounts = k.getAccounts();
                 expect(accounts?.length).toBe(3);
-                expect(
-                    accounts?.find(
-                        (anAccount) =>
-                            anAccount.derivationPath === "m/44'/784'/1'/0'/0'"
-                    )
-                ).toBeTruthy();
                 expect(eventSpy).toHaveBeenCalledOnce();
                 expect(eventSpy.mock.calls[0][0].length).toBe(3);
             });

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -59,7 +59,7 @@ type MethodToPayloads = {
     };
     deriveNextAccount: {
         args: void;
-        return: void;
+        return: { accountAddress: SuiAddress };
     };
     verifyPassword: {
         args: { password: string };

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -284,7 +284,20 @@ export class BackgroundClient {
                     type: 'keyring',
                     method: 'deriveNextAccount',
                 })
-            ).pipe(take(1))
+            ).pipe(
+                take(1),
+                map(({ payload }) => {
+                    if (
+                        isKeyringPayload(payload, 'deriveNextAccount') &&
+                        payload.return
+                    ) {
+                        return payload.return.accountAddress;
+                    }
+                    throw new Error(
+                        'Error unknown response for derive account message'
+                    );
+                })
+            )
         );
     }
 

--- a/apps/wallet/src/ui/app/components/WalletListSelect.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelect.tsx
@@ -77,6 +77,7 @@ export function WalletListSelect({
                                 selected={values.includes(address)}
                                 mode={mode}
                                 disabled={disabled}
+                                isNew={deriveNextAccount.data === address}
                             />
                         </li>
                     ))}
@@ -109,7 +110,21 @@ export function WalletListSelect({
                                 text="New account"
                                 disabled={disabled}
                                 loading={deriveNextAccount.isLoading}
-                                onClick={() => deriveNextAccount.mutate()}
+                                onClick={async () => {
+                                    const newAccountAddress =
+                                        await deriveNextAccount.mutateAsync();
+                                    if (
+                                        !visibleValues ||
+                                        visibleValues.includes(
+                                            newAccountAddress
+                                        )
+                                    ) {
+                                        onChange([
+                                            ...values,
+                                            newAccountAddress,
+                                        ]);
+                                    }
+                                }}
                             />
                         </div>
                     </div>

--- a/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
@@ -4,6 +4,7 @@
 import { CheckFill16, XFill16 } from '@mysten/icons';
 import { formatAddress } from '@mysten/sui.js';
 import { cva, cx, type VariantProps } from 'class-variance-authority';
+import { useEffect, useRef } from 'react';
 
 import { Text } from '../shared/text';
 
@@ -51,6 +52,7 @@ export interface WalletListSelectItemProps
     selected: NonNullable<StyleProps['selected']>;
     mode: NonNullable<StyleProps['mode']>;
     address: string;
+    isNew?: boolean;
 }
 
 export function WalletListSelectItem({
@@ -58,9 +60,24 @@ export function WalletListSelectItem({
     selected,
     mode,
     disabled = false,
+    isNew = false,
 }: WalletListSelectItemProps) {
+    const elementRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            if (elementRef.current && isNew) {
+                elementRef.current.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'center',
+                });
+            }
+        }, 80);
+        return () => {
+            clearTimeout(timeout);
+        };
+    }, [isNew]);
     return (
-        <div className={styles({ selected, mode, disabled })}>
+        <div ref={elementRef} className={styles({ selected, mode, disabled })}>
             {mode === 'select' ? (
                 <CheckFill16
                     className={cx(
@@ -79,6 +96,13 @@ export function WalletListSelectItem({
                 <div className="flex flex-1 justify-end text-issue-dark">
                     <Text variant="subtitle" weight="normal">
                         Disconnect
+                    </Text>
+                </div>
+            ) : null}
+            {mode === 'select' && isNew ? (
+                <div className="flex-1 flex justify-end">
+                    <Text variant="subtitleSmall" color="steel">
+                        NEW
                     </Text>
                 </div>
             ) : null}

--- a/apps/wallet/src/ui/app/hooks/useDeriveNextAccountMutation.ts
+++ b/apps/wallet/src/ui/app/hooks/useDeriveNextAccountMutation.ts
@@ -9,9 +9,8 @@ import { useBackgroundClient } from './useBackgroundClient';
 export function useDeriveNextAccountMutation() {
     const backgroundClient = useBackgroundClient();
     return useMutation({
-        mutationFn: async () => {
-            await backgroundClient.deriveNextAccount();
-            return null;
+        mutationFn: () => {
+            return backgroundClient.deriveNextAccount();
         },
         onSuccess: () => {
             toast.success('New account created');


### PR DESCRIPTION
## Description 

* when user clicks New account, display new next to it
* select the new account by default
* scroll new account into view, towards the center of the view


https://user-images.githubusercontent.com/10210143/222484875-6a5b06cc-645d-44e4-9a56-83158ca149e1.mov



## Test Plan 

manual testing - create new account from the site-connect view


closes APPS-521