### PR TITLE
[clock] Documenting ways to access time

### DIFF
--- a/crates/sui-framework/docs/tx_context.md
+++ b/crates/sui-framework/docs/tx_context.md
@@ -9,7 +9,7 @@
 -  [Constants](#@Constants_0)
 -  [Function `sender`](#0x2_tx_context_sender)
 -  [Function `epoch`](#0x2_tx_context_epoch)
--  [Function `epoch_timestamp`](#0x2_tx_context_epoch_timestamp)
+-  [Function `epoch_timestamp_ms`](#0x2_tx_context_epoch_timestamp_ms)
 -  [Function `new_object`](#0x2_tx_context_new_object)
 -  [Function `ids_created`](#0x2_tx_context_ids_created)
 -  [Function `derive_id`](#0x2_tx_context_derive_id)
@@ -150,14 +150,14 @@ Return the current epoch
 
 </details>
 
-<a name="0x2_tx_context_epoch_timestamp"></a>
+<a name="0x2_tx_context_epoch_timestamp_ms"></a>
 
-## Function `epoch_timestamp`
+## Function `epoch_timestamp_ms`
 
 Return the epoch start time as a unix timestamp in milliseconds.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_epoch_timestamp">epoch_timestamp</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_epoch_timestamp_ms">epoch_timestamp_ms</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
 </code></pre>
 
 
@@ -166,7 +166,7 @@ Return the epoch start time as a unix timestamp in milliseconds.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_epoch_timestamp">epoch_timestamp</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_epoch_timestamp_ms">epoch_timestamp_ms</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): u64 {
    self.epoch_timestamp_ms
 }
 </code></pre>

--- a/crates/sui-framework/sources/test/test_scenario.move
+++ b/crates/sui-framework/sources/test/test_scenario.move
@@ -105,12 +105,12 @@ module sui::test_scenario {
         // digest (and consequently, different object ID's) than the previous tx
         scenario.txn_number = scenario.txn_number + 1;
         let epoch = tx_context::epoch(&scenario.ctx);
-        let epoch_timestamp = tx_context::epoch_timestamp(&scenario.ctx);
+        let epoch_timestamp_ms = tx_context::epoch_timestamp_ms(&scenario.ctx);
         scenario.ctx = tx_context::new_from_hint(
             sender,
             scenario.txn_number,
             epoch,
-            epoch_timestamp,
+            epoch_timestamp_ms,
             0,
         );
         // end the transaction

--- a/crates/sui-framework/sources/tx_context.move
+++ b/crates/sui-framework/sources/tx_context.move
@@ -47,7 +47,7 @@ module sui::tx_context {
     }
 
     /// Return the epoch start time as a unix timestamp in milliseconds.
-    public fun epoch_timestamp(self: &TxContext): u64 {
+    public fun epoch_timestamp_ms(self: &TxContext): u64 {
        self.epoch_timestamp_ms
     }
 

--- a/crates/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/tests/test_scenario_tests.move
@@ -430,31 +430,31 @@ module sui::test_scenarioTests {
         let sender = @0x0;
         let scenario = ts::begin(sender);
 
-        let ts0 = tx_context::epoch_timestamp(ts::ctx(&mut scenario));
+        let ts0 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
 
         // epoch timestamp doesn't change between transactions
         ts::next_tx(&mut scenario, sender);
-        let ts1 = tx_context::epoch_timestamp(ts::ctx(&mut scenario));
+        let ts1 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
         assert!(ts1 == ts0, 0);
 
         // ...or between epochs when `next_epoch` is used
         ts::next_epoch(&mut scenario, sender);
-        let ts2 = tx_context::epoch_timestamp(ts::ctx(&mut scenario));
+        let ts2 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
         assert!(ts2 == ts1, 1);
 
         // ...but does change when `later_epoch` is used
         ts::later_epoch(&mut scenario, 42, sender);
-        let ts3 = tx_context::epoch_timestamp(ts::ctx(&mut scenario));
+        let ts3 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
         assert!(ts3 == ts2 + 42, 2);
 
         // ...and persists across further transactions
         ts::next_tx(&mut scenario, sender);
-        let ts4 = tx_context::epoch_timestamp(ts::ctx(&mut scenario));
+        let ts4 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
         assert!(ts4 == ts3, 3);
 
         // ...and epochs
         ts::next_epoch(&mut scenario, sender);
-        let ts5 = tx_context::epoch_timestamp(ts::ctx(&mut scenario));
+        let ts5 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
         assert!(ts5 == ts4, 4);
 
         ts::end(scenario);

--- a/doc/in-progress/time.md
+++ b/doc/in-progress/time.md
@@ -1,0 +1,59 @@
+# Accessing Time in Move
+
+## `sui::clock::Clock`
+
+Transactions that need access to an accurate clock must pass a read-only reference of `sui::clock::Clock` in as an entry function parameter.  The only available instance is found at address `0x6`.
+
+A unix timestamp in milliseconds can be extracted from an instance of `Clock` using
+
+```
+module sui::clock {
+    public fun timestamp_ms(clock: &Clock): u64;
+}
+```
+
+**The resulting value is expected to change every 2 to 3 seconds**, at the rate that checkpoints are committed by the network.
+
+Successive calls to `sui::clock::timestamp_ms` in the same transaction will always produce the same result (transactions are considered to take effect instantly), and may also overlap with other transactions that touch the same shared objects, so it is not safe to assume that time progresses between transactions that are sequenced relative to each other.
+
+Any transaction that requires access to a `Clock` must go through **consensus**, because the only available instance is a **shared object**, so this technique is not suitable for transactions that must use the single-owner fast-path (see "Epoch timestamps" for a single-owner-compatible source of timestamps).
+
+**Transactions that use the clock must accept it as an immutable reference** (not a mutable reference or value).  This prevents contention, as transactions that access the `Clock` can only read it, so do not need to be sequenced relative to each other.  Validators will refuse to sign transactions that do not meet this requirement and packages that include entry functions that accept a `Clock` or `&mut Clock` will fail to publish.
+
+Code that depends on `Clock` can be tested using
+
+```
+module sui::clock {
+    #[test_only]
+    public fun increment_for_testing(clock: &mut Clock, tick: u64);
+}
+```
+
+which can increment the timestamp in the `Clock` in test code.
+
+
+## Epoch timestamps
+
+All transactions (including ones that do not go through consensus) can access the timestamp for the start of the current epoch, via the following function:
+
+```
+module sui::tx_context {
+    public fun epoch_timestamp_ms(ctx: &TxContext): u64;
+}
+```
+
+Which returns the point in time when the current epoch started, as a millisecond granularity unix timestamp in a `u64`.  **This value changes roughly once every 24 hours**, when the Epoch changes.
+
+The value returned by this function can be updated in tests for time-sensitive code that use `sui::test_scenario`, using
+
+```
+module sui::test_scenario {
+    public fun later_epoch(
+        scenario: &mut Scenario,
+        delta_ms: u64,
+        sender: address,
+    ): TransactionEffects;
+}
+```
+
+which behaves like `sui::test_scenario::next_epoch` (finishes the current transaction and epoch), but also increments the timestamp by `delta_ms` milliseconds.

--- a/doc/in-progress/time.md
+++ b/doc/in-progress/time.md
@@ -67,7 +67,7 @@ module sui::tx_context {
 
 The preceding function returns the point in time when the current epoch started, as a millisecond granularity unix timestamp in a `u64`.  **This value changes roughly once every 24 hours**, when the epoch changes.
 
-Tests based on `sui::test_scenario` can use `later_epoch` (below), to exercise time-sensitive code that uses `epoch_timestamp_ms` (above):
+Tests based on `sui::test_scenario` can use `later_epoch` (following code), to exercise time-sensitive code that uses `epoch_timestamp_ms` (previous code):
 
 ```
 module sui::test_scenario {


### PR DESCRIPTION
## Description 

Also tweaking the name of `sui::tx_context::epoch_timestamp` to include a `_ms` suffix, like `sui::clock::timestamp_ms`.

## Test Plan 

Make sure to catch all call-sites for `epoch_timestamp`:

```
cargo simtest
```

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
