### PR TITLE
[staking] use pre epoch exchange rate at undelegation

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -242,22 +242,19 @@ validators:
           id: "0xe63945cec193ca7ac76960370028110a907ad1c22ff90b1fd57ea3c441c766b4"
           size: 1
         pending_delegation: 0
-        pending_withdraws:
-          contents:
-            id: "0xab8235dace3d68c7fb48110d63cbf4d6fd81ce101610b747b049f97dec31140c"
-            size: 0
+        pending_total_sui_withdraw: 0
+        pending_pool_token_withdraw: 0
       commission_rate: 0
       next_epoch_stake: 1
-      next_epoch_delegation: 0
       next_epoch_gas_price: 1
       next_epoch_commission_rate: 0
   pending_validators:
     contents:
-      id: "0x1ace65f54d65a96251b3f46bfa720ab65a7ebe0174caa9fa1dc0d65a56ae7872"
+      id: "0x628ffd0e51e9a6ea32c13c2739a31a8f344b557d3429e057b377a9c499b9bb13"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x628ffd0e51e9a6ea32c13c2739a31a8f344b557d3429e057b377a9c499b9bb13"
+    id: "0x18b8140c8a6ea340142f128061016fc4bd8220ec88875a8e573a5f72a85a15c1"
     size: 1
 storage_fund:
   value: 0

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -787,6 +787,7 @@ Withdraw some portion of a delegation from a validator's staking pool.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
+    <b>assert</b>!(delegation_activation_epoch(&staked_sui) &lt;= <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx), 0);
     <a href="validator_set.md#0x2_validator_set_request_withdraw_delegation">validator_set::request_withdraw_delegation</a>(
         &<b>mut</b> self.validators, staked_sui, ctx,
     );

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -1548,7 +1548,6 @@ The staking rewards are shared with the delegators while the storage fund ones a
     storage_fund_reward: &<b>mut</b> Balance&lt;SUI&gt;,
     ctx: &<b>mut</b> TxContext
 ) {
-    <b>let</b> new_epoch = <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1;
     <b>let</b> length = <a href="_length">vector::length</a>(validators);
     <b>assert</b>!(length &gt; 0, 0);
     <b>let</b> i = 0;
@@ -1575,7 +1574,7 @@ The staking rewards are shared with the delegators while the storage fund ones a
         };
 
         // Add rewards <b>to</b> delegation staking pool <b>to</b> auto compound for delegators.
-        <a href="validator.md#0x2_validator_deposit_delegation_rewards">validator::deposit_delegation_rewards</a>(<a href="validator.md#0x2_validator">validator</a>, delegator_reward, new_epoch);
+        <a href="validator.md#0x2_validator_deposit_delegation_rewards">validator::deposit_delegation_rewards</a>(<a href="validator.md#0x2_validator">validator</a>, delegator_reward);
         i = i + 1;
     }
 }

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -6,7 +6,7 @@ module sui::sui_system {
     use sui::clock::{Self, Clock};
     use sui::coin::{Self, Coin};
     use sui::object::{Self, ID, UID};
-    use sui::staking_pool::StakedSui;
+    use sui::staking_pool::{delegation_activation_epoch, StakedSui};
     use sui::locked_coin::{Self, LockedCoin};
     use sui::sui::SUI;
     use sui::transfer;
@@ -326,6 +326,7 @@ module sui::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
+        assert!(delegation_activation_epoch(&staked_sui) <= tx_context::epoch(ctx), 0);
         validator_set::request_withdraw_delegation(
             &mut self.validators, staked_sui, ctx,
         );

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -708,7 +708,6 @@ module sui::validator_set {
         storage_fund_reward: &mut Balance<SUI>,
         ctx: &mut TxContext
     ) {
-        let new_epoch = tx_context::epoch(ctx) + 1;
         let length = vector::length(validators);
         assert!(length > 0, 0);
         let i = 0;
@@ -735,7 +734,7 @@ module sui::validator_set {
             };
 
             // Add rewards to delegation staking pool to auto compound for delegators.
-            validator::deposit_delegation_rewards(validator, delegator_reward, new_epoch);
+            validator::deposit_delegation_rewards(validator, delegator_reward);
             i = i + 1;
         }
     }

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -8,6 +8,7 @@ module sui::governance_test_utils {
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
     use sui::staking_pool::{Self, StakedSui, StakingPool};
+    use sui::test_utils::assert_eq;
     use sui::tx_context::{Self, TxContext};
     use sui::validator::{Self, Validator};
     use sui::sui_system::{Self, SuiSystemState};
@@ -199,7 +200,7 @@ module sui::governance_test_utils {
             test_scenario::next_tx(scenario, validator_addr);
             let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
             let stake_plus_rewards = stake_plus_current_rewards_for_validator(validator_addr, &system_state, scenario);
-            assert!(stake_plus_rewards == amount, 0);
+            assert_eq(stake_plus_rewards, amount);
             test_scenario::return_shared(system_state);
             i = i + 1;
         };

--- a/crates/sui-framework/tests/validator_tests.move
+++ b/crates/sui-framework/tests/validator_tests.move
@@ -13,7 +13,6 @@ module sui::validator_tests {
     use sui::coin::{Self, Coin};
     use sui::balance;
     use sui::staking_pool::{Self, StakedSui};
-    use sui::tx_context;
     use std::vector;
 
 
@@ -127,16 +126,16 @@ module sui::validator_tests {
 
             assert!(validator::total_stake(&validator) == 10, 0);
             assert!(validator::pending_stake_amount(&validator) == 30, 0);
-            assert!(validator::pending_principal_withdrawals(&validator) == 10, 0);
+            assert!(validator::pending_stake_withdraw_amount(&validator) == 10, 0);
 
-            validator::deposit_delegation_rewards(&mut validator, balance::zero(), tx_context::epoch(ctx) + 1);
+            validator::deposit_delegation_rewards(&mut validator, balance::zero());
 
             // Calling `process_pending_delegations_and_withdraws` will withdraw the coin and transfer to sender.
             validator::process_pending_delegations_and_withdraws(&mut validator, ctx);
 
             assert!(validator::total_stake(&validator) == 30, 0);
             assert!(validator::pending_stake_amount(&validator) == 0, 0);
-            assert!(validator::pending_principal_withdrawals(&validator) == 0, 0);
+            assert!(validator::pending_stake_withdraw_amount(&validator) == 0, 0);
         };
 
         test_scenario::next_tx(scenario, sender);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5542,7 +5542,8 @@
           "exchange_rates",
           "id",
           "pending_delegation",
-          "pending_withdraws",
+          "pending_pool_token_withdraw",
+          "pending_total_sui_withdraw",
           "pool_token_balance",
           "rewards_pool",
           "starting_epoch",
@@ -5560,8 +5561,15 @@
             "format": "uint64",
             "minimum": 0.0
           },
-          "pending_withdraws": {
-            "$ref": "#/components/schemas/TableVec"
+          "pending_pool_token_withdraw": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "pending_total_sui_withdraw": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "pool_token_balance": {
             "type": "integer",
@@ -6786,7 +6794,6 @@
           "gas_price",
           "metadata",
           "next_epoch_commission_rate",
-          "next_epoch_delegation",
           "next_epoch_gas_price",
           "next_epoch_stake",
           "staking_pool",
@@ -6807,11 +6814,6 @@
             "$ref": "#/components/schemas/ValidatorMetadata"
           },
           "next_epoch_commission_rate": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "next_epoch_delegation": {
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -164,7 +164,6 @@ pub struct Validator {
     pub staking_pool: StakingPool,
     pub commission_rate: u64,
     pub next_epoch_stake: u64,
-    pub next_epoch_delegation: u64,
     pub next_epoch_gas_price: u64,
     pub next_epoch_commission_rate: u64,
 }
@@ -270,7 +269,8 @@ pub struct StakingPool {
     pub pool_token_balance: u64,
     pub exchange_rates: Table,
     pub pending_delegation: u64,
-    pub pending_withdraws: TableVec,
+    pub pending_total_sui_withdraw: u64,
+    pub pending_pool_token_withdraw: u64,
 }
 
 /// Rust version of the Move sui::validator_set::ValidatorPair type

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -46,7 +46,8 @@ pub fn test_staking_pool(sui_balance: u64) -> StakingPool {
         pool_token_balance: 0,
         exchange_rates: Table::default(),
         pending_delegation: 0,
-        pending_withdraws: TableVec::default(),
+        pending_total_sui_withdraw: 0,
+        pending_pool_token_withdraw: 0,
     }
 }
 
@@ -64,7 +65,6 @@ pub fn test_validator(
         staking_pool: test_staking_pool(delegated_amount + stake_amount),
         commission_rate: 0,
         next_epoch_stake: 1,
-        next_epoch_delegation: 1,
         next_epoch_gas_price: 1,
         next_epoch_commission_rate: 0,
     }

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -116,10 +116,6 @@ export const Contents = object({
   fields: ContentsFields,
 });
 
-export const PendingWithdawFields = object({
-  contents: ContentsFieldsWithdraw,
-});
-
 export const DelegationStakingPoolFields = object({
   exchange_rates: object({
     id: string(),
@@ -127,7 +123,8 @@ export const DelegationStakingPoolFields = object({
   }),
   id: string(),
   pending_delegation: number(),
-  pending_withdraws: PendingWithdawFields,
+  pending_pool_token_withdraw: number(),
+  pending_total_sui_withdraw: number(),
   pool_token_balance: number(),
   rewards_pool: object({ value: number() }),
   starting_epoch: number(),
@@ -160,7 +157,6 @@ export const Validator = object({
   staking_pool: DelegationStakingPoolFields,
   commission_rate: number(),
   next_epoch_stake: number(),
-  next_epoch_delegation: number(),
   next_epoch_gas_price: number(),
   next_epoch_commission_rate: number(),
 });

--- a/sui_programmability/examples/new-frenemies/sources/leaderboard.move
+++ b/sui_programmability/examples/new-frenemies/sources/leaderboard.move
@@ -257,7 +257,7 @@ module frenemies::leaderboard {
         while (i < num_validators) {
             let validator = vector::borrow(validators, i);
             let addr = validator::sui_address(validator);
-            let stake = validator::total_stake(validator) + validator::pending_stake_amount(validator) - validator::pending_principal_withdrawals(validator);
+            let stake = validator::total_stake(validator) + validator::pending_stake_amount(validator) - validator::pending_stake_withdraw_amount(validator);
             validator_insertion_sort(&mut next_epoch_stakes, Validator { addr, stake });
             i = i + 1
         };

--- a/sui_programmability/examples/old-frenemies/sources/leaderboard.move
+++ b/sui_programmability/examples/old-frenemies/sources/leaderboard.move
@@ -231,7 +231,7 @@ module frenemies::leaderboard {
         while (i < num_validators) {
             let validator = vector::borrow(validators, i);
             let addr = validator::sui_address(validator);
-            let stake = validator::total_stake(validator) + validator::pending_stake_amount(validator) - validator::pending_principal_withdrawals(validator);
+            let stake = validator::total_stake(validator) + validator::pending_stake_amount(validator) - validator::pending_stake_withdraw_amount(validator);
             validator_insertion_sort(&mut next_epoch_stakes, Validator { addr, stake });
             i = i + 1
         };


### PR DESCRIPTION
## Description 

This PR changes delegation withdraw flow to use pre-epoch exchange rate when calculating rewards. This way both principal and rewards are returned to the undelegator right away, and we no longer need to process pending delegations one by one at epoch change time.

## Test Plan 

cargo test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
