### PR TITLE
[ts-sdk] Use pre-built binary in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Run TS SDK e2e tests
         if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isRust == 'true'}}
         run: pnpm dlx concurrently --kill-others --success command-1 'RUST_LOG="consensus=off" cargo run --bin sui-test-validator' 'pnpm sdk test:e2e'
+        env:
+          VITE_SUI_BIN: $PWD/target/debug/sui
 
       - name: Run Explorer e2e tests
         # need to run Explorer e2e when its upstream(TS SDK and Rust) or itself is changed
@@ -60,7 +62,7 @@ jobs:
         # need to run Wallet e2e when its upstream(TS SDK and Rust) or itself is changed
         if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
         run: pnpm wallet build
-      # Disable wallet devenet test, 
+      # Disable wallet devenet test,
       # - name: Run Wallet e2e tests
       #   if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
       #   run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm wallet playwright test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+      # Disabled for now as it makes test runs take longer
+      # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
       - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
         with:
           version: 7
@@ -41,11 +42,14 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm explorer playwright install --with-deps chromium
 
+      - name: Set env
+        run: |
+          echo "VITE_SUI_BIN=$PWD/target/debug/sui" >> $GITHUB_ENV
+          echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG=\"consensus=off\" $(echo $PWD/target/debug/sui-test-validator))" >> $GITHUB_ENV
+
       - name: Run TS SDK e2e tests
         if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isRust == 'true'}}
-        run: pnpm dlx concurrently --kill-others --success command-1 'RUST_LOG="consensus=off" cargo run --bin sui-test-validator' 'pnpm sdk test:e2e'
-        env:
-          VITE_SUI_BIN: $PWD/target/debug/sui
+        run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
 
       - name: Run Explorer e2e tests
         # need to run Explorer e2e when its upstream(TS SDK and Rust) or itself is changed
@@ -58,11 +62,11 @@ jobs:
           path: apps/explorer/playwright-report/
           retention-days: 30
 
-      - name: Build Wallet
-        # need to run Wallet e2e when its upstream(TS SDK and Rust) or itself is changed
-        if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
-        run: pnpm wallet build
-      # Disable wallet devenet test,
+      # Disable wallet devenet test
+      # - name: Build Wallet
+      #   # need to run Wallet e2e when its upstream(TS SDK and Rust) or itself is changed
+      #   if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
+      #   run: pnpm wallet build
       # - name: Run Wallet e2e tests
       #   if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
       #   run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm wallet playwright test

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -12,7 +12,6 @@ The SDK will be published to [npm registry](https://www.npmjs.com/package/@myste
 $ npm install @mysten/sui.js
 ```
 
-
 You can also use your preferred npm client, such as yarn or pnpm.
 
 ## Working with local network

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -12,6 +12,7 @@ The SDK will be published to [npm registry](https://www.npmjs.com/package/@myste
 $ npm install @mysten/sui.js
 ```
 
+
 You can also use your preferred npm client, such as yarn or pnpm.
 
 ## Working with local network


### PR DESCRIPTION
## Description 

I noticed that there are some cases where `cargo run` will trigger a rebuild, making localnet tests incredible slow in some cases. This always uses the built binary to avoid triggering a build.

## Test Plan 

TS e2e tests pass with no cargo output in test runs