### PR TITLE
[rcp] Fullnode always read latest system state object

### DIFF
--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -88,8 +88,11 @@ impl GovernanceReadApiServer for GovernanceReadApi {
     }
 
     async fn get_sui_system_state(&self) -> RpcResult<SuiSystemState> {
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
-        Ok(epoch_store.system_state_object().clone())
+        Ok(self
+            .state
+            .database
+            .get_sui_system_state_object()
+            .map_err(Error::from)?)
     }
 
     async fn get_reference_gas_price(&self) -> RpcResult<u64> {


### PR DESCRIPTION
This reverts the fullnode RPC behavior to previous, that we always read from db. While this is less efficient, it is also less surprise.
Down the road we will introduce a separate API to return epoch static data.