### PR TITLE
[stress tests] simplify Payload trait to make it easier to add new st…

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -356,9 +356,6 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                     .then(|res| async move  {
                                         match res {
                                             Ok(effects) => {
-                                                let new_version = effects.mutated().iter().find(|(object_ref, _)| {
-                                                    object_ref.0 == b.1.get_object_id()
-                                                }).map(|x| x.0).unwrap();
                                                 let latency = start.elapsed();
                                                 metrics_cloned.latency_s.with_label_values(&[&b.1.get_workload_type().to_string()]).observe(latency.as_secs_f64());
                                                 metrics_cloned.num_success.with_label_values(&[&b.1.get_workload_type().to_string()]).inc();
@@ -370,7 +367,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                                 }
                                                 NextOp::Response(Some((
                                                     latency,
-                                                    b.1.make_new_payload(new_version, effects.gas_object().0, &effects),
+                                                    b.1.make_new_payload(&effects),
                                                 ),
                                                 ))
                                             }
@@ -404,9 +401,6 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                 .then(|res| async move {
                                     match res {
                                         Ok(effects) => {
-                                            let new_version = effects.mutated().iter().find(|(object_ref, _)| {
-                                                object_ref.0 == payload.get_object_id()
-                                            }).map(|x| x.0).unwrap();
                                             let latency = start.elapsed();
                                             metrics_cloned.latency_s.with_label_values(&[&payload.get_workload_type().to_string()]).observe(latency.as_secs_f64());
                                             metrics_cloned.num_success.with_label_values(&[&payload.get_workload_type().to_string()]).inc();
@@ -416,7 +410,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                             if let Some(sig_info) = effects.quorum_sig() { sig_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_effects_cert.with_label_values(&[&name.unwrap().to_string()]).inc()) }
                                             NextOp::Response(Some((
                                                 latency,
-                                                payload.make_new_payload(new_version, effects.gas_object().0, &effects),
+                                                payload.make_new_payload(&effects),
                                             )))
                                         }
                                         Err(err) => {

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use rand::seq::IteratorRandom;
 use std::sync::Arc;
 use sui_core::test_utils::make_transfer_sui_transaction;
-use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::messages::VerifiedTransaction;
 use test_utils::messages::make_delegation_transaction;
@@ -50,19 +50,14 @@ impl Payload for DelegationTestPayload {
         }
     }
 
-    fn make_new_payload(
-        self: Box<Self>,
-        _: ObjectRef,
-        new_gas: ObjectRef,
-        effects: &ExecutionEffects,
-    ) -> Box<dyn Payload> {
+    fn make_new_payload(self: Box<Self>, effects: &ExecutionEffects) -> Box<dyn Payload> {
         let coin = match self.coin {
             None => Some(effects.created().get(0).unwrap().0),
             Some(_) => None,
         };
         Box::new(DelegationTestPayload {
             coin,
-            gas: new_gas,
+            gas: effects.gas_object().0,
             validator: self.validator,
             sender: self.sender,
             keypair: self.keypair,
@@ -70,16 +65,8 @@ impl Payload for DelegationTestPayload {
         })
     }
 
-    fn get_object_id(&self) -> ObjectID {
-        self.gas.0
-    }
-
     fn get_workload_type(&self) -> WorkloadType {
         WorkloadType::Delegation
-    }
-
-    fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self as &DelegationTestPayload)
     }
 }
 

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -35,17 +35,12 @@ pub struct SharedCounterTestPayload {
 }
 
 impl Payload for SharedCounterTestPayload {
-    fn make_new_payload(
-        self: Box<Self>,
-        _: ObjectRef,
-        new_gas: ObjectRef,
-        _: &ExecutionEffects,
-    ) -> Box<dyn Payload> {
+    fn make_new_payload(self: Box<Self>, effects: &ExecutionEffects) -> Box<dyn Payload> {
         Box::new(SharedCounterTestPayload {
             package_id: self.package_id,
             counter_id: self.counter_id,
             counter_initial_shared_version: self.counter_initial_shared_version,
-            gas: (new_gas, self.gas.1, self.gas.2),
+            gas: (effects.gas_object().0, self.gas.1, self.gas.2),
             system_state_observer: self.system_state_observer,
         })
     }
@@ -63,15 +58,9 @@ impl Payload for SharedCounterTestPayload {
             Some(*self.system_state_observer.reference_gas_price.borrow()),
         )
     }
-    fn get_object_id(&self) -> ObjectID {
-        self.counter_id
-    }
+
     fn get_workload_type(&self) -> WorkloadType {
         WorkloadType::SharedCounter
-    }
-
-    fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self as &SharedCounterTestPayload)
     }
 }
 


### PR DESCRIPTION
…ress-test workloads

- Remove `get_object_id` function + `new_object` and `new_gas` arguments to `make_new_paylod`
- Derive `Debug` instead of hand-rolling

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
