### PR TITLE
Switch SharedWorkerCache instances with WorkerCache

### DIFF
--- a/crates/sui-core/src/narwhal_manager/mod.rs
+++ b/crates/sui-core/src/narwhal_manager/mod.rs
@@ -114,7 +114,7 @@ impl NarwhalManager {
     pub async fn start<State, TxValidator: TransactionValidator>(
         &self,
         committee: Committee,
-        shared_worker_cache: WorkerCache,
+        worker_cache: WorkerCache,
         execution_state: Arc<State>,
         tx_validator: TxValidator,
     ) where
@@ -150,7 +150,7 @@ impl NarwhalManager {
                     self.primary_keypair.copy(),
                     self.network_keypair.copy(),
                     committee.clone(),
-                    shared_worker_cache.clone(),
+                    worker_cache.clone(),
                     &store,
                     execution_state.clone(),
                 )
@@ -187,7 +187,7 @@ impl NarwhalManager {
                     name.clone(),
                     id_keypair_copy,
                     committee.clone(),
-                    shared_worker_cache.clone(),
+                    worker_cache.clone(),
                     &store,
                     tx_validator.clone(),
                 )

--- a/crates/sui-core/src/narwhal_manager/mod.rs
+++ b/crates/sui-core/src/narwhal_manager/mod.rs
@@ -7,7 +7,7 @@ pub mod narwhal_manager_tests;
 
 use fastcrypto::traits::KeyPair;
 use mysten_metrics::RegistryService;
-use narwhal_config::{Committee, Epoch, Parameters, SharedWorkerCache, WorkerId};
+use narwhal_config::{Committee, Epoch, Parameters, WorkerCache, WorkerId};
 use narwhal_executor::ExecutionState;
 use narwhal_node::primary_node::PrimaryNode;
 use narwhal_node::worker_node::WorkerNodes;
@@ -114,7 +114,7 @@ impl NarwhalManager {
     pub async fn start<State, TxValidator: TransactionValidator>(
         &self,
         committee: Committee,
-        shared_worker_cache: SharedWorkerCache,
+        shared_worker_cache: WorkerCache,
         execution_state: Arc<State>,
         tx_validator: TxValidator,
     ) where

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -7,7 +7,7 @@ use bytes::Bytes;
 use fastcrypto::bls12381;
 use fastcrypto::traits::KeyPair;
 use mysten_metrics::RegistryService;
-use narwhal_config::{Epoch, SharedWorkerCache};
+use narwhal_config::{Epoch, WorkerCache};
 use narwhal_executor::ExecutionState;
 use narwhal_types::{ConsensusOutput, TransactionProto, TransactionsClient};
 use narwhal_worker::TrivialTransactionValidator;
@@ -42,12 +42,11 @@ impl ExecutionState for NoOpExecutionState {
 
 async fn send_transactions(
     name: &bls12381::min_sig::BLS12381PublicKey,
-    worker_cache: SharedWorkerCache,
+    worker_cache: WorkerCache,
     epoch: Epoch,
     mut rx_shutdown: broadcast::Receiver<()>,
 ) {
     let target = worker_cache
-        .load()
         .worker(name, /* id */ &0)
         .expect("Our key or worker id is not in the worker cache")
         .transactions;
@@ -123,7 +122,7 @@ async fn test_narwhal_manager() {
         let narwhal_manager = NarwhalManager::new(narwhal_config, metrics);
 
         // start narwhal
-        let shared_worker_cache = SharedWorkerCache::from(worker_cache.clone());
+        let shared_worker_cache = worker_cache.clone();
         narwhal_manager
             .start(
                 narwhal_committee.clone(),
@@ -190,7 +189,7 @@ async fn test_narwhal_manager() {
         });
 
         // start narwhal with advanced epoch
-        let shared_worker_cache = SharedWorkerCache::from(worker_cache.clone());
+        let shared_worker_cache = worker_cache.clone();
         narwhal_manager
             .start(
                 narwhal_committee.clone(),

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -122,11 +122,10 @@ async fn test_narwhal_manager() {
         let narwhal_manager = NarwhalManager::new(narwhal_config, metrics);
 
         // start narwhal
-        let shared_worker_cache = worker_cache.clone();
         narwhal_manager
             .start(
                 narwhal_committee.clone(),
-                shared_worker_cache.clone(),
+                worker_cache.clone(),
                 Arc::new(execution_state.clone()),
                 TrivialTransactionValidator::default(),
             )
@@ -145,7 +144,7 @@ async fn test_narwhal_manager() {
         tokio::spawn(async move {
             send_transactions(
                 &name,
-                shared_worker_cache,
+                worker_cache.clone(),
                 narwhal_committee.epoch,
                 rx_shutdown,
             )
@@ -189,11 +188,10 @@ async fn test_narwhal_manager() {
         });
 
         // start narwhal with advanced epoch
-        let shared_worker_cache = worker_cache.clone();
         narwhal_manager
             .start(
                 narwhal_committee.clone(),
-                shared_worker_cache.clone(),
+                worker_cache.clone(),
                 Arc::new(execution_state.clone()),
                 TrivialTransactionValidator::default(),
             )
@@ -204,7 +202,7 @@ async fn test_narwhal_manager() {
         tokio::spawn(async move {
             send_transactions(
                 &name,
-                shared_worker_cache,
+                worker_cache.clone(),
                 narwhal_committee.epoch,
                 rx_shutdown,
             )

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -60,7 +60,6 @@ pub mod admin;
 mod handle;
 pub mod metrics;
 pub use handle::SuiNodeHandle;
-use narwhal_config::SharedWorkerCache;
 use narwhal_types::TransactionsClient;
 use sui_core::authority::authority_per_epoch_store::{
     AuthorityPerEpochStore, EpochStartConfiguration,
@@ -566,7 +565,7 @@ impl SuiNode {
         narwhal_manager
             .start(
                 committee.clone(),
-                SharedWorkerCache::from(worker_cache),
+                worker_cache,
                 consensus_handler,
                 SuiTxValidator::new(
                     epoch_store,

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -9,7 +9,6 @@
 )]
 #![allow(clippy::mutable_key_type)]
 
-use arc_swap::ArcSwap;
 use crypto::{NetworkPublicKey, PublicKey};
 use fastcrypto::traits::EncodeDecodeBase64;
 use multiaddr::Multiaddr;
@@ -20,7 +19,6 @@ use std::{
     fs::{self, OpenOptions},
     io::{BufWriter, Write as _},
     num::NonZeroU32,
-    sync::Arc,
     time::Duration,
 };
 use thiserror::Error;

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -545,8 +545,6 @@ pub struct WorkerInfo {
     pub worker_address: Multiaddr,
 }
 
-pub type SharedWorkerCache = Arc<ArcSwap<WorkerCache>>;
-
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct WorkerIndex(pub BTreeMap<WorkerId, WorkerInfo>);
 
@@ -556,12 +554,6 @@ pub struct WorkerCache {
     pub workers: BTreeMap<PublicKey, WorkerIndex>,
     /// The epoch number for workers
     pub epoch: Epoch,
-}
-
-impl From<WorkerCache> for SharedWorkerCache {
-    fn from(worker_cache: WorkerCache) -> Self {
-        Arc::new(ArcSwap::from_pointee(worker_cache))
-    }
 }
 
 impl std::fmt::Display for WorkerIndex {
@@ -698,20 +690,12 @@ pub struct Authority {
     pub network_key: NetworkPublicKey,
 }
 
-pub type SharedCommittee = Arc<ArcSwap<Committee>>;
-
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct Committee {
     /// The authorities of epoch.
     pub authorities: BTreeMap<PublicKey, Authority>,
     /// The epoch number of this committee
     pub epoch: Epoch,
-}
-
-impl From<Committee> for SharedCommittee {
-    fn from(committee: Committee) -> Self {
-        Arc::new(ArcSwap::from_pointee(committee))
-    }
 }
 
 impl std::fmt::Display for Committee {

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -12,7 +12,7 @@ use tracing::info;
 
 use crate::metrics::ExecutorMetrics;
 use async_trait::async_trait;
-use config::{Committee, SharedWorkerCache};
+use config::{Committee, WorkerCache};
 use crypto::PublicKey;
 
 use prometheus::Registry;
@@ -54,7 +54,7 @@ impl Executor {
     pub fn spawn<State>(
         name: PublicKey,
         network: oneshot::Receiver<anemo::Network>,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         committee: Committee,
         execution_state: State,
         shutdown_receivers: Vec<ConditionalBroadcastReceiver>,

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -8,7 +8,6 @@
     rust_2021_compatibility
 )]
 
-use arc_swap::ArcSwap;
 use clap::{crate_name, crate_version, App, AppSettings, ArgMatches, SubCommand};
 use config::{Committee, Import, Parameters, WorkerCache, WorkerId};
 use crypto::{KeyPair, NetworkKeyPair};
@@ -252,9 +251,8 @@ async fn run(
     // Read the committee, workers and node's keypair from file.
     let committee =
         Committee::import(committee_file).context("Failed to load the committee information")?;
-    let worker_cache = Arc::new(ArcSwap::from_pointee(
-        WorkerCache::import(workers_file).context("Failed to load the worker information")?,
-    ));
+    let worker_cache =
+        WorkerCache::import(workers_file).context("Failed to load the worker information")?;
 
     // Load default parameters if none are specified.
     let parameters = match parameters_file {

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::metrics::new_registry;
 use crate::{try_join_all, FuturesUnordered, NodeError};
-use config::{Committee, Parameters, SharedWorkerCache};
+use config::{Committee, Parameters, WorkerCache};
 use consensus::bullshark::Bullshark;
 use consensus::dag::Dag;
 use consensus::metrics::{ChannelMetrics, ConsensusMetrics};
@@ -57,7 +57,7 @@ impl PrimaryNodeInner {
         // The committee information.
         committee: Committee,
         // The worker information cache.
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         // The node's store //TODO: replace this by a path so the method can open and independent storage
         store: &NodeStorage,
         // The state used by the client to execute transactions.
@@ -169,7 +169,7 @@ impl PrimaryNodeInner {
         // The committee information.
         committee: Committee,
         // The worker information cache.
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         // The node's storage.
         store: &NodeStorage,
         // The configuration parameters.
@@ -280,7 +280,7 @@ impl PrimaryNodeInner {
     async fn spawn_consensus<State>(
         name: PublicKey,
         rx_executor_network: oneshot::Receiver<anemo::Network>,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         committee: Committee,
         store: &NodeStorage,
         parameters: Parameters,
@@ -393,7 +393,7 @@ impl PrimaryNode {
         // The committee information.
         committee: Committee,
         // The worker information cache.
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         // The node's store //TODO: replace this by a path so the method can open and independent storage
         store: &NodeStorage,
         // The state used by the client to execute transactions.

--- a/narwhal/node/src/worker_node.rs
+++ b/narwhal/node/src/worker_node.rs
@@ -4,7 +4,7 @@
 use crate::metrics::new_registry;
 use crate::{try_join_all, FuturesUnordered, NodeError};
 use arc_swap::{ArcSwap, ArcSwapOption};
-use config::{Committee, Parameters, SharedWorkerCache, WorkerId};
+use config::{Committee, Parameters, WorkerCache, WorkerId};
 use crypto::{NetworkKeyPair, PublicKey};
 use mysten_metrics::{RegistryID, RegistryService};
 use prometheus::Registry;
@@ -47,7 +47,7 @@ impl WorkerNodeInner {
         // The committee information.
         committee: Committee,
         // The worker information cache.
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         // The node's store //TODO: replace this by a path so the method can open and independent storage
         store: &NodeStorage,
         // The transaction validator that should be used
@@ -188,7 +188,7 @@ impl WorkerNode {
         // The committee information.
         committee: Committee,
         // The worker information cache.
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         // The node's store //TODO: replace this by a path so the method can open and independent storage
         store: &NodeStorage,
         // The transaction validator defining Tx acceptance,
@@ -253,7 +253,7 @@ impl WorkerNodes {
         // The committee information.
         committee: Committee,
         // The worker information cache.
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         // The node's store //TODO: replace this by a path so the method can open and independent storage
         store: &NodeStorage,
         // The transaction validator defining Tx acceptance,

--- a/narwhal/node/tests/node_smoke_test.rs
+++ b/narwhal/node/tests/node_smoke_test.rs
@@ -16,7 +16,7 @@ fn test_primary_no_consensus() {
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary_keys_file_path = format!("{config_path}/smoke_test_primary_keys.json");
     fixture
         .authorities()
@@ -100,7 +100,7 @@ fn test_primary_with_consensus() {
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary_keys_file_path = format!("{config_path}/smoke_test_primary_keys.json");
     fixture
         .authorities()

--- a/narwhal/node/tests/node_test.rs
+++ b/narwhal/node/tests/node_test.rs
@@ -29,8 +29,7 @@ async fn simple_primary_worker_node_start_stop() {
         .randomize_ports(true)
         .build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
-    let shared_committee = committee.clone();
+    let worker_cache = fixture.worker_cache();
 
     let authority = fixture.authorities().next().unwrap();
     let key_pair = authority.keypair();
@@ -47,7 +46,7 @@ async fn simple_primary_worker_node_start_stop() {
         .start(
             key_pair.copy(),
             network_key_pair.copy(),
-            shared_committee.clone(),
+            committee.clone(),
             worker_cache.clone(),
             &store,
             execution_state,
@@ -62,7 +61,7 @@ async fn simple_primary_worker_node_start_stop() {
         .start(
             key_pair.public().clone(),
             vec![(0, authority.worker(0).keypair().copy())],
-            shared_committee,
+            committee,
             worker_cache,
             &store,
             TrivialTransactionValidator::default(),
@@ -109,8 +108,7 @@ async fn primary_node_restart() {
         .randomize_ports(true)
         .build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
-    let shared_committee = committee.clone();
+    let worker_cache = fixture.worker_cache();
 
     let authority = fixture.authorities().next().unwrap();
     let key_pair = authority.keypair();
@@ -127,7 +125,7 @@ async fn primary_node_restart() {
         .start(
             key_pair.copy(),
             network_key_pair.copy(),
-            shared_committee.clone(),
+            committee.clone(),
             worker_cache.clone(),
             &store,
             execution_state.clone(),
@@ -147,7 +145,7 @@ async fn primary_node_restart() {
         .start(
             key_pair.copy(),
             network_key_pair.copy(),
-            shared_committee.clone(),
+            committee.clone(),
             worker_cache.clone(),
             &store,
             execution_state,

--- a/narwhal/primary/src/block_remover.rs
+++ b/narwhal/primary/src/block_remover.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::utils;
 use anyhow::Result;
-use config::{SharedWorkerCache, WorkerId};
+use config::{WorkerCache, WorkerId};
 use consensus::dag::{Dag, ValidatorDagError};
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
@@ -33,7 +33,7 @@ pub struct BlockRemover {
     name: PublicKey,
 
     /// The worker information cache.
-    worker_cache: SharedWorkerCache,
+    worker_cache: WorkerCache,
 
     /// Storage that keeps the Certificates by their digest id.
     certificate_store: CertificateStore,
@@ -58,7 +58,7 @@ impl BlockRemover {
     #[must_use]
     pub fn new(
         name: PublicKey,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         certificate_store: CertificateStore,
         header_store: Store<HeaderDigest, Header>,
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
@@ -101,7 +101,6 @@ impl BlockRemover {
         for (worker_id, batch_digests) in batches_by_worker.iter() {
             let worker_name = self
                 .worker_cache
-                .load()
                 .worker(&self.name, worker_id)
                 .expect("Worker id not found")
                 .name;

--- a/narwhal/primary/src/block_synchronizer/mod.rs
+++ b/narwhal/primary/src/block_synchronizer/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use anemo::PeerId;
 use anyhow::anyhow;
-use config::{Committee, Parameters, SharedWorkerCache, WorkerId};
+use config::{Committee, Parameters, WorkerCache, WorkerId};
 use crypto::traits::ToFromBytes;
 use crypto::{NetworkPublicKey, PublicKey};
 use fastcrypto::hash::Hash;
@@ -153,7 +153,7 @@ pub struct BlockSynchronizer {
     committee: Committee,
 
     /// The worker information cache.
-    worker_cache: SharedWorkerCache,
+    worker_cache: WorkerCache,
 
     /// Receiver for shutdown.
     rx_shutdown: ConditionalBroadcastReceiver,
@@ -188,7 +188,7 @@ impl BlockSynchronizer {
     pub fn spawn(
         name: PublicKey,
         committee: Committee,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         rx_shutdown: ConditionalBroadcastReceiver,
         rx_block_synchronizer_commands: metered_channel::Receiver<Command>,
         network: anemo::Network,
@@ -642,7 +642,6 @@ impl BlockSynchronizer {
         for (worker_id, batch_ids) in batches_by_worker {
             let worker_name = self
                 .worker_cache
-                .load()
                 .worker(&self.name, &worker_id)
                 .expect("Worker id not found")
                 .name;
@@ -703,7 +702,7 @@ impl BlockSynchronizer {
         targets: Vec<NetworkPublicKey>,
         timeout: Duration,
         committee: Committee,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         digests: Vec<CertificateDigest>,
     ) -> State {
         let request = GetCertificatesRequest {

--- a/narwhal/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/narwhal/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -36,7 +36,7 @@ async fn test_successful_headers_synchronization() {
     // AND the necessary keys
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let author = fixture.authorities().next().unwrap();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();
@@ -178,7 +178,7 @@ async fn test_successful_payload_synchronization() {
     // AND the necessary keys
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let author = fixture.authorities().next().unwrap();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();
@@ -358,7 +358,7 @@ async fn test_timeout_while_waiting_for_certificates() {
     // AND the necessary keys
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let author = fixture.authorities().next().unwrap();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();
@@ -466,7 +466,7 @@ async fn test_reply_with_certificates_already_in_storage() {
     // AND the necessary keys
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let author = fixture.authorities().next().unwrap();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();
@@ -566,7 +566,7 @@ async fn test_reply_with_payload_already_in_storage() {
     // AND the necessary keys
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let author = fixture.authorities().next().unwrap();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();
@@ -668,7 +668,7 @@ async fn test_reply_with_payload_already_in_storage_for_own_certificates() {
     // AND the necessary keys
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
 

--- a/narwhal/primary/src/block_waiter.rs
+++ b/narwhal/primary/src/block_waiter.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::block_synchronizer::handler::Handler;
 use anyhow::Result;
-use config::SharedWorkerCache;
+use config::WorkerCache;
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
 use futures::{
@@ -41,7 +41,7 @@ pub struct BlockWaiter<SynchronizerHandler: Handler + Send + Sync + 'static> {
     name: PublicKey,
 
     /// The worker information cache.
-    worker_cache: SharedWorkerCache,
+    worker_cache: WorkerCache,
 
     /// Network driver allowing to send messages.
     worker_network: anemo::Network,
@@ -56,7 +56,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
     #[must_use]
     pub fn new(
         name: PublicKey,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         worker_network: anemo::Network,
         block_synchronizer_handler: Arc<SynchronizerHandler>,
     ) -> BlockWaiter<SynchronizerHandler> {
@@ -130,7 +130,6 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
                 debug!("Sending batch {batch_digest} request to worker id {worker_id}");
                 let worker_name = self
                     .worker_cache
-                    .load()
                     .worker(&self.name, worker_id)
                     .expect("Worker id not found")
                     .name;

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use anemo::{Network, Request};
-use config::{Committee, Epoch, SharedWorkerCache, WorkerId};
+use config::{Committee, Epoch, WorkerCache, WorkerId};
 use consensus::dag::Dag;
 use crypto::{NetworkPublicKey, PublicKey};
 use fastcrypto::hash::Hash as _;
@@ -47,7 +47,7 @@ struct Inner {
     /// Committee of the current epoch.
     committee: Committee,
     /// The worker information cache.
-    worker_cache: SharedWorkerCache,
+    worker_cache: WorkerCache,
     /// The depth of the garbage collector.
     gc_depth: Round,
     /// Highest round that has been GC'ed.
@@ -184,7 +184,7 @@ impl Synchronizer {
     pub fn new(
         name: PublicKey,
         committee: Committee,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         gc_depth: Round,
         certificate_store: CertificateStore,
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
@@ -746,7 +746,6 @@ impl Synchronizer {
             let inner = inner.clone();
             let worker_name = inner
                 .worker_cache
-                .load()
                 .worker(&inner.name, &worker_id)
                 .expect("Author of valid header is not in the worker cache")
                 .name;

--- a/narwhal/primary/src/tests/block_remover_tests.rs
+++ b/narwhal/primary/src/tests/block_remover_tests.rs
@@ -26,7 +26,7 @@ async fn test_successful_blocks_delete() {
     // AND the necessary keys
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let author = fixture.authorities().next().unwrap();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();
@@ -201,7 +201,7 @@ async fn test_failed_blocks_delete() {
     // AND the necessary keys
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let author = fixture.authorities().next().unwrap();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();

--- a/narwhal/primary/src/tests/block_waiter_tests.rs
+++ b/narwhal/primary/src/tests/block_waiter_tests.rs
@@ -23,7 +23,7 @@ async fn test_successfully_retrieve_block() {
     // GIVEN
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let author = fixture.authorities().next().unwrap();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();
@@ -103,7 +103,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
     // GIVEN
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let author = fixture.authorities().next().unwrap();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();
@@ -264,7 +264,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
 async fn test_return_error_when_certificate_is_missing() {
     // GIVEN
     let fixture = CommitteeFixture::builder().build();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();
 
@@ -305,7 +305,7 @@ async fn test_return_error_when_certificate_is_missing() {
 async fn test_return_error_when_certificate_is_missing_when_get_blocks() {
     // GIVEN
     let fixture = CommitteeFixture::builder().build();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().nth(1).unwrap();
     let name = primary.public_key();
 

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -140,7 +140,7 @@ struct BadHeader {
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn fetch_certificates_basic() {
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let name = primary.public_key();
     let fake_primary = fixture.authorities().nth(1).unwrap();

--- a/narwhal/primary/src/tests/certificate_tests.rs
+++ b/narwhal/primary/src/tests/certificate_tests.rs
@@ -24,7 +24,7 @@ fn test_empty_certificate_verification() {
 
     let certificate = Certificate::new_unsigned(&committee, header, Vec::new()).unwrap();
     assert!(certificate
-        .verify(&committee, fixture.worker_cache().into())
+        .verify(&committee, fixture.worker_cache())
         .is_err());
 }
 
@@ -45,7 +45,7 @@ fn test_valid_certificate_verification() {
     let certificate = Certificate::new(&committee, header, signatures).unwrap();
 
     assert!(certificate
-        .verify(&committee, fixture.worker_cache().into())
+        .verify(&committee, fixture.worker_cache())
         .is_ok());
 }
 
@@ -68,7 +68,7 @@ fn test_certificate_insufficient_signatures() {
     let certificate = Certificate::new_unsigned(&committee, header, signatures).unwrap();
 
     assert!(certificate
-        .verify(&committee, fixture.worker_cache().into())
+        .verify(&committee, fixture.worker_cache())
         .is_err());
 }
 
@@ -93,7 +93,7 @@ fn test_certificate_validly_repeated_public_keys() {
     let certificate = certificate_res.unwrap();
 
     assert!(certificate
-        .verify(&committee, fixture.worker_cache().into())
+        .verify(&committee, fixture.worker_cache())
         .is_ok());
 }
 
@@ -142,7 +142,7 @@ proptest::proptest! {
         let certificate = Certificate::new(&committee, header, signatures).unwrap();
 
         assert!(certificate
-            .verify(&committee, fixture.worker_cache().into())
+            .verify(&committee, fixture.worker_cache())
             .is_ok());
     }
 }

--- a/narwhal/primary/src/tests/core_tests.rs
+++ b/narwhal/primary/src/tests/core_tests.rs
@@ -19,7 +19,7 @@ async fn propose_header() {
     telemetry_subscribers::init_for_testing();
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().last().unwrap();
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
     let name = primary.public_key();
@@ -130,7 +130,7 @@ async fn propose_header_failure() {
     telemetry_subscribers::init_for_testing();
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().last().unwrap();
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
     let name = primary.public_key();
@@ -224,7 +224,7 @@ async fn propose_header_failure() {
 async fn shutdown_core() {
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
     let name = primary.public_key();

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -53,7 +53,7 @@ async fn get_network_peers_from_admin_server() {
     };
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let authority_1 = fixture.authorities().next().unwrap();
     let name_1 = authority_1.public_key();
     let signer_1 = authority_1.keypair().copy();
@@ -300,7 +300,7 @@ async fn test_request_vote_send_missing_parents() {
     let author = fixture.authorities().nth(2).unwrap();
     let target_name = target.public_key();
     let author_name = author.public_key();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let signature_service = SignatureService::new(target.keypair().copy());
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
     let network = test_utils::test_network(target.network_keypair(), target.address());
@@ -443,7 +443,7 @@ async fn test_request_vote_accept_missing_parents() {
     let author = fixture.authorities().nth(2).unwrap();
     let target_name = target.public_key();
     let author_name = author.public_key();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let signature_service = SignatureService::new(target.keypair().copy());
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
     let network = test_utils::test_network(target.network_keypair(), target.address());
@@ -575,7 +575,7 @@ async fn test_request_vote_missing_batches() {
         .randomize_ports(true)
         .committee_size(NonZeroUsize::new(4).unwrap())
         .build();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let name = primary.public_key();
     let author = fixture.authorities().nth(2).unwrap();
@@ -699,7 +699,7 @@ async fn test_request_vote_already_voted() {
         .randomize_ports(true)
         .committee_size(NonZeroUsize::new(4).unwrap())
         .build();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let name = primary.public_key();
     let author = fixture.authorities().nth(2).unwrap();
@@ -859,7 +859,7 @@ async fn test_fetch_certificates_handler() {
         .committee_size(NonZeroUsize::new(4).unwrap())
         .build();
     let name = fixture.authorities().next().unwrap().public_key();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let signature_service = SignatureService::new(primary.keypair().copy());
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
@@ -1026,7 +1026,7 @@ async fn test_process_payload_availability_success() {
         .build();
     let author = fixture.authorities().next().unwrap();
     let name = author.public_key();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let signature_service = SignatureService::new(primary.keypair().copy());
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
@@ -1176,7 +1176,7 @@ async fn test_process_payload_availability_when_failures() {
     let committee = fixture.committee();
     let author = fixture.authorities().next().unwrap();
     let name = author.public_key();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let signature_service = SignatureService::new(primary.keypair().copy());
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
@@ -1271,7 +1271,7 @@ async fn test_request_vote_created_at_in_future() {
         .randomize_ports(true)
         .committee_size(NonZeroUsize::new(4).unwrap())
         .build();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let name = primary.public_key();
     let author = fixture.authorities().nth(2).unwrap();

--- a/narwhal/primary/src/tests/proposer_tests.rs
+++ b/narwhal/primary/src/tests/proposer_tests.rs
@@ -13,7 +13,7 @@ use types::PreSubscribedBroadcastSender;
 async fn propose_empty() {
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
-    let shared_worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let name = primary.public_key();
     let signature_service = SignatureService::new(primary.keypair().copy());
@@ -52,14 +52,14 @@ async fn propose_empty() {
     let header = rx_headers.recv().await.unwrap();
     assert_eq!(header.round, 1);
     assert!(header.payload.is_empty());
-    assert!(header.verify(&committee, shared_worker_cache).is_ok());
+    assert!(header.verify(&committee, worker_cache).is_ok());
 }
 
 #[tokio::test]
 async fn propose_payload_and_repropose_after_n_seconds() {
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
-    let shared_worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let name = primary.public_key();
     let header_resend_delay = Duration::from_secs(3);
@@ -124,7 +124,7 @@ async fn propose_payload_and_repropose_after_n_seconds() {
         header.payload.get(&digest),
         Some(&(worker_id, created_at_ts))
     );
-    assert!(header.verify(&committee, shared_worker_cache).is_ok());
+    assert!(header.verify(&committee, worker_cache).is_ok());
 
     // WHEN available batches are more than the maximum ones
     let batches: IndexMap<BatchDigest, (WorkerId, TimestampMs)> =
@@ -185,7 +185,7 @@ async fn propose_payload_and_repropose_after_n_seconds() {
 async fn equivocation_protection() {
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
-    let shared_worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
     let name = primary.public_key();
     let signature_service = SignatureService::new(primary.keypair().copy());
@@ -258,7 +258,7 @@ async fn equivocation_protection() {
         header.payload.get(&digest),
         Some(&(worker_id, created_at_ts))
     );
-    assert!(header.verify(&committee, shared_worker_cache).is_ok());
+    assert!(header.verify(&committee, worker_cache).is_ok());
 
     // restart the proposer.
     tx_shutdown.send().unwrap();

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -23,7 +23,7 @@ use types::{error::DagError, Certificate, PreSubscribedBroadcastSender};
 async fn accept_certificates() {
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().last().unwrap();
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
     let name = primary.public_key();
@@ -120,7 +120,7 @@ async fn accept_suspended_certificates() {
         .randomize_ports(true)
         .committee_size(NonZeroUsize::new(NUM_AUTHORITIES).unwrap())
         .build();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
     let primary = fixture.authorities().next().unwrap();
     let name = primary.public_key();
@@ -207,7 +207,7 @@ async fn accept_suspended_certificates() {
 async fn synchronizer_recover_basic() {
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().last().unwrap();
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
     let name = primary.public_key();
@@ -321,7 +321,7 @@ async fn synchronizer_recover_basic() {
 async fn synchronizer_recover_partial_certs() {
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().last().unwrap();
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
     let name = primary.public_key();
@@ -429,7 +429,7 @@ async fn synchronizer_recover_partial_certs() {
 async fn synchronizer_recover_previous_round() {
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().last().unwrap();
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
     let name = primary.public_key();
@@ -539,7 +539,7 @@ async fn deliver_certificate_using_dag() {
     let fixture = CommitteeFixture::builder().build();
     let name = fixture.authorities().next().unwrap().public_key();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     let (_, certificates_store, payload_store) = create_db_stores();
@@ -615,7 +615,7 @@ async fn deliver_certificate_using_store() {
     let fixture = CommitteeFixture::builder().build();
     let name = fixture.authorities().next().unwrap().public_key();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     let (_, certificates_store, payload_store) = create_db_stores();
@@ -678,7 +678,7 @@ async fn deliver_certificate_not_found_parents() {
     let fixture = CommitteeFixture::builder().build();
     let name = fixture.authorities().next().unwrap().public_key();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     let (_, certificates_store, payload_store) = create_db_stores();
@@ -744,7 +744,7 @@ async fn sync_batches_drops_old() {
         .randomize_ports(true)
         .committee_size(NonZeroUsize::new(4).unwrap())
         .build();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
     let primary = fixture.authorities().next().unwrap();
     let name = primary.public_key();
@@ -820,7 +820,7 @@ async fn gc_suspended_certificates() {
         .randomize_ports(true)
         .committee_size(NonZeroUsize::new(NUM_AUTHORITIES).unwrap())
         .build();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
     let primary = fixture.authorities().next().unwrap();
     let name = primary.public_key();

--- a/narwhal/primary/tests/integration_tests_configuration_api.rs
+++ b/narwhal/primary/tests/integration_tests_configuration_api.rs
@@ -54,7 +54,7 @@ async fn test_new_network_info() {
     // give some time for nodes to bootstrap
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    let committee = cluster.committee_shared.clone();
+    let committee = cluster.committee.clone();
     let authority = cluster.authority(0);
 
     // Test gRPC server with client call
@@ -108,7 +108,7 @@ async fn test_get_primary_address() {
     // give some time for nodes to bootstrap
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    let committee = cluster.committee_shared.clone();
+    let committee = cluster.committee.clone();
     let authority = cluster.authority(0);
     let name = authority.name.clone();
 

--- a/narwhal/primary/tests/integration_tests_proposer_api.rs
+++ b/narwhal/primary/tests/integration_tests_proposer_api.rs
@@ -35,7 +35,7 @@ async fn test_rounds_errors() {
     // GIVEN keys
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
 
     let author = fixture.authorities().last().unwrap();
     let keypair = author.keypair().copy();
@@ -166,7 +166,7 @@ async fn test_rounds_return_successful_response() {
     // GIVEN keys
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
 
     let author = fixture.authorities().last().unwrap();
     let keypair = author.keypair().copy();
@@ -273,7 +273,7 @@ async fn test_rounds_return_successful_response() {
 async fn test_node_read_causal_signed_certificates() {
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
 
     let authority_1 = fixture.authorities().next().unwrap();
     let authority_2 = fixture.authorities().nth(1).unwrap();

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -40,7 +40,7 @@ async fn test_get_collections() {
     };
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
 
     let author = fixture.authorities().last().unwrap();
 
@@ -243,7 +243,7 @@ async fn test_remove_collections() {
     };
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
 
     let author = fixture.authorities().last().unwrap();
 
@@ -481,7 +481,7 @@ async fn test_remove_collections() {
 async fn test_read_causal_signed_certificates() {
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
 
     let authority_1 = fixture.authorities().next().unwrap();
     let authority_2 = fixture.authorities().nth(1).unwrap();
@@ -696,7 +696,7 @@ async fn test_read_causal_unsigned_certificates() {
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
 
     let authority_1 = fixture.authorities().next().unwrap();
     let authority_2 = fixture.authorities().nth(1).unwrap();
@@ -936,7 +936,7 @@ async fn test_get_collections_with_missing_certificates() {
     // GIVEN keys for two primary nodes
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
 
     let authority_1 = fixture.authorities().next().unwrap();
     let authority_2 = fixture.authorities().nth(1).unwrap();

--- a/narwhal/test-utils/src/cluster.rs
+++ b/narwhal/test-utils/src/cluster.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{temp_dir, CommitteeFixture};
-use config::{Committee, Parameters, SharedWorkerCache, WorkerId};
+use config::{Committee, Parameters, WorkerCache, WorkerId};
 use crypto::{KeyPair, NetworkKeyPair, PublicKey};
 use executor::SerializedTransaction;
 use fastcrypto::traits::KeyPair as _;
@@ -33,7 +33,7 @@ pub struct Cluster {
     fixture: CommitteeFixture,
     authorities: HashMap<usize, AuthorityDetails>,
     pub committee_shared: Committee,
-    pub worker_cache_shared: SharedWorkerCache,
+    pub worker_cache_shared: WorkerCache,
     #[allow(dead_code)]
     parameters: Parameters,
 }
@@ -280,7 +280,7 @@ pub struct PrimaryNodeDetails {
     store_path: PathBuf,
     parameters: Parameters,
     committee: Committee,
-    worker_cache: SharedWorkerCache,
+    worker_cache: WorkerCache,
     handlers: Rc<RefCell<Vec<JoinHandle<()>>>>,
     internal_consensus_enabled: bool,
 }
@@ -292,7 +292,7 @@ impl PrimaryNodeDetails {
         network_key_pair: NetworkKeyPair,
         parameters: Parameters,
         committee: Committee,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         internal_consensus_enabled: bool,
     ) -> Self {
         // used just to initialise the struct value
@@ -408,7 +408,7 @@ pub struct WorkerNodeDetails {
     name: PublicKey,
     node: WorkerNode,
     committee: Committee,
-    worker_cache: SharedWorkerCache,
+    worker_cache: WorkerCache,
     store_path: PathBuf,
 }
 
@@ -419,7 +419,7 @@ impl WorkerNodeDetails {
         parameters: Parameters,
         transactions_address: Multiaddr,
         committee: Committee,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
     ) -> Self {
         let registry_service = RegistryService::new(Registry::new());
         let node = WorkerNode::new(id, parameters, registry_service);
@@ -515,7 +515,7 @@ impl AuthorityDetails {
         worker_keypairs: Vec<NetworkKeyPair>,
         parameters: Parameters,
         committee: Committee,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         internal_consensus_enabled: bool,
     ) -> Self {
         // Create all the nodes we have in the committee
@@ -534,7 +534,7 @@ impl AuthorityDetails {
         // act as place holder setups. That gives us the power in a clear way manage
         // the nodes independently.
         let mut workers = HashMap::new();
-        for (worker_id, addresses) in worker_cache.load().workers.get(&name).unwrap().0.clone() {
+        for (worker_id, addresses) in worker_cache.workers.get(&name).unwrap().0.clone() {
             let worker = WorkerNodeDetails::new(
                 worker_id,
                 name.clone(),

--- a/narwhal/test-utils/src/cluster.rs
+++ b/narwhal/test-utils/src/cluster.rs
@@ -32,8 +32,8 @@ pub struct Cluster {
     #[allow(unused)]
     fixture: CommitteeFixture,
     authorities: HashMap<usize, AuthorityDetails>,
-    pub committee_shared: Committee,
-    pub worker_cache_shared: WorkerCache,
+    pub committee: Committee,
+    pub worker_cache: WorkerCache,
     #[allow(dead_code)]
     parameters: Parameters,
 }
@@ -52,9 +52,8 @@ impl Cluster {
     /// DAG externally.
     pub fn new(parameters: Option<Parameters>, internal_consensus_enabled: bool) -> Self {
         let fixture = CommitteeFixture::builder().randomize_ports(true).build();
-        let c = fixture.committee();
-        let shared_worker_cache = fixture.shared_worker_cache();
-        let shared_committee = c;
+        let committee = fixture.committee();
+        let worker_cache = fixture.worker_cache();
         let params = parameters.unwrap_or_else(Self::parameters);
 
         info!("###### Creating new cluster ######");
@@ -70,8 +69,8 @@ impl Cluster {
                 authority_fixture.network_keypair().copy(),
                 authority_fixture.worker_keypairs(),
                 params.with_available_ports(),
-                shared_committee.clone(),
-                shared_worker_cache.clone(),
+                committee.clone(),
+                worker_cache.clone(),
                 internal_consensus_enabled,
             );
             nodes.insert(id, authority);
@@ -80,8 +79,8 @@ impl Cluster {
         Self {
             fixture,
             authorities: nodes,
-            committee_shared: shared_committee,
-            worker_cache_shared: shared_worker_cache,
+            committee,
+            worker_cache,
             parameters: params,
         }
     }
@@ -105,7 +104,7 @@ impl Cluster {
         workers_per_authority: Option<usize>,
         boot_wait_time: Option<Duration>,
     ) {
-        let max_authorities = self.committee_shared.authorities.len();
+        let max_authorities = self.committee.authorities.len();
         let authorities = authorities_number.unwrap_or(max_authorities);
 
         if authorities > max_authorities {

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -695,10 +695,6 @@ impl CommitteeFixture {
         }
     }
 
-    pub fn shared_worker_cache(&self) -> WorkerCache {
-        self.worker_cache()
-    }
-
     // pub fn header(&self, author: PublicKey) -> Header {
     // Currently sign with the last authority
     pub fn header(&self) -> Header {

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -4,8 +4,8 @@
 
 use anemo::async_trait;
 use config::{
-    utils::get_available_port, Authority, Committee, Epoch, SharedWorkerCache, Stake, WorkerCache,
-    WorkerId, WorkerIndex, WorkerInfo,
+    utils::get_available_port, Authority, Committee, Epoch, Stake, WorkerCache, WorkerId,
+    WorkerIndex, WorkerInfo,
 };
 use crypto::{KeyPair, NetworkKeyPair, NetworkPublicKey, PublicKey};
 use fastcrypto::{
@@ -695,8 +695,8 @@ impl CommitteeFixture {
         }
     }
 
-    pub fn shared_worker_cache(&self) -> SharedWorkerCache {
-        self.worker_cache().into()
+    pub fn shared_worker_cache(&self) -> WorkerCache {
+        self.worker_cache()
     }
 
     // pub fn header(&self, author: PublicKey) -> Header {

--- a/narwhal/types/benches/verify_certificate.rs
+++ b/narwhal/types/benches/verify_certificate.rs
@@ -38,7 +38,7 @@ pub fn verify_certificates(c: &mut Criterion) {
             &certificate,
             |b, cert| {
                 b.iter(|| {
-                    let worker_cache = fixture.shared_worker_cache();
+                    let worker_cache = fixture.worker_cache();
                     let _ = cert.verify(&committee, worker_cache);
                 })
             },

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -7,7 +7,7 @@ use crate::{
     CertificateDigestProto,
 };
 use bytes::Bytes;
-use config::{Committee, Epoch, SharedWorkerCache, Stake, WorkerId, WorkerInfo};
+use config::{Committee, Epoch, Stake, WorkerCache, WorkerId, WorkerInfo};
 use crypto::{AggregateSignature, PublicKey, Signature};
 use dag::node_dag::Affiliated;
 use derive_builder::Builder;
@@ -239,7 +239,7 @@ impl Header {
         *self.digest.get_or_init(|| Hash::digest(self))
     }
 
-    pub fn verify(&self, committee: &Committee, worker_cache: SharedWorkerCache) -> DagResult<()> {
+    pub fn verify(&self, committee: &Committee, worker_cache: WorkerCache) -> DagResult<()> {
         // Ensure the header is from the correct epoch.
         ensure!(
             self.epoch == committee.epoch(),
@@ -265,7 +265,6 @@ impl Header {
         // Ensure all worker ids are correct.
         for (worker_id, _) in self.payload.values() {
             worker_cache
-                .load()
                 .worker(&self.author, worker_id)
                 .map_err(|_| DagError::HeaderHasBadWorkerIds(self.digest()))?;
         }
@@ -660,7 +659,7 @@ impl Certificate {
 
     /// Verifies the validaity of the certificate.
     /// TODO: Output a different type, similar to Sui VerifiedCertificate.
-    pub fn verify(&self, committee: &Committee, worker_cache: SharedWorkerCache) -> DagResult<()> {
+    pub fn verify(&self, committee: &Committee, worker_cache: WorkerCache) -> DagResult<()> {
         // Ensure the header is from the correct epoch.
         ensure!(
             self.epoch() == committee.epoch(),

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -4,7 +4,7 @@
 use anemo::types::response::StatusCode;
 use anyhow::Result;
 use async_trait::async_trait;
-use config::{Committee, SharedWorkerCache, WorkerId};
+use config::{Committee, WorkerCache, WorkerId};
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -88,7 +88,7 @@ pub struct PrimaryReceiverHandler<V> {
     // The committee information.
     pub committee: Committee,
     // The worker information cache.
-    pub worker_cache: SharedWorkerCache,
+    pub worker_cache: WorkerCache,
     // The batch store
     pub store: Store<BatchDigest, Batch>,
     // Timeout on RequestBatch RPC.
@@ -171,7 +171,7 @@ impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
                 };
             if first_attempt {
                 // Send first sync request to a single node.
-                let worker_name = match self.worker_cache.load().worker(&message.target, &self.id) {
+                let worker_name = match self.worker_cache.worker(&message.target, &self.id) {
                     Ok(worker_info) => worker_info.name,
                     Err(e) => {
                         return Err(anemo::rpc::Status::internal(format!(
@@ -199,7 +199,6 @@ impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
                 // If first request timed out or was missing batches, try broadcasting to some others.
                 let names: Vec<_> = self
                     .worker_cache
-                    .load()
                     .others_workers_by_id(&self.name, &self.id)
                     .into_iter()
                     .map(|(_, info)| info.name)

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::batch_maker::MAX_PARALLEL_BATCH;
-use config::{Committee, SharedWorkerCache, Stake, WorkerId};
+use config::{Committee, Stake, WorkerCache, WorkerId};
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
 use futures::stream::{futures_unordered::FuturesUnordered, FuturesOrdered, StreamExt as _};
@@ -27,7 +27,7 @@ pub struct QuorumWaiter {
     /// The committee information.
     committee: Committee,
     /// The worker information cache.
-    worker_cache: SharedWorkerCache,
+    worker_cache: WorkerCache,
     /// Receiver for shutdown.
     rx_shutdown: ConditionalBroadcastReceiver,
     /// Input Channel to receive commands.
@@ -43,7 +43,7 @@ impl QuorumWaiter {
         name: PublicKey,
         id: WorkerId,
         committee: Committee,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         rx_shutdown: ConditionalBroadcastReceiver,
         rx_message: Receiver<(Batch, Option<tokio::sync::oneshot::Sender<()>>)>,
         network: anemo::Network,
@@ -92,7 +92,6 @@ impl QuorumWaiter {
                     // Broadcast the batch to the other workers.
                     let workers: Vec<_> = self
                         .worker_cache
-                        .load()
                         .others_workers_by_id(&self.name, &self.id)
                         .into_iter()
                         .map(|(name, info)| (name, info.name))

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -14,7 +14,7 @@ async fn synchronize() {
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let name = fixture.authorities().next().unwrap().public_key();
     let id = 0;
 
@@ -84,7 +84,7 @@ async fn synchronize_when_batch_exists() {
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let name = fixture.authorities().next().unwrap().public_key();
     let id = 0;
 
@@ -129,7 +129,7 @@ async fn delete_batches() {
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let name = fixture.authorities().next().unwrap().public_key();
     let id = 0;
 

--- a/narwhal/worker/src/tests/quorum_waiter_tests.rs
+++ b/narwhal/worker/src/tests/quorum_waiter_tests.rs
@@ -11,7 +11,7 @@ async fn wait_for_quorum() {
     let (tx_message, rx_message) = test_utils::test_channel!(1);
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let my_primary = fixture.authorities().next().unwrap().public_key();
     let myself = fixture.authorities().next().unwrap().worker(0);
 
@@ -68,7 +68,7 @@ async fn pipeline_for_quorum() {
     let (tx_message, rx_message) = test_utils::test_channel!(1);
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let my_primary = fixture.authorities().next().unwrap().public_key();
     let myself = fixture.authorities().next().unwrap().worker(0);
 

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -43,7 +43,7 @@ impl TransactionValidator for NilTxValidator {
 async fn reject_invalid_clients_transactions() {
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
 
     let worker_id = 0;
     let my_primary = fixture.authorities().next().unwrap();
@@ -133,7 +133,7 @@ async fn reject_invalid_clients_transactions() {
 async fn handle_clients_transactions() {
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
 
     let worker_id = 0;
     let my_primary = fixture.authorities().next().unwrap();
@@ -251,7 +251,7 @@ async fn get_network_peers_from_admin_server() {
     };
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
+    let worker_cache = fixture.worker_cache();
     let authority_1 = fixture.authorities().next().unwrap();
     let name_1 = authority_1.public_key();
     let signer_1 = authority_1.keypair().copy();

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -88,11 +88,7 @@ async fn reject_invalid_clients_transactions() {
     // Wait till other services have been able to start up
     tokio::task::yield_now().await;
     // Send enough transactions to create a batch.
-    let address = worker_cache
-        .load()
-        .worker(&name, &worker_id)
-        .unwrap()
-        .transactions;
+    let address = worker_cache.worker(&name, &worker_id).unwrap().transactions;
     let config = mysten_network::config::Config::new();
     let channel = config.connect_lazy(&address).unwrap();
     let mut client = TransactionsClient::new(channel);
@@ -105,7 +101,7 @@ async fn reject_invalid_clients_transactions() {
     let res = client.submit_transaction(txn).await;
     assert!(res.is_err());
 
-    let worker_pk = worker_cache.load().worker(&name, &worker_id).unwrap().name;
+    let worker_pk = worker_cache.worker(&name, &worker_id).unwrap().name;
 
     let batch = batch();
     let batch_message = WorkerBatchMessage {
@@ -215,11 +211,7 @@ async fn handle_clients_transactions() {
     // Wait till other services have been able to start up
     tokio::task::yield_now().await;
     // Send enough transactions to create a batch.
-    let address = worker_cache
-        .load()
-        .worker(&name, &worker_id)
-        .unwrap()
-        .transactions;
+    let address = worker_cache.worker(&name, &worker_id).unwrap().transactions;
     let config = mysten_network::config::Config::new();
     let channel = config.connect_lazy(&address).unwrap();
     let client = TransactionsClient::new(channel);

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -18,7 +18,7 @@ use anemo_tower::{
     trace::{DefaultMakeSpan, DefaultOnFailure, TraceLayer},
 };
 use anemo_tower::{rate_limit, set_header::SetResponseHeaderLayer};
-use config::{Committee, Parameters, SharedWorkerCache, WorkerId};
+use config::{Committee, Parameters, WorkerCache, WorkerId};
 use crypto::{traits::KeyPair as _, NetworkKeyPair, NetworkPublicKey, PublicKey};
 use multiaddr::{Multiaddr, Protocol};
 use mysten_metrics::spawn_logged_monitored_task;
@@ -59,7 +59,7 @@ pub struct Worker {
     /// The committee information.
     committee: Committee,
     /// The worker information cache.
-    worker_cache: SharedWorkerCache,
+    worker_cache: WorkerCache,
     /// The configuration parameters
     parameters: Parameters,
     /// The persistent storage.
@@ -72,7 +72,7 @@ impl Worker {
         keypair: NetworkKeyPair,
         id: WorkerId,
         committee: Committee,
-        worker_cache: SharedWorkerCache,
+        worker_cache: WorkerCache,
         parameters: Parameters,
         validator: impl TransactionValidator,
         store: Store<BatchDigest, Batch>,
@@ -155,7 +155,6 @@ impl Worker {
         // Receive incoming messages from other workers.
         let address = worker
             .worker_cache
-            .load()
             .worker(&primary_name, &id)
             .expect("Our public key or worker id is not in the worker cache")
             .worker_address;
@@ -277,7 +276,6 @@ impl Worker {
 
         let other_workers = worker
             .worker_cache
-            .load()
             .others_workers_by_id(&primary_name, &id)
             .into_iter()
             .map(|(_, info)| (info.name, info.worker_address));
@@ -373,7 +371,6 @@ impl Worker {
             id,
             worker
                 .worker_cache
-                .load()
                 .worker(&worker.primary_name, &worker.id)
                 .expect("Our public key or worker id is not in the worker cache")
                 .transactions
@@ -456,7 +453,6 @@ impl Worker {
         // We first receive clients' transactions from the network.
         let address = self
             .worker_cache
-            .load()
             .worker(&self.primary_name, &self.id)
             .expect("Our public key or worker id is not in the worker cache")
             .transactions;


### PR DESCRIPTION
## Description 

Use directly WorkerCache instead of SharedWorkerCache since narwhal is recareated on every epoch.
Clean up SharedCommittee and SharedWorkerCache definitions.
## Test Plan 

Standard tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
