### PR TITLE
Remove protocol version from Committee

### DIFF
--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -76,7 +76,6 @@ impl ReconfigObserver<NetworkAuthorityClient> for FullNodeReconfigObserver {
                                 // Safe to unwrap, checked above
                                 Committee::new(
                                     committee.epoch,
-                                    committee.protocol_version,
                                     BTreeMap::from_iter(committee.committee_info.into_iter())).unwrap_or_else(
                                     |e| panic!("Can't create a valid Committee given info returned from Full Node: {:?}", e)
                                 )

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -25,7 +25,7 @@ use sui_types::base_types::{AuthorityName, SuiAddress};
 use sui_types::messages::TransactionEvents;
 use sui_types::{
     base_types::ObjectID,
-    committee::{Committee, EpochId, ProtocolVersion},
+    committee::{Committee, EpochId},
     crypto::{
         AggregateAuthenticator, AggregateAuthoritySignature, AuthorityQuorumSignInfo,
         AuthoritySignature,
@@ -153,7 +153,7 @@ impl LocalValidatorAggregatorProxy {
             .unwrap();
 
         let validator_info = genesis.validator_set();
-        let committee = make_committee(0, ProtocolVersion::MIN, &validator_info).unwrap();
+        let committee = make_committee(0, &validator_info).unwrap();
         let clients = make_authority_clients(
             &validator_info,
             DEFAULT_CONNECT_TIMEOUT_SEC,
@@ -181,7 +181,7 @@ impl LocalValidatorAggregatorProxy {
             .unwrap();
 
         let validator_info = configs.validator_set();
-        let committee = make_committee(0, ProtocolVersion::MIN, &validator_info).unwrap();
+        let committee = make_committee(0, &validator_info).unwrap();
         let clients = make_authority_clients(
             &validator_info,
             DEFAULT_CONNECT_TIMEOUT_SEC,
@@ -485,11 +485,10 @@ impl FullNodeProxy {
 
         let resp = sui_client.read_api().get_committee_info(None).await?;
         let epoch = resp.epoch;
-        let protocol_version = resp.protocol_version;
         let committee_vec = resp.committee_info;
         let committee_map =
             BTreeMap::from_iter(committee_vec.into_iter().map(|(name, stake)| (name, stake)));
-        let committee = Committee::new(epoch, protocol_version, committee_map)?;
+        let committee = Committee::new(epoch, committee_map)?;
 
         Ok(Self {
             sui_client,

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1365,7 +1365,7 @@ impl<'a> AuthorityAggregatorBuilder<'a> {
         } else {
             anyhow::bail!("need either NetworkConfig or Genesis.");
         };
-        let committee = make_committee(0, self.protocol_version, &validator_info)?;
+        let committee = make_committee(0, &validator_info)?;
         let mut registry = &prometheus::Registry::new();
         if self.registry.is_some() {
             registry = self.registry.unwrap();

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -29,6 +29,7 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_protocol_config::ProtocolVersion;
 use sui_types::base_types::{EpochId, TransactionDigest};
 use sui_types::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
 use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest};
@@ -688,7 +689,9 @@ impl CheckpointBuilder {
 
                 Some(EndOfEpochData {
                     next_epoch_committee: committee.voting_rights,
-                    next_epoch_protocol_version: committee.protocol_version,
+                    next_epoch_protocol_version: ProtocolVersion::new(
+                        system_state_obj.protocol_version,
+                    ),
                     root_state_digest: Accumulator::default().digest(),
                 })
             } else {

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -716,7 +716,7 @@ mod adapter_tests {
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use sui_types::{
         base_types::TransactionDigest,
-        committee::{Committee, ProtocolVersion},
+        committee::Committee,
         crypto::{get_key_pair_from_rng, AuthorityKeyPair, AuthorityPublicKeyBytes},
     };
 
@@ -737,12 +737,7 @@ mod adapter_tests {
                 )
             })
             .collect::<Vec<_>>();
-        let committee = Committee::new(
-            0,
-            ProtocolVersion::MIN,
-            authorities.iter().cloned().collect(),
-        )
-        .unwrap();
+        let committee = Committee::new(0, authorities.iter().cloned().collect()).unwrap();
 
         // generate random transaction digests, and account for validator selection
         const NUM_TEST_TRANSACTIONS: usize = 1000;

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -3,6 +3,7 @@
 
 use async_trait::async_trait;
 use std::sync::Arc;
+use sui_protocol_config::ProtocolVersion;
 use sui_types::committee::Committee;
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{info, warn};
@@ -26,7 +27,7 @@ pub trait ReconfigObserver<A> {
 /// A ReconfigObserver that subscribes to a reconfig channel of new committee.
 /// This is used in TransactionOrchestrator.
 pub struct OnsiteReconfigObserver {
-    reconfig_rx: tokio::sync::broadcast::Receiver<Committee>,
+    reconfig_rx: tokio::sync::broadcast::Receiver<(Committee, ProtocolVersion)>,
     authority_store: Arc<AuthorityStore>,
     committee_store: Arc<CommitteeStore>,
     safe_client_metrics_base: SafeClientMetricsBase,
@@ -35,7 +36,7 @@ pub struct OnsiteReconfigObserver {
 
 impl OnsiteReconfigObserver {
     pub fn new(
-        reconfig_rx: tokio::sync::broadcast::Receiver<Committee>,
+        reconfig_rx: tokio::sync::broadcast::Receiver<(Committee, ProtocolVersion)>,
         authority_store: Arc<AuthorityStore>,
         committee_store: Arc<CommitteeStore>,
         safe_client_metrics_base: SafeClientMetricsBase,
@@ -94,7 +95,7 @@ impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
         }
         loop {
             match self.reconfig_rx.recv().await {
-                Ok(committee) => {
+                Ok((committee, _protocol_version)) => {
                     info!("Got reconfig message: {}", committee);
                     if committee.epoch > quorum_driver.current_epoch() {
                         let authority_agg =

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -117,17 +117,12 @@ impl WriteStore for RocksDbStore {
     fn insert_checkpoint(&self, checkpoint: VerifiedCheckpoint) -> Result<(), Self::Error> {
         if let Some(EndOfEpochData {
             next_epoch_committee,
-            next_epoch_protocol_version,
             ..
         }) = checkpoint.summary.end_of_epoch_data.as_ref()
         {
             let next_committee = next_epoch_committee.iter().cloned().collect();
-            let committee = Committee::new(
-                checkpoint.epoch().saturating_add(1),
-                *next_epoch_protocol_version,
-                next_committee,
-            )
-            .expect("new committee from consensus should be constructable");
+            let committee = Committee::new(checkpoint.epoch().saturating_add(1), next_committee)
+                .expect("new committee from consensus should be constructable");
             self.insert_committee(committee)?;
         }
 

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -23,6 +23,7 @@ use prometheus::{
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_protocol_config::ProtocolVersion;
 use sui_storage::write_path_pending_tx_log::WritePathPendingTransactionLog;
 use sui_types::base_types::TransactionDigest;
 use sui_types::committee::Committee;
@@ -36,7 +37,7 @@ use sui_types::quorum_driver_types::{
     QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResult,
 };
 use tokio::sync::broadcast::error::RecvError;
-use tokio::sync::broadcast::{self, Receiver};
+use tokio::sync::broadcast::Receiver;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tracing::{debug, error, error_span, info, instrument, warn, Instrument};
@@ -61,7 +62,7 @@ pub struct TransactiondOrchestrator<A> {
 impl TransactiondOrchestrator<NetworkAuthorityClient> {
     pub async fn new_with_network_clients(
         validator_state: Arc<AuthorityState>,
-        reconfig_channel: broadcast::Receiver<Committee>,
+        reconfig_channel: Receiver<(Committee, ProtocolVersion)>,
         parent_path: &Path,
         prometheus_registry: &Registry,
     ) -> anyhow::Result<Self> {

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -623,7 +623,7 @@ fn get_agg<A>(
     clients: BTreeMap<AuthorityName, A>,
     epoch: EpochId,
 ) -> AuthorityAggregator<A> {
-    let committee = Committee::new(epoch, ProtocolVersion::MIN, authorities).unwrap();
+    let committee = Committee::new(epoch, authorities).unwrap();
     let committee_store = Arc::new(CommitteeStore::new_for_testing(&committee));
 
     AuthorityAggregator::new_with_timeouts(
@@ -700,7 +700,7 @@ async fn test_handle_transaction_response() {
     // Case 2
     // Validators return signed-tx with epoch 0, client expects 1
     // Update client to epoch 1
-    let committee_1 = Committee::new(1, ProtocolVersion::MIN, authorities.clone()).unwrap();
+    let committee_1 = Committee::new(1, authorities.clone()).unwrap();
     agg.committee_store
         .insert_new_committee(&committee_1)
         .unwrap();
@@ -751,7 +751,7 @@ async fn test_handle_transaction_response() {
     )
     .await;
 
-    let committee_1 = Committee::new(1, ProtocolVersion::MIN, authorities.clone()).unwrap();
+    let committee_1 = Committee::new(1, authorities.clone()).unwrap();
     agg.committee_store
         .insert_new_committee(&committee_1)
         .unwrap();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4726,6 +4726,7 @@ fn test_choose_next_system_packages() {
     assert_eq!(
         (ver(1), vec![]),
         AuthorityState::choose_protocol_version_and_system_packages(
+            ProtocolVersion::MIN,
             &committee,
             &protocol_config,
             capabilities
@@ -4743,6 +4744,7 @@ fn test_choose_next_system_packages() {
     assert_eq!(
         (ver(1), vec![]),
         AuthorityState::choose_protocol_version_and_system_packages(
+            ProtocolVersion::MIN,
             &committee,
             &protocol_config,
             capabilities.clone(),
@@ -4755,6 +4757,7 @@ fn test_choose_next_system_packages() {
     assert_eq!(
         (ver(2), sort(vec![o1, o2])),
         AuthorityState::choose_protocol_version_and_system_packages(
+            ProtocolVersion::MIN,
             &committee,
             &protocol_config,
             capabilities
@@ -4772,6 +4775,7 @@ fn test_choose_next_system_packages() {
     assert_eq!(
         (ver(1), vec![]),
         AuthorityState::choose_protocol_version_and_system_packages(
+            ProtocolVersion::MIN,
             &committee,
             &protocol_config,
             capabilities,
@@ -4789,6 +4793,7 @@ fn test_choose_next_system_packages() {
     assert_eq!(
         (ver(2), sort(vec![o1, o2])),
         AuthorityState::choose_protocol_version_and_system_packages(
+            ProtocolVersion::MIN,
             &committee,
             &protocol_config,
             capabilities
@@ -4806,6 +4811,7 @@ fn test_choose_next_system_packages() {
     assert_eq!(
         (ver(1), vec![]),
         AuthorityState::choose_protocol_version_and_system_packages(
+            ProtocolVersion::MIN,
             &committee,
             &protocol_config,
             capabilities
@@ -4823,6 +4829,7 @@ fn test_choose_next_system_packages() {
     assert_eq!(
         (ver(1), vec![]),
         AuthorityState::choose_protocol_version_and_system_packages(
+            ProtocolVersion::MIN,
             &committee,
             &protocol_config,
             capabilities

--- a/crates/sui-core/src/validator_info.rs
+++ b/crates/sui-core/src/validator_info.rs
@@ -3,18 +3,11 @@
 
 use sui_config::ValidatorInfo;
 use sui_types::{
-    committee::{Committee, EpochId, ProtocolVersion},
+    committee::{Committee, EpochId},
     error::SuiResult,
 };
 
-pub fn make_committee(
-    epoch: EpochId,
-    protocol_version: ProtocolVersion,
-    validator_set: &[ValidatorInfo],
-) -> SuiResult<Committee> {
-    Committee::new(
-        epoch,
-        protocol_version,
-        ValidatorInfo::voting_rights(validator_set),
-    )
+// TODO: Why dod we need this file?
+pub fn make_committee(epoch: EpochId, validator_set: &[ValidatorInfo]) -> SuiResult<Committee> {
+    Committee::new(epoch, ValidatorInfo::voting_rights(validator_set))
 }

--- a/crates/sui-network/src/state_sync/test_utils.rs
+++ b/crates/sui-network/src/state_sync/test_utils.rs
@@ -6,7 +6,7 @@ use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::intent::{Intent, IntentMessage, IntentScope};
 use sui_types::{
     base_types::AuthorityName,
-    committee::{Committee, EpochId, ProtocolVersion, StakeUnit},
+    committee::{Committee, EpochId, StakeUnit},
     crypto::{
         AuthorityKeyPair, AuthoritySignInfo, AuthoritySignature, KeypairTraits,
         SuiAuthoritySignature,
@@ -36,7 +36,6 @@ impl CommitteeFixture {
 
         let committee = Committee::new(
             epoch,
-            ProtocolVersion::MIN,
             validators
                 .iter()
                 .map(|(name, (_, stake))| (*name, *stake))

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -43,7 +43,7 @@ use sui_network::discovery;
 use sui_network::{state_sync, DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_HTTP2_KEEPALIVE_SEC};
 use tracing::debug;
 
-use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
+use sui_protocol_config::{ProtocolConfig, ProtocolVersion, SupportedProtocolVersions};
 
 use sui_storage::{
     event_store::{EventStoreType, SqlEventStore},
@@ -88,7 +88,7 @@ use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{AuthorityCapabilities, ConsensusTransaction};
 
 pub struct ValidatorComponents {
-    validator_server_handle: tokio::task::JoinHandle<Result<()>>,
+    validator_server_handle: JoinHandle<Result<()>>,
     narwhal_manager: NarwhalManager,
     narwhal_epoch_data_remover: EpochDataRemover,
     consensus_adapter: Arc<ConsensusAdapter>,
@@ -116,7 +116,8 @@ pub struct SuiNode {
     accumulator: Arc<StateAccumulator>,
     connection_monitor_status: Arc<ConnectionMonitorStatus>,
 
-    end_of_epoch_channel: tokio::sync::broadcast::Sender<Committee>,
+    /// Broadcast channel to send the committee and protocol version for the next epoch.
+    end_of_epoch_channel: broadcast::Sender<(Committee, ProtocolVersion)>,
 
     #[cfg(msim)]
     sim_node: sui_simulator::runtime::NodeHandle,
@@ -273,14 +274,15 @@ impl SuiNode {
                 .unwrap();
         }
 
-        let (end_of_epoch_channel, _receiver) =
-            broadcast::channel::<Committee>(config.end_of_epoch_broadcast_channel_capacity);
+        let (end_of_epoch_channel, receiver) = broadcast::channel::<(Committee, ProtocolVersion)>(
+            config.end_of_epoch_broadcast_channel_capacity,
+        );
 
         let transaction_orchestrator = if is_full_node {
             Some(Arc::new(
                 TransactiondOrchestrator::new_with_network_clients(
                     state.clone(),
-                    end_of_epoch_channel.subscribe(),
+                    receiver,
                     config.db_path(),
                     &prometheus_registry,
                 )
@@ -371,7 +373,7 @@ impl SuiNode {
         Ok(node)
     }
 
-    pub fn subscribe_to_epoch_change(&self) -> tokio::sync::broadcast::Receiver<Committee> {
+    pub fn subscribe_to_epoch_change(&self) -> broadcast::Receiver<(Committee, ProtocolVersion)> {
         self.end_of_epoch_channel.subscribe()
     }
 
@@ -817,18 +819,14 @@ impl SuiNode {
                     .submit(transaction, None, &cur_epoch_store)?;
             }
 
-            let next_epoch_committee = checkpoint_executor.run_epoch(cur_epoch_store.clone()).await;
-            let next_epoch = next_epoch_committee.epoch();
-            assert_eq!(cur_epoch_store.epoch() + 1, next_epoch);
+            checkpoint_executor.run_epoch(cur_epoch_store.clone()).await;
             let system_state = self
                 .state
                 .get_sui_system_state_object_during_reconfig()
                 .expect("Read Sui System State object cannot fail");
-            // Double check that the committee in the last checkpoint is identical to what's on-chain.
-            assert_eq!(
-                system_state.get_current_epoch_committee().committee,
-                next_epoch_committee
-            );
+            let next_epoch_committee = system_state.get_current_epoch_committee().committee;
+            let next_epoch = next_epoch_committee.epoch();
+            assert_eq!(cur_epoch_store.epoch() + 1, next_epoch);
 
             // If we eventually add tests that exercise safe mode, we will need a configurable way of
             // guarding against unexpected safe_mode.
@@ -849,7 +847,10 @@ impl SuiNode {
                 .update_mapping_for_epoch(authority_names_to_peer_ids);
 
             cur_epoch_store.record_epoch_reconfig_start_time_metric();
-            let _ = self.end_of_epoch_channel.send(next_epoch_committee.clone());
+            let _ = self.end_of_epoch_channel.send((
+                next_epoch_committee.clone(),
+                ProtocolVersion::new(system_state.protocol_version),
+            ));
 
             // The following code handles 4 different cases, depending on whether the node
             // was a validator in the previous epoch, and whether the node is a validator

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -3206,8 +3206,7 @@
         "type": "object",
         "required": [
           "committee_info",
-          "epoch",
-          "protocol_version"
+          "epoch"
         ],
         "properties": {
           "committee_info": {
@@ -3232,9 +3231,6 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
-          },
-          "protocol_version": {
-            "$ref": "#/components/schemas/ProtocolVersion"
           }
         }
       },

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -31,7 +31,6 @@ pub type CommitteeDigest = [u8; 32];
 #[derive(Clone, Debug, Serialize, Deserialize, Eq)]
 pub struct Committee {
     pub epoch: EpochId,
-    pub protocol_version: ProtocolVersion,
     pub voting_rights: Vec<(AuthorityName, StakeUnit)>,
     pub total_votes: StakeUnit,
     #[serde(skip)]
@@ -45,7 +44,6 @@ pub struct Committee {
 impl Committee {
     pub fn new(
         epoch: EpochId,
-        protocol_version: ProtocolVersion,
         voting_rights: BTreeMap<AuthorityName, StakeUnit>,
     ) -> SuiResult<Self> {
         let mut voting_rights: Vec<(AuthorityName, StakeUnit)> =
@@ -77,7 +75,6 @@ impl Committee {
 
         Ok(Committee {
             epoch,
-            protocol_version,
             voting_rights,
             total_votes,
             expanded_keys,
@@ -302,7 +299,6 @@ impl Committee {
         let key_pairs: Vec<_> = random_committee_key_pairs().into_iter().collect();
         let committee = Self::new(
             0,
-            ProtocolVersion::MIN,
             key_pairs
                 .iter()
                 .map(|key| {
@@ -320,7 +316,6 @@ impl TryFrom<CommitteeInfo> for Committee {
     fn try_from(committee_info: CommitteeInfo) -> Result<Self, Self::Error> {
         Self::new(
             committee_info.epoch,
-            committee_info.protocol_version,
             committee_info
                 .committee_info
                 .into_iter()
@@ -407,7 +402,7 @@ mod test {
         authorities.insert(a2, 1);
         authorities.insert(a3, 1);
 
-        let committee = Committee::new(0, ProtocolVersion::MIN, authorities).unwrap();
+        let committee = Committee::new(0, authorities).unwrap();
 
         assert_eq!(committee.shuffle_by_stake(None, None).len(), 3);
 
@@ -458,7 +453,7 @@ mod test {
         authorities.insert(a2, 1);
         authorities.insert(a3, 1);
         authorities.insert(a4, 1);
-        let committee = Committee::new(0, ProtocolVersion::MIN, authorities).unwrap();
+        let committee = Committee::new(0, authorities).unwrap();
         let items = vec![(a1, 666), (a2, 1), (a3, 2), (a4, 0)];
         assert_eq!(
             committee.robust_value(items.into_iter(), committee.quorum_threshold()),

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2883,7 +2883,7 @@ pub struct TransactionEffects {
     /// It's also included in mutated.
     pub gas_object: (ObjectRef, Owner),
     /// The digest of the events emitted during execution,
-    /// can be None if the transaction does not emmit any event.
+    /// can be None if the transaction does not emit any event.
     pub events_digest: Option<TransactionEventsDigest>,
     /// The set of transaction digests this transaction depends on.
     pub dependencies: Vec<TransactionDigest>,
@@ -3522,7 +3522,6 @@ pub struct CommitteeInfoRequest {
 #[derive(Serialize, Deserialize, Clone, schemars::JsonSchema, Debug)]
 pub struct CommitteeInfoResponse {
     pub epoch: EpochId,
-    pub protocol_version: ProtocolVersion,
     pub committee_info: Vec<(AuthorityName, StakeUnit)>,
     // TODO: We could also return the certified checkpoint that contains this committee.
     // This would allows a client to verify the authenticity of the committee.
@@ -3536,10 +3535,10 @@ impl CommitteeInfoResponse {
     }
 }
 
+// TODO: What's the difference between CommitteeInfoResponse and CommitteeInfo?
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CommitteeInfo {
     pub epoch: EpochId,
-    pub protocol_version: ProtocolVersion,
     pub committee_info: Vec<(AuthorityName, StakeUnit)>,
     // TODO: We could also return the certified checkpoint that contains this committee.
     // This would allows a client to verify the authenticity of the committee.

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -416,12 +416,8 @@ impl InMemoryStore {
                 .iter()
                 .cloned()
                 .collect();
-            let committee = Committee::new(
-                checkpoint.epoch().saturating_add(1),
-                end_of_epoch_data.next_epoch_protocol_version,
-                next_committee,
-            )
-            .expect("new committee from consensus should be constructable");
+            let committee = Committee::new(checkpoint.epoch().saturating_add(1), next_committee)
+                .expect("new committee from consensus should be constructable");
             self.insert_committee(committee);
         }
 

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -424,14 +424,10 @@ impl SuiSystemState {
             net_addresses.insert(name, net_address);
         }
         CommitteeWithNetAddresses {
-            committee: Committee::new(
-                self.epoch,
-                ProtocolVersion::new(self.protocol_version),
-                voting_rights,
-            )
-            // unwrap is safe because we should have verified the committee on-chain.
-            // TODO: Make sure we actually verify it.
-            .unwrap(),
+            committee: Committee::new(self.epoch, voting_rights)
+                // unwrap is safe because we should have verified the committee on-chain.
+                // TODO: Make sure we actually verify it.
+                .unwrap(),
             net_addresses,
         }
     }

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -43,7 +43,7 @@ fn test_signed_values() {
         /* address */ AuthorityPublicKeyBytes::from(sec2.public()),
         /* voting right */ 0,
     );
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities).unwrap();
+    let committee = Committee::new(0, authorities).unwrap();
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -120,7 +120,7 @@ fn test_certificates() {
         /* address */ AuthorityPublicKeyBytes::from(sec2.public()),
         /* voting right */ 1,
     );
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities).unwrap();
+    let committee = Committee::new(0, authorities).unwrap();
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -193,7 +193,7 @@ fn test_new_with_signatures() {
     let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
     authorities.insert(AuthorityPublicKeyBytes::from(sec.public()), 1);
 
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone()).unwrap();
     let quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures.clone(), &committee)
             .unwrap();
@@ -240,7 +240,7 @@ fn test_handle_reject_malicious_signature() {
         };
     }
 
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone()).unwrap();
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
     {
@@ -321,7 +321,7 @@ fn test_bitmap_out_of_range() {
         ));
     }
 
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone()).unwrap();
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
 
@@ -362,7 +362,7 @@ fn test_reject_extra_public_key() {
         signatures[3].clone(),
     ];
 
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone()).unwrap();
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(used_signatures, &committee)
             .unwrap();
@@ -400,7 +400,7 @@ fn test_reject_reuse_signatures() {
         signatures[2].clone(),
     ];
 
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone()).unwrap();
     let quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(used_signatures, &committee)
             .unwrap();
@@ -429,7 +429,7 @@ fn test_empty_bitmap() {
         ));
     }
 
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone()).unwrap();
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
     quorum.signers_map = RoaringBitmap::new();
@@ -453,7 +453,7 @@ fn test_digest_caching() {
     authorities.insert(sec1.public().into(), 1);
     authorities.insert(sec2.public().into(), 0);
 
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities).unwrap();
+    let committee = Committee::new(0, authorities).unwrap();
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -621,7 +621,7 @@ fn test_user_signature_committed_in_signed_transactions() {
     // Ensure that signed tx verifies against the transaction with a correct user signature.
     let mut authorities: BTreeMap<AuthorityPublicKeyBytes, u64> = BTreeMap::new();
     authorities.insert(AuthorityPublicKeyBytes::from(sec1.public()), 1);
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone()).unwrap();
     assert!(signed_tx_a
         .auth_sig()
         .verify_secure(
@@ -734,9 +734,9 @@ fn test_sponsored_transaction_message() {
     ));
 
     // Test incomplete signature lists (more sigs than expected)
-    let thrid_party_kp = SuiKeyPair::Ed25519(get_key_pair().1);
+    let third_party_kp = SuiKeyPair::Ed25519(get_key_pair().1);
     let third_party_sig: GenericSignature =
-        signature_from_signer(tx_data.clone(), intent.clone(), &thrid_party_kp).into();
+        signature_from_signer(tx_data.clone(), intent.clone(), &third_party_kp).into();
     assert!(matches!(
         Transaction::from_generic_sig_data(
             tx_data.clone(),
@@ -770,7 +770,7 @@ fn test_sponsored_transaction_validity_check() {
     let sponsor_kp = SuiKeyPair::Ed25519(get_key_pair().1);
     let sponsor = (&sponsor_kp.public()).into();
 
-    // This is a sponsored transation
+    // This is a sponsored transaction
     assert_ne!(sender, sponsor);
     let gas_data = GasData {
         payment: random_object_ref(),
@@ -899,7 +899,7 @@ fn verify_sender_signature_correctly_with_flag() {
     let (_, sec2): (_, AuthorityKeyPair) = get_key_pair();
     authorities.insert(sec1.public().into(), 1);
     authorities.insert(sec2.public().into(), 0);
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities).unwrap();
+    let committee = Committee::new(0, authorities).unwrap();
 
     // create a receiver keypair with Secp256k1
     let receiver_kp = SuiKeyPair::Secp256k1(get_key_pair().1);

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -6,7 +6,7 @@ use fastcrypto::traits::KeyPair as KeypairTraits;
 use crate::crypto::Signer;
 use crate::{
     base_types::{dbg_addr, ExecutionDigests, ObjectID},
-    committee::{Committee, ProtocolVersion},
+    committee::Committee,
     crypto::{
         get_key_pair, get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair,
         AuthorityPublicKeyBytes, Signature,
@@ -44,7 +44,7 @@ where
         keys.push(inner_authority_key);
     }
 
-    let committee = Committee::new(0, ProtocolVersion::MIN, authorities).unwrap();
+    let committee = Committee::new(0, authorities).unwrap();
     (keys, committee)
 }
 

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -315,7 +315,10 @@ mod sim_only_tests {
         // The dissenting node receives the correct framework via state sync and completes the upgrade
         node_handle.with(|node| {
             let committee = node.state().epoch_store_for_testing().committee().clone();
-            assert_eq!(committee.protocol_version, ProtocolVersion::new(2));
+            assert_eq!(
+                node.state().epoch_store_for_testing().protocol_version(),
+                ProtocolVersion::new(2)
+            );
             assert_eq!(committee.epoch, 2);
         });
     }
@@ -358,17 +361,11 @@ mod sim_only_tests {
             .subscribe_to_epoch_change();
 
         timeout(Duration::from_secs(60), async move {
-            while let Ok(committee) = epoch_rx.recv().await {
-                info!(
-                    "received epoch {} {:?}",
-                    committee.epoch, committee.protocol_version
-                );
+            while let Ok((committee, protocol_version)) = epoch_rx.recv().await {
+                info!("received epoch {} {:?}", committee.epoch, protocol_version);
                 match committee.epoch {
-                    0 => assert_eq!(committee.protocol_version, ProtocolVersion::new(1)),
-                    1 => assert_eq!(
-                        committee.protocol_version,
-                        ProtocolVersion::new(final_version)
-                    ),
+                    0 => assert_eq!(protocol_version, ProtocolVersion::new(1)),
+                    1 => assert_eq!(protocol_version, ProtocolVersion::new(final_version)),
                     2 => break,
                     _ => unreachable!(),
                 }

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -256,7 +256,7 @@ async fn test_passive_reconfig() {
         .unwrap_or(4);
 
     timeout(Duration::from_secs(60), async move {
-        while let Ok(committee) = epoch_rx.recv().await {
+        while let Ok((committee, _)) = epoch_rx.recv().await {
             info!("received epoch {}", committee.epoch);
             if committee.epoch >= target_epoch {
                 break;

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -409,7 +409,7 @@ pub async fn wait_for_nodes_transition_to_epoch<'a>(
                 let mut rx = node.subscribe_to_epoch_change();
                 let epoch = node.current_epoch_for_testing();
                 if epoch != expected_epoch {
-                    let committee = rx.recv().await.unwrap();
+                    let (committee, _) = rx.recv().await.unwrap();
                     assert_eq!(committee.epoch, expected_epoch);
                 }
             })


### PR DESCRIPTION
We don't need it there since it's already in system state object, which is cached in epoch start config.