### PR TITLE
[wallet-ext] update receipt page to show information about gas sponsors

### DIFF
--- a/apps/wallet/src/ui/app/components/receipt-card/SponsoredTxnGasSummary.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/SponsoredTxnGasSummary.tsx
@@ -5,7 +5,7 @@ import { type SuiAddress } from '@mysten/sui.js';
 
 import { TxnAddressLink } from './TxnAddressLink';
 import { useFormatCoin } from '_hooks';
-import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
+import { GAS_SYMBOL, GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 import { Text } from '_src/ui/app/shared/text';
 
 type SponsoredTxnGasSummaryProps = {
@@ -17,10 +17,6 @@ export function SponsoredTxnGasSummary({
     totalGas,
     sponsor,
 }: SponsoredTxnGasSummaryProps) {
-    const [senderTotalAmount, senderTotalAmountSymbol] = useFormatCoin(
-        0,
-        GAS_TYPE_ARG
-    );
     const [sponsorTotalAmount, sponsorTotalAmountSymbol] = useFormatCoin(
         totalGas,
         GAS_TYPE_ARG
@@ -36,7 +32,7 @@ export function SponsoredTxnGasSummary({
                     You Paid
                 </Text>
                 <Text variant="body" weight="medium" color="steel-darker">
-                    {senderTotalAmount} {senderTotalAmountSymbol}
+                    0 {GAS_SYMBOL}
                 </Text>
             </div>
             <div className="flex justify-between items-center w-full">

--- a/apps/wallet/src/ui/app/components/receipt-card/SponsoredTxnGasSummary.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/SponsoredTxnGasSummary.tsx
@@ -35,29 +35,23 @@ export function SponsoredTxnGasSummary({
                 <Text variant="body" weight="medium" color="steel-darker">
                     You Paid
                 </Text>
-                <div className="flex gap-1 items-center">
-                    <Text variant="body" weight="medium" color="steel-darker">
-                        {senderTotalAmount} {senderTotalAmountSymbol}
-                    </Text>
-                </div>
+                <Text variant="body" weight="medium" color="steel-darker">
+                    {senderTotalAmount} {senderTotalAmountSymbol}
+                </Text>
             </div>
             <div className="flex justify-between items-center w-full">
                 <Text variant="body" weight="medium" color="steel-darker">
                     Paid by Sponsor
                 </Text>
-                <div className="flex gap-1 items-center">
-                    <Text variant="body" weight="medium" color="steel-darker">
-                        {sponsorTotalAmount} {sponsorTotalAmountSymbol}
-                    </Text>
-                </div>
+                <Text variant="body" weight="medium" color="steel-darker">
+                    {sponsorTotalAmount} {sponsorTotalAmountSymbol}
+                </Text>
             </div>
             <div className="flex justify-between items-center w-full">
                 <Text variant="body" weight="medium" color="steel-darker">
                     Sponsor
                 </Text>
-                <div className="flex gap-1 items-center">
-                    <TxnAddressLink address={sponsor} />
-                </div>
+                <TxnAddressLink address={sponsor} />
             </div>
         </div>
     );

--- a/apps/wallet/src/ui/app/components/receipt-card/SponsoredTxnGasSummary.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/SponsoredTxnGasSummary.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type SuiAddress } from '@mysten/sui.js';
+
+import { TxnAddressLink } from './TxnAddressLink';
+import { useFormatCoin } from '_hooks';
+import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
+import { Text } from '_src/ui/app/shared/text';
+
+type SponsoredTxnGasSummaryProps = {
+    totalGas: number;
+    sponsor: SuiAddress;
+};
+
+export function SponsoredTxnGasSummary({
+    totalGas,
+    sponsor,
+}: SponsoredTxnGasSummaryProps) {
+    const [senderTotalAmount, senderTotalAmountSymbol] = useFormatCoin(
+        0,
+        GAS_TYPE_ARG
+    );
+    const [sponsorTotalAmount, sponsorTotalAmountSymbol] = useFormatCoin(
+        totalGas,
+        GAS_TYPE_ARG
+    );
+
+    return (
+        <div className="flex flex-col w-full gap-3.5 border-t border-solid border-steel/20 border-x-0 border-b-0 py-3.5 first:pt-0">
+            <Text variant="body" weight="medium" color="steel">
+                Gas Fees
+            </Text>
+            <div className="flex justify-between items-center w-full">
+                <Text variant="body" weight="medium" color="steel-darker">
+                    You Paid
+                </Text>
+                <div className="flex gap-1 items-center">
+                    <Text variant="body" weight="medium" color="steel-darker">
+                        {senderTotalAmount} {senderTotalAmountSymbol}
+                    </Text>
+                </div>
+            </div>
+            <div className="flex justify-between items-center w-full">
+                <Text variant="body" weight="medium" color="steel-darker">
+                    Paid by Sponsor
+                </Text>
+                <div className="flex gap-1 items-center">
+                    <Text variant="body" weight="medium" color="steel-darker">
+                        {sponsorTotalAmount} {sponsorTotalAmountSymbol}
+                    </Text>
+                </div>
+            </div>
+            <div className="flex justify-between items-center w-full">
+                <Text variant="body" weight="medium" color="steel-darker">
+                    Sponsor
+                </Text>
+                <div className="flex gap-1 items-center">
+                    <TxnAddressLink address={sponsor} />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/wallet/src/ui/app/components/receipt-card/TxnAddress.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/TxnAddress.tsx
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { formatAddress } from '@mysten/sui.js';
-
-import ExplorerLink from '_components/explorer-link';
-import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
+import { TxnAddressLink } from './TxnAddressLink';
 import { Text } from '_src/ui/app/shared/text';
 
 type TxnAddressProps = {
@@ -18,17 +15,8 @@ export function TxnAddress({ address, label }: TxnAddressProps) {
             <Text variant="body" weight="medium" color="steel-darker">
                 {label}
             </Text>
-
             <div className="flex gap-1 items-center">
-                <ExplorerLink
-                    type={ExplorerLinkType.address}
-                    address={address}
-                    title="View on Sui Explorer"
-                    className="text-sui-dark font-mono text-body font-semibold no-underline tracking-wider"
-                    showIcon={false}
-                >
-                    {formatAddress(address)}
-                </ExplorerLink>
+                <TxnAddressLink address={address} />
             </div>
         </div>
     );

--- a/apps/wallet/src/ui/app/components/receipt-card/TxnAddressLink.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/TxnAddressLink.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { formatAddress } from '@mysten/sui.js';
+
+import ExplorerLink from '_components/explorer-link';
+import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
+
+type TxnAddressLinkProps = {
+    address: string;
+};
+
+export function TxnAddressLink({ address }: TxnAddressLinkProps) {
+    return (
+        <ExplorerLink
+            type={ExplorerLinkType.address}
+            address={address}
+            title="View on Sui Explorer"
+            className="text-sui-dark font-mono text-body font-semibold no-underline tracking-wider"
+            showIcon={false}
+        >
+            {formatAddress(address)}
+        </ExplorerLink>
+    );
+}

--- a/apps/wallet/src/ui/app/components/receipt-card/TxnGasSummary.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/TxnGasSummary.tsx
@@ -31,27 +31,18 @@ export function TxnGasSummary({
                 <Text variant="body" weight="medium" color="steel-darker">
                     Gas Fees
                 </Text>
-                <div className="flex gap-1 items-center">
-                    <Text variant="body" weight="medium" color="steel-darker">
-                        {gas} {symbol}
-                    </Text>
-                </div>
+                <Text variant="body" weight="medium" color="steel-darker">
+                    {gas} {symbol}
+                </Text>
             </div>
             {transferAmount ? (
                 <div className="flex justify-between items-center w-full">
                     <Text variant="body" weight="medium" color="steel-darker">
                         Total Amount
                     </Text>
-
-                    <div className="flex gap-1 items-center">
-                        <Text
-                            variant="body"
-                            weight="medium"
-                            color="steel-darker"
-                        >
-                            {totalAmount} {totalAmountSymbol}
-                        </Text>
-                    </div>
+                    <Text variant="body" weight="medium" color="steel-darker">
+                        {totalAmount} {totalAmountSymbol}
+                    </Text>
                 </div>
             ) : null}
         </div>

--- a/apps/wallet/src/ui/app/components/receipt-card/TxnGasSummary.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/TxnGasSummary.tsx
@@ -7,18 +7,18 @@ import { Text } from '_src/ui/app/shared/text';
 
 import type { GasCostSummary } from '@mysten/sui.js';
 
-type TxnGasSummeryProps = {
+type TxnGasSummaryProps = {
     gasSummary?: GasCostSummary;
     totalGas: number;
     transferAmount: number | null;
 };
 
 //TODO add gas breakdown
-export function TxnGasSummery({
+export function TxnGasSummary({
     gasSummary,
     totalGas,
     transferAmount,
-}: TxnGasSummeryProps) {
+}: TxnGasSummaryProps) {
     const [totalAmount, totalAmountSymbol] = useFormatCoin(
         totalGas + (transferAmount || 0),
         GAS_TYPE_ARG
@@ -31,7 +31,6 @@ export function TxnGasSummery({
                 <Text variant="body" weight="medium" color="steel-darker">
                     Gas Fees
                 </Text>
-
                 <div className="flex gap-1 items-center">
                     <Text variant="body" weight="medium" color="steel-darker">
                         {gas} {symbol}

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -137,7 +137,7 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
                             <Text
                                 variant="body"
                                 weight="medium"
-                                color="steel-darker"
+                                color="issue-dark"
                             >
                                 {error}
                             </Text>

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -133,13 +133,15 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
             <ReceiptCardBg status={isSuccessful}>
                 <div className="divide-y divide-solid divide-steel/20 divide-x-0 flex flex-col pt-3.5 first:pt-0">
                     {error && (
-                        <Text
-                            variant="body"
-                            weight="medium"
-                            color="steel-darker"
-                        >
-                            {error}
-                        </Text>
+                        <div className="py-3.5 first:pt-0">
+                            <Text
+                                variant="body"
+                                weight="medium"
+                                color="steel-darker"
+                            >
+                                {error}
+                            </Text>
+                        </div>
                     )}
 
                     {isStakeTxn ? (

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -12,23 +12,26 @@ import {
     getTransactions,
     getTransactionSender,
     getTransactionDigest,
+    getGasData,
 } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
 import { DateCard } from '../../shared/date-card';
 import { ReceiptCardBg } from './ReceiptCardBg';
+import { SponsoredTxnGasSummary } from './SponsoredTxnGasSummary';
 import { StatusIcon } from './StatusIcon';
+import { TxnAddressLink } from './TxnAddressLink';
 import ExplorerLink from '_components/explorer-link';
 import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
 import { StakeTxnCard } from '_components/receipt-card/StakeTxnCard';
 import { TxnAddress } from '_components/receipt-card/TxnAddress';
 import { TxnAmount } from '_components/receipt-card/TxnAmount';
-import { TxnGasSummery } from '_components/receipt-card/TxnGasSummery';
 import { UnStakeTxnCard } from '_components/receipt-card/UnstakeTxnCard';
 import { getTxnEffectsEventID } from '_components/transactions-card';
 import { TxnImage } from '_components/transactions-card/TxnImage';
 import { checkStakingTxn } from '_helpers';
 import { useGetTxnRecipientAddress, useGetTransferAmount } from '_hooks';
+import { TxnGasSummary } from '_src/ui/app/components/receipt-card/TxnGasSummary';
 import { Text } from '_src/ui/app/shared/text';
 
 import type { SuiTransactionResponse, SuiAddress } from '@mysten/sui.js';
@@ -61,8 +64,6 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
             : getTxnEffectsEventID(effects, events, activeAddress)[0];
     }, [transaction, effects, events, activeAddress]);
 
-    const gasTotal = getTotalGasUsed(txn);
-
     const moveCallLabel = useMemo(() => {
         if (txnKind !== 'Call') return null;
         const moveCallLabel = checkStakingTxn(txn);
@@ -81,15 +82,42 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
         return amount ? Math.abs(amount) : null;
     }, [transferAmount]);
 
-    const isSender = activeAddress === getTransactionSender(txn);
     const isStakeTxn =
         moveCallLabel === 'Staked' || moveCallLabel === 'Unstaked';
 
-    const nftObjectLabel = transferAmount?.length
-        ? isSender
-            ? 'Sent'
-            : 'Received'
-        : 'Call';
+    const { owner } = getGasData(txn);
+    const transactionSender = getTransactionSender(txn);
+    const isSender = activeAddress === transactionSender;
+    const isSponsoredTransaction = transactionSender !== owner;
+    const gasTotal = getTotalGasUsed(txn);
+
+    const showGasSummary = isSuccessful && isSender && gasTotal;
+    const showSponsorInfo = !isSuccessful && isSender && isSponsoredTransaction;
+
+    let txnGasSummary: JSX.Element | undefined;
+    if (showGasSummary && isSponsoredTransaction) {
+        txnGasSummary = (
+            <SponsoredTxnGasSummary sponsor={owner} totalGas={gasTotal} />
+        );
+    } else if (showGasSummary) {
+        txnGasSummary = (
+            <TxnGasSummary
+                totalGas={gasTotal}
+                transferAmount={totalSuiAmount}
+            />
+        );
+    }
+
+    let txnStatusText = '';
+    if (isSender && isSuccessful) {
+        txnStatusText = 'Sent';
+    } else if (isSender && !isSuccessful) {
+        txnStatusText = 'Failed to Send';
+    } else {
+        txnStatusText = 'Received';
+    }
+
+    const nftObjectLabel = transferAmount?.length ? txnStatusText : 'Call';
 
     return (
         <div className="block relative w-full">
@@ -158,11 +186,7 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
                                               >
                                                   <TxnAmount
                                                       amount={amount}
-                                                      label={
-                                                          isSender
-                                                              ? 'Sent'
-                                                              : 'Received'
-                                                      }
+                                                      label={txnStatusText}
                                                       coinType={coinType}
                                                   />
 
@@ -180,6 +204,19 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
                                   )
                                 : null}
 
+                            {showSponsorInfo && (
+                                <div className="flex justify-between items-center py-3.5">
+                                    <Text
+                                        variant="p1"
+                                        weight="medium"
+                                        color="steel-darker"
+                                    >
+                                        Sponsor
+                                    </Text>
+                                    <TxnAddressLink address={owner} />
+                                </div>
+                            )}
+
                             {txnKind === 'ChangeEpoch' &&
                                 !transferAmount.length && (
                                     <TxnAddress
@@ -188,12 +225,7 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
                                     />
                                 )}
 
-                            {gasTotal && isSender ? (
-                                <TxnGasSummery
-                                    totalGas={gasTotal}
-                                    transferAmount={totalSuiAmount}
-                                />
-                            ) : null}
+                            {txnGasSummary}
                         </>
                     )}
 


### PR DESCRIPTION
## Description 
This change updates the wallet receipt pages to show extra information for sponsored transactions. This isn't totally up to spec because we don't have enough granularity to identify error messages (ideally we should show "Out of funds" text for failed sponsored transactions where the sponsor ran out of gas), but I'll work with @mystie711 on this as a follow-up.

Failed transaction with error message:
<img width="354" alt="Pasted Graphic 6" src="https://user-images.githubusercontent.com/7453188/222235993-8bbe742f-9139-4c5a-b9a9-e598710cd150.png">

Failed sponsored transaction (ignore the "Successful" text - that was for testing):
<img width="368" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/7453188/222236037-d724c8a0-d153-49f4-b5a7-dde22d029478.png">

Successful transaction:
<img width="368" alt="Pasted Graphic 5" src="https://user-images.githubusercontent.com/7453188/222235852-ac1dbc2f-3519-4458-b393-f92f4763d7cc.png">

Successful sponsored transaction:
<img width="373" alt="Pasted Graphic 4" src="https://user-images.githubusercontent.com/7453188/222235894-b1102f78-73fb-4325-86f7-c6cec73d8363.png">

## Test Plan 
- Manual testing (failed transaction w/ and w/o error, successful NFT mint txn, sent txn, received txn, etc.)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A