### PR TITLE
crypto: Add a validation test for sui-operation keystores

### DIFF
--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -143,6 +143,40 @@ fn test_read_write_keystore_with_flag() {
 }
 
 #[test]
+fn test_sui_operations_config() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("sui.keystore");
+    let path1 = path.clone();
+    // This is the hardcoded keystore in sui-operation: https://github.com/MystenLabs/sui-operations/blob/af04c9d3b61610dbb36401aff6bef29d06ef89f8/docker/config/generate/static/sui.keystore
+    // If this test fails, address hardcoded in sui-operations is likely needed be updated.
+    let kp = SuiKeyPair::decode_base64("ANRj4Rx5FZRehqwrctiLgZDPrY/3tI5+uJLCdaXPCj6C").unwrap();
+    let contents = kp.encode_base64();
+    let res = std::fs::write(path, contents);
+    assert!(res.is_ok());
+    let kp_read = read_keypair_from_file(path1);
+    assert_eq!(
+        SuiAddress::from_str("849d63687330447431a2e76fecca4f3c10f6884ebaa9909674123c6c662612a3")
+            .unwrap(),
+        SuiAddress::from(&kp_read.unwrap().public())
+    );
+
+    // This is the hardcoded keystore in sui-operation: https://github.com/MystenLabs/sui-operations/blob/af04c9d3b61610dbb36401aff6bef29d06ef89f8/docker/config/generate/static/sui-benchmark.keystore
+    // If this test fails, address hardcoded in sui-operations is likely needed be updated.
+    let path2 = temp_dir.path().join("sui-benchmark.keystore");
+    let path3 = path2.clone();
+    let kp = SuiKeyPair::decode_base64("APCWxPNCbgGxOYKeMfPqPmXmwdNVyau9y4IsyBcmC14A").unwrap();
+    let contents = kp.encode_base64();
+    let res = std::fs::write(path2, contents);
+    assert!(res.is_ok());
+    let kp_read = read_keypair_from_file(path3);
+    assert_eq!(
+        SuiAddress::from_str("b9e0a0d97f83b5cd84a2df2f83c9d72af19a6952ed637a36dfacf884a2d6e27f")
+            .unwrap(),
+        SuiAddress::from(&kp_read.unwrap().public())
+    );
+}
+
+#[test]
 fn test_load_keystore_err() {
     let temp_dir = TempDir::new().unwrap();
     let path = temp_dir.path().join("sui.keystore");


### PR DESCRIPTION
## Description 

Add validation test for keys in sui-operations. 
## Test Plan 

unit test
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
