### PR TITLE
[sui-framework] Support deactivated staking pools

### DIFF
--- a/.changeset/red-pants-shave.md
+++ b/.changeset/red-pants-shave.md
@@ -1,0 +1,13 @@
+---
+"@mysten/wallet-adapter-wallet-standard": minor
+"@mysten/wallet-adapter-unsafe-burner": minor
+"@mysten/wallet-adapter-base": minor
+"@mysten/wallet-adapter-all-wallets": minor
+"@mysten/wallet-kit-core": minor
+"@mysten/wallet-standard": minor
+"@mysten/wallet-kit": minor
+"@mysten/sui.js": minor
+"@mysten/bcs": minor
+---
+
+Adds `deactivation_epoch` to staking pool object, and adds `inactive_pools` to the validator set object.

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ storage/
 Move.lock
 !crates/sui-framework/Move.lock
 !crates/sui-framework/deps/move-stdlib/Move.lock
+.trace
+.coverage_map.mvcov
 
 # Thumbnails
 ._*

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -242,6 +242,8 @@ validators:
       staking_pool:
         id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f65e4b0dea15829e3157962e1"
         starting_epoch: 0
+        deactivation_epoch:
+          vec: []
         sui_balance: 25000000000000000
         rewards_pool:
           value: 0
@@ -264,6 +266,9 @@ validators:
   staking_pool_mappings:
     id: "0x18b8140c8a6ea340142f128061016fc4bd8220ec88875a8e573a5f72a85a15c1"
     size: 1
+  inactive_pools:
+    id: "0x1ace65f54d65a96251b3f46bfa720ab65a7ebe0174caa9fa1dc0d65a56ae7872"
+    size: 0
 storage_fund:
   value: 0
 parameters:

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -537,9 +537,6 @@ The amount of stake in the <code><a href="validator.md#0x2_validator">validator<
         ctx
     );
 
-    // TODO: We need <b>to</b> verify the <a href="validator.md#0x2_validator">validator</a> metadata.
-    // https://github.com/MystenLabs/<a href="sui.md#0x2_sui">sui</a>/issues/7323
-
     <a href="validator_set.md#0x2_validator_set_request_add_validator">validator_set::request_add_validator</a>(&<b>mut</b> self.validators, <a href="validator.md#0x2_validator">validator</a>);
 }
 </code></pre>

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -11,7 +11,7 @@
 -  [Function `verify_proof_of_possession`](#0x2_validator_verify_proof_of_possession)
 -  [Function `new_metadata`](#0x2_validator_new_metadata)
 -  [Function `new`](#0x2_validator_new)
--  [Function `destroy`](#0x2_validator_destroy)
+-  [Function `deactivate`](#0x2_validator_deactivate)
 -  [Function `adjust_stake_and_gas_price`](#0x2_validator_adjust_stake_and_gas_price)
 -  [Function `request_add_delegation`](#0x2_validator_request_add_delegation)
 -  [Function `request_withdraw_delegation`](#0x2_validator_request_withdraw_delegation)
@@ -594,13 +594,14 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 
 </details>
 
-<a name="0x2_validator_destroy"></a>
+<a name="0x2_validator_deactivate"></a>
 
-## Function `destroy`
+## Function `deactivate`
+
+Deactivate this validator's staking pool
 
 
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_destroy">destroy</a>(self: <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deactivate">deactivate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -609,18 +610,8 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_destroy">destroy</a>(self: <a href="validator.md#0x2_validator_Validator">Validator</a>, ctx: &<b>mut</b> TxContext) {
-    <b>let</b> <a href="validator.md#0x2_validator_Validator">Validator</a> {
-        metadata: _,
-        <a href="voting_power.md#0x2_voting_power">voting_power</a>: _,
-        gas_price: _,
-        <a href="staking_pool.md#0x2_staking_pool">staking_pool</a>,
-        commission_rate: _,
-        next_epoch_stake: _,
-        next_epoch_gas_price: _,
-        next_epoch_commission_rate: _,
-    } = self;
-    <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">staking_pool::deactivate_staking_pool</a>(<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, ctx);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deactivate">deactivate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, ctx: &<b>mut</b> TxContext) {
+    <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">staking_pool::deactivate_staking_pool</a>(&<b>mut</b> self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, ctx)
 }
 </code></pre>
 

--- a/crates/sui-framework/sources/governance/staking_pool.move
+++ b/crates/sui-framework/sources/governance/staking_pool.move
@@ -27,13 +27,17 @@ module sui::staking_pool {
     const EWrongDelegation: u64 = 7;
     const EPendingDelegationDoesNotExist: u64 = 8;
     const ETokenBalancesDoNotMatchExchangeRate: u64 = 9;
-    const EWithdrawalInSameEpoch: u64 = 10;
+    const EDelegationToInactivePool: u64 = 10;
+    const EDeactivationOfInactivePool: u64 = 10;
 
     /// A staking pool embedded in each validator struct in the system state object.
     struct StakingPool has key, store {
         id: UID,
         /// The epoch at which this pool started operating. Should be the epoch at which the validator became active.
         starting_epoch: u64,
+        /// The epoch at which this staking pool ceased to be active. `None` = {pre-active, active},
+        /// `Some(<epoch_number>)` if in-active, and it was de-activated at epoch `<epoch_number>`.
+        deactivation_epoch: Option<u64>,
         /// The total number of SUI tokens in this pool, including the SUI in the rewards_pool, as well as in all the principal
         /// in the `StakedSui` object, updated at epoch boundaries.
         sui_balance: u64,
@@ -58,13 +62,6 @@ module sui::staking_pool {
     struct PoolTokenExchangeRate has store, copy, drop {
         sui_amount: u64,
         pool_token_amount: u64,
-    }
-
-    /// An inactive staking pool associated with an inactive validator.
-    /// Only withdraws can be made from this pool.
-    struct InactiveStakingPool has key {
-        id: UID, // TODO: inherit an ID from active staking pool?
-        pool: StakingPool,
     }
 
     /// A self-custodial object holding the staked SUI tokens.
@@ -96,6 +93,7 @@ module sui::staking_pool {
         StakingPool {
             id: object::new(ctx),
             starting_epoch,
+            deactivation_epoch: option::none(),
             sui_balance: 0,
             rewards_pool: balance::zero(),
             pool_token_balance: 0,
@@ -119,6 +117,7 @@ module sui::staking_pool {
         ctx: &mut TxContext
     ) {
         let sui_amount = balance::value(&stake);
+        assert!(pool_active(pool), EDelegationToInactivePool);
         assert!(sui_amount > 0, 0);
         let staked_sui = StakedSui {
             id: object::new(ctx),
@@ -149,8 +148,12 @@ module sui::staking_pool {
             pool, principal_withdraw_amount, pool_token_withdraw_amount, tx_context::epoch(ctx)
         );
         let total_sui_withdraw_amount = principal_withdraw_amount + balance::value(&rewards_withdraw);
+
         pool.pending_total_sui_withdraw = pool.pending_total_sui_withdraw + total_sui_withdraw_amount;
         pool.pending_pool_token_withdraw = pool.pending_pool_token_withdraw + pool_token_withdraw_amount;
+
+        // If the pool is inactive, we immediately process the withdrawal.
+        if (!pool_active(pool)) process_pending_delegation_withdraw(pool);
 
         // TODO: implement withdraw bonding period here.
         if (option::is_some(&time_lock)) {
@@ -166,6 +169,8 @@ module sui::staking_pool {
             option::destroy_none(time_lock);
         };
         total_sui_withdraw_amount
+
+        // payment_amount
     }
 
     /// Withdraw the principal SUI stored in the StakedSui object, and calculate the corresponding amount of pool
@@ -225,6 +230,7 @@ module sui::staking_pool {
     }
 
     /// Called at epoch boundaries to process pending delegation withdraws requested during the epoch.
+    /// Also called immediately upon withdrawal if the pool is inactive.
     fun process_pending_delegation_withdraw(pool: &mut StakingPool) {
         pool.sui_balance = pool.sui_balance - pool.pending_total_sui_withdraw;
         pool.pool_token_balance = pool.pool_token_balance - pool.pending_pool_token_withdraw;
@@ -271,18 +277,20 @@ module sui::staking_pool {
 
     // ==== inactive pool related ====
 
-    /// Deactivate a staking pool by wrapping it in an `InactiveStakingPool` and sharing this newly created object.
-    /// After this pool deactivation, the pool stops earning rewards. Only delegation withdraws can be made to the pool.
-    public(friend) fun deactivate_staking_pool(pool: StakingPool, ctx: &mut TxContext) {
-        let inactive_pool = InactiveStakingPool { id: object::new(ctx), pool};
-        transfer::share_object(inactive_pool);
+    /// Deactivate a staking pool by setting the `deactivation_epoch`. After
+    /// this pool deactivation, the pool stops earning rewards. Only delegation
+    /// withdraws can be made to the pool.
+    public(friend) fun deactivate_staking_pool(pool: &mut StakingPool, ctx: &mut TxContext) {
+        // We can't deactivate an already deactivated pool.
+        assert!(pool_active(pool), EDeactivationOfInactivePool);
+        pool.deactivation_epoch = option::some(tx_context::epoch(ctx));
     }
 
     // ==== getters and misc utility functions ====
 
-    public fun sui_balance(pool: &StakingPool) : u64 { pool.sui_balance }
+    public fun sui_balance(pool: &StakingPool): u64 { pool.sui_balance }
 
-    public fun pool_id(staked_sui: &StakedSui) : ID { staked_sui.pool_id }
+    public fun pool_id(staked_sui: &StakedSui): ID { staked_sui.pool_id }
 
     public fun staked_sui_amount(staked_sui: &StakedSui): u64 { balance::value(&staked_sui.principal) }
 
@@ -290,7 +298,13 @@ module sui::staking_pool {
         staked_sui.delegation_activation_epoch
     }
 
+    public fun pool_active(pool: &StakingPool): bool {
+        option::is_none(&pool.deactivation_epoch)
+    }
+
     public fun pool_token_exchange_rate_at_epoch(pool: &StakingPool, epoch: u64): PoolTokenExchangeRate {
+        let clamped_epoch = option::get_with_default(&pool.deactivation_epoch, epoch);
+        let epoch = math::min(clamped_epoch, epoch);
         *table::borrow(&pool.exchange_rates, epoch)
     }
 
@@ -335,6 +349,7 @@ module sui::staking_pool {
         let actual = pool.pool_token_balance;
         assert!(expected == actual, ETokenBalancesDoNotMatchExchangeRate)
     }
+
     // ==== test-related functions ====
 
     // Given the `staked_sui` receipt calculate the current rewards (in terms of SUI) for it.

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -219,9 +219,6 @@ module sui::sui_system {
             ctx
         );
 
-        // TODO: We need to verify the validator metadata.
-        // https://github.com/MystenLabs/sui/issues/7323
-
         validator_set::request_add_validator(&mut self.validators, validator);
     }
 

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -249,18 +249,9 @@ module sui::validator {
         }
     }
 
-    public(friend) fun destroy(self: Validator, ctx: &mut TxContext) {
-        let Validator {
-            metadata: _,
-            voting_power: _,
-            gas_price: _,
-            staking_pool,
-            commission_rate: _,
-            next_epoch_stake: _,
-            next_epoch_gas_price: _,
-            next_epoch_commission_rate: _,
-        } = self;
-        staking_pool::deactivate_staking_pool(staking_pool, ctx);
+    /// Deactivate this validator's staking pool
+    public(friend) fun deactivate(self: &mut Validator, ctx: &mut TxContext) {
+        staking_pool::deactivate_staking_pool(&mut self.staking_pool, ctx)
     }
 
     /// Process pending stake and pending withdraws, and update the gas price.
@@ -527,7 +518,7 @@ module sui::validator {
         self.metadata.next_epoch_protocol_pubkey_bytes = option::some(protocol_pubkey);
         self.metadata.next_epoch_proof_of_possession = option::some(proof_of_possession);
         validate_metadata(&self.metadata);
-    } 
+    }
 
     /// Update network public key of this validator, taking effects from next epoch
     public(friend) fun update_next_epoch_network_pubkey(self: &mut Validator, network_pubkey: vector<u8>) {

--- a/crates/sui-framework/tests/delegation_tests.move
+++ b/crates/sui-framework/tests/delegation_tests.move
@@ -7,12 +7,16 @@ module sui::delegation_tests {
     use sui::test_scenario::{Self, Scenario};
     use sui::sui_system::{Self, SuiSystemState};
     use sui::staking_pool::{Self, StakedSui};
+    use sui::test_utils::assert_eq;
+    use sui::validator_set;
 
 
     use sui::governance_test_utils::{
         Self,
         create_validator_for_testing,
         create_sui_system_state_for_testing,
+        total_sui_balance,
+        undelegate,
     };
 
     const VALIDATOR_ADDR_1: address = @0x1;
@@ -76,6 +80,118 @@ module sui::delegation_tests {
             assert!(sui_system::validator_stake_amount(&mut system_state, VALIDATOR_ADDR_1) == 100, 107);
             test_scenario::return_shared(system_state);
         };
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_remove_delegation_post_active_flow_no_rewards() {
+        test_remove_delegation_post_active_flow(false)
+    }
+
+    #[test]
+    fun test_remove_delegation_post_active_flow_with_rewards() {
+        test_remove_delegation_post_active_flow(true)
+    }
+
+    fun test_remove_delegation_post_active_flow(should_distribute_rewards: bool) {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        governance_test_utils::delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
+
+        governance_test_utils::advance_epoch(scenario);
+
+        governance_test_utils::assert_validator_total_stake_amounts(
+            vector[VALIDATOR_ADDR_1, VALIDATOR_ADDR_2],
+            vector[200, 100],
+            scenario
+        );
+
+        if (should_distribute_rewards) {
+            // advance the epoch and set rewards at 10 SUI for each 100 SUI staked.
+            governance_test_utils::advance_epoch_with_reward_amounts(0, 40, scenario);
+        } else {
+            governance_test_utils::advance_epoch(scenario);
+        };
+
+        governance_test_utils::remove_validator(VALIDATOR_ADDR_1, scenario);
+
+        governance_test_utils::advance_epoch(scenario);
+
+        // 110 = stake + rewards for that stake
+        // 5 = validator rewards
+        let reward_amt = if (should_distribute_rewards) 10 else 0;
+        let validator_reward_amt = if (should_distribute_rewards) 5 else 0;
+
+        // Make sure delegation withdrawal happens
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let system_state_mut_ref = &mut system_state;
+
+            assert!(!validator_set::is_active_validator_by_sui_address(
+                        sui_system::validators(system_state_mut_ref),
+                        VALIDATOR_ADDR_1
+                    ), 0);
+
+            let staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
+            assert_eq(staking_pool::staked_sui_amount(&staked_sui), 100);
+
+            // Undelegate from VALIDATOR_ADDR_1
+            assert_eq(total_sui_balance(DELEGATOR_ADDR_1, scenario), 0);
+            let ctx = test_scenario::ctx(scenario);
+            sui_system::request_withdraw_delegation(system_state_mut_ref, staked_sui, ctx);
+
+            // Make sure they have all of their stake.
+            assert_eq(total_sui_balance(DELEGATOR_ADDR_1, scenario), 100 + reward_amt);
+
+            test_scenario::return_shared(system_state);
+        };
+
+        // Validator undelegates now.
+        assert_eq(total_sui_balance(VALIDATOR_ADDR_1, scenario), 0);
+        undelegate(VALIDATOR_ADDR_1, 0, scenario);
+        if (should_distribute_rewards) undelegate(VALIDATOR_ADDR_1, 0, scenario);
+
+        // Make sure have all of their stake. NB there is no epoch change. This is immediate.
+        assert_eq(total_sui_balance(VALIDATOR_ADDR_1, scenario), 100 + reward_amt + validator_reward_amt);
+
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = validator_set::ENotAValidator)]
+    fun test_add_delegation_post_active_flow() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        governance_test_utils::delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
+
+        governance_test_utils::advance_epoch(scenario);
+
+        governance_test_utils::remove_validator(VALIDATOR_ADDR_1, scenario);
+
+        governance_test_utils::advance_epoch(scenario);
+
+        // Make sure the validator is no longer active.
+        test_scenario::next_tx(scenario, DELEGATOR_ADDR_1);
+        {
+            let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let system_state_mut_ref = &mut system_state;
+
+            assert!(!validator_set::is_active_validator_by_sui_address(
+                        sui_system::validators(system_state_mut_ref),
+                        VALIDATOR_ADDR_1
+                    ), 0);
+
+            test_scenario::return_shared(system_state);
+        };
+
+        // Now try and delegate to the old validator/staking pool. This should fail!
+        governance_test_utils::delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
+
         test_scenario::end(scenario_val);
     }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4717,6 +4717,23 @@
           }
         ]
       },
+      "MoveOption_for_uint64": {
+        "description": "Rust version of the Move std::option::Option type. Putting it in this file because it's only used here.",
+        "type": "object",
+        "required": [
+          "vec"
+        ],
+        "properties": {
+          "vec": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
       "MovePackage": {
         "type": "object",
         "required": [
@@ -5565,6 +5582,7 @@
         "description": "Rust version of the Move sui::staking_pool::StakingPool type",
         "type": "object",
         "required": [
+          "deactivation_epoch",
           "exchange_rates",
           "id",
           "pending_delegation",
@@ -5576,6 +5594,9 @@
           "sui_balance"
         ],
         "properties": {
+          "deactivation_epoch": {
+            "$ref": "#/components/schemas/MoveOption_for_uint64"
+          },
           "exchange_rates": {
             "$ref": "#/components/schemas/Table"
           },
@@ -7069,6 +7090,7 @@
         "type": "object",
         "required": [
           "active_validators",
+          "inactive_pools",
           "pending_removals",
           "pending_validators",
           "staking_pool_mappings",
@@ -7080,6 +7102,9 @@
             "items": {
               "$ref": "#/components/schemas/Validator"
             }
+          },
+          "inactive_pools": {
+            "$ref": "#/components/schemas/Table"
           },
           "pending_removals": {
             "type": "array",

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -56,6 +56,12 @@ pub struct MoveOption<T> {
     pub vec: Vec<T>,
 }
 
+impl<T> MoveOption<T> {
+    pub fn empty() -> Self {
+        Self { vec: vec![] }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct ValidatorMetadata {
     pub sui_address: SuiAddress,
@@ -350,6 +356,7 @@ impl<K> Default for LinkedTable<K> {
 pub struct StakingPool {
     pub id: ObjectID,
     pub starting_epoch: u64,
+    pub deactivation_epoch: MoveOption<u64>,
     pub sui_balance: u64,
     pub rewards_pool: Balance,
     pub pool_token_balance: u64,
@@ -374,6 +381,7 @@ pub struct ValidatorSet {
     pub pending_validators: TableVec,
     pub pending_removals: Vec<u64>,
     pub staking_pool_mappings: Table,
+    pub inactive_pools: Table,
 }
 
 /// Rust version of the Move sui::sui_system::SuiSystemStateInner type
@@ -595,6 +603,7 @@ impl Default for SuiSystemStateInnerV1 {
             pending_validators: TableVec::default(),
             pending_removals: vec![],
             staking_pool_mappings: Table::default(),
+            inactive_pools: Table::default(),
         };
         Self {
             epoch: 0,

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -137,6 +137,7 @@ export const DelegationStakingPoolFields = object({
   pool_token_balance: number(),
   rewards_pool: object({ value: number() }),
   starting_epoch: number(),
+  deactivation_epoch: object({ vec: array() }),
   sui_balance: number(),
 });
 
@@ -192,6 +193,10 @@ export const ValidatorSet = object({
     object({ contents: array(ValidatorPair) }),
   ),
   staking_pool_mappings: object({
+    id: string(),
+    size: number(),
+  }),
+  inactive_pools: object({
     id: string(),
     size: number(),
   }),


### PR DESCRIPTION
## Description 

This adds logic for the transition from an active validator to an inactive staking pool and adds the logic for withdrawing from an inactive staking pool.

## Test Plan 

Added a unit test making sure withdrawals could be performed from an inactive staking pool, and that trying to delegate to an inactive staking pool errors out.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] breaking change for a client SDKs
- [X] breaking change for FNs (FN binary must upgrade)
- [X] breaking change for validators or node operators (must upgrade binaries)
- [X] breaking change for on-chain data layout
- [X] necessitate either a data wipe or data migration

### Release notes
