### PR TITLE
[10/x][programmable transactions] Add migration and builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9429,6 +9429,7 @@ dependencies = [
  "enum_dispatch",
  "eyre",
  "fastcrypto",
+ "indexmap",
  "itertools",
  "move-binary-format",
  "move-bytecode-utils",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1158,7 +1158,7 @@ impl AuthorityState {
             cert.data()
                 .intent_message
                 .value
-                .move_calls()
+                .legacy_move_calls()
                 .iter()
                 .map(|mc| (mc.package, mc.module.clone(), mc.function.clone())),
             changes,

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -36,6 +36,7 @@ roaring = "0.10.1"
 enum_dispatch = "^0.3"
 eyre = "0.6.8"
 multiaddr = "0.17.0"
+indexmap = "1.9.2"
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -45,6 +45,7 @@ pub mod messages_checkpoint;
 pub mod move_package;
 pub mod multisig;
 pub mod object;
+pub mod programmable_transaction_builder;
 pub mod query;
 pub mod quorum_driver_types;
 pub mod signature;

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -794,6 +794,26 @@ impl ProgrammableTransaction {
         }
         Ok(())
     }
+
+    fn shared_input_objects(&self) -> impl Iterator<Item = SharedInputObject> + '_ {
+        self.inputs
+            .iter()
+            .filter_map(|arg| match arg {
+                CallArg::Pure(_) | CallArg::Object(ObjectArg::ImmOrOwnedObject(_)) => None,
+                CallArg::Object(ObjectArg::SharedObject {
+                    id,
+                    initial_shared_version,
+                    mutable,
+                }) => Some(vec![SharedInputObject {
+                    id: *id,
+                    initial_shared_version: *initial_shared_version,
+                    mutable: *mutable,
+                }]),
+                // Not supported in programmable transactions
+                CallArg::ObjVec(_) => None,
+            })
+            .flatten()
+    }
 }
 
 impl Display for Argument {
@@ -900,7 +920,10 @@ impl SingleTransactionKind {
             Self::Call(_) | Self::ChangeEpoch(_) | Self::ConsensusCommitPrologue(_) => {
                 Either::Left(self.all_move_call_shared_input_objects())
             }
-            _ => Either::Right(iter::empty()),
+            Self::ProgrammableTransaction(pt) => {
+                Either::Right(Either::Left(pt.shared_input_objects()))
+            }
+            _ => Either::Right(Either::Right(iter::empty())),
         }
     }
 
@@ -961,7 +984,7 @@ impl SingleTransactionKind {
         }
     }
 
-    pub fn move_call(&self) -> Option<&MoveCall> {
+    pub fn legacy_move_call(&self) -> Option<&MoveCall> {
         match &self {
             Self::Call(call @ MoveCall { .. }) => Some(call),
             _ => None,
@@ -1593,10 +1616,10 @@ impl TransactionData {
         self.kind.shared_input_objects()
     }
 
-    pub fn move_calls(&self) -> Vec<&MoveCall> {
+    pub fn legacy_move_calls(&self) -> Vec<&MoveCall> {
         self.kind
             .single_transactions()
-            .flat_map(|s| s.move_call())
+            .flat_map(|s| s.legacy_move_call())
             .collect()
     }
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -809,8 +809,12 @@ impl ProgrammableTransaction {
                     initial_shared_version: *initial_shared_version,
                     mutable: *mutable,
                 }]),
-                // Not supported in programmable transactions
-                CallArg::ObjVec(_) => None,
+                CallArg::ObjVec(_) => {
+                    panic!(
+                        "not supported in programmable transactions, \
+                        should be unreachable if the input checker was run"
+                    )
+                }
             })
             .flatten()
     }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -988,6 +988,7 @@ impl SingleTransactionKind {
         }
     }
 
+    /// Actively being replaced by programmable transactions
     pub fn legacy_move_call(&self) -> Option<&MoveCall> {
         match &self {
             Self::Call(call @ MoveCall { .. }) => Some(call),
@@ -1620,6 +1621,7 @@ impl TransactionData {
         self.kind.shared_input_objects()
     }
 
+    /// Actively being replaced by programmable transactions
     pub fn legacy_move_calls(&self) -> Vec<&MoveCall> {
         self.kind
             .single_transactions()

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -1,0 +1,244 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Utility for generating programmable transactions, either by specifying a command or for
+//! migrating legacy transactions
+
+use indexmap::IndexSet;
+use move_core_types::{identifier::Identifier, language_storage::TypeTag};
+use serde::Serialize;
+
+use crate::{
+    base_types::{ObjectID, ObjectRef, SuiAddress},
+    messages::{
+        Argument, CallArg, Command, MoveCall, MoveModulePublish, ObjectArg, Pay, PayAllSui, PaySui,
+        ProgrammableMoveCall, ProgrammableTransaction, SingleTransactionKind, TransactionData,
+        TransactionKind, TransferObject, TransferSui,
+    },
+};
+
+pub fn migrate_transaction_data(mut m: TransactionData) -> anyhow::Result<TransactionData> {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    match m.kind {
+        TransactionKind::Single(SingleTransactionKind::PaySui(PaySui {
+            coins: _coins,
+            recipients,
+            amounts,
+        })) => {
+            builder.pay_sui(recipients, amounts)?;
+            anyhow::bail!("blocked by gas smashing")
+        }
+        TransactionKind::Single(SingleTransactionKind::PayAllSui(PayAllSui {
+            coins: _coins,
+            recipient,
+        })) => {
+            builder.pay_all_sui(recipient);
+            anyhow::bail!("blocked by gas smashing")
+        }
+        TransactionKind::Single(t) => builder.single_transaction(t)?,
+        TransactionKind::Batch(ts) => {
+            for t in ts {
+                builder.single_transaction(t)?
+            }
+        }
+    };
+    let pt = builder.finish();
+    m.kind = TransactionKind::Single(SingleTransactionKind::ProgrammableTransaction(pt));
+    Ok(m)
+}
+
+#[derive(Default)]
+pub struct ProgrammableTransactionBuilder {
+    inputs: IndexSet<CallArg>,
+    commands: Vec<Command>,
+}
+
+impl ProgrammableTransactionBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn finish(self) -> ProgrammableTransaction {
+        let Self { inputs, commands } = self;
+        let inputs = inputs.into_iter().collect();
+        ProgrammableTransaction { inputs, commands }
+    }
+
+    pub fn pure<T: Serialize>(&mut self, value: T) -> anyhow::Result<Argument> {
+        Ok(self.input(CallArg::Pure(bcs::to_bytes(&value).map_err(|e| {
+            anyhow::anyhow!("Unable to serialize pure argument. Got error: {e}")
+        })?)))
+    }
+
+    pub fn obj(&mut self, obj_arg: ObjectArg) -> Argument {
+        self.input(CallArg::Object(obj_arg))
+    }
+
+    pub fn input(&mut self, call_arg: CallArg) -> Argument {
+        assert!(!matches!(call_arg, CallArg::ObjVec(_)));
+        Argument::Input(self.inputs.insert_full(call_arg).0 as u16)
+    }
+
+    pub fn command(&mut self, command: Command) -> Argument {
+        let i = self.commands.len();
+        self.commands.push(command);
+        Argument::Result(i as u16)
+    }
+
+    pub fn single_transaction(&mut self, t: SingleTransactionKind) -> anyhow::Result<()> {
+        match t {
+            SingleTransactionKind::ProgrammableTransaction(_) => anyhow::bail!(
+                "ProgrammableTransaction are not supported in ProgrammableTransactionBuilder"
+            ),
+            SingleTransactionKind::TransferObject(TransferObject {
+                recipient,
+                object_ref,
+            }) => self.transfer_object(recipient, object_ref),
+            SingleTransactionKind::Publish(MoveModulePublish { modules }) => self.publish(modules),
+            SingleTransactionKind::Call(MoveCall {
+                package,
+                module,
+                function,
+                type_arguments,
+                arguments,
+            }) => self.move_call(package, module, function, type_arguments, arguments)?,
+            SingleTransactionKind::TransferSui(TransferSui { recipient, amount }) => {
+                self.transfer_sui(recipient, amount)
+            }
+            SingleTransactionKind::Pay(Pay {
+                coins,
+                recipients,
+                amounts,
+            }) => self.pay(coins, recipients, amounts)?,
+            SingleTransactionKind::PaySui(_) | SingleTransactionKind::PayAllSui(_) => {
+                anyhow::bail!(
+                    "PaySui and PayAllSui cannot be migrated as a single transaction kind, \
+                only as a full transaction"
+                )
+            }
+            SingleTransactionKind::ChangeEpoch(_)
+            | SingleTransactionKind::Genesis(_)
+            | SingleTransactionKind::ConsensusCommitPrologue(_) => anyhow::bail!(
+                "System transactions are not expressed with programmable transactions"
+            ),
+        };
+        Ok(())
+    }
+
+    /// Will fail to generate if given an empty ObjVec
+    pub fn move_call(
+        &mut self,
+        package: ObjectID,
+        module: Identifier,
+        function: Identifier,
+        type_arguments: Vec<TypeTag>,
+        call_args: Vec<CallArg>,
+    ) -> anyhow::Result<()> {
+        let mut arguments = vec![];
+        for call_arg in call_args {
+            let arg = match call_arg {
+                call_arg @ (CallArg::Pure(_) | CallArg::Object(_)) => self.input(call_arg),
+                CallArg::ObjVec(objs) if objs.is_empty() => {
+                    anyhow::bail!(
+                        "Empty ObjVec is not supported in programmable transactions \
+                        without a type annotation"
+                    )
+                }
+                CallArg::ObjVec(objs) => {
+                    let make_vec_args = objs.into_iter().map(|obj| self.obj(obj)).collect();
+                    self.command(Command::MakeMoveVec(None, make_vec_args))
+                }
+            };
+            arguments.push(arg)
+        }
+        self.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
+            package,
+            module,
+            function,
+            type_arguments,
+            arguments,
+        })));
+        Ok(())
+    }
+
+    pub fn publish(&mut self, modules: Vec<Vec<u8>>) {
+        self.commands.push(Command::Publish(modules))
+    }
+
+    pub fn transfer_object(&mut self, recipient: SuiAddress, object_ref: ObjectRef) {
+        let rec_arg = self.pure(recipient).unwrap();
+        let obj_arg = self.obj(ObjectArg::ImmOrOwnedObject(object_ref));
+        self.commands
+            .push(Command::TransferObjects(vec![obj_arg], rec_arg));
+    }
+
+    pub fn transfer_sui(&mut self, recipient: SuiAddress, amount: Option<u64>) {
+        let rec_arg = self.pure(recipient).unwrap();
+        let coin_arg = if let Some(amount) = amount {
+            let amt_arg = self.pure(amount).unwrap();
+            self.command(Command::SplitCoin(Argument::GasCoin, amt_arg))
+        } else {
+            Argument::GasCoin
+        };
+        self.command(Command::TransferObjects(vec![coin_arg], rec_arg));
+    }
+
+    pub fn pay_all_sui(&mut self, recipient: SuiAddress) {
+        let rec_arg = self.pure(recipient).unwrap();
+        self.command(Command::TransferObjects(vec![Argument::GasCoin], rec_arg));
+    }
+
+    /// Will fail to generate if recipients and amounts do not have the same lengths
+    pub fn pay_sui(
+        &mut self,
+        recipients: Vec<SuiAddress>,
+        amounts: Vec<u64>,
+    ) -> anyhow::Result<()> {
+        self.pay_impl(recipients, amounts, Argument::GasCoin)
+    }
+
+    /// Will fail to generate if recipients and amounts do not have the same lengths.
+    /// Or if coins is empty
+    pub fn pay(
+        &mut self,
+        coins: Vec<ObjectRef>,
+        recipients: Vec<SuiAddress>,
+        amounts: Vec<u64>,
+    ) -> anyhow::Result<()> {
+        let mut coins = coins.into_iter();
+        let Some(coin) = coins.next()
+        else {
+            anyhow::bail!("coins vector is empty");
+        };
+        let coin_arg = self.obj(ObjectArg::ImmOrOwnedObject(coin));
+        let merge_args: Vec<_> = coins
+            .map(|c| self.obj(ObjectArg::ImmOrOwnedObject(c)))
+            .collect();
+        if !merge_args.is_empty() {
+            self.command(Command::MergeCoins(coin_arg, merge_args));
+        }
+        self.pay_impl(recipients, amounts, coin_arg)
+    }
+
+    fn pay_impl(
+        &mut self,
+        recipients: Vec<SuiAddress>,
+        amounts: Vec<u64>,
+        coin: Argument,
+    ) -> anyhow::Result<()> {
+        if recipients.len() != amounts.len() {
+            anyhow::bail!(
+                "Recipients and amounts mismatch. Got {} recipients but {} amounts",
+                recipients.len(),
+                amounts.len()
+            )
+        }
+        for (recipient, amount) in recipients.into_iter().zip(amounts) {
+            let rec_arg = self.pure(recipient).unwrap();
+            let amt_arg = self.pure(amount).unwrap();
+            let coin_arg = self.command(Command::SplitCoin(coin, amt_arg));
+            self.command(Command::TransferObjects(vec![coin_arg], rec_arg));
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description 

Adds a programmable transaction builder. APIs are there mostly for migration. 

Builds on #8767 

## Test Plan 

Not yet in use 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
