### PR TITLE
Take db snapshots at epoch boundary and test snapshot restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8456,6 +8456,7 @@ dependencies = [
  "sui-simulator",
  "sui-source-validation",
  "sui-swarm",
+ "sui-tool",
  "sui-types",
  "telemetry-subscribers",
  "tempfile",

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -3,7 +3,7 @@
 
 use crate::node::{
     default_end_of_epoch_broadcast_channel_capacity, default_epoch_duration_ms,
-    AuthorityKeyPairWithPath, KeyPairWithPath, StateSnapshotConfig,
+    AuthorityKeyPairWithPath, DBCheckpointConfig, KeyPairWithPath,
 };
 use crate::{
     genesis,
@@ -79,6 +79,8 @@ pub struct ConfigBuilder<R = OsRng> {
 
     // the versions that are supported by each validator
     supported_protocol_versions_config: ProtocolVersionsConfig,
+
+    db_checkpoint_config: DBCheckpointConfig,
 }
 
 impl ConfigBuilder {
@@ -101,6 +103,7 @@ impl ConfigBuilder {
             epoch_duration_ms: default_epoch_duration_ms(),
             protocol_version: ProtocolVersion::MAX,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
+            db_checkpoint_config: DBCheckpointConfig::default(),
         }
     }
 }
@@ -169,6 +172,11 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn with_db_checkpoint_config(mut self, db_checkpoint_config: DBCheckpointConfig) -> Self {
+        self.db_checkpoint_config = db_checkpoint_config;
+        self
+    }
+
     pub fn rng<N: rand::RngCore + rand::CryptoRng>(self, rng: N) -> ConfigBuilder<N> {
         ConfigBuilder {
             rng: Some(rng),
@@ -182,6 +190,7 @@ impl<R> ConfigBuilder<R> {
             epoch_duration_ms: self.epoch_duration_ms,
             protocol_version: self.protocol_version,
             supported_protocol_versions_config: self.supported_protocol_versions_config,
+            db_checkpoint_config: self.db_checkpoint_config,
         }
     }
 }
@@ -451,7 +460,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     checkpoint_executor_config: Default::default(),
                     metrics: None,
                     supported_protocol_versions: Some(supported_protocol_versions),
-                    state_snapshot_config: StateSnapshotConfig::validator_config(),
+                    db_checkpoint_config: self.db_checkpoint_config.clone(),
                 }
             })
             .collect();

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -100,7 +100,7 @@ pub struct NodeConfig {
     pub supported_protocol_versions: Option<SupportedProtocolVersions>,
 
     #[serde(default)]
-    pub state_snapshot_config: StateSnapshotConfig,
+    pub db_checkpoint_config: DBCheckpointConfig,
 }
 
 fn default_authority_store_pruning_config() -> AuthorityStorePruningConfig {
@@ -198,8 +198,12 @@ impl NodeConfig {
         (&self.account_key_pair().public()).into()
     }
 
-    pub fn db_path(&self) -> &Path {
-        &self.db_path
+    pub fn db_path(&self) -> PathBuf {
+        self.db_path.join("live")
+    }
+
+    pub fn db_checkpoint_path(&self) -> PathBuf {
+        self.db_path.join("db_checkpoints")
     }
 
     pub fn network_address(&self) -> &Multiaddr {
@@ -339,17 +343,11 @@ pub struct MetricsConfig {
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub struct StateSnapshotConfig {
-    pub enabled: bool,
-}
-
-impl StateSnapshotConfig {
-    pub fn validator_config() -> Self {
-        Self { enabled: false }
-    }
-    pub fn fullnode_config() -> Self {
-        Self { enabled: true }
-    }
+pub struct DBCheckpointConfig {
+    #[serde(default)]
+    pub perform_db_checkpoints_at_epoch_end: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint_path: Option<PathBuf>,
 }
 
 /// Publicly known information about a validator

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::node::AuthorityStorePruningConfig;
 use crate::node::{
     default_end_of_epoch_broadcast_channel_capacity, default_epoch_duration_ms,
-    AuthorityKeyPairWithPath, KeyPairWithPath,
+    AuthorityKeyPairWithPath, DBCheckpointConfig, KeyPairWithPath,
 };
-use crate::node::{AuthorityStorePruningConfig, StateSnapshotConfig};
 use crate::p2p::{P2pConfig, SeedPeer};
 use crate::{
     builder::{self, ProtocolVersionsConfig, SupportedProtocolVersionsCallback},
@@ -88,6 +88,7 @@ pub struct FullnodeConfigBuilder<'a> {
     // port for admin interface
     admin_port: Option<u16>,
     supported_protocol_versions_config: ProtocolVersionsConfig,
+    db_checkpoint_config: DBCheckpointConfig,
 }
 
 impl<'a> FullnodeConfigBuilder<'a> {
@@ -102,6 +103,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             rpc_port: None,
             admin_port: None,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
+            db_checkpoint_config: DBCheckpointConfig::default(),
         }
     }
 
@@ -175,6 +177,11 @@ impl<'a> FullnodeConfigBuilder<'a> {
 
     pub fn with_supported_protocol_versions_config(mut self, c: ProtocolVersionsConfig) -> Self {
         self.supported_protocol_versions_config = c;
+        self
+    }
+
+    pub fn with_db_checkpoint_config(mut self, db_checkpoint_config: DBCheckpointConfig) -> Self {
+        self.db_checkpoint_config = db_checkpoint_config;
         self
     }
 
@@ -271,7 +278,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             checkpoint_executor_config: Default::default(),
             metrics: None,
             supported_protocol_versions: Some(supported_protocol_versions),
-            state_snapshot_config: StateSnapshotConfig::fullnode_config(),
+            db_checkpoint_config: self.db_checkpoint_config,
         })
     }
 }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -72,8 +72,8 @@ validator_configs:
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
-    state-snapshot-config:
-      enabled: false
+    db-checkpoint-config:
+      perform-db-checkpoints-at-epoch-end: false
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -143,8 +143,8 @@ validator_configs:
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
-    state-snapshot-config:
-      enabled: false
+    db-checkpoint-config:
+      perform-db-checkpoints-at-epoch-end: false
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -214,8 +214,8 @@ validator_configs:
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
-    state-snapshot-config:
-      enabled: false
+    db-checkpoint-config:
+      perform-db-checkpoints-at-epoch-end: false
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -285,8 +285,8 @@ validator_configs:
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
-    state-snapshot-config:
-      enabled: false
+    db-checkpoint-config:
+      perform-db-checkpoints-at-epoch-end: false
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -356,8 +356,8 @@ validator_configs:
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
-    state-snapshot-config:
-      enabled: false
+    db-checkpoint-config:
+      perform-db-checkpoints-at-epoch-end: false
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -427,8 +427,8 @@ validator_configs:
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
-    state-snapshot-config:
-      enabled: false
+    db-checkpoint-config:
+      perform-db-checkpoints-at-epoch-end: false
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -498,8 +498,8 @@ validator_configs:
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
       local-execution-timeout-sec: 10
-    state-snapshot-config:
-      enabled: false
+    db-checkpoint-config:
+      perform-db-checkpoints-at-epoch-end: false
 account_keys:
   - 10wECHkYvXqL5/CY6WhjbfFPotZb5tjEbpmumqbRxuk=
   - ZTWBfKEmFOyYM9oBU9dNfREBuAU5fm2OBhg/vPtI00c=

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -197,6 +197,13 @@ impl AuthorityPerpetualTables {
             prev: None,
         }
     }
+
+    pub fn checkpoint_db(&self, path: &Path) -> SuiResult {
+        // This checkpoints the entire db and not just objects table
+        self.objects
+            .checkpoint_db(path)
+            .map_err(SuiError::StorageError)
+    }
 }
 
 impl ObjectStore for AuthorityPerpetualTables {

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -31,7 +31,7 @@ use sui_protocol_config::ProtocolVersion;
 use sui_types::base_types::{EpochId, TransactionDigest};
 use sui_types::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
 use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest};
-use sui_types::error::SuiResult;
+use sui_types::error::{SuiError, SuiResult};
 use sui_types::gas::GasCostSummary;
 use sui_types::messages::{
     ConsensusTransactionKey, SingleTransactionKind, TransactionDataAPI, TransactionEffects,
@@ -387,6 +387,13 @@ impl CheckpointStore {
                 .epoch_rolling_gas_cost_summary
                 .computation_cost,
         })
+    }
+
+    pub fn checkpoint_db(&self, path: &Path) -> SuiResult {
+        // This checkpoints the entire db and not one column family
+        self.checkpoint_content
+            .checkpoint_db(path)
+            .map_err(SuiError::StorageError)
     }
 }
 

--- a/crates/sui-core/src/epoch/committee_store.rs
+++ b/crates/sui-core/src/epoch/committee_store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use rocksdb::Options;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use sui_storage::default_db_options;
 use sui_types::base_types::ObjectID;
 use sui_types::committee::{Committee, EpochId};
@@ -76,7 +76,6 @@ impl CommitteeStore {
             .unwrap()
             .1
     }
-
     /// Return the committee specified by `epoch`. If `epoch` is `None`, return the latest committee.
     pub fn get_or_latest_committee(&self, epoch: Option<EpochId>) -> SuiResult<Committee> {
         Ok(match epoch {
@@ -85,6 +84,12 @@ impl CommitteeStore {
                 .ok_or(SuiError::MissingCommitteeAtEpoch(epoch))?,
             None => self.get_latest_committee(),
         })
+    }
+
+    pub fn checkpoint_db(&self, path: &Path) -> SuiResult {
+        self.committee_map
+            .checkpoint_db(path)
+            .map_err(SuiError::StorageError)
     }
 
     fn database_is_empty(&self) -> bool {

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2744,7 +2744,7 @@ async fn test_authority_persist() {
             AuthorityStorePruningConfig::default(),
             &[], // no genesis objects
             10000,
-            &StateSnapshotConfig::default(),
+            &DBCheckpointConfig::default(),
         )
         .await
     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -19,6 +19,7 @@ use narwhal_network::metrics::{NetworkConnectionMetrics, NetworkMetrics};
 use prometheus::Registry;
 use std::collections::HashMap;
 use std::fmt;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_config::{ConsensusConfig, NodeConfig};
@@ -66,6 +67,7 @@ mod handle;
 pub mod metrics;
 pub use handle::SuiNodeHandle;
 use narwhal_types::TransactionsClient;
+use sui_config::node::DBCheckpointConfig;
 use sui_core::authority::authority_per_epoch_store::{
     AuthorityPerEpochStore, EpochStartConfiguration,
 };
@@ -245,7 +247,15 @@ impl SuiNode {
             &prometheus_registry,
         )?;
 
-        // Create Authority State
+        let db_checkpoint_config = if config.db_checkpoint_config.checkpoint_path.is_none() {
+            DBCheckpointConfig {
+                checkpoint_path: Some(config.db_checkpoint_path()),
+                ..config.db_checkpoint_config
+            }
+        } else {
+            config.db_checkpoint_config.clone()
+        };
+
         let state = AuthorityState::new(
             config.protocol_public_key(),
             secret,
@@ -260,10 +270,9 @@ impl SuiNode {
             config.authority_store_pruning_config,
             genesis.objects(),
             config.epoch_duration_ms,
-            &config.state_snapshot_config,
+            &db_checkpoint_config,
         )
         .await;
-
         // ensure genesis txn was executed
         if epoch_store.epoch() == 0 {
             let txn = &genesis.transaction();
@@ -286,7 +295,7 @@ impl SuiNode {
                 TransactiondOrchestrator::new_with_network_clients(
                     state.clone(),
                     end_of_epoch_receiver,
-                    config.db_path(),
+                    &config.db_path(),
                     &prometheus_registry,
                 )
                 .await?,
@@ -384,6 +393,10 @@ impl SuiNode {
 
     pub fn current_epoch_for_testing(&self) -> EpochId {
         self.state.current_epoch_for_testing()
+    }
+
+    pub fn db_checkpoint_path(&self) -> PathBuf {
+        self.config.db_checkpoint_path()
     }
 
     // Init reconfig process by starting to reject user certs

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -16,6 +16,7 @@ use sui_config::builder::{
     CommitteeConfig, ConfigBuilder, ProtocolVersionsConfig, SupportedProtocolVersionsCallback,
 };
 use sui_config::genesis_config::{GenesisConfig, ValidatorConfigInfo};
+use sui_config::node::DBCheckpointConfig;
 use sui_config::NetworkConfig;
 use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
 use sui_types::base_types::AuthorityName;
@@ -35,6 +36,7 @@ pub struct SwarmBuilder<R = OsRng> {
     epoch_duration_ms: Option<u64>,
     initial_protocol_version: ProtocolVersion,
     supported_protocol_versions_config: ProtocolVersionsConfig,
+    db_checkpoint_config: DBCheckpointConfig,
 }
 
 impl SwarmBuilder {
@@ -52,6 +54,7 @@ impl SwarmBuilder {
             epoch_duration_ms: None,
             initial_protocol_version: SupportedProtocolVersions::SYSTEM_DEFAULT.max,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
+            db_checkpoint_config: DBCheckpointConfig::default(),
         }
     }
 }
@@ -70,6 +73,7 @@ impl<R> SwarmBuilder<R> {
             epoch_duration_ms: None,
             initial_protocol_version: SupportedProtocolVersions::SYSTEM_DEFAULT.max,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
+            db_checkpoint_config: DBCheckpointConfig::default(),
         }
     }
 
@@ -143,6 +147,11 @@ impl<R> SwarmBuilder<R> {
         self.supported_protocol_versions_config = c;
         self
     }
+
+    pub fn with_db_checkpoint_config(mut self, db_checkpoint_config: DBCheckpointConfig) -> Self {
+        self.db_checkpoint_config = db_checkpoint_config;
+        self
+    }
 }
 
 impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
@@ -190,6 +199,7 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 let mut config = network_config
                     .fullnode_config_builder()
                     .with_supported_protocol_versions_config(spvc)
+                    .with_db_checkpoint_config(self.db_checkpoint_config.clone())
                     .with_random_dir()
                     .build()
                     .unwrap();

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -431,6 +431,9 @@ pub enum SuiError {
 
     #[error("unknown error: {0}")]
     Unknown(String),
+
+    #[error("Failed to perform file operation: {0}")]
+    FileIOError(String),
 }
 
 #[repr(u64)]

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -84,6 +84,7 @@ sui-node = { path = "../sui-node" }
 sui-macros = { path = "../sui-macros" }
 sui-simulator = { path = "../sui-simulator" }
 mysten-metrics = { path = "../mysten-metrics" }
+sui-tool = { path = "../sui-tool" }
 
 assert_cmd = "2.0.6"
 

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -19,6 +19,7 @@ use sui::config::SuiEnv;
 use sui::{client_commands::WalletContext, config::SuiClientConfig};
 use sui_config::builder::{ProtocolVersionsConfig, SupportedProtocolVersionsCallback};
 use sui_config::genesis_config::GenesisConfig;
+use sui_config::node::DBCheckpointConfig;
 use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_NETWORK_CONFIG};
 use sui_config::{FullnodeConfigBuilder, NodeConfig, PersistedConfig, SUI_KEYSTORE_FILENAME};
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
@@ -209,6 +210,8 @@ pub struct TestClusterBuilder {
     epoch_duration_ms: Option<u64>,
     initial_protocol_version: ProtocolVersion,
     supported_protocol_versions_config: ProtocolVersionsConfig,
+    db_checkpoint_config_validators: DBCheckpointConfig,
+    db_checkpoint_config_fullnodes: DBCheckpointConfig,
 }
 
 impl TestClusterBuilder {
@@ -222,6 +225,8 @@ impl TestClusterBuilder {
             epoch_duration_ms: None,
             initial_protocol_version: SupportedProtocolVersions::SYSTEM_DEFAULT.max,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
+            db_checkpoint_config_validators: DBCheckpointConfig::default(),
+            db_checkpoint_config_fullnodes: DBCheckpointConfig::default(),
         }
     }
 
@@ -247,6 +252,22 @@ impl TestClusterBuilder {
 
     pub fn enable_fullnode_events(mut self) -> Self {
         self.enable_fullnode_events = true;
+        self
+    }
+
+    pub fn with_enable_db_checkpoints_validators(mut self) -> Self {
+        self.db_checkpoint_config_validators = DBCheckpointConfig {
+            perform_db_checkpoints_at_epoch_end: true,
+            checkpoint_path: None,
+        };
+        self
+    }
+
+    pub fn with_enable_db_checkpoints_fullnodes(mut self) -> Self {
+        self.db_checkpoint_config_fullnodes = DBCheckpointConfig {
+            perform_db_checkpoints_at_epoch_end: true,
+            checkpoint_path: None,
+        };
         self
     }
 
@@ -293,6 +314,7 @@ impl TestClusterBuilder {
             .with_supported_protocol_versions_config(
                 self.supported_protocol_versions_config.clone(),
             )
+            .with_db_checkpoint_config(self.db_checkpoint_config_fullnodes)
             .set_event_store(self.enable_fullnode_events)
             .set_rpc_port(self.fullnode_rpc_port)
             .build()
@@ -332,6 +354,7 @@ impl TestClusterBuilder {
             )
             .with_objects(self.additional_objects.clone())
             .with_protocol_version(self.initial_protocol_version)
+            .with_db_checkpoint_config(self.db_checkpoint_config_validators.clone())
             .with_supported_protocol_versions_config(
                 self.supported_protocol_versions_config.clone(),
             );

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -26,6 +26,7 @@ pub use traits::Map;
 pub mod metrics;
 pub mod rocks;
 use crate::rocks::RocksDB;
+pub use rocks::TypedStoreError;
 pub mod sally;
 pub mod test_db;
 pub use metrics::DBMetrics;


### PR DESCRIPTION
## Description 

This PR adds more databases that need chaeckpointing to enable quick restore. We checkpoint committee store, checkpoint store and perpetual while we take copy of epoch configuration in epoch db. Added db-tool command for quick restore (but it is a trivial copy which could be performed without it as well)

## Test Plan 

Tested restore from snapshot in a test by bringing up a full node from it.
