### PR TITLE
[transactional tests] Fixed missing input object checks

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -1,29 +1,30 @@
 processed 8 tasks
 
+init:
+A: object(100)
+
 task 1 'publish'. lines 6-21:
-created: object(104)
-written: object(103)
+created: object(105)
+written: object(104)
 
 task 2 'publish'. lines 23-52:
-created: object(106)
-written: object(105)
+created: object(107)
+written: object(106)
 
 task 3 'publish'. lines 55-82:
-created: object(108)
-written: object(107)
+created: object(109)
+written: object(108)
 
 task 4 'run'. lines 84-84:
-created: object(110)
-written: object(109)
+created: object(111)
+written: object(110)
 
 task 5 'run'. lines 86-88:
-created: object(112), object(113)
-written: object(110), object(111)
+created: object(113), object(114)
+written: object(111), object(112)
 
 task 6 'run'. lines 89-89:
-Error: Transaction Effects Status: Invalid Object Owned Argument. Object fake(112) is owned by object fake(113). Objects owned by other objects cannot be used as input arguments.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidChildObjectArgument(InvalidChildObjectArgument { child: fake(112), parent: fake(113) }), source: None, command: None } }
+Error: Object 0x5e8b4686eb9ef82f1a4daecb1648bf43a5d232bcd119d1613a2c47acb575393c is owned by object 0x06b70f0fddd32895de05c5682c623e06dd60863d5a6688d0736907ac3cf1c59a. Objects owned by other objects cannot be used as input arguments.
 
 task 7 'run'. lines 91-91:
-Error: Transaction Effects Status: Invalid Object Owned Argument. Object fake(112) is owned by object fake(113). Objects owned by other objects cannot be used as input arguments.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidChildObjectArgument(InvalidChildObjectArgument { child: fake(112), parent: fake(113) }), source: None, command: None } }
+Error: Object 0x5e8b4686eb9ef82f1a4daecb1648bf43a5d232bcd119d1613a2c47acb575393c is owned by object 0x06b70f0fddd32895de05c5682c623e06dd60863d5a6688d0736907ac3cf1c59a. Objects owned by other objects cannot be used as input arguments.

--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 t3=0x0 A=0x42
+//# init --addresses t1=0x0 t2=0x0 t3=0x0 --accounts A
 
 //# publish
 
@@ -81,11 +81,11 @@ module t1::o1 {
     }
 }
 
-//# run t3::o3::create
+//# run t3::o3::create --sender A
 
-//# run t2::o2::create_shared --args object(110)
+//# run t2::o2::create_shared --args object(111) --sender A
 
-// This run should error as Obj2/Obj3 were not defined in o1
-//# run t1::o1::use_o2_o3 --args object(112) object(110)
+// child arguments cannot be taken directly
+//# run t1::o1::use_o2_o3 --args object(113) object(114) --sender A
 
-//# run t2::o2::use_o2_o3 --args object(112) object(110)
+//# run t2::o2::use_o2_o3 --args object(113) object(110) --sender A

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -27,8 +27,7 @@ created: object(113), object(114)
 written: object(111), object(112)
 
 task 7 'run'. lines 132-136:
-Error: Transaction Effects Status: Invalid Object Owned Argument. Object fake(113) is owned by object fake(114). Objects owned by other objects cannot be used as input arguments.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidChildObjectArgument(InvalidChildObjectArgument { child: fake(113), parent: fake(114) }), source: None, command: None } }
+Error: Object 0x01b2156087ad45d0d2fb96eb055cd6257a53618f4086e94ee301ec3388d82896 is owned by object 0xb221913a3af7acfea147609cf80ac9ff54e941c3fc918fc4972a9a2c95b9c5ba. Objects owned by other objects cannot be used as input arguments.
 
 task 8 'run'. lines 138-138:
 created: object(117)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
@@ -24,8 +24,7 @@ created: object(112), object(113)
 written: object(110), object(111)
 
 task 6 'run'. lines 129-133:
-Error: Transaction Effects Status: Invalid Object Owned Argument. Object fake(112) is owned by object fake(113). Objects owned by other objects cannot be used as input arguments.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidChildObjectArgument(InvalidChildObjectArgument { child: fake(112), parent: fake(113) }), source: None, command: None } }
+Error: Object 0x032f88b6c64f0b334f8b020b385d08aa9df5c5625f1df486ace408ebf6096f6e is owned by object 0xf82d67caa424708f3f28fe5146d03bd9c1617bab2ba5142e8545541f41fe7d8d. Objects owned by other objects cannot be used as input arguments.
 
 task 7 'run'. lines 135-135:
 created: object(116)

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
@@ -1,33 +1,36 @@
 processed 9 tasks
 
+init:
+A: object(100)
+
 task 1 'publish'. lines 8-79:
-created: object(104)
-written: object(103)
+created: object(105)
+written: object(104)
 
 task 2 'run'. lines 80-82:
 Error: Transaction Effects Status: Move object with size 256001 is larger than the maximum object size 256000
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveObjectTooBig { object_size: 256001, max_object_size: 256000 }, source: None, command: None } }
 
 task 3 'run'. lines 83-85:
-created: object(107)
-written: object(106)
+created: object(108)
+written: object(107)
 
 task 4 'run'. lines 86-88:
-created: object(109)
-written: object(108)
+created: object(110)
+written: object(109)
 
 task 5 'run'. lines 89-91:
 Error: Transaction Effects Status: Move object with size 256001 is larger than the maximum object size 256000
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveObjectTooBig { object_size: 256001, max_object_size: 256000 }, source: None, command: None } }
 
 task 6 'run'. lines 92-92:
-created: object(112)
-written: object(111)
+created: object(113)
+written: object(112)
 
 task 7 'run'. lines 94-94:
-created: object(114)
-written: object(113)
-deleted: object(112)
+created: object(115)
+written: object(114)
+deleted: object(113)
 
 task 8 'run'. lines 96-96:
 Error: Transaction Effects Status: Move object with size 256001 is larger than the maximum object size 256000

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.move
@@ -3,7 +3,7 @@
 
 // Test creating objects just below the size limit, and above it
 
-//# init --addresses Test=0x0
+//# init --addresses Test=0x0 --accounts A
 
 //# publish
 
@@ -77,20 +77,20 @@ module Test::M1 {
 }
 
 // create above size limit should fail
-//# run Test::M1::transfer_object_with_size --args 256001
+//# run Test::M1::transfer_object_with_size --args 256001 --sender A
 
 // create under size limit should succeed
-//# run Test::M1::transfer_object_with_size --args 255999
+//# run Test::M1::transfer_object_with_size --args 255999 --sender A
 
 // create at size limit should succeed
-//# run Test::M1::transfer_object_with_size --args 256000
+//# run Test::M1::transfer_object_with_size --args 256000 --sender A
 
 // adding 1 byte to an object at the size limit should fail
-//# run Test::M1::add_byte --args object(109)
+//# run Test::M1::add_byte --args object(110) --sender A
 
 // create at size limit, wrap, increase to over size limit while wrapped, then unwrap. should fail
-//# run Test::M1::transfer_object_with_size --args 255968
+//# run Test::M1::transfer_object_with_size --args 255968 --sender A
 
-//# run Test::M1::wrap --args object(112)
+//# run Test::M1::wrap --args object(113) --sender A
 
-//# run Test::M1::add_bytes_then_unwrap --args object(114) 33
+//# run Test::M1::add_bytes_then_unwrap --args object(115) 33 --sender A

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
@@ -18,15 +18,14 @@ Version: 2
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 999990u64}}
 
 task 4 'view-object'. lines 14-14:
-Owner: Account Address ( B )
+Owner: Account Address ( A )
 Version: 2
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 10u64}}
 
 task 5 'run'. lines 16-16:
-created: object(109)
-written: object(101), object(108)
+Error: Transaction was not signed by the correct sender: Object 0xbea8d80a001a7aaf43f65d32de297e626941d085d8ba7d961aabb0a9d5743c4e is owned by account address 0x7712d02e8b2f08d9ab748bcf206bda1f5ca6190b05275ca35f38e1e5ac2fbf40, but given owner/signer address is 0x71ec6a1723a2c1e61444626d6a90d65f2b750d681e01c9b4c9780946b0eadbb0
 
 task 6 'view-object'. lines 18-18:
 Owner: Account Address ( B )
-Version: 3
+Version: 2
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 999990u64}}

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.move
@@ -7,12 +7,12 @@
 
 //# view-object 101
 
-//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(101) 10 @B --sender A
+//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(101) 10 @A --sender B
 
 //# view-object 101
 
 //# view-object 107
 
-//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(101) 0 @C --sender B
+//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(101) 0 @C --sender A
 
 //# view-object 101

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze.move
@@ -69,10 +69,10 @@ module test::object_basics {
     }
 }
 
-//# run test::object_basics::create --args 10 @A
+//# run test::object_basics::create --args 10 @A --sender A
 
-//# run test::object_basics::freeze_object --args object(107)
+//# run test::object_basics::freeze_object --args object(107) --sender A
 
-//# run test::object_basics::transfer --args object(107) @A
+//# run test::object_basics::transfer --args object(107) @A --sender A
 
-//# run test::object_basics::set_value --args object(107) 1
+//# run test::object_basics::set_value --args object(107) 1 --sender A

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.exp
@@ -17,12 +17,11 @@ Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(108)}}}
 
 task 4 'transfer-object'. lines 35-35:
-Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None, command: None } }
+Error: Attempt to transfer object 0x082da293d12d8186c1f1ff6ceee9e1ab0ccc9a298d8fa6c3975312671c259cc9 that does not have public transfer. Object transfer must be done instead using a distinct Move function call.
 
 task 5 'view-object'. lines 37-40:
 Owner: Account Address ( A )
-Version: 3
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(108)}}}
 
 task 6 'run'. lines 42-42:
@@ -35,10 +34,9 @@ Version: 2
 Contents: test::m::Cup<test::m::S> {id: sui::object::UID {id: sui::object::ID {bytes: fake(111)}}}
 
 task 8 'transfer-object'. lines 46-46:
-Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None, command: None } }
+Error: Attempt to transfer object 0x31fc0da61fb90473750ddd04b7772869f37dccbfffc7edd4cd50acbf26157dfe that does not have public transfer. Object transfer must be done instead using a distinct Move function call.
 
 task 9 'view-object'. lines 48-48:
 Owner: Account Address ( A )
-Version: 3
+Version: 2
 Contents: test::m::Cup<test::m::S> {id: sui::object::UID {id: sui::object::ID {bytes: fake(111)}}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.exp
@@ -17,8 +17,7 @@ Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(108)}}}
 
 task 4 'transfer-object'. lines 28-28:
-Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None, command: None } }
+Error: Attempt to transfer object 0x082da293d12d8186c1f1ff6ceee9e1ab0ccc9a298d8fa6c3975312671c259cc9 that does not have public transfer. Object transfer must be done instead using a distinct Move function call.
 
 task 5 'view-object'. lines 30-30:
 Owner: Immutable

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
@@ -11,8 +11,7 @@ task 2 'view-object'. lines 13-13:
 106::m
 
 task 3 'transfer-object'. lines 15-15:
-Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None, command: None } }
+Error: Attempt to transfer object 0x3d018ae3eb4670e1f112839d8343a6702525cbe9ea60ad59ff9f2f2743cccf6f that does not have public transfer. Object transfer must be done instead using a distinct Move function call.
 
 task 4 'view-object'. lines 17-17:
 106::m

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
@@ -21,10 +21,9 @@ Version: 3
 Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(110)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(111)}}
 
 task 5 'transfer-object'. lines 35-35:
-Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None, command: None } }
+Error: Attempt to transfer object 0x6275cf6234e8410dffa1af64cf108d68e1912de97438e7a3c75d73e8ff5ca38f that does not have public transfer. Object transfer must be done instead using a distinct Move function call.
 
 task 6 'view-object'. lines 37-37:
 Owner: Object ID: ( fake(108) )
-Version: 4
+Version: 3
 Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(110)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(111)}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
@@ -17,10 +17,9 @@ Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(108)}}}
 
 task 4 'transfer-object'. lines 27-27:
-Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None, command: None } }
+Error: Attempt to transfer object 0x745ea5d547883aa753c1f9ad61290dafd7a462cc162ae5ddf2ede94917e3bf49 that does not have public transfer. Object transfer must be done instead using a distinct Move function call.
 
 task 5 'view-object'. lines 29-29:
 Owner: Shared
-Version: 3
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(108)}}}

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -56,7 +56,7 @@ pub async fn check_transaction_input(
     let gas_status = get_gas_status(store, epoch_store, transaction).await?;
     let input_objects = transaction.input_objects()?;
     let objects = store.check_input_objects(&input_objects)?;
-    let input_objects = check_objects(transaction, input_objects, objects).await?;
+    let input_objects = check_objects(transaction, input_objects, objects)?;
     Ok((gas_status, input_objects))
 }
 
@@ -122,7 +122,7 @@ pub async fn check_certificate_input(
     } else {
         store.check_sequenced_input_objects(cert.digest(), &input_object_kinds, epoch_store)?
     };
-    let input_objects = check_objects(tx_data, input_object_kinds, input_object_data).await?;
+    let input_objects = check_objects(tx_data, input_object_kinds, input_object_data)?;
     Ok((gas_status, input_objects))
 }
 
@@ -217,7 +217,7 @@ async fn check_gas(
 /// Check all the objects used in the transaction against the database, and ensure
 /// that they are all the correct version and number.
 #[instrument(level = "trace", skip_all)]
-async fn check_objects(
+pub fn check_objects(
     transaction: &TransactionData,
     input_objects: Vec<InputObjectKind>,
     objects: Vec<Object>,


### PR DESCRIPTION
## Description 

Input checker was not run before execution in transactional tests. The programmable transaction runtime relies on these checks

## Test Plan 

Just test fixes 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
