### PR TITLE
move: use lock resolver helper everywhere

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -40,10 +40,8 @@ impl Build {
         path: Option<PathBuf>,
         build_config: MoveBuildConfig,
     ) -> anyhow::Result<()> {
-        let rerooted_path = base::reroot_path(path)?;
-        let lock_file_path = rerooted_path.join("Move.lock");
-        let mut build_config = build_config;
-        build_config.lock_file = Some(lock_file_path);
+        let rerooted_path = base::reroot_path(path.clone())?;
+        let build_config = resolve_lock_file_path(build_config, path)?;
         Self::execute_internal(
             &rerooted_path,
             build_config,
@@ -85,4 +83,16 @@ impl Build {
 
         Ok(())
     }
+}
+
+/// Resolve Move.lock file path in package directory (where Move.toml is).
+pub fn resolve_lock_file_path(
+    build_config: MoveBuildConfig,
+    package_path: Option<PathBuf>,
+) -> Result<MoveBuildConfig, anyhow::Error> {
+    let package_root = base::reroot_path(package_path)?;
+    let lock_file_path = package_root.join("Move.lock");
+    let mut build_config = build_config;
+    build_config.lock_file = Some(lock_file_path);
+    Ok(build_config)
 }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -19,7 +19,6 @@ use fastcrypto::{
     encoding::{Base64, Encoding},
     traits::ToFromBytes,
 };
-use move_cli::base;
 use move_core_types::language_storage::TypeTag;
 use move_package::BuildConfig as MoveBuildConfig;
 use prettytable::Table;
@@ -27,6 +26,7 @@ use prettytable::{row, table};
 use serde::Serialize;
 use serde_json::{json, Value};
 use sui_framework::build_move_package;
+use sui_move::build::resolve_lock_file_path;
 use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 use sui_types::error::SuiError;
 
@@ -467,7 +467,8 @@ impl SuiClientCommands {
                 let sender = context.try_get_object_owner(&gas).await?;
                 let sender = sender.unwrap_or(context.active_address()?);
 
-                let build_config = resolve_lock_file_path(build_config, package_path.clone())?;
+                let build_config =
+                    resolve_lock_file_path(build_config, Some(package_path.clone()))?;
 
                 let compiled_package = build_move_package(
                     &package_path,
@@ -1007,7 +1008,8 @@ impl SuiClientCommands {
                     ));
                 }
 
-                let build_config = resolve_lock_file_path(build_config, package_path.clone())?;
+                let build_config =
+                    resolve_lock_file_path(build_config, Some(package_path.clone()))?;
 
                 let compiled_package = build_move_package(
                     &package_path,
@@ -1044,18 +1046,6 @@ impl SuiClientCommands {
         config.active_env = env;
         Ok(())
     }
-}
-
-/// Resolve Move.lock file path in package directory (where Move.toml is).
-fn resolve_lock_file_path(
-    build_config: MoveBuildConfig,
-    package_path: PathBuf,
-) -> Result<MoveBuildConfig, anyhow::Error> {
-    let package_root = base::reroot_path(Some(package_path))?;
-    let lock_file_path = package_root.join("Move.lock");
-    let mut build_config = build_config;
-    build_config.lock_file = Some(lock_file_path);
-    Ok(build_config)
 }
 
 pub struct WalletContext {


### PR DESCRIPTION
## Description 

Follow up of https://github.com/MystenLabs/sui/pull/8565/files#r1118646046 that I missed addressing.

## Test Plan 

Semantics-preserving change, existing tests pass.
