### PR TITLE
[Narwhal] ensure worker can handle temporary errors

### DIFF
--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -49,7 +49,7 @@ pub struct BatchMaker {
     /// Channel to receive transactions from the network.
     rx_batch_maker: Receiver<(Transaction, TxResponse)>,
     /// Output channel to deliver sealed batches to the `QuorumWaiter`.
-    tx_quorum_waiter: Sender<(Batch, Option<tokio::sync::oneshot::Sender<()>>)>,
+    tx_quorum_waiter: Sender<(Batch, tokio::sync::oneshot::Sender<()>)>,
     /// Metrics handler
     node_metrics: Arc<WorkerMetrics>,
     /// The timestamp of the batch creation.
@@ -69,7 +69,7 @@ impl BatchMaker {
         max_batch_delay: Duration,
         rx_shutdown: ConditionalBroadcastReceiver,
         rx_batch_maker: Receiver<(Transaction, TxResponse)>,
-        tx_quorum_waiter: Sender<(Batch, Option<tokio::sync::oneshot::Sender<()>>)>,
+        tx_quorum_waiter: Sender<(Batch, tokio::sync::oneshot::Sender<()>)>,
         node_metrics: Arc<WorkerMetrics>,
         store: Store<BatchDigest, Batch>,
         tx_our_batch: Sender<(WorkerOurBatchMessage, PrimaryResponse)>,
@@ -233,7 +233,7 @@ impl BatchMaker {
         let (notify_done, done_sending) = tokio::sync::oneshot::channel();
         if self
             .tx_quorum_waiter
-            .send((batch.clone(), Some(notify_done)))
+            .send((batch.clone(), notify_done))
             .await
             .is_err()
         {

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -6,12 +6,12 @@ use crate::batch_maker::MAX_PARALLEL_BATCH;
 use config::{Committee, SharedWorkerCache, Stake, WorkerId};
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
-use futures::stream::{futures_unordered::FuturesUnordered, FuturesOrdered, StreamExt as _};
+use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
 use mysten_metrics::{monitored_future, spawn_logged_monitored_task};
 use network::{CancelOnDropHandler, ReliableNetwork};
 use std::time::Duration;
 use tokio::{task::JoinHandle, time::timeout};
-use tracing::{error, trace};
+use tracing::{trace, warn};
 use types::{metered_channel::Receiver, Batch, ConditionalBroadcastReceiver, WorkerBatchMessage};
 
 #[cfg(test)]
@@ -77,8 +77,7 @@ impl QuorumWaiter {
 
     /// Main loop.
     async fn run(&mut self) {
-        //
-        let mut pipeline = FuturesOrdered::new();
+        let mut pipeline = FuturesUnordered::new();
         let mut best_effort_with_timeout = FuturesUnordered::new();
 
         loop {
@@ -88,7 +87,7 @@ impl QuorumWaiter {
                 // task to the pipeline to send this batch to workers.
                 //
                 // TODO: make the constant a config parameter.
-                Some((batch, opt_channel)) = self.rx_quorum_waiter.recv(), if pipeline.len() < MAX_PARALLEL_BATCH => {
+                Some((batch, mut opt_channel)) = self.rx_quorum_waiter.recv(), if pipeline.len() < MAX_PARALLEL_BATCH => {
                     // Broadcast the batch to the other workers.
                     let workers: Vec<_> = self
                         .worker_cache
@@ -117,40 +116,41 @@ impl QuorumWaiter {
                     let threshold = self.committee.quorum_threshold();
                     let mut total_stake = self.committee.stake(&self.name);
 
-                    pipeline.push_back(async move {
+                    pipeline.push(async move {
                         // A future that sends to 2/3 stake then returns. Also prints an error
                         // if we terminate before we have managed to get to the full 2/3 stake.
-
                         loop{
                             if let Some(stake) = wait_for_quorum.next().await {
                                 total_stake += stake;
                                 if total_stake >= threshold {
-
                                     // Notify anyone waiting for this.
-                                    if let Some(channel) = opt_channel {
+                                    if let Some(channel) = opt_channel.take() {
                                         if let Err(e) = channel.send(()) {
-                                            error!("Channel waiting for quorum response dropped: {:?}", e);
+                                            warn!("Channel waiting for quorum response dropped: {:?}", e);
                                         }
                                     }
                                     break
                                 }
                             } else {
-                                // TODO: maybe we should be stopping the system if that happens,
-                                //       since it seems serious. However, it may happen at the
-                                //       start of the epoch when not everyone is ready?
-                                tracing::error!("Batch dissemination ended without a quorum.");
+                                // This should not happen, because `broadcast()` is supposed to
+                                // keep retrying.
+                                warn!("Batch dissemination ended without a quorum. Shutting down.");
                                 break;
                             }
                         }
-                        (batch, wait_for_quorum)
+                        (batch, opt_channel, wait_for_quorum)
                     });
                 },
 
                 // Process futures in the pipeline. They complete when we have sent to >2/3
                 // of other worker by stake, but after that we still try to send to the remaining
                 // on a best effort basis.
-                Some((batch, mut remaining)) = pipeline.next() => {
-
+                Some((batch, opt_channel, mut remaining)) = pipeline.next() => {
+                    // opt_channel is not consumed only when the worker is shutting down and
+                    // broadcast fails. TODO: switch to returning a status from pipeline.
+                    if opt_channel.is_some() {
+                        return;
+                    }
                     // Attempt to send messages to the remaining workers
                     if !remaining.is_empty() {
                         trace!("Best effort dissemination for batch {} for remaining {}", batch.digest(), remaining.len());
@@ -164,7 +164,6 @@ impl QuorumWaiter {
                            }).await
                        });
                     }
-
                 },
 
                 // Drive the best effort send efforts which may update remaining workers

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -29,7 +29,7 @@ async fn make_batch() {
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let (tx_batch_maker, rx_batch_maker) = test_utils::test_channel!(1);
     let (tx_quorum_waiter, mut rx_quorum_waiter) = test_utils::test_channel!(1);
-    let (tx_digest, mut rx_digest) = test_utils::test_channel!(1);
+    let (tx_our_batch, mut rx_our_batch) = test_utils::test_channel!(1);
     let node_metrics = WorkerMetrics::new(&Registry::new());
 
     // Spawn a `BatchMaker` instance.
@@ -44,7 +44,7 @@ async fn make_batch() {
         tx_quorum_waiter,
         Arc::new(node_metrics),
         store.clone(),
-        tx_digest,
+        tx_our_batch,
     );
 
     // Send enough transactions to seal a batch.
@@ -66,7 +66,7 @@ async fn make_batch() {
     }
 
     // Now we send to primary
-    let (_message, respond) = rx_digest.recv().await.unwrap();
+    let (_message, respond) = rx_our_batch.recv().await.unwrap();
     assert!(respond.unwrap().send(()).is_ok());
 
     assert!(r0.await.is_ok());
@@ -87,7 +87,7 @@ async fn batch_timeout() {
     let (tx_batch_maker, rx_batch_maker) = test_utils::test_channel!(1);
     let (tx_quorum_waiter, mut rx_quorum_waiter) = test_utils::test_channel!(1);
     let node_metrics = WorkerMetrics::new(&Registry::new());
-    let (tx_digest, mut rx_digest) = test_utils::test_channel!(1);
+    let (tx_our_batch, mut rx_our_batch) = test_utils::test_channel!(1);
 
     // Spawn a `BatchMaker` instance.
     let id = 0;
@@ -101,7 +101,7 @@ async fn batch_timeout() {
         tx_quorum_waiter,
         Arc::new(node_metrics),
         store.clone(),
-        tx_digest,
+        tx_our_batch,
     );
 
     // Do not send enough transactions to seal a batch.
@@ -120,7 +120,7 @@ async fn batch_timeout() {
     }
 
     // Now we send to primary
-    let (_message, respond) = rx_digest.recv().await.unwrap();
+    let (_message, respond) = rx_our_batch.recv().await.unwrap();
     assert!(respond.unwrap().send(()).is_ok());
 
     assert!(r0.await.is_ok());

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -56,14 +56,12 @@ async fn make_batch() {
 
     // Ensure the batch is as expected.
     let expected_batch = Batch::new(vec![tx.clone(), tx.clone()]);
-    let (batch, overall_response) = rx_quorum_waiter.recv().await.unwrap();
+    let (batch, resp) = rx_quorum_waiter.recv().await.unwrap();
 
     assert_eq!(batch.transactions, expected_batch.transactions);
 
     // Eventually deliver message
-    if let Some(resp) = overall_response {
-        assert!(resp.send(()).is_ok());
-    }
+    assert!(resp.send(()).is_ok());
 
     // Now we send to primary
     let (_message, respond) = rx_our_batch.recv().await.unwrap();
@@ -110,14 +108,12 @@ async fn batch_timeout() {
     tx_batch_maker.send((tx.clone(), s0)).await.unwrap();
 
     // Ensure the batch is as expected.
-    let (batch, overall_response) = rx_quorum_waiter.recv().await.unwrap();
+    let (batch, resp) = rx_quorum_waiter.recv().await.unwrap();
     let expected_batch = Batch::new(vec![tx.clone()]);
     assert_eq!(batch.transactions, expected_batch.transactions);
 
     // Eventually deliver message
-    if let Some(resp) = overall_response {
-        assert!(resp.send(()).is_ok());
-    }
+    assert!(resp.send(()).is_ok());
 
     // Now we send to primary
     let (_message, respond) = rx_our_batch.recv().await.unwrap();

--- a/narwhal/worker/src/tests/quorum_waiter_tests.rs
+++ b/narwhal/worker/src/tests/quorum_waiter_tests.rs
@@ -52,10 +52,7 @@ async fn wait_for_quorum() {
 
     // Forward the batch along with the handlers to the `QuorumWaiter`.
     let (s, r) = tokio::sync::oneshot::channel();
-    tx_quorum_waiter
-        .send((batch.clone(), Some(s)))
-        .await
-        .unwrap();
+    tx_quorum_waiter.send((batch.clone(), s)).await.unwrap();
 
     // Wait for the `QuorumWaiter` to gather enough acknowledgements and output the batch.
     r.await.unwrap();
@@ -112,17 +109,11 @@ async fn pipeline_for_quorum() {
 
     // Forward the batch along with the handlers to the `QuorumWaiter`.
     let (s0, r0) = tokio::sync::oneshot::channel();
-    tx_quorum_waiter
-        .send((batch.clone(), Some(s0)))
-        .await
-        .unwrap();
+    tx_quorum_waiter.send((batch.clone(), s0)).await.unwrap();
 
     // Forward the batch along with the handlers to the `QuorumWaiter`.
     let (s1, r1) = tokio::sync::oneshot::channel();
-    tx_quorum_waiter
-        .send((batch.clone(), Some(s1)))
-        .await
-        .unwrap();
+    tx_quorum_waiter.send((batch.clone(), s1)).await.unwrap();
 
     // Wait for the `QuorumWaiter` to gather enough acknowledgements and output the batch.
     r0.await.unwrap();

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -494,7 +494,7 @@ impl Worker {
             self.committee.clone(),
             self.worker_cache.clone(),
             shutdown_receivers.pop().unwrap(),
-            /* rx_message */ rx_quorum_waiter,
+            rx_quorum_waiter,
             network,
         );
 


### PR DESCRIPTION
## Description 

Currently BatchMaker and QuorumWaiter uses FuturesOrdered internally, so a slow operation can block all other operations behind. I don't think order is important here, so changing to FuturesUnordered.

Increase the size of batch pipeline from 25 to 100. Otherwise batch pipeline blocks if there are network issues lasting longer than 2.5s.

Also make some cleanups.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
