### PR TITLE
Update QD/AuthAggregator error handling & retry logic

### DIFF
--- a/crates/sui-core/src/quorum_driver/metrics.rs
+++ b/crates/sui-core/src/quorum_driver/metrics.rs
@@ -15,7 +15,6 @@ pub struct QuorumDriverMetrics {
     pub(crate) total_enqueued: IntCounter,
     pub(crate) total_ok_responses: IntCounter,
     pub(crate) total_err_responses: IntCounterVec,
-    pub(crate) total_aggregated_non_recoverable_err: IntCounterVec,
     pub(crate) attempt_times_ok_response: Histogram,
 
     // TODO: add histogram of attempt that tx succeeds
@@ -25,8 +24,6 @@ pub struct QuorumDriverMetrics {
     pub(crate) total_attempts_retrying_conflicting_transaction: IntCounter,
     pub(crate) total_successful_attempts_retrying_conflicting_transaction: IntCounter,
     pub(crate) total_times_conflicting_transaction_already_finalized_when_retrying: IntCounter,
-
-    pub(crate) total_equivocation_detected: IntCounter,
 }
 
 impl QuorumDriverMetrics {
@@ -54,13 +51,6 @@ impl QuorumDriverMetrics {
                 "quorum_driver_total_err_responses",
                 "Total number of requests returned with Err responses, grouped by error type",
                 &["error"],
-                registry,
-            )
-            .unwrap(),
-            total_aggregated_non_recoverable_err: register_int_counter_vec_with_registry!(
-                "quorum_driver_total_aggregated_non_recoverable_err",
-                "Total number of errors return from validators per transaction, grouped by error type",
-                &["error", "tx_recoverable"],
                 registry,
             )
             .unwrap(),
@@ -96,12 +86,6 @@ impl QuorumDriverMetrics {
             total_times_conflicting_transaction_already_finalized_when_retrying: register_int_counter_with_registry!(
                 "quorum_driver_total_times_conflicting_transaction_already_finalized_when_retrying",
                 "Total number of times the conflicting transaction is already finalized when retrying",
-                registry,
-            )
-            .unwrap(),
-            total_equivocation_detected: register_int_counter_with_registry!(
-                "quorum_driver_total_equivocation_detected",
-                "Total number of equivocations that are detected",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -289,10 +289,7 @@ where
                         .attempt_conflicting_transaction(
                             &conflicting_tx_digest,
                             &tx_digest,
-                            validators
-                                .iter()
-                                .map(|(pub_key, _)| pub_key.clone())
-                                .collect(),
+                            validators.iter().map(|(pub_key, _)| *pub_key).collect(),
                         )
                         .await;
 

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -294,7 +294,7 @@ where
                         ?errors,
                         "Observed Tx {tx_digest:} is still in retryable state. Conflicting Txes: {conflicting_tx_digests:?}", 
                     );
-                    return Err(None);
+                    Err(None)
                 }
             }
 

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -10,11 +10,10 @@ use crate::{
     authority::authority_notify_read::NotifyRead, quorum_driver::QuorumDriverMetrics,
     test_utils::init_local_authorities,
 };
+use std::sync::Arc;
 use std::time::Duration;
-use std::{collections::BTreeMap, sync::Arc};
 use sui_types::base_types::SuiAddress;
-use sui_types::crypto::get_key_pair;
-use sui_types::crypto::{deterministic_random_account_key, AccountKeyPair};
+use sui_types::crypto::{deterministic_random_account_key, get_key_pair, AccountKeyPair};
 use sui_types::messages::{TransactionEffectsAPI, VerifiedTransaction};
 use sui_types::object::{generate_test_gas_objects, Object};
 use sui_types::quorum_driver_types::{QuorumDriverError, QuorumDriverResult};
@@ -202,7 +201,7 @@ async fn test_quorum_driver_update_validators_and_max_retry_times() {
 }
 
 #[tokio::test]
-async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error> {
+async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let gas_objects = generate_test_gas_objects();
     let (sender, keypair): (SuiAddress, AccountKeyPair) = deterministic_random_account_key();
 
@@ -241,20 +240,23 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
     let client1 = aggregator.clone_client(names[1]);
     let client2 = aggregator.clone_client(names[2]);
 
-    // Case 1 - two validators lock the object with the same tx
+    println!("Case 0 - two validators lock the object with the same tx");
     assert!(client0.handle_transaction(tx.clone()).await.is_ok());
     assert!(client1.handle_transaction(tx.clone()).await.is_ok());
 
     let tx2 = make_tx(&gas, sender, &keypair);
     let res = quorum_driver.submit_transaction(tx2).await.unwrap().await;
-    // If aggregator gets two bad responses from 0 and 1 before getting two good responses from 2 and 3,
-    // it will retry tx, but it will fail due to equivocaiton.
-    // If aggregator gets two good responses from client 2 and 3 before two bad responses from 0 and 1,
-    // tx will not be retried.
+    // Aggregator waits for all responses when it sees a conflicting tx and because
+    // there are >= f+1 good responses and conflicting tx1. Neither transaction
+    // can be retried due to equivocation and this is a fatal error.
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes, ..
+        conflicting_txes,
+        retried_tx,
+        retried_tx_success,
     }) = res
     {
+        assert_eq!(retried_tx, None);
+        assert_eq!(retried_tx_success, None);
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -264,7 +266,7 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
         );
     }
 
-    // Case 2 - three validators lock the object with the same tx
+    println!("Case 1 - three validators lock the object with the same tx");
     let gas = gas_objects.pop().unwrap();
     let tx = make_tx(&gas, sender, &keypair);
 
@@ -293,7 +295,7 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
         )
     }
 
-    // Case 3 - one validator locks the object
+    println!("Case 2 - one validator locks the object");
     let gas = gas_objects.pop().unwrap();
     let tx = make_tx(&gas, sender, &keypair);
     assert!(client0.handle_transaction(tx.clone()).await.is_ok());
@@ -312,7 +314,7 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
     let QuorumDriverResponse { effects_cert, .. } = res;
     assert_eq!(*effects_cert.transaction_digest(), tx2_digest);
 
-    // Case 4 - object is locked by 2 txes with weight 2 and 1 respectivefully. Then try to execute the third txn
+    println!("Case 3 - object is locked by 2 txes with weight 2 and 1 respectivefully. Then try to execute the third txn");
     let gas = gas_objects.pop().unwrap();
     let tx = make_tx(&gas, sender, &keypair);
     let tx2 = make_tx(&gas, sender, &keypair);
@@ -325,16 +327,27 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
 
     let res = quorum_driver.submit_transaction(tx3).await.unwrap().await;
 
-    // If aggregator gets two bad responses from 0 and 1, it will retry tx, but it will fail due to equivocaiton.
-    // If aggregator gets two bad responses of which one from 2, then no tx will be retried.
-    if !matches!(res, Err(QuorumDriverError::ObjectsDoubleUsed { .. })) {
+    // Aggregator waits for all responses when it sees a conflicting tx and because
+    // there are >= f+1 conflicting tx1, so it will retry that one, which should fail.
+    if let Err(QuorumDriverError::ObjectsDoubleUsed {
+        conflicting_txes,
+        retried_tx,
+        retried_tx_success,
+    }) = res
+    {
+        assert_eq!(retried_tx, Some(*tx.digest()));
+        assert_eq!(retried_tx_success, Some(false));
+        assert_eq!(conflicting_txes.len(), 2);
+        assert_eq!(conflicting_txes.get(tx.digest()).unwrap().1, 5000);
+        assert_eq!(conflicting_txes.get(tx2.digest()).unwrap().1, 2500);
+    } else {
         panic!(
             "expect Err(QuorumDriverError::ObjectsDoubleUsed) but got {:?}",
             res
         )
     }
 
-    // Case 5 - object is locked by 2 txes with weight 2 and 1, try to execute the lighter stake tx
+    println!("Case 4 - object is locked by 2 txes with weight 2 and 1, try to execute the lighter stake tx");
     let gas = gas_objects.pop().unwrap();
     let tx = make_tx(&gas, sender, &keypair);
     let tx2 = make_tx(&gas, sender, &keypair);
@@ -344,16 +357,27 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
     println!("tx2: {:?}", tx2.digest());
     let res = quorum_driver.submit_transaction(tx2).await.unwrap().await;
 
-    // if aggregator gets two bad responses from 0 and 1 first, it will try to retry tx (stake = 2), but that will fail
-    // If aggregator gets two bad responses of which one from 2, then no tx will be retried.
-    if !matches!(res, Err(QuorumDriverError::ObjectsDoubleUsed { .. })) {
+    // Aggregator waits for all responses when it sees a conflicting tx and because
+    // there are >= f+1 good responses and conflicting tx1. Neither transaction
+    // can be retried due to equivocation and this is a fatal error.
+    if let Err(QuorumDriverError::ObjectsDoubleUsed {
+        conflicting_txes,
+        retried_tx,
+        retried_tx_success,
+    }) = res
+    {
+        assert_eq!(retried_tx, None);
+        assert_eq!(retried_tx_success, None);
+        assert_eq!(conflicting_txes.len(), 1);
+        assert_eq!(conflicting_txes.get(tx.digest()).unwrap().1, 5000);
+    } else {
         panic!(
             "expect Err(QuorumDriverError::ObjectsDoubleUsed) but got {:?}",
             res
         )
     }
 
-    // Case 6 - object is locked by 2 txes with weight 2 and 1, try to execute the heavier stake tx
+    println!("Case 5 - object is locked by 2 txes with weight 2 and 1, try to execute the heavier stake tx");
     let gas = gas_objects.pop().unwrap();
     let tx = make_tx(&gas, sender, &keypair);
     let tx_digest = *tx.digest();
@@ -373,86 +397,43 @@ async fn test_quorum_driver_retry_on_object_locked() -> Result<(), anyhow::Error
     let QuorumDriverResponse { effects_cert, .. } = res;
     assert_eq!(*effects_cert.transaction_digest(), tx_digest);
 
-    // Case 7 - three validators lock the object, by different txes
+    println!("Case 6 - three validators lock the object, by different txes");
     let gas = gas_objects.pop().unwrap();
     let tx = make_tx(&gas, sender, &keypair);
     let tx2 = make_tx(&gas, sender, &keypair);
     let tx3 = make_tx(&gas, sender, &keypair);
-    assert!(client0.handle_transaction(tx).await.is_ok());
-    assert!(client1.handle_transaction(tx2).await.is_ok());
-    assert!(client2.handle_transaction(tx3).await.is_ok());
+    assert!(client0.handle_transaction(tx.clone()).await.is_ok());
+    assert!(client1.handle_transaction(tx2.clone()).await.is_ok());
+    assert!(client2.handle_transaction(tx3.clone()).await.is_ok());
 
     let tx4 = make_tx(&gas, sender, &keypair);
-    let res = quorum_driver.submit_transaction(tx4).await.unwrap().await;
+    let res = quorum_driver
+        .submit_transaction(tx4.clone())
+        .await
+        .unwrap()
+        .await;
 
-    if !matches!(res, Err(QuorumDriverError::ObjectsDoubleUsed { .. })) {
+    // Aggregator waits for all responses when it sees a conflicting tx and because
+    // there are no conflicting tx >= f+1 none can be retryed. Additionally the original
+    // transaction also does not have >= f+1 good stake so it cannot be retried.
+    if let Err(QuorumDriverError::ObjectsDoubleUsed {
+        conflicting_txes,
+        retried_tx,
+        retried_tx_success,
+    }) = res
+    {
+        assert_eq!(retried_tx, None);
+        assert_eq!(retried_tx_success, None);
+        assert_eq!(conflicting_txes.len(), 3);
+        assert_eq!(conflicting_txes.get(tx.digest()).unwrap().1, 2500);
+        assert_eq!(conflicting_txes.get(tx2.digest()).unwrap().1, 2500);
+        assert_eq!(conflicting_txes.get(tx3.digest()).unwrap().1, 2500);
+    } else {
         panic!(
-            "expect Err(QuorumDriverError::ObjectsEquivocated) but got {:?}",
+            "expect Err(QuorumDriverError::ObjectsDoubleUsed) but got {:?}",
             res
         )
     }
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_quorum_driver_not_retry_on_object_locked() -> Result<(), anyhow::Error> {
-    let (auth_agg, _) = setup().await;
-
-    let quorum_driver_handler = QuorumDriverHandlerBuilder::new(
-        Arc::new(auth_agg.clone()),
-        Arc::new(QuorumDriverMetrics::new_for_tests()),
-    )
-    .with_notifier(Arc::new(NotifyRead::new()))
-    .with_reconfig_observer(Arc::new(DummyReconfigObserver {}))
-    .start();
-
-    let quorum_driver = quorum_driver_handler.clone_quorum_driver();
-    let validity = quorum_driver
-        .authority_aggregator()
-        .load()
-        .committee
-        .validity_threshold();
-
-    assert_eq!(auth_agg.clone_inner_clients().keys().cloned().count(), 4);
-
-    // good stake >= validity, no transaction will be retried, expect Ok(None)
-    assert_eq!(
-        quorum_driver
-            .attempt_conflicting_transactions_maybe(
-                validity,
-                &BTreeMap::new(),
-                &TransactionDigest::random()
-            )
-            .await,
-        Ok(None)
-    );
-    assert_eq!(
-        quorum_driver
-            .attempt_conflicting_transactions_maybe(
-                validity + 1,
-                &BTreeMap::new(),
-                &TransactionDigest::random()
-            )
-            .await,
-        Ok(None)
-    );
-
-    // good stake < validity, but the top transaction total stake < validaty too, no transaction will be retried, expect Ok(None)
-    let conflicting_tx_digests = BTreeMap::from([
-        (TransactionDigest::random(), (vec![], validity - 1)),
-        (TransactionDigest::random(), (vec![], 1)),
-    ]);
-    assert_eq!(
-        quorum_driver
-            .attempt_conflicting_transactions_maybe(
-                validity - 1,
-                &conflicting_tx_digests,
-                &TransactionDigest::random()
-            )
-            .await,
-        Ok(None)
-    );
 
     Ok(())
 }

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -248,7 +248,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let res = quorum_driver.submit_transaction(tx2).await.unwrap().await;
     // Aggregator waits for all responses when it sees a conflicting tx and because
     // there are >= f+1 good responses and conflicting tx1. Neither transaction
-    // can be retried due to equivocation and this is a fatal error.
+    // can be retried due to client double spend and this is a fatal error.
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
         retried_tx,
@@ -359,7 +359,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     // Aggregator waits for all responses when it sees a conflicting tx and because
     // there are >= f+1 good responses and conflicting tx1. Neither transaction
-    // can be retried due to equivocation and this is a fatal error.
+    // can be retried due to client double spend and this is a fatal error.
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
         retried_tx,

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -317,6 +317,10 @@ impl HandleTransactionTestAuthorityClient {
         self.tx_info_resp_to_return = Ok(resp);
     }
 
+    pub fn set_tx_info_response_error(&mut self, error: SuiError) {
+        self.tx_info_resp_to_return = Err(error);
+    }
+
     pub fn reset_tx_info_response(&mut self) {
         self.tx_info_resp_to_return = Err(SuiError::Unknown("".to_string()));
     }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1129,9 +1129,9 @@ async fn test_handle_conflicting_transaction_response() {
             matches!(
                 e,
                 AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    tx_digest_to_retry,
+                    conflicting_tx_digest_to_retry,
                     ..
-                } if tx_digest_to_retry.is_none()
+                } if conflicting_tx_digest_to_retry.is_none()
             )
         },
         |e| {
@@ -1162,9 +1162,9 @@ async fn test_handle_conflicting_transaction_response() {
             matches!(
                 e,
                 AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    tx_digest_to_retry,
+                    conflicting_tx_digest_to_retry,
                     ..
-                } if tx_digest_to_retry.is_none()
+                } if conflicting_tx_digest_to_retry.is_none()
             )
         },
         |e| {
@@ -1194,9 +1194,9 @@ async fn test_handle_conflicting_transaction_response() {
             matches!(
                 e,
                 AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    tx_digest_to_retry,
+                    conflicting_tx_digest_to_retry,
                     ..
-                } if *tx_digest_to_retry == Some(*conflicting_tx2.digest())
+                } if *conflicting_tx_digest_to_retry == Some(*conflicting_tx2.digest())
             )
         },
         |e| {
@@ -1208,7 +1208,7 @@ async fn test_handle_conflicting_transaction_response() {
     )
     .await;
 
-    println!("Case 3 - Non-retryable Tx due to equivocation");
+    println!("Case 3 - Non-retryable Tx due to client double spend");
     // Validators return >= f+1 conflicting Tx2 & >= f+1 good stake for Tx1
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 0);
     for (name, _) in authority_keys.iter().skip(2) {
@@ -1472,7 +1472,7 @@ async fn test_handle_conflicting_transaction_response() {
 
     println!("Case 5.1 - Retryable Transaction (WrongEpoch Error)");
     // Update committee store to epoch 2, now SafeClient will pass
-    let committee_2 = Committee::new(2, ProtocolVersion::MIN, authorities.clone()).unwrap();
+    let committee_2 = Committee::new(2, authorities.clone()).unwrap();
     agg.committee_store
         .insert_new_committee(&committee_2)
         .unwrap();
@@ -1513,7 +1513,7 @@ async fn assert_resp_err<E, F>(
         Err(received_agg_err) if agg_err_checker(&received_agg_err) => match received_agg_err {
             AggregatorProcessTransactionError::RetryableConflictingTransaction {
                 errors,
-                tx_digest_to_retry: _tx_digest_to_retry,
+                conflicting_tx_digest_to_retry: _,
                 conflicting_tx_digests,
             } => {
                 assert!(!conflicting_tx_digests.is_empty());

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -582,6 +582,19 @@ impl SuiError {
             _ => (false, false),
         }
     }
+
+    pub fn is_object_or_package_not_found(&self) -> bool {
+        match self {
+            SuiError::UserInputError { error } => {
+                matches!(
+                    error,
+                    UserInputError::ObjectNotFound { .. }
+                        | UserInputError::DependentPackageNotFound { .. }
+                )
+            }
+            _ => false,
+        }
+    }
 }
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;


### PR DESCRIPTION
## Description 

Part of the Quorum Driver Error Handling [workstream](https://www.notion.so/mystenlabs/Quorum-Driver-Error-Handling-37190cb8d68345eabaf9d337fdbbf784?pvs=4) for mainnet

All retry logic has been moved from QuorumDriver to AuthorityAggregator. QD will just be in charge of managing how many times to retry after receiving a determination from AA. 

This is the retry logic that has been implemented in AA:

Transactions are considered retryable until we hit one of the following exit criteria
- \>= 2f+1 good stake
- \>= f+1 non-retryable stake
- \>= 2f+1 `ObjectNotFound` or `DependentPackageNotFound` stake

If a conflicting Tx is encountered, we will wait for all responses to make one of the following determinations
- good stake + retryable stake >= 2f+1 -> **Tx is retryable**
- most staked conflicting stake + retryable stake >= 2f+1 -> **conflicting Tx is retryable**

If a non-quorum of effects is encountered, the tx is still considered retryable if most staked effects stake + retryable stake >= 2f+1. Otherwise we have encountered a safety violation or a fork.

Certificates are considered retryable until we hit one of the following exit criteria
- \>= 2f+1 good stake
- \>= f+1 non-retryable stake

## Test Plan 

How did you test the new or updated feature?

Added unit tests. Will see if additional tests are needed after review.
