### PR TITLE
rename consensus address to primary address in ValidatorMetadata

### DIFF
--- a/.changeset/heavy-steaks-act.md
+++ b/.changeset/heavy-steaks-act.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Correct "consensus_address" in ValidatorMetadata to "primary_address"

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -996,7 +996,7 @@ pub fn generate_genesis_system_object(
     let mut sui_addresses = Vec::new();
     let mut network_addresses = Vec::new();
     let mut p2p_addresses = Vec::new();
-    let mut consensus_addresses = Vec::new();
+    let mut primary_addresses = Vec::new();
     let mut worker_addresses = Vec::new();
     let mut names = Vec::new();
     let mut descriptions = Vec::new();
@@ -1017,7 +1017,7 @@ pub fn generate_genesis_system_object(
         sui_addresses.push(validator.sui_address());
         network_addresses.push(validator.network_address());
         p2p_addresses.push(validator.p2p_address());
-        consensus_addresses.push(validator.narwhal_primary_address());
+        primary_addresses.push(validator.narwhal_primary_address());
         worker_addresses.push(validator.narwhal_worker_address());
         names.push(validator.name().to_owned().into_bytes());
         descriptions.push(validator.description.clone().into_bytes());
@@ -1046,7 +1046,7 @@ pub fn generate_genesis_system_object(
             CallArg::Pure(bcs::to_bytes(&project_url).unwrap()),
             CallArg::Pure(bcs::to_bytes(&network_addresses).unwrap()),
             CallArg::Pure(bcs::to_bytes(&p2p_addresses).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&consensus_addresses).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&primary_addresses).unwrap()),
             CallArg::Pure(bcs::to_bytes(&worker_addresses).unwrap()),
             CallArg::Pure(bcs::to_bytes(&gas_prices).unwrap()),
             CallArg::Pure(bcs::to_bytes(&commission_rates).unwrap()),

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -227,7 +227,7 @@ validators:
         project_url: ""
         net_address: []
         p2p_address: []
-        consensus_address: []
+        primary_address: []
         worker_address: []
         next_epoch_protocol_pubkey_bytes: ~
         next_epoch_proof_of_possession: ~
@@ -235,7 +235,7 @@ validators:
         next_epoch_worker_pubkey_bytes: ~
         next_epoch_net_address: ~
         next_epoch_p2p_address: ~
-        next_epoch_consensus_address: ~
+        next_epoch_primary_address: ~
         next_epoch_worker_address: ~
       voting_power: 10000
       gas_price: 1

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -77,7 +77,7 @@ It will create a singleton SuiSystemState object, which contains
 all the information we need in the system.
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(initial_sui_custody_account_address: <b>address</b>, validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_p2p_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_consensus_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, protocol_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(initial_sui_custody_account_address: <b>address</b>, validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_p2p_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_primary_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, protocol_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -99,7 +99,7 @@ all the information we need in the system.
     validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_p2p_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
-    validator_consensus_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
+    validator_primary_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_gas_prices: <a href="">vector</a>&lt;u64&gt;,
     validator_commission_rates: <a href="">vector</a>&lt;u64&gt;,
@@ -120,7 +120,7 @@ all the information we need in the system.
             && <a href="_length">vector::length</a>(&validator_project_urls) == count
             && <a href="_length">vector::length</a>(&validator_net_addresses) == count
             && <a href="_length">vector::length</a>(&validator_p2p_addresses) == count
-            && <a href="_length">vector::length</a>(&validator_consensus_addresses) == count
+            && <a href="_length">vector::length</a>(&validator_primary_addresses) == count
             && <a href="_length">vector::length</a>(&validator_worker_addresses) == count
             && <a href="_length">vector::length</a>(&validator_gas_prices) == count
             && <a href="_length">vector::length</a>(&validator_commission_rates) == count,
@@ -139,7 +139,7 @@ all the information we need in the system.
         <b>let</b> project_url = *<a href="_borrow">vector::borrow</a>(&validator_project_urls, i);
         <b>let</b> net_address = *<a href="_borrow">vector::borrow</a>(&validator_net_addresses, i);
         <b>let</b> p2p_address = *<a href="_borrow">vector::borrow</a>(&validator_p2p_addresses, i);
-        <b>let</b> consensus_address = *<a href="_borrow">vector::borrow</a>(&validator_consensus_addresses, i);
+        <b>let</b> primary_address = *<a href="_borrow">vector::borrow</a>(&validator_primary_addresses, i);
         <b>let</b> worker_address = *<a href="_borrow">vector::borrow</a>(&validator_worker_addresses, i);
         <b>let</b> gas_price = *<a href="_borrow">vector::borrow</a>(&validator_gas_prices, i);
         <b>let</b> commission_rate = *<a href="_borrow">vector::borrow</a>(&validator_commission_rates, i);
@@ -155,7 +155,7 @@ all the information we need in the system.
             project_url,
             net_address,
             p2p_address,
-            consensus_address,
+            primary_address,
             worker_address,
             // TODO Figure out <b>if</b> we want <b>to</b> instead initialize validators <b>with</b> 0 stake.
             // Initialize all validators <b>with</b> 1 Mist stake.

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -28,7 +28,7 @@
 -  [Function `update_validator_project_url`](#0x2_sui_system_update_validator_project_url)
 -  [Function `update_validator_next_epoch_network_address`](#0x2_sui_system_update_validator_next_epoch_network_address)
 -  [Function `update_validator_next_epoch_p2p_address`](#0x2_sui_system_update_validator_next_epoch_p2p_address)
--  [Function `update_validator_next_epoch_consensus_address`](#0x2_sui_system_update_validator_next_epoch_consensus_address)
+-  [Function `update_validator_next_epoch_primary_address`](#0x2_sui_system_update_validator_next_epoch_primary_address)
 -  [Function `update_validator_next_epoch_worker_address`](#0x2_sui_system_update_validator_next_epoch_worker_address)
 -  [Function `update_validator_next_epoch_protocol_pubkey`](#0x2_sui_system_update_validator_next_epoch_protocol_pubkey)
 -  [Function `update_validator_next_epoch_worker_pubkey`](#0x2_sui_system_update_validator_next_epoch_worker_pubkey)
@@ -464,7 +464,7 @@ The <code><a href="validator.md#0x2_validator">validator</a></code> object needs
 The amount of stake in the <code><a href="validator.md#0x2_validator">validator</a></code> object must meet the requirements.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_validator">request_add_validator</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, consensus_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, stake: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, gas_price: u64, commission_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_validator">request_add_validator</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, primary_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, stake: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, gas_price: u64, commission_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -485,7 +485,7 @@ The amount of stake in the <code><a href="validator.md#0x2_validator">validator<
     project_url: <a href="">vector</a>&lt;u8&gt;,
     net_address: <a href="">vector</a>&lt;u8&gt;,
     p2p_address: <a href="">vector</a>&lt;u8&gt;,
-    consensus_address: <a href="">vector</a>&lt;u8&gt;,
+    primary_address: <a href="">vector</a>&lt;u8&gt;,
     worker_address: <a href="">vector</a>&lt;u8&gt;,
     stake: Coin&lt;SUI&gt;,
     gas_price: u64,
@@ -514,7 +514,7 @@ The amount of stake in the <code><a href="validator.md#0x2_validator">validator<
         project_url,
         net_address,
         p2p_address,
-        consensus_address,
+        primary_address,
         worker_address,
         <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(stake),
         <a href="_none">option::none</a>(),
@@ -1083,15 +1083,15 @@ The change will only take effects starting from the next epoch.
 
 </details>
 
-<a name="0x2_sui_system_update_validator_next_epoch_consensus_address"></a>
+<a name="0x2_sui_system_update_validator_next_epoch_primary_address"></a>
 
-## Function `update_validator_next_epoch_consensus_address`
+## Function `update_validator_next_epoch_primary_address`
 
-Update a validator's consensus address.
+Update a validator's narwhal primary address.
 The change will only take effects starting from the next epoch.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_update_validator_next_epoch_consensus_address">update_validator_next_epoch_consensus_address</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, consensus_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_update_validator_next_epoch_primary_address">update_validator_next_epoch_primary_address</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, primary_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1100,14 +1100,14 @@ The change will only take effects starting from the next epoch.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_update_validator_next_epoch_consensus_address">update_validator_next_epoch_consensus_address</a>(
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_update_validator_next_epoch_primary_address">update_validator_next_epoch_primary_address</a>(
     self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
-    consensus_address: <a href="">vector</a>&lt;u8&gt;,
+    primary_address: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
     <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x2_validator_update_next_epoch_consensus_address">validator::update_next_epoch_consensus_address</a>(<a href="validator.md#0x2_validator">validator</a>, consensus_address);
+    <a href="validator.md#0x2_validator_update_next_epoch_primary_address">validator::update_next_epoch_primary_address</a>(<a href="validator.md#0x2_validator">validator</a>, primary_address);
 }
 </code></pre>
 
@@ -1119,7 +1119,7 @@ The change will only take effects starting from the next epoch.
 
 ## Function `update_validator_next_epoch_worker_address`
 
-Update a validator's worker address.
+Update a validator's narwhal worker address.
 The change will only take effects starting from the next epoch.
 
 

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -28,7 +28,7 @@
 -  [Function `project_url`](#0x2_validator_project_url)
 -  [Function `network_address`](#0x2_validator_network_address)
 -  [Function `p2p_address`](#0x2_validator_p2p_address)
--  [Function `consensus_address`](#0x2_validator_consensus_address)
+-  [Function `primary_address`](#0x2_validator_primary_address)
 -  [Function `worker_address`](#0x2_validator_worker_address)
 -  [Function `protocol_pubkey_bytes`](#0x2_validator_protocol_pubkey_bytes)
 -  [Function `proof_of_possession`](#0x2_validator_proof_of_possession)
@@ -36,7 +36,7 @@
 -  [Function `worker_pubkey_bytes`](#0x2_validator_worker_pubkey_bytes)
 -  [Function `next_epoch_network_address`](#0x2_validator_next_epoch_network_address)
 -  [Function `next_epoch_p2p_address`](#0x2_validator_next_epoch_p2p_address)
--  [Function `next_epoch_consensus_address`](#0x2_validator_next_epoch_consensus_address)
+-  [Function `next_epoch_primary_address`](#0x2_validator_next_epoch_primary_address)
 -  [Function `next_epoch_worker_address`](#0x2_validator_next_epoch_worker_address)
 -  [Function `next_epoch_protocol_pubkey_bytes`](#0x2_validator_next_epoch_protocol_pubkey_bytes)
 -  [Function `next_epoch_proof_of_possession`](#0x2_validator_next_epoch_proof_of_possession)
@@ -60,7 +60,7 @@
 -  [Function `update_project_url`](#0x2_validator_update_project_url)
 -  [Function `update_next_epoch_network_address`](#0x2_validator_update_next_epoch_network_address)
 -  [Function `update_next_epoch_p2p_address`](#0x2_validator_update_next_epoch_p2p_address)
--  [Function `update_next_epoch_consensus_address`](#0x2_validator_update_next_epoch_consensus_address)
+-  [Function `update_next_epoch_primary_address`](#0x2_validator_update_next_epoch_primary_address)
 -  [Function `update_next_epoch_worker_address`](#0x2_validator_update_next_epoch_worker_address)
 -  [Function `update_next_epoch_protocol_pubkey`](#0x2_validator_update_next_epoch_protocol_pubkey)
 -  [Function `update_next_epoch_network_pubkey`](#0x2_validator_update_next_epoch_network_pubkey)
@@ -174,7 +174,7 @@
  The address of the validator used for p2p activities such as state sync (could also contain extra info such as port, DNS and etc.).
 </dd>
 <dt>
-<code>consensus_address: <a href="">vector</a>&lt;u8&gt;</code>
+<code>primary_address: <a href="">vector</a>&lt;u8&gt;</code>
 </dt>
 <dd>
  The address of the narwhal primary
@@ -223,7 +223,7 @@
 
 </dd>
 <dt>
-<code>next_epoch_consensus_address: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
+<code>next_epoch_primary_address: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
 </dt>
 <dd>
 
@@ -323,16 +323,6 @@
 
 
 
-<a name="0x2_validator_EMetadataInvalidConsensusAddr"></a>
-
-Invalid consensus_address field in ValidatorMetadata
-
-
-<pre><code><b>const</b> <a href="validator.md#0x2_validator_EMetadataInvalidConsensusAddr">EMetadataInvalidConsensusAddr</a>: u64 = 6;
-</code></pre>
-
-
-
 <a name="0x2_validator_EMetadataInvalidNetAddr"></a>
 
 Invalid net_address field in ValidatorMetadata
@@ -359,6 +349,16 @@ Invalid p2p_address field in ValidatorMetadata
 
 
 <pre><code><b>const</b> <a href="validator.md#0x2_validator_EMetadataInvalidP2pAddr">EMetadataInvalidP2pAddr</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x2_validator_EMetadataInvalidPrimaryAddr"></a>
+
+Invalid primary_address field in ValidatorMetadata
+
+
+<pre><code><b>const</b> <a href="validator.md#0x2_validator_EMetadataInvalidPrimaryAddr">EMetadataInvalidPrimaryAddr</a>: u64 = 6;
 </code></pre>
 
 
@@ -445,7 +445,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new_metadata">new_metadata</a>(sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="_String">string::String</a>, description: <a href="_String">string::String</a>, image_url: <a href="url.md#0x2_url_Url">url::Url</a>, project_url: <a href="url.md#0x2_url_Url">url::Url</a>, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, consensus_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;): <a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new_metadata">new_metadata</a>(sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="_String">string::String</a>, description: <a href="_String">string::String</a>, image_url: <a href="url.md#0x2_url_Url">url::Url</a>, project_url: <a href="url.md#0x2_url_Url">url::Url</a>, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, primary_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;): <a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>
 </code></pre>
 
 
@@ -466,7 +466,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
     project_url: Url,
     net_address: <a href="">vector</a>&lt;u8&gt;,
     p2p_address: <a href="">vector</a>&lt;u8&gt;,
-    consensus_address: <a href="">vector</a>&lt;u8&gt;,
+    primary_address: <a href="">vector</a>&lt;u8&gt;,
     worker_address: <a href="">vector</a>&lt;u8&gt;,
 ): <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> {
     <b>let</b> metadata = <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> {
@@ -481,7 +481,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
         project_url,
         net_address,
         p2p_address,
-        consensus_address,
+        primary_address,
         worker_address,
         next_epoch_protocol_pubkey_bytes: <a href="_none">option::none</a>(),
         next_epoch_network_pubkey_bytes: <a href="_none">option::none</a>(),
@@ -489,7 +489,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
         next_epoch_proof_of_possession: <a href="_none">option::none</a>(),
         next_epoch_net_address: <a href="_none">option::none</a>(),
         next_epoch_p2p_address: <a href="_none">option::none</a>(),
-        next_epoch_consensus_address: <a href="_none">option::none</a>(),
+        next_epoch_primary_address: <a href="_none">option::none</a>(),
         next_epoch_worker_address: <a href="_none">option::none</a>(),
     };
     metadata
@@ -506,7 +506,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new">new</a>(sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, consensus_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, gas_price: u64, commission_rate: u64, starting_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new">new</a>(sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, primary_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, gas_price: u64, commission_rate: u64, starting_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
 </code></pre>
 
 
@@ -527,7 +527,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
     project_url: <a href="">vector</a>&lt;u8&gt;,
     net_address: <a href="">vector</a>&lt;u8&gt;,
     p2p_address: <a href="">vector</a>&lt;u8&gt;,
-    consensus_address: <a href="">vector</a>&lt;u8&gt;,
+    primary_address: <a href="">vector</a>&lt;u8&gt;,
     worker_address: <a href="">vector</a>&lt;u8&gt;,
     stake: Balance&lt;SUI&gt;,
     coin_locked_until_epoch: Option&lt;EpochTimeLock&gt;,
@@ -564,7 +564,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
         <a href="url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(project_url),
         net_address,
         p2p_address,
-        consensus_address,
+        primary_address,
         worker_address,
     );
 
@@ -1040,13 +1040,13 @@ Called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></
 
 </details>
 
-<a name="0x2_validator_consensus_address"></a>
+<a name="0x2_validator_primary_address"></a>
 
-## Function `consensus_address`
+## Function `primary_address`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_consensus_address">consensus_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_primary_address">primary_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -1055,8 +1055,8 @@ Called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_consensus_address">consensus_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="">vector</a>&lt;u8&gt; {
-    &self.metadata.consensus_address
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_primary_address">primary_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &<a href="">vector</a>&lt;u8&gt; {
+    &self.metadata.primary_address
 }
 </code></pre>
 
@@ -1232,13 +1232,13 @@ Called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></
 
 </details>
 
-<a name="0x2_validator_next_epoch_consensus_address"></a>
+<a name="0x2_validator_next_epoch_primary_address"></a>
 
-## Function `next_epoch_consensus_address`
+## Function `next_epoch_primary_address`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_consensus_address">next_epoch_consensus_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_primary_address">next_epoch_primary_address</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -1247,8 +1247,8 @@ Called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_consensus_address">next_epoch_consensus_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
-    &self.metadata.next_epoch_consensus_address
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_next_epoch_primary_address">next_epoch_primary_address</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): &Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    &self.metadata.next_epoch_primary_address
 }
 </code></pre>
 
@@ -1839,14 +1839,14 @@ Update p2p address of this validator, taking effects from next epoch
 
 </details>
 
-<a name="0x2_validator_update_next_epoch_consensus_address"></a>
+<a name="0x2_validator_update_next_epoch_primary_address"></a>
 
-## Function `update_next_epoch_consensus_address`
+## Function `update_next_epoch_primary_address`
 
 Update consensus address of this validator, taking effects from next epoch
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_consensus_address">update_next_epoch_consensus_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, consensus_address: <a href="">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_primary_address">update_next_epoch_primary_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, primary_address: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -1855,8 +1855,8 @@ Update consensus address of this validator, taking effects from next epoch
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_consensus_address">update_next_epoch_consensus_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, consensus_address: <a href="">vector</a>&lt;u8&gt;) {
-    self.metadata.next_epoch_consensus_address = <a href="_some">option::some</a>(consensus_address);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_update_next_epoch_primary_address">update_next_epoch_primary_address</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, primary_address: <a href="">vector</a>&lt;u8&gt;) {
+    self.metadata.next_epoch_primary_address = <a href="_some">option::some</a>(primary_address);
     <a href="validator.md#0x2_validator_validate_metadata">validate_metadata</a>(&self.metadata);
 }
 </code></pre>
@@ -2001,9 +2001,9 @@ advancing an epoch.
         self.metadata.next_epoch_p2p_address = <a href="_none">option::none</a>();
     };
 
-    <b>if</b> (<a href="_is_some">option::is_some</a>(<a href="validator.md#0x2_validator_next_epoch_consensus_address">next_epoch_consensus_address</a>(self))) {
-        self.metadata.consensus_address = <a href="_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_consensus_address);
-        self.metadata.next_epoch_consensus_address = <a href="_none">option::none</a>();
+    <b>if</b> (<a href="_is_some">option::is_some</a>(<a href="validator.md#0x2_validator_next_epoch_primary_address">next_epoch_primary_address</a>(self))) {
+        self.metadata.primary_address = <a href="_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_primary_address);
+        self.metadata.next_epoch_primary_address = <a href="_none">option::none</a>();
     };
 
     <b>if</b> (<a href="_is_some">option::is_some</a>(<a href="validator.md#0x2_validator_next_epoch_worker_address">next_epoch_worker_address</a>(self))) {

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -42,7 +42,7 @@ module sui::genesis {
         validator_project_urls: vector<vector<u8>>,
         validator_net_addresses: vector<vector<u8>>,
         validator_p2p_addresses: vector<vector<u8>>,
-        validator_consensus_addresses: vector<vector<u8>>,
+        validator_primary_addresses: vector<vector<u8>>,
         validator_worker_addresses: vector<vector<u8>>,
         validator_gas_prices: vector<u64>,
         validator_commission_rates: vector<u64>,
@@ -63,7 +63,7 @@ module sui::genesis {
                 && vector::length(&validator_project_urls) == count
                 && vector::length(&validator_net_addresses) == count
                 && vector::length(&validator_p2p_addresses) == count
-                && vector::length(&validator_consensus_addresses) == count
+                && vector::length(&validator_primary_addresses) == count
                 && vector::length(&validator_worker_addresses) == count
                 && vector::length(&validator_gas_prices) == count
                 && vector::length(&validator_commission_rates) == count,
@@ -82,7 +82,7 @@ module sui::genesis {
             let project_url = *vector::borrow(&validator_project_urls, i);
             let net_address = *vector::borrow(&validator_net_addresses, i);
             let p2p_address = *vector::borrow(&validator_p2p_addresses, i);
-            let consensus_address = *vector::borrow(&validator_consensus_addresses, i);
+            let primary_address = *vector::borrow(&validator_primary_addresses, i);
             let worker_address = *vector::borrow(&validator_worker_addresses, i);
             let gas_price = *vector::borrow(&validator_gas_prices, i);
             let commission_rate = *vector::borrow(&validator_commission_rates, i);
@@ -98,7 +98,7 @@ module sui::genesis {
                 project_url,
                 net_address,
                 p2p_address,
-                consensus_address,
+                primary_address,
                 worker_address,
                 // TODO Figure out if we want to instead initialize validators with 0 stake.
                 // Initialize all validators with 1 Mist stake.

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -171,7 +171,7 @@ module sui::sui_system {
         project_url: vector<u8>,
         net_address: vector<u8>,
         p2p_address: vector<u8>,
-        consensus_address: vector<u8>,
+        primary_address: vector<u8>,
         worker_address: vector<u8>,
         stake: Coin<SUI>,
         gas_price: u64,
@@ -200,7 +200,7 @@ module sui::sui_system {
             project_url,
             net_address,
             p2p_address,
-            consensus_address,
+            primary_address,
             worker_address,
             coin::into_balance(stake),
             option::none(),
@@ -446,19 +446,19 @@ module sui::sui_system {
         validator::update_next_epoch_p2p_address(validator, p2p_address);
     }
 
-    /// Update a validator's consensus address.
+    /// Update a validator's narwhal primary address.
     /// The change will only take effects starting from the next epoch.
-    public entry fun update_validator_next_epoch_consensus_address(
+    public entry fun update_validator_next_epoch_primary_address(
         self: &mut SuiSystemState,
-        consensus_address: vector<u8>,
+        primary_address: vector<u8>,
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
         let validator = validator_set::get_active_or_pending_validator_mut(&mut self.validators, ctx);
-        validator::update_next_epoch_consensus_address(validator, consensus_address);
+        validator::update_next_epoch_primary_address(validator, primary_address);
     }
 
-    /// Update a validator's worker address.
+    /// Update a validator's narwhal worker address.
     /// The change will only take effects starting from the next epoch.
     public entry fun update_validator_next_epoch_worker_address(
         self: &mut SuiSystemState,

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -47,8 +47,8 @@ module sui::validator {
     /// Invalid p2p_address field in ValidatorMetadata
     const EMetadataInvalidP2pAddr: u64 = 5;
 
-    /// Invalid consensus_address field in ValidatorMetadata
-    const EMetadataInvalidConsensusAddr: u64 = 6;
+    /// Invalid primary_address field in ValidatorMetadata
+    const EMetadataInvalidPrimaryAddr: u64 = 6;
 
     /// Invalidworker_address field in ValidatorMetadata
     const EMetadataInvalidWorkerAddr: u64 = 7;
@@ -79,7 +79,7 @@ module sui::validator {
         /// The address of the validator used for p2p activities such as state sync (could also contain extra info such as port, DNS and etc.).
         p2p_address: vector<u8>,
         /// The address of the narwhal primary
-        consensus_address: vector<u8>,
+        primary_address: vector<u8>,
         /// The address of the narwhal worker
         worker_address: vector<u8>,
 
@@ -91,7 +91,7 @@ module sui::validator {
         next_epoch_worker_pubkey_bytes: Option<vector<u8>>,
         next_epoch_net_address: Option<vector<u8>>,
         next_epoch_p2p_address: Option<vector<u8>>,
-        next_epoch_consensus_address: Option<vector<u8>>,
+        next_epoch_primary_address: Option<vector<u8>>,
         next_epoch_worker_address: Option<vector<u8>>,
     }
 
@@ -146,7 +146,7 @@ module sui::validator {
         project_url: Url,
         net_address: vector<u8>,
         p2p_address: vector<u8>,
-        consensus_address: vector<u8>,
+        primary_address: vector<u8>,
         worker_address: vector<u8>,
     ): ValidatorMetadata {
         let metadata = ValidatorMetadata {
@@ -161,7 +161,7 @@ module sui::validator {
             project_url,
             net_address,
             p2p_address,
-            consensus_address,
+            primary_address,
             worker_address,
             next_epoch_protocol_pubkey_bytes: option::none(),
             next_epoch_network_pubkey_bytes: option::none(),
@@ -169,7 +169,7 @@ module sui::validator {
             next_epoch_proof_of_possession: option::none(),
             next_epoch_net_address: option::none(),
             next_epoch_p2p_address: option::none(),
-            next_epoch_consensus_address: option::none(),
+            next_epoch_primary_address: option::none(),
             next_epoch_worker_address: option::none(),
         };
         metadata
@@ -187,7 +187,7 @@ module sui::validator {
         project_url: vector<u8>,
         net_address: vector<u8>,
         p2p_address: vector<u8>,
-        consensus_address: vector<u8>,
+        primary_address: vector<u8>,
         worker_address: vector<u8>,
         stake: Balance<SUI>,
         coin_locked_until_epoch: Option<EpochTimeLock>,
@@ -224,7 +224,7 @@ module sui::validator {
             url::new_unsafe_from_bytes(project_url),
             net_address,
             p2p_address,
-            consensus_address,
+            primary_address,
             worker_address,
         );
 
@@ -355,8 +355,8 @@ module sui::validator {
         &self.metadata.p2p_address
     }
 
-    public fun consensus_address(self: &Validator): &vector<u8> {
-        &self.metadata.consensus_address
+    public fun primary_address(self: &Validator): &vector<u8> {
+        &self.metadata.primary_address
     }
 
     public fun worker_address(self: &Validator): &vector<u8> {
@@ -387,8 +387,8 @@ module sui::validator {
         &self.metadata.next_epoch_p2p_address
     }
 
-    public fun next_epoch_consensus_address(self: &Validator): &Option<vector<u8>> {
-        &self.metadata.next_epoch_consensus_address
+    public fun next_epoch_primary_address(self: &Validator): &Option<vector<u8>> {
+        &self.metadata.next_epoch_primary_address
     }
 
     public fun next_epoch_worker_address(self: &Validator): &Option<vector<u8>> {
@@ -509,8 +509,8 @@ module sui::validator {
     }
 
     /// Update consensus address of this validator, taking effects from next epoch
-    public(friend) fun update_next_epoch_consensus_address(self: &mut Validator, consensus_address: vector<u8>) {
-        self.metadata.next_epoch_consensus_address = option::some(consensus_address);
+    public(friend) fun update_next_epoch_primary_address(self: &mut Validator, primary_address: vector<u8>) {
+        self.metadata.next_epoch_primary_address = option::some(primary_address);
         validate_metadata(&self.metadata);
     }
 
@@ -555,9 +555,9 @@ module sui::validator {
             self.metadata.next_epoch_p2p_address = option::none();
         };
 
-        if (option::is_some(next_epoch_consensus_address(self))) {
-            self.metadata.consensus_address = option::extract(&mut self.metadata.next_epoch_consensus_address);
-            self.metadata.next_epoch_consensus_address = option::none();
+        if (option::is_some(next_epoch_primary_address(self))) {
+            self.metadata.primary_address = option::extract(&mut self.metadata.next_epoch_primary_address);
+            self.metadata.next_epoch_primary_address = option::none();
         };
 
         if (option::is_some(next_epoch_worker_address(self))) {
@@ -618,7 +618,7 @@ module sui::validator {
         project_url: vector<u8>,
         net_address: vector<u8>,
         p2p_address: vector<u8>,
-        consensus_address: vector<u8>,
+        primary_address: vector<u8>,
         worker_address: vector<u8>,
         stake: Balance<SUI>,
         coin_locked_until_epoch: Option<EpochTimeLock>,
@@ -655,7 +655,7 @@ module sui::validator {
                 url::new_unsafe_from_bytes(project_url),
                 net_address,
                 p2p_address,
-                consensus_address,
+                primary_address,
                 worker_address,
             ),
             voting_power: stake_amount,

--- a/crates/sui-framework/tests/sui_system_tests.move
+++ b/crates/sui-framework/tests/sui_system_tests.move
@@ -179,7 +179,7 @@ module sui::sui_system_tests {
         sui_system::update_validator_project_url(system_state, b"new_project_url", ctx);
         sui_system::update_validator_next_epoch_network_address(system_state, network_address, ctx);
         sui_system::update_validator_next_epoch_p2p_address(system_state, p2p_address, ctx);
-        sui_system::update_validator_next_epoch_consensus_address(system_state, vector[4, 168, 168, 168, 168], ctx);
+        sui_system::update_validator_next_epoch_primary_address(system_state, vector[4, 168, 168, 168, 168], ctx);
         sui_system::update_validator_next_epoch_worker_address(system_state, vector[4, 168, 168, 168, 168], ctx);
         sui_system::update_validator_next_epoch_protocol_pubkey(
             system_state,
@@ -210,7 +210,7 @@ module sui::sui_system_tests {
         assert!(validator::project_url(validator) == &url::new_unsafe_from_bytes(b"new_project_url"), 0);
         assert!(validator::network_address(validator) == &network_address, 0);
         assert!(validator::p2p_address(validator) == &p2p_address, 0);
-        assert!(validator::consensus_address(validator) == &vector[4, 127, 0, 0, 1], 0);
+        assert!(validator::primary_address(validator) == &vector[4, 127, 0, 0, 1], 0);
         assert!(validator::worker_address(validator) == &vector[4, 127, 0, 0, 1], 0);
         assert!(validator::protocol_pubkey_bytes(validator) == &protocol_pub_key, 0);
         assert!(validator::proof_of_possession(validator) == &pop, 0);
@@ -220,7 +220,7 @@ module sui::sui_system_tests {
         // Next epoch
         assert!(validator::next_epoch_network_address(validator) == &option::some(new_network_address), 0);
         assert!(validator::next_epoch_p2p_address(validator) == &option::some(new_p2p_address), 0);
-        assert!(validator::next_epoch_consensus_address(validator) == &option::some(vector[4, 168, 168, 168, 168]), 0);
+        assert!(validator::next_epoch_primary_address(validator) == &option::some(vector[4, 168, 168, 168, 168]), 0);
         assert!(validator::next_epoch_worker_address(validator) == &option::some(vector[4, 168, 168, 168, 168]), 0);
         assert!(
             validator::next_epoch_protocol_pubkey_bytes(validator) == &option::some(new_protocol_pub_key),
@@ -255,7 +255,7 @@ module sui::sui_system_tests {
         assert!(validator::project_url(validator) == &url::new_unsafe_from_bytes(b"new_project_url"), 0);
         assert!(validator::network_address(validator) == &network_address, 0);
         assert!(validator::p2p_address(validator) == &p2p_address, 0);
-        assert!(validator::consensus_address(validator) == &vector[4, 168, 168, 168, 168], 0);
+        assert!(validator::primary_address(validator) == &vector[4, 168, 168, 168, 168], 0);
         assert!(validator::worker_address(validator) == &vector[4, 168, 168, 168, 168], 0);
         assert!(validator::protocol_pubkey_bytes(validator) == &protocol_pub_key, 0);
         assert!(validator::proof_of_possession(validator) == &pop, 0);
@@ -265,7 +265,7 @@ module sui::sui_system_tests {
         // Next epoch
         assert!(option::is_none(validator::next_epoch_network_address(validator)), 0);
         assert!(option::is_none(validator::next_epoch_p2p_address(validator)), 0);
-        assert!(option::is_none(validator::next_epoch_consensus_address(validator)), 0);
+        assert!(option::is_none(validator::next_epoch_primary_address(validator)), 0);
         assert!(option::is_none(validator::next_epoch_worker_address(validator)), 0);
         assert!(option::is_none(validator::next_epoch_protocol_pubkey_bytes(validator)), 0);
         assert!(option::is_none(validator::next_epoch_proof_of_possession(validator)), 0);

--- a/crates/sui-framework/tests/validator_tests.move
+++ b/crates/sui-framework/tests/validator_tests.move
@@ -269,7 +269,7 @@ module sui::validator_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = validator::EMetadataInvalidConsensusAddr)]
+    #[expected_failure(abort_code = validator::EMetadataInvalidPrimaryAddr)]
     fun test_metadata_invalid_consensus_addr() {
         let metadata = validator::new_metadata(
             @0x42,
@@ -330,7 +330,7 @@ module sui::validator_tests {
         {
             validator::update_next_epoch_network_address(&mut validator, vector[4, 192, 168, 1, 1]);
             validator::update_next_epoch_p2p_address(&mut validator, vector[4, 192, 168, 1, 1]);
-            validator::update_next_epoch_consensus_address(&mut validator, vector[4, 192, 168, 1, 1]);
+            validator::update_next_epoch_primary_address(&mut validator, vector[4, 192, 168, 1, 1]);
             validator::update_next_epoch_worker_address(&mut validator, vector[4, 192, 168, 1, 1]);
             validator::update_next_epoch_protocol_pubkey(
                 &mut validator,
@@ -361,7 +361,7 @@ module sui::validator_tests {
             assert!(validator::project_url(&mut validator) == &url::new_unsafe_from_bytes(b"new_proj_url"), 0);
             assert!(validator::network_address(&validator) == &VALID_NET_ADDR, 0);
             assert!(validator::p2p_address(&validator) == &VALID_P2P_ADDR, 0);
-            assert!(validator::consensus_address(&validator) == &VALID_CONSENSUS_ADDR, 0);
+            assert!(validator::primary_address(&validator) == &VALID_CONSENSUS_ADDR, 0);
             assert!(validator::worker_address(&validator) == &VALID_WORKER_ADDR, 0);
             assert!(validator::protocol_pubkey_bytes(&validator) == &VALID_PUBKEY, 0);
             assert!(validator::proof_of_possession(&validator) == &PROOF_OF_POSESSION, 0);
@@ -371,7 +371,7 @@ module sui::validator_tests {
             // Next epoch
             assert!(validator::next_epoch_network_address(&validator) == &option::some(vector[4, 192, 168, 1, 1]), 0);
             assert!(validator::next_epoch_p2p_address(&validator) == &option::some(vector[4, 192, 168, 1, 1]), 0);
-            assert!(validator::next_epoch_consensus_address(&validator) == &option::some(vector[4, 192, 168, 1, 1]), 0);
+            assert!(validator::next_epoch_primary_address(&validator) == &option::some(vector[4, 192, 168, 1, 1]), 0);
             assert!(validator::next_epoch_worker_address(&validator) == &option::some(vector[4, 192, 168, 1, 1]), 0);
             assert!(
                 validator::next_epoch_protocol_pubkey_bytes(&validator) == &option::some(new_protocol_pub_key),
@@ -490,7 +490,7 @@ module sui::validator_tests {
         test_scenario::end(scenario_val);
     }
 
-    #[expected_failure(abort_code = sui::validator::EMetadataInvalidConsensusAddr)]
+    #[expected_failure(abort_code = sui::validator::EMetadataInvalidPrimaryAddr)]
     #[test]
     fun test_validator_update_metadata_invalid_consensus_addr() {
         let sender = @0xaf76afe6f866d8426d2be85d6ef0b11f871a251d043b2f11e15563bf418f5a5a;
@@ -503,7 +503,7 @@ module sui::validator_tests {
 
         test_scenario::next_tx(scenario, sender);
         {
-            validator::update_next_epoch_consensus_address(
+            validator::update_next_epoch_primary_address(
                 &mut validator,
                 x"beef",
             );

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6841,13 +6841,13 @@
       "ValidatorMetadata": {
         "type": "object",
         "required": [
-          "consensus_address",
           "description",
           "image_url",
           "name",
           "net_address",
           "network_pubkey_bytes",
           "p2p_address",
+          "primary_address",
           "project_url",
           "proof_of_possession_bytes",
           "protocol_pubkey_bytes",
@@ -6856,14 +6856,6 @@
           "worker_pubkey_bytes"
         ],
         "properties": {
-          "consensus_address": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          },
           "description": {
             "type": "string"
           },
@@ -6883,17 +6875,6 @@
           },
           "network_pubkey_bytes": {
             "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          },
-          "next_epoch_consensus_address": {
-            "type": [
-              "array",
-              "null"
-            ],
             "items": {
               "type": "integer",
               "format": "uint8",
@@ -6923,6 +6904,17 @@
             }
           },
           "next_epoch_p2p_address": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_primary_address": {
             "type": [
               "array",
               "null"
@@ -6978,6 +6970,14 @@
             }
           },
           "p2p_address": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "primary_address": {
             "type": "array",
             "items": {
               "type": "integer",

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -34,7 +34,7 @@ const E_METADATA_INVALID_NET_PUBKEY: u64 = 2;
 const E_METADATA_INVALID_WORKER_PUBKEY: u64 = 3;
 const E_METADATA_INVALID_NET_ADDR: u64 = 4;
 const E_METADATA_INVALID_P2P_ADDR: u64 = 5;
-const E_METADATA_INVALID_CONSENSUS_ADDR: u64 = 6;
+const E_METADATA_INVALID_PRIMARY_ADDR: u64 = 6;
 const E_METADATA_INVALID_WORKER_ADDR: u64 = 7;
 
 /// Rust version of the Move sui::sui_system::SystemParameters type
@@ -64,7 +64,7 @@ pub struct ValidatorMetadata {
     pub project_url: String,
     pub net_address: Vec<u8>,
     pub p2p_address: Vec<u8>,
-    pub consensus_address: Vec<u8>,
+    pub primary_address: Vec<u8>,
     pub worker_address: Vec<u8>,
     pub next_epoch_protocol_pubkey_bytes: Option<Vec<u8>>,
     pub next_epoch_proof_of_possession: Option<Vec<u8>>,
@@ -72,7 +72,7 @@ pub struct ValidatorMetadata {
     pub next_epoch_worker_pubkey_bytes: Option<Vec<u8>>,
     pub next_epoch_net_address: Option<Vec<u8>>,
     pub next_epoch_p2p_address: Option<Vec<u8>>,
-    pub next_epoch_consensus_address: Option<Vec<u8>>,
+    pub next_epoch_primary_address: Option<Vec<u8>>,
     pub next_epoch_worker_address: Option<Vec<u8>>,
 }
 
@@ -89,7 +89,7 @@ pub struct VerifiedValidatorMetadata {
     pub project_url: String,
     pub net_address: Multiaddr,
     pub p2p_address: Multiaddr,
-    pub consensus_address: Multiaddr,
+    pub primary_address: Multiaddr,
     pub worker_address: Multiaddr,
     pub next_epoch_protocol_pubkey: Option<narwhal_crypto::PublicKey>,
     pub next_epoch_proof_of_possession: Option<Vec<u8>>,
@@ -97,7 +97,7 @@ pub struct VerifiedValidatorMetadata {
     pub next_epoch_worker_pubkey: Option<narwhal_crypto::NetworkPublicKey>,
     pub next_epoch_net_address: Option<Multiaddr>,
     pub next_epoch_p2p_address: Option<Multiaddr>,
-    pub next_epoch_consensus_address: Option<Multiaddr>,
+    pub next_epoch_primary_address: Option<Multiaddr>,
     pub next_epoch_worker_address: Option<Multiaddr>,
 }
 
@@ -119,8 +119,8 @@ impl ValidatorMetadata {
             .map_err(|_| E_METADATA_INVALID_NET_ADDR)?;
         let p2p_address = Multiaddr::try_from(self.p2p_address.clone())
             .map_err(|_| E_METADATA_INVALID_P2P_ADDR)?;
-        let consensus_address = Multiaddr::try_from(self.consensus_address.clone())
-            .map_err(|_| E_METADATA_INVALID_CONSENSUS_ADDR)?;
+        let primary_address = Multiaddr::try_from(self.primary_address.clone())
+            .map_err(|_| E_METADATA_INVALID_PRIMARY_ADDR)?;
         let worker_address = Multiaddr::try_from(self.worker_address.clone())
             .map_err(|_| E_METADATA_INVALID_WORKER_ADDR)?;
 
@@ -163,10 +163,10 @@ impl ValidatorMetadata {
             )),
         }?;
 
-        let next_epoch_consensus_address = match self.next_epoch_consensus_address.clone() {
+        let next_epoch_primary_address = match self.next_epoch_primary_address.clone() {
             None => Ok::<Option<Multiaddr>, u64>(None),
             Some(address) => Ok(Some(
-                Multiaddr::try_from(address).map_err(|_| E_METADATA_INVALID_CONSENSUS_ADDR)?,
+                Multiaddr::try_from(address).map_err(|_| E_METADATA_INVALID_PRIMARY_ADDR)?,
             )),
         }?;
 
@@ -189,7 +189,7 @@ impl ValidatorMetadata {
             project_url: self.project_url.clone(),
             net_address,
             p2p_address,
-            consensus_address,
+            primary_address,
             worker_address,
             next_epoch_protocol_pubkey,
             next_epoch_proof_of_possession: self.next_epoch_proof_of_possession.clone(),
@@ -197,7 +197,7 @@ impl ValidatorMetadata {
             next_epoch_worker_pubkey,
             next_epoch_net_address,
             next_epoch_p2p_address,
-            next_epoch_consensus_address,
+            next_epoch_primary_address,
             next_epoch_worker_address,
         })
     }
@@ -213,7 +213,7 @@ impl ValidatorMetadata {
     }
 
     pub fn narwhal_primary_address(&self) -> Result<Multiaddr> {
-        Multiaddr::try_from(self.consensus_address.clone()).map_err(Into::into)
+        Multiaddr::try_from(self.primary_address.clone()).map_err(Into::into)
     }
 
     pub fn narwhal_worker_address(&self) -> Result<Multiaddr> {
@@ -449,7 +449,7 @@ impl SuiSystemState {
                     .expect("Metadata should have been verified upon request");
                 let authority = narwhal_config::Authority {
                     stake: validator.voting_power as narwhal_config::Stake,
-                    primary_address: verified_metadata.consensus_address,
+                    primary_address: verified_metadata.primary_address,
                     network_key: verified_metadata.network_pubkey,
                 };
                 (verified_metadata.protocol_pubkey, authority)

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -32,7 +32,7 @@ pub fn test_validatdor_metadata(
         project_url: "".to_string(),
         net_address,
         p2p_address: vec![],
-        consensus_address: vec![],
+        primary_address: vec![],
         worker_address: vec![],
         next_epoch_protocol_pubkey_bytes: None,
         next_epoch_proof_of_possession: None,
@@ -40,7 +40,7 @@ pub fn test_validatdor_metadata(
         next_epoch_worker_pubkey_bytes: None,
         next_epoch_net_address: None,
         next_epoch_p2p_address: None,
-        next_epoch_consensus_address: None,
+        next_epoch_primary_address: None,
         next_epoch_worker_address: None,
     }
 }

--- a/dapps/frenemies/src/network/bcs.ts
+++ b/dapps/frenemies/src/network/bcs.ts
@@ -170,7 +170,7 @@ export const bcs = suiBcs
     /** The p2p address of the validator (could also contain extra info such as port, DNS and etc.).  */
     p2pAddress: "vector<u8>",
     /** The address of the narwhal primary  */
-    consensusAddress: "vector<u8>",
+    primaryAddress: "vector<u8>",
     /** The address of the narwhal worker  */
     workerAddress: "vector<u8>",
     /** Total amount of validator stake that would be active in the next epoch.  */
@@ -194,7 +194,7 @@ export const bcs = suiBcs
     /** Next epoch's p2p address of the validator*/
     nextEpochP2pAddress: "Option<vector<u8>>",
     /** Next epoch's consensus address of the validator*/
-    nextEpochConsensusAddress: "Option<vector<u8>>",
+    nextEpochPrimaryAddress: "Option<vector<u8>>",
     /** Next epoch's worker address of the validator*/
     nextEpochWorkerAddress: "Option<vector<u8>>",
   })

--- a/dapps/frenemies/src/network/types.ts
+++ b/dapps/frenemies/src/network/types.ts
@@ -224,7 +224,7 @@ export type ValidatorMetadata = {
   /** The p2p address of the validator (could also contain extra info such as port, DNS and etc.).  */
   p2pAddress: number[];
   /** The address of the narwhal primary  */
-  consensusAddress: number[];
+  primaryAddress: number[];
   /** The address of the narwhal worker  */
   workerAddress: number[];
   /** Total amount of validator stake that would be active in the next epoch.  */
@@ -249,7 +249,7 @@ export type ValidatorMetadata = {
   /** Next epoch's p2p address of the validator*/
   nextEpochP2pAddress: number[];
   /** Next epoch's consensus address of the validator*/
-  nextEpochConsensusAddress: number[];
+  nextEpochPrimaryAddress: number[];
   /** Next epoch's worker address of the validator*/
   nextEpochWorkerAddress: number[];
 };

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -31,7 +31,7 @@ export const ValidatorMetaData = object({
   project_url: string(),
   p2p_address: array(number()),
   net_address: array(number()),
-  consensus_address: array(number()),
+  primary_address: array(number()),
   worker_address: array(number()),
   next_epoch_protocol_pubkey_bytes: nullable(array(number())),
   next_epoch_proof_of_possession: nullable(array(number())),
@@ -39,7 +39,7 @@ export const ValidatorMetaData = object({
   next_epoch_worker_pubkey_bytes: nullable(array(number())),
   next_epoch_net_address: nullable(array(number())),
   next_epoch_p2p_address: nullable(array(number())),
-  next_epoch_consensus_address: nullable(array(number())),
+  next_epoch_primary_address: nullable(array(number())),
   next_epoch_worker_address: nullable(array(number())),
 });
 


### PR DESCRIPTION
## Description 

We have been using `consensus_address` to represent the narwhal primary address in `ValidatorMetadata`. This PR corrects it.

## Test Plan 

ran existing tests locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
Correct "consensus_address" in ValidatorMetadata to "primary_address"
