### PR TITLE
[sui-framework] Add a generic `destroy` function to `test_utils`

### DIFF
--- a/crates/sui-framework/sources/balance.move
+++ b/crates/sui-framework/sources/balance.move
@@ -104,14 +104,14 @@ module sui::balance {
         aborts_if balance.value != 0 with ENonZero;
     }
 
-    /// CAUTION: this function creates a `Balance` without increasing the supply. 
+    /// CAUTION: this function creates a `Balance` without increasing the supply.
     /// It should only be called by `sui_system::advance_epoch` to create staking rewards,
     /// and nowhere else.
     public(friend) fun create_staking_rewards<T>(value: u64): Balance<T> {
         Balance { value }
     }
 
-    /// CAUTION: this function destroys a `Balance` without decreasing the supply. 
+    /// CAUTION: this function destroys a `Balance` without decreasing the supply.
     /// It should only be called by `sui_system::advance_epoch` to destroy storage rebates,
     /// and nowhere else.
     public(friend) fun destroy_storage_rebates<T>(self: Balance<T>) {
@@ -129,26 +129,13 @@ module sui::balance {
     public fun create_for_testing<T>(value: u64): Balance<T> {
         Balance { value }
     }
-
-    #[test_only]
-    /// Destroy a `Balance` with any value in it for testing purposes.
-    public fun destroy_for_testing<T>(self: Balance<T>): u64 {
-        let Balance { value } = self;
-        value
-    }
-
-    #[test_only]
-    /// Destroy a `Supply` with any value in it for testing purposes.
-    public fun destroy_supply_for_testing<T>(self: Supply<T>): u64 {
-        let Supply { value } = self;
-        value
-    }
 }
 
 #[test_only]
 module sui::balance_tests {
     use sui::balance;
     use sui::sui::SUI;
+    use sui::test_utils;
 
     #[test]
     fun test_balance() {
@@ -169,8 +156,8 @@ module sui::balance_tests {
         assert!(balance::value(&balance2) == 333, 2);
         assert!(balance::value(&balance3) == 334, 3);
 
-        balance::destroy_for_testing(balance1);
-        balance::destroy_for_testing(balance2);
-        balance::destroy_for_testing(balance3);
+        test_utils::destroy(balance1);
+        test_utils::destroy(balance2);
+        test_utils::destroy(balance3);
     }
 }

--- a/crates/sui-framework/sources/coin.move
+++ b/crates/sui-framework/sources/coin.move
@@ -431,12 +431,4 @@ module sui::coin {
     public fun mint_for_testing<T>(value: u64, ctx: &mut TxContext): Coin<T> {
         Coin { id: object::new(ctx), balance: balance::create_for_testing(value) }
     }
-
-    #[test_only]
-    /// Destroy a `Coin` with any value in it for testing purposes.
-    public fun destroy_for_testing<T>(self: Coin<T>): u64 {
-        let Coin { id, balance } = self;
-        object::delete(id);
-        balance::destroy_for_testing(balance)
-    }
 }

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -857,29 +857,4 @@ module sui::validator_set {
     public fun active_validators(self: &ValidatorSet): &vector<Validator> {
         &self.active_validators
     }
-
-    #[test_only]
-    public fun destroy_for_testing(
-        self: ValidatorSet,
-    ) {
-        let ValidatorSet {
-            total_stake: _,
-            active_validators,
-            pending_validators,
-            pending_removals: _,
-            staking_pool_mappings,
-        } = self;
-        destroy_validators_for_testing(active_validators);
-        table_vec::destroy_empty(pending_validators);
-        table::drop(staking_pool_mappings);
-    }
-
-    #[test_only]
-    public fun destroy_validators_for_testing(v: vector<Validator>) {
-        while (!vector::is_empty(&v)) {
-            let v = vector::pop_back(&mut v);
-            validator::destroy(v, &mut tx_context::dummy());
-        };
-        vector::destroy_empty(v)
-    }
 }

--- a/crates/sui-framework/sources/table.move
+++ b/crates/sui-framework/sources/table.move
@@ -100,5 +100,4 @@ public fun drop<K: copy + drop + store, V: drop + store>(table: Table<K, V>) {
     let Table { id, size: _ } = table;
     object::delete(id)
 }
-
 }

--- a/crates/sui-framework/sources/test/test_utils.move
+++ b/crates/sui-framework/sources/test/test_utils.move
@@ -21,4 +21,6 @@ module sui::test_utils {
     public fun print(str: vector<u8>) {
         std::debug::print(&std::ascii::string(str))
     }
+
+    public native fun destroy<T>(x: T);
 }

--- a/crates/sui-framework/src/natives/mod.rs
+++ b/crates/sui-framework/src/natives/mod.rs
@@ -8,6 +8,7 @@ mod event;
 mod object;
 pub mod object_runtime;
 mod test_scenario;
+mod test_utils;
 mod transfer;
 mod tx_context;
 mod types;
@@ -230,6 +231,7 @@ pub fn all_natives(
             "validate_metadata_bcs",
             make_native!(validator::validate_metadata_bcs),
         ),
+        ("test_utils", "destroy", make_native!(test_utils::destroy)),
     ];
     sui_natives
         .iter()

--- a/crates/sui-framework/src/natives/test_utils.rs
+++ b/crates/sui-framework/src/natives/test_utils.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::legacy_test_cost;
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub fn destroy(
+    _context: &mut NativeContext,
+    _ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    args.pop_back();
+    Ok(NativeResult::ok(legacy_test_cost(), smallvec![]))
+}

--- a/crates/sui-framework/tests/coin_balance_tests.move
+++ b/crates/sui-framework/tests/coin_balance_tests.move
@@ -12,6 +12,7 @@ module sui::coin_balance_tests {
     use sui::tx_context;
     use sui::locked_coin;
     use sui::coin::Coin;
+    use sui::test_utils;
 
     #[test]
     fun type_morphing() {
@@ -68,7 +69,7 @@ module sui::coin_balance_tests {
         test_scenario::next_tx(scenario, TEST_RECIPIENT_ADDR);
         let unlocked_coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
         assert!(coin::value(&unlocked_coin) == 42, 2);
-        coin::destroy_for_testing(unlocked_coin);
+        test_utils::destroy(unlocked_coin);
         test_scenario::end(scenario_val);
     }
 

--- a/crates/sui-framework/tests/pay_tests.move
+++ b/crates/sui-framework/tests/pay_tests.move
@@ -9,6 +9,7 @@ module sui::pay_tests {
     use sui::pay;
     use sui::balance;
     use sui::sui::SUI;
+    use sui::test_utils;
 
     const TEST_SENDER_ADDR: address = @0xA11CE;
 
@@ -37,9 +38,9 @@ module sui::pay_tests {
             1
         );
 
-        coin::destroy_for_testing(coin);
-        coin::destroy_for_testing(coin1);
-        coin::destroy_for_testing(coin2);
+        test_utils::destroy(coin);
+        test_utils::destroy(coin1);
+        test_utils::destroy(coin2);
         test_scenario::end(scenario_val);
     }
 
@@ -61,9 +62,9 @@ module sui::pay_tests {
         assert!(coin::value(&coin) == 4, 0);
 
         vector::destroy_empty(split_coins);
-        coin::destroy_for_testing(coin);
-        coin::destroy_for_testing(coin1);
-        coin::destroy_for_testing(coin2);
+        test_utils::destroy(coin);
+        test_utils::destroy(coin1);
+        test_utils::destroy(coin2);
         test_scenario::end(scenario_val);
     }
 
@@ -88,9 +89,9 @@ module sui::pay_tests {
         assert!(coin::value(&coin2) == 1, 0);
         assert!(coin::value(&coin) == 5, 0);
 
-        coin::destroy_for_testing(coin);
-        coin::destroy_for_testing(coin1);
-        coin::destroy_for_testing(coin2);
+        test_utils::destroy(coin);
+        test_utils::destroy(coin1);
+        test_utils::destroy(coin2);
         test_scenario::end(scenario_val);
     }
 
@@ -110,9 +111,9 @@ module sui::pay_tests {
         assert!(coin::value(&coin1) == 3, 0);
         assert!(coin::value(&coin) == 7, 0);
 
-        coin::destroy_for_testing(coin);
-        coin::destroy_for_testing(coin1);
-        test_scenario::end(scenario_val);        
+        test_utils::destroy(coin);
+        test_utils::destroy(coin1);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
@@ -130,9 +131,9 @@ module sui::pay_tests {
         let coin_transfer_fail = test_scenario::take_from_sender<Coin<SUI>>(scenario);
         assert!(coin::value(&coin_transfer_fail) == 7, 0);
 
-        coin::destroy_for_testing(coin);
-        coin::destroy_for_testing(coin_transfer_fail);
-        test_scenario::end(scenario_val);   
+        test_utils::destroy(coin);
+        test_utils::destroy(coin_transfer_fail);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
@@ -150,12 +151,12 @@ module sui::pay_tests {
         test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
         let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
 
-        // result is `3` coins of balance `2`        
+        // result is `3` coins of balance `2`
         assert!(coin::value(&coin1) == 6, 0);
         assert!(coin::value(&coin) == 4, 0);
 
-        coin::destroy_for_testing(coin);
-        coin::destroy_for_testing(coin1);
-        test_scenario::end(scenario_val);   
+        test_utils::destroy(coin);
+        test_utils::destroy(coin1);
+        test_scenario::end(scenario_val);
     }
 }

--- a/crates/sui-framework/tests/safe_tests.move
+++ b/crates/sui-framework/tests/safe_tests.move
@@ -7,9 +7,9 @@ module sui::safe_tests {
     use sui::test_scenario::{Self as ts, Scenario, ctx};
     use sui::coin::{Self, Coin};
     use sui::object::{Self, ID};
-    use sui::balance;
     use sui::sui::SUI;
     use sui::transfer;
+    use sui::test_utils;
 
     const TEST_SENDER_ADDR: address = @0x1;
     const TEST_OWNER_ADDR: address = @0x1337;
@@ -42,7 +42,7 @@ module sui::safe_tests {
         let safe = ts::take_shared<Safe<SUI>>(scenario);
         let capability = ts::take_from_sender<TransferCapability<SUI>>(scenario);
         let balance = safe::debit(&mut safe, &mut capability, withdraw_amount);
-        balance::destroy_for_testing(balance);
+        test_utils::destroy(balance);
 
         ts::return_to_sender(scenario, capability);
         ts::return_shared(safe);
@@ -77,7 +77,7 @@ module sui::safe_tests {
         let withdrawn_coin = ts::take_from_sender<Coin<SUI>>(scenario);
         assert!(coin::value(&withdrawn_coin) == initial_funds, 0);
 
-        coin::destroy_for_testing(withdrawn_coin);
+        test_utils::destroy(withdrawn_coin);
         ts::return_to_sender(scenario, cap);
         ts::return_shared(safe);
 
@@ -171,7 +171,7 @@ module sui::safe_tests {
         ts::next_tx(scenario, owner);
         let safe = ts::take_shared<Safe<SUI>>(scenario);
         let balance = safe::debit(&mut safe, &mut transfer_capability, 1000u64);
-        balance::destroy_for_testing(balance);
+        test_utils::destroy(balance);
 
         ts::return_shared(safe);
         ts::return_to_sender(scenario, cap);

--- a/crates/sui-framework/tests/validator_set_tests.move
+++ b/crates/sui-framework/tests/validator_set_tests.move
@@ -12,7 +12,7 @@ module sui::validator_set_tests {
     use sui::vec_map;
     use std::ascii;
     use std::option;
-    use sui::test_utils::assert_eq;
+    use sui::test_utils::{Self, assert_eq};
 
     #[test]
     fun test_validator_set_flow() {
@@ -83,7 +83,7 @@ module sui::validator_set_tests {
             assert!(validator_set::total_stake(&validator_set) == 900, 0);
         };
 
-        validator_set::destroy_for_testing(validator_set);
+        test_utils::destroy(validator_set);
         test_scenario::end(scenario);
     }
 
@@ -135,7 +135,7 @@ module sui::validator_set_tests {
 
         assert_eq(validator_set::derive_reference_gas_price(&validator_set), 43);
 
-        validator_set::destroy_for_testing(validator_set);
+        test_utils::destroy(validator_set);
         test_scenario::end(scenario);
     }
 

--- a/crates/sui-framework/tests/validator_tests.move
+++ b/crates/sui-framework/tests/validator_tests.move
@@ -16,6 +16,7 @@ module sui::validator_tests {
     use sui::balance;
     use sui::staking_pool::{Self, StakedSui};
     use std::vector;
+    use sui::test_utils;
 
 
     const VALID_PUBKEY: vector<u8> = vector[153, 242, 94, 246, 31, 128, 50, 185, 20, 99, 100, 96, 152, 44, 92, 198, 241, 52, 239, 29, 218, 231, 102, 87, 242, 203, 254, 193, 235, 252, 141, 9, 115, 116, 8, 13, 246, 252, 240, 220, 184, 188, 75, 13, 142, 10, 245, 216, 14, 187, 255, 43, 76, 89, 159, 84, 244, 45, 99, 18, 223, 195, 20, 39, 96, 120, 193, 204, 52, 126, 187, 190, 197, 25, 139, 226, 88, 81, 63, 56, 107, 147, 13, 2, 194, 116, 154, 128, 62, 35, 48, 149, 94, 189, 26, 16];
@@ -72,7 +73,7 @@ module sui::validator_tests {
             assert!(validator::total_stake_amount(&validator) == 10, 0);
             assert!(validator::sui_address(&validator) == sender, 0);
 
-            validator::destroy(validator, ctx);
+            test_utils::destroy(validator);
         };
 
         // Check that after destroy, the original stake still exists.
@@ -133,7 +134,7 @@ module sui::validator_tests {
             test_scenario::return_to_sender(scenario, withdraw);
         };
 
-        validator::destroy(validator, test_scenario::ctx(scenario));
+        test_utils::destroy(validator);
         test_scenario::end(scenario_val);
     }
 
@@ -391,7 +392,7 @@ module sui::validator_tests {
             );
         };
 
-        validator::destroy(validator, test_scenario::ctx(scenario));
+        test_utils::destroy(validator);
         test_scenario::end(scenario_val);
     }
 
@@ -416,7 +417,7 @@ module sui::validator_tests {
             );
         };
 
-        validator::destroy(validator, test_scenario::ctx(scenario));
+        test_utils::destroy(validator);
         test_scenario::end(scenario_val);
     }
 
@@ -439,7 +440,7 @@ module sui::validator_tests {
             );
         };
 
-        validator::destroy(validator, test_scenario::ctx(scenario));
+        test_utils::destroy(validator);
         test_scenario::end(scenario_val);
     }
 
@@ -463,7 +464,7 @@ module sui::validator_tests {
             );
         };
 
-        validator::destroy(validator, test_scenario::ctx(scenario));
+        test_utils::destroy(validator);
         test_scenario::end(scenario_val);
     }
 
@@ -486,7 +487,7 @@ module sui::validator_tests {
             );
         };
 
-        validator::destroy(validator, test_scenario::ctx(scenario));
+        test_utils::destroy(validator);
         test_scenario::end(scenario_val);
     }
 
@@ -509,7 +510,7 @@ module sui::validator_tests {
             );
         };
 
-        validator::destroy(validator, test_scenario::ctx(scenario));
+        test_utils::destroy(validator);
         test_scenario::end(scenario_val);
     }
 
@@ -532,7 +533,7 @@ module sui::validator_tests {
             );
         };
 
-        validator::destroy(validator, test_scenario::ctx(scenario));
+        test_utils::destroy(validator);
         test_scenario::end(scenario_val);
     }
 
@@ -555,7 +556,7 @@ module sui::validator_tests {
             );
         };
 
-        validator::destroy(validator, test_scenario::ctx(scenario));
+        test_utils::destroy(validator);
         test_scenario::end(scenario_val);
     }
 }

--- a/crates/sui-framework/tests/voting_power_tests.move
+++ b/crates/sui-framework/tests/voting_power_tests.move
@@ -4,7 +4,6 @@
 #[test_only]
 module sui::voting_power_tests {
     use sui::governance_test_utils as gtu;
-    use sui::validator_set;
     use sui::voting_power;
     use sui::test_scenario;
     use sui::test_utils;
@@ -20,7 +19,7 @@ module sui::voting_power_tests {
         let validators = gtu::create_validators_with_stakes(stakes, ctx);
         voting_power::set_voting_power(&mut validators);
         test_utils::assert_eq(get_voting_power(&validators), voting_power);
-        validator_set::destroy_validators_for_testing(validators);
+        test_utils::destroy(validators);
     }
 
     #[test]

--- a/sui_programmability/examples/defi/sources/pool.move
+++ b/sui_programmability/examples/defi/sources/pool.move
@@ -345,10 +345,10 @@ module defi::pool {
 /// ```
 module defi::pool_tests {
     use sui::sui::SUI;
-    use sui::coin::{mint_for_testing as mint, destroy_for_testing as burn};
-    use sui::test_scenario::{Self as test, Scenario, next_tx, ctx}
-    ;
+    use sui::coin::{Self, Coin, mint_for_testing as mint};
+    use sui::test_scenario::{Self as test, Scenario, next_tx, ctx};
     use defi::pool::{Self, Pool, LSP};
+    use sui::test_utils;
 
     /// Gonna be our test token.
     struct BEEP {}
@@ -397,6 +397,13 @@ module defi::pool_tests {
         let scenario = scenario();
         test_math_(&mut scenario);
         test::end(scenario);
+    }
+
+    #[test_only]
+    fun burn<T>(x: Coin<T>): u64 {
+        let value = coin::value(&x);
+        test_utils::destroy(x);
+        value
     }
 
     /// Init a Pool with a 1_000_000 BEEP and 1_000_000_000 SUI;


### PR DESCRIPTION
## Description 

Adding a generic `destroy` function to the `test_utils` module allows us to drop a non-`drop` value any time we like/need to during testing which means that we can get rid of all of the `destroy_yyy_for_testing` type functions 🎉 

## Test Plan 

Test-only change so make sure existing tests pass. 

~This is stacked on #8768 so only look at the top commit in this PR.~