### PR TITLE
genesis, governance: introduce 'governace_start_epoch' for delaying some onchain functionalities

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -324,6 +324,13 @@ pub struct GenesisChainParameters {
     /// initial stake.
     #[serde(default = "GenesisChainParameters::test_initial_validator_stake_mist")]
     pub initial_validator_stake_mist: u64,
+
+    /// The starting epoch in which various on-chain governance features take effect. E.g.
+    /// - stake subsidies are paid out
+    /// - validators with stake less than a 'validator_stake_threshold' are
+    ///   kicked from the validator set
+    #[serde(default)]
+    pub governance_start_epoch: u64,
     // Most other parameters (e.g. initial gas schedule) should be derived from protocol_version.
 }
 
@@ -335,6 +342,7 @@ impl GenesisChainParameters {
             allow_insertion_of_extra_objects: true,
             initial_sui_custody_account_address: SuiAddress::default(),
             initial_validator_stake_mist: Self::test_initial_validator_stake_mist(),
+            governance_start_epoch: 0,
         }
     }
 
@@ -1028,6 +1036,7 @@ pub fn generate_genesis_system_object(
         vec![
             CallArg::Pure(bcs::to_bytes(&parameters.initial_sui_custody_account_address).unwrap()),
             CallArg::Pure(bcs::to_bytes(&parameters.initial_validator_stake_mist).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&parameters.governance_start_epoch).unwrap()),
             CallArg::Pure(bcs::to_bytes(&pubkeys).unwrap()),
             CallArg::Pure(bcs::to_bytes(&network_pubkeys).unwrap()),
             CallArg::Pure(bcs::to_bytes(&worker_pubkeys).unwrap()),

--- a/crates/sui-config/tests/snapshot_tests.rs
+++ b/crates/sui-config/tests/snapshot_tests.rs
@@ -24,7 +24,6 @@ use rand::SeedableRng;
 use sui_config::genesis::GenesisChainParameters;
 use sui_config::ValidatorInfo;
 use sui_config::{genesis::Builder, genesis_config::GenesisConfig};
-use sui_protocol_config::ProtocolVersion;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::crypto::{
     generate_proof_of_possession, get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair,
@@ -85,9 +84,7 @@ fn populated_genesis_snapshot_matches() {
         .add_validator(validator, pop)
         .with_parameters(GenesisChainParameters {
             timestamp_ms: 10,
-            protocol_version: ProtocolVersion::MAX,
-            allow_insertion_of_extra_objects: true,
-            initial_sui_custody_account_address: SuiAddress::default(),
+            ..GenesisChainParameters::new()
         })
         .add_validator_signature(&key)
         .build();

--- a/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -9,6 +9,7 @@ parameters:
   allow_insertion_of_extra_objects: true
   initial_sui_custody_account_address: "0x0000000000000000000000000000000000000000000000000000000000000000"
   initial_validator_stake_mist: 25000000000000000
+  governance_start_epoch: 0
 committee_size: 4
 grpc_load_shed: ~
 grpc_concurrency_limit: 20000000000

--- a/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -8,6 +8,7 @@ parameters:
   protocol_version: 1
   allow_insertion_of_extra_objects: true
   initial_sui_custody_account_address: "0x0000000000000000000000000000000000000000000000000000000000000000"
+  initial_validator_stake_mist: 25000000000000000
 committee_size: 4
 grpc_load_shed: ~
 grpc_concurrency_limit: 20000000000

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -5,7 +5,7 @@ expression: genesis.sui_system_object()
 epoch: 0
 protocol_version: 1
 validators:
-  total_stake: 1
+  total_stake: 25000000000000000
   active_validators:
     - metadata:
         sui_address: "0x21b60aa9a8cb189ccbe20461dbfad2202fdef55b9418f30ac2c5fe632f6e1cb7"
@@ -242,10 +242,10 @@ validators:
       staking_pool:
         id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f65e4b0dea15829e3157962e1"
         starting_epoch: 0
-        sui_balance: 1
+        sui_balance: 25000000000000000
         rewards_pool:
           value: 0
-        pool_token_balance: 1
+        pool_token_balance: 25000000000000000
         exchange_rates:
           id: "0xe63945cec193ca7ac76960370028110a907ad1c22ff90b1fd57ea3c441c766b4"
           size: 1
@@ -253,7 +253,7 @@ validators:
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
       commission_rate: 0
-      next_epoch_stake: 1
+      next_epoch_stake: 25000000000000000
       next_epoch_gas_price: 1
       next_epoch_commission_rate: 0
   pending_validators:
@@ -275,7 +275,7 @@ validator_report_records:
 stake_subsidy:
   epoch_counter: 0
   balance:
-    value: 1000000000000000000
+    value: 975000000000000000
   current_epoch_amount: 1000000
 safe_mode: false
 epoch_start_timestamp_ms: 10

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -269,6 +269,7 @@ storage_fund:
 parameters:
   min_validator_stake: 1
   max_validator_candidate_count: 100
+  governance_start_epoch: 0
 reference_gas_price: 1
 validator_report_records:
   contents: []

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -176,6 +176,7 @@ all the information we need in the system.
         storage_fund,
         <a href="genesis.md#0x2_genesis_INIT_MAX_VALIDATOR_COUNT">INIT_MAX_VALIDATOR_COUNT</a>,
         <a href="genesis.md#0x2_genesis_INIT_MIN_VALIDATOR_STAKE">INIT_MIN_VALIDATOR_STAKE</a>,
+        0,
         <a href="genesis.md#0x2_genesis_INIT_STAKE_SUBSIDY_AMOUNT">INIT_STAKE_SUBSIDY_AMOUNT</a>,
         protocol_version,
         system_state_version,

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -77,7 +77,7 @@ It will create a singleton SuiSystemState object, which contains
 all the information we need in the system.
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(initial_sui_custody_account_address: <b>address</b>, initial_validator_stake_mist: u64, validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_p2p_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_primary_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(initial_sui_custody_account_address: <b>address</b>, initial_validator_stake_mist: u64, governance_start_epoch: u64, validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_p2p_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_primary_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -89,6 +89,7 @@ all the information we need in the system.
 <pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(
     initial_sui_custody_account_address: <b>address</b>,
     initial_validator_stake_mist: u64,
+    governance_start_epoch: u64,
     validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
@@ -176,7 +177,7 @@ all the information we need in the system.
         storage_fund,
         <a href="genesis.md#0x2_genesis_INIT_MAX_VALIDATOR_COUNT">INIT_MAX_VALIDATOR_COUNT</a>,
         <a href="genesis.md#0x2_genesis_INIT_MIN_VALIDATOR_STAKE">INIT_MIN_VALIDATOR_STAKE</a>,
-        0,
+        governance_start_epoch,
         <a href="genesis.md#0x2_genesis_INIT_STAKE_SUBSIDY_AMOUNT">INIT_STAKE_SUBSIDY_AMOUNT</a>,
         protocol_version,
         system_state_version,

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -77,7 +77,7 @@ It will create a singleton SuiSystemState object, which contains
 all the information we need in the system.
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(initial_sui_custody_account_address: <b>address</b>, validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_p2p_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_primary_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(initial_sui_custody_account_address: <b>address</b>, initial_validator_stake_mist: u64, validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_p2p_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_primary_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -88,6 +88,7 @@ all the information we need in the system.
 
 <pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(
     initial_sui_custody_account_address: <b>address</b>,
+    initial_validator_stake_mist: u64,
     validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
     validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;,
@@ -158,9 +159,8 @@ all the information we need in the system.
             p2p_address,
             primary_address,
             worker_address,
-            // TODO Figure out <b>if</b> we want <b>to</b> instead initialize validators <b>with</b> 0 stake.
-            // Initialize all validators <b>with</b> 1 Mist stake.
-            <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> sui_supply, 1),
+            // Initialize all validators <b>with</b> uniform stake taken from the subsidy fund.
+            <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> subsidy_fund, initial_validator_stake_mist),
             <a href="_none">option::none</a>(),
             gas_price,
             commission_rate,

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -114,7 +114,7 @@ A list of system config parameters.
 </dt>
 <dd>
  The starting epoch in which various on-chain governance features take effect:
- - TODO stake subsidies are paid out
+ - stake subsidies are paid out
  - TODO validators with stake less than a 'validator_stake_threshold' are
    kicked from the validator set
 </dd>
@@ -1316,7 +1316,13 @@ gas coins.
     <b>let</b> computation_reward = <a href="balance.md#0x2_balance_create_staking_rewards">balance::create_staking_rewards</a>(computation_charge);
 
     // Include stake subsidy in the rewards given out <b>to</b> validators and delegators.
-    <b>let</b> <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a> = <a href="stake_subsidy.md#0x2_stake_subsidy_advance_epoch">stake_subsidy::advance_epoch</a>(&<b>mut</b> self.<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>);
+    // Delay distributing any stake subsidies until after `governance_start_epoch`.
+    <b>let</b> <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a> = <b>if</b> (<a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) &gt;= self.parameters.governance_start_epoch) {
+        <a href="stake_subsidy.md#0x2_stake_subsidy_advance_epoch">stake_subsidy::advance_epoch</a>(&<b>mut</b> self.<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>)
+    } <b>else</b> {
+        <a href="balance.md#0x2_balance_zero">balance::zero</a>()
+    };
+
     <b>let</b> stake_subsidy_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&<a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>);
     <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> computation_reward, <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>);
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -109,6 +109,15 @@ A list of system config parameters.
  Maximum number of validator candidates at any moment.
  We do not allow the number of validators in any epoch to go above this.
 </dd>
+<dt>
+<code>governance_start_epoch: u64</code>
+</dt>
+<dd>
+ The starting epoch in which various on-chain governance features take effect:
+ - TODO stake subsidies are paid out
+ - TODO validators with stake less than a 'validator_stake_threshold' are
+   kicked from the validator set
+</dd>
 </dl>
 
 
@@ -405,7 +414,7 @@ Create a new SuiSystemState object and make it shared.
 This function will be called only once in genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_candidate_count: u64, min_validator_stake: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_candidate_count: u64, min_validator_stake: u64, governance_start_epoch: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -420,6 +429,7 @@ This function will be called only once in genesis.
     storage_fund: Balance&lt;SUI&gt;,
     max_validator_candidate_count: u64,
     min_validator_stake: u64,
+    governance_start_epoch: u64,
     initial_stake_subsidy_amount: u64,
     protocol_version: u64,
     system_state_version: u64,
@@ -436,6 +446,7 @@ This function will be called only once in genesis.
         parameters: <a href="sui_system.md#0x2_sui_system_SystemParameters">SystemParameters</a> {
             min_validator_stake,
             max_validator_candidate_count,
+            governance_start_epoch,
         },
         reference_gas_price,
         validator_report_records: <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>(),

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -32,6 +32,7 @@ module sui::genesis {
     fun create(
         initial_sui_custody_account_address: address,
         initial_validator_stake_mist: u64,
+        governance_start_epoch: u64,
         validator_pubkeys: vector<vector<u8>>,
         validator_network_pubkeys: vector<vector<u8>>,
         validator_worker_pubkeys: vector<vector<u8>>,
@@ -119,7 +120,7 @@ module sui::genesis {
             storage_fund,
             INIT_MAX_VALIDATOR_COUNT,
             INIT_MIN_VALIDATOR_STAKE,
-            0,
+            governance_start_epoch,
             INIT_STAKE_SUBSIDY_AMOUNT,
             protocol_version,
             system_state_version,

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -119,6 +119,7 @@ module sui::genesis {
             storage_fund,
             INIT_MAX_VALIDATOR_COUNT,
             INIT_MIN_VALIDATOR_STAKE,
+            0,
             INIT_STAKE_SUBSIDY_AMOUNT,
             protocol_version,
             system_state_version,

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -31,6 +31,7 @@ module sui::genesis {
     /// all the information we need in the system.
     fun create(
         initial_sui_custody_account_address: address,
+        initial_validator_stake_mist: u64,
         validator_pubkeys: vector<vector<u8>>,
         validator_network_pubkeys: vector<vector<u8>>,
         validator_worker_pubkeys: vector<vector<u8>>,
@@ -101,9 +102,8 @@ module sui::genesis {
                 p2p_address,
                 primary_address,
                 worker_address,
-                // TODO Figure out if we want to instead initialize validators with 0 stake.
-                // Initialize all validators with 1 Mist stake.
-                balance::split(&mut sui_supply, 1),
+                // Initialize all validators with uniform stake taken from the subsidy fund.
+                balance::split(&mut subsidy_fund, initial_validator_stake_mist),
                 option::none(),
                 gas_price,
                 commission_rate,

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -45,6 +45,12 @@ module sui::sui_system {
         /// Maximum number of validator candidates at any moment.
         /// We do not allow the number of validators in any epoch to go above this.
         max_validator_candidate_count: u64,
+
+        /// The starting epoch in which various on-chain governance features take effect:
+        /// - TODO stake subsidies are paid out
+        /// - TODO validators with stake less than a 'validator_stake_threshold' are
+        ///   kicked from the validator set
+        governance_start_epoch: u64,
     }
 
     /// The top-level object containing all information of the Sui system.
@@ -121,6 +127,7 @@ module sui::sui_system {
         storage_fund: Balance<SUI>,
         max_validator_candidate_count: u64,
         min_validator_stake: u64,
+        governance_start_epoch: u64,
         initial_stake_subsidy_amount: u64,
         protocol_version: u64,
         system_state_version: u64,
@@ -137,6 +144,7 @@ module sui::sui_system {
             parameters: SystemParameters {
                 min_validator_stake,
                 max_validator_candidate_count,
+                governance_start_epoch,
             },
             reference_gas_price,
             validator_report_records: vec_map::empty(),

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -65,6 +65,7 @@ module sui::governance_test_utils {
             balance::create_for_testing<SUI>(storage_fund_amount), // storage_fund
             1024, // max_validator_candidate_count
             0, // min_validator_stake
+            0, // governance_start_epoch
             0, // stake subsidy
             1, // protocol version
             1, // system state version

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6272,10 +6272,16 @@
         "description": "Rust version of the Move sui::sui_system::SystemParameters type",
         "type": "object",
         "required": [
+          "governance_start_epoch",
           "max_validator_candidate_count",
           "min_validator_stake"
         ],
         "properties": {
+          "governance_start_epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
           "max_validator_candidate_count": {
             "type": "integer",
             "format": "uint64",

--- a/crates/sui-types/src/gas_coin.rs
+++ b/crates/sui-types/src/gas_coin.rs
@@ -20,6 +20,15 @@ use crate::{
     SUI_FRAMEWORK_ADDRESS,
 };
 
+/// The number of Mist per Sui token
+pub const MIST_PER_SUI: u64 = 1_000_000_000;
+
+/// Total supply denominated in Sui
+pub const TOTAL_SUPPLY_SUI: u64 = 10_000_000_000;
+
+/// Total supply denominated in Mist
+pub const TOTAL_SUPPLY_MIST: u64 = TOTAL_SUPPLY_SUI * MIST_PER_SUI;
+
 pub const GAS_MODULE_NAME: &IdentStr = ident_str!("sui");
 pub const GAS_STRUCT_NAME: &IdentStr = ident_str!("SUI");
 

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -14,6 +14,9 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
+/// Minimum amount of stake required for a validator to be in the validator set
+pub const MINIMUM_VALIDATOR_STAKE_SUI: u64 = 25_000_000;
+
 pub const STAKING_POOL_MODULE_NAME: &IdentStr = ident_str!("staking_pool");
 pub const STAKED_SUI_STRUCT_NAME: &IdentStr = ident_str!("StakedSui");
 pub const DELEGATION_STRUCT_NAME: &IdentStr = ident_str!("Delegation");

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -44,6 +44,7 @@ const E_METADATA_INVALID_WORKER_ADDR: u64 = 7;
 pub struct SystemParameters {
     pub min_validator_stake: u64,
     pub max_validator_candidate_count: u64,
+    pub governance_start_epoch: u64,
 }
 
 /// Rust version of the Move std::option::Option type.
@@ -537,6 +538,7 @@ impl Default for SuiSystemState {
             parameters: SystemParameters {
                 min_validator_stake: 1,
                 max_validator_candidate_count: 100,
+                governance_start_epoch: 0,
             },
             reference_gas_price: 1,
             validator_report_records: VecMap { contents: vec![] },

--- a/crates/test-utils/src/sui_system_state.rs
+++ b/crates/test-utils/src/sui_system_state.rs
@@ -94,6 +94,7 @@ pub fn test_sui_system_state(epoch: EpochId, validators: Vec<Validator>) -> SuiS
         parameters: SystemParameters {
             min_validator_stake: 1,
             max_validator_candidate_count: 100,
+            governance_start_epoch: 0,
         },
         reference_gas_price: 1,
         validator_report_records: VecMap { contents: vec![] },

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -156,6 +156,7 @@ export const CommitteeInfo = object({
 export const SystemParameters = object({
   min_validator_stake: number(),
   max_validator_candidate_count: number(),
+  governance_start_epoch: number(),
   storage_gas_price: optional(number()),
 });
 


### PR DESCRIPTION
## Description 

genesis, governance: introduce 'governace_start_epoch' for delaying some onchain functionalities

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
