### PR TITLE
Migrate Sui/Narwhal codebase to use BCS over bincode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5128,13 +5128,15 @@ dependencies = [
 name = "mysten-network"
 version = "0.2.0"
 dependencies = [
- "bincode",
+ "anemo",
+ "bcs",
  "bytes",
  "eyre",
  "futures",
  "http",
  "multiaddr",
  "serde 1.0.152",
+ "snap",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5316,6 +5318,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
+ "bcs",
  "bincode",
  "bytes",
  "fastcrypto",
@@ -5449,6 +5452,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "base64",
+ "bcs",
  "bincode",
  "bytes",
  "dashmap",
@@ -5568,6 +5572,7 @@ dependencies = [
  "anemo-build",
  "async-trait",
  "base64",
+ "bcs",
  "bincode",
  "bytes",
  "criterion",
@@ -5577,6 +5582,7 @@ dependencies = [
  "futures",
  "indexmap",
  "mockall",
+ "mysten-network",
  "mysten-util-mem",
  "narwhal-config",
  "narwhal-crypto",
@@ -8013,6 +8019,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
+name = "snap"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
+
+[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10354,6 +10366,7 @@ name = "typed-store"
 version = "0.4.0"
 dependencies = [
  "async-trait",
+ "bcs",
  "bincode",
  "collectable",
  "eyre",
@@ -11589,6 +11602,7 @@ dependencies = [
  "slug",
  "smallvec",
  "smawk",
+ "snap",
  "socket2",
  "soketto",
  "spin 0.5.2",

--- a/crates/mysten-network/Cargo.toml
+++ b/crates/mysten-network/Cargo.toml
@@ -8,13 +8,15 @@ description = "Mysten's network tooling"
 publish = false
 
 [dependencies]
-bincode = "1.3.3"
+anemo.workspace = true
+bcs = "0.1.4"
 bytes = "1.3.0"
 eyre = "0.6.8"
 futures = "0.3.21"
 http = "0.2.8"
 multiaddr = "0.17.0"
 serde = { version = "1.0.140", features = ["derive"] }
+snap = "1.1.0"
 tokio = { workspace = true, features = ["sync", "rt", "macros"] }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tonic = { version = "0.8.2", features = ["transport"] }

--- a/crates/mysten-network/src/codec.rs
+++ b/crates/mysten-network/src/codec.rs
@@ -9,21 +9,21 @@ use tonic::{
 };
 
 #[derive(Debug)]
-pub struct BincodeEncoder<T>(PhantomData<T>);
+pub struct BcsEncoder<T>(PhantomData<T>);
 
-impl<T: serde::Serialize> Encoder for BincodeEncoder<T> {
+impl<T: serde::Serialize> Encoder for BcsEncoder<T> {
     type Item = T;
     type Error = Status;
 
     fn encode(&mut self, item: Self::Item, buf: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
-        bincode::serialize_into(buf.writer(), &item).map_err(|e| Status::internal(e.to_string()))
+        bcs::serialize_into(&mut buf.writer(), &item).map_err(|e| Status::internal(e.to_string()))
     }
 }
 
 #[derive(Debug)]
-pub struct BincodeDecoder<U>(PhantomData<U>);
+pub struct BcsDecoder<U>(PhantomData<U>);
 
-impl<U: serde::de::DeserializeOwned> Decoder for BincodeDecoder<U> {
+impl<U: serde::de::DeserializeOwned> Decoder for BcsDecoder<U> {
     type Item = U;
     type Error = Status;
 
@@ -35,38 +35,109 @@ impl<U: serde::de::DeserializeOwned> Decoder for BincodeDecoder<U> {
         let chunk = buf.chunk();
 
         let item: Self::Item =
-            bincode::deserialize(chunk).map_err(|e| Status::internal(e.to_string()))?;
+            bcs::from_bytes(chunk).map_err(|e| Status::internal(e.to_string()))?;
         buf.advance(chunk.len());
 
         Ok(Some(item))
     }
 }
 
-/// A [`Codec`] that implements `application/grpc+bincode` via the serde library.
+/// A [`Codec`] that implements `application/grpc+bcs` via the serde library.
 #[derive(Debug, Clone)]
-pub struct BincodeCodec<T, U>(PhantomData<(T, U)>);
+pub struct BcsCodec<T, U>(PhantomData<(T, U)>);
 
-impl<T, U> Default for BincodeCodec<T, U> {
+impl<T, U> Default for BcsCodec<T, U> {
     fn default() -> Self {
         Self(PhantomData)
     }
 }
 
-impl<T, U> Codec for BincodeCodec<T, U>
+impl<T, U> Codec for BcsCodec<T, U>
 where
     T: serde::Serialize + Send + 'static,
     U: serde::de::DeserializeOwned + Send + 'static,
 {
     type Encode = T;
     type Decode = U;
-    type Encoder = BincodeEncoder<T>;
-    type Decoder = BincodeDecoder<U>;
+    type Encoder = BcsEncoder<T>;
+    type Decoder = BcsDecoder<U>;
 
     fn encoder(&mut self) -> Self::Encoder {
-        BincodeEncoder(PhantomData)
+        BcsEncoder(PhantomData)
     }
 
     fn decoder(&mut self) -> Self::Decoder {
-        BincodeDecoder(PhantomData)
+        BcsDecoder(PhantomData)
+    }
+}
+
+// Anemo variant of BCS codec using Snappy for compression.
+pub mod anemo {
+    use ::anemo::rpc::codec::{Codec, Decoder, Encoder};
+    use bytes::{Buf, BufMut};
+    use std::{io::Read, marker::PhantomData};
+
+    #[derive(Debug)]
+    pub struct BcsSnappyEncoder<T>(PhantomData<T>);
+
+    impl<T: serde::Serialize> Encoder for BcsSnappyEncoder<T> {
+        type Item = T;
+        type Error = bcs::Error;
+
+        fn encode(
+            &mut self,
+            item: Self::Item,
+            buf: &mut bytes::BytesMut,
+        ) -> Result<(), Self::Error> {
+            let mut snappy_encoder = snap::write::FrameEncoder::new(buf.writer());
+            bcs::serialize_into(&mut snappy_encoder, &item)
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct BcsSnappyDecoder<U>(PhantomData<U>);
+
+    impl<U: serde::de::DeserializeOwned> Decoder for BcsSnappyDecoder<U> {
+        type Item = U;
+        type Error = bcs::Error;
+
+        fn decode(&mut self, buf: bytes::Bytes) -> Result<Self::Item, Self::Error> {
+            let compressed_size = buf.len();
+            let mut snappy_decoder = snap::read::FrameDecoder::new(buf.reader());
+            let mut bytes = Vec::with_capacity(compressed_size);
+            snappy_decoder.read_to_end(&mut bytes)?;
+            bcs::from_bytes(bytes.as_slice())
+        }
+    }
+
+    /// A [`Codec`] that implements `bcs` encoding/decoding via the serde library.
+    #[derive(Debug, Clone)]
+    pub struct BcsSnappyCodec<T, U>(PhantomData<(T, U)>);
+
+    impl<T, U> Default for BcsSnappyCodec<T, U> {
+        fn default() -> Self {
+            Self(PhantomData)
+        }
+    }
+
+    impl<T, U> Codec for BcsSnappyCodec<T, U>
+    where
+        T: serde::Serialize + Send + 'static,
+        U: serde::de::DeserializeOwned + Send + 'static,
+    {
+        const FORMAT_NAME: &'static str = "bcs";
+
+        type Encode = T;
+        type Decode = U;
+        type Encoder = BcsSnappyEncoder<T>;
+        type Decoder = BcsSnappyDecoder<U>;
+
+        fn encoder(&mut self) -> Self::Encoder {
+            BcsSnappyEncoder(PhantomData)
+        }
+
+        fn decoder(&mut self) -> Self::Decoder {
+            BcsSnappyDecoder(PhantomData)
+        }
     }
 }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -150,7 +150,7 @@ impl SubmitToConsensus for TransactionsClient<sui_network::tonic::transport::Cha
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         let serialized =
-            bincode::serialize(transaction).expect("Serializing consensus transaction cannot fail");
+            bcs::to_bytes(transaction).expect("Serializing consensus transaction cannot fail");
         let bytes = Bytes::from(serialized.clone());
 
         self.clone()

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -123,7 +123,7 @@ impl<T: ParentSync + Send + Sync> ExecutionState for ConsensusHandler<T> {
                 for serialized_transaction in batch.transactions {
                     bytes += serialized_transaction.len();
 
-                    let transaction = match bincode::deserialize::<ConsensusTransaction>(
+                    let transaction = match bcs::from_bytes::<ConsensusTransaction>(
                         &serialized_transaction,
                     ) {
                         Ok(transaction) => transaction,

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -45,7 +45,7 @@ impl SuiTxValidator {
 }
 
 fn tx_from_bytes(tx: &[u8]) -> Result<ConsensusTransaction, eyre::Report> {
-    bincode::deserialize::<ConsensusTransaction>(tx)
+    bcs::from_bytes::<ConsensusTransaction>(tx)
         .wrap_err("Malformed transaction (failed to deserialize)")
 }
 
@@ -189,7 +189,7 @@ mod tests {
         let certificates = test_certificates(&state).await;
 
         let first_transaction = certificates[0].clone();
-        let first_transaction_bytes: Vec<u8> = bincode::serialize(
+        let first_transaction_bytes: Vec<u8> = bcs::to_bytes(
             &ConsensusTransaction::new_certificate_message(&name1, first_transaction),
         )
         .unwrap();
@@ -207,8 +207,7 @@ mod tests {
             .clone()
             .into_iter()
             .map(|cert| {
-                bincode::serialize(&ConsensusTransaction::new_certificate_message(&name1, cert))
-                    .unwrap()
+                bcs::to_bytes(&ConsensusTransaction::new_certificate_message(&name1, cert)).unwrap()
             })
             .collect();
 
@@ -224,8 +223,7 @@ mod tests {
                     GenericSignature::Signature(sui_types::crypto::Signature::Ed25519SuiSignature(
                         Ed25519SuiSignature::default(),
                     ));
-                bincode::serialize(&ConsensusTransaction::new_certificate_message(&name1, cert))
-                    .unwrap()
+                bcs::to_bytes(&ConsensusTransaction::new_certificate_message(&name1, cert)).unwrap()
             })
             .collect();
 

--- a/crates/sui-framework/src/natives/crypto/ecvrf.rs
+++ b/crates/sui-framework/src/natives/crypto/ecvrf.rs
@@ -39,12 +39,12 @@ pub fn ecvrf_verify(
         Err(_) => return Ok(NativeResult::err(cost, INVALID_ECVRF_HASH_LENGTH)),
     };
 
-    let public_key = match bincode::deserialize(public_key_bytes.as_bytes_ref().as_slice()) {
+    let public_key = match bcs::from_bytes(public_key_bytes.as_bytes_ref().as_slice()) {
         Ok(pk) => pk,
         Err(_) => return Ok(NativeResult::err(cost, INVALID_ECVRF_PUBLIC_KEY)),
     };
 
-    let proof: ECVRFProof = match bincode::deserialize(proof_bytes.as_bytes_ref().as_slice()) {
+    let proof: ECVRFProof = match bcs::from_bytes(proof_bytes.as_bytes_ref().as_slice()) {
         Ok(p) => p,
         Err(_) => return Ok(NativeResult::err(cost, INVALID_ECVRF_PROOF)),
     };

--- a/crates/sui-framework/src/natives/crypto/tbls.rs
+++ b/crates/sui-framework/src/natives/crypto/tbls.rs
@@ -37,7 +37,7 @@ pub fn tbls_verify_signature(
     let (pk_bls, _pk_vss) = mocked_dkg::generate_public_keys(1, epoch);
 
     // Verify the given signature.
-    let sig: Result<types::Signature, _> = bincode::deserialize(&sig.as_bytes_ref());
+    let sig: Result<types::Signature, _> = bcs::from_bytes(&sig.as_bytes_ref());
     let valid = sig.is_ok()
         && types::ThresholdBls12381MinSig::verify(&pk_bls, &msg.as_bytes_ref(), &sig.unwrap())
             .is_ok();
@@ -65,7 +65,7 @@ pub fn tbls_sign(
 
     let (sk, _pk) = mocked_dkg::generate_full_key_pair(epoch);
     let sig = types::ThresholdBls12381MinSig::sign(&sk, &msg.as_bytes_ref());
-    let sig = bincode::serialize(&sig);
+    let sig = bcs::to_bytes(&sig);
 
     match sig {
         Ok(sig) => Ok(NativeResult::ok(cost, smallvec![Value::vector_u8(sig)])),

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -16,7 +16,7 @@ fn main() -> Result<()> {
         PathBuf::from(env::var("OUT_DIR")?)
     };
 
-    let codec_path = "mysten_network::codec::BincodeCodec";
+    let codec_path = "mysten_network::codec::BcsCodec";
 
     let validator_service = Service::builder()
         .name("Validator")
@@ -100,6 +100,8 @@ fn main() -> Result<()> {
 }
 
 fn build_anemo_services(out_dir: &Path) {
+    let codec_path = "mysten_network::codec::anemo::BcsSnappyCodec";
+
     let discovery = anemo_build::manual::Service::builder()
         .name("Discovery")
         .package("sui")
@@ -109,7 +111,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("GetKnownPeers")
                 .request_type("()")
                 .response_type("crate::discovery::GetKnownPeersResponse")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .build();
@@ -123,7 +125,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("PushCheckpointSummary")
                 .request_type("sui_types::messages_checkpoint::CertifiedCheckpointSummary")
                 .response_type("()")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -132,7 +134,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("GetCheckpointSummary")
                 .request_type("crate::state_sync::GetCheckpointSummaryRequest")
                 .response_type("Option<sui_types::messages_checkpoint::CertifiedCheckpointSummary>")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -141,7 +143,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("GetCheckpointContents")
                 .request_type("sui_types::messages_checkpoint::CheckpointContentsDigest")
                 .response_type("Option<sui_types::messages_checkpoint::CheckpointContents>")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -150,7 +152,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("GetTransactionAndEffects")
                 .request_type("sui_types::base_types::ExecutionDigests")
                 .response_type("Option<(sui_types::messages::Transaction, sui_types::messages::TransactionEffects)>")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .build();

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -44,6 +44,7 @@ pub struct DynamicFieldName {
     #[serde_as(as = "Readable<DisplayFromStr, _>")]
     pub type_: TypeTag,
     // Bincode does not like serde_json::Value, rocksdb will not insert the value without serializing value as string.
+    // TODO: investigate if this can be removed after switch to BCS.
     #[schemars(with = "Value")]
     #[serde_as(as = "Readable<_, DisplayFromStr>")]
     pub value: Value,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -465,7 +465,7 @@ impl From<VMError> for SuiError {
 
 impl From<Status> for SuiError {
     fn from(status: Status) -> Self {
-        let result = bincode::deserialize::<SuiError>(status.details());
+        let result = bcs::from_bytes::<SuiError>(status.details());
         if let Ok(sui_error) = result {
             sui_error
         } else {
@@ -479,7 +479,7 @@ impl From<Status> for SuiError {
 
 impl From<SuiError> for Status {
     fn from(error: SuiError) -> Self {
-        let bytes = bincode::serialize(&error).unwrap();
+        let bytes = bcs::to_bytes(&error).unwrap();
         Status::with_details(tonic::Code::Internal, error.to_string(), bytes.into())
     }
 }

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -44,9 +44,9 @@ fn test_signatures_serde() {
     let foo = Foo("hello".into());
     let s = Signature::new(&foo, &sec1);
 
-    let serialized = bincode::serialize(&s).unwrap();
+    let serialized = bcs::to_bytes(&s).unwrap();
     println!("{:?}", serialized);
-    let deserialized: Signature = bincode::deserialize(&serialized).unwrap();
+    let deserialized: Signature = bcs::from_bytes(&serialized).unwrap();
     assert_eq!(deserialized.as_ref(), s.as_ref());
 }
 
@@ -197,9 +197,9 @@ fn test_object_id_serde_json() {
 #[test]
 fn test_object_id_serde_not_human_readable() {
     let obj_id = ObjectID::random();
-    let serialized = bincode::serialize(&obj_id).unwrap();
+    let serialized = bcs::to_bytes(&obj_id).unwrap();
     assert_eq!(obj_id.0.to_vec(), serialized);
-    let deserialized: ObjectID = bincode::deserialize(&serialized).unwrap();
+    let deserialized: ObjectID = bcs::from_bytes(&serialized).unwrap();
     assert_eq!(deserialized, obj_id);
 }
 

--- a/crates/sui-types/src/unit_tests/crypto_tests.rs
+++ b/crates/sui-types/src/unit_tests/crypto_tests.rs
@@ -103,8 +103,8 @@ proptest! {
     fn test_deserialize_keypair(
         bytes in collection::vec(any::<u8>(), 0..1024)
     ){
-        let _skp: Result<SuiKeyPair, _> = bincode::deserialize(&bytes);
-        let _pk: Result<PublicKey, _> = bincode::deserialize(&bytes);
+        let _skp: Result<SuiKeyPair, _> = bcs::from_bytes(&bytes);
+        let _pk: Result<PublicKey, _> = bcs::from_bytes(&bytes);
     }
 
 

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -489,9 +489,9 @@ fn test_digest_caching() {
     // digest is cached
     assert_eq!(initial_digest, *signed_tx.digest());
 
-    let serialized_tx = bincode::serialize(&signed_tx).unwrap();
+    let serialized_tx = bcs::to_bytes(&signed_tx).unwrap();
 
-    let deserialized_tx: SignedTransaction = bincode::deserialize(&serialized_tx).unwrap();
+    let deserialized_tx: SignedTransaction = bcs::from_bytes(&serialized_tx).unwrap();
 
     // cached digest was not serialized/deserialized
     assert_ne!(initial_digest, *deserialized_tx.digest());
@@ -518,10 +518,10 @@ fn test_digest_caching() {
     // digest is cached
     assert_eq!(initial_effects_digest, *signed_effects.digest());
 
-    let serialized_effects = bincode::serialize(&signed_effects).unwrap();
+    let serialized_effects = bcs::to_bytes(&signed_effects).unwrap();
 
     let deserialized_effects: SignedTransactionEffects =
-        bincode::deserialize(&serialized_effects).unwrap();
+        bcs::from_bytes(&serialized_effects).unwrap();
 
     // cached digest was not serialized/deserialized
     assert_ne!(initial_effects_digest, *deserialized_effects.digest());

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+bcs = "0.1.4"
 bincode = "1.3.3"
 collectable = "0.0.2"
 eyre = "0.6.8"

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -240,7 +240,7 @@ where
             .expect("Failed to receive reply to RemoveAll command from store")
     }
 
-    /// Returns the read value in raw bincode bytes
+    /// Returns the read value in raw bytes
     pub async fn read_raw_bytes(&self, key: Key) -> StoreResult<Option<Vec<u8>>> {
         let (sender, receiver) = oneshot::channel();
         if let Err(e) = self

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -110,6 +110,12 @@ impl From<bincode::Error> for BincodeErrorDef {
     }
 }
 
+impl From<bcs::Error> for TypedStoreError {
+    fn from(err: bcs::Error) -> Self {
+        TypedStoreError::SerializationError(format!("{err}"))
+    }
+}
+
 impl From<bincode::Error> for TypedStoreError {
     fn from(err: bincode::Error) -> Self {
         TypedStoreError::SerializationError(format!("{err}"))

--- a/crates/typed-store/src/rocks/iter.rs
+++ b/crates/typed-store/src/rocks/iter.rs
@@ -55,7 +55,7 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for Iter<'a, K, V> {
                 .value()
                 .expect("Valid iterator failed to get value");
             let key = config.deserialize(raw_key).ok();
-            let value = bincode::deserialize(raw_value).ok();
+            let value = bcs::from_bytes(raw_value).ok();
             if self.iter_bytes_sample_interval.sample() {
                 let total_bytes_read = (raw_key.len() + raw_value.len()) as f64;
                 self.db_metrics

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -110,10 +110,7 @@ async fn test_get_raw(#[values(true, false)] is_transactional: bool) {
         .expect("Failed to get_raw_bytes")
         .unwrap();
 
-    assert_eq!(
-        bincode::serialize(&"123456789".to_string()).unwrap(),
-        val_bytes
-    );
+    assert_eq!(bcs::to_bytes(&"123456789".to_string()).unwrap(), val_bytes);
     assert_eq!(
         None,
         db.get_raw_bytes(&000000000)

--- a/crates/typed-store/src/rocks/values.rs
+++ b/crates/typed-store/src/rocks/values.rs
@@ -26,11 +26,10 @@ impl<'a, V: DeserializeOwned> Iterator for Values<'a, V> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.db_iter.valid() {
-            let value = self.db_iter.key().and_then(|_| {
-                self.db_iter
-                    .value()
-                    .and_then(|v| bincode::deserialize(v).ok())
-            });
+            let value = self
+                .db_iter
+                .key()
+                .and_then(|_| self.db_iter.value().and_then(|v| bcs::from_bytes(v).ok()));
 
             self.db_iter.next();
             value

--- a/crates/typed-store/src/tests/store_tests.rs
+++ b/crates/typed-store/src/tests/store_tests.rs
@@ -98,7 +98,7 @@ async fn read_raw_write_value() {
     assert!(result.is_ok());
     let read_value = result.unwrap();
     assert!(read_value.is_some());
-    assert_eq!(read_value, Some(bincode::serialize(&value).unwrap()));
+    assert_eq!(read_value, Some(bcs::to_bytes(&value).unwrap()));
 }
 
 #[tokio::test]

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -20,7 +20,7 @@ where
     /// Returns the value for the given key from the map, if it exists.
     fn get(&self, key: &K) -> Result<Option<V>, Self::Error>;
 
-    /// Returns the raw value (bincode serialized bytes) for the given key from the map, if it exists.
+    /// Returns the raw value (serialized bytes) for the given key from the map, if it exists.
     fn get_raw_bytes(&self, key: &K) -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Returns the value for the given key from the map, if it exists
@@ -113,7 +113,7 @@ where
     /// Returns the value for the given key from the map, if it exists.
     async fn get(&self, key: &K) -> Result<Option<V>, Self::Error>;
 
-    /// Returns the raw value (bincode serialized bytes) for the given key from the map, if it exists.
+    /// Returns the raw value (serialized bytes) for the given key from the map, if it exists.
     async fn get_raw_bytes(&self, key: &K) -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Returns true if the map is empty, otherwise false.

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -76,7 +76,7 @@ async fn macro_test() {
         let key = i.to_string();
         let value = i.to_string();
         let k_buf = be_fix_int_ser::<String>(&key).unwrap();
-        let value_buf = bincode::serialize::<String>(&value).unwrap();
+        let value_buf = bcs::to_bytes::<String>(&value).unwrap();
         raw_key_bytes1 += k_buf.len();
         raw_value_bytes1 += value_buf.len();
     }
@@ -93,7 +93,7 @@ async fn macro_test() {
         let key = i;
         let value = i.to_string();
         let k_buf = be_fix_int_ser(key.borrow()).unwrap();
-        let value_buf = bincode::serialize::<String>(&value).unwrap();
+        let value_buf = bcs::to_bytes::<String>(&value).unwrap();
         raw_key_bytes2 += k_buf.len();
         raw_value_bytes2 += value_buf.len();
     }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -515,6 +515,7 @@ slip10_ed25519 = { version = "0.1", default-features = false }
 slug = { version = "0.1", default-features = false }
 smallvec = { version = "1", default-features = false }
 smawk = { version = "0.3", default-features = false }
+snap = { version = "1", default-features = false }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
 soketto = { version = "0.7", features = ["http"] }
 spin-274715c4dabd11b0 = { package = "spin", version = "0.9" }
@@ -1224,6 +1225,7 @@ slip10_ed25519 = { version = "0.1", default-features = false }
 slug = { version = "0.1", default-features = false }
 smallvec = { version = "1", default-features = false }
 smawk = { version = "0.3", default-features = false }
+snap = { version = "1", default-features = false }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
 soketto = { version = "0.7", features = ["http"] }
 spin-274715c4dabd11b0 = { package = "spin", version = "0.9" }

--- a/narwhal/consensus/benches/process_certificates.rs
+++ b/narwhal/consensus/benches/process_certificates.rs
@@ -48,7 +48,7 @@ pub fn process_certificates(c: &mut Criterion) {
 
         let data_size: usize = certificates
             .iter()
-            .map(|cert| bincode::serialize(&cert).unwrap().len())
+            .map(|cert| bcs::to_bytes(&cert).unwrap().len())
             .sum();
         consensus_group.throughput(Throughput::Bytes(data_size as u64));
 

--- a/narwhal/executor/Cargo.toml
+++ b/narwhal/executor/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1.61"
+bcs = "0.1.4"
 bincode = "1.3.3"
 bytes = "1.3.0"
 config = { path = "../config", package = "narwhal-config" }

--- a/narwhal/executor/src/errors.rs
+++ b/narwhal/executor/src/errors.rs
@@ -57,6 +57,12 @@ pub enum SubscriberError {
     ClientExecutionError(String),
 }
 
+impl From<Box<bcs::Error>> for SubscriberError {
+    fn from(e: Box<bcs::Error>) -> Self {
+        Self::SerializationError(e.to_string())
+    }
+}
+
 impl From<Box<bincode::ErrorKind>> for SubscriberError {
     fn from(e: Box<bincode::ErrorKind>) -> Self {
         Self::SerializationError(e.to_string())

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -166,7 +166,7 @@ async fn test_internal_consensus_output() {
         let tx = string_transaction(i);
 
         // serialise and send
-        let tr = bincode::serialize(&tx).unwrap();
+        let tr = bcs::to_bytes(&tx).unwrap();
         let txn = TransactionProto {
             transaction: Bytes::from(tr),
         };
@@ -180,7 +180,7 @@ async fn test_internal_consensus_output() {
         let result = receiver.recv().await.unwrap();
 
         // deserialise transaction
-        let output_transaction = bincode::deserialize::<String>(&result).unwrap();
+        let output_transaction = bcs::from_bytes::<String>(&result).unwrap();
 
         // we always remove the first transaction and check with the one
         // sequenced. We want the transactions to be sequenced in the

--- a/narwhal/primary/Cargo.toml
+++ b/narwhal/primary/Cargo.toml
@@ -12,6 +12,7 @@ arc-swap = "1.5.1"
 async-trait = "0.1.61"
 backoff = { version = "0.4", features = ["futures", "futures-core", "pin-project-lite", "tokio", "tokio_1"] }
 base64 = "0.13.0"
+bcs = "0.1.4"
 bincode = "1.3.3"
 bytes = "1.3.0"
 config = { path = "../config", package = "narwhal-config" }

--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -170,7 +170,7 @@ impl CertificateFetcher {
                             // Otherwise, continue to update fetch targets.
                         }
                         Err(e) => {
-                            // If this happens, it is most likely due to bincode serialization error.
+                            // If this happens, it is most likely due to serialization error.
                             error!("Failed to read latest round for {}: {}", header.author, e);
                             continue;
                         }

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -1240,7 +1240,7 @@ async fn test_process_payload_availability_when_failures() {
             .expect("Couldn't serialise key");
 
         // Just serialise the "false" value
-        let dummy_value = bincode::serialize(false.borrow()).expect("Couldn't serialise value");
+        let dummy_value = bcs::to_bytes(false.borrow()).expect("Couldn't serialise value");
 
         rocksdb
             .put_cf(

--- a/narwhal/primary/tests/causal_completion_tests.rs
+++ b/narwhal/primary/tests/causal_completion_tests.rs
@@ -40,7 +40,7 @@ async fn test_restore_from_disk() {
     ] {
         let mut c = client.clone();
         tokio::spawn(async move {
-            let tr = bincode::serialize(&tx).unwrap();
+            let tr = bcs::to_bytes(&tx).unwrap();
             let txn = TransactionProto {
                 transaction: Bytes::from(tr),
             };

--- a/narwhal/primary/tests/nodes_bootstrapping_tests.rs
+++ b/narwhal/primary/tests/nodes_bootstrapping_tests.rs
@@ -67,7 +67,7 @@ async fn test_response_error_after_shutdown_internal_consensus() {
 
     // Create a fake transaction
     let tx_str = "test transaction".to_string();
-    let tx = bincode::serialize(&tx_str).unwrap();
+    let tx = bcs::to_bytes(&tx_str).unwrap();
     let txn = TransactionProto {
         transaction: Bytes::from(tx),
     };

--- a/narwhal/types/Cargo.toml
+++ b/narwhal/types/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 async-trait = "0.1.61"
 base64 = "0.13.0"
+bcs = "0.1.4"
 bincode = "1.3.3"
 bytes = "1.3.0"
 dashmap = "5.4.0"
@@ -40,6 +41,7 @@ workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 once_cell = "1.16.0"
 
 store = { path = "../../crates/typed-store", package = "typed-store" }
+mysten-network.workspace = true
 mysten-util-mem.workspace = true
 
 [dev-dependencies]

--- a/narwhal/types/benches/batch_digest.rs
+++ b/narwhal/types/benches/batch_digest.rs
@@ -6,7 +6,7 @@ use criterion::{
 use fastcrypto::hash::Hash;
 use narwhal_types as types;
 use rand::Rng;
-use types::{serialized_batch_digest, Batch, WorkerBatchMessage};
+use types::Batch;
 
 pub fn batch_digest(c: &mut Criterion) {
     let mut digest_group = c.benchmark_group("Batch digests");
@@ -21,18 +21,7 @@ pub fn batch_digest(c: &mut Criterion) {
                 .collect::<Vec<u8>>()
         };
         let batch = Batch::new((0..size).map(|_| tx_gen()).collect::<Vec<_>>());
-        let message = WorkerBatchMessage {
-            batch: batch.clone(),
-        };
-        let serialized_batch = bincode::serialize(&message).unwrap();
-
         digest_group.throughput(Throughput::Bytes(512 * size as u64));
-
-        digest_group.bench_with_input(
-            BenchmarkId::new("serialized batch digest", size),
-            &serialized_batch,
-            |b, i| b.iter(|| serialized_batch_digest(i)),
-        );
         digest_group.bench_with_input(BenchmarkId::new("batch digest", size), &batch, |b, i| {
             b.iter(|| i.digest())
         });

--- a/narwhal/types/benches/verify_certificate.rs
+++ b/narwhal/types/benches/verify_certificate.rs
@@ -30,7 +30,7 @@ pub fn verify_certificates(c: &mut Criterion) {
             make_optimal_certificates(&committee, 1..=1, &genesis, &keys);
         let certificate = certificates.front().unwrap().clone();
 
-        let data_size: usize = bincode::serialize(&certificate).unwrap().len();
+        let data_size: usize = bcs::to_bytes(&certificate).unwrap().len();
         bench_group.throughput(Throughput::Bytes(data_size as u64));
 
         bench_group.bench_with_input(

--- a/narwhal/types/build.rs
+++ b/narwhal/types/build.rs
@@ -46,6 +46,8 @@ fn build_anemo_services(out_dir: &Path) {
     let mut automock_attribute = anemo_build::Attributes::default();
     automock_attribute.push_trait(".", r#"#[mockall::automock]"#);
 
+    let codec_path = "mysten_network::codec::anemo::BcsSnappyCodec";
+
     let primary_to_primary = anemo_build::manual::Service::builder()
         .name("PrimaryToPrimary")
         .package("narwhal")
@@ -56,7 +58,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("SendCertificate")
                 .request_type("crate::SendCertificateRequest")
                 .response_type("crate::SendCertificateResponse")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -65,7 +67,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("RequestVote")
                 .request_type("crate::RequestVoteRequest")
                 .response_type("crate::RequestVoteResponse")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -74,7 +76,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("GetPayloadAvailability")
                 .request_type("crate::PayloadAvailabilityRequest")
                 .response_type("crate::PayloadAvailabilityResponse")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -83,7 +85,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("GetCertificates")
                 .request_type("crate::GetCertificatesRequest")
                 .response_type("crate::GetCertificatesResponse")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -92,7 +94,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("FetchCertificates")
                 .request_type("crate::FetchCertificatesRequest")
                 .response_type("crate::FetchCertificatesResponse")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .build();
@@ -107,7 +109,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("Synchronize")
                 .request_type("crate::WorkerSynchronizeMessage")
                 .response_type("()")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -116,7 +118,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("DeleteBatches")
                 .request_type("crate::WorkerDeleteBatchesMessage")
                 .response_type("()")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .build();
@@ -131,7 +133,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("ReportOurBatch")
                 .request_type("crate::WorkerOurBatchMessage")
                 .response_type("()")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -140,7 +142,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("ReportOthersBatch")
                 .request_type("crate::WorkerOthersBatchMessage")
                 .response_type("()")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -149,7 +151,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("WorkerInfo")
                 .request_type("()")
                 .response_type("crate::WorkerInfoResponse")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .build();
@@ -164,7 +166,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("ReportBatch")
                 .request_type("crate::WorkerBatchMessage")
                 .response_type("()")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .method(
@@ -173,7 +175,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("RequestBatch")
                 .request_type("crate::RequestBatchRequest")
                 .response_type("crate::RequestBatchResponse")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .codec_path(codec_path)
                 .build(),
         )
         .build();

--- a/narwhal/types/src/tests/batch_serde.rs
+++ b/narwhal/types/src/tests/batch_serde.rs
@@ -1,12 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{serialized_batch_digest, Batch, Metadata, WorkerBatchMessage};
-use fastcrypto::{
-    encoding::{Encoding, Hex},
-    hash::Hash,
-};
-use proptest::arbitrary::Arbitrary;
+use crate::{Batch, Metadata};
 use serde_test::{assert_tokens, Token};
 
 #[test]
@@ -55,79 +50,4 @@ fn test_serde_batch() {
             Token::StructEnd,
         ],
     );
-}
-
-#[test]
-fn test_bincode_serde_batch() {
-    let tx = || vec![1; 5];
-
-    let txes = Batch {
-        transactions: (0..2).map(|_| tx()).collect(),
-        metadata: Metadata {
-            created_at: 1666205365890,
-        },
-    };
-
-    let txes_bytes = bincode::serialize(&txes).unwrap();
-
-    // Length as u64: 0000000000000002,
-    let bytes: [u8; 8] = Hex::decode("0200000000000000").unwrap().try_into().unwrap();
-    assert_eq!(u64::from_le_bytes(bytes), 2u64);
-
-    // Length-prefix 2, length-prefix 5, 11111, length-prefix 5, 11111,
-    let expected_bytes = Hex::decode(
-        "02000000000000000500000000000000010101010105000000000000000101010101823694f183010000",
-    )
-    .unwrap();
-
-    assert_eq!(
-        txes_bytes.clone(),
-        expected_bytes,
-        "received {}",
-        Hex::encode(txes_bytes)
-    );
-}
-
-#[test]
-fn test_bincode_serde_batch_message() {
-    let tx = || vec![1; 5];
-
-    let txes = WorkerBatchMessage {
-        batch: Batch {
-            transactions: (0..2).map(|_| tx()).collect(),
-            metadata: Metadata {
-                created_at: 1666205365890,
-            },
-        },
-    };
-
-    let txes_bytes = bincode::serialize(&txes).unwrap();
-
-    // We expect this will be the same as the above.
-    // Length-prefix 2, length-prefix 5, 11111, length-prefix 5, 11111
-    let expected_bytes = Hex::decode(
-        "02000000000000000500000000000000010101010105000000000000000101010101823694f183010000",
-    )
-    .unwrap();
-
-    assert_eq!(
-        txes_bytes.clone(),
-        expected_bytes,
-        "received {}",
-        Hex::encode(txes_bytes)
-    );
-}
-
-proptest::proptest! {
-
-    #[test]
-    fn test_batch_and_serialized(
-        batch in Batch::arbitrary()
-    ) {
-        let digest = batch.digest();
-        let message = WorkerBatchMessage{batch};
-        let serialized = bincode::serialize(&message).expect("Failed to serialize our own batch");
-        let digest_from_serialized = serialized_batch_digest(serialized).expect("Failed to hash serialized batch");
-        assert_eq!(digest, digest_from_serialized);
-    }
 }

--- a/narwhal/types/src/tests/primary_type_tests.rs
+++ b/narwhal/types/src/tests/primary_type_tests.rs
@@ -91,8 +91,8 @@ fn arb_header() -> impl Strategy<Value = Header> {
 proptest! {
     #[test]
     fn header_deserializes_to_correct_id(header in arb_header()) {
-        let serialized = bincode::serialize(&header).unwrap();
-        let deserialized: Header = bincode::deserialize(&serialized).unwrap();
+        let serialized = bcs::to_bytes(&header).unwrap();
+        let deserialized: Header = bcs::from_bytes(&serialized).unwrap();
         // We may not have header.digest() == Hash::digest(header), due to the naughty cases above.
         //
         // Indeed, the naughty headers are specially crafted so that their `digest` is populated with a wrong digest.

--- a/narwhal/types/src/worker.rs
+++ b/narwhal/types/src/worker.rs
@@ -3,7 +3,6 @@
 
 use crate::{Batch, BatchDigest};
 
-use fastcrypto::hash::HashFunction;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -31,37 +30,6 @@ pub struct RequestBatchResponse {
 pub type TxResponse = tokio::sync::oneshot::Sender<BatchDigest>;
 pub type PrimaryResponse = Option<tokio::sync::oneshot::Sender<()>>;
 
-/// Hashes a serialized batch message without deserializing it into a batch.
-///
-/// See the test `test_batch_and_serialized`, which guarantees that the output of this
-/// function remains the same as the [`fastcrypto::hash::Hash::digest`] result you would get from [`Batch`].
-/// See also the micro-benchmark `batch_digest`, which checks the performance of this is
-/// identical to hashing a serialized batch.
-///
-/// TODO: remove the expects in the below, making this return a `Result` and correspondingly
-/// doing error management at the callers. See #268
-/// TODO: update batch hashing to reflect hashing fixed sequences of transactions, see #87.
-pub fn serialized_batch_digest<K: AsRef<[u8]>>(sbm: K) -> Result<BatchDigest, DigestError> {
-    let sbm = sbm.as_ref();
-    let mut offset = 0;
-    let num_transactions = u64::from_le_bytes(
-        sbm.get(offset..offset + 8)
-            .ok_or(DigestError::InvalidLengthError)?
-            .try_into()
-            .map_err(|_| DigestError::InvalidArgumentError(offset))?,
-    );
-    offset += 8;
-    let mut transactions = Vec::new();
-    for _i in 0..num_transactions {
-        let (tx_ref, new_offset) = read_one_transaction(sbm, offset)?;
-        transactions.push(tx_ref);
-        offset = new_offset;
-    }
-    Ok(BatchDigest::new(
-        crypto::DefaultHashFunction::digest_iterator(transactions.iter()).into(),
-    ))
-}
-
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum DigestError {
@@ -69,16 +37,4 @@ pub enum DigestError {
     InvalidArgumentError(usize),
     #[error("Invalid length")]
     InvalidLengthError,
-}
-
-fn read_one_transaction(sbm: &[u8], offset: usize) -> Result<(&[u8], usize), DigestError> {
-    let length = u64::from_le_bytes(
-        sbm.get(offset..offset + 8)
-            .ok_or(DigestError::InvalidLengthError)?
-            .try_into()
-            .map_err(|_| DigestError::InvalidArgumentError(offset))?,
-    );
-    let length = usize::try_from(length).map_err(|_| DigestError::InvalidArgumentError(offset))?;
-    let end = offset + 8 + length;
-    Ok((&sbm[offset + 8..end], end))
 }


### PR DESCRIPTION
## Description 

Migrates everything except RocksDB keys, which rely on the big-endian fixint encoding from bincode.

Also adds snappy compression to the anemo network codec.

Fixes issue #8714.

## Test Plan 

Updated tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes

Serialization format for RPCs and DB storage changed. Binaries must all be updated in order to use the same, new format.