### PR TITLE
Update siteconfig.json to remove "external" from link

### DIFF
--- a/doc/src/siteconfig.json
+++ b/doc/src/siteconfig.json
@@ -137,7 +137,6 @@
           {
             "name": "Sui Breaking Changes",
             "url": "/doc-updates/sui-breaking-changes",
-            "external": true
           },
           {
             "name": "Sui Announcements (Discord)",


### PR DESCRIPTION
## Description 

Update siteconfig.json to remove "external" from link

## Test Plan 

Staging server

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
