### PR TITLE
[core] Fix framework upgrade checkpointing bug

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -892,10 +892,19 @@ impl CheckpointAggregator {
     async fn run_inner(&mut self) -> SuiResult {
         let _scope = monitored_scope("CheckpointAggregator");
         'outer: loop {
+            let next_to_certify = self.next_checkpoint_to_certify();
             let current = if let Some(current) = &mut self.current {
+                // It's possible that the checkpoint was already certified by
+                // the rest of the network and we've already received the
+                // certified checkpoint via StateSync. In this case, we reset
+                // the current signature aggregator to the next checkpoint to
+                // be certified
+                if current.summary.sequence_number < next_to_certify {
+                    self.current = None;
+                    continue;
+                }
                 current
             } else {
-                let next_to_certify = self.next_checkpoint_to_certify();
                 let Some(summary) = self.epoch_store.get_built_checkpoint_summary(next_to_certify)? else { return Ok(()); };
                 self.current = Some(CheckpointSignatureAggregator {
                     next_index: 0,


### PR DESCRIPTION
## Description 

The test listed in the test plan below failed with a timeout while trying to certify a checkpoint. This was root caused to a situation where a sufficient number of validators, at some historical checkpoint, stopped performing the step of aggregating checkpoint signatures to create a certified checkpoint (despite having a quorum). Once this had happened across enough validators, there were no validators left in the network to certify future checkpoints. 

Investigation uncovered that this was happening because, after a checkpoint had been certified from elsewhere and received via `StateSync`, we continue to try and accumulate signatures for the now certified checkpoint. At the same time, [the following logic](https://github.com/MystenLabs/sui/blob/84af1162150757ba108fdeb7811f11350c14a584/crates/sui-core/src/checkpoints/mod.rs#L1118) prevents the validator from writing any new checkpoint signatures to epoch store once we have received a checkpoint certification. Therefore the signatures never exist locally to get quorum and we never get past trying to certify this checkpoint.

The fix is to reset `CheckpointSignatureAggregator` to `None`  when we have already received the certified checkpoint, so that in the next loop iteration, it will be updated to reflect the next checkpoint to certify.

## Test Plan 

Can repro bug at commit `5528b24c8` via 

```
RUST_LOG=sui=debug,error MSIM_TEST_SEED=9176646232036327306 cargo simtest --test protocol_version_tests test_framework_upgrade_conflicting_versions
```
Tested fix against this commit and saw that it passed with `MSIM_TEST_NUM=20`


---

Not user facing
