### PR TITLE
Expose metrics to compute stdev

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -372,10 +372,16 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                         match res {
                                             Ok(effects) => {
                                                 let latency = start.elapsed();
+                                                let time_from_start = start_time.elapsed();
+
+                                                if let Some(delta) = time_from_start.as_secs().checked_sub(metrics_cloned.benchmark_duration.get()) {
+                                                    metrics_cloned.benchmark_duration.inc_by(delta);
+                                                }
+
                                                 let square_latency_ms = latency.as_secs_f64().powf(2.0);
                                                 metrics_cloned.latency_s.with_label_values(&[&b.1.get_workload_type().to_string()]).observe(latency.as_secs_f64());
                                                 metrics_cloned.latency_squared_s.with_label_values(&[&b.1.get_workload_type().to_string()]).inc_by(square_latency_ms);
-                                                metrics_cloned.benchmark_duration.inc_by(start_time.elapsed().as_secs() - metrics_cloned.benchmark_duration.get());
+
                                                 metrics_cloned.num_success.with_label_values(&[&b.1.get_workload_type().to_string()]).inc();
                                                 metrics_cloned.num_in_flight.with_label_values(&[&b.1.get_workload_type().to_string()]).dec();
                                                 // let auth_sign_info = AuthorityStrongQuorumSignInfo::try_from(&cert.auth_sign_info).unwrap();
@@ -420,10 +426,16 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                     match res {
                                         Ok(effects) => {
                                             let latency = start.elapsed();
+                                            let time_from_start = start_time.elapsed();
+
+                                            if let Some(delta) = time_from_start.as_secs().checked_sub(metrics_cloned.benchmark_duration.get()) {
+                                                metrics_cloned.benchmark_duration.inc_by(delta);
+                                            }
+
                                             let square_latency_ms = latency.as_secs_f64().powf(2.0);
                                             metrics_cloned.latency_s.with_label_values(&[&payload.get_workload_type().to_string()]).observe(latency.as_secs_f64());
                                             metrics_cloned.latency_squared_s.with_label_values(&[&payload.get_workload_type().to_string()]).inc_by(square_latency_ms);
-                                            metrics_cloned.benchmark_duration.inc_by(start_time.elapsed().as_secs() - metrics_cloned.benchmark_duration.get());
+
                                             metrics_cloned.num_success.with_label_values(&[&payload.get_workload_type().to_string()]).inc();
                                             metrics_cloned.num_in_flight.with_label_values(&[&payload.get_workload_type().to_string()]).dec();
                                             // let auth_sign_info = AuthorityStrongQuorumSignInfo::try_from(&cert.auth_sign_info).unwrap();


### PR DESCRIPTION
## Description 

This PR exposes two extra metrics on the stress client:
* The benchmark duration to compute measurements snapshots (this help to determine when the system finished warming up).
* The sum of the square of the latencies (to compute stdefv)
