### PR TITLE
[tests] adding two tests to cover cases around Bullshark garbage collection

### DIFF
--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -299,8 +299,6 @@ impl Bullshark {
         // yet (see issue #10), repeated calls to this function should still pick from the whole roster of leaders.
         let leader = Self::leader_authority(committee, round);
 
-        println!("Leader for round {}: {:?}", round, leader);
-
         // Return its certificate and the certificate's digest.
         dag.get(&round).and_then(|x| x.get(&leader))
     }

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -273,7 +273,7 @@ impl Bullshark {
             if #[cfg(test)] {
                 // We apply round robin in leader election. Since we expect round to be an even number,
                 // 2, 4, 6, 8... it can't work well for leader election as we'll omit leaders. Thus
-                // we can always dive by 2 to get a monotonically incremented sequence,
+                // we can always divide by 2 to get a monotonically incremented sequence,
                 // 2/2 = 1, 4/2 = 2, 6/2 = 3, 8/2 = 4  etc, and then do minus 1 so we can always
                 // start with base zero 0.
                 let next_leader = (round/2 - 1) as usize % committee.authorities.len();

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -844,3 +844,243 @@ async fn restart_with_new_committee() {
         handle.await.unwrap();
     }
 }
+
+/// The test ensures the following things:
+/// * garbage collection is removing the certificates from lower rounds according to gc depth
+/// * we garbage collect/delete certificates bellow the last commit round immediately once we commit them
+/// * no certificate will ever get committed past the gc round
+/// * existing uncommitted certificates in DAG (ex from slow nodes where no-one references them) they
+/// get cleaned up.
+#[tokio::test]
+async fn garbage_collection_basic() {
+    const GC_DEPTH: Round = 4;
+
+    let fixture = CommitteeFixture::builder().build();
+    let committee: Committee = fixture.committee();
+
+    // We create certificates for rounds 1 to 7. For the authorities 1 to 3 the references
+    // to previous rounds between them are fully connected - meaning that we always add all the parents
+    // from previous round, except for the authority 4 which we consider it to be slow, so no one
+    // refers to their certificates. Authority 4 still produces certificates, and uses as parents
+    // all the certificates of the other authorities but never anyone else is referring to its
+    // certificates. That will create a lone chain for authority 4. We should not see any certificate
+    // committed for authority 4.
+    let keys: Vec<PublicKey> = committee
+        .authorities()
+        .map(|(key, _)| key.clone())
+        .collect();
+    let slow_node = keys[3].clone();
+    let genesis = Certificate::genesis(&committee);
+
+    let slow_nodes = vec![(slow_node.clone(), 0.0_f64)];
+    let (certificates, _round_5_certificates) = test_utils::make_certificates_with_slow_nodes(
+        &committee,
+        1..=7,
+        genesis,
+        &keys,
+        slow_nodes.as_slice(),
+    );
+
+    // Create Bullshark consensus engine
+    let store = make_consensus_store(&test_utils::temp_dir());
+
+    let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
+    let mut state = ConsensusState::new(metrics.clone());
+    let mut bullshark = Bullshark::new(committee, store, GC_DEPTH, metrics);
+
+    // Now start feeding the certificates per round
+    for c in certificates {
+        let (_, sub_dags) = bullshark.process_certificate(&mut state, c).unwrap();
+
+        sub_dags.iter().for_each(|sub_dag| {
+            // ensure nothing has been committed for authority 4
+            assert!(
+                !sub_dag
+                    .certificates
+                    .iter()
+                    .any(|c| c.header.author == slow_node),
+                "Slow authority shouldn't be amongst the committed ones"
+            );
+
+            // Once leader of round 6 is committed then we know that garbage
+            // collection has run. In this case no certificate of round 1 should exist.
+            if sub_dag.leader.round() == 6 {
+                assert_eq!(
+                    state
+                        .dag
+                        .iter()
+                        .filter(|(round, _)| **round <= 1_u64)
+                        .count(),
+                    0,
+                    "Didn't expect to still have certificates from round 1 and 2"
+                );
+            }
+
+            // When we do commit for authorities, we always keep the certificates up to their latest
+            // commit round + 1. Since we always commit for authorities 1 to 3 we expect to see no
+            // certificates for them, but only for the slow authority 4 for which we never commit.
+            // In this case the highest commit round for the authorities should be the leader.round() - 1,
+            // except for the latest leader which should be leader.round().
+            for (round, certificates) in state
+                .dag
+                .iter()
+                .filter(|(round, _)| **round <= sub_dag.leader.round())
+            {
+                if *round == sub_dag.leader.round() {
+                    assert_eq!(
+                        certificates.len(),
+                        3,
+                        "We expect to have three certificates, everyone's except the leader's"
+                    );
+
+                    assert!(
+                        !certificates
+                            .clone()
+                            .iter()
+                            .any(|(key, _)| *key == sub_dag.leader.origin()),
+                        "Leader's certificate shouldn't be present"
+                    );
+                } else {
+                    assert_eq!(
+                        certificates.len(),
+                        1,
+                        "We expect to have only one certificate, that of slow node's"
+                    );
+                    assert!(
+                        certificates.iter().any(|(key, _)| *key == slow_node),
+                        "Slow node's certificate should be present"
+                    );
+                }
+            }
+        })
+    }
+}
+
+// This test ensures that:
+// * a slow node will never commit anything until it get referred by someone
+// * certificates arriving bellow the gc round will eventually not get committed
+#[tokio::test]
+async fn slow_node() {
+    const GC_DEPTH: Round = 4;
+
+    let fixture = CommitteeFixture::builder().build();
+    let committee: Committee = fixture.committee();
+
+    // We create certificates for rounds 1 to 8. For the authorities 1 to 3 the references
+    // to previous rounds between them are fully connected - meaning that we always add all the parents
+    // from previous round, except for the authority 4 which we consider it to be slow, so no one
+    // refers to their certificates. Authority 4 still produces certificates, and uses as parents
+    // all the certificates of the other authorities but never anyone else is referring to its
+    // certificates. That will create a lone chain for authority 4. We should not see any certificate
+    // committed for authority 4.
+    let keys: Vec<PublicKey> = committee
+        .authorities()
+        .map(|(key, _)| key.clone())
+        .collect();
+    let slow_node = keys[3].clone();
+    let genesis = Certificate::genesis(&committee);
+
+    let slow_nodes = vec![(slow_node.clone(), 0.0_f64)];
+    let (certificates, round_8_certificates) = test_utils::make_certificates_with_slow_nodes(
+        &committee,
+        1..=8,
+        genesis,
+        &keys,
+        slow_nodes.as_slice(),
+    );
+
+    let mut certificates: VecDeque<Certificate> = certificates;
+    let mut slow_node_certificates = VecDeque::new();
+
+    // Now we keep only the certificates from authorities 1-3
+    certificates.retain(|c| {
+        if c.origin() == slow_node {
+            // if it is slow node's add it to the dedicated vec
+            slow_node_certificates.push_back(c.clone());
+            return false;
+        }
+        true
+    });
+
+    // Create Bullshark consensus engine
+    let store = make_consensus_store(&test_utils::temp_dir());
+    let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
+    let mut state = ConsensusState::new(metrics.clone());
+    let mut bullshark = Bullshark::new(committee.clone(), store, GC_DEPTH, metrics);
+
+    // Now start feeding the certificates per round up to 8. We expect to have
+    // triggered a commit up to round 6 and gc round 1.
+    for c in certificates {
+        let _ = bullshark
+            .process_certificate(&mut state, c.clone())
+            .unwrap();
+    }
+
+    // We expect everything to have been cleaned up by standard gc until round 3 (included)
+    assert_eq!(
+        state
+            .dag
+            .iter()
+            .filter(|(round, _)| **round <= 1_u64)
+            .count(),
+        0,
+        "Didn't expect to still have certificates from round 1 and 2"
+    );
+
+    // Now send the certificates of slow node. Now leader election can happen for round 8
+    // as we haven't sent yet certificates of round 9
+    for c in slow_node_certificates {
+        let _ = bullshark.process_certificate(&mut state, c).unwrap();
+    }
+
+    // Now create the certificates of round 9, and ensure everyone gives support to
+    // leader of round 8 (the slow node - 4) so we can trigger a commit. Also since slow node
+    // refers to always all the parents of previous rounds, there will be a link to the previous
+    // leader, so commit should be triggered immediately.
+    let (certificates, _) = test_utils::make_certificates_with_slow_nodes(
+        &committee,
+        9..=9,
+        round_8_certificates,
+        &keys,
+        &[],
+    );
+
+    // send the certificates - they should trigger a commit.
+    // We should see certificates for authorities 1-3 only for round 7
+    // We should see certificates for authority 4 only for round > 1 , as round 1 should have been
+    // garbage collected.
+    let mut committed = false;
+    for c in certificates {
+        let (outcome, sub_dags) = bullshark.process_certificate(&mut state, c).unwrap();
+
+        match outcome {
+            Outcome::NotEnoughSupportForLeader => {}
+            Outcome::LeaderBelowCommitRound => {}
+            Outcome::Commit => {
+                assert_eq!(sub_dags.len(), 1);
+
+                let sub_dag = sub_dags.get(0).unwrap();
+
+                for committed in &sub_dag.certificates {
+                    assert!(
+                        committed.round() >= 2,
+                        "We don't expect to see any certificate below round 2 because of gc"
+                    );
+                }
+
+                let slow_node_total = sub_dag
+                    .certificates
+                    .iter()
+                    .filter(|c| c.origin() == slow_node)
+                    .count();
+
+                assert_eq!(slow_node_total, 7);
+
+                committed = true;
+            }
+            _ => panic!("Unexpected outcome {:?}", outcome),
+        }
+    }
+
+    assert!(committed, "We expect to have commit for round 8");
+}

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -923,7 +923,7 @@ async fn garbage_collection_basic() {
                         .filter(|(round, _)| **round <= 1_u64)
                         .count(),
                     0,
-                    "Didn't expect to still have certificates from round 1 and 2"
+                    "Didn't expect to still have certificates from round 1"
                 );
             }
 
@@ -1055,6 +1055,8 @@ async fn slow_node() {
     // leader of round 8 (the slow node - 4) so we can trigger a commit. Also since slow node
     // refers to always all the parents of previous rounds, there will be a link to the previous
     // leader, so commit should be triggered immediately.
+    // It is reminded that the leader election for testing is round robin, thus we can deterministically
+    // know the leader of each round.
     let (certificates, _) = test_utils::make_certificates_with_slow_nodes(
         &committee,
         9..=9,

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -968,8 +968,8 @@ async fn garbage_collection_basic() {
 }
 
 // This test ensures that:
-// * a slow node will never commit anything until it get referred by someone
-// * certificates arriving bellow the gc round will eventually not get committed
+// * a slow node will never commit anything until its certificates get linked by others
+// * certificates arriving bellow the gc round will never get committed
 #[tokio::test]
 async fn slow_node() {
     const GC_DEPTH: Round = 4;

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -854,6 +854,7 @@ async fn restart_with_new_committee() {
 #[tokio::test]
 async fn garbage_collection_basic() {
     const GC_DEPTH: Round = 4;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     let fixture = CommitteeFixture::builder().build();
     let committee: Committee = fixture.committee();
@@ -886,7 +887,13 @@ async fn garbage_collection_basic() {
 
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let mut state = ConsensusState::new(metrics.clone());
-    let mut bullshark = Bullshark::new(committee, store, GC_DEPTH, metrics);
+    let mut bullshark = Bullshark::new(
+        committee,
+        store,
+        GC_DEPTH,
+        metrics,
+        NUM_SUB_DAGS_PER_SCHEDULE,
+    );
 
     // Now start feeding the certificates per round
     for c in certificates {
@@ -962,6 +969,7 @@ async fn garbage_collection_basic() {
 #[tokio::test]
 async fn slow_node() {
     const GC_DEPTH: Round = 4;
+    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     let fixture = CommitteeFixture::builder().build();
     let committee: Committee = fixture.committee();
@@ -1006,7 +1014,13 @@ async fn slow_node() {
     let store = make_consensus_store(&test_utils::temp_dir());
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let mut state = ConsensusState::new(metrics.clone());
-    let mut bullshark = Bullshark::new(committee.clone(), store, GC_DEPTH, metrics);
+    let mut bullshark = Bullshark::new(
+        committee.clone(),
+        store,
+        GC_DEPTH,
+        metrics,
+        NUM_SUB_DAGS_PER_SCHEDULE,
+    );
 
     // Now start feeding the certificates per round up to 8. We expect to have
     // triggered a commit up to round 6 and gc round 1.

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -460,7 +460,7 @@ pub fn make_certificates(
 // `keys`: the authorities for which it will create certificates for
 // `slow_nodes`: the authorities which are considered slow. Being a slow authority means that we will
 //  still create certificates for them on each round, but no other authority from higher round will refer
-// to those certificates. The number (by stake) o slow_nodes can not be > f , as otherwise no valid graph will be
+// to those certificates. The number (by stake) of slow_nodes can not be > f , as otherwise no valid graph will be
 // produced.
 pub fn make_certificates_with_slow_nodes(
     committee: &Committee,


### PR DESCRIPTION
## Description 

The PR is introducing two new tests to cover cases around garbage collection and especially when dealing with slow nodes as well. Also refactored the leader election method when is used under testing, so we can use it in a round robin fashion, instead of always having the first only node doing the election.

## Test Plan 


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
