### PR TITLE
[programmable transactions] Publish produces UpgradeCap as result

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/publish/publish_with_upgrade.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/publish_with_upgrade.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 1 'publish'. lines 6-10:
+created: object(104), object(105)
+written: object(103)
+
+task 2 'view-object'. lines 12-12:
+Owner: Account Address ( _ )
+Version: 2
+Contents: sui::package::UpgradeCap {id: sui::object::UID {id: sui::object::ID {bytes: fake(105)}}, package: sui::object::ID {bytes: Test}, version: 1u64, policy: 0u8}

--- a/crates/sui-adapter-transactional-tests/tests/publish/publish_with_upgrade.move
+++ b/crates/sui-adapter-transactional-tests/tests/publish/publish_with_upgrade.move
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0
+
+//# publish --upgradeable
+module Test::M1 {
+    use sui::tx_context::TxContext;
+    fun init(_ctx: &mut TxContext) { }
+}
+
+//# view-object 105

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -330,7 +330,7 @@ where
     pub fn new_package(
         &mut self,
         modules: Vec<move_binary_format::CompiledModule>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<ObjectID, ExecutionError> {
         // wrap the modules in an object, write it to the store
         let package_object = Object::new_package(
             modules,
@@ -338,8 +338,9 @@ where
             self.tx_context.digest(),
             self.protocol_config.max_move_package_size(),
         )?;
+        let id = package_object.id();
         self.new_packages.push(package_object);
-        Ok(())
+        Ok(id)
     }
 
     /// Finish a command: clearing the borrows and adding the results to the result vector

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -32,6 +32,7 @@ use sui_types::{
     messages::{
         Argument, Command, CommandArgumentError, ProgrammableMoveCall, ProgrammableTransaction,
     },
+    move_package::UpgradeCap,
     SUI_FRAMEWORK_ADDRESS,
 };
 use sui_verifier::{
@@ -258,8 +259,7 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>>(
             )?
         }
         Command::Publish(modules) => {
-            execute_move_publish(context, modules)?;
-            vec![]
+            vec![execute_move_publish(context, modules)?]
         }
     };
     context.push_command_results(results)?;
@@ -357,11 +357,12 @@ fn make_value(
     })
 }
 
-/// Publish Move modules and call the init functions
+/// Publish Move modules and call the init functions.  Returns an `UpgradeCap` for the newly
+/// published package on success.
 fn execute_move_publish<E: fmt::Debug, S: StorageView<E>>(
     context: &mut ExecutionContext<E, S>,
     module_bytes: Vec<Vec<u8>>,
-) -> Result<(), ExecutionError> {
+) -> Result<Value, ExecutionError> {
     assert_invariant!(
         !module_bytes.is_empty(),
         "empty package is checked in transaction input checker"
@@ -384,7 +385,7 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>>(
         })
         .collect::<Vec<_>>();
 
-    context.new_package(modules)?;
+    let package_id = context.new_package(modules)?;
     for module_id in &modules_to_init {
         let return_values = execute_move_call(
             context,
@@ -399,7 +400,13 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>>(
             "init should not have return values"
         )
     }
-    Ok(())
+
+    Ok(Value::Object(ObjectValue::new(
+        UpgradeCap::type_(),
+        /* has_public_transfer */ true,
+        /* used_in_non_entry_move_call */ false,
+        &bcs::to_bytes(&UpgradeCap::new(context.fresh_id()?, package_id)).unwrap(),
+    )?))
 }
 
 /***************************************************************************************************

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -341,7 +341,11 @@ async fn test_publish_gas() -> anyhow::Result<()> {
         gas_object.object_size_for_gas_metering(),
         0.into(),
     )?;
-    assert_eq!(gas_cost, &gas_status.summary(true));
+    // Actual gas cost will be greater than the expected summary because of the cost to discard the
+    // `UpgradeCap`.
+    let gas_summary = gas_status.summary(true);
+    assert!(gas_cost.computation_cost >= gas_summary.computation_cost);
+    assert_eq!(gas_cost.storage_cost, gas_summary.storage_cost);
 
     // Create a transaction with budget DELTA less than the gas cost required.
     let total_gas_used = gas_cost.gas_used();

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -9,7 +9,7 @@ expression: common_costs_actual
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 639,
+    "computation_cost": 646,
     "storage_cost": 140,
     "storage_rebate": 0
   },

--- a/crates/sui-framework/docs/package.md
+++ b/crates/sui-framework/docs/package.md
@@ -236,7 +236,7 @@ Add new functions or types, or change dependencies, existing
 functions can't change.
 
 
-<pre><code><b>const</b> <a href="package.md#0x2_package_ADDITIVE">ADDITIVE</a>: u8 = 1;
+<pre><code><b>const</b> <a href="package.md#0x2_package_ADDITIVE">ADDITIVE</a>: u8 = 128;
 </code></pre>
 
 
@@ -257,7 +257,7 @@ functions or types, change dependencies)
 Only be able to change dependencies.
 
 
-<pre><code><b>const</b> <a href="package.md#0x2_package_DEP_ONLY">DEP_ONLY</a>: u8 = 2;
+<pre><code><b>const</b> <a href="package.md#0x2_package_DEP_ONLY">DEP_ONLY</a>: u8 = 192;
 </code></pre>
 
 

--- a/crates/sui-framework/sources/package.move
+++ b/crates/sui-framework/sources/package.move
@@ -28,9 +28,9 @@ module sui::package {
     const COMPATIBLE: u8 = 0;
     /// Add new functions or types, or change dependencies, existing
     /// functions can't change.
-    const ADDITIVE: u8 = 1;
+    const ADDITIVE: u8 = 128;
     /// Only be able to change dependencies.
-    const DEP_ONLY: u8 = 2;
+    const DEP_ONLY: u8 = 192;
 
     /// This type can only be created in the transaction that
     /// generates a module, by consuming its one-time witness, so it

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -27,6 +27,8 @@ pub struct SuiRunArgs {
 pub struct SuiPublishArgs {
     #[clap(long = "sender")]
     pub sender: Option<String>,
+    #[clap(long = "upgradeable", action = clap::ArgAction::SetTrue)]
+    pub upgradeable: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -300,7 +300,10 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         gas_budget: Option<u64>,
         extra: Self::ExtraPublishArgs,
     ) -> anyhow::Result<(Option<String>, CompiledModule)> {
-        let SuiPublishArgs { sender } = extra;
+        let SuiPublishArgs {
+            sender,
+            upgradeable,
+        } = extra;
         let module_name = module.self_id().name().to_string();
         let module_bytes = {
             let mut buf = vec![];
@@ -310,7 +313,12 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let gas_budget = gas_budget.unwrap_or(GAS_VALUE_FOR_TESTING);
         let data = |sender, gas| {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder.publish(vec![module_bytes]);
+            if upgradeable {
+                let cap = builder.publish_upgradeable(vec![module_bytes]);
+                builder.transfer_arg(sender, cap);
+            } else {
+                builder.publish(vec![module_bytes]);
+            };
             let pt = builder.finish();
             TransactionData::new_programmable_with_dummy_gas_price(
                 sender,

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -43,7 +43,6 @@ use sui_types::epoch_data::EpochData;
 use sui_types::gas::SuiCostTable;
 use sui_types::id::UID;
 use sui_types::in_memory_storage::InMemoryStorage;
-use sui_types::messages::Command;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -311,7 +311,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let gas_budget = gas_budget.unwrap_or(GAS_VALUE_FOR_TESTING);
         let data = |sender, gas| {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder.command(Command::Publish(vec![module_bytes]));
+            builder.publish(vec![module_bytes]);
             let pt = builder.finish();
             TransactionData::new_programmable_with_dummy_gas_price(
                 sender,

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -197,8 +197,12 @@ impl ProgrammableTransactionBuilder {
         })))
     }
 
+    pub fn publish_upgradeable(&mut self, modules: Vec<Vec<u8>>) -> Argument {
+        self.command(Command::Publish(modules))
+    }
+
     pub fn publish(&mut self, modules: Vec<Vec<u8>>) {
-        let cap = self.command(Command::Publish(modules));
+        let cap = self.publish_upgradeable(modules);
         self.commands
             .push(Command::MoveCall(Box::new(ProgrammableMoveCall {
                 package: SUI_FRAMEWORK_OBJECT_ID,
@@ -207,6 +211,15 @@ impl ProgrammableTransactionBuilder {
                 type_arguments: vec![],
                 arguments: vec![cap],
             })));
+    }
+
+    pub fn transfer_arg(&mut self, recipient: SuiAddress, arg: Argument) {
+        self.transfer_args(recipient, vec![arg])
+    }
+
+    pub fn transfer_args(&mut self, recipient: SuiAddress, args: Vec<Argument>) {
+        let rec_arg = self.pure(recipient).unwrap();
+        self.commands.push(Command::TransferObjects(args, rec_arg));
     }
 
     pub fn transfer_object(&mut self, recipient: SuiAddress, object_ref: ObjectRef) {

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Context;
 use indexmap::{IndexMap, IndexSet};
-use move_core_types::{identifier::Identifier, language_storage::TypeTag};
+use move_core_types::{ident_str, identifier::Identifier, language_storage::TypeTag};
 use serde::Serialize;
 
 use crate::{
@@ -16,6 +16,7 @@ use crate::{
         ProgrammableMoveCall, ProgrammableTransaction, SingleTransactionKind, TransactionData,
         TransactionKind, TransferObject, TransferSui,
     },
+    SUI_FRAMEWORK_OBJECT_ID,
 };
 
 pub fn migrate_transaction_data(m: TransactionData) -> anyhow::Result<TransactionData> {
@@ -196,7 +197,15 @@ impl ProgrammableTransactionBuilder {
     }
 
     pub fn publish(&mut self, modules: Vec<Vec<u8>>) {
-        self.commands.push(Command::Publish(modules))
+        let cap = self.command(Command::Publish(modules));
+        self.commands
+            .push(Command::MoveCall(Box::new(ProgrammableMoveCall {
+                package: SUI_FRAMEWORK_OBJECT_ID,
+                module: ident_str!("package").to_owned(),
+                function: ident_str!("make_immutable").to_owned(),
+                type_arguments: vec![],
+                arguments: vec![cap],
+            })));
     }
 
     pub fn transfer_object(&mut self, recipient: SuiAddress, object_ref: ObjectRef) {

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -16,6 +16,7 @@ use crate::{
         ProgrammableMoveCall, ProgrammableTransaction, SingleTransactionKind, TransactionData,
         TransactionKind, TransferObject, TransferSui,
     },
+    move_package::PACKAGE_MODULE_NAME,
     SUI_FRAMEWORK_OBJECT_ID,
 };
 
@@ -201,7 +202,7 @@ impl ProgrammableTransactionBuilder {
         self.commands
             .push(Command::MoveCall(Box::new(ProgrammableMoveCall {
                 package: SUI_FRAMEWORK_OBJECT_ID,
-                module: ident_str!("package").to_owned(),
+                module: PACKAGE_MODULE_NAME.to_owned(),
                 function: ident_str!("make_immutable").to_owned(),
                 type_arguments: vec![],
                 arguments: vec![cap],

--- a/sdk/typescript/src/builder/legacy.ts
+++ b/sdk/typescript/src/builder/legacy.ts
@@ -132,7 +132,14 @@ export async function convertToTransactionBuilder(
           ...(typeof data === 'string' ? fromB64(data) : Array.from(data)),
         ],
       );
-      tx.add(Commands.Publish(modules));
+      const cap = tx.add(Commands.Publish(modules));
+      tx.add(
+        Commands.MoveCall({
+          target: '0x2::package::make_immutable',
+          typeArguments: [],
+          arguments: [cap],
+        }),
+      );
       break;
     }
     case 'pay': {

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -112,9 +112,17 @@ export async function publishPackage(
   );
   const tx = new Transaction();
   tx.setGasBudget(DEFAULT_GAS_BUDGET);
-  tx.add(
+  const cap = tx.add(
     Commands.Publish(compiledModules.map((m: any) => Array.from(fromB64(m)))),
   );
+  tx.add(
+    Commands.MoveCall({
+      target: '0x2::package::make_immutable',
+      typeArguments: [],
+      arguments: [cap],
+    }),
+  );
+
   const publishTxn = await toolbox.signer.signAndExecuteTransaction(tx);
   expect(getExecutionStatusType(publishTxn)).toEqual('success');
 


### PR DESCRIPTION
## Description 

When a package is successfully published in a programmable transaction, produce an `UpgradeCap` which gives its owner the ability to upgrade the just-published package.

## Test Plan 

TBD, waiting on tests to migrate to using programmable transactions, at which point, we can test that publish produces this new object.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Publish events now return an `UpgradeCap` as their command result, on success, which gives its owner the ability to upgrade the published package.  Note that this value cannot be dropped, so it must either be transfered, or explicitly burned using `public entry fun sui::packge::make_immutable(cap: UpgradeCap)`.