### PR TITLE
[DO NOT MERGE] example showing how we might evolve TransactionData

### DIFF
--- a/.changeset/late-spoons-crash.md
+++ b/.changeset/late-spoons-crash.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Support for new versioned TransactionData format

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -200,7 +200,11 @@ fn execution_loop<
     // once across single tx, we should be able to run them in parallel.
     for (idx, single_tx) in transaction_kind.into_single_transactions().enumerate() {
         match single_tx {
-            SingleTransactionKind::TransferObject(TransferObject {
+            SingleTransactionKind::TransferObjectExtended(TransferObject {
+                recipient,
+                object_ref,
+            })
+            | SingleTransactionKind::TransferObject(TransferObject {
                 recipient,
                 object_ref,
             }) => {

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -33,7 +33,7 @@ use sui_types::{
     message_envelope::Envelope,
     messages::{
         CertifiedTransaction, CertifiedTransactionEffects, HandleCertificateResponse,
-        QuorumDriverResponse, Transaction, TransactionStatus,
+        QuorumDriverResponse, Transaction, TransactionEffectsAPI, TransactionStatus,
     },
     object::Object,
 };
@@ -65,7 +65,7 @@ impl ExecutionEffects {
     pub fn mutated(&self) -> Vec<(ObjectRef, Owner)> {
         match self {
             ExecutionEffects::CertifiedTransactionEffects(certified_effects, ..) => {
-                certified_effects.data().mutated.clone()
+                certified_effects.data().mutated().to_vec()
             }
             ExecutionEffects::SuiTransactionEffects(sui_tx_effects) => sui_tx_effects
                 .mutated
@@ -79,7 +79,7 @@ impl ExecutionEffects {
     pub fn created(&self) -> Vec<(ObjectRef, Owner)> {
         match self {
             ExecutionEffects::CertifiedTransactionEffects(certified_effects, ..) => {
-                certified_effects.data().created.clone()
+                certified_effects.data().created().to_vec()
             }
             ExecutionEffects::SuiTransactionEffects(sui_tx_effects) => sui_tx_effects
                 .created
@@ -102,7 +102,7 @@ impl ExecutionEffects {
     pub fn gas_object(&self) -> (ObjectRef, Owner) {
         match self {
             ExecutionEffects::CertifiedTransactionEffects(certified_effects, ..) => {
-                certified_effects.data().gas_object
+                *certified_effects.data().gas_object()
             }
             ExecutionEffects::SuiTransactionEffects(sui_tx_effects) => {
                 let refe = &sui_tx_effects.gas_object;

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -31,9 +31,9 @@ use sui_types::gas::SuiGasStatus;
 use sui_types::in_memory_storage::InMemoryStorage;
 use sui_types::intent::{Intent, IntentMessage, IntentScope};
 use sui_types::message_envelope::Message;
-use sui_types::messages::Transaction;
-use sui_types::messages::{CallArg, TransactionEffects};
-use sui_types::messages::{InputObjects, TransactionEvents};
+use sui_types::messages::{
+    CallArg, InputObjects, Transaction, TransactionDataAPI, TransactionEffects, TransactionEvents,
+};
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary, VerifiedCheckpoint,
 };
@@ -827,7 +827,7 @@ fn create_genesis_transaction(
             >(
                 vec![],
                 temporary_store,
-                transaction_data.kind,
+                transaction_data.into_kind(),
                 signer,
                 gas,
                 *genesis_transaction.digest(),
@@ -1171,7 +1171,7 @@ mod test {
             >(
                 vec![],
                 temporary_store,
-                transaction_data.kind,
+                transaction_data.into_kind(),
                 signer,
                 gas,
                 *genesis_transaction.digest(),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2161,7 +2161,7 @@ impl AuthorityState {
 
         for effect in effects.iter() {
             match effect {
-                Some(eff) => events_digests.push(eff.events_digest.unwrap()),
+                Some(eff) => events_digests.push(*eff.events_digest().unwrap()),
                 _ => continue,
             }
         }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -530,6 +530,8 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
         transaction: VerifiedTransaction,
     ) -> Result<HandleTransactionResponse, SuiError> {
+        transaction.check_version_supported(epoch_store.protocol_version())?;
+
         let tx_digest = *transaction.digest();
         debug!(
             "handle_transaction with transaction data: {:?}",
@@ -562,7 +564,7 @@ impl AuthorityState {
         }
 
         // Checks to see if the transaction has expired
-        if match &transaction.inner().data().transaction_data().expiration {
+        if match &transaction.inner().data().transaction_data().expiration() {
             TransactionExpiration::None => false,
             TransactionExpiration::Epoch(epoch) => *epoch < epoch_store.epoch(),
         } {
@@ -611,7 +613,7 @@ impl AuthorityState {
         let digest = *transaction.digest();
         debug!("execute_certificate_with_effects");
         fp_ensure!(
-            effects.data().transaction_digest == digest,
+            *effects.data().transaction_digest() == digest,
             SuiError::ErrorWhileProcessingCertificate {
                 err: "effects/tx digest mismatch".to_string()
             }
@@ -855,7 +857,7 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         let input_object_count = inner_temporary_store.objects.len();
-        let shared_object_count = effects.shared_objects.len();
+        let shared_object_count = effects.shared_objects().len();
 
         // If commit_certificate returns an error, tx_guard will be dropped and the certificate
         // will be persisted in the log for later recovery.
@@ -907,7 +909,7 @@ impl AuthorityState {
             .observe(shared_object_count as f64);
         self.metrics
             .batch_size
-            .observe(certificate.data().intent_message.value.kind.batch_size() as f64);
+            .observe(certificate.data().intent_message.value.kind().batch_size() as f64);
 
         Ok(())
     }
@@ -956,7 +958,7 @@ impl AuthorityState {
             execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
                 shared_object_refs,
                 temporary_store,
-                transaction_data.kind,
+                transaction_data.into_kind(),
                 signer,
                 gas,
                 *certificate.digest(),
@@ -1018,7 +1020,7 @@ impl AuthorityState {
             execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
                 shared_object_refs,
                 temporary_store,
-                transaction.kind,
+                transaction.into_kind(),
                 signer,
                 gas,
                 transaction_digest,
@@ -1048,6 +1050,9 @@ impl AuthorityState {
         if !self.is_fullnode(&epoch_store) {
             return Err(anyhow!("dev-inspect is only supported on fullnodes"));
         }
+
+        transaction_kind.check_version_supported(epoch_store.protocol_version())?;
+
         let gas_price = gas_price.unwrap_or_else(|| epoch_store.reference_gas_price());
 
         let protocol_config = epoch_store.protocol_config();
@@ -1081,7 +1086,7 @@ impl AuthorityState {
             gas_budget,
         );
         let transaction_digest = TransactionDigest::new(sha3_hash(&data));
-        let transaction_kind = data.kind;
+        let transaction_kind = data.into_kind();
         let transaction_dependencies = input_objects.transaction_dependencies();
         let temporary_store = TemporaryStore::new(
             self.database.clone(),
@@ -1154,6 +1159,7 @@ impl AuthorityState {
                 .map(|o| o.object_id()),
             effects
                 .all_mutated()
+                .into_iter()
                 .map(|(obj_ref, owner, _kind)| (*obj_ref, *owner)),
             cert.data()
                 .intent_message
@@ -1173,14 +1179,14 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> Result<ObjectIndexChanges, SuiError> {
         let modified_at_version = effects
-            .modified_at_versions
+            .modified_at_versions()
             .iter()
             .cloned()
             .collect::<HashMap<_, _>>();
 
         let mut deleted_owners = vec![];
         let mut deleted_dynamic_fields = vec![];
-        for (id, _, _) in &effects.deleted {
+        for (id, _, _) in effects.deleted() {
             let old_version = modified_at_version.get(id).unwrap();
 
             match self.get_owner_at_version(id, *old_version)? {
@@ -1200,11 +1206,11 @@ impl AuthorityState {
             // For mutated objects, retrieve old owner and delete old index if there is a owner change.
             if let WriteKind::Mutate = kind {
                 let Some(old_version) = modified_at_version.get(id) else{
-                        error!("Error processing object owner index for tx [{:?}], cannot find modified at version for mutated object [{id}].", effects.transaction_digest);
+                        error!("Error processing object owner index for tx [{:?}], cannot find modified at version for mutated object [{id}].", effects.transaction_digest());
                         continue;
                     };
                 let Some(old_object) = self.database.get_object_by_key(id, *old_version)? else {
-                        error!("Error processing object owner index for tx [{:?}], cannot find object [{id}] at version [{old_version}].", effects.transaction_digest);
+                        error!("Error processing object owner index for tx [{:?}], cannot find object [{id}] at version [{old_version}].", effects.transaction_digest());
                         continue;
                     };
                 if &old_object.owner != owner {
@@ -1240,7 +1246,7 @@ impl AuthorityState {
                             digest: oref.2,
                             type_,
                             owner: *owner,
-                            previous_transaction: effects.transaction_digest,
+                            previous_transaction: *effects.transaction_digest(),
                         },
                     ));
                 }
@@ -2433,8 +2439,8 @@ impl AuthorityState {
         {
             if let Some(transaction) = self.database.get_transaction(transaction_digest)? {
                 let cert_sig = epoch_store.get_transaction_cert_sig(transaction_digest)?;
-                let events = if let Some(digest) = effects.events_digest {
-                    self.database.get_events(&digest)?
+                let events = if let Some(digest) = effects.events_digest() {
+                    self.database.get_events(digest)?
                 } else {
                     TransactionEvents::default()
                 };
@@ -2478,7 +2484,7 @@ impl AuthorityState {
         effects: TransactionEffects,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> Result<VerifiedSignedTransactionEffects, SuiError> {
-        let tx_digest = effects.transaction_digest;
+        let tx_digest = *effects.transaction_digest();
         let signed_effects = match epoch_store.get_effects_signature(&tx_digest)? {
             Some(sig) if sig.epoch == epoch_store.epoch() => {
                 SignedTransactionEffects::new_from_data_and_sig(effects, sig)
@@ -3053,7 +3059,7 @@ impl AuthorityState {
         );
         epoch_store.record_is_safe_mode_metric(system_obj.safe_mode);
         // The change epoch transaction cannot fail to execute.
-        assert!(effects.status.is_ok());
+        assert!(effects.status().is_ok());
         Ok((system_obj, effects))
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -530,8 +530,6 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
         transaction: VerifiedTransaction,
     ) -> Result<HandleTransactionResponse, SuiError> {
-        transaction.check_version_supported(epoch_store.protocol_version())?;
-
         let tx_digest = *transaction.digest();
         debug!(
             "handle_transaction with transaction data: {:?}",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1049,7 +1049,7 @@ impl AuthorityState {
             return Err(anyhow!("dev-inspect is only supported on fullnodes"));
         }
 
-        transaction_kind.check_version_supported(epoch_store.protocol_version())?;
+        transaction_kind.check_version_supported(epoch_store.protocol_config())?;
 
         let gas_price = gas_price.unwrap_or_else(|| epoch_store.reference_gas_price());
 

--- a/crates/sui-core/src/authority/authority_notify_read.rs
+++ b/crates/sui-core/src/authority/authority_notify_read.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use sui_types::base_types::TransactionDigest;
 use sui_types::error::SuiResult;
-use sui_types::messages::TransactionEffects;
+use sui_types::messages::{TransactionEffects, TransactionEffectsAPI};
 use tokio::sync::oneshot;
 use tokio::time::Instant;
 use tracing::debug;
@@ -206,8 +206,8 @@ impl EffectsNotifyRead for Arc<AuthorityStore> {
         let mut effects_map = HashMap::new();
         let mut last_finished = None;
         while let Some(finished) = results.next().await {
-            last_finished = Some(finished.transaction_digest);
-            effects_map.insert(finished.transaction_digest, finished);
+            last_finished = Some(*finished.transaction_digest());
+            effects_map.insert(*finished.transaction_digest(), finished);
         }
         if needs_wait {
             // Only log the duration if we ended up waiting.

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -25,8 +25,8 @@ use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     AuthorityCapabilities, CertifiedTransaction, ConsensusTransaction, ConsensusTransactionKey,
     ConsensusTransactionKind, SenderSignedData, SharedInputObject, TransactionData,
-    TransactionEffects, TrustedExecutableTransaction, VerifiedCertificate,
-    VerifiedExecutableTransaction, VerifiedSignedTransaction,
+    TransactionDataAPI, TransactionEffects, TransactionEffectsAPI, TrustedExecutableTransaction,
+    VerifiedCertificate, VerifiedExecutableTransaction, VerifiedSignedTransaction,
 };
 use sui_types::signature::GenericSignature;
 use tracing::{debug, info, trace, warn};
@@ -474,6 +474,10 @@ impl AuthorityPerEpochStore {
         &self.committee
     }
 
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.committee.protocol_version
+    }
+
     pub fn protocol_config(&self) -> &ProtocolConfig {
         &self.protocol_config
     }
@@ -801,6 +805,7 @@ impl AuthorityPerEpochStore {
             // from the cert.
             let initial_versions: HashMap<_, _> = tx_data
                 .shared_input_objects()
+                .into_iter()
                 .map(SharedInputObject::into_id_and_version)
                 .collect();
 
@@ -900,7 +905,7 @@ impl AuthorityPerEpochStore {
         self.set_assigned_shared_object_versions(
             certificate,
             &effects
-                .shared_objects
+                .shared_objects()
                 .iter()
                 .map(|(id, version, _)| (*id, *version))
                 .collect(),

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -474,10 +474,6 @@ impl AuthorityPerEpochStore {
         &self.committee
     }
 
-    pub fn protocol_version(&self) -> ProtocolVersion {
-        self.committee.protocol_version
-    }
-
     pub fn protocol_config(&self) -> &ProtocolConfig {
         &self.protocol_config
     }

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -298,7 +298,6 @@ impl ValidatorService {
         let epoch_store = state.load_epoch_store_one_call_per_task();
 
         let certificate = request.into_inner();
-        certificate.check_version_supported(epoch_store.protocol_version())?;
 
         let shared_object_tx = certificate.contains_shared_object();
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -298,6 +298,8 @@ impl ValidatorService {
         let epoch_store = state.load_epoch_store_one_call_per_task();
 
         let certificate = request.into_inner();
+        certificate.check_version_supported(epoch_store.protocol_version())?;
+
         let shared_object_tx = certificate.contains_shared_object();
 
         let _metrics_guard = if shared_object_tx {
@@ -313,8 +315,8 @@ impl ValidatorService {
         if let Some(signed_effects) =
             state.get_signed_effects_and_maybe_resign(&tx_digest, &epoch_store)?
         {
-            let events = if let Some(digest) = signed_effects.events_digest {
-                state.get_transaction_events(digest).await?
+            let events = if let Some(digest) = signed_effects.events_digest() {
+                state.get_transaction_events(*digest).await?
             } else {
                 TransactionEvents::default()
             };
@@ -342,7 +344,7 @@ impl ValidatorService {
                 .data()
                 .intent_message
                 .value
-                .kind
+                .kind()
                 .input_objects()
                 .map_err(SuiError::from)?
                 .into_iter()
@@ -407,8 +409,8 @@ impl ValidatorService {
         let res = state.execute_certificate(&certificate, &epoch_store).await;
         match res {
             Ok(effects) => {
-                let events = if let Some(event_digest) = effects.events_digest {
-                    state.get_transaction_events(event_digest).await?
+                let events = if let Some(event_digest) = effects.events_digest() {
+                    state.get_transaction_events(*event_digest).await?
                 } else {
                     TransactionEvents::default()
                 };

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -34,7 +34,7 @@ use sui_types::message_envelope::Message;
 use sui_types::messages::VerifiedExecutableTransaction;
 use sui_types::{
     base_types::{ExecutionDigests, TransactionDigest},
-    messages::TransactionEffects,
+    messages::{TransactionEffects, TransactionEffectsAPI},
     messages_checkpoint::{CheckpointSequenceNumber, EndOfEpochData, VerifiedCheckpoint},
 };
 use tap::TapFallible;
@@ -457,7 +457,7 @@ async fn execute_transactions(
                 panic!("Transaction effects do not exist in effects table");
             }
             let fx = fx.unwrap();
-            (fx.transaction_digest, fx)
+            (*fx.transaction_digest(), fx)
         })
         .collect();
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -36,7 +36,8 @@ use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest};
 use sui_types::error::SuiResult;
 use sui_types::gas::GasCostSummary;
 use sui_types::messages::{
-    ConsensusTransactionKey, SingleTransactionKind, TransactionEffects, TransactionKind,
+    ConsensusTransactionKey, SingleTransactionKind, TransactionDataAPI, TransactionEffects,
+    TransactionEffectsAPI, TransactionKind,
 };
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
@@ -612,7 +613,7 @@ impl CheckpointBuilder {
             let last_checkpoint_of_epoch = details.last_of_epoch && index == chunks_count - 1;
 
             let digests_without_epoch_augment: Vec<_> =
-                effects.iter().map(|e| e.transaction_digest).collect();
+                effects.iter().map(|e| *e.transaction_digest()).collect();
             debug!("Waiting for checkpoint user signatures for certificates {:?} to appear in consensus", digests_without_epoch_augment);
             for digest in digests_without_epoch_augment.iter() {
                 let transaction = self
@@ -622,7 +623,7 @@ impl CheckpointBuilder {
                     .expect("Could not find executed transaction");
                 // ConsensusCommitPrologue is guaranteed to be processed before we reach here
                 if !matches!(
-                    transaction.inner().transaction_data().kind,
+                    transaction.inner().transaction_data().kind(),
                     TransactionKind::Single(SingleTransactionKind::ConsensusCommitPrologue(..))
                 ) {
                     // todo - use NotifyRead::register_all might be faster
@@ -796,14 +797,14 @@ impl CheckpointBuilder {
         loop {
             let mut pending = HashSet::new();
             for effect in roots {
-                let digest = effect.transaction_digest;
+                let digest = effect.transaction_digest();
                 if self
                     .epoch_store
-                    .builder_included_transaction_in_checkpoint(&digest)?
+                    .builder_included_transaction_in_checkpoint(digest)?
                 {
                     continue;
                 }
-                let executed_epoch = self.state.database.get_transaction_checkpoint(&digest)?;
+                let executed_epoch = self.state.database.get_transaction_checkpoint(digest)?;
                 if let Some((executed_epoch, _checkpoint)) = executed_epoch {
                     // Skip here if transaction was executed in previous epoch
                     //
@@ -814,7 +815,7 @@ impl CheckpointBuilder {
                         continue;
                     }
                 }
-                for dependency in effect.dependencies.iter() {
+                for dependency in effect.dependencies().iter() {
                     if seen.insert(*dependency) {
                         pending.insert(*dependency);
                     }
@@ -1408,11 +1409,10 @@ mod tests {
         dependencies: Vec<TransactionDigest>,
         gas_used: GasCostSummary,
     ) -> TransactionEffects {
-        TransactionEffects {
-            transaction_digest,
-            dependencies,
-            gas_used,
-            ..Default::default()
-        }
+        let mut effects = TransactionEffects::default();
+        *effects.transaction_digest_mut_for_testing() = transaction_digest;
+        *effects.dependencies_mut_for_testing() = dependencies;
+        *effects.gas_cost_summary_mut_for_testing() = gas_used;
+        effects
     }
 }

--- a/crates/sui-core/src/event_handler.rs
+++ b/crates/sui-core/src/event_handler.rs
@@ -16,7 +16,7 @@ use sui_types::messages::TransactionEvents;
 use sui_types::{
     error::{SuiError, SuiResult},
     event::{Event, EventEnvelope},
-    messages::TransactionEffects,
+    messages::{TransactionEffects, TransactionEffectsAPI},
 };
 
 use crate::authority::{AuthorityStore, ResolverWrapper};
@@ -56,7 +56,7 @@ impl EventHandler {
         });
     }
 
-    #[instrument(level = "debug", skip_all, fields(seq=?seq_num, tx_digest=?effects.transaction_digest), err)]
+    #[instrument(level = "debug", skip_all, fields(seq=?seq_num, tx_digest=?effects.transaction_digest()), err)]
     pub async fn process_events(
         &self,
         effects: &TransactionEffects,
@@ -72,7 +72,7 @@ impl EventHandler {
             .map(|(event_num, e)| {
                 self.create_envelope(
                     e,
-                    effects.transaction_digest,
+                    *effects.transaction_digest(),
                     event_num.try_into().unwrap(),
                     seq_num,
                     timestamp_ms,
@@ -89,14 +89,14 @@ impl EventHandler {
             warn!(
                 num_events = envelopes.len(),
                 row_inserted = row_inserted,
-                tx_digest =? effects.transaction_digest,
+                tx_digest =? effects.transaction_digest(),
                 "Inserted event record is less than expected."
             );
         }
 
         trace!(
             num_events = envelopes.len(),
-            tx_digest =? effects.transaction_digest,
+            tx_digest =? effects.transaction_digest(),
             "Finished writing events to event store"
         );
 

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -188,7 +188,7 @@ impl<C> SafeClient<C> {
         );
         // Checks it concerns the right tx
         fp_ensure!(
-            signed_effects.data().transaction_digest == *digest,
+            *signed_effects.data().transaction_digest() == *digest,
             SuiError::ByzantineAuthoritySuspicion {
                 authority: self.address,
                 reason: "Unexpected tx digest in the signed effects".to_string()

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -19,7 +19,7 @@ use sui_types::{
     messages::{
         CertifiedTransaction, CommitteeInfoRequest, CommitteeInfoResponse,
         HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, SystemStateRequest,
-        Transaction, TransactionInfoRequest, TransactionInfoResponse,
+        Transaction, TransactionEffectsAPI, TransactionInfoRequest, TransactionInfoResponse,
     },
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     sui_system_state::SuiSystemState,
@@ -162,8 +162,8 @@ impl LocalAuthorityClient {
             }
             .into_inner();
 
-        let events = if let Some(digest) = signed_effects.events_digest {
-            state.get_transaction_events(digest).await?
+        let events = if let Some(digest) = signed_effects.events_digest() {
+            state.get_transaction_events(*digest).await?
         } else {
             TransactionEvents::default()
         };

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -27,15 +27,12 @@ use sui_types::object::OBJECT_START_VERSION;
 use sui_types::utils::create_fake_transaction;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
-    base_types::{
-        random_object_ref, AuthorityName, ExecutionDigests, ObjectRef, SuiAddress,
-        TransactionDigest,
-    },
+    base_types::{AuthorityName, ExecutionDigests, ObjectRef, SuiAddress, TransactionDigest},
     committee::Committee,
     crypto::{AuthoritySignInfo, AuthoritySignature},
     message_envelope::Message,
     messages::{CertifiedTransaction, Transaction, TransactionEffects},
-    object::{Object, Owner},
+    object::Object,
 };
 use tokio::time::timeout;
 use tracing::{info, warn};
@@ -127,14 +124,7 @@ pub fn create_fake_cert_and_effect_digest<'a>(
 }
 
 pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
-    TransactionEffects {
-        transaction_digest: *tx.digest(),
-        gas_object: (
-            random_object_ref(),
-            Owner::AddressOwner(tx.data().intent_message.value.sender()),
-        ),
-        ..Default::default()
-    }
+    TransactionEffects::new_with_tx(tx)
 }
 
 pub fn compile_basics_package() -> CompiledPackage {

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -56,7 +56,7 @@ pub async fn check_transaction_input(
     epoch_store: &AuthorityPerEpochStore,
     transaction: &TransactionData,
 ) -> SuiResult<(SuiGasStatus<'static>, InputObjects)> {
-    transaction.check_version_supported(epoch_store.protocol_version())?;
+    transaction.check_version_supported(epoch_store.protocol_config())?;
     transaction.validity_check(epoch_store.protocol_config())?;
     let gas_status = get_gas_status(store, epoch_store, transaction).await?;
     let input_objects = transaction.input_objects()?;
@@ -123,7 +123,7 @@ pub async fn check_certificate_input(
     assert!(
         cert.data()
             .transaction_data()
-            .check_version_supported(protocol_version)
+            .check_version_supported(epoch_store.protocol_config())
             .is_ok(),
         "Certificate formed with unsupported message version {:?} for protocol version {:?}",
         cert.message_version(),

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -78,6 +78,7 @@ pub(crate) async fn check_dev_inspect_input(
     for k in kind.single_transactions() {
         match k {
             SingleTransactionKind::TransferObject(_)
+            | SingleTransactionKind::TransferObjectExtended(_)
             | SingleTransactionKind::Call(_)
             | SingleTransactionKind::TransferSui(_)
             | SingleTransactionKind::Pay(_)

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -8,7 +8,9 @@ use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::ObjectRef;
 use sui_types::error::{SuiError, UserInputError, UserInputResult};
 use sui_types::gas::SuiCostTable;
-use sui_types::messages::{TransactionKind, VerifiedExecutableTransaction};
+use sui_types::messages::{
+    TransactionKind, VerifiedExecutableTransaction, VersionedProtocolMessage,
+};
 use sui_types::{
     base_types::{SequenceNumber, SuiAddress},
     error::SuiResult,
@@ -54,6 +56,7 @@ pub async fn check_transaction_input(
     epoch_store: &AuthorityPerEpochStore,
     transaction: &TransactionData,
 ) -> SuiResult<(SuiGasStatus<'static>, InputObjects)> {
+    transaction.check_version_supported(epoch_store.protocol_version())?;
     transaction.validity_check(epoch_store.protocol_config())?;
     let gas_status = get_gas_status(store, epoch_store, transaction).await?;
     let input_objects = transaction.input_objects()?;
@@ -114,6 +117,19 @@ pub async fn check_certificate_input(
     epoch_store: &AuthorityPerEpochStore,
     cert: &VerifiedExecutableTransaction,
 ) -> SuiResult<(SuiGasStatus<'static>, InputObjects)> {
+    let protocol_version = epoch_store.protocol_version();
+
+    // This should not happen - validators should not have signed the txn in the first place.
+    assert!(
+        cert.data()
+            .transaction_data()
+            .check_version_supported(protocol_version)
+            .is_ok(),
+        "Certificate formed with unsupported message version {:?} for protocol version {:?}",
+        cert.message_version(),
+        protocol_version
+    );
+
     let tx_data = &cert.data().intent_message.value;
     let gas_status = get_gas_status(store, epoch_store, tx_data).await?;
     let input_object_kinds = tx_data.input_objects()?;

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use sui_types::{
     base_types::ObjectID,
     committee::EpochId,
-    messages::{VerifiedCertificate, VerifiedExecutableTransaction},
+    messages::{TransactionDataAPI, VerifiedCertificate, VerifiedExecutableTransaction},
 };
 use sui_types::{base_types::TransactionDigest, error::SuiResult};
 use tokio::sync::mpsc::UnboundedSender;

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -30,8 +30,8 @@ use sui_types::committee::Committee;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    FinalizedEffects, QuorumDriverResponse, VerifiedCertifiedTransactionEffects,
-    VerifiedExecutableTransaction,
+    FinalizedEffects, QuorumDriverResponse, TransactionEffectsAPI,
+    VerifiedCertifiedTransactionEffects, VerifiedExecutableTransaction,
 };
 use sui_types::quorum_driver_types::{
     QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResult,
@@ -221,7 +221,7 @@ where
                 }
                 let executable_tx = VerifiedExecutableTransaction::new_from_quorum_execution(
                     transaction,
-                    effects_cert.executed_epoch,
+                    effects_cert.executed_epoch(),
                 );
 
                 match Self::execute_finalized_tx_locally_with_timeout(
@@ -347,7 +347,7 @@ where
                 Ok(Ok((transaction, QuorumDriverResponse { effects_cert, .. }))) => {
                     let executable_tx = VerifiedExecutableTransaction::new_from_quorum_execution(
                         transaction,
-                        effects_cert.executed_epoch,
+                        effects_cert.executed_epoch(),
                     );
                     let tx_digest = executable_tx.digest();
                     if let Err(err) = pending_transaction_log.finish_transaction(tx_digest) {

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -301,6 +301,12 @@ async fn execute_transaction_with_fault_configs(
         .is_ok()
 }
 
+fn effects_with_tx(digest: TransactionDigest) -> TransactionEffects {
+    let mut effects = TransactionEffects::default();
+    *effects.transaction_digest_mut_for_testing() = digest;
+    effects
+}
+
 /// The intent of this is to test whether client side timeouts
 /// have any impact on the server execution. Turns out because
 /// we spawn a tokio task on the server, client timing out and
@@ -712,10 +718,7 @@ async fn test_handle_transaction_response() {
 
     // Case 3
     // Val-0 returns tx-cert
-    let effects = TransactionEffects {
-        transaction_digest: *cert_epoch_0.digest(),
-        ..Default::default()
-    };
+    let effects = effects_with_tx(*cert_epoch_0.digest());
     let (name_0, key_0) = &authority_keys[0];
     let resp = HandleTransactionResponse {
         status: TransactionStatus::Executed(
@@ -764,10 +767,7 @@ async fn test_handle_transaction_response() {
 
     // Case 5
     // Validators return tx-cert with epoch 0, client expects 1
-    let effects = TransactionEffects {
-        transaction_digest: *cert_epoch_0.digest(),
-        ..Default::default()
-    };
+    let effects = effects_with_tx(*cert_epoch_0.digest());
     set_tx_info_response_with_cert_and_effects(
         &mut clients,
         authority_keys.iter(),
@@ -804,13 +804,10 @@ async fn test_handle_transaction_response() {
 
     // Case 6
     // Validators 2 and 3 returns tx-cert with epoch 1, but different signed effects from 0 and 1
-    let effects = TransactionEffects {
-        transaction_digest: *cert_epoch_0.digest(),
-        status: ExecutionStatus::Failure {
-            error: ExecutionFailureStatus::InsufficientGas,
-            command: None,
-        },
-        ..Default::default()
+    let mut effects = effects_with_tx(*cert_epoch_0.digest());
+    *effects.status_mut_for_testing() = ExecutionStatus::Failure {
+        error: ExecutionFailureStatus::InsufficientGas,
+        command: None,
     };
     set_tx_info_response_with_cert_and_effects(
         &mut clients,
@@ -836,10 +833,7 @@ async fn test_handle_transaction_response() {
 
     // Case 7
     // Validators return tx-cert with epoch 1, client expects 0
-    let effects = TransactionEffects {
-        transaction_digest: *cert_epoch_1.digest(),
-        ..Default::default()
-    };
+    let effects = effects_with_tx(*cert_epoch_1.digest());
     set_tx_info_response_with_cert_and_effects(
         &mut clients,
         authority_keys.iter(),

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -64,16 +64,19 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
     let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
     let effects = response.1.into_data();
-    assert!(effects.status.is_ok());
-    assert_eq!((effects.created.len(), effects.mutated.len()), (N, N + 1),);
+    assert!(effects.status().is_ok());
+    assert_eq!(
+        (effects.created().len(), effects.mutated().len()),
+        (N, N + 1),
+    );
     assert!(effects
-        .created
+        .created()
         .iter()
         .all(|(_, owner)| owner == &Owner::AddressOwner(sender)));
     // N of the objects should now be owned by recipient.
     assert_eq!(
         effects
-            .mutated
+            .mutated()
             .iter()
             .filter(|(_, owner)| owner == &Owner::AddressOwner(recipient))
             .count(),
@@ -129,8 +132,11 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
 
     let response = send_and_confirm_transaction(&authority_state, tx).await?.1;
     let effects = response.into_data();
-    assert!(effects.status.is_err());
-    assert_eq!((effects.created.len(), effects.mutated.len()), (0, N + 1));
+    assert!(effects.status().is_err());
+    assert_eq!(
+        (effects.created().len(), effects.mutated().len()),
+        (0, N + 1)
+    );
 
     Ok(())
 }

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -19,7 +19,9 @@ use sui_types::base_types::TransactionDigest;
 use sui_types::committee::Committee;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::error::SuiResult;
-use sui_types::messages::{TransactionEffects, VerifiedCertificate, VerifiedTransaction};
+use sui_types::messages::{
+    TransactionEffects, TransactionEffectsAPI, VerifiedCertificate, VerifiedTransaction,
+};
 use sui_types::object::{Object, Owner};
 use test_utils::messages::{make_counter_create_transaction, make_counter_increment_transaction};
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -315,7 +317,7 @@ async fn test_transaction_manager() {
         execute_owned_on_first_three_authorities(&authority_clients, &aggregator.committee, &tx1)
             .await;
     executed_owned_certs.push(cert);
-    let mut owned_object_ref = effects1.created[0].0;
+    let mut owned_object_ref = effects1.created()[0].0;
 
     // Initialize a shared counter, re-using gas_ref_0 so it has to execute after tx1.
     let gas_ref = get_latest_ref(authority_clients[0], gas_objects[0][0].id()).await;
@@ -324,7 +326,7 @@ async fn test_transaction_manager() {
         execute_owned_on_first_three_authorities(&authority_clients, &aggregator.committee, &tx2)
             .await;
     executed_owned_certs.push(cert);
-    let (mut shared_counter_ref, owner) = effects2.created[0];
+    let (mut shared_counter_ref, owner) = effects2.created()[0];
     let shared_counter_initial_version = if let Owner::Shared {
         initial_shared_version,
     } = owner
@@ -366,7 +368,7 @@ async fn test_transaction_manager() {
         )
         .await;
         executed_owned_certs.push(cert);
-        owned_object_ref = effects.mutated_excluding_gas().next().unwrap().0;
+        owned_object_ref = effects.mutated_excluding_gas().first().unwrap().0;
 
         let gas_ref = get_latest_ref(
             authority_clients[source_index],
@@ -389,7 +391,7 @@ async fn test_transaction_manager() {
         )
         .await;
         executed_shared_certs.push(cert);
-        shared_counter_ref = effects.mutated_excluding_gas().next().unwrap().0;
+        shared_counter_ref = effects.mutated_excluding_gas().first().unwrap().0;
     }
 
     // ---- Execute transactions in reverse dependency order on the last authority.
@@ -497,7 +499,7 @@ async fn test_per_object_overload() {
         .unwrap()
         .pop()
         .unwrap();
-    let (shared_counter_ref, owner) = create_counter_effects.created[0];
+    let (shared_counter_ref, owner) = create_counter_effects.created()[0];
     let Owner::Shared {
         initial_shared_version: shared_counter_initial_version
     } = owner else {

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -11,7 +11,7 @@ use sui_types::coin::PAY_JOIN_FUNC_NAME;
 use sui_types::coin::PAY_MODULE_NAME;
 use sui_types::coin::PAY_SPLIT_VEC_FUNC_NAME;
 use sui_types::crypto::{deterministic_random_account_key, AccountKeyPair};
-use sui_types::messages::VerifiedTransaction;
+use sui_types::messages::{TransactionEffectsAPI, VerifiedTransaction};
 use sui_types::object::{generate_test_gas_objects, Object};
 use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 use sui_types::{
@@ -212,8 +212,8 @@ async fn create_txes(
     );
     let (effects, _) =
         submit_single_owner_transaction(transaction.clone(), &configs.validator_set()).await;
-    assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
-    let ((counter_id, counter_initial_shared_version, _), _) = effects.created[0];
+    assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));
+    let ((counter_id, counter_initial_shared_version, _), _) = effects.created()[0];
     let counter_object_arg = ObjectArg::SharedObject {
         id: counter_id,
         initial_shared_version: counter_initial_shared_version,

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1639,7 +1639,8 @@ impl TryFrom<SingleTransactionKind> for SuiTransactionKind {
 
     fn try_from(tx: SingleTransactionKind) -> Result<Self, Self::Error> {
         Ok(match tx {
-            SingleTransactionKind::TransferObject(t) => Self::TransferObject(SuiTransferObject {
+            SingleTransactionKind::TransferObjectExtended(t)
+            | SingleTransactionKind::TransferObject(t) => Self::TransferObject(SuiTransferObject {
                 recipient: t.recipient,
                 object_ref: t.object_ref.into(),
             }),

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -47,7 +47,8 @@ use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
     CallArg, EffectsFinalityInfo, ExecutionStatus, GenesisObject, InputObjectKind,
     MoveModulePublish, ObjectArg, Pay, PayAllSui, PaySui, SenderSignedData, SingleTransactionKind,
-    TransactionData, TransactionEffects, TransactionEvents, TransactionKind,
+    TransactionData, TransactionDataAPI, TransactionEffects, TransactionEffectsAPI,
+    TransactionEvents, TransactionKind,
 };
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointDigest, CheckpointSequenceNumber, CheckpointSummary,
@@ -1441,7 +1442,7 @@ impl TryFrom<TransactionData> for SuiTransactionData {
     type Error = anyhow::Error;
 
     fn try_from(data: TransactionData) -> Result<Self, Self::Error> {
-        let transactions = match data.kind.clone() {
+        let transactions = match data.kind().clone() {
             TransactionKind::Single(tx) => {
                 vec![tx.try_into()?]
             }
@@ -1827,23 +1828,23 @@ impl SuiTransactionEffects {
 impl From<TransactionEffects> for SuiTransactionEffects {
     fn from(effect: TransactionEffects) -> Self {
         Self {
-            status: effect.status.into(),
-            executed_epoch: effect.executed_epoch,
-            gas_used: effect.gas_used.into(),
-            shared_objects: to_sui_object_ref(effect.shared_objects),
-            transaction_digest: effect.transaction_digest,
-            created: to_owned_ref(effect.created),
-            mutated: to_owned_ref(effect.mutated),
-            unwrapped: to_owned_ref(effect.unwrapped),
-            deleted: to_sui_object_ref(effect.deleted),
-            unwrapped_then_deleted: to_sui_object_ref(effect.unwrapped_then_deleted),
-            wrapped: to_sui_object_ref(effect.wrapped),
+            status: effect.status().clone().into(),
+            executed_epoch: effect.executed_epoch(),
+            gas_used: effect.gas_cost_summary().clone().into(),
+            shared_objects: to_sui_object_ref(effect.shared_objects().to_vec()),
+            transaction_digest: *effect.transaction_digest(),
+            created: to_owned_ref(effect.created().to_vec()),
+            mutated: to_owned_ref(effect.mutated().to_vec()),
+            unwrapped: to_owned_ref(effect.unwrapped().to_vec()),
+            deleted: to_sui_object_ref(effect.deleted().to_vec()),
+            unwrapped_then_deleted: to_sui_object_ref(effect.unwrapped_then_deleted().to_vec()),
+            wrapped: to_sui_object_ref(effect.wrapped().to_vec()),
             gas_object: OwnedObjectRef {
-                owner: effect.gas_object.1,
-                reference: effect.gas_object.0.into(),
+                owner: effect.gas_object().1,
+                reference: effect.gas_object().0.into(),
             },
-            events_digest: effect.events_digest,
-            dependencies: effect.dependencies,
+            events_digest: effect.events_digest().copied(),
+            dependencies: effect.dependencies().to_vec(),
         }
     }
 }

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -48,7 +48,7 @@ use sui_types::messages::{
     CallArg, EffectsFinalityInfo, ExecutionStatus, GenesisObject, InputObjectKind,
     MoveModulePublish, ObjectArg, Pay, PayAllSui, PaySui, SenderSignedData, SingleTransactionKind,
     TransactionData, TransactionDataAPI, TransactionEffects, TransactionEffectsAPI,
-    TransactionEvents, TransactionKind,
+    TransactionEvents, TransactionKind, VersionedProtocolMessage,
 };
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointDigest, CheckpointSequenceNumber, CheckpointSummary,
@@ -1400,6 +1400,7 @@ pub struct SuiGasData {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename = "TransactionData", rename_all = "camelCase")]
 pub struct SuiTransactionData {
+    pub message_version: u64,
     pub transactions: Vec<SuiTransactionKind>,
     pub sender: SuiAddress,
     pub gas_data: SuiGasData,
@@ -1452,6 +1453,9 @@ impl TryFrom<TransactionData> for SuiTransactionData {
                 .collect::<Result<Vec<_>, _>>()?,
         };
         Ok(Self {
+            message_version: data
+                .message_version()
+                .expect("TransactionData defines message_version()"),
             transactions,
             sender: data.sender(),
             gas_data: SuiGasData {
@@ -1777,6 +1781,7 @@ impl Display for SuiFinalizedEffects {
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "TransactionEffects", rename_all = "camelCase")]
 pub struct SuiTransactionEffects {
+    pub message_version: u64,
     /// The status of the execution
     pub status: SuiExecutionStatus,
     /// The epoch when this transaction was executed.
@@ -1828,6 +1833,9 @@ impl SuiTransactionEffects {
 impl From<TransactionEffects> for SuiTransactionEffects {
     fn from(effect: TransactionEffects) -> Self {
         Self {
+            message_version: effect
+                .message_version()
+                .expect("TransactionEffects defines message_version()"),
             status: effect.status().clone().into(),
             executed_epoch: effect.executed_epoch(),
             gas_used: effect.gas_cost_summary().clone().into(),

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -21,7 +21,7 @@ use sui_types::coin::{Coin, CoinMetadata, LockedCoin, TreasuryCap};
 use sui_types::error::SuiError;
 use sui_types::event::Event;
 use sui_types::gas_coin::GAS;
-use sui_types::messages::TransactionEvents;
+use sui_types::messages::{TransactionEffectsAPI, TransactionEvents};
 use sui_types::object::Object;
 use sui_types::parse_sui_struct_tag;
 
@@ -129,8 +129,8 @@ impl CoinReadApi {
             .get_executed_transaction_and_effects(publish_txn_digest)
             .await?;
 
-        let events = if let Some(digests) = effect.events_digest {
-            self.state.get_transaction_events(digests).await?
+        let events = if let Some(digests) = effect.events_digest() {
+            self.state.get_transaction_events(*digests).await?
         } else {
             TransactionEvents::default()
         };

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -30,7 +30,7 @@ use sui_open_rpc::Module;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest, TxSequenceNumber};
 use sui_types::crypto::sha3_hash;
-use sui_types::messages::TransactionData;
+use sui_types::messages::{TransactionData, TransactionEffectsAPI};
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
     CheckpointSummary,
@@ -167,10 +167,10 @@ impl ReadApiServer for ReadApi {
             .map_err(|e| anyhow!("{e}"))?;
         let checkpoint_timestamp = checkpoint.as_ref().map(|c| c.summary.timestamp_ms);
 
-        let events = if let Some(digest) = effects.events_digest {
+        let events = if let Some(digest) = effects.events_digest() {
             let events = self
                 .state
-                .get_transaction_events(digest)
+                .get_transaction_events(*digest)
                 .await
                 .map_err(Error::from)?;
             SuiTransactionEvents::try_from(

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -60,6 +60,7 @@ use sui_types::{
     base_types::ExecutionDigests,
     digests::{CheckpointContentsDigest, CheckpointDigest},
     message_envelope::Message,
+    messages::TransactionEffectsAPI,
     messages_checkpoint::{
         CertifiedCheckpointSummary as Checkpoint, CheckpointContents, CheckpointSequenceNumber,
         VerifiedCheckpoint,
@@ -1166,7 +1167,7 @@ where
         {
             if transaction.digest() == &digests.transaction
                 && effects.digest() == digests.effects
-                && effects.transaction_digest == digests.transaction
+                && *effects.transaction_digest() == digests.transaction
             {
                 store
                     .insert_transaction_and_effects(

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -123,7 +123,7 @@
           "result": {
             "name": "Result",
             "value": {
-              "txBytes": "AQICAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIKZGV2bmV0X25mdARtaW50AAMAC0V4YW1wbGUgTkZUACtBbiBORlQgY3JlYXRlZCBieSB0aGUgU3VpIENvbW1hbmQgTGluZSBUb29sAEJpcGZzOi8vYmFma3JlaWJuZ3FobDNnYWE3ZGFvYjRpMnZjY3ppYXkyampscDQzNWNmNjZ2aG9ubzducnZ3dzUzdHkAskuOwWj+SJb1twzLEPGnBeBh0P36GJYY0osNRO/vkstnLw2+Ep8eORE/n2Fk6ihn+N7M88PFGPFG3pVU8D8nqAEAAAAAAAAAID1bEYXznnHvNX4r2eE5YlFrCkFAMnZDeyXw/76JfPR2mweBXwRJfi4F0iysOqBhQQsghozGGRVMQqHGG+mQJxf0S1gfIyIsEJFrF6NptNoDnQdZUrWANvKntWFEZZJAPAEAAAAAAAAAIMB3fp0kb/OXSsXxs1CqFsQuoNcRezDIyENs56klSzDSmweBXwRJfi4F0iysOqBhQQsghozGGRVMQqHGG+mQJxcBAAAAAAAAAOgDAAAAAAAAAA==",
+              "txBytes": "AAECAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACCmRldm5ldF9uZnQEbWludAADAAtFeGFtcGxlIE5GVAArQW4gTkZUIGNyZWF0ZWQgYnkgdGhlIFN1aSBDb21tYW5kIExpbmUgVG9vbABCaXBmczovL2JhZmtyZWlibmdxaGwzZ2FhN2Rhb2I0aTJ2Y2N6aWF5MmpqbHA0MzVjZjY2dmhvbm83bnJ2d3c1M3R5ALJLjsFo/kiW9bcMyxDxpwXgYdD9+hiWGNKLDUTv75LLZy8NvhKfHjkRP59hZOooZ/jezPPDxRjxRt6VVPA/J6gBAAAAAAAAACA9WxGF855x7zV+K9nhOWJRawpBQDJ2Q3sl8P++iXz0dpsHgV8ESX4uBdIsrDqgYUELIIaMxhkVTEKhxhvpkCcX9EtYHyMiLBCRaxejabTaA50HWVK1gDbyp7VhRGWSQDwBAAAAAAAAACDAd36dJG/zl0rF8bNQqhbELqDXEXswyMhDbOepJUsw0psHgV8ESX4uBdIsrDqgYUELIIaMxhkVTEKhxhvpkCcXAQAAAAAAAADoAwAAAAAAAAA=",
               "gas": {
                 "objectId": "0xf44b581f23222c10916b17a369b4da039d075952b58036f2a7b561446592403c",
                 "version": 1,
@@ -276,11 +276,11 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AABVfcQqrv7rjBVNfdxFa4rqoxMsdANTHcmOg/bhmNLX0XupHdx+cXz3CMk3Bg8EBIc27DP7F0bZmaXljNXGd+2AAgAAAAAAAAAgzMqpegLMOpgEFnDhYJ23FOmFjJbp5GmFXxzzv9+X6GVPuIgKC69cF+3DB1mtlwVnAyS6rhgBhRo36LTApC3mdU+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNH9ysPcAgAAAAAAAAAg6NjHzoY/MT2j29kqg+8m0Si4j+Zr8m4ODQnNr3J9HYRPuIgKC69cF+3DB1mtlwVnAyS6rhgBhRo36LTApC3mdQEAAAAAAAAA6AMAAAAAAAAA"
+              "value": "AAAAVX3EKq7+64wVTX3cRWuK6qMTLHQDUx3JjoP24ZjS19F7qR3cfnF89wjJNwYPBASHNuwz+xdG2Zml5YzVxnftgAIAAAAAAAAAIMzKqXoCzDqYBBZw4WCdtxTphYyW6eRphV8c87/fl+hlT7iICguvXBftwwdZrZcFZwMkuq4YAYUaN+i0wKQt5nVPgvHIWHuY1kwAv7RsOEO9i/bM+nxlqGE4aYzR/crD3AIAAAAAAAAAIOjYx86GPzE9o9vZKoPvJtEouI/ma/JuDg0Jza9yfR2ET7iICguvXBftwwdZrZcFZwMkuq4YAYUaN+i0wKQt5nUBAAAAAAAAAOgDAAAAAAAAAA=="
             },
             {
               "name": "signature",
-              "value": "AH6XTo1HVHf4m92sObAgdmoNTFLiCFSzj7eOJobK8KjO3xa0NIv6WEOBVcC19elqJ+OmstR38vGS8P6j+eG4Aw5tqSk/XTlS5stFH/W02Kxeyb0TWYjhlUjBKhMcXPgTNg=="
+              "value": "AF1A5hlA2ZoTg1J/WK8eBzAokdf41B8fOdVMA/SYdp0dJcFUP6xkdrgXGQ2l6ACU7gOMLJm2H6rY0g9l/Ap5JgxtqSk/XTlS5stFH/W02Kxeyb0TWYjhlUjBKhMcXPgTNg=="
             },
             {
               "name": "request_type",
@@ -317,7 +317,7 @@
                   }
                 },
                 "txSignatures": [
-                  "AH6XTo1HVHf4m92sObAgdmoNTFLiCFSzj7eOJobK8KjO3xa0NIv6WEOBVcC19elqJ+OmstR38vGS8P6j+eG4Aw5tqSk/XTlS5stFH/W02Kxeyb0TWYjhlUjBKhMcXPgTNg=="
+                  "AF1A5hlA2ZoTg1J/WK8eBzAokdf41B8fOdVMA/SYdp0dJcFUP6xkdrgXGQ2l6ACU7gOMLJm2H6rY0g9l/Ap5JgxtqSk/XTlS5stFH/W02Kxeyb0TWYjhlUjBKhMcXPgTNg=="
                 ]
               },
               "effects": {
@@ -1009,9 +1009,9 @@
               "data": [
                 {
                   "timestamp": 0,
-                  "txDigest": "HzTi7BC8QyKBMEbcLMUF7H219B1LXC1EaE7hhCCQArJa",
+                  "txDigest": "HFcoZDqVzQjWXCux1uzczVDNgUB9WbfpTuPGJWP5DJZ",
                   "id": {
-                    "txDigest": "HzTi7BC8QyKBMEbcLMUF7H219B1LXC1EaE7hhCCQArJa",
+                    "txDigest": "HFcoZDqVzQjWXCux1uzczVDNgUB9WbfpTuPGJWP5DJZ",
                     "eventSeq": 0
                   },
                   "event": {
@@ -1605,7 +1605,7 @@
                   }
                 },
                 "txSignatures": [
-                  "AGslC3jrqZbH8FVkZXU3usnxIf7DDSdoxmPnV3548G/pwcwY8/Frtaktfjba1lQG73/cbIcTM/3fhW5bnpvMbQfrrHXjLu++Rq9ubpXx7Qa15+TAMzHp1FEJlaxEOtOHYQ=="
+                  "ADSyUHGm3NjvMch+U3NMEd0nflLDLEDerEK6xbRFdoDQSXdaAOvxhShuDl4kHM31bfynQ1slAc5yuLJSZEvKhAnrrHXjLu++Rq9ubpXx7Qa15+TAMzHp1FEJlaxEOtOHYQ=="
                 ]
               },
               "effects": {
@@ -2567,12 +2567,12 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AAAy9L9sPorELu8TheAUA+SaSylq3LIuon08kuTOIlasZFy6vcNs8bny7ISBomyn2BFpVZeUAouPAuQwKlWV2IiaAgAAAAAAAAAgLEOAXQ1vVAKnrQ2lvexUnHzeoGvEodM5oiUh7qkzuInTBWxU38/Wzpg7ga1fbxcalrZhjj8rLo7egQ86U3GPP2fG0xxslw5WfwPvZ9gRpPhDZluN4/KC+kiz4BA7qbvtAgAAAAAAAAAgagYVO5/EhuEB8OnicDrIZm0GrsxN3355JqNhlwxlpbHTBWxU38/Wzpg7ga1fbxcalrZhjj8rLo7egQ86U3GPPwEAAAAAAAAA6AMAAAAAAAAA"
+              "value": "AAAAMvS/bD6KxC7vE4XgFAPkmkspatyyLqJ9PJLkziJWrGRcur3DbPG58uyEgaJsp9gRaVWXlAKLjwLkMCpVldiImgIAAAAAAAAAICxDgF0Nb1QCp60Npb3sVJx83qBrxKHTOaIlIe6pM7iJ0wVsVN/P1s6YO4GtX28XGpa2YY4/Ky6O3oEPOlNxjz9nxtMcbJcOVn8D72fYEaT4Q2ZbjePygvpIs+AQO6m77QIAAAAAAAAAIGoGFTufxIbhAfDp4nA6yGZtBq7MTd9+eSajYZcMZaWx0wVsVN/P1s6YO4GtX28XGpa2YY4/Ky6O3oEPOlNxjz8BAAAAAAAAAOgDAAAAAAAAAA=="
             },
             {
               "name": "signatures",
               "value": [
-                "ANz1nc//IojONTcCQoBBkZPEoxhksBhL7jqy/JOSIMX9DPjIcAAEOJceXRDhHWGf1sxYS2QXeO/fVrJACZ7VFASRFyzRWy5Z5Iom1zB2m6Vx2RU7g7aQu+hOm3dBh5doKQ=="
+                "ADg1ulaEF0jYTNZJSpGPuMfF3Faqik3Xu81tGC4iOpEXkfl1WJW7kXgvyp1+8NFWmpp5ZWAfj8s/rppCjtMbUwmRFyzRWy5Z5Iom1zB2m6Vx2RU7g7aQu+hOm3dBh5doKQ=="
               ]
             },
             {
@@ -2610,7 +2610,7 @@
                   }
                 },
                 "txSignatures": [
-                  "ANz1nc//IojONTcCQoBBkZPEoxhksBhL7jqy/JOSIMX9DPjIcAAEOJceXRDhHWGf1sxYS2QXeO/fVrJACZ7VFASRFyzRWy5Z5Iom1zB2m6Vx2RU7g7aQu+hOm3dBh5doKQ=="
+                  "ADg1ulaEF0jYTNZJSpGPuMfF3Faqik3Xu81tGC4iOpEXkfl1WJW7kXgvyp1+8NFWmpp5ZWAfj8s/rppCjtMbUwmRFyzRWy5Z5Iom1zB2m6Vx2RU7g7aQu+hOm3dBh5doKQ=="
                 ]
               },
               "effects": {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -292,6 +292,7 @@
             "value": {
               "transaction": {
                 "data": {
+                  "messageVersion": 1,
                   "transactions": [
                     {
                       "TransferObject": {
@@ -321,6 +322,7 @@
                 ]
               },
               "effects": {
+                "messageVersion": 1,
                 "status": {
                   "status": "success"
                 },
@@ -1580,6 +1582,7 @@
             "value": {
               "transaction": {
                 "data": {
+                  "messageVersion": 1,
                   "transactions": [
                     {
                       "TransferObject": {
@@ -1609,6 +1612,7 @@
                 ]
               },
               "effects": {
+                "messageVersion": 1,
                 "status": {
                   "status": "success"
                 },
@@ -2585,6 +2589,7 @@
             "value": {
               "transaction": {
                 "data": {
+                  "messageVersion": 1,
                   "transactions": [
                     {
                       "TransferObject": {
@@ -2614,6 +2619,7 @@
                 ]
               },
               "effects": {
+                "messageVersion": 1,
                 "status": {
                   "status": "success"
                 },
@@ -6373,12 +6379,18 @@
         "type": "object",
         "required": [
           "gasData",
+          "messageVersion",
           "sender",
           "transactions"
         ],
         "properties": {
           "gasData": {
             "$ref": "#/components/schemas/GasData"
+          },
+          "messageVersion": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "sender": {
             "$ref": "#/components/schemas/SuiAddress"
@@ -6406,6 +6418,7 @@
           "executedEpoch",
           "gasObject",
           "gasUsed",
+          "messageVersion",
           "status",
           "transactionDigest"
         ],
@@ -6458,6 +6471,11 @@
           },
           "gasUsed": {
             "$ref": "#/components/schemas/GasCostSummary"
+          },
+          "messageVersion": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "mutated": {
             "description": "ObjectRef and owner of mutated objects, including gas object.",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -453,6 +453,7 @@ impl RpcExampleProvider {
         }];
         let result = SuiTransactionResponse {
             effects: SuiTransactionEffects {
+                message_version: 1,
                 status: SuiExecutionStatus::Success,
                 executed_epoch: 0,
                 gas_used: SuiGasCostSummary {

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -30,13 +30,13 @@ impl ProtocolVersion {
 
     // We create one additional "fake" version in simulator builds so that we can test upgrades.
     #[cfg(msim)]
-    const MAX_ALLOWED: Self = Self(MAX_PROTOCOL_VERSION + 1);
+    pub const MAX_ALLOWED: Self = Self(MAX_PROTOCOL_VERSION + 1);
 
     pub fn new(v: u64) -> Self {
         Self(v)
     }
 
-    pub fn as_u64(&self) -> u64 {
+    pub const fn as_u64(&self) -> u64 {
         self.0
     }
 
@@ -44,6 +44,12 @@ impl ProtocolVersion {
     // universally appropriate default value.
     pub fn max() -> Self {
         Self::MAX
+    }
+}
+
+impl From<u64> for ProtocolVersion {
+    fn from(v: u64) -> Self {
+        Self::new(v)
     }
 }
 
@@ -66,8 +72,8 @@ impl std::ops::Add<u64> for ProtocolVersion {
 /// to be able to inject arbitrary versions into SuiNode.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct SupportedProtocolVersions {
-    min: ProtocolVersion,
-    max: ProtocolVersion,
+    pub min: ProtocolVersion,
+    pub max: ProtocolVersion,
 }
 
 impl SupportedProtocolVersions {
@@ -85,8 +91,8 @@ impl SupportedProtocolVersions {
     }
 
     pub fn new_for_testing(min: u64, max: u64) -> Self {
-        let min = ProtocolVersion::new(min);
-        let max = ProtocolVersion::new(max);
+        let min = min.into();
+        let max = max.into();
         Self { min, max }
     }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -64,7 +64,7 @@ impl std::ops::Add<u64> for ProtocolVersion {
 /// Models the set of protocol versions supported by a validator.
 /// The `sui-node` binary will always use the SYSTEM_DEFAULT constant, but for testing we need
 /// to be able to inject arbitrary versions into SuiNode.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct SupportedProtocolVersions {
     min: ProtocolVersion,
     max: ProtocolVersion,
@@ -75,6 +75,14 @@ impl SupportedProtocolVersions {
         min: ProtocolVersion::MIN,
         max: ProtocolVersion::MAX,
     };
+
+    /// Use by VersionedProtocolMessage implementors to describe in which range of versions a
+    /// message variant is supported.
+    pub fn new_for_message(min: u64, max: u64) -> Self {
+        let min = ProtocolVersion::new(min);
+        let max = ProtocolVersion::new(max);
+        Self { min, max }
+    }
 
     pub fn new_for_testing(min: u64, max: u64) -> Self {
         let min = ProtocolVersion::new(min);
@@ -106,6 +114,8 @@ impl SupportedProtocolVersions {
 /// result in forking if not prevented here).
 #[derive(Clone)]
 pub struct ProtocolConfig {
+    pub version: ProtocolVersion,
+
     // ==== Transaction input limits ====
     /// Maximum serialized size of a transaction (in bytes).
     max_tx_size: Option<usize>,
@@ -461,7 +471,8 @@ impl ProtocolConfig {
         assert!(version.0 >= ProtocolVersion::MIN.0, "{:?}", version);
         assert!(version.0 <= ProtocolVersion::MAX_ALLOWED.0, "{:?}", version);
 
-        let ret = Self::get_for_version_impl(version);
+        let mut ret = Self::get_for_version_impl(version);
+        ret.version = version;
 
         CONFIG_OVERRIDE.with(|ovr| {
             if let Some(override_fn) = &*ovr.borrow() {
@@ -528,6 +539,7 @@ impl ProtocolConfig {
         // To change the values here you must create a new protocol version with the new values!
         match version.0 {
             1 => Self {
+                version, // will be overwitten before being returned
                 max_tx_size: Some(64 * 1024),
                 max_tx_in_batch: Some(10),
                 max_modules_in_publish: Some(128),

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -5,7 +5,9 @@ use axum::{Extension, Json};
 use fastcrypto::encoding::{Encoding, Hex};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{SignatureScheme, ToFromBytes};
-use sui_types::messages::{ExecuteTransactionRequestType, Transaction, TransactionData};
+use sui_types::messages::{
+    ExecuteTransactionRequestType, Transaction, TransactionData, TransactionDataAPI,
+};
 use sui_types::signature::GenericSignature;
 
 use crate::errors::Error;

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -25,7 +25,7 @@ use sui_types::intent::Intent;
 use sui_types::messages::{
     CallArg, ExecuteTransactionRequestType, InputObjectKind, MoveCall, MoveModulePublish,
     ObjectArg, Pay, PayAllSui, PaySui, SingleTransactionKind, Transaction, TransactionData,
-    TransactionKind, TransferSui,
+    TransactionDataAPI, TransactionKind, TransferSui,
 };
 use test_utils::network::TestClusterBuilder;
 
@@ -184,7 +184,7 @@ async fn test_split_coin() {
         .split_coin(sender, coin.0, vec![100000], None, 10000)
         .await
         .unwrap();
-    let tx = tx.kind.single_transactions().next().unwrap().clone();
+    let tx = tx.into_kind().single_transactions().next().unwrap().clone();
     test_transaction(&client, keystore, vec![], sender, tx, None, 10000, false).await;
 }
 
@@ -203,7 +203,7 @@ async fn test_merge_coin() {
         .merge_coins(sender, coin.0, coin2.0, None, 10000)
         .await
         .unwrap();
-    let tx = tx.kind.single_transactions().next().unwrap().clone();
+    let tx = tx.into_kind().single_transactions().next().unwrap().clone();
     test_transaction(&client, keystore, vec![], sender, tx, None, 10000, false).await;
 }
 
@@ -378,7 +378,7 @@ async fn test_delegate_sui() {
         )
         .await
         .unwrap();
-    let tx = tx.kind.into_single_transactions().next().unwrap();
+    let tx = tx.into_kind().into_single_transactions().next().unwrap();
 
     test_transaction(&client, keystore, vec![], sender, tx, None, 10000, false).await;
 }
@@ -407,7 +407,7 @@ async fn test_delegate_sui_with_none_amount() {
         )
         .await
         .unwrap();
-    let tx = tx.kind.into_single_transactions().next().unwrap();
+    let tx = tx.into_kind().into_single_transactions().next().unwrap();
 
     test_transaction(&client, keystore, vec![], sender, tx, None, 10000, false).await;
 }

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -17,7 +17,7 @@ use sui_config::builder::{
 };
 use sui_config::genesis_config::{GenesisConfig, ValidatorConfigInfo};
 use sui_config::NetworkConfig;
-use sui_protocol_config::SupportedProtocolVersions;
+use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
 use sui_types::base_types::AuthorityName;
 use sui_types::object::Object;
 use tempfile::TempDir;
@@ -33,6 +33,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_rpc_addr: Option<SocketAddr>,
     with_event_store: bool,
     epoch_duration_ms: Option<u64>,
+    initial_protocol_version: ProtocolVersion,
     supported_protocol_versions_config: ProtocolVersionsConfig,
 }
 
@@ -49,6 +50,7 @@ impl SwarmBuilder {
             fullnode_rpc_addr: None,
             with_event_store: false,
             epoch_duration_ms: None,
+            initial_protocol_version: SupportedProtocolVersions::SYSTEM_DEFAULT.max,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
         }
     }
@@ -66,6 +68,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_rpc_addr: self.fullnode_rpc_addr,
             with_event_store: false,
             epoch_duration_ms: None,
+            initial_protocol_version: SupportedProtocolVersions::SYSTEM_DEFAULT.max,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
         }
     }
@@ -118,6 +121,11 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
+    pub fn with_protocol_version(mut self, v: ProtocolVersion) -> Self {
+        self.initial_protocol_version = v;
+        self
+    }
+
     pub fn with_supported_protocol_versions(mut self, c: SupportedProtocolVersions) -> Self {
         self.supported_protocol_versions_config = ProtocolVersionsConfig::Global(c);
         self
@@ -161,6 +169,7 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             .with_swarm()
             .rng(self.rng)
             .with_objects(self.additional_objects)
+            .with_protocol_version(self.initial_protocol_version)
             .with_supported_protocol_versions_config(
                 self.supported_protocol_versions_config.clone(),
             )

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -49,7 +49,10 @@ use sui_types::{
     crypto::{get_key_pair_from_rng, AccountKeyPair},
     event::Event,
     gas,
-    messages::{ExecutionStatus, TransactionData, TransactionEffects, VerifiedTransaction},
+    messages::{
+        ExecutionStatus, TransactionData, TransactionDataAPI, TransactionEffectsAPI,
+        VerifiedTransaction,
+    },
     object::{self, Object, ObjectFormatOptions, GAS_VALUE_FOR_TESTING},
     object::{MoveObject, Owner},
     MOVE_STDLIB_ADDRESS, SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION,
@@ -600,6 +603,8 @@ impl<'a> SuiTestAdapter<'a> {
         let gas = transaction_data.gas();
         let (
             inner,
+            effects,
+            /*
             TransactionEffects {
                 status,
                 created,
@@ -612,11 +617,12 @@ impl<'a> SuiTestAdapter<'a> {
                 gas_object: _,
                 ..
             },
+            */
             execution_error,
         ) = execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
             shared_object_refs,
             temporary_store,
-            transaction_data.kind,
+            transaction_data.into_kind(),
             signer,
             gas,
             transaction_digest,
@@ -628,12 +634,25 @@ impl<'a> SuiTestAdapter<'a> {
             &PROTOCOL_CONSTANTS,
         );
 
-        let mut created_ids: Vec<_> = created.iter().map(|((id, _, _), _)| *id).collect();
-        let unwrapped_ids: Vec<_> = unwrapped.iter().map(|((id, _, _), _)| *id).collect();
-        let mut written_ids: Vec<_> = mutated.iter().map(|((id, _, _), _)| *id).collect();
-        let mut deleted_ids: Vec<_> = deleted
+        let mut created_ids: Vec<_> = effects
+            .created()
             .iter()
-            .chain(&wrapped)
+            .map(|((id, _, _), _)| *id)
+            .collect();
+        let unwrapped_ids: Vec<_> = effects
+            .unwrapped()
+            .iter()
+            .map(|((id, _, _), _)| *id)
+            .collect();
+        let mut written_ids: Vec<_> = effects
+            .mutated()
+            .iter()
+            .map(|((id, _, _), _)| *id)
+            .collect();
+        let mut deleted_ids: Vec<_> = effects
+            .deleted()
+            .iter()
+            .chain(effects.wrapped())
             .map(|(id, _, _)| *id)
             .collect();
 
@@ -664,7 +683,7 @@ impl<'a> SuiTestAdapter<'a> {
         written_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
         deleted_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
 
-        match status {
+        match effects.status() {
             ExecutionStatus::Success { .. } => Ok(TxnSummary {
                 created: created_ids,
                 written: written_ids,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -22,7 +22,6 @@ pub use move_vm_runtime::move_vm::MoveVM;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt::Debug};
 use strum_macros::{AsRefStr, IntoStaticStr};
-use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
 use thiserror::Error;
 use tonic::Status;
 use typed_store::rocks::TypedStoreError;
@@ -423,13 +422,7 @@ pub enum SuiError {
     SuiSystemStateNotFound,
 
     #[error("Message version is not supported at the current protocol version")]
-    WrongMessageVersion {
-        message_version: u64,
-        // the range in which the given message version is supported
-        supported: SupportedProtocolVersions,
-        // the current protocol version which is outside of that range
-        current_protocol_version: ProtocolVersion,
-    },
+    WrongMessageVersion { error: String },
 
     #[error("unknown error: {0}")]
     Unknown(String),
@@ -449,6 +442,12 @@ pub enum VMMemoryLimitExceededSubStatusCode {
 
 pub type SuiResult<T = ()> = Result<T, SuiError>;
 pub type UserInputResult<T = ()> = Result<T, UserInputError>;
+
+impl From<sui_protocol_config::Error> for SuiError {
+    fn from(error: sui_protocol_config::Error) -> Self {
+        SuiError::WrongMessageVersion { error: error.0 }
+    }
+}
 
 // TODO these are both horribly wrong, categorization needs to be considered
 impl From<PartialVMError> for SuiError {

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -22,6 +22,7 @@ pub use move_vm_runtime::move_vm::MoveVM;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt::Debug};
 use strum_macros::{AsRefStr, IntoStaticStr};
+use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
 use thiserror::Error;
 use tonic::Status;
 use typed_store::rocks::TypedStoreError;
@@ -420,6 +421,15 @@ pub enum SuiError {
 
     #[error("Failed to get the system state object content")]
     SuiSystemStateNotFound,
+
+    #[error("Message version is not supported at the current protocol version")]
+    WrongMessageVersion {
+        message_version: u64,
+        // the range in which the given message version is supported
+        supported: SupportedProtocolVersions,
+        // the current protocol version which is outside of that range
+        current_protocol_version: ProtocolVersion,
+    },
 
     #[error("unknown error: {0}")]
     Unknown(String),

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -7,6 +7,7 @@ use crate::messages::TransactionEffects;
 use crate::{
     error::{ExecutionError, ExecutionErrorKind},
     gas_coin::GasCoin,
+    messages::TransactionEffectsAPI,
     object::{Object, Owner},
 };
 use itertools::MultiUnzip;
@@ -98,9 +99,9 @@ impl GasCostSummary {
             transactions
                 .map(|e| {
                     (
-                        e.gas_used.storage_cost,
-                        e.gas_used.computation_cost,
-                        e.gas_used.storage_rebate,
+                        e.gas_cost_summary().storage_cost,
+                        e.gas_cost_summary().computation_cost,
+                        e.gas_cost_summary().storage_rebate,
                     )
                 })
                 .multiunzip();

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -16,7 +16,7 @@ use once_cell::sync::OnceCell;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::{Deref, DerefMut};
-use sui_protocol_config::ProtocolVersion;
+use sui_protocol_config::ProtocolConfig;
 
 pub trait Message {
     type DigestType: Clone + Debug;
@@ -88,8 +88,8 @@ impl<T: Message, S> Envelope<T, S> {
 }
 
 impl<T: Message + VersionedProtocolMessage, S> VersionedProtocolMessage for Envelope<T, S> {
-    fn check_version_supported(&self, current_protocol_version: ProtocolVersion) -> SuiResult {
-        self.data.check_version_supported(current_protocol_version)
+    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
+        self.data.check_version_supported(protocol_config)
     }
 }
 
@@ -311,9 +311,8 @@ impl<T: Message, S> VerifiedEnvelope<T, S> {
 }
 
 impl<T: Message + VersionedProtocolMessage, S> VersionedProtocolMessage for VerifiedEnvelope<T, S> {
-    fn check_version_supported(&self, current_protocol_version: ProtocolVersion) -> SuiResult {
-        self.inner()
-            .check_version_supported(current_protocol_version)
+    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
+        self.inner().check_version_supported(protocol_config)
     }
 }
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -417,7 +417,7 @@ pub enum SingleTransactionKind {
 }
 
 impl VersionedProtocolMessage for SingleTransactionKind {
-    fn check_version_supported(&self, _current_protocol_version: ProtocolVersion) -> SuiResult {
+    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
         // This code does nothing right now - it exists to cause a compiler error when new
         // enumerants are added to SingleTransactionKind.
         //
@@ -1188,14 +1188,14 @@ pub enum TransactionKind {
 }
 
 impl VersionedProtocolMessage for TransactionKind {
-    fn check_version_supported(&self, current_protocol_version: ProtocolVersion) -> SuiResult {
+    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
         // If we add new cases here, check that current_protocol_version does not pre-date the
         // addition of that enumerant.
         match &self {
-            TransactionKind::Single(s) => s.check_version_supported(current_protocol_version),
+            TransactionKind::Single(s) => s.check_version_supported(protocol_config),
             TransactionKind::Batch(v) => {
                 for s in v {
-                    s.check_version_supported(current_protocol_version)?
+                    s.check_version_supported(protocol_config)?
                 }
                 Ok(())
             }
@@ -1379,7 +1379,8 @@ impl VersionedProtocolMessage for TransactionData {
         })
     }
 
-    fn check_version_supported(&self, current_protocol_version: ProtocolVersion) -> SuiResult {
+    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
+        // First check the gross version
         let (message_version, supported) = match self {
             Self::V1(_) => (1, SupportedProtocolVersions::new_for_message(1, u64::MAX)),
             // Suppose we add V2 at protocol version 7, then we must change this to:
@@ -1390,15 +1391,19 @@ impl VersionedProtocolMessage for TransactionData {
             // Self::V1 => (1, SupportedProtocolVersions::new_for_message(1, 12)),
         };
 
-        if supported.is_version_supported(current_protocol_version) {
-            Ok(())
-        } else {
-            Err(SuiError::WrongMessageVersion {
-                message_version,
-                supported,
-                current_protocol_version,
-            })
+        if !supported.is_version_supported(protocol_config.version) {
+            return Err(SuiError::WrongMessageVersion {
+                error: format!(
+                    "TransactionDataV{} is not supported at {:?}. (Supported range is {:?}",
+                    message_version, protocol_config.version, supported
+                ),
+            });
         }
+
+        // Now check interior versioned data
+        self.kind().check_version_supported(protocol_config)?;
+
+        Ok(())
     }
 }
 
@@ -1930,9 +1935,9 @@ impl VersionedProtocolMessage for SenderSignedData {
         self.transaction_data().message_version()
     }
 
-    fn check_version_supported(&self, current_protocol_version: ProtocolVersion) -> SuiResult {
+    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
         self.transaction_data()
-            .check_version_supported(current_protocol_version)?;
+            .check_version_supported(protocol_config)?;
 
         // This code does nothing right now. Its purpose is to cause a compiler error when a
         // new signature type is added.
@@ -3059,7 +3064,7 @@ pub trait VersionedProtocolMessage {
     }
 
     /// Check that the version of the message is the correct one to use at this protocol version.
-    fn check_version_supported(&self, current_protocol_version: ProtocolVersion) -> SuiResult;
+    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult;
 }
 
 /// The response from processing a transaction or a certified transaction
@@ -3076,7 +3081,7 @@ impl VersionedProtocolMessage for TransactionEffects {
         })
     }
 
-    fn check_version_supported(&self, current_protocol_version: ProtocolVersion) -> SuiResult {
+    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
         let (message_version, supported) = match self {
             Self::V1(_) => (1, SupportedProtocolVersions::new_for_message(1, u64::MAX)),
             // Suppose we add V2 at protocol version 7, then we must change this to:
@@ -3084,13 +3089,14 @@ impl VersionedProtocolMessage for TransactionEffects {
             // Self::V2 => (2, SupportedProtocolVersions::new_for_message(7, u64::MAX)),
         };
 
-        if supported.is_version_supported(current_protocol_version) {
+        if supported.is_version_supported(protocol_config.version) {
             Ok(())
         } else {
             Err(SuiError::WrongMessageVersion {
-                message_version,
-                supported,
-                current_protocol_version,
+                error: format!(
+                    "TransactionEffectsV{} is not supported at {:?}. (Supported range is {:?}",
+                    message_version, protocol_config.version, supported
+                ),
             })
         }
     }

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -10,7 +10,8 @@ use crate::error::SuiError;
 use crate::message_envelope::Message;
 use crate::messages::InputObjectKind::{ImmOrOwnedMoveObject, MovePackage, SharedMoveObject};
 use crate::messages::{
-    SenderSignedData, TransactionEffects, TransactionEvents, VerifiedTransaction,
+    SenderSignedData, TransactionDataAPI, TransactionEffects, TransactionEvents,
+    VerifiedTransaction,
 };
 use crate::messages_checkpoint::{
     CheckpointContents, CheckpointSequenceNumber, VerifiedCheckpoint,

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -11,7 +11,7 @@ use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
 use tracing::trace;
 
 use crate::coin::Coin;
@@ -117,6 +117,7 @@ pub struct TemporaryStore<S> {
     events: Vec<Event>,
     gas_charged: Option<(SuiAddress, ObjectID, GasCostSummary)>,
     storage_rebate_rate: u64,
+    protocol_version: ProtocolVersion,
 }
 
 impl<S> TemporaryStore<S> {
@@ -142,6 +143,7 @@ impl<S> TemporaryStore<S> {
             events: Vec::new(),
             gas_charged: None,
             storage_rebate_rate: protocol_config.storage_rebate_rate(),
+            protocol_version: protocol_config.version,
         }
     }
 
@@ -583,6 +585,7 @@ impl<S> TemporaryStore<S> {
             modified_at_versions.push((*id, *version));
         });
 
+        let protocol_version = self.protocol_version;
         let inner = self.into_inner();
 
         // In the case of special transactions that don't require a gas object,
@@ -624,27 +627,28 @@ impl<S> TemporaryStore<S> {
             }
         }
 
-        let effects = TransactionEffects {
+        let effects = TransactionEffects::new_from_execution(
+            protocol_version,
             status,
-            executed_epoch: epoch,
-            gas_used: gas_cost_summary,
+            epoch,
+            gas_cost_summary,
             modified_at_versions,
-            shared_objects: shared_object_refs,
-            transaction_digest: *transaction_digest,
+            shared_object_refs,
+            *transaction_digest,
             created,
             mutated,
             unwrapped,
             deleted,
             unwrapped_then_deleted,
             wrapped,
-            gas_object: updated_gas_object_info,
-            events_digest: if inner.events.data.is_empty() {
+            updated_gas_object_info,
+            if inner.events.data.is_empty() {
                 None
             } else {
                 Some(inner.events.digest())
             },
-            dependencies: transaction_dependencies,
-        };
+            transaction_dependencies,
+        );
         (inner, effects)
     }
 

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -75,18 +75,23 @@ mod sim_only_tests {
     use tokio::time::{sleep, timeout, Duration};
     use tracing::info;
 
+    const START: u64 = ProtocolVersion::MAX.as_u64();
+    const FINISH: u64 = ProtocolVersion::MAX_ALLOWED.as_u64();
+
     #[sim_test]
     async fn test_protocol_version_upgrade() {
         ProtocolConfig::poison_get_for_min_version();
 
         let test_cluster = TestClusterBuilder::new()
             .with_epoch_duration_ms(10000)
-            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(1, 2))
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                START, FINISH,
+            ))
             .build()
             .await
             .unwrap();
 
-        monitor_version_change(&test_cluster, 2 /* expected proto version */).await;
+        monitor_version_change(&test_cluster, FINISH /* expected proto version */).await;
     }
 
     #[sim_test]
@@ -102,17 +107,17 @@ mod sim_only_tests {
             .with_epoch_duration_ms(10000)
             .with_supported_protocol_version_callback(Arc::new(|idx, name| {
                 if name.is_some() && idx == 0 {
-                    // first validator only does not support version 2.
-                    SupportedProtocolVersions::new_for_testing(1, 1)
+                    // first validator only does not support version FINISH.
+                    SupportedProtocolVersions::new_for_testing(START, START)
                 } else {
-                    SupportedProtocolVersions::new_for_testing(1, 2)
+                    SupportedProtocolVersions::new_for_testing(START, FINISH)
                 }
             }))
             .build()
             .await
             .unwrap();
 
-        monitor_version_change(&test_cluster, 2 /* expected proto version */).await;
+        monitor_version_change(&test_cluster, FINISH /* expected proto version */).await;
 
         // verify that the node that didn't support the new version shut itself down.
         for v in test_cluster.swarm.validators() {
@@ -120,7 +125,7 @@ mod sim_only_tests {
                 .config
                 .supported_protocol_versions
                 .unwrap()
-                .is_version_supported(ProtocolVersion::new(2))
+                .is_version_supported(ProtocolVersion::new(FINISH))
             {
                 assert!(!v.is_running(), "{:?}", v.name().concise());
             } else {
@@ -137,17 +142,17 @@ mod sim_only_tests {
             .with_epoch_duration_ms(10000)
             .with_supported_protocol_version_callback(Arc::new(|idx, name| {
                 if name.is_some() && idx <= 1 {
-                    // two validators don't support version 2, so we never advance to 2.
-                    SupportedProtocolVersions::new_for_testing(1, 1)
+                    // two validators don't support version FINISH, so we never advance to FINISH.
+                    SupportedProtocolVersions::new_for_testing(START, START)
                 } else {
-                    SupportedProtocolVersions::new_for_testing(1, 2)
+                    SupportedProtocolVersions::new_for_testing(START, FINISH)
                 }
             }))
             .build()
             .await
             .unwrap();
 
-        monitor_version_change(&test_cluster, 1 /* expected proto version */).await;
+        monitor_version_change(&test_cluster, START /* expected proto version */).await;
     }
 
     #[sim_test]
@@ -219,7 +224,9 @@ mod sim_only_tests {
         TestClusterBuilder::new()
             .with_epoch_duration_ms(10000)
             .with_objects([sui_framework_object(from)])
-            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(1, 2))
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                START, FINISH,
+            ))
             .build()
             .await
             .unwrap()
@@ -254,11 +261,11 @@ mod sim_only_tests {
     }
 
     async fn expect_upgrade_failed(cluster: &TestCluster) {
-        monitor_version_change(&cluster, 1 /* expected proto version */).await;
+        monitor_version_change(&cluster, START /* expected proto version */).await;
     }
 
     async fn expect_upgrade_succeeded(cluster: &TestCluster) {
-        monitor_version_change(&cluster, 2 /* expected proto version */).await;
+        monitor_version_change(&cluster, FINISH /* expected proto version */).await;
     }
 
     #[sim_test]
@@ -270,12 +277,14 @@ mod sim_only_tests {
         let test_cluster = TestClusterBuilder::new()
             .with_epoch_duration_ms(10000)
             .with_objects([sui_framework_object("base")])
-            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(1, 1))
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                START, START,
+            ))
             .build()
             .await
             .unwrap();
 
-        monitor_version_change(&test_cluster, 1 /* expected proto version */).await;
+        monitor_version_change(&test_cluster, START /* expected proto version */).await;
     }
 
     #[sim_test]
@@ -289,7 +298,9 @@ mod sim_only_tests {
 
         let test_cluster = TestClusterBuilder::new()
             .with_epoch_duration_ms(10000)
-            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(1, 2))
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                START, FINISH,
+            ))
             .build()
             .await
             .unwrap();
@@ -305,7 +316,7 @@ mod sim_only_tests {
             }
         }));
 
-        monitor_version_change(&test_cluster, 2 /* expected proto version */).await;
+        monitor_version_change(&test_cluster, FINISH /* expected proto version */).await;
 
         // monitor_version_change only waits for fullnode to reconfigure - validator can actually be
         // slower than fullnode if it wasn't one of the signers of the final checkpoint.
@@ -317,7 +328,7 @@ mod sim_only_tests {
             let committee = node.state().epoch_store_for_testing().committee().clone();
             assert_eq!(
                 node.state().epoch_store_for_testing().protocol_version(),
-                ProtocolVersion::new(2)
+                ProtocolVersion::new(FINISH)
             );
             assert_eq!(committee.epoch, 2);
         });
@@ -335,7 +346,9 @@ mod sim_only_tests {
 
         let test_cluster = TestClusterBuilder::new()
             .with_epoch_duration_ms(10000)
-            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(1, 2))
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                START, FINISH,
+            ))
             .build()
             .await
             .unwrap();
@@ -351,7 +364,7 @@ mod sim_only_tests {
             }
         }));
 
-        monitor_version_change(&test_cluster, 1 /* expected proto version */).await;
+        monitor_version_change(&test_cluster, START /* expected proto version */).await;
     }
 
     async fn monitor_version_change(test_cluster: &TestCluster, final_version: u64) {
@@ -364,7 +377,7 @@ mod sim_only_tests {
             while let Ok((committee, protocol_version)) = epoch_rx.recv().await {
                 info!("received epoch {} {:?}", committee.epoch, protocol_version);
                 match committee.epoch {
-                    0 => assert_eq!(protocol_version, ProtocolVersion::new(1)),
+                    0 => assert_eq!(protocol_version, ProtocolVersion::new(START)),
                     1 => assert_eq!(protocol_version, ProtocolVersion::new(final_version)),
                     2 => break,
                     _ => unreachable!(),

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -18,7 +18,8 @@ use sui_types::crypto::{generate_proof_of_possession, get_account_key_pair};
 use sui_types::gas::GasCostSummary;
 use sui_types::message_envelope::Message;
 use sui_types::messages::{
-    CallArg, CertifiedTransactionEffects, ObjectArg, TransactionData, VerifiedTransaction,
+    CallArg, CertifiedTransactionEffects, ObjectArg, TransactionData, TransactionEffectsAPI,
+    VerifiedTransaction,
 };
 use sui_types::object::Object;
 use sui_types::utils::to_sender_signed_transaction;
@@ -55,7 +56,7 @@ async fn advance_epoch_tx_test() {
             // Check that the validator didn't commit the transaction yet.
             assert!(state
                 .get_signed_effects_and_maybe_resign(
-                    &effects.transaction_digest,
+                    effects.transaction_digest(),
                     &state.epoch_store_for_testing()
                 )
                 .unwrap()
@@ -402,7 +403,7 @@ async fn test_reconfig_with_committee_change_basic() {
     let effects = execute_transaction(&authorities, transaction)
         .await
         .unwrap();
-    assert!(effects.status.is_ok());
+    assert!(effects.status().is_ok());
 
     trigger_reconfiguration(&authorities).await;
     // Check that a new validator has joined the committee.
@@ -468,7 +469,7 @@ async fn test_reconfig_with_committee_change_basic() {
     let effects = execute_transaction(&authorities, transaction)
         .await
         .unwrap();
-    assert!(effects.status.is_ok());
+    assert!(effects.status().is_ok());
 
     authorities.push(handle);
     trigger_reconfiguration(&authorities).await;

--- a/crates/sui/tests/shared_objects_version_tests.rs
+++ b/crates/sui/tests/shared_objects_version_tests.rs
@@ -10,7 +10,7 @@ use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber};
 use sui_types::error::SuiResult;
 use sui_types::messages::{
     CallArg, ExecutionFailureStatus, ExecutionStatus, ObjectArg, TransactionEffects,
-    TransactionEvents,
+    TransactionEffectsAPI, TransactionEvents,
 };
 use sui_types::object::{generate_test_gas_objects, Object, Owner, OBJECT_START_VERSION};
 use sui_types::SUI_FRAMEWORK_ADDRESS;
@@ -181,9 +181,9 @@ impl TestEnvironment {
 
     async fn create_counter(&mut self) -> (ObjectRef, Owner) {
         let (fx, _) = self.owned_move_call("create_counter", vec![]).await;
-        assert!(fx.status.is_ok());
+        assert!(fx.status().is_ok());
 
-        *fx.created
+        *fx.created()
             .iter()
             .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
             .expect("Owned object created")
@@ -191,9 +191,9 @@ impl TestEnvironment {
 
     async fn create_shared_counter(&mut self) -> (ObjectRef, Owner) {
         let (fx, _) = self.owned_move_call("create_shared_counter", vec![]).await;
-        assert!(fx.status.is_ok());
+        assert!(fx.status().is_ok());
 
-        *fx.created
+        *fx.created()
             .iter()
             .find(|(_, owner)| owner.is_shared())
             .expect("Shared object created")
@@ -210,12 +210,12 @@ impl TestEnvironment {
             )
             .await;
 
-        if let ExecutionStatus::Failure { error, .. } = fx.status {
-            return Err(error);
+        if let ExecutionStatus::Failure { error, .. } = fx.status() {
+            return Err(error.clone());
         }
 
         Ok(*fx
-            .mutated
+            .mutated()
             .iter()
             .find(|(obj, _)| obj.0 == counter.0)
             .expect("Counter mutated"))
@@ -229,9 +229,9 @@ impl TestEnvironment {
             )
             .await;
 
-        assert!(fx.status.is_ok());
+        assert!(fx.status().is_ok());
 
-        *fx.mutated
+        *fx.mutated()
             .iter()
             .find(|(obj, _)| obj.0 == counter.0)
             .expect("Counter modified")
@@ -253,10 +253,10 @@ impl TestEnvironment {
             )
             .await?;
 
-        assert!(fx.status.is_ok());
+        assert!(fx.status().is_ok());
 
         Ok(*fx
-            .mutated
+            .mutated()
             .iter()
             .find(|(obj, _)| obj.0 == counter)
             .expect("Counter modified"))

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -24,7 +24,7 @@ use sui_config::{FullnodeConfigBuilder, NodeConfig, PersistedConfig, SUI_KEYSTOR
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_node::SuiNode;
 use sui_node::SuiNodeHandle;
-use sui_protocol_config::SupportedProtocolVersions;
+use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
 use sui_sdk::{SuiClient, SuiClientBuilder};
 use sui_swarm::memory::{Swarm, SwarmBuilder};
 use sui_types::base_types::{AuthorityName, SuiAddress};
@@ -207,6 +207,7 @@ pub struct TestClusterBuilder {
     fullnode_rpc_port: Option<u16>,
     enable_fullnode_events: bool,
     epoch_duration_ms: Option<u64>,
+    initial_protocol_version: ProtocolVersion,
     supported_protocol_versions_config: ProtocolVersionsConfig,
 }
 
@@ -219,6 +220,7 @@ impl TestClusterBuilder {
             num_validators: None,
             enable_fullnode_events: false,
             epoch_duration_ms: None,
+            initial_protocol_version: SupportedProtocolVersions::SYSTEM_DEFAULT.max,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
         }
     }
@@ -255,6 +257,11 @@ impl TestClusterBuilder {
 
     pub fn with_supported_protocol_versions(mut self, c: SupportedProtocolVersions) -> Self {
         self.supported_protocol_versions_config = ProtocolVersionsConfig::Global(c);
+        self
+    }
+
+    pub fn with_protocol_version(mut self, v: ProtocolVersion) -> Self {
+        self.initial_protocol_version = v;
         self
     }
 
@@ -324,6 +331,7 @@ impl TestClusterBuilder {
                 NonZeroUsize::new(self.num_validators.unwrap_or(NUM_VALIDAOTR)).unwrap(),
             )
             .with_objects(self.additional_objects.clone())
+            .with_protocol_version(self.initial_protocol_version)
             .with_supported_protocol_versions_config(
                 self.supported_protocol_versions_config.clone(),
             );

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -23,7 +23,7 @@ use sui_types::intent::Intent;
 use sui_types::message_envelope::Message;
 use sui_types::messages::{
     CallArg, ObjectArg, ObjectInfoRequest, ObjectInfoResponse, Transaction, TransactionData,
-    TransactionEffects, TransactionEvents, VerifiedTransaction,
+    TransactionEffects, TransactionEffectsAPI, TransactionEvents, VerifiedTransaction,
 };
 use sui_types::messages::{ExecuteTransactionRequestType, HandleCertificateResponse};
 use sui_types::object::{Object, Owner};
@@ -55,7 +55,7 @@ pub async fn publish_package(
     configs: &[ValidatorInfo],
 ) -> ObjectRef {
     let (effects, _) = publish_package_for_effects(gas_object, path, configs).await;
-    parse_package_ref(&effects.created).unwrap()
+    parse_package_ref(effects.created()).unwrap()
 }
 
 pub async fn publish_package_for_effects(

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -19,6 +19,7 @@ import {
   bcsForVersion,
   GasData,
   RpcApiVersion,
+  prepareTxDataForBcs,
 } from '../../types';
 import {
   MoveCallTransaction,
@@ -356,6 +357,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
       );
     }
     return {
+      messageVersion: 1,
       kind: tx,
       sender: signerAddress,
       gasData: {
@@ -377,7 +379,8 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     size: number = 8192,
   ): Promise<Uint8Array> {
     const bcs = bcsForVersion(await this.provider.getRpcApiVersion());
-    const dataBytes = bcs.ser('TransactionData', tx, size).toBytes();
+    let txBcs = prepareTxDataForBcs(tx);
+    const dataBytes = bcs.ser('TransactionData', txBcs, size).toBytes();
     return dataBytes;
   }
 

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -10,7 +10,7 @@ import {
   union,
   unknown,
 } from 'superstruct';
-import { CallArg, TransactionData } from './sui-bcs';
+import { CallArg, TransactionData, TransactionDataBCS } from './sui-bcs';
 import { sha256Hash } from '../cryptography/hash';
 import { BCS, fromB58, toB58 } from '@mysten/bcs';
 
@@ -117,6 +117,18 @@ export function normalizeSuiObjectId(
   return normalizeSuiAddress(value, forceAdd0x);
 }
 
+export function prepareTxDataForBcs(
+  data: TransactionData,
+): TransactionDataBCS {
+  switch (data.messageVersion) {
+    case 1: {
+      let { messageVersion: _, ...rest } = data;
+      return { V1: rest };
+    }
+    default: throw new Error(`Unknown message version ${ data.messageVersion }`);
+  }
+}
+
 /**
  * Generate transaction digest.
  *
@@ -129,7 +141,8 @@ export function generateTransactionDigest(
   data: TransactionData,
   bcs: BCS,
 ): string {
-  const txBytes = bcs.ser('TransactionData', data).toBytes();
+  let dataBcs = prepareTxDataForBcs(data);
+  const txBytes = bcs.ser('TransactionData', dataBcs).toBytes();
   const hash = sha256Hash('TransactionData', txBytes);
 
   return toB58(hash);

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -221,6 +221,7 @@ describe('Transaction Serialization and deserialization', () => {
     } as PaySuiTx;
 
     const tx_data = {
+      messageVersion: 1,
       sender: DEFAULT_RECIPIENT_2,
       kind: { Single: paySuiTx } as TransactionKind,
       gasData: {
@@ -267,6 +268,7 @@ describe('Transaction Serialization and deserialization', () => {
       },
     } as PayAllSuiTx;
     const tx_data = {
+      messageVersion: 1,
       sender: DEFAULT_RECIPIENT_2,
       kind: { Single: payAllSui } as TransactionKind,
       gasData: {

--- a/sdk/typescript/test/unit/types/common.test.ts
+++ b/sdk/typescript/test/unit/types/common.test.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from 'vitest';
-import { bcs, generateTransactionDigest } from '../../../src';
+import { bcs, generateTransactionDigest, TransactionData } from '../../../src';
 
 describe('Test common functions', () => {
   describe('Calculate transaction digest', () => {
     it('Test calculate transaction digest for ED25519', () => {
-      const transactionData = {
+      const transactionData: TransactionData = {
+        messageVersion: 1,
         kind: {
           Single: {
             TransferSui: {


### PR DESCRIPTION
The first commit is just prep work that will be merged into main. The second commit shows how we evolve the protocol.

Question for reviewers: This PR demonstrates how we can safely evolve enums like SingleTransactionKind without changing the top-level format. However, should we always bump the top-level format for clarity? Will it make any difference to the clients.