### PR TITLE
Add a checkpoint serialized size limit.

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1207,6 +1207,23 @@ impl AuthorityStore {
             .map(|v| v.map(|v| v.into()))
     }
 
+    pub fn get_transaction_and_serialized_size(
+        &self,
+        tx_digest: &TransactionDigest,
+    ) -> Result<Option<(VerifiedTransaction, usize)>, TypedStoreError> {
+        self.perpetual_tables
+            .transactions
+            .get_raw_bytes(tx_digest)
+            .and_then(|v| match v {
+                Some(tx_bytes) => {
+                    let tx: VerifiedTransaction =
+                        bcs::from_bytes::<TrustedTransaction>(&tx_bytes)?.into();
+                    Ok(Some((tx, tx_bytes.len())))
+                }
+                None => Ok(None),
+            })
+    }
+
     // TODO: Transaction Orchestrator also calls this, which is not ideal.
     // Instead of this function use AuthorityEpochStore::epoch_start_configuration() to access this object everywhere
     // besides when we are reading fields for the current epoch

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -412,6 +412,7 @@ pub struct CheckpointBuilder {
     exit: watch::Receiver<()>,
     metrics: Arc<CheckpointMetrics>,
     max_transactions_per_checkpoint: usize,
+    max_checkpoint_size: usize,
 }
 
 pub struct CheckpointAggregator {
@@ -445,6 +446,7 @@ impl CheckpointBuilder {
         notify_aggregator: Arc<Notify>,
         metrics: Arc<CheckpointMetrics>,
         max_transactions_per_checkpoint: usize,
+        max_checkpoint_size: usize,
     ) -> Self {
         Self {
             state,
@@ -458,6 +460,7 @@ impl CheckpointBuilder {
             notify_aggregator,
             metrics,
             max_transactions_per_checkpoint,
+            max_checkpoint_size,
         }
     }
 
@@ -577,21 +580,98 @@ impl CheckpointBuilder {
                 }
             }
         }
-        let chunks = all_effects.chunks(self.max_transactions_per_checkpoint);
-        let chunks = chunks.into_iter().map(|ch| ch.to_vec());
-        let mut chunks: Vec<_> = chunks.collect();
-        if chunks.is_empty() {
-            // We intentionally create an empty checkpoint here if there is no content provided
+
+        let all_digests: Vec<_> = all_effects
+            .iter()
+            .map(|effect| *effect.transaction_digest())
+            .collect();
+        let mut all_effects_and_transaction_sizes = Vec::with_capacity(all_effects.len());
+        for effects in all_effects {
+            let (transaction, transaction_size) = self
+                .state
+                .database
+                .get_transaction_and_serialized_size(effects.transaction_digest())?
+                .unwrap_or_else(|| panic!("Could not find executed transaction {effects:?}"));
+            // ConsensusCommitPrologue is guaranteed to be processed before we reach here
+            if !matches!(
+                transaction.inner().transaction_data().kind(),
+                TransactionKind::Single(SingleTransactionKind::ConsensusCommitPrologue(..))
+            ) {
+                // todo - use NotifyRead::register_all might be faster
+                self.epoch_store
+                    .consensus_message_processed_notify(SequencedConsensusTransactionKey::External(
+                        ConsensusTransactionKey::Certificate(*effects.transaction_digest()),
+                    ))
+                    .await?;
+            }
+            all_effects_and_transaction_sizes.push((effects, transaction_size));
+        }
+
+        debug!(
+            "Waiting for checkpoint user signatures for certificates {:?} to appear in consensus",
+            all_effects_and_transaction_sizes
+                .iter()
+                .map(|(effects, _)| effects)
+                .collect::<Vec<_>>()
+        );
+        let signatures = {
+            let _guard = monitored_scope("CheckpointBuilder::wait_user_signatures");
+            self.epoch_store
+                .user_signatures_for_checkpoint(&all_digests)?
+        };
+        debug!(
+            "Received {} checkpoint user signatures from consensus",
+            signatures.len()
+        );
+
+        struct CheckpointTransaction {
+            effects: TransactionEffects,
+            signatures: Vec<GenericSignature>,
+        }
+        let mut chunks: Vec<Vec<CheckpointTransaction>> = Vec::new();
+        let mut chunk: Vec<CheckpointTransaction> = Vec::new();
+        let mut chunk_size: usize = 0;
+        for ((effects, transaction_size), signatures) in all_effects_and_transaction_sizes
+            .into_iter()
+            .zip(signatures.into_iter())
+        {
+            // Roll over to a new chunk after either max count or max size is reached.
+            let size = transaction_size
+                + bcs::serialized_size(&effects)?
+                + bcs::serialized_size(&signatures)?;
+            if chunk.len() == self.max_transactions_per_checkpoint
+                || (chunk_size + size) > self.max_checkpoint_size
+            {
+                if chunk.is_empty() {
+                    // Always allow at least one tx in a checkpoint.
+                    warn!("Size of single transaction ({size}) exceeds max checkpoint size ({}); allowing excessively large checkpoint to go through.", self.max_checkpoint_size);
+                } else {
+                    chunks.push(chunk);
+                    chunk = Vec::new();
+                    chunk_size = 0;
+                }
+            }
+
+            chunk.push(CheckpointTransaction {
+                effects,
+                signatures,
+            });
+            chunk_size += size;
+        }
+
+        if !chunk.is_empty() || chunks.is_empty() {
+            // We intentionally create an empty checkpoint if there is no content provided
             // to make a 'heartbeat' checkpoint.
             // Important: if some conditions are added here later, we need to make sure we always
             // have at least one chunk if last_pending_of_epoch is set
-            chunks.push(vec![]);
+            chunks.push(chunk);
             // Note: empty checkpoints are ok - they shouldn't happen at all on a network with even
             // modest load. Even if they do happen, it is still useful as it allows fullnodes to
             // distinguish between "no transactions have happened" and "i am not receiving new
             // checkpoints".
         }
         let chunks_count = chunks.len();
+
         let mut checkpoints = Vec::with_capacity(chunks_count);
         debug!(
             "Creating {} checkpoints with {} transactions total after sequence {:?}",
@@ -599,8 +679,9 @@ impl CheckpointBuilder {
             total,
             last_checkpoint.as_ref().map(|(seq, _)| *seq)
         );
+
         let epoch = self.epoch_store.epoch();
-        for (index, mut effects) in chunks.into_iter().enumerate() {
+        for (index, transactions) in chunks.into_iter().enumerate() {
             let first_checkpoint_of_epoch = index == 0
                 && last_checkpoint
                     .as_ref()
@@ -612,39 +693,6 @@ impl CheckpointBuilder {
             }
             let last_checkpoint_of_epoch = details.last_of_epoch && index == chunks_count - 1;
 
-            let digests_without_epoch_augment: Vec<_> =
-                effects.iter().map(|e| *e.transaction_digest()).collect();
-            debug!("Waiting for checkpoint user signatures for certificates {:?} to appear in consensus", digests_without_epoch_augment);
-            for digest in digests_without_epoch_augment.iter() {
-                let transaction = self
-                    .state
-                    .database
-                    .get_transaction(digest)?
-                    .expect("Could not find executed transaction");
-                // ConsensusCommitPrologue is guaranteed to be processed before we reach here
-                if !matches!(
-                    transaction.inner().transaction_data().kind(),
-                    TransactionKind::Single(SingleTransactionKind::ConsensusCommitPrologue(..))
-                ) {
-                    // todo - use NotifyRead::register_all might be faster
-                    self.epoch_store
-                        .consensus_message_processed_notify(
-                            SequencedConsensusTransactionKey::External(
-                                ConsensusTransactionKey::Certificate(*digest),
-                            ),
-                        )
-                        .await?;
-                }
-            }
-            let mut signatures = {
-                let _guard = monitored_scope("CheckpointBuilder::wait_user_signatures");
-                self.epoch_store
-                    .user_signatures_for_checkpoint(&digests_without_epoch_augment)?
-            };
-            debug!(
-                "Received {} checkpoint user signatures from consensus",
-                signatures.len()
-            );
             let sequence_number = last_checkpoint
                 .as_ref()
                 .map(|(_, c)| c.sequence_number + 1)
@@ -657,6 +705,10 @@ impl CheckpointBuilder {
                 }
             }
 
+            let (mut effects, mut signatures): (Vec<_>, Vec<_>) = transactions
+                .into_iter()
+                .map(|tx| (tx.effects, tx.signatures))
+                .unzip();
             let epoch_rolling_gas_cost_summary =
                 self.get_epoch_total_gas_cost(last_checkpoint.as_ref().map(|(_, c)| c), &effects);
 
@@ -1049,10 +1101,10 @@ impl CheckpointService {
         certified_checkpoint_output: Box<dyn CertifiedCheckpointOutput>,
         metrics: Arc<CheckpointMetrics>,
         max_transactions_per_checkpoint: usize,
+        max_checkpoint_size: usize,
     ) -> (Arc<Self>, watch::Sender<()> /* The exit sender */) {
         info!(
-            "Starting checkpoint service with {} max_transactions_per_checkpoint",
-            max_transactions_per_checkpoint
+            "Starting checkpoint service with {max_transactions_per_checkpoint} max_transactions_per_checkpoint and {max_checkpoint_size} max_checkpoint_size"
         );
         let notify_builder = Arc::new(Notify::new());
         let notify_aggregator = Arc::new(Notify::new());
@@ -1071,6 +1123,7 @@ impl CheckpointService {
             notify_aggregator.clone(),
             metrics.clone(),
             max_transactions_per_checkpoint,
+            max_checkpoint_size,
         );
 
         spawn_monitored_task!(builder.run());
@@ -1206,10 +1259,13 @@ mod tests {
     use crate::state_accumulator::StateAccumulator;
     use async_trait::async_trait;
     use fastcrypto::traits::KeyPair;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
+    use sui_types::base_types::{ObjectID, SequenceNumber};
     use sui_types::crypto::Signature;
-    use sui_types::messages::VerifiedTransaction;
+    use sui_types::messages::{GenesisObject, VerifiedTransaction};
     use sui_types::messages_checkpoint::SignedCheckpointSummary;
+    use sui_types::move_package::MovePackage;
+    use sui_types::object;
     use tempfile::tempdir;
     use tokio::sync::mpsc;
 
@@ -1227,12 +1283,33 @@ mod tests {
             AuthorityState::new_for_testing(committee.clone(), &keypair, None, &genesis).await;
 
         let dummy_tx = VerifiedTransaction::new_genesis_transaction(vec![]);
+        let dummy_tx_with_data =
+            VerifiedTransaction::new_genesis_transaction(vec![GenesisObject::RawObject {
+                data: object::Data::Package(
+                    MovePackage::new(
+                        ObjectID::random(),
+                        SequenceNumber::new(),
+                        &BTreeMap::from([(format!("{:0>40000}", "1"), Vec::new())]),
+                        100_000,
+                    )
+                    .unwrap(),
+                ),
+                owner: object::Owner::Immutable,
+            }]);
         for i in 0..15 {
             state
                 .database
                 .perpetual_tables
                 .transactions
                 .insert(&d(i), dummy_tx.serializable_ref())
+                .unwrap();
+        }
+        for i in 15..20 {
+            state
+                .database
+                .perpetual_tables
+                .transactions
+                .insert(&d(i), dummy_tx_with_data.serializable_ref())
                 .unwrap();
         }
 
@@ -1249,6 +1326,9 @@ mod tests {
         store.insert(d(4), e(d(4), vec![], GasCostSummary::new(41, 42, 43)));
         for i in [10, 11, 12, 13] {
             store.insert(d(i), e(d(i), vec![], GasCostSummary::new(41, 42, 43)));
+        }
+        for i in [15, 16, 17] {
+            store.insert(d(i), e(d(i), vec![], GasCostSummary::new(51, 52, 53)));
         }
         let all_digests: Vec<_> = store.keys().copied().collect();
         for digest in all_digests {
@@ -1278,6 +1358,7 @@ mod tests {
             Box::new(certified_output),
             CheckpointMetrics::new_for_tests(),
             3,
+            100_000,
         );
 
         checkpoint_service
@@ -1292,6 +1373,9 @@ mod tests {
             .unwrap();
         checkpoint_service
             .notify_checkpoint(&epoch_store, p(2, vec![10, 11, 12, 13]))
+            .unwrap();
+        checkpoint_service
+            .notify_checkpoint(&epoch_store, p(3, vec![15, 16, 17]))
             .unwrap();
 
         let (c1c, c1s) = result.recv().await.unwrap();
@@ -1315,8 +1399,8 @@ mod tests {
             GasCostSummary::new(104, 108, 112)
         );
 
-        // Pending at index 2 had 4 transactions, and we configured 3 transactions max
-        // Verify that we split that we generated 2 checkpoints
+        // Pending at index 2 had 4 transactions, and we configured 3 transactions max.
+        // Verify that we split into 2 checkpoints.
         let (c3c, c3s) = result.recv().await.unwrap();
         let c3t = c3c.iter().map(|d| d.transaction).collect::<Vec<_>>();
         let (c4c, c4s) = result.recv().await.unwrap();
@@ -1327,6 +1411,19 @@ mod tests {
         assert_eq!(c4s.previous_digest, Some(c3s.digest()));
         assert_eq!(c3t, vec![d(10), d(11), d(12)]);
         assert_eq!(c4t, vec![d(13)]);
+
+        // Pending at index 3 had 3 transactions of 40K size, and we configured 100K max.
+        // Verify that we split into 2 checkpoints.
+        let (c5c, c5s) = result.recv().await.unwrap();
+        let c5t = c5c.iter().map(|d| d.transaction).collect::<Vec<_>>();
+        let (c6c, c6s) = result.recv().await.unwrap();
+        let c6t = c6c.iter().map(|d| d.transaction).collect::<Vec<_>>();
+        assert_eq!(c5s.sequence_number, 4);
+        assert_eq!(c5s.previous_digest, Some(c4s.digest()));
+        assert_eq!(c6s.sequence_number, 5);
+        assert_eq!(c6s.previous_digest, Some(c5s.digest()));
+        assert_eq!(c5t, vec![d(15), d(16)]);
+        assert_eq!(c6t, vec![d(17)]);
 
         let c1ss =
             SignedCheckpointSummary::new_from_summary(c1s, keypair.public().into(), &keypair);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -652,6 +652,7 @@ impl SuiNode {
 
         let certified_checkpoint_output = SendCheckpointToStateSync::new(state_sync_handle);
         let max_tx_per_checkpoint = max_tx_per_checkpoint(epoch_store.protocol_config());
+        let max_checkpoint_size = epoch_store.protocol_config().max_checkpoint_size();
 
         CheckpointService::spawn(
             state.clone(),
@@ -663,6 +664,7 @@ impl SuiNode {
             Box::new(certified_checkpoint_output),
             checkpoint_metrics,
             max_tx_per_checkpoint,
+            max_checkpoint_size,
         )
     }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -283,8 +283,14 @@ pub struct ProtocolConfig {
     /// === Core Protocol ===
 
     /// Max number of transactions per checkpoint.
-    /// Note that this is constant and not a config as validators must have this set to the same value, otherwise they *will* fork
+    /// Note that this is a protocol constant and not a config as validators must have this set to
+    /// the same value, otherwise they *will* fork.
     max_transactions_per_checkpoint: Option<usize>,
+
+    /// Max size of a checkpoint in bytes.
+    /// Note that this is a protocol constant and not a config as validators must have this set to
+    /// the same value, otherwise they *will* fork.
+    max_checkpoint_size: Option<usize>,
 
     /// A protocol upgrade always requires 2f+1 stake to agree. We support a buffer of additional
     /// stake (as a fraction of f, expressed in basis points) that is required before an upgrade
@@ -462,6 +468,9 @@ impl ProtocolConfig {
     pub fn max_transactions_per_checkpoint(&self) -> usize {
         self.max_transactions_per_checkpoint
             .expect(CONSTANT_ERR_MSG)
+    }
+    pub fn max_checkpoint_size(&self) -> usize {
+        self.max_checkpoint_size.expect(CONSTANT_ERR_MSG)
     }
     pub fn buffer_stake_for_protocol_upgrade_bps(&self) -> u64 {
         self.buffer_stake_for_protocol_upgrade_bps
@@ -648,6 +657,7 @@ impl ProtocolConfig {
                 reward_slashing_rate: Some(5000),
                 storage_gas_price: Some(1),
                 max_transactions_per_checkpoint: Some(1000),
+                max_checkpoint_size: Some(30 * 1024 * 1024),
                 // require 2f+1 + 0.75 * f stake for automatic protocol upgrades.
                 // TODO: tune based on experience in testnet
                 buffer_stake_for_protocol_upgrade_bps: Some(7500),

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
@@ -49,6 +49,7 @@ storage_fund_reinvest_rate: 500
 reward_slashing_rate: 5000
 storage_gas_price: 1
 max_transactions_per_checkpoint: 1000
+max_checkpoint_size: 31457280
 buffer_stake_for_protocol_upgrade_bps: 7500
 copy_bytes_to_address_cost_per_byte: 10
 address_to_vec_cost_per_byte: 10


### PR DESCRIPTION
## Description 

Complements the checkpoint transaction count limit. Includes serialized size of transaction, effects, and signatures.

## Test Plan 

Added unit test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
