### PR TITLE
[framework] implement pre active validator and staking

### DIFF
--- a/.changeset/tricky-windows-compete.md
+++ b/.changeset/tricky-windows-compete.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Adds support for validator candidate.

--- a/apps/explorer/src/components/validator/calculateAPY.ts
+++ b/apps/explorer/src/components/validator/calculateAPY.ts
@@ -7,16 +7,23 @@ import { roundFloat } from '~/utils/roundFloat';
 
 const APY_DECIMALS = 4;
 
+// TODO: share code with `calculateAPY` for wallet?
 export function calculateAPY(validator: Validator, epoch: number) {
-    const { sui_balance, starting_epoch, pool_token_balance } =
+    let apy;
+    const { sui_balance, activation_epoch, pool_token_balance } =
         validator.staking_pool;
 
-    const num_epochs_participated = +epoch - +starting_epoch;
-    const apy =
-        Math.pow(
-            1 + (+sui_balance - +pool_token_balance) / +pool_token_balance,
-            365 / num_epochs_participated
-        ) - 1;
+    // If the staking pool is active then we calculate its APY.
+    if (activation_epoch.vec.length > 0) {
+        const num_epochs_participated = +epoch - +activation_epoch.vec[0];
+        apy =
+            Math.pow(
+                1 + (+sui_balance - +pool_token_balance) / +pool_token_balance,
+                365 / num_epochs_participated
+            ) - 1;
+    } else {
+        apy = 0;
+    }
 
     //guard against NaN
     const apyReturn = apy ? roundFloat(apy, APY_DECIMALS) : 0;

--- a/apps/wallet/src/ui/app/staking/calculateAPY.ts
+++ b/apps/wallet/src/ui/app/staking/calculateAPY.ts
@@ -7,16 +7,22 @@ import { roundFloat } from '_helpers';
 
 const APY_DECIMALS = 4;
 
-export function calculateAPY(validators: Validator, epoch: number) {
-    const { sui_balance, starting_epoch, pool_token_balance } =
-        validators.staking_pool;
+export function calculateAPY(validator: Validator, epoch: number) {
+    let apy;
+    const { sui_balance, activation_epoch, pool_token_balance } =
+        validator.staking_pool;
 
-    const num_epochs_participated = +epoch - +starting_epoch;
-    const apy =
-        Math.pow(
-            1 + (+sui_balance - +pool_token_balance) / +pool_token_balance,
-            365 / num_epochs_participated
-        ) - 1;
+    // If the staking pool is active then we calculate its APY.
+    if (activation_epoch.vec.length > 0) {
+        const num_epochs_participated = +epoch - +activation_epoch.vec[0];
+        apy =
+            Math.pow(
+                1 + (+sui_balance - +pool_token_balance) / +pool_token_balance,
+                365 / num_epochs_participated
+            ) - 1;
+    } else {
+        apy = 0;
+    }
 
     //guard against NaN
     const apyReturn = apy ? roundFloat(apy, APY_DECIMALS) : 0;

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -241,7 +241,9 @@ validators:
       gas_price: 1
       staking_pool:
         id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f65e4b0dea15829e3157962e1"
-        starting_epoch: 0
+        activation_epoch:
+          vec:
+            - 0
         deactivation_epoch:
           vec: []
         sui_balance: 25000000000000000
@@ -258,7 +260,7 @@ validators:
       next_epoch_stake: 25000000000000000
       next_epoch_gas_price: 1
       next_epoch_commission_rate: 0
-  pending_validators:
+  pending_active_validators:
     contents:
       id: "0x628ffd0e51e9a6ea32c13c2739a31a8f344b557d3429e057b377a9c499b9bb13"
       size: 0
@@ -269,11 +271,14 @@ validators:
   inactive_pools:
     id: "0x1ace65f54d65a96251b3f46bfa720ab65a7ebe0174caa9fa1dc0d65a56ae7872"
     size: 0
+  validator_candidates:
+    id: "0x9dc97c4be6f1d0e61fbdf2cc9d78f9df04cdff7a473e2ec3a65853766dca1177"
+    size: 0
 storage_fund:
   value: 0
 parameters:
-  min_validator_stake: 1
-  max_validator_candidate_count: 100
+  min_validator_stake: 25000000000000000
+  max_validator_count: 100
   governance_start_epoch: 0
 reference_gas_price: 1
 validator_report_records:

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -40,10 +40,9 @@ Initial value of the upper-bound on the number of validators.
 <a name="0x2_genesis_INIT_MIN_VALIDATOR_STAKE"></a>
 
 Initial value of the lower-bound on the amount of stake required to become a validator.
-TODO: testnet only. Needs to be changed.
 
 
-<pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_MIN_VALIDATOR_STAKE">INIT_MIN_VALIDATOR_STAKE</a>: u64 = 1;
+<pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_MIN_VALIDATOR_STAKE">INIT_MIN_VALIDATOR_STAKE</a>: u64 = 25000000000000000;
 </code></pre>
 
 
@@ -161,11 +160,11 @@ all the information we need in the system.
             primary_address,
             worker_address,
             // Initialize all validators <b>with</b> uniform stake taken from the subsidy fund.
-            <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> subsidy_fund, initial_validator_stake_mist),
+            <a href="_some">option::some</a>(<a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> subsidy_fund, initial_validator_stake_mist)),
             <a href="_none">option::none</a>(),
             gas_price,
             commission_rate,
-            0, // start operating right away at epoch 0
+            <b>true</b>, // <a href="validator.md#0x2_validator">validator</a> is active right away
             ctx
         ));
         i = i + 1;

--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -19,6 +19,8 @@
 -  [Function `process_pending_delegation_withdraw`](#0x2_staking_pool_process_pending_delegation_withdraw)
 -  [Function `process_pending_delegation`](#0x2_staking_pool_process_pending_delegation)
 -  [Function `withdraw_rewards_and_burn_pool_tokens`](#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens)
+-  [Function `activate_staking_pool`](#0x2_staking_pool_activate_staking_pool)
+-  [Function `request_withdraw_delegation_preactive`](#0x2_staking_pool_request_withdraw_delegation_preactive)
 -  [Function `deactivate_staking_pool`](#0x2_staking_pool_deactivate_staking_pool)
 -  [Function `sui_balance`](#0x2_staking_pool_sui_balance)
 -  [Function `pool_id`](#0x2_staking_pool_pool_id)
@@ -32,8 +34,11 @@
 -  [Function `pool_token_exchange_rate_at_epoch`](#0x2_staking_pool_pool_token_exchange_rate_at_epoch)
 -  [Function `pending_stake_amount`](#0x2_staking_pool_pending_stake_amount)
 -  [Function `pending_stake_withdraw_amount`](#0x2_staking_pool_pending_stake_withdraw_amount)
+-  [Function `is_preactive_at_epoch`](#0x2_staking_pool_is_preactive_at_epoch)
+-  [Function `is_preactive`](#0x2_staking_pool_is_preactive)
 -  [Function `get_sui_amount`](#0x2_staking_pool_get_sui_amount)
 -  [Function `get_token_amount`](#0x2_staking_pool_get_token_amount)
+-  [Function `initial_exchange_rate`](#0x2_staking_pool_initial_exchange_rate)
 -  [Function `check_balance_invariants`](#0x2_staking_pool_check_balance_invariants)
 
 
@@ -76,10 +81,11 @@ A staking pool embedded in each validator struct in the system state object.
 
 </dd>
 <dt>
-<code>starting_epoch: u64</code>
+<code>activation_epoch: <a href="_Option">option::Option</a>&lt;u64&gt;</code>
 </dt>
 <dd>
- The epoch at which this pool started operating. Should be the epoch at which the validator became active.
+ The epoch at which this pool became active.
+ The value is <code>None</code> if the pool is pre-active and <code>Some(&lt;epoch_number&gt;)</code> if active or inactive.
 </dd>
 <dt>
 <code>deactivation_epoch: <a href="_Option">option::Option</a>&lt;u64&gt;</code>
@@ -309,6 +315,24 @@ A self-custodial object holding the staked SUI tokens.
 
 
 
+<a name="0x2_staking_pool_EPoolAlreadyActive"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EPoolAlreadyActive">EPoolAlreadyActive</a>: u64 = 14;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_EPoolNotPreactive"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EPoolNotPreactive">EPoolNotPreactive</a>: u64 = 15;
+</code></pre>
+
+
+
 <a name="0x2_staking_pool_ETokenBalancesDoNotMatchExchangeRate"></a>
 
 
@@ -332,6 +356,15 @@ A self-custodial object holding the staked SUI tokens.
 
 
 <pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWithdrawAmountCannotBeZero">EWithdrawAmountCannotBeZero</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_staking_pool_EWithdrawalInSameEpoch"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_pool.md#0x2_staking_pool_EWithdrawalInSameEpoch">EWithdrawalInSameEpoch</a>: u64 = 13;
 </code></pre>
 
 
@@ -361,7 +394,7 @@ A self-custodial object holding the staked SUI tokens.
 Create a new, empty staking pool.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(starting_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>
 </code></pre>
 
 
@@ -370,16 +403,11 @@ Create a new, empty staking pool.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(starting_epoch: u64, ctx: &<b>mut</b> TxContext) : <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_new">new</a>(ctx: &<b>mut</b> TxContext) : <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> {
     <b>let</b> exchange_rates = <a href="table.md#0x2_table_new">table::new</a>(ctx);
-    <a href="table.md#0x2_table_add">table::add</a>(
-        &<b>mut</b> exchange_rates,
-        starting_epoch,
-        <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> { sui_amount: 0, pool_token_amount: 0 }
-    );
     <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a> {
         id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
-        starting_epoch,
+        activation_epoch: <a href="_none">option::none</a>(),
         deactivation_epoch: <a href="_none">option::none</a>(),
         sui_balance: 0,
         rewards_pool: <a href="balance.md#0x2_balance_zero">balance::zero</a>(),
@@ -743,6 +771,84 @@ portion because the principal portion was already taken out of the delegator's s
 
 </details>
 
+<a name="0x2_staking_pool_activate_staking_pool"></a>
+
+## Function `activate_staking_pool`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_activate_staking_pool">activate_staking_pool</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, activation_epoch: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_activate_staking_pool">activate_staking_pool</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, activation_epoch: u64) {
+    // Add the initial exchange rate <b>to</b> the <a href="table.md#0x2_table">table</a>.
+    <a href="table.md#0x2_table_add">table::add</a>(
+        &<b>mut</b> pool.exchange_rates,
+        activation_epoch,
+        <a href="staking_pool.md#0x2_staking_pool_initial_exchange_rate">initial_exchange_rate</a>()
+    );
+    // Fill in the active epoch.
+    <b>assert</b>!(<a href="_is_none">option::is_none</a>(&pool.activation_epoch), <a href="staking_pool.md#0x2_staking_pool_EPoolAlreadyActive">EPoolAlreadyActive</a>);
+    <a href="_fill">option::fill</a>(&<b>mut</b> pool.activation_epoch, activation_epoch);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_request_withdraw_delegation_preactive"></a>
+
+## Function `request_withdraw_delegation_preactive`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_withdraw_delegation_preactive">request_withdraw_delegation_preactive</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_request_withdraw_delegation_preactive">request_withdraw_delegation_preactive</a>(
+    pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>,
+    staked_sui: <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>,
+    ctx: &<b>mut</b> TxContext
+) : u64 {
+    // Check that the delegation information matches the pool.
+    <b>assert</b>!(staked_sui.pool_id == <a href="object.md#0x2_object_id">object::id</a>(pool), <a href="staking_pool.md#0x2_staking_pool_EWrongPool">EWrongPool</a>);
+
+    <b>assert</b>!(<a href="staking_pool.md#0x2_staking_pool_is_preactive">is_preactive</a>(pool), <a href="staking_pool.md#0x2_staking_pool_EPoolNotPreactive">EPoolNotPreactive</a>);
+
+    <b>let</b> delegator = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+
+    <b>let</b> (principal, time_lock) = <a href="staking_pool.md#0x2_staking_pool_unwrap_staked_sui">unwrap_staked_sui</a>(staked_sui);
+    <b>let</b> withdraw_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&principal);
+    pool.sui_balance = pool.sui_balance - withdraw_amount;
+    pool.pool_token_balance = pool.pool_token_balance - withdraw_amount;
+
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&time_lock)) {
+        <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(principal, <a href="_destroy_some">option::destroy_some</a>(time_lock), delegator, ctx);
+    } <b>else</b> {
+        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(principal, ctx), delegator);
+        <a href="_destroy_none">option::destroy_none</a>(time_lock);
+    };
+    withdraw_amount
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_staking_pool_deactivate_staking_pool"></a>
 
 ## Function `deactivate_staking_pool`
@@ -1041,8 +1147,14 @@ Returns true if all the staking parameters of the staked sui except the principa
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, epoch: u64): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> {
+    // If the pool is preactive then the exchange rate is always 1:1.
+    <b>if</b> (<a href="staking_pool.md#0x2_staking_pool_is_preactive_at_epoch">is_preactive_at_epoch</a>(pool, epoch)) {
+        <b>return</b> <a href="staking_pool.md#0x2_staking_pool_initial_exchange_rate">initial_exchange_rate</a>()
+    };
     <b>let</b> clamped_epoch = <a href="_get_with_default">option::get_with_default</a>(&pool.deactivation_epoch, epoch);
     <b>let</b> epoch = <a href="math.md#0x2_math_min">math::min</a>(clamped_epoch, epoch);
+    // TODO: there might be epochs <b>where</b> we skip updating the exchange rate <a href="table.md#0x2_table">table</a>, in which case
+    // we need <b>to</b> find the latest entry in the <a href="table.md#0x2_table">table</a> earlier than this epoch.
     *<a href="table.md#0x2_table_borrow">table::borrow</a>(&pool.exchange_rates, epoch)
 }
 </code></pre>
@@ -1094,6 +1206,55 @@ Calculate the current the total withdrawal from the staking pool this epoch.
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_pending_stake_withdraw_amount">pending_stake_withdraw_amount</a>(<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>): u64 {
     <a href="staking_pool.md#0x2_staking_pool">staking_pool</a>.pending_total_sui_withdraw
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_is_preactive_at_epoch"></a>
+
+## Function `is_preactive_at_epoch`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_is_preactive_at_epoch">is_preactive_at_epoch</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, epoch: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_is_preactive_at_epoch">is_preactive_at_epoch</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, epoch: u64): bool{
+    // Either the pool is currently preactive or the pool's starting epoch is later than the provided epoch.
+    <a href="staking_pool.md#0x2_staking_pool_is_preactive">is_preactive</a>(pool) || (*<a href="_borrow">option::borrow</a>(&pool.activation_epoch) &gt; epoch)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_is_preactive"></a>
+
+## Function `is_preactive`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_is_preactive">is_preactive</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_is_preactive">is_preactive</a>(pool: &<a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>): bool{
+    <a href="_is_none">option::is_none</a>(&pool.activation_epoch)
 }
 </code></pre>
 
@@ -1158,6 +1319,30 @@ Calculate the current the total withdrawal from the staking pool this epoch.
             * (sui_amount <b>as</b> u128)
             / (exchange_rate.sui_amount <b>as</b> u128);
     (res <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_staking_pool_initial_exchange_rate"></a>
+
+## Function `initial_exchange_rate`
+
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_initial_exchange_rate">initial_exchange_rate</a>(): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="staking_pool.md#0x2_staking_pool_initial_exchange_rate">initial_exchange_rate</a>(): <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> {
+    <a href="staking_pool.md#0x2_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> { sui_amount: 0, pool_token_amount: 0 }
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -11,6 +11,7 @@
 -  [Struct `SystemEpochInfo`](#0x2_sui_system_SystemEpochInfo)
 -  [Constants](#@Constants_0)
 -  [Function `create`](#0x2_sui_system_create)
+-  [Function `request_add_validator_candidate`](#0x2_sui_system_request_add_validator_candidate)
 -  [Function `request_add_validator`](#0x2_sui_system_request_add_validator)
 -  [Function `request_remove_validator`](#0x2_sui_system_request_remove_validator)
 -  [Function `request_set_gas_price`](#0x2_sui_system_request_set_gas_price)
@@ -103,7 +104,7 @@ A list of system config parameters.
  Lower-bound on the amount of stake required to become a validator.
 </dd>
 <dt>
-<code>max_validator_candidate_count: u64</code>
+<code>max_validator_count: u64</code>
 </dt>
 <dd>
  Maximum number of validator candidates at any moment.
@@ -417,7 +418,7 @@ Create a new SuiSystemState object and make it shared.
 This function will be called only once in genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_candidate_count: u64, min_validator_stake: u64, governance_start_epoch: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_count: u64, min_validator_stake: u64, governance_start_epoch: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -430,7 +431,7 @@ This function will be called only once in genesis.
     validators: <a href="">vector</a>&lt;Validator&gt;,
     stake_subsidy_fund: Balance&lt;SUI&gt;,
     storage_fund: Balance&lt;SUI&gt;,
-    max_validator_candidate_count: u64,
+    max_validator_count: u64,
     min_validator_stake: u64,
     governance_start_epoch: u64,
     initial_stake_subsidy_amount: u64,
@@ -448,7 +449,7 @@ This function will be called only once in genesis.
         storage_fund,
         parameters: <a href="sui_system.md#0x2_sui_system_SystemParameters">SystemParameters</a> {
             min_validator_stake,
-            max_validator_candidate_count,
+            max_validator_count,
             governance_start_epoch,
         },
         reference_gas_price,
@@ -471,16 +472,17 @@ This function will be called only once in genesis.
 
 </details>
 
-<a name="0x2_sui_system_request_add_validator"></a>
+<a name="0x2_sui_system_request_add_validator_candidate"></a>
 
-## Function `request_add_validator`
+## Function `request_add_validator_candidate`
 
-Can be called by anyone who wishes to become a validator in the next epoch.
-The <code><a href="validator.md#0x2_validator">validator</a></code> object needs to be created before calling this.
-The amount of stake in the <code><a href="validator.md#0x2_validator">validator</a></code> object must meet the requirements.
+Can be called by anyone who wishes to become a validator candidate and starts accuring delegated
+stakes in their staking pool. Once they have at least <code>min_validator_stake</code> amount of stake they
+can call <code>request_add_validator</code> to officially become an active validator at the next epoch.
+Aborts if the caller is already a pending or active validator, or a validator candidate.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_validator">request_add_validator</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, primary_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, stake: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, gas_price: u64, commission_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_validator_candidate">request_add_validator_candidate</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, primary_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, gas_price: u64, commission_rate: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -489,7 +491,7 @@ The amount of stake in the <code><a href="validator.md#0x2_validator">validator<
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_validator">request_add_validator</a>(
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_validator_candidate">request_add_validator_candidate</a>(
     wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
     pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
     network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
@@ -503,21 +505,11 @@ The amount of stake in the <code><a href="validator.md#0x2_validator">validator<
     p2p_address: <a href="">vector</a>&lt;u8&gt;,
     primary_address: <a href="">vector</a>&lt;u8&gt;,
     worker_address: <a href="">vector</a>&lt;u8&gt;,
-    stake: Coin&lt;SUI&gt;,
     gas_price: u64,
     commission_rate: u64,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <b>assert</b>!(
-        <a href="validator_set.md#0x2_validator_set_next_epoch_validator_count">validator_set::next_epoch_validator_count</a>(&self.validators) &lt; self.parameters.max_validator_candidate_count,
-        <a href="sui_system.md#0x2_sui_system_ELimitExceeded">ELimitExceeded</a>,
-    );
-    <b>let</b> stake_amount = <a href="coin.md#0x2_coin_value">coin::value</a>(&stake);
-    <b>assert</b>!(
-        stake_amount &gt;= self.parameters.min_validator_stake,
-        <a href="sui_system.md#0x2_sui_system_ELimitExceeded">ELimitExceeded</a>,
-    );
     <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator.md#0x2_validator_new">validator::new</a>(
         <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx),
         pubkey_bytes,
@@ -532,15 +524,52 @@ The amount of stake in the <code><a href="validator.md#0x2_validator">validator<
         p2p_address,
         primary_address,
         worker_address,
-        <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(stake),
+        <a href="_none">option::none</a>(),
         <a href="_none">option::none</a>(),
         gas_price,
         commission_rate,
-        <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1, // starting next epoch
+        <b>false</b>, // not an initial <a href="validator.md#0x2_validator">validator</a> active at <a href="genesis.md#0x2_genesis">genesis</a>
         ctx
     );
 
-    <a href="validator_set.md#0x2_validator_set_request_add_validator">validator_set::request_add_validator</a>(&<b>mut</b> self.validators, <a href="validator.md#0x2_validator">validator</a>);
+    <a href="validator_set.md#0x2_validator_set_request_add_validator_candidate">validator_set::request_add_validator_candidate</a>(&<b>mut</b> self.validators, <a href="validator.md#0x2_validator">validator</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_add_validator"></a>
+
+## Function `request_add_validator`
+
+Called by a validator candidate to add themselves to the active validator set beginning next epoch.
+Aborts if the validator is a duplicate with one of the pending or active validators, or if the amount of
+stake the validator has doesn't meet the min threshold, or if the number of new validators for the next
+epoch has already reached the maximum.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_validator">request_add_validator</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_add_validator">request_add_validator</a>(
+    wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
+    <b>assert</b>!(
+        <a href="validator_set.md#0x2_validator_set_next_epoch_validator_count">validator_set::next_epoch_validator_count</a>(&self.validators) &lt; self.parameters.max_validator_count,
+        <a href="sui_system.md#0x2_sui_system_ELimitExceeded">ELimitExceeded</a>,
+    );
+
+    <a href="validator_set.md#0x2_validator_set_request_add_validator">validator_set::request_add_validator</a>(&<b>mut</b> self.validators, self.parameters.min_validator_stake, ctx);
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -12,6 +12,7 @@
 -  [Constants](#@Constants_0)
 -  [Function `create`](#0x2_sui_system_create)
 -  [Function `request_add_validator_candidate`](#0x2_sui_system_request_add_validator_candidate)
+-  [Function `request_remove_validator_candidate`](#0x2_sui_system_request_remove_validator_candidate)
 -  [Function `request_add_validator`](#0x2_sui_system_request_add_validator)
 -  [Function `request_remove_validator`](#0x2_sui_system_request_remove_validator)
 -  [Function `request_set_gas_price`](#0x2_sui_system_request_set_gas_price)
@@ -107,7 +108,7 @@ A list of system config parameters.
 <code>max_validator_count: u64</code>
 </dt>
 <dd>
- Maximum number of validator candidates at any moment.
+ Maximum number of active validators at any moment.
  We do not allow the number of validators in any epoch to go above this.
 </dd>
 <dt>
@@ -533,6 +534,36 @@ Aborts if the caller is already a pending or active validator, or a validator ca
     );
 
     <a href="validator_set.md#0x2_validator_set_request_add_validator_candidate">validator_set::request_add_validator_candidate</a>(&<b>mut</b> self.validators, <a href="validator.md#0x2_validator">validator</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_request_remove_validator_candidate"></a>
+
+## Function `request_remove_validator_candidate`
+
+Called by a validator candidate to remove themselves from the candidacy. After this call
+their staking pool becomes deactive.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_remove_validator_candidate">request_remove_validator_candidate</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_remove_validator_candidate">request_remove_validator_candidate</a>(
+    wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
+    <a href="validator_set.md#0x2_validator_set_request_remove_validator_candidate">validator_set::request_remove_validator_candidate</a>(&<b>mut</b> self.validators, ctx);
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -7,11 +7,13 @@
 
 -  [Struct `ValidatorMetadata`](#0x2_validator_ValidatorMetadata)
 -  [Struct `Validator`](#0x2_validator_Validator)
+-  [Struct `DelegationRequestEvent`](#0x2_validator_DelegationRequestEvent)
 -  [Constants](#@Constants_0)
 -  [Function `verify_proof_of_possession`](#0x2_validator_verify_proof_of_possession)
 -  [Function `new_metadata`](#0x2_validator_new_metadata)
 -  [Function `new`](#0x2_validator_new)
 -  [Function `deactivate`](#0x2_validator_deactivate)
+-  [Function `activate`](#0x2_validator_activate)
 -  [Function `adjust_stake_and_gas_price`](#0x2_validator_adjust_stake_and_gas_price)
 -  [Function `request_add_delegation`](#0x2_validator_request_add_delegation)
 -  [Function `request_withdraw_delegation`](#0x2_validator_request_withdraw_delegation)
@@ -19,7 +21,7 @@
 -  [Function `request_set_commission_rate`](#0x2_validator_request_set_commission_rate)
 -  [Function `deposit_delegation_rewards`](#0x2_validator_deposit_delegation_rewards)
 -  [Function `process_pending_delegations_and_withdraws`](#0x2_validator_process_pending_delegations_and_withdraws)
--  [Function `get_staking_pool_mut_ref`](#0x2_validator_get_staking_pool_mut_ref)
+-  [Function `is_preactive`](#0x2_validator_is_preactive)
 -  [Function `metadata`](#0x2_validator_metadata)
 -  [Function `sui_address`](#0x2_validator_sui_address)
 -  [Function `name`](#0x2_validator_name)
@@ -80,6 +82,7 @@
 <b>use</b> <a href="bcs.md#0x2_bcs">0x2::bcs</a>;
 <b>use</b> <a href="bls12381.md#0x2_bls12381">0x2::bls12381</a>;
 <b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
+<b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="staking_pool.md#0x2_staking_pool">0x2::staking_pool</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
@@ -310,6 +313,58 @@
 
 </details>
 
+<a name="0x2_validator_DelegationRequestEvent"></a>
+
+## Struct `DelegationRequestEvent`
+
+Event emitted when a new delegation request is received.
+
+
+<pre><code><b>struct</b> <a href="validator.md#0x2_validator_DelegationRequestEvent">DelegationRequestEvent</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>pool_id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>validator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delegator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
 <a name="@Constants_0"></a>
 
 ## Constants
@@ -325,8 +380,19 @@ Commission rate set by the validator is higher than the threshold
 
 
 
+<a name="0x2_validator_EEmptyStakeWithNonEmptyTimeLock"></a>
+
+No stake balance is provided but an epoch time lock for the stake is provided.
+
+
+<pre><code><b>const</b> <a href="validator.md#0x2_validator_EEmptyStakeWithNonEmptyTimeLock">EEmptyStakeWithNonEmptyTimeLock</a>: u64 = 9;
+</code></pre>
+
+
+
 <a name="0x2_validator_EInvalidProofOfPossession"></a>
 
+Invalid proof_of_possesion field in ValidatorMetadata
 
 
 <pre><code><b>const</b> <a href="validator.md#0x2_validator_EInvalidProofOfPossession">EInvalidProofOfPossession</a>: u64 = 0;
@@ -374,12 +440,12 @@ Invalid primary_address field in ValidatorMetadata
 
 
 
-<a name="0x2_validator_EMetadataInvalidPubKey"></a>
+<a name="0x2_validator_EMetadataInvalidPubkey"></a>
 
 Invalid pubkey_bytes field in ValidatorMetadata
 
 
-<pre><code><b>const</b> <a href="validator.md#0x2_validator_EMetadataInvalidPubKey">EMetadataInvalidPubKey</a>: u64 = 1;
+<pre><code><b>const</b> <a href="validator.md#0x2_validator_EMetadataInvalidPubkey">EMetadataInvalidPubkey</a>: u64 = 1;
 </code></pre>
 
 
@@ -394,12 +460,12 @@ Invalidworker_address field in ValidatorMetadata
 
 
 
-<a name="0x2_validator_EMetadataInvalidWorkerPubKey"></a>
+<a name="0x2_validator_EMetadataInvalidWorkerPubkey"></a>
 
 Invalid worker_pubkey_bytes field in ValidatorMetadata
 
 
-<pre><code><b>const</b> <a href="validator.md#0x2_validator_EMetadataInvalidWorkerPubKey">EMetadataInvalidWorkerPubKey</a>: u64 = 3;
+<pre><code><b>const</b> <a href="validator.md#0x2_validator_EMetadataInvalidWorkerPubkey">EMetadataInvalidWorkerPubkey</a>: u64 = 3;
 </code></pre>
 
 
@@ -526,7 +592,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new">new</a>(sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, primary_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, gas_price: u64, commission_rate: u64, starting_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new">new</a>(sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, primary_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, initial_stake_option: <a href="_Option">option::Option</a>&lt;<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, gas_price: u64, commission_rate: u64, is_active_at_genesis: bool, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
 </code></pre>
 
 
@@ -549,11 +615,11 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
     p2p_address: <a href="">vector</a>&lt;u8&gt;,
     primary_address: <a href="">vector</a>&lt;u8&gt;,
     worker_address: <a href="">vector</a>&lt;u8&gt;,
-    stake: Balance&lt;SUI&gt;,
+    initial_stake_option: Option&lt;Balance&lt;SUI&gt;&gt;,
     coin_locked_until_epoch: Option&lt;EpochTimeLock&gt;,
     gas_price: u64,
     commission_rate: u64,
-    starting_epoch: u64,
+    is_active_at_genesis: bool,
     ctx: &<b>mut</b> TxContext
 ): <a href="validator.md#0x2_validator_Validator">Validator</a> {
     <b>assert</b>!(
@@ -592,11 +658,11 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 
     <a href="validator.md#0x2_validator_new_from_metadata">new_from_metadata</a>(
         metadata,
-        stake,
+        initial_stake_option,
         coin_locked_until_epoch,
         gas_price,
         commission_rate,
-        starting_epoch,
+        is_active_at_genesis,
         ctx
     )
 }
@@ -624,6 +690,30 @@ Deactivate this validator's staking pool
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deactivate">deactivate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, deactivation_epoch: u64) {
     <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">staking_pool::deactivate_staking_pool</a>(&<b>mut</b> self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, deactivation_epoch)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_activate"></a>
+
+## Function `activate`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_activate">activate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, activation_epoch: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_activate">activate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, activation_epoch: u64) {
+    <a href="staking_pool.md#0x2_staking_pool_activate_staking_pool">staking_pool::activate_staking_pool</a>(&<b>mut</b> self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, activation_epoch);
 }
 </code></pre>
 
@@ -664,7 +754,7 @@ Process pending stake and pending withdraws, and update the gas price.
 Request to add delegation to the validator's staking pool, processed at the end of the epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_add_delegation">request_add_delegation</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, delegated_stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, locking_period: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, delegator: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_request_add_delegation">request_add_delegation</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, delegated_stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, locking_period: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, delegator_address: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -677,16 +767,29 @@ Request to add delegation to the validator's staking pool, processed at the end 
     self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>,
     delegated_stake: Balance&lt;SUI&gt;,
     locking_period: Option&lt;EpochTimeLock&gt;,
-    delegator: <b>address</b>,
+    delegator_address: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> delegate_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&delegated_stake);
     <b>assert</b>!(delegate_amount &gt; 0, 0);
     <b>let</b> delegation_epoch = <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1;
     <a href="staking_pool.md#0x2_staking_pool_request_add_delegation">staking_pool::request_add_delegation</a>(
-        &<b>mut</b> self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, delegated_stake, locking_period, self.metadata.sui_address, delegator, delegation_epoch, ctx
+        &<b>mut</b> self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, delegated_stake, locking_period, self.metadata.sui_address, delegator_address, delegation_epoch, ctx
     );
+    // Process delegation right away <b>if</b> staking pool is preactive.
+    <b>if</b> (<a href="staking_pool.md#0x2_staking_pool_is_preactive">staking_pool::is_preactive</a>(&self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>)) {
+        <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation">staking_pool::process_pending_delegation</a>(&<b>mut</b> self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>);
+    };
     self.next_epoch_stake = self.next_epoch_stake + delegate_amount;
+    <a href="event.md#0x2_event_emit">event::emit</a>(
+        <a href="validator.md#0x2_validator_DelegationRequestEvent">DelegationRequestEvent</a> {
+            pool_id: <a href="validator.md#0x2_validator_staking_pool_id">staking_pool_id</a>(self),
+            validator_address: self.metadata.sui_address,
+            delegator_address,
+            epoch: <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
+            amount: delegate_amount,
+        }
+    );
 }
 </code></pre>
 
@@ -827,14 +930,14 @@ Process pending delegations and withdraws, called at the end of the epoch.
 
 </details>
 
-<a name="0x2_validator_get_staking_pool_mut_ref"></a>
+<a name="0x2_validator_is_preactive"></a>
 
-## Function `get_staking_pool_mut_ref`
+## Function `is_preactive`
 
-Called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></code> for handling delegation switches.
+Returns true if the validator is preactive.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_get_staking_pool_mut_ref">get_staking_pool_mut_ref</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>): &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_is_preactive">is_preactive</a>(self: &<a href="validator.md#0x2_validator_Validator">validator::Validator</a>): bool
 </code></pre>
 
 
@@ -843,8 +946,8 @@ Called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_get_staking_pool_mut_ref">get_staking_pool_mut_ref</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>) : &<b>mut</b> StakingPool {
-    &<b>mut</b> self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>
+<pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x2_validator_is_preactive">is_preactive</a>(self: &<a href="validator.md#0x2_validator_Validator">Validator</a>): bool {
+    <a href="staking_pool.md#0x2_staking_pool_is_preactive">staking_pool::is_preactive</a>(&self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>)
 }
 </code></pre>
 
@@ -2105,7 +2208,7 @@ Aborts if validator metadata is valid
 Create a new validator from the given <code><a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a></code>, called by both <code>new</code> and <code>new_for_testing</code>.
 
 
-<pre><code><b>fun</b> <a href="validator.md#0x2_validator_new_from_metadata">new_from_metadata</a>(metadata: <a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>, stake: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, gas_price: u64, commission_rate: u64, starting_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+<pre><code><b>fun</b> <a href="validator.md#0x2_validator_new_from_metadata">new_from_metadata</a>(metadata: <a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>, initial_stake_option: <a href="_Option">option::Option</a>&lt;<a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;&gt;, coin_locked_until_epoch: <a href="_Option">option::Option</a>&lt;<a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>&gt;, gas_price: u64, commission_rate: u64, is_active_at_genesis: bool, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
 </code></pre>
 
 
@@ -2116,21 +2219,44 @@ Create a new validator from the given <code><a href="validator.md#0x2_validator_
 
 <pre><code><b>fun</b> <a href="validator.md#0x2_validator_new_from_metadata">new_from_metadata</a>(
     metadata: <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a>,
-    stake: Balance&lt;SUI&gt;,
+    initial_stake_option: Option&lt;Balance&lt;SUI&gt;&gt;,
     coin_locked_until_epoch: Option&lt;EpochTimeLock&gt;,
     gas_price: u64,
     commission_rate: u64,
-    starting_epoch: u64,
+    is_active_at_genesis: bool,
     ctx: &<b>mut</b> TxContext
 ): <a href="validator.md#0x2_validator_Validator">Validator</a> {
     <b>let</b> sui_address = metadata.sui_address;
-    <b>let</b> stake_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&stake);
 
-    <b>let</b> <a href="staking_pool.md#0x2_staking_pool">staking_pool</a> = <a href="staking_pool.md#0x2_staking_pool_new">staking_pool::new</a>(starting_epoch, ctx);
-    // Add the <a href="validator.md#0x2_validator">validator</a>'s starting stake <b>to</b> the staking pool.
-    <a href="staking_pool.md#0x2_staking_pool_request_add_delegation">staking_pool::request_add_delegation</a>(&<b>mut</b> <a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, stake, coin_locked_until_epoch, sui_address, sui_address, starting_epoch, ctx);
-    // We immediately process this delegation <b>as</b> they are at <a href="validator.md#0x2_validator">validator</a> setup time and this is the <a href="validator.md#0x2_validator">validator</a> staking <b>with</b> itself.
-    <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation">staking_pool::process_pending_delegation</a>(&<b>mut</b> <a href="staking_pool.md#0x2_staking_pool">staking_pool</a>);
+    <b>let</b> stake_amount =
+        <b>if</b> (<a href="_is_some">option::is_some</a>(&initial_stake_option)) <a href="balance.md#0x2_balance_value">balance::value</a>(<a href="_borrow">option::borrow</a>(&initial_stake_option))
+        <b>else</b> 0;
+
+    <b>let</b> <a href="staking_pool.md#0x2_staking_pool">staking_pool</a> = <a href="staking_pool.md#0x2_staking_pool_new">staking_pool::new</a>(ctx);
+
+    <b>if</b> (is_active_at_genesis) {
+        <a href="staking_pool.md#0x2_staking_pool_activate_staking_pool">staking_pool::activate_staking_pool</a>(&<b>mut</b> <a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, 0);
+    };
+
+    // Add the <a href="validator.md#0x2_validator">validator</a>'s starting stake <b>to</b> the staking pool <b>if</b> there <b>exists</b> one.
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&initial_stake_option)) {
+        <a href="staking_pool.md#0x2_staking_pool_request_add_delegation">staking_pool::request_add_delegation</a>(
+            &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool">staking_pool</a>,
+            <a href="_destroy_some">option::destroy_some</a>(initial_stake_option),
+            coin_locked_until_epoch,
+            sui_address,
+            sui_address,
+            <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
+            ctx
+        );
+        // We immediately process this delegation <b>as</b> they are at <a href="validator.md#0x2_validator">validator</a> setup time and this is the <a href="validator.md#0x2_validator">validator</a> staking <b>with</b> itself.
+        <a href="staking_pool.md#0x2_staking_pool_process_pending_delegation">staking_pool::process_pending_delegation</a>(&<b>mut</b> <a href="staking_pool.md#0x2_staking_pool">staking_pool</a>);
+    } <b>else</b> {
+        <b>assert</b>!(<a href="_is_none">option::is_none</a>(&coin_locked_until_epoch), <a href="validator.md#0x2_validator_EEmptyStakeWithNonEmptyTimeLock">EEmptyStakeWithNonEmptyTimeLock</a>);
+        <a href="_destroy_none">option::destroy_none</a>(coin_locked_until_epoch);
+        <a href="_destroy_none">option::destroy_none</a>(initial_stake_option);
+    };
+
     <a href="validator.md#0x2_validator_Validator">Validator</a> {
         metadata,
         // Initialize the voting power <b>to</b> be the same <b>as</b> the stake amount.

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -6,10 +6,10 @@
 
 
 -  [Struct `ValidatorSet`](#0x2_validator_set_ValidatorSet)
--  [Struct `DelegationRequestEvent`](#0x2_validator_set_DelegationRequestEvent)
 -  [Struct `ValidatorEpochInfo`](#0x2_validator_set_ValidatorEpochInfo)
 -  [Constants](#@Constants_0)
 -  [Function `new`](#0x2_validator_set_new)
+-  [Function `request_add_validator_candidate`](#0x2_validator_set_request_add_validator_candidate)
 -  [Function `request_add_validator`](#0x2_validator_set_request_add_validator)
 -  [Function `request_remove_validator`](#0x2_validator_set_request_remove_validator)
 -  [Function `request_add_delegation`](#0x2_validator_set_request_add_delegation)
@@ -28,6 +28,7 @@
 -  [Function `is_active_validator_by_sui_address`](#0x2_validator_set_is_active_validator_by_sui_address)
 -  [Function `is_duplicate_with_active_validator`](#0x2_validator_set_is_duplicate_with_active_validator)
 -  [Function `is_duplicate_with_pending_validator`](#0x2_validator_set_is_duplicate_with_pending_validator)
+-  [Function `get_preactive_or_active_validator_mut`](#0x2_validator_set_get_preactive_or_active_validator_mut)
 -  [Function `find_validator`](#0x2_validator_set_find_validator)
 -  [Function `find_validator_from_table_vec`](#0x2_validator_set_find_validator_from_table_vec)
 -  [Function `get_validator_indices`](#0x2_validator_set_get_validator_indices)
@@ -102,7 +103,7 @@
  The current list of active validators.
 </dd>
 <dt>
-<code>pending_validators: <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;</code>
+<code>pending_active_validators: <a href="table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;</code>
 </dt>
 <dd>
  List of new validator candidates added during the current epoch.
@@ -129,51 +130,15 @@
  When a validator is deactivated the validator is removed from <code>active_validators</code> it
  is added to this table so that delegators can continue to withdraw their stake from it.
 </dd>
-</dl>
-
-
-</details>
-
-<a name="0x2_validator_set_DelegationRequestEvent"></a>
-
-## Struct `DelegationRequestEvent`
-
-Event emitted when a new delegation request is received.
-
-
-<pre><code><b>struct</b> <a href="validator_set.md#0x2_validator_set_DelegationRequestEvent">DelegationRequestEvent</a> <b>has</b> <b>copy</b>, drop
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
 <dt>
-<code>validator_address: <b>address</b></code>
+<code>validator_candidates: <a href="table.md#0x2_table_Table">table::Table</a>&lt;<b>address</b>, <a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;</code>
 </dt>
 <dd>
-
-</dd>
-<dt>
-<code>delegator_address: <b>address</b></code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>epoch: u64</code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>amount: u64</code>
-</dt>
-<dd>
-
+ Table storing preactive validators, mapping their addresses to their <code>Validator </code> structs.
+ When an address calls <code>request_add_validator_candidate</code>, they get added to this table and become a preactive
+ validator.
+ When the candidate has met the min stake requirement, they can call <code>request_add_validator</code> to
+ officially add them to the active validator set <code>active_validators</code> next epoch.
 </dd>
 </dl>
 
@@ -271,6 +236,15 @@ each validator, emitted during epoch advancement.
 
 
 
+<a name="0x2_validator_set_EAlreadyValidatorCandidate"></a>
+
+
+
+<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_EAlreadyValidatorCandidate">EAlreadyValidatorCandidate</a>: u64 = 6;
+</code></pre>
+
+
+
 <a name="0x2_validator_set_EDuplicateValidator"></a>
 
 
@@ -285,6 +259,15 @@ each validator, emitted during epoch advancement.
 
 
 <pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_EInvalidStakeAdjustmentAmount">EInvalidStakeAdjustmentAmount</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_validator_set_EMinJoiningStakeNotReached"></a>
+
+
+
+<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_EMinJoiningStakeNotReached">EMinJoiningStakeNotReached</a>: u64 = 5;
 </code></pre>
 
 
@@ -312,6 +295,24 @@ each validator, emitted during epoch advancement.
 
 
 <pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_ENotAValidator">ENotAValidator</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x2_validator_set_ENotValidatorCandidate"></a>
+
+
+
+<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_ENotValidatorCandidate">ENotValidatorCandidate</a>: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x2_validator_set_EValidatorNotPreactive"></a>
+
+
+
+<pre><code><b>const</b> <a href="validator_set.md#0x2_validator_set_EValidatorNotPreactive">EValidatorNotPreactive</a>: u64 = 7;
 </code></pre>
 
 
@@ -344,13 +345,52 @@ each validator, emitted during epoch advancement.
     <b>let</b> validators = <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a> {
         total_stake,
         active_validators: init_active_validators,
-        pending_validators: <a href="table_vec.md#0x2_table_vec_empty">table_vec::empty</a>(ctx),
+        pending_active_validators: <a href="table_vec.md#0x2_table_vec_empty">table_vec::empty</a>(ctx),
         pending_removals: <a href="_empty">vector::empty</a>(),
         staking_pool_mappings,
         inactive_validators: <a href="table.md#0x2_table_new">table::new</a>(ctx),
+        validator_candidates: <a href="table.md#0x2_table_new">table::new</a>(ctx),
     };
     <a href="voting_power.md#0x2_voting_power_set_voting_power">voting_power::set_voting_power</a>(&<b>mut</b> validators.active_validators);
     validators
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_request_add_validator_candidate"></a>
+
+## Function `request_add_validator_candidate`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_validator_candidate">request_add_validator_candidate</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, <a href="validator.md#0x2_validator">validator</a>: <a href="validator.md#0x2_validator_Validator">validator::Validator</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_validator_candidate">request_add_validator_candidate</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, <a href="validator.md#0x2_validator">validator</a>: Validator) {
+    <b>assert</b>!(
+        !<a href="validator_set.md#0x2_validator_set_is_duplicate_with_active_validator">is_duplicate_with_active_validator</a>(self, &<a href="validator.md#0x2_validator">validator</a>)
+            && !<a href="validator_set.md#0x2_validator_set_is_duplicate_with_pending_validator">is_duplicate_with_pending_validator</a>(self, &<a href="validator.md#0x2_validator">validator</a>),
+        <a href="validator_set.md#0x2_validator_set_EDuplicateValidator">EDuplicateValidator</a>
+    );
+    <b>assert</b>!(<a href="validator.md#0x2_validator_is_preactive">validator::is_preactive</a>(&<a href="validator.md#0x2_validator">validator</a>), <a href="validator_set.md#0x2_validator_set_EValidatorNotPreactive">EValidatorNotPreactive</a>);
+    <b>let</b> validator_address = sui_address(&<a href="validator.md#0x2_validator">validator</a>);
+    <b>assert</b>!(
+        !<a href="table.md#0x2_table_contains">table::contains</a>(&self.validator_candidates, validator_address),
+        <a href="validator_set.md#0x2_validator_set_EAlreadyValidatorCandidate">EAlreadyValidatorCandidate</a>
+    );
+    // Add <a href="validator.md#0x2_validator">validator</a> <b>to</b> the candidates mapping and the pool id mappings so that users can start
+    // delegating <b>with</b> this candidate.
+    <a href="table.md#0x2_table_add">table::add</a>(&<b>mut</b> self.staking_pool_mappings, staking_pool_id(&<a href="validator.md#0x2_validator">validator</a>), validator_address);
+    <a href="table.md#0x2_table_add">table::add</a>(&<b>mut</b> self.validator_candidates, sui_address(&<a href="validator.md#0x2_validator">validator</a>), <a href="validator.md#0x2_validator">validator</a>);
 }
 </code></pre>
 
@@ -362,11 +402,11 @@ each validator, emitted during epoch advancement.
 
 ## Function `request_add_validator`
 
-Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>, add a new validator to <code>pending_validators</code>, which will be
+Called by <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code> to add a new validator to <code>pending_active_validators</code>, which will be
 processed at the end of epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, <a href="validator.md#0x2_validator">validator</a>: <a href="validator.md#0x2_validator_Validator">validator::Validator</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, min_joining_stake_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -375,13 +415,22 @@ processed at the end of epoch.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, <a href="validator.md#0x2_validator">validator</a>: Validator) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, min_joining_stake_amount: u64, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> validator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>assert</b>!(
+        <a href="table.md#0x2_table_contains">table::contains</a>(&self.validator_candidates, validator_address),
+        <a href="validator_set.md#0x2_validator_set_ENotValidatorCandidate">ENotValidatorCandidate</a>
+    );
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="table.md#0x2_table_remove">table::remove</a>(&<b>mut</b> self.validator_candidates, validator_address);
     <b>assert</b>!(
         !<a href="validator_set.md#0x2_validator_set_is_duplicate_with_active_validator">is_duplicate_with_active_validator</a>(self, &<a href="validator.md#0x2_validator">validator</a>)
             && !<a href="validator_set.md#0x2_validator_set_is_duplicate_with_pending_validator">is_duplicate_with_pending_validator</a>(self, &<a href="validator.md#0x2_validator">validator</a>),
         <a href="validator_set.md#0x2_validator_set_EDuplicateValidator">EDuplicateValidator</a>
     );
-    <a href="table_vec.md#0x2_table_vec_push_back">table_vec::push_back</a>(&<b>mut</b> self.pending_validators, <a href="validator.md#0x2_validator">validator</a>);
+    <b>assert</b>!(<a href="validator.md#0x2_validator_is_preactive">validator::is_preactive</a>(&<a href="validator.md#0x2_validator">validator</a>), <a href="validator_set.md#0x2_validator_set_EValidatorNotPreactive">EValidatorNotPreactive</a>);
+    <b>assert</b>!(<a href="validator.md#0x2_validator_total_stake_amount">validator::total_stake_amount</a>(&<a href="validator.md#0x2_validator">validator</a>) &gt;= min_joining_stake_amount, <a href="validator_set.md#0x2_validator_set_EMinJoiningStakeNotReached">EMinJoiningStakeNotReached</a>);
+
+    <a href="table_vec.md#0x2_table_vec_push_back">table_vec::push_back</a>(&<b>mut</b> self.pending_active_validators, <a href="validator.md#0x2_validator">validator</a>);
 }
 </code></pre>
 
@@ -453,18 +502,8 @@ of the epoch.
     locking_period: Option&lt;EpochTimeLock&gt;,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
-    <b>let</b> delegator_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
-    <b>let</b> amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&delegated_stake);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_preactive_or_active_validator_mut">get_preactive_or_active_validator_mut</a>(self, validator_address);
     <a href="validator.md#0x2_validator_request_add_delegation">validator::request_add_delegation</a>(<a href="validator.md#0x2_validator">validator</a>, delegated_stake, locking_period, <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx), ctx);
-    <a href="event.md#0x2_event_emit">event::emit</a>(
-        <a href="validator_set.md#0x2_validator_set_DelegationRequestEvent">DelegationRequestEvent</a> {
-            validator_address,
-            delegator_address,
-            epoch: <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
-            amount,
-        }
-    );
 }
 </code></pre>
 
@@ -501,11 +540,8 @@ the delegation and any rewards corresponding to it will be immediately processed
     <b>let</b> staking_pool_id = pool_id(&staked_sui);
     // This is an active <a href="validator.md#0x2_validator">validator</a>.
     <b>if</b> (<a href="table.md#0x2_table_contains">table::contains</a>(&self.staking_pool_mappings, staking_pool_id)) {
-        <b>let</b> validator_address = *<a href="table.md#0x2_table_borrow">table::borrow</a>(&self.staking_pool_mappings, staking_pool_id);
-        <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address);
-        <b>assert</b>!(<a href="_is_some">option::is_some</a>(&validator_index_opt), 0);
-        <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.active_validators, validator_index);
+        <b>let</b> validator_address = *<a href="table.md#0x2_table_borrow">table::borrow</a>(&self.staking_pool_mappings, pool_id(&staked_sui));
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_preactive_or_active_validator_mut">get_preactive_or_active_validator_mut</a>(self, validator_address);
         <a href="validator.md#0x2_validator_request_withdraw_delegation">validator::request_withdraw_delegation</a>(<a href="validator.md#0x2_validator">validator</a>, staked_sui, ctx);
     } <b>else</b> { // This is an inactive pool.
         <b>assert</b>!(<a href="table.md#0x2_table_contains">table::contains</a>(&self.inactive_validators, staking_pool_id), <a href="validator_set.md#0x2_validator_set_ENoPoolFound">ENoPoolFound</a>);
@@ -675,7 +711,7 @@ It does the following things:
     <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(new_epoch, &self.active_validators, &adjusted_staking_reward_amounts,
         validator_report_records, &slashed_validators);
 
-    <a href="validator_set.md#0x2_validator_set_process_pending_validators">process_pending_validators</a>(self);
+    <a href="validator_set.md#0x2_validator_set_process_pending_validators">process_pending_validators</a>(self, new_epoch);
 
     <a href="validator_set.md#0x2_validator_set_process_pending_removals">process_pending_removals</a>(self, validator_report_records, ctx);
 
@@ -916,7 +952,7 @@ Get the total number of validators in the next epoch.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x2_validator_set_next_epoch_validator_count">next_epoch_validator_count</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>): u64 {
-    <a href="_length">vector::length</a>(&self.active_validators) - <a href="_length">vector::length</a>(&self.pending_removals) + <a href="table_vec.md#0x2_table_vec_length">table_vec::length</a>(&self.pending_validators)
+    <a href="_length">vector::length</a>(&self.active_validators) - <a href="_length">vector::length</a>(&self.pending_removals) + <a href="table_vec.md#0x2_table_vec_length">table_vec::length</a>(&self.pending_active_validators)
 }
 </code></pre>
 
@@ -1005,16 +1041,44 @@ Checks whether <code>new_validator</code> is duplicate with any currently pendin
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_is_duplicate_with_pending_validator">is_duplicate_with_pending_validator</a>(self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, new_validator: &Validator): bool {
-    <b>let</b> len = <a href="table_vec.md#0x2_table_vec_length">table_vec::length</a>(&self.pending_validators);
+    <b>let</b> len = <a href="table_vec.md#0x2_table_vec_length">table_vec::length</a>(&self.pending_active_validators);
     <b>let</b> i = 0;
     <b>while</b> (i &lt; len) {
-        <b>let</b> v = <a href="table_vec.md#0x2_table_vec_borrow">table_vec::borrow</a>(&self.pending_validators, i);
+        <b>let</b> v = <a href="table_vec.md#0x2_table_vec_borrow">table_vec::borrow</a>(&self.pending_active_validators, i);
         <b>if</b> (<a href="validator.md#0x2_validator_is_duplicate">validator::is_duplicate</a>(v, new_validator)) {
             <b>return</b> <b>true</b>
         };
         i = i + 1;
     };
     <b>false</b>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_set_get_preactive_or_active_validator_mut"></a>
+
+## Function `get_preactive_or_active_validator_mut`
+
+Get mutable reference to either a preactive or an active validator by address.
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_get_preactive_or_active_validator_mut">get_preactive_or_active_validator_mut</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>): &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_get_preactive_or_active_validator_mut">get_preactive_or_active_validator_mut</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, validator_address: <b>address</b>): &<b>mut</b> Validator {
+    <b>if</b> (<a href="table.md#0x2_table_contains">table::contains</a>(&self.validator_candidates, validator_address)) {
+        <b>return</b> <a href="table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.validator_candidates, validator_address)
+    };
+    <a href="validator_set.md#0x2_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address)
 }
 </code></pre>
 
@@ -1186,9 +1250,9 @@ Aborts if any address isn't in the given validator set.
         <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
         <b>return</b> <a href="_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.active_validators, validator_index)
     };
-    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(&self.pending_validators, validator_address);
+    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(&self.pending_active_validators, validator_address);
     <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-    <b>return</b> <a href="table_vec.md#0x2_table_vec_borrow_mut">table_vec::borrow_mut</a>(&<b>mut</b> self.pending_validators, validator_index)
+    <b>return</b> <a href="table_vec.md#0x2_table_vec_borrow_mut">table_vec::borrow_mut</a>(&<b>mut</b> self.pending_active_validators, validator_index)
 }
 </code></pre>
 
@@ -1275,10 +1339,10 @@ Aborts if any address isn't in the given validator set.
     self: &<a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
     validator_address: <b>address</b>,
 ): &Validator {
-    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(&self.pending_validators, validator_address);
+    <b>let</b> validator_index_opt = <a href="validator_set.md#0x2_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(&self.pending_active_validators, validator_address);
     <b>assert</b>!(<a href="_is_some">option::is_some</a>(&validator_index_opt), 0);
     <b>let</b> validator_index = <a href="_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-    <a href="table_vec.md#0x2_table_vec_borrow">table_vec::borrow</a>(&self.pending_validators, validator_index)
+    <a href="table_vec.md#0x2_table_vec_borrow">table_vec::borrow</a>(&self.pending_active_validators, validator_index)
 }
 </code></pre>
 
@@ -1381,10 +1445,10 @@ is removed from <code>validators</code> and its staking pool is put into the <co
 
 ## Function `process_pending_validators`
 
-Process the pending new validators. They are simply inserted into <code>validators</code>.
+Process the pending new validators. They are activated and inserted into <code>validators</code>.
 
 
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_validators">process_pending_validators</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>)
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_validators">process_pending_validators</a>(self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, new_epoch: u64)
 </code></pre>
 
 
@@ -1394,11 +1458,11 @@ Process the pending new validators. They are simply inserted into <code>validato
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_process_pending_validators">process_pending_validators</a>(
-    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
+    self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>, new_epoch: u64,
 ) {
-    <b>while</b> (!<a href="table_vec.md#0x2_table_vec_is_empty">table_vec::is_empty</a>(&self.pending_validators)) {
-        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="table_vec.md#0x2_table_vec_pop_back">table_vec::pop_back</a>(&<b>mut</b> self.pending_validators);
-        <a href="table.md#0x2_table_add">table::add</a>(&<b>mut</b> self.staking_pool_mappings, staking_pool_id(&<a href="validator.md#0x2_validator">validator</a>), sui_address(&<a href="validator.md#0x2_validator">validator</a>));
+    <b>while</b> (!<a href="table_vec.md#0x2_table_vec_is_empty">table_vec::is_empty</a>(&self.pending_active_validators)) {
+        <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="table_vec.md#0x2_table_vec_pop_back">table_vec::pop_back</a>(&<b>mut</b> self.pending_active_validators);
+        <a href="validator.md#0x2_validator_activate">validator::activate</a>(&<b>mut</b> <a href="validator.md#0x2_validator">validator</a>, new_epoch);
         <a href="_push_back">vector::push_back</a>(&<b>mut</b> self.active_validators, <a href="validator.md#0x2_validator">validator</a>);
     }
 }

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -14,8 +14,7 @@ module sui::genesis {
     use std::option;
 
     /// Initial value of the lower-bound on the amount of stake required to become a validator.
-    /// TODO: testnet only. Needs to be changed.
-    const INIT_MIN_VALIDATOR_STAKE: u64 = 1;
+    const INIT_MIN_VALIDATOR_STAKE: u64 = 25_000_000_000_000_000;
 
     /// Initial value of the upper-bound on the number of validators.
     const INIT_MAX_VALIDATOR_COUNT: u64 = 100;
@@ -104,11 +103,11 @@ module sui::genesis {
                 primary_address,
                 worker_address,
                 // Initialize all validators with uniform stake taken from the subsidy fund.
-                balance::split(&mut subsidy_fund, initial_validator_stake_mist),
+                option::some(balance::split(&mut subsidy_fund, initial_validator_stake_mist)),
                 option::none(),
                 gas_price,
                 commission_rate,
-                0, // start operating right away at epoch 0
+                true, // validator is active right away
                 ctx
             ));
             i = i + 1;

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -38,13 +38,14 @@ module sui::sui_system {
     // - the change in stake across epochs can be at most +/- x%
     // - the change in the validator set across epochs can be at most x validators
     //
-    // TODO: The stake threshold should be % threshold instead of amount threshold.
     struct SystemParameters has store {
         /// Lower-bound on the amount of stake required to become a validator.
+        // TODO: use a different threshold for new validator joining vs. validator keeping their
+        // spot in the validator set.
         min_validator_stake: u64,
         /// Maximum number of validator candidates at any moment.
         /// We do not allow the number of validators in any epoch to go above this.
-        max_validator_candidate_count: u64,
+        max_validator_count: u64,
 
         /// The starting epoch in which various on-chain governance features take effect:
         /// - stake subsidies are paid out
@@ -128,7 +129,7 @@ module sui::sui_system {
         validators: vector<Validator>,
         stake_subsidy_fund: Balance<SUI>,
         storage_fund: Balance<SUI>,
-        max_validator_candidate_count: u64,
+        max_validator_count: u64,
         min_validator_stake: u64,
         governance_start_epoch: u64,
         initial_stake_subsidy_amount: u64,
@@ -146,7 +147,7 @@ module sui::sui_system {
             storage_fund,
             parameters: SystemParameters {
                 min_validator_stake,
-                max_validator_candidate_count,
+                max_validator_count,
                 governance_start_epoch,
             },
             reference_gas_price,
@@ -166,12 +167,11 @@ module sui::sui_system {
 
     // ==== entry functions ====
 
-    /// Can be called by anyone who wishes to become a validator in the next epoch.
-    /// The `validator` object needs to be created before calling this.
-    /// The amount of stake in the `validator` object must meet the requirements.
-    // TODO: Does this need to go through a voting process? Any other criteria for
-    // someone to become a validator?
-    public entry fun request_add_validator(
+    /// Can be called by anyone who wishes to become a validator candidate and starts accuring delegated
+    /// stakes in their staking pool. Once they have at least `min_validator_stake` amount of stake they
+    /// can call `request_add_validator` to officially become an active validator at the next epoch.
+    /// Aborts if the caller is already a pending or active validator, or a validator candidate.
+    public entry fun request_add_validator_candidate(
         wrapper: &mut SuiSystemState,
         pubkey_bytes: vector<u8>,
         network_pubkey_bytes: vector<u8>,
@@ -185,21 +185,11 @@ module sui::sui_system {
         p2p_address: vector<u8>,
         primary_address: vector<u8>,
         worker_address: vector<u8>,
-        stake: Coin<SUI>,
         gas_price: u64,
         commission_rate: u64,
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        assert!(
-            validator_set::next_epoch_validator_count(&self.validators) < self.parameters.max_validator_candidate_count,
-            ELimitExceeded,
-        );
-        let stake_amount = coin::value(&stake);
-        assert!(
-            stake_amount >= self.parameters.min_validator_stake,
-            ELimitExceeded,
-        );
         let validator = validator::new(
             tx_context::sender(ctx),
             pubkey_bytes,
@@ -214,15 +204,32 @@ module sui::sui_system {
             p2p_address,
             primary_address,
             worker_address,
-            coin::into_balance(stake),
+            option::none(),
             option::none(),
             gas_price,
             commission_rate,
-            tx_context::epoch(ctx) + 1, // starting next epoch
+            false, // not an initial validator active at genesis
             ctx
         );
 
-        validator_set::request_add_validator(&mut self.validators, validator);
+        validator_set::request_add_validator_candidate(&mut self.validators, validator);
+    }
+
+    /// Called by a validator candidate to add themselves to the active validator set beginning next epoch.
+    /// Aborts if the validator is a duplicate with one of the pending or active validators, or if the amount of
+    /// stake the validator has doesn't meet the min threshold, or if the number of new validators for the next
+    /// epoch has already reached the maximum.
+    public entry fun request_add_validator(
+        wrapper: &mut SuiSystemState,
+        ctx: &mut TxContext,
+    ) {
+        let self = load_system_state_mut(wrapper);
+        assert!(
+            validator_set::next_epoch_validator_count(&self.validators) < self.parameters.max_validator_count,
+            ELimitExceeded,
+        );
+
+        validator_set::request_add_validator(&mut self.validators, self.parameters.min_validator_stake, ctx);
     }
 
     /// A validator can call this function to request a removal in the next epoch.

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -43,7 +43,7 @@ module sui::sui_system {
         // TODO: use a different threshold for new validator joining vs. validator keeping their
         // spot in the validator set.
         min_validator_stake: u64,
-        /// Maximum number of validator candidates at any moment.
+        /// Maximum number of active validators at any moment.
         /// We do not allow the number of validators in any epoch to go above this.
         max_validator_count: u64,
 
@@ -213,6 +213,16 @@ module sui::sui_system {
         );
 
         validator_set::request_add_validator_candidate(&mut self.validators, validator);
+    }
+
+    /// Called by a validator candidate to remove themselves from the candidacy. After this call
+    /// their staking pool becomes deactive.
+    public entry fun request_remove_validator_candidate(
+        wrapper: &mut SuiSystemState,
+        ctx: &mut TxContext,
+    ) {
+        let self = load_system_state_mut(wrapper);
+        validator_set::request_remove_validator_candidate(&mut self.validators, ctx);
     }
 
     /// Called by a validator candidate to add themselves to the active validator set beginning next epoch.

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -18,6 +18,7 @@ module sui::validator {
     use std::string::{Self, String};
     use sui::url::Url;
     use sui::url;
+    use sui::event;
     friend sui::genesis;
     friend sui::sui_system;
     friend sui::validator_set;
@@ -32,14 +33,17 @@ module sui::validator {
     #[test_only]
     friend sui::governance_test_utils;
 
+    /// Invalid proof_of_possesion field in ValidatorMetadata
+    const EInvalidProofOfPossession: u64 = 0;
+
     /// Invalid pubkey_bytes field in ValidatorMetadata
-    const EMetadataInvalidPubKey: u64 = 1;
+    const EMetadataInvalidPubkey: u64 = 1;
 
     /// Invalid network_pubkey_bytes field in ValidatorMetadata
     const EMetadataInvalidNetPubkey: u64 = 2;
 
     /// Invalid worker_pubkey_bytes field in ValidatorMetadata
-    const EMetadataInvalidWorkerPubKey: u64 = 3;
+    const EMetadataInvalidWorkerPubkey: u64 = 3;
 
     /// Invalid net_address field in ValidatorMetadata
     const EMetadataInvalidNetAddr: u64 = 4;
@@ -56,7 +60,8 @@ module sui::validator {
     /// Commission rate set by the validator is higher than the threshold
     const ECommissionRateTooHigh: u64 = 8;
 
-    const EInvalidProofOfPossession: u64 = 0;
+    /// No stake balance is provided but an epoch time lock for the stake is provided.
+    const EEmptyStakeWithNonEmptyTimeLock: u64 = 9;
 
     const MAX_COMMISSION_RATE: u64 = 10_000; // Max rate is 100%, which is 10K base points
 
@@ -118,6 +123,15 @@ module sui::validator {
         next_epoch_gas_price: u64,
         /// The commission rate of the validator starting the next epoch, in basis point.
         next_epoch_commission_rate: u64,
+    }
+
+    /// Event emitted when a new delegation request is received.
+    struct DelegationRequestEvent has copy, drop {
+        pool_id: ID,
+        validator_address: address,
+        delegator_address: address,
+        epoch: u64,
+        amount: u64,
     }
 
     const PROOF_OF_POSSESSION_DOMAIN: vector<u8> = vector[107, 111, 115, 107];
@@ -194,11 +208,11 @@ module sui::validator {
         p2p_address: vector<u8>,
         primary_address: vector<u8>,
         worker_address: vector<u8>,
-        stake: Balance<SUI>,
+        initial_stake_option: Option<Balance<SUI>>,
         coin_locked_until_epoch: Option<EpochTimeLock>,
         gas_price: u64,
         commission_rate: u64,
-        starting_epoch: u64,
+        is_active_at_genesis: bool,
         ctx: &mut TxContext
     ): Validator {
         assert!(
@@ -237,11 +251,11 @@ module sui::validator {
 
         new_from_metadata(
             metadata,
-            stake,
+            initial_stake_option,
             coin_locked_until_epoch,
             gas_price,
             commission_rate,
-            starting_epoch,
+            is_active_at_genesis,
             ctx
         )
     }
@@ -249,6 +263,10 @@ module sui::validator {
     /// Deactivate this validator's staking pool
     public(friend) fun deactivate(self: &mut Validator, deactivation_epoch: u64) {
         staking_pool::deactivate_staking_pool(&mut self.staking_pool, deactivation_epoch)
+    }
+
+    public(friend) fun activate(self: &mut Validator, activation_epoch: u64) {
+        staking_pool::activate_staking_pool(&mut self.staking_pool, activation_epoch);
     }
 
     /// Process pending stake and pending withdraws, and update the gas price.
@@ -262,16 +280,29 @@ module sui::validator {
         self: &mut Validator,
         delegated_stake: Balance<SUI>,
         locking_period: Option<EpochTimeLock>,
-        delegator: address,
+        delegator_address: address,
         ctx: &mut TxContext,
     ) {
         let delegate_amount = balance::value(&delegated_stake);
         assert!(delegate_amount > 0, 0);
         let delegation_epoch = tx_context::epoch(ctx) + 1;
         staking_pool::request_add_delegation(
-            &mut self.staking_pool, delegated_stake, locking_period, self.metadata.sui_address, delegator, delegation_epoch, ctx
+            &mut self.staking_pool, delegated_stake, locking_period, self.metadata.sui_address, delegator_address, delegation_epoch, ctx
         );
+        // Process delegation right away if staking pool is preactive.
+        if (staking_pool::is_preactive(&self.staking_pool)) {
+            staking_pool::process_pending_delegation(&mut self.staking_pool);
+        };
         self.next_epoch_stake = self.next_epoch_stake + delegate_amount;
+        event::emit(
+            DelegationRequestEvent {
+                pool_id: staking_pool_id(self),
+                validator_address: self.metadata.sui_address,
+                delegator_address,
+                epoch: tx_context::epoch(ctx),
+                amount: delegate_amount,
+            }
+        );
     }
 
     /// Request to withdraw delegation from the validator's staking pool, processed at the end of the epoch.
@@ -307,9 +338,9 @@ module sui::validator {
         assert!(delegate_amount(self) == self.next_epoch_stake, 0);
     }
 
-    /// Called by `validator_set` for handling delegation switches.
-    public(friend) fun get_staking_pool_mut_ref(self: &mut Validator) : &mut StakingPool {
-        &mut self.staking_pool
+    /// Returns true if the validator is preactive.
+    public fun is_preactive(self: &Validator): bool {
+        staking_pool::is_preactive(&self.staking_pool)
     }
 
     public fun metadata(self: &Validator): &ValidatorMetadata {
@@ -400,6 +431,8 @@ module sui::validator {
         &self.metadata.next_epoch_worker_pubkey_bytes
     }
 
+    // TODO: this and `delegate_amount` and `total_stake` all seem to return the same value?
+    // two of the functions can probably be removed.
     public fun total_stake_amount(self: &Validator): u64 {
         spec {
             // TODO: this should be provable rather than assumed
@@ -594,21 +627,44 @@ module sui::validator {
     /// Create a new validator from the given `ValidatorMetadata`, called by both `new` and `new_for_testing`.
     fun new_from_metadata(
         metadata: ValidatorMetadata,
-        stake: Balance<SUI>,
+        initial_stake_option: Option<Balance<SUI>>,
         coin_locked_until_epoch: Option<EpochTimeLock>,
         gas_price: u64,
         commission_rate: u64,
-        starting_epoch: u64,
+        is_active_at_genesis: bool,
         ctx: &mut TxContext
     ): Validator {
         let sui_address = metadata.sui_address;
-        let stake_amount = balance::value(&stake);
 
-        let staking_pool = staking_pool::new(starting_epoch, ctx);
-        // Add the validator's starting stake to the staking pool.
-        staking_pool::request_add_delegation(&mut staking_pool, stake, coin_locked_until_epoch, sui_address, sui_address, starting_epoch, ctx);
-        // We immediately process this delegation as they are at validator setup time and this is the validator staking with itself.
-        staking_pool::process_pending_delegation(&mut staking_pool);
+        let stake_amount =
+            if (option::is_some(&initial_stake_option)) balance::value(option::borrow(&initial_stake_option))
+            else 0;
+
+        let staking_pool = staking_pool::new(ctx);
+
+        if (is_active_at_genesis) {
+            staking_pool::activate_staking_pool(&mut staking_pool, 0);
+        };
+
+        // Add the validator's starting stake to the staking pool if there exists one.
+        if (option::is_some(&initial_stake_option)) {
+            staking_pool::request_add_delegation(
+                &mut staking_pool,
+                option::destroy_some(initial_stake_option),
+                coin_locked_until_epoch,
+                sui_address,
+                sui_address,
+                tx_context::epoch(ctx),
+                ctx
+            );
+            // We immediately process this delegation as they are at validator setup time and this is the validator staking with itself.
+            staking_pool::process_pending_delegation(&mut staking_pool);
+        } else {
+            assert!(option::is_none(&coin_locked_until_epoch), EEmptyStakeWithNonEmptyTimeLock);
+            option::destroy_none(coin_locked_until_epoch);
+            option::destroy_none(initial_stake_option);
+        };
+
         Validator {
             metadata,
             // Initialize the voting power to be the same as the stake amount.
@@ -641,11 +697,11 @@ module sui::validator {
         p2p_address: vector<u8>,
         primary_address: vector<u8>,
         worker_address: vector<u8>,
-        stake: Balance<SUI>,
+        initial_stake_option: Option<Balance<SUI>>,
         coin_locked_until_epoch: Option<EpochTimeLock>,
         gas_price: u64,
         commission_rate: u64,
-        starting_epoch: u64,
+        is_active_at_genesis: bool,
         ctx: &mut TxContext
     ): Validator {
         new_from_metadata(
@@ -664,11 +720,11 @@ module sui::validator {
                 primary_address,
                 worker_address,
             ),
-            stake,
+            initial_stake_option,
             coin_locked_until_epoch,
             gas_price,
             commission_rate,
-            starting_epoch,
+            is_active_at_genesis,
             ctx
         )
     }

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -37,7 +37,7 @@ module sui::validator_set {
 
         /// List of new validator candidates added during the current epoch.
         /// They will be processed at the end of the epoch.
-        pending_validators: TableVec<Validator>,
+        pending_active_validators: TableVec<Validator>,
 
         /// Removal requests from the validators. Each element is an index
         /// pointing to `active_validators`.
@@ -50,14 +50,14 @@ module sui::validator_set {
         /// When a validator is deactivated the validator is removed from `active_validators` it
         /// is added to this table so that delegators can continue to withdraw their stake from it.
         inactive_validators: Table<ID, Validator>,
-    }
 
-    /// Event emitted when a new delegation request is received.
-    struct DelegationRequestEvent has copy, drop {
-        validator_address: address,
-        delegator_address: address,
-        epoch: u64,
-        amount: u64,
+        // TODO: support transition from candidate -> inactive.
+        /// Table storing preactive validators, mapping their addresses to their `Validator ` structs.
+        /// When an address calls `request_add_validator_candidate`, they get added to this table and become a preactive
+        /// validator.
+        /// When the candidate has met the min stake requirement, they can call `request_add_validator` to
+        /// officially add them to the active validator set `active_validators` next epoch.
+        validator_candidates: Table<address, Validator>,
     }
 
     /// Event containing staking and rewards related information of
@@ -82,6 +82,10 @@ module sui::validator_set {
     const EDuplicateValidator: u64 = 2;
     const ENoPoolFound: u64 = 3;
     const ENotAValidator: u64 = 4;
+    const EMinJoiningStakeNotReached: u64 = 5;
+    const EAlreadyValidatorCandidate: u64 = 6;
+    const EValidatorNotPreactive: u64 = 7;
+    const ENotValidatorCandidate: u64 = 8;
 
     // ==== initialization at genesis ====
 
@@ -98,10 +102,11 @@ module sui::validator_set {
         let validators = ValidatorSet {
             total_stake,
             active_validators: init_active_validators,
-            pending_validators: table_vec::empty(ctx),
+            pending_active_validators: table_vec::empty(ctx),
             pending_removals: vector::empty(),
             staking_pool_mappings,
             inactive_validators: table::new(ctx),
+            validator_candidates: table::new(ctx),
         };
         voting_power::set_voting_power(&mut validators.active_validators);
         validators
@@ -110,15 +115,42 @@ module sui::validator_set {
 
     // ==== functions to add or remove validators ====
 
-    /// Called by `sui_system`, add a new validator to `pending_validators`, which will be
-    /// processed at the end of epoch.
-    public(friend) fun request_add_validator(self: &mut ValidatorSet, validator: Validator) {
+    public(friend) fun request_add_validator_candidate(self: &mut ValidatorSet, validator: Validator) {
         assert!(
             !is_duplicate_with_active_validator(self, &validator)
                 && !is_duplicate_with_pending_validator(self, &validator),
             EDuplicateValidator
         );
-        table_vec::push_back(&mut self.pending_validators, validator);
+        assert!(validator::is_preactive(&validator), EValidatorNotPreactive);
+        let validator_address = sui_address(&validator);
+        assert!(
+            !table::contains(&self.validator_candidates, validator_address),
+            EAlreadyValidatorCandidate
+        );
+        // Add validator to the candidates mapping and the pool id mappings so that users can start
+        // delegating with this candidate.
+        table::add(&mut self.staking_pool_mappings, staking_pool_id(&validator), validator_address);
+        table::add(&mut self.validator_candidates, sui_address(&validator), validator);
+    }
+
+    /// Called by `sui_system` to add a new validator to `pending_active_validators`, which will be
+    /// processed at the end of epoch.
+    public(friend) fun request_add_validator(self: &mut ValidatorSet, min_joining_stake_amount: u64, ctx: &mut TxContext) {
+        let validator_address = tx_context::sender(ctx);
+        assert!(
+            table::contains(&self.validator_candidates, validator_address),
+            ENotValidatorCandidate
+        );
+        let validator = table::remove(&mut self.validator_candidates, validator_address);
+        assert!(
+            !is_duplicate_with_active_validator(self, &validator)
+                && !is_duplicate_with_pending_validator(self, &validator),
+            EDuplicateValidator
+        );
+        assert!(validator::is_preactive(&validator), EValidatorNotPreactive);
+        assert!(validator::total_stake_amount(&validator) >= min_joining_stake_amount, EMinJoiningStakeNotReached);
+
+        table_vec::push_back(&mut self.pending_active_validators, validator);
     }
 
     /// Called by `sui_system`, to remove a validator.
@@ -153,18 +185,8 @@ module sui::validator_set {
         locking_period: Option<EpochTimeLock>,
         ctx: &mut TxContext,
     ) {
-        let validator = get_validator_mut(&mut self.active_validators, validator_address);
-        let delegator_address = tx_context::sender(ctx);
-        let amount = balance::value(&delegated_stake);
+        let validator = get_preactive_or_active_validator_mut(self, validator_address);
         validator::request_add_delegation(validator, delegated_stake, locking_period, tx_context::sender(ctx), ctx);
-        event::emit(
-            DelegationRequestEvent {
-                validator_address,
-                delegator_address,
-                epoch: tx_context::epoch(ctx),
-                amount,
-            }
-        );
     }
 
     /// Called by `sui_system`, to withdraw some share of a delegation from the validator. The share to withdraw
@@ -181,11 +203,8 @@ module sui::validator_set {
         let staking_pool_id = pool_id(&staked_sui);
         // This is an active validator.
         if (table::contains(&self.staking_pool_mappings, staking_pool_id)) {
-            let validator_address = *table::borrow(&self.staking_pool_mappings, staking_pool_id);
-            let validator_index_opt = find_validator(&self.active_validators, validator_address);
-            assert!(option::is_some(&validator_index_opt), 0);
-            let validator_index = option::extract(&mut validator_index_opt);
-            let validator = vector::borrow_mut(&mut self.active_validators, validator_index);
+            let validator_address = *table::borrow(&self.staking_pool_mappings, pool_id(&staked_sui));
+            let validator = get_preactive_or_active_validator_mut(self, validator_address);
             validator::request_withdraw_delegation(validator, staked_sui, ctx);
         } else { // This is an inactive pool.
             assert!(table::contains(&self.inactive_validators, staking_pool_id), ENoPoolFound);
@@ -300,7 +319,7 @@ module sui::validator_set {
         emit_validator_epoch_events(new_epoch, &self.active_validators, &adjusted_staking_reward_amounts,
             validator_report_records, &slashed_validators);
 
-        process_pending_validators(self);
+        process_pending_validators(self, new_epoch);
 
         process_pending_removals(self, validator_report_records, ctx);
 
@@ -383,7 +402,7 @@ module sui::validator_set {
 
     /// Get the total number of validators in the next epoch.
     public(friend) fun next_epoch_validator_count(self: &ValidatorSet): u64 {
-        vector::length(&self.active_validators) - vector::length(&self.pending_removals) + table_vec::length(&self.pending_validators)
+        vector::length(&self.active_validators) - vector::length(&self.pending_removals) + table_vec::length(&self.pending_active_validators)
     }
 
     /// Returns true iff the address exists in active validators.
@@ -414,16 +433,24 @@ module sui::validator_set {
 
     /// Checks whether `new_validator` is duplicate with any currently pending validators.
     fun is_duplicate_with_pending_validator(self: &ValidatorSet, new_validator: &Validator): bool {
-        let len = table_vec::length(&self.pending_validators);
+        let len = table_vec::length(&self.pending_active_validators);
         let i = 0;
         while (i < len) {
-            let v = table_vec::borrow(&self.pending_validators, i);
+            let v = table_vec::borrow(&self.pending_active_validators, i);
             if (validator::is_duplicate(v, new_validator)) {
                 return true
             };
             i = i + 1;
         };
         false
+    }
+
+    /// Get mutable reference to either a preactive or an active validator by address.
+    fun get_preactive_or_active_validator_mut(self: &mut ValidatorSet, validator_address: address): &mut Validator {
+        if (table::contains(&self.validator_candidates, validator_address)) {
+            return table::borrow_mut(&mut self.validator_candidates, validator_address)
+        };
+        get_validator_mut(&mut self.active_validators, validator_address)
     }
 
     /// Find validator by `validator_address`, in `validators`.
@@ -496,9 +523,9 @@ module sui::validator_set {
             let validator_index = option::extract(&mut validator_index_opt);
             return vector::borrow_mut(&mut self.active_validators, validator_index)
         };
-        let validator_index_opt = find_validator_from_table_vec(&self.pending_validators, validator_address);
+        let validator_index_opt = find_validator_from_table_vec(&self.pending_active_validators, validator_address);
         let validator_index = option::extract(&mut validator_index_opt);
-        return table_vec::borrow_mut(&mut self.pending_validators, validator_index)
+        return table_vec::borrow_mut(&mut self.pending_active_validators, validator_index)
     }
 
     fun get_validator_ref(
@@ -525,10 +552,10 @@ module sui::validator_set {
         self: &ValidatorSet,
         validator_address: address,
     ): &Validator {
-        let validator_index_opt = find_validator_from_table_vec(&self.pending_validators, validator_address);
+        let validator_index_opt = find_validator_from_table_vec(&self.pending_active_validators, validator_address);
         assert!(option::is_some(&validator_index_opt), 0);
         let validator_index = option::extract(&mut validator_index_opt);
-        table_vec::borrow(&self.pending_validators, validator_index)
+        table_vec::borrow(&self.pending_active_validators, validator_index)
     }
 
     /// Process the pending withdraw requests. For each pending request, the validator
@@ -564,7 +591,7 @@ module sui::validator_set {
         if (vec_map::contains(validator_report_records, &leaving_validator_addr)) {
             vec_map::remove(validator_report_records, &leaving_validator_addr);
         };
-        
+
         // Remove the reports submitted by this validator
         let reported_validators = vec_map::keys(validator_report_records);
         let length = vector::length(&reported_validators);
@@ -582,13 +609,13 @@ module sui::validator_set {
         }
     }
 
-    /// Process the pending new validators. They are simply inserted into `validators`.
+    /// Process the pending new validators. They are activated and inserted into `validators`.
     fun process_pending_validators(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSet, new_epoch: u64,
     ) {
-        while (!table_vec::is_empty(&self.pending_validators)) {
-            let validator = table_vec::pop_back(&mut self.pending_validators);
-            table::add(&mut self.staking_pool_mappings, staking_pool_id(&validator), sui_address(&validator));
+        while (!table_vec::is_empty(&self.pending_active_validators)) {
+            let validator = table_vec::pop_back(&mut self.pending_active_validators);
+            validator::activate(&mut validator, new_epoch);
             vector::push_back(&mut self.active_validators, validator);
         }
     }

--- a/crates/sui-framework/tests/delegation_tests.move
+++ b/crates/sui-framework/tests/delegation_tests.move
@@ -14,6 +14,8 @@ module sui::delegation_tests {
 
     use sui::governance_test_utils::{
         Self,
+        add_validator,
+        add_validator_candidate,
         advance_epoch,
         advance_epoch_with_reward_amounts,
         create_validator_for_testing,
@@ -29,6 +31,11 @@ module sui::delegation_tests {
 
     const DELEGATOR_ADDR_1: address = @0x42;
     const DELEGATOR_ADDR_2: address = @0x43;
+    const DELEGATOR_ADDR_3: address = @0x44;
+
+    const NEW_VALIDATOR_ADDR: address = @0x1a4623343cd42be47d67314fce0ad042f3c82685544bc91d8c11d24e74ba7357;
+    const NEW_VALIDATOR_PUBKEY: vector<u8> = x"99f25ef61f8032b914636460982c5cc6f134ef1ddae76657f2cbfec1ebfc8d097374080df6fcf0dcb8bc4b0d8e0af5d80ebbff2b4c599f54f42d6312dfc314276078c1cc347ebbbec5198be258513f386b930d02c2749a803e2330955ebd1a10";
+    const NEW_VALIDATOR_POP: vector<u8> = x"8080980b89554e7f03b625ba4104d05d19b523a737e2d09a69d4498a1bcac154fcb29f6334b7e8b99b8f3aa95153232d";
 
     #[test]
     fun test_split_join_staked_sui() {
@@ -335,6 +342,110 @@ module sui::delegation_tests {
 
         // Now try and delegate to the old validator/staking pool. This should fail!
         governance_test_utils::delegate_to(DELEGATOR_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
+
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_add_preactive_remove_preactive() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        governance_test_utils::add_validator_candidate(NEW_VALIDATOR_ADDR, NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
+
+        // Delegate 100 MIST to the preactive validator
+        governance_test_utils::delegate_to(DELEGATOR_ADDR_1, NEW_VALIDATOR_ADDR, 100, scenario);
+
+        // Advance epoch twice with some rewards
+        advance_epoch_with_reward_amounts(0, 400, scenario);
+        advance_epoch_with_reward_amounts(0, 900, scenario);
+
+        // Undelegate from the preactive validator. There should be no rewards earned.
+        governance_test_utils::undelegate(DELEGATOR_ADDR_1, 0, scenario);
+        assert_eq(total_sui_balance(DELEGATOR_ADDR_1, scenario), 100);
+
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = validator_set::ENotAValidator)]
+    fun test_add_preactive_remove_pending_failure() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        governance_test_utils::add_validator_candidate(NEW_VALIDATOR_ADDR, NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
+
+        governance_test_utils::add_validator(NEW_VALIDATOR_ADDR, scenario);
+
+        // Delegate 100 MIST to the pending validator. This should fail because pending active validators don't accept
+        // new delegations or withdraws.
+        governance_test_utils::delegate_to(DELEGATOR_ADDR_1, NEW_VALIDATOR_ADDR, 100, scenario);
+
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_add_preactive_remove_active() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        add_validator_candidate(NEW_VALIDATOR_ADDR, NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
+
+        // Delegate 100 MIST to the preactive validator
+        delegate_to(DELEGATOR_ADDR_1, NEW_VALIDATOR_ADDR, 100, scenario);
+        advance_epoch_with_reward_amounts(0, 70, scenario);
+        delegate_to(DELEGATOR_ADDR_2, NEW_VALIDATOR_ADDR, 300, scenario);
+        delegate_to(DELEGATOR_ADDR_3, NEW_VALIDATOR_ADDR, 100, scenario);
+
+        // Now the preactive becomes active
+        add_validator(NEW_VALIDATOR_ADDR, scenario);
+        advance_epoch(scenario);
+
+        advance_epoch_with_reward_amounts(0, 80, scenario);
+
+        // delegator 1 and 3 undelegate from the validator and earns 9 MIST.
+        // Although they delegate in different epochs, they earn the same rewards as long as they undelegate
+        // in the same epoch because the validator was preactive when they delegated.
+        undelegate(DELEGATOR_ADDR_1, 0, scenario);
+        assert_eq(total_sui_balance(DELEGATOR_ADDR_1, scenario), 109);
+        undelegate(DELEGATOR_ADDR_3, 0, scenario);
+        assert_eq(total_sui_balance(DELEGATOR_ADDR_3, scenario), 109);
+
+        advance_epoch_with_reward_amounts(0, 100, scenario);
+        undelegate(DELEGATOR_ADDR_2, 0, scenario);
+        // delegator 2 earns about 27 MIST from the previous epoch and 5/8 of the 100 MIST.
+        assert_eq(total_sui_balance(DELEGATOR_ADDR_2, scenario), 300 + 27 + 59);
+
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_add_preactive_remove_post_active() {
+        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(scenario);
+
+        add_validator_candidate(NEW_VALIDATOR_ADDR, NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
+
+        // Delegate 100 MIST to the preactive validator
+        delegate_to(DELEGATOR_ADDR_1, NEW_VALIDATOR_ADDR, 100, scenario);
+
+        // Now the preactive becomes active
+        add_validator(NEW_VALIDATOR_ADDR, scenario);
+        advance_epoch(scenario);
+
+        advance_epoch_with_reward_amounts(0, 80, scenario); // delegator 1 earns 20 MIST here.
+
+        // And now the validator leaves the validator set.
+        remove_validator(NEW_VALIDATOR_ADDR, scenario);
+
+        advance_epoch(scenario);
+
+        undelegate(DELEGATOR_ADDR_1, 0, scenario);
+        assert_eq(total_sui_balance(DELEGATOR_ADDR_1, scenario), 100 + 20);
 
         test_scenario::end(scenario_val);
     }

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -236,6 +236,18 @@ module sui::governance_test_utils {
         test_scenario::return_shared(system_state);
     }
 
+    public fun remove_validator_candidate(validator: address, scenario: &mut Scenario) {
+        test_scenario::next_tx(scenario, validator);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let ctx = test_scenario::ctx(scenario);
+
+        sui_system::request_remove_validator_candidate(
+            &mut system_state,
+            ctx
+        );
+        test_scenario::return_shared(system_state);
+    }
+
     public fun add_validator(validator: address, scenario: &mut Scenario) {
         test_scenario::next_tx(scenario, validator);
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -35,11 +35,11 @@ module sui::governance_test_utils {
             x"FFFF",
             x"FFFF",
             x"FFFF",
-            balance::create_for_testing<SUI>(init_stake_amount),
+            option::some(balance::create_for_testing<SUI>(init_stake_amount)),
             option::none(),
             1,
             0,
-            0,
+            true,
             ctx
         );
         validator
@@ -140,14 +140,14 @@ module sui::governance_test_utils {
 
     public fun delegate_locked_to(
         delegator: address, validator: address, amount: u64, locked_until_epoch: u64, scenario: &mut Scenario
-    ) {        
+    ) {
         // First lock the coin
         test_scenario::next_tx(scenario, delegator);
         {
             let ctx = test_scenario::ctx(scenario);
             locked_coin::lock_coin<SUI>(coin::mint_for_testing(amount, ctx), delegator, locked_until_epoch, ctx);
         };
-        
+
         // Next delegate the locked coin
         test_scenario::next_tx(scenario, delegator);
         {
@@ -177,7 +177,7 @@ module sui::governance_test_utils {
         test_scenario::return_shared(system_state);
     }
 
-    public fun add_validator(validator: address, init_stake_amount: u64, pop: vector<u8>, scenario: &mut Scenario) {
+    public fun add_validator_full_flow(validator: address, init_stake_amount: u64, pop: vector<u8>, scenario: &mut Scenario) {
         test_scenario::next_tx(scenario, validator);
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
         let pubkey = x"99f25ef61f8032b914636460982c5cc6f134ef1ddae76657f2cbfec1ebfc8d097374080df6fcf0dcb8bc4b0d8e0af5d80ebbff2b4c599f54f42d6312dfc314276078c1cc347ebbbec5198be258513f386b930d02c2749a803e2330955ebd1a10";
@@ -185,7 +185,7 @@ module sui::governance_test_utils {
         let addr = vector[4, 127, 0, 0, 1];
         let ctx = test_scenario::ctx(scenario);
 
-        sui_system::request_add_validator(
+        sui_system::request_add_validator_candidate(
             &mut system_state,
             pubkey,
             vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38],
@@ -199,9 +199,50 @@ module sui::governance_test_utils {
             addr,
             addr,
             addr,
-            coin::mint_for_testing<SUI>(init_stake_amount, ctx),
             1,
             0,
+            ctx
+        );
+        sui_system::request_add_delegation(&mut system_state, coin::mint_for_testing<SUI>(init_stake_amount, ctx), validator, ctx);
+        sui_system::request_add_validator(&mut system_state, ctx);
+        test_scenario::return_shared(system_state);
+    }
+
+    public fun add_validator_candidate(validator: address, pubkey: vector<u8>, pop: vector<u8>, scenario: &mut Scenario) {
+        test_scenario::next_tx(scenario, validator);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        // This is  equivalent to /ip4/127.0.0.1
+        let addr = vector[4, 127, 0, 0, 1];
+        let ctx = test_scenario::ctx(scenario);
+
+        sui_system::request_add_validator_candidate(
+            &mut system_state,
+            pubkey,
+            vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38],
+            vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38],
+            pop,
+            b"name",
+            b"description",
+            b"image_url",
+            b"project_url",
+            addr,
+            addr,
+            addr,
+            addr,
+            1,
+            0,
+            ctx
+        );
+        test_scenario::return_shared(system_state);
+    }
+
+    public fun add_validator(validator: address, scenario: &mut Scenario) {
+        test_scenario::next_tx(scenario, validator);
+        let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let ctx = test_scenario::ctx(scenario);
+
+        sui_system::request_add_validator(
+            &mut system_state,
             ctx
         );
         test_scenario::return_shared(system_state);

--- a/crates/sui-framework/tests/validator_set_tests.move
+++ b/crates/sui-framework/tests/validator_set_tests.move
@@ -5,10 +5,10 @@
 module sui::validator_set_tests {
     use sui::balance;
     use sui::coin;
-    use sui::tx_context::{Self, TxContext};
+    use sui::tx_context::TxContext;
     use sui::validator::{Self, Validator};
     use sui::validator_set::{Self, ValidatorSet};
-    use sui::test_scenario;
+    use sui::test_scenario::{Self, Scenario};
     use sui::vec_map;
     use std::ascii;
     use std::option;
@@ -16,35 +16,38 @@ module sui::validator_set_tests {
 
     #[test]
     fun test_validator_set_flow() {
-        let scenario = test_scenario::begin(@0x1);
-        let ctx1 = test_scenario::ctx(&mut scenario);
+        let scenario_val = test_scenario::begin(@0x1);
+        let scenario = &mut scenario_val;
+        let ctx1 = test_scenario::ctx(scenario);
 
-        // Create 4 validators, with stake 100, 200, 300, 400.
-        let validator1 = create_validator(@0x1, 1, ctx1);
-        let validator2 = create_validator(@0x2, 2, ctx1);
-        let validator3 = create_validator(@0x3, 3, ctx1);
-        let validator4 = create_validator(@0x4, 4, ctx1);
+        // Create 4 validators, with stake 100, 200, 300, 400. Only the first validator is an initial validator.
+        let validator1 = create_validator(@0x1, 1, 1, true, ctx1);
+        let validator2 = create_validator(@0x2, 2, 1, false, ctx1);
+        let validator3 = create_validator(@0x3, 3, 1, false, ctx1);
+        let validator4 = create_validator(@0x4, 4, 1, false, ctx1);
 
         // Create a validator set with only the first validator in it.
         let validator_set = validator_set::new(vector[validator1], ctx1);
         assert!(validator_set::total_stake(&validator_set) == 100, 0);
 
         // Add the other 3 validators one by one.
-        validator_set::request_add_validator(
+        add_and_activate_validator(
             &mut validator_set,
             validator2,
+            scenario
         );
         // Adding validator during the epoch should not affect stake and quorum threshold.
         assert!(validator_set::total_stake(&validator_set) == 100, 0);
 
-        validator_set::request_add_validator(
+        add_and_activate_validator(
             &mut validator_set,
             validator3,
+            scenario
         );
 
-        test_scenario::next_tx(&mut scenario, @0x1);
+        test_scenario::next_tx(scenario, @0x1);
         {
-            let ctx1 = test_scenario::ctx(&mut scenario);
+            let ctx1 = test_scenario::ctx(scenario);
             validator_set::request_add_delegation(
                 &mut validator_set,
                 @0x1,
@@ -57,92 +60,168 @@ module sui::validator_set_tests {
             assert!(validator_set::total_stake(&validator_set) == 100, 0);
         };
 
-        test_scenario::next_tx(&mut scenario, @0x1);
-        {
-            validator_set::request_add_validator(
-                &mut validator_set,
-                validator4,
-            );
-        };
+        add_and_activate_validator(
+            &mut validator_set,
+            validator4,
+            scenario
+        );
 
-        test_scenario::next_tx(&mut scenario, @0x1);
+        advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
+        // Total stake for these should be the starting stake + the 500 delegated to validator 1 in addition to the starting stake.
+        assert!(validator_set::total_stake(&validator_set) == 1500, 0);
+
+        test_scenario::next_tx(scenario, @0x1);
         {
-            let ctx1 = test_scenario::ctx(&mut scenario);
-            advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
-            // Total stake for these should be the starting stake + the 500 delegated to validator 1 in addition to the starting stake.
-            assert!(validator_set::total_stake(&validator_set) == 1500, 0);
+            let ctx1 = test_scenario::ctx(scenario);
 
             validator_set::request_remove_validator(
                 &mut validator_set,
                 ctx1,
             );
-            // Total validator candidate count changes, but total stake remains during epoch.
-            assert!(validator_set::total_stake(&validator_set) == 1500, 0);
-            advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
-            // Validator1 is gone. This removes its stake (100) + the stake delegated to it (500).
-            assert!(validator_set::total_stake(&validator_set) == 900, 0);
         };
 
+        // Total validator candidate count changes, but total stake remains during epoch.
+        assert!(validator_set::total_stake(&validator_set) == 1500, 0);
+        advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
+        // Validator1 is gone. This removes its stake (100) + the stake delegated to it (500).
+        assert!(validator_set::total_stake(&validator_set) == 900, 0);
+
         test_utils::destroy(validator_set);
-        test_scenario::end(scenario);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
     fun test_reference_gas_price_derivation() {
-        let scenario = test_scenario::begin(@0x1);
-        let ctx1 = test_scenario::ctx(&mut scenario);
+        let scenario_val = test_scenario::begin(@0x1);
+        let scenario = &mut scenario_val;
+        let ctx1 = test_scenario::ctx(scenario);
         // Create 5 validators with different stakes and different gas prices.
-        let v1 = create_validator_with_gas_price(@0x1, 1, 45, ctx1);
-        let v2 = create_validator_with_gas_price(@0x2, 2, 42, ctx1);
-        let v3 = create_validator_with_gas_price(@0x3, 3, 40, ctx1);
-        let v4 = create_validator_with_gas_price(@0x4, 4, 41, ctx1);
-        let v5 = create_validator_with_gas_price(@0x5, 10, 43, ctx1);
+        let v1 = create_validator(@0x1, 1, 45, true, ctx1);
+        let v2 = create_validator(@0x2, 2, 42, false, ctx1);
+        let v3 = create_validator(@0x3, 3, 40, false, ctx1);
+        let v4 = create_validator(@0x4, 4, 41, false, ctx1);
+        let v5 = create_validator(@0x5, 10, 43, false, ctx1);
 
         // Create a validator set with only the first validator in it.
         let validator_set = validator_set::new(vector[v1], ctx1);
 
         assert_eq(validator_set::derive_reference_gas_price(&validator_set), 45);
 
-        validator_set::request_add_validator(
-            &mut validator_set,
-            v2,
-        );
-        advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
+        add_and_activate_validator(&mut validator_set, v2, scenario);
+        advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
 
         assert_eq(validator_set::derive_reference_gas_price(&validator_set), 45);
 
-        validator_set::request_add_validator(
+        add_and_activate_validator(
             &mut validator_set,
             v3,
+            scenario
         );
-        advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
+        advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
 
         assert_eq(validator_set::derive_reference_gas_price(&validator_set), 42);
 
-        validator_set::request_add_validator(
+        add_and_activate_validator(
             &mut validator_set,
             v4,
+            scenario
         );
-        advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
+        advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
 
         assert_eq(validator_set::derive_reference_gas_price(&validator_set), 42);
 
-        validator_set::request_add_validator(
+        add_and_activate_validator(
             &mut validator_set,
             v5,
+            scenario
         );
-        advance_epoch_with_dummy_rewards(&mut validator_set, ctx1);
+        advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
 
         assert_eq(validator_set::derive_reference_gas_price(&validator_set), 43);
 
         test_utils::destroy(validator_set);
-        test_scenario::end(scenario);
+        test_scenario::end(scenario_val);
     }
 
-    fun create_validator(addr: address, hint: u8, ctx: &mut TxContext): Validator {
+    #[test]
+    #[expected_failure(abort_code = validator_set::EMinJoiningStakeNotReached)]
+    fun test_add_validator_failure_below_min_stake() {
+        let scenario_val = test_scenario::begin(@0x1);
+        let scenario = &mut scenario_val;
+        let ctx1 = test_scenario::ctx(scenario);
+
+        // Create 2 validators, with stake 100 and 200.
+        let validator1 = create_validator(@0x1, 1, 1, true, ctx1);
+        let validator2 = create_validator(@0x2, 2, 1, false, ctx1);
+
+        // Create a validator set with only the first validator in it.
+        let validator_set = validator_set::new(vector[validator1], ctx1);
+        assert_eq(validator_set::total_stake(&validator_set), 100);
+
+        validator_set::request_add_validator_candidate(&mut validator_set, validator2);
+
+        test_scenario::next_tx(scenario, @0x42);
+        {
+            let ctx = test_scenario::ctx(scenario);
+            validator_set::request_add_delegation(
+                &mut validator_set,
+                @0x2,
+                balance::create_for_testing(500),
+                option::none(),
+                ctx,
+            );
+            // Adding stake to a preactive validator should not change total stake.
+            assert_eq(validator_set::total_stake(&validator_set), 100);
+        };
+
+        test_scenario::next_tx(scenario, @0x2);
+        // Validator 2 now has 700 MIST in stake but that's not enough because we need 701.
+        validator_set::request_add_validator(&mut validator_set, 701, test_scenario::ctx(scenario));
+
+        test_utils::destroy(validator_set);
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
+    fun test_add_validator_with_nonzero_min_stake() {
+        let scenario_val = test_scenario::begin(@0x1);
+        let scenario = &mut scenario_val;
+        let ctx1 = test_scenario::ctx(scenario);
+
+        // Create 2 validators, with stake 100 and 200.
+        let validator1 = create_validator(@0x1, 1, 1, true, ctx1);
+        let validator2 = create_validator(@0x2, 2, 1, false, ctx1);
+
+        // Create a validator set with only the first validator in it.
+        let validator_set = validator_set::new(vector[validator1], ctx1);
+        assert_eq(validator_set::total_stake(&validator_set), 100);
+
+        validator_set::request_add_validator_candidate(&mut validator_set, validator2);
+
+        test_scenario::next_tx(scenario, @0x42);
+        {
+            let ctx = test_scenario::ctx(scenario);
+            validator_set::request_add_delegation(
+                &mut validator_set,
+                @0x2,
+                balance::create_for_testing(500),
+                option::none(),
+                ctx,
+            );
+            // Adding stake to a preactive validator should not change total stake.
+            assert_eq(validator_set::total_stake(&validator_set), 100);
+        };
+
+        test_scenario::next_tx(scenario, @0x2);
+        // Validator 2 now has 700 MIST in stake and that's just enough.
+        validator_set::request_add_validator(&mut validator_set, 700, test_scenario::ctx(scenario));
+
+        test_utils::destroy(validator_set);
+        test_scenario::end(scenario_val);
+    }
+
+    fun create_validator(addr: address, hint: u8, gas_price: u64, is_initial_validator: bool, ctx: &mut TxContext): Validator {
         let stake_value = (hint as u64) * 100;
-        let init_stake = coin::mint_for_testing(stake_value, ctx);
-        let init_stake = coin::into_balance(init_stake);
         let name = hint_to_ascii(hint);
         let validator = validator::new_for_testing(
             addr,
@@ -158,40 +237,11 @@ module sui::validator_set_tests {
             vector[hint],
             vector[hint],
             vector[hint],
-            init_stake,
-            option::none(),
-            1,
-            0,
-            0,
-            ctx
-        );
-        validator
-    }
-
-    fun create_validator_with_gas_price(addr: address, hint: u8, gas_price: u64, ctx: &mut TxContext): Validator {
-        let stake_value = (hint as u64) * 100;
-        let init_stake = coin::mint_for_testing(stake_value, ctx);
-        let init_stake = coin::into_balance(init_stake);
-        let name = hint_to_ascii(hint);
-        let validator = validator::new_for_testing(
-            addr,
-            vector[hint],
-            vector[hint],
-            vector[hint],
-            vector[hint],
-            copy name,
-            copy name,
-            copy name,
-            name,
-            vector[hint],
-            vector[hint],
-            vector[hint],
-            vector[hint],
-            init_stake,
+            option::some(balance::create_for_testing(stake_value)),
             option::none(),
             gas_price,
             0,
-            0,
+            is_initial_validator,
             ctx
         );
         validator
@@ -202,11 +252,10 @@ module sui::validator_set_tests {
         ascii::into_bytes(ascii::string(ascii_bytes))
     }
 
-    fun advance_epoch_with_dummy_rewards(validator_set: &mut ValidatorSet, ctx: &mut TxContext) {
+    fun advance_epoch_with_dummy_rewards(validator_set: &mut ValidatorSet, scenario: &mut Scenario) {
+        test_scenario::next_epoch(scenario, @0x0);
         let dummy_computation_reward = balance::zero();
         let dummy_storage_fund_reward = balance::zero();
-
-        tx_context::increment_epoch_number(ctx);
 
         validator_set::advance_epoch(
             validator_set,
@@ -214,10 +263,16 @@ module sui::validator_set_tests {
             &mut dummy_storage_fund_reward,
             &mut vec_map::empty(),
             0,
-            ctx
+            test_scenario::ctx(scenario)
         );
 
         balance::destroy_zero(dummy_computation_reward);
         balance::destroy_zero(dummy_storage_fund_reward);
+    }
+
+    fun add_and_activate_validator(validator_set: &mut ValidatorSet, validator: Validator, scenario: &mut Scenario) {
+        test_scenario::next_tx(scenario, validator::sui_address(&validator));
+        validator_set::request_add_validator_candidate(validator_set, validator);
+        validator_set::request_add_validator(validator_set, 0, test_scenario::ctx(scenario));
     }
 }

--- a/crates/sui-framework/tests/validator_tests.move
+++ b/crates/sui-framework/tests/validator_tests.move
@@ -51,11 +51,11 @@ module sui::validator_tests {
             VALID_P2P_ADDR,
             VALID_CONSENSUS_ADDR,
             VALID_WORKER_ADDR,
-            init_stake,
+            option::some(init_stake),
             option::none(),
             1,
             0,
-            0,
+            true,
             ctx
         )
     }
@@ -160,7 +160,7 @@ module sui::validator_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = validator::EMetadataInvalidPubKey)]
+    #[expected_failure(abort_code = validator::EMetadataInvalidPubkey)]
     fun test_metadata_invalid_pubkey() {
         let metadata = validator::new_metadata(
             @0x42,
@@ -204,7 +204,7 @@ module sui::validator_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = validator::EMetadataInvalidWorkerPubKey)]
+    #[expected_failure(abort_code = validator::EMetadataInvalidWorkerPubkey)]
     fun test_metadata_invalid_worker_pubkey() {
         let metadata = validator::new_metadata(
             @0x42,
@@ -445,7 +445,7 @@ module sui::validator_tests {
     }
 
 
-    #[expected_failure(abort_code = sui::validator::EMetadataInvalidWorkerPubKey)]
+    #[expected_failure(abort_code = sui::validator::EMetadataInvalidWorkerPubkey)]
     #[test]
     fun test_validator_update_metadata_invalid_worker_key() {
         let sender = @0xaf76afe6f866d8426d2be85d6ef0b11f871a251d043b2f11e15563bf418f5a5a;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6612,7 +6612,6 @@
           "protocol_pubkey_bytes",
           "rewards_pool",
           "staking_pool_id",
-          "staking_pool_starting_epoch",
           "staking_pool_sui_balance",
           "sui_address",
           "voting_power",
@@ -6818,6 +6817,14 @@
             "format": "uint64",
             "minimum": 0.0
           },
+          "staking_pool_activation_epoch": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          },
           "staking_pool_deactivation_epoch": {
             "type": [
               "integer",
@@ -6828,11 +6835,6 @@
           },
           "staking_pool_id": {
             "$ref": "#/components/schemas/ObjectID"
-          },
-          "staking_pool_starting_epoch": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
           },
           "staking_pool_sui_balance": {
             "type": "integer",

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5528,6 +5528,7 @@
         "description": "Rust version of the Move sui::staking_pool::StakingPool type",
         "type": "object",
         "required": [
+          "activation_epoch",
           "deactivation_epoch",
           "exchange_rates",
           "id",
@@ -5536,10 +5537,12 @@
           "pending_total_sui_withdraw",
           "pool_token_balance",
           "rewards_pool",
-          "starting_epoch",
           "sui_balance"
         ],
         "properties": {
+          "activation_epoch": {
+            "$ref": "#/components/schemas/MoveOption_for_uint64"
+          },
           "deactivation_epoch": {
             "$ref": "#/components/schemas/MoveOption_for_uint64"
           },
@@ -5571,11 +5574,6 @@
           },
           "rewards_pool": {
             "$ref": "#/components/schemas/Balance"
-          },
-          "starting_epoch": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
           },
           "sui_balance": {
             "type": "integer",
@@ -6885,7 +6883,7 @@
         "type": "object",
         "required": [
           "governance_start_epoch",
-          "max_validator_candidate_count",
+          "max_validator_count",
           "min_validator_stake"
         ],
         "properties": {
@@ -6894,7 +6892,7 @@
             "format": "uint64",
             "minimum": 0.0
           },
-          "max_validator_candidate_count": {
+          "max_validator_count": {
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
@@ -7709,10 +7707,11 @@
         "required": [
           "active_validators",
           "inactive_pools",
+          "pending_active_validators",
           "pending_removals",
-          "pending_validators",
           "staking_pool_mappings",
-          "total_stake"
+          "total_stake",
+          "validator_candidates"
         ],
         "properties": {
           "active_validators": {
@@ -7724,6 +7723,9 @@
           "inactive_pools": {
             "$ref": "#/components/schemas/Table"
           },
+          "pending_active_validators": {
+            "$ref": "#/components/schemas/TableVec"
+          },
           "pending_removals": {
             "type": "array",
             "items": {
@@ -7732,9 +7734,6 @@
               "minimum": 0.0
             }
           },
-          "pending_validators": {
-            "$ref": "#/components/schemas/TableVec"
-          },
           "staking_pool_mappings": {
             "$ref": "#/components/schemas/Table"
           },
@@ -7742,6 +7741,9 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
+          },
+          "validator_candidates": {
+            "$ref": "#/components/schemas/Table"
           }
         }
       },

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -69,7 +69,7 @@ pub struct SuiValidatorSummary {
 
     // Staking pool information
     pub staking_pool_id: ObjectID,
-    pub staking_pool_starting_epoch: u64,
+    pub staking_pool_activation_epoch: Option<u64>,
     pub staking_pool_deactivation_epoch: Option<u64>,
     pub staking_pool_sui_balance: u64,
     pub rewards_pool: u64,

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -83,7 +83,7 @@ export const DelegatedStake = object({
 });
 
 export const ParametersFields = object({
-  max_validator_candidate_count: string(),
+  max_validator_count: string(),
   min_validator_stake: string(),
   storage_gas_price: optional(string()),
 });
@@ -136,7 +136,7 @@ export const DelegationStakingPoolFields = object({
   pending_total_sui_withdraw: number(),
   pool_token_balance: number(),
   rewards_pool: object({ value: number() }),
-  starting_epoch: number(),
+  activation_epoch: object({ vec: array(number()) }),
   deactivation_epoch: object({ vec: array() }),
   sui_balance: number(),
 });
@@ -154,7 +154,7 @@ export const CommitteeInfo = object({
 
 export const SystemParameters = object({
   min_validator_stake: number(),
-  max_validator_candidate_count: number(),
+  max_validator_count: number(),
   governance_start_epoch: number(),
   storage_gas_price: optional(number()),
 });
@@ -179,7 +179,7 @@ export const ValidatorPair = object({
 export const ValidatorSet = object({
   total_stake: number(),
   active_validators: array(Validator),
-  pending_validators: object({
+  pending_active_validators: object({
     contents: object({
       id: string(),
       size: number(),
@@ -191,6 +191,10 @@ export const ValidatorSet = object({
     size: number(),
   }),
   inactive_pools: object({
+    id: string(),
+    size: number(),
+  }),
+  validator_candidates: object({
     id: string(),
     size: number(),
   }),
@@ -240,7 +244,7 @@ export const SuiValidatorSummary = object({
   next_epoch_gas_price: number(),
   next_epoch_commission_rate: number(),
   staking_pool_id: string(),
-  staking_pool_starting_epoch: number(),
+  staking_pool_activation_epoch: nullable(number()),
   staking_pool_deactivation_epoch: nullable(number()),
   staking_pool_sui_balance: number(),
   rewards_pool: number(),


### PR DESCRIPTION
## Description 

This PR 
- Adds an entry function `request_add_validator_candidate` that adds an address as a validator candidate (aka preactive valdiator)
- Modifies `request_add_validator` to be only callable by someone who has already registered as a candidate and enforces the minimum stake requirement
- Adds support for delegation and undelegation for preactive staking pools

## Test Plan 

Added tests for preactive validators for scenarios including
       - `request_add_validator_candidate` fails because already signed up as candidate
       - `request_add_validator_candidate` fails because duplicate with an active validator
       - `request_add_validator_candidate` fails because validator metadata is invalid
       - `request_add_validator` fails because min stake threshold is not met
       - `request_add_delegation` to a preactive validator, and withdraws when it's still preactive,
          within the same epoch and a few epochs later
       - `request_add_delegation` to a preactive validator, and withdraw should fail after the preactive
          validator becomes pending (i.e., called `request_add_validator` but epoch hasn't changed yet).
       - `request_add_delegation` to a preactive validator, and withdraw after it becomes active
       - `request_add_delegation` to a preactive validator, and withdraw after it becomes inactive
       
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
