### PR TITLE
[framework] Keep validator reporting across epochs

### DIFF
--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -67,11 +67,14 @@ module sui::sui_system {
         parameters: SystemParameters,
         /// The reference gas price for the current epoch.
         reference_gas_price: u64,
-        /// A map storing the records of validator reporting each other during the current epoch.
+        /// A map storing the records of validator reporting each other.
         /// There is an entry in the map for each validator that has been reported
         /// at least once. The entry VecSet contains all the validators that reported
         /// them. If a validator has never been reported they don't have an entry in this map.
-        /// This map resets every epoch.
+        /// This map persists across epoch: a peer continues being in a reported state until the
+        /// reporter doesn't explicitly remove their report.
+        /// Note that in case we want to support validator address change in future,
+        /// the reports should be based on validator ids
         validator_report_records: VecMap<address, VecSet<address>>,
         /// Schedule of stake subsidies given out each epoch.
         stake_subsidy: StakeSubsidy,
@@ -343,7 +346,7 @@ module sui::sui_system {
 
     /// Report a validator as a bad or non-performant actor in the system.
     /// Succeeds iff both the sender and the input `validator_addr` are active validators
-    /// and they are not the same address. This function is idempotent within an epoch.
+    /// and they are not the same address. This function is idempotent.
     public entry fun report_validator(
         wrapper: &mut SuiSystemState,
         validator_addr: address,
@@ -366,8 +369,8 @@ module sui::sui_system {
         }
     }
 
-    /// Undo a `report_validator` action. Aborts if the sender has not reported the
-    /// `validator_addr` within this epoch.
+    /// Undo a `report_validator` action. Aborts if the sender has not previously reported the
+    /// `validator_addr`.
     public entry fun undo_report_validator(
         wrapper: &mut SuiSystemState,
         validator_addr: address,
@@ -380,6 +383,9 @@ module sui::sui_system {
         let reporters = vec_map::get_mut(&mut self.validator_report_records, &validator_addr);
         assert!(vec_set::contains(reporters, &sender), EReportRecordNotFound);
         vec_set::remove(reporters, &sender);
+        if (vec_set::is_empty(reporters)) {
+            vec_map::remove(&mut self.validator_report_records, &validator_addr);
+        }
     }
 
     // ==== validator metadata management functions ====
@@ -592,7 +598,7 @@ module sui::sui_system {
             &mut self.validators,
             &mut computation_reward,
             &mut storage_fund_reward,
-            self.validator_report_records,
+            &mut self.validator_report_records,
             reward_slashing_rate,
             ctx,
         );
@@ -610,10 +616,6 @@ module sui::sui_system {
         // Destroy the storage rebate.
         assert!(balance::value(&self.storage_fund) >= storage_rebate, 0);
         balance::destroy_storage_rebates(balance::split(&mut self.storage_fund, storage_rebate));
-
-        // Validator reports are only valid for the epoch.
-        // TODO: or do we want to make it persistent and validators have to explicitly change their scores?
-        self.validator_report_records = vec_map::empty();
 
         let new_total_stake = validator_set::total_stake(&self.validators);
 
@@ -709,7 +711,7 @@ module sui::sui_system {
         validator_set::staking_pool_mappings(&self.validators)
     }
 
-    /// Returns all the validators who have reported `addr` this epoch.
+    /// Returns all the validators who are currently reporting `addr`
     public fun get_reporters_of(wrapper: &SuiSystemState, addr: address): VecSet<address> {
         let self = load_system_state(wrapper);
         if (vec_map::contains(&self.validator_report_records, &addr)) {

--- a/crates/sui-framework/tests/sui_system_tests.move
+++ b/crates/sui-framework/tests/sui_system_tests.move
@@ -46,9 +46,26 @@ module sui::sui_system_tests {
 
         advance_epoch(scenario);
 
-        // After an epoch ends, report records are reset.
-        assert!(get_reporters_of(@0x2, scenario) == vector[], 0);
+        // After an epoch ends, report records are still present.
+        assert!(get_reporters_of(@0x2, scenario) == vector[@0x1], 0);
 
+        report_helper(@0x2, @0x1, false, scenario);
+        assert!(get_reporters_of(@0x1, scenario) == vector[@0x2], 0);
+
+
+        report_helper(@0x3, @0x2, false, scenario);
+        assert!(get_reporters_of(@0x2, scenario) == vector[@0x1, @0x3], 0);
+        
+        // After 0x3 leaves, its reports are gone
+        remove_validator(@0x3, scenario);
+        advance_epoch(scenario);
+        assert!(get_reporters_of(@0x2, scenario) == vector[@0x1], 0);
+
+        // After 0x1 leaves, both its reports and the reports on its name are gone
+        remove_validator(@0x1, scenario);
+        advance_epoch(scenario);
+        assert!(vector::is_empty(&get_reporters_of(@0x1, scenario)), 0);
+        assert!(vector::is_empty(&get_reporters_of(@0x2, scenario)), 0);
         test_scenario::end(scenario_val);
     }
 

--- a/crates/sui-framework/tests/validator_set_tests.move
+++ b/crates/sui-framework/tests/validator_set_tests.move
@@ -212,7 +212,7 @@ module sui::validator_set_tests {
             validator_set,
             &mut dummy_computation_reward,
             &mut dummy_storage_fund_reward,
-            vec_map::empty(),
+            &mut vec_map::empty(),
             0,
             ctx
         );


### PR DESCRIPTION
Once a validator reports its peer, it should explicitly send an undo_report request to remove the report: it doesn't clear in the next epoch.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
