### PR TITLE
Object versioning system

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -584,7 +584,7 @@ impl AuthorityStore {
         if let Some(indirect_obj) = indirect_object {
             write_batch = write_batch.insert_batch(
                 &self.perpetual_tables.indirect_move_objects,
-                std::iter::once((indirect_obj.digest(), indirect_obj)),
+                std::iter::once((indirect_obj.inner().digest(), indirect_obj)),
             )?;
         }
 
@@ -630,7 +630,7 @@ impl AuthorityStore {
                 ref_and_objects.iter().filter_map(|(_, o)| {
                     let StoreObjectPair(_, indirect_object) =
                         get_store_object_pair((**o).clone(), self.indirect_objects_threshold);
-                    indirect_object.map(|obj| (obj.digest(), obj))
+                    indirect_object.map(|obj| (obj.inner().digest(), obj))
                 }),
             )?
             .insert_batch(
@@ -745,7 +745,7 @@ impl AuthorityStore {
             .filter_map(|(_, (_, object, _))| {
                 let StoreObjectPair(_, indirect_object) =
                     get_store_object_pair(object.clone(), self.indirect_objects_threshold);
-                indirect_object.map(|obj| obj.digest())
+                indirect_object.map(|obj| obj.inner().digest())
             })
             .collect();
         self.objects_lock_table.acquire_read_locks(digests).await
@@ -811,7 +811,7 @@ impl AuthorityStore {
                     get_store_object_pair(new_object.clone(), self.indirect_objects_threshold);
                 (
                     (ObjectKey::from(obj_ref), store_object),
-                    indirect_object.map(|obj| (obj.digest(), obj)),
+                    indirect_object.map(|obj| (obj.inner().digest(), obj)),
                 )
             })
             .unzip();
@@ -902,9 +902,8 @@ impl AuthorityStore {
             .owned_object_transaction_locks
             .multi_get(owned_input_objects)?;
 
-        for ((i, lock), obj_ref) in locks.iter().enumerate().zip(owned_input_objects) {
+        for ((i, lock), obj_ref) in locks.into_iter().enumerate().zip(owned_input_objects) {
             // The object / version must exist, and therefore lock initialized.
-            let lock = lock.as_ref();
             if lock.is_none() {
                 let latest_lock = self.get_latest_lock_for_object_id(obj_ref.0)?;
                 fp_bail!(UserInputError::ObjectVersionUnavailableForConsumption {
@@ -914,12 +913,12 @@ impl AuthorityStore {
                 .into());
             }
             // Safe to unwrap as it is checked above
-            let lock = lock.unwrap();
+            let lock = lock.unwrap().map(|l| l.migrate().into_inner());
 
             if let Some(LockDetails {
                 epoch: previous_epoch,
                 tx_digest: previous_tx_digest,
-            }) = lock
+            }) = &lock
             {
                 fp_ensure!(
                     &epoch >= previous_epoch,
@@ -951,7 +950,8 @@ impl AuthorityStore {
                 }
             }
             let obj_ref = owned_input_objects[i];
-            locks_to_write.push((obj_ref, Some(LockDetails { epoch, tx_digest })));
+            let lock_details = LockDetails { epoch, tx_digest };
+            locks_to_write.push((obj_ref, Some(lock_details.into())));
         }
 
         if !locks_to_write.is_empty() {
@@ -981,6 +981,7 @@ impl AuthorityStore {
             {
                 match lock_info {
                     Some(lock_info) => {
+                        let lock_info = lock_info.migrate().into_inner();
                         match Ord::cmp(&lock_info.epoch, &epoch_id) {
                             // If the object was locked in a previous epoch, we can say that it's
                             // no longer locked and is considered as just Initialized.
@@ -1460,9 +1461,52 @@ pub enum ObjectLockStatus {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LockDetails {
+pub enum LockDetailsWrapper {
+    V1(LockDetailsV1),
+}
+
+impl LockDetailsWrapper {
+    pub fn migrate(self) -> Self {
+        // TODO: when there are multiple versions, we must iteratively migrate from version N to
+        // N+1 until we arrive at the latest version
+        self
+    }
+
+    // Always returns the most recent version. Older versions are migrated to the latest version at
+    // read time, so there is never a need to access older versions.
+    pub fn inner(&self) -> &LockDetails {
+        match self {
+            Self::V1(v1) => v1,
+
+            // can remove #[allow] when there are multiple versions
+            #[allow(unreachable_patterns)]
+            _ => panic!("lock details should have been migrated to latest version at read time"),
+        }
+    }
+    pub fn into_inner(self) -> LockDetails {
+        match self {
+            Self::V1(v1) => v1,
+
+            // can remove #[allow] when there are multiple versions
+            #[allow(unreachable_patterns)]
+            _ => panic!("lock details should have been migrated to latest version at read time"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockDetailsV1 {
     pub epoch: EpochId,
     pub tx_digest: TransactionDigest,
+}
+
+pub type LockDetails = LockDetailsV1;
+
+impl From<LockDetails> for LockDetailsWrapper {
+    fn from(details: LockDetails) -> Self {
+        // always use latest version.
+        LockDetailsWrapper::V1(details)
+    }
 }
 
 /// A potential input to a transaction.

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::authority::authority_store::LockDetails;
+use crate::authority::authority_store::LockDetailsWrapper;
 use rocksdb::Options;
 use std::path::Path;
 use sui_storage::default_db_options;
@@ -16,7 +16,8 @@ use typed_store::rocks::{DBBatch, DBMap, DBOptions, MetricConf, ReadWriteOptions
 use typed_store::traits::{Map, TableSummary, TypedStoreDebug};
 
 use crate::authority::authority_store_types::{
-    ObjectContentDigest, StoreData, StoreMoveObject, StoreObject, StoreObjectPair,
+    MigratedStoreObjectPair, ObjectContentDigest, StoreData, StoreMoveObjectWrapper,
+    StoreObjectWrapper,
 };
 use typed_store_derive::DBMapUtils;
 
@@ -37,10 +38,10 @@ pub struct AuthorityPerpetualTables {
     /// been written out, and which must be retried. But, they cannot be retried unless their input
     /// objects are still accessible!
     #[default_options_override_fn = "objects_table_default_config"]
-    pub(crate) objects: DBMap<ObjectKey, StoreObject>,
+    pub(crate) objects: DBMap<ObjectKey, StoreObjectWrapper>,
 
     #[default_options_override_fn = "indirect_move_objects_table_default_config"]
-    pub(crate) indirect_move_objects: DBMap<ObjectContentDigest, StoreMoveObject>,
+    pub(crate) indirect_move_objects: DBMap<ObjectContentDigest, StoreMoveObjectWrapper>,
 
     /// This is a map between object references of currently active objects that can be mutated,
     /// and the transaction that they are lock on for use by this specific authority. Where an object
@@ -49,7 +50,7 @@ pub struct AuthorityPerpetualTables {
     /// the lock once it is set. After a certificate for this object is processed it can be
     /// forgotten.
     #[default_options_override_fn = "owned_object_transaction_locks_table_default_config"]
-    pub(crate) owned_object_transaction_locks: DBMap<ObjectRef, Option<LockDetails>>,
+    pub(crate) owned_object_transaction_locks: DBMap<ObjectRef, Option<LockDetailsWrapper>>,
 
     /// This is a map between the transaction digest and the corresponding transaction that's known to be
     /// executable. This means that it may have been executed locally, or it may have been synced through
@@ -135,14 +136,16 @@ impl AuthorityPerpetualTables {
         iter.reverse().next().and_then(|(_, o)| self.object(o).ok())
     }
 
-    pub fn object(&self, store_object: StoreObject) -> Result<Object, SuiError> {
+    pub fn object(&self, store_object: StoreObjectWrapper) -> Result<Object, SuiError> {
+        let store_object = store_object.migrate().into_inner();
         let indirect_object = match store_object.data {
-            StoreData::IndirectObject(ref metadata) => {
-                self.indirect_move_objects.get(&metadata.digest)?
-            }
+            StoreData::IndirectObject(ref metadata) => self
+                .indirect_move_objects
+                .get(&metadata.digest)?
+                .map(|o| o.migrate().into_inner()),
             _ => None,
         };
-        StoreObjectPair(store_object, indirect_object).try_into()
+        MigratedStoreObjectPair(store_object, indirect_object).try_into()
     }
 
     pub fn get_latest_parent_entry(

--- a/crates/sui-tool/src/db_tool/db_dump.rs
+++ b/crates/sui-tool/src/db_tool/db_dump.rs
@@ -102,6 +102,8 @@ pub fn duplicate_objects_summary(db_path: PathBuf) -> (usize, usize, usize, usiz
     let mut data: HashMap<Vec<u8>, usize> = HashMap::new();
 
     for (key, value) in iter {
+        let value = value.migrate().into_inner();
+
         if let StoreData::Move(object) = value.data {
             if object_id != key.0 {
                 for (k, cnt) in data.iter() {


### PR DESCRIPTION
## Description 

Prepares for future versioning of the object storage format.

Versioning process:

Object storage versioning is done lazily (at read time) - therefore we must always preserve the
code for reading the very first storage version. For all versions, a migration function

       f(V_n) -> V_(n+1)

must be defined. This way we can iteratively migrate the very oldest version to the very newest
version at any point in the future.

To change the format of the object table value types (StoreObject and StoreMoveObject), use the
following process:
- Add a new variant to the enum to store the new version type.
- Extend the `migrate` functions to migrate from the previous version to the new version.
- Change `From<Object> for StoreObjectPair` to create the newest version only.

Additionally, the first time we version these formats, we will need to:
- Add a check in the `TryFrom<StoreObjectPair> for Object` to see if the object that was just
  read is the latest version.
- If it is not, use the migration function (as explained above) to migrate it to the next
  version.
- Repeat until we have arrive at the current version.



## Test Plan 

`cargo simtest`

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
