### PR TITLE
[Bench] Sync checkpoints from another read-only DB

### DIFF
--- a/crates/mysten-metrics/src/histogram.rs
+++ b/crates/mysten-metrics/src/histogram.rs
@@ -7,6 +7,7 @@ use prometheus::{
     register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, IntCounterVec,
     IntGaugeVec, Registry,
 };
+use tracing::log::debug;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -184,7 +185,7 @@ impl Histogram {
             Err(TrySendError::Closed(_)) => {
                 // can happen during runtime shutdown
             }
-            Err(TrySendError::Full(_)) => error!("Histogram channel is full, dropping data"),
+            Err(TrySendError::Full(_)) => debug!("Histogram channel is full, dropping data"),
         }
     }
 

--- a/crates/mysten-metrics/src/histogram.rs
+++ b/crates/mysten-metrics/src/histogram.rs
@@ -7,7 +7,6 @@ use prometheus::{
     register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, IntCounterVec,
     IntGaugeVec, Registry,
 };
-use tracing::log::debug;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -18,6 +17,7 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::time::Instant;
 use tracing::error;
+use tracing::log::debug;
 
 type Point = u64;
 type HistogramMessage = (HistogramLabels, Point);

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -390,6 +390,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                         default_end_of_epoch_broadcast_channel_capacity(),
                     checkpoint_executor_config: Default::default(),
                     supported_protocol_versions: Some(SupportedProtocolVersions::SYSTEM_DEFAULT),
+                    sync_db_path: None,
                 }
             })
             .collect();

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -96,6 +96,12 @@ pub struct NodeConfig {
     /// order to test protocol upgrades.
     #[serde(skip)]
     pub supported_protocol_versions: Option<SupportedProtocolVersions>,
+
+    /// A database from which to read checkpoints and their
+    /// contents instead of doing sync over the network when
+    /// possible.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_db_path: Option<PathBuf>,
 }
 
 fn default_authority_store_pruning_config() -> AuthorityStorePruningConfig {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -260,11 +260,11 @@ pub struct CheckpointExecutorConfig {
 }
 
 fn default_checkpoint_execution_max_concurrency() -> usize {
-    200
+    2_000
 }
 
 fn default_local_execution_timeout_sec() -> u64 {
-    10
+    30
 }
 
 impl Default for CheckpointExecutorConfig {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -260,11 +260,11 @@ pub struct CheckpointExecutorConfig {
 }
 
 fn default_checkpoint_execution_max_concurrency() -> usize {
-    2_000
+    200
 }
 
 fn default_local_execution_timeout_sec() -> u64 {
-    30
+    10
 }
 
 impl Default for CheckpointExecutorConfig {

--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -132,34 +132,34 @@ impl StateSyncConfig {
     }
 
     pub fn mailbox_capacity(&self) -> usize {
-        const MAILBOX_CAPACITY: usize = 128;
+        const MAILBOX_CAPACITY: usize = 12_800;
 
         self.mailbox_capacity.unwrap_or(MAILBOX_CAPACITY)
     }
 
     pub fn synced_checkpoint_broadcast_channel_capacity(&self) -> usize {
-        const SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY: usize = 128;
+        const SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY: usize = 12_800;
 
         self.synced_checkpoint_broadcast_channel_capacity
             .unwrap_or(SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY)
     }
 
     pub fn checkpoint_header_download_concurrency(&self) -> usize {
-        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 100;
+        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 6_000;
 
         self.checkpoint_header_download_concurrency
             .unwrap_or(CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY)
     }
 
     pub fn checkpoint_content_download_concurrency(&self) -> usize {
-        const CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY: usize = 100;
+        const CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY: usize = 1000;
 
         self.checkpoint_content_download_concurrency
             .unwrap_or(CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY)
     }
 
     pub fn transaction_download_concurrency(&self) -> usize {
-        const TRANSACTION_DOWNLOAD_CONCURRENCY: usize = 100;
+        const TRANSACTION_DOWNLOAD_CONCURRENCY: usize = 1000;
 
         self.transaction_download_concurrency
             .unwrap_or(TRANSACTION_DOWNLOAD_CONCURRENCY)

--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -80,12 +80,6 @@ pub struct StateSyncConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint_header_download_concurrency: Option<usize>,
 
-    /// Set the upper bound on the number of checkpoint contents to be downloaded concurrently.
-    ///
-    /// If unspecified, this will default to `100`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub checkpoint_content_download_concurrency: Option<usize>,
-
     /// Set the upper bound on the number of transactions to be downloaded concurrently from a
     /// single checkpoint.
     ///
@@ -132,41 +126,34 @@ impl StateSyncConfig {
     }
 
     pub fn mailbox_capacity(&self) -> usize {
-        const MAILBOX_CAPACITY: usize = 12_800;
+        const MAILBOX_CAPACITY: usize = 128;
 
         self.mailbox_capacity.unwrap_or(MAILBOX_CAPACITY)
     }
 
     pub fn synced_checkpoint_broadcast_channel_capacity(&self) -> usize {
-        const SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY: usize = 12_800;
+        const SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY: usize = 128;
 
         self.synced_checkpoint_broadcast_channel_capacity
             .unwrap_or(SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY)
     }
 
     pub fn checkpoint_header_download_concurrency(&self) -> usize {
-        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 6_000;
+        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 100;
 
         self.checkpoint_header_download_concurrency
             .unwrap_or(CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY)
     }
 
-    pub fn checkpoint_content_download_concurrency(&self) -> usize {
-        const CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY: usize = 1000;
-
-        self.checkpoint_content_download_concurrency
-            .unwrap_or(CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY)
-    }
-
     pub fn transaction_download_concurrency(&self) -> usize {
-        const TRANSACTION_DOWNLOAD_CONCURRENCY: usize = 1000;
+        const TRANSACTION_DOWNLOAD_CONCURRENCY: usize = 100;
 
         self.transaction_download_concurrency
             .unwrap_or(TRANSACTION_DOWNLOAD_CONCURRENCY)
     }
 
     pub fn timeout(&self) -> Duration {
-        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
         self.timeout_ms
             .map(Duration::from_millis)

--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -145,7 +145,7 @@ impl StateSyncConfig {
     }
 
     pub fn checkpoint_header_download_concurrency(&self) -> usize {
-        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 6_000;
+        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 12_000;
 
         self.checkpoint_header_download_concurrency
             .unwrap_or(CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY)
@@ -166,7 +166,7 @@ impl StateSyncConfig {
     }
 
     pub fn timeout(&self) -> Duration {
-        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
         self.timeout_ms
             .map(Duration::from_millis)

--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -145,7 +145,7 @@ impl StateSyncConfig {
     }
 
     pub fn checkpoint_header_download_concurrency(&self) -> usize {
-        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 12_000;
+        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 6_000;
 
         self.checkpoint_header_download_concurrency
             .unwrap_or(CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY)

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -241,6 +241,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
                 default_end_of_epoch_broadcast_channel_capacity(),
             checkpoint_executor_config: Default::default(),
             supported_protocol_versions: Some(SupportedProtocolVersions::SYSTEM_DEFAULT),
+            sync_db_path: None,
         })
     }
 }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -9,6 +9,7 @@ use prometheus::{
 use std::sync::Arc;
 
 pub struct CheckpointExecutorMetrics {
+    pub checkpoint_exec_sync_tps: IntGauge,
     pub last_executed_checkpoint: IntGauge,
     pub checkpoint_exec_errors: IntCounter,
     pub checkpoint_exec_epoch: IntGauge,
@@ -19,6 +20,12 @@ pub struct CheckpointExecutorMetrics {
 impl CheckpointExecutorMetrics {
     pub fn new(registry: &Registry) -> Arc<Self> {
         let this = Self {
+            checkpoint_exec_sync_tps: register_int_gauge_with_registry!(
+                "checkpoint_exec_sync_tps",
+                "Checkpoint sync estimated transactions per second",
+                registry
+            )
+            .unwrap(),
             last_executed_checkpoint: register_int_gauge_with_registry!(
                 "last_executed_checkpoint",
                 "Last executed checkpoint",

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -21,7 +21,7 @@
 use std::{
     collections::HashMap,
     sync::Arc,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 
 use futures::stream::FuturesOrdered;
@@ -150,6 +150,13 @@ impl CheckpointExecutor {
                 0
             });
         let mut pending: CheckpointExecutionBuffer = FuturesOrdered::new();
+
+        let mut now_time = Instant::now();
+        let mut now_transaction_num = highest_executed
+            .as_ref()
+            .map(|c| c.summary.network_total_transactions)
+            .unwrap_or(0);
+
         loop {
             // If we have executed the last checkpoint of the current epoch, stop.
             if let Some(next_epoch_committee) =
@@ -177,6 +184,17 @@ impl CheckpointExecutor {
                 Some(Ok((checkpoint, checkpoint_execution_state))) = pending.next() => {
                     self.process_executed_checkpoint(&checkpoint, checkpoint_execution_state).await;
                     highest_executed = Some(checkpoint);
+
+                    // Estimate TPS every 10k transactions or 30 sec
+                    let elapsed = now_time.elapsed().as_millis();
+                    let current_transaction_num =  highest_executed.as_ref().map(|c| c.summary.network_total_transactions).unwrap_or(0);
+                    if current_transaction_num - now_transaction_num > 10_000 || elapsed > 30_000{
+                        let tps = (1000.0 * (current_transaction_num - now_transaction_num) as f64 / elapsed as f64) as i32;
+                        self.metrics.checkpoint_exec_sync_tps.set(tps as i64);
+                        now_time = Instant::now();
+                        now_transaction_num = current_transaction_num;
+                    }
+
                 }
                 // Check for newly synced checkpoints from StateSync.
                 received = self.mailbox.recv() => match received {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -185,10 +185,10 @@ impl CheckpointExecutor {
                     self.process_executed_checkpoint(&checkpoint, checkpoint_execution_state).await;
                     highest_executed = Some(checkpoint);
 
-                    // Estimate TPS every 10k transactions or 30 sec
+                    // Estimate TPS every 10k transactions or 5 sec
                     let elapsed = now_time.elapsed().as_millis();
                     let current_transaction_num =  highest_executed.as_ref().map(|c| c.summary.network_total_transactions).unwrap_or(0);
-                    if current_transaction_num - now_transaction_num > 10_000 || elapsed > 30_000{
+                    if current_transaction_num - now_transaction_num > 10_000 || elapsed > 5_000{
                         let tps = (1000.0 * (current_transaction_num - now_transaction_num) as f64 / elapsed as f64) as i32;
                         self.metrics.checkpoint_exec_sync_tps.set(tps as i64);
                         now_time = Instant::now();
@@ -197,6 +197,7 @@ impl CheckpointExecutor {
 
                 }
                 // Check for newly synced checkpoints from StateSync.
+                // This is simply used to 'wake up' this thread
                 received = self.mailbox.recv() => match received {
                     Ok(checkpoint) => {
                         debug!(

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -19,6 +19,7 @@ use futures::FutureExt;
 use mysten_metrics::{monitored_scope, spawn_monitored_task, MonitoredFutureExt};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use sui_types::storage::CheckpointBundle;
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority_aggregator::TransactionCertifier;
@@ -32,7 +33,7 @@ use sui_types::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
 use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::gas::GasCostSummary;
-use sui_types::messages::{TransactionEffects, VerifiedCertificate};
+use sui_types::messages::TransactionEffects;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
     CheckpointSignatureMessage, CheckpointSummary, CheckpointTimestamp, VerifiedCheckpoint,
@@ -136,11 +137,7 @@ impl CheckpointStore {
 
     pub fn insert_full_verified_bundle(
         &self,
-        bundle: &Vec<(
-            VerifiedCheckpoint,
-            CheckpointContents,
-            Vec<(VerifiedCertificate, TransactionEffects)>,
-        )>,
+        bundle: &[CheckpointBundle],
     ) -> Result<(), TypedStoreError> {
         // Define a bunch of iterators to do the bulk db inserts
         // Let's try to not copy data again into new vectors.

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -134,10 +134,9 @@ impl WriteStore for RocksDbStore {
             Vec<(VerifiedCertificate, TransactionEffects)>,
         )>,
     ) -> Result<(), Self::Error> {
-        
         // Strange that we have an empty bundle, but it happens
         if bundle.is_empty() {
-            return Ok(())
+            return Ok(());
         }
 
         // First write the transactions and effects as a bundle
@@ -191,13 +190,14 @@ impl WriteStore for RocksDbStore {
                     next_committee,
                 )
                 .expect("new committee from consensus should be constructable");
-                self.insert_committee(committee).expect("database cannot fail here.")
+                self.insert_committee(committee)
+                    .expect("database cannot fail here.")
             }
         });
 
         // The write the checkpoint structure
         self.checkpoint_store.insert_full_verified_bundle(&bundle)?;
-        
+
         Ok(())
     }
 

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -140,19 +140,15 @@ impl WriteStore for RocksDbStore {
         }
 
         // First write the transactions and effects as a bundle
-        let transaction_inserts = bundle
-            .iter()
-            .map(|(_, _, tx_effs)| {
-                tx_effs
-                    .iter()
-                    .map(|(tx, _effs)| (tx.digest(), tx.serializable_ref()))
-            })
-            .flatten();
+        let transaction_inserts = bundle.iter().flat_map(|(_, _, tx_effs)| {
+            tx_effs
+                .iter()
+                .map(|(tx, _effs)| (tx.digest(), tx.serializable_ref()))
+        });
 
         let effects_inserts = bundle
             .iter()
-            .map(|(_, _, tx_effs)| tx_effs.iter().map(|(_tx, effs)| (effs.digest(), effs)))
-            .flatten();
+            .flat_map(|(_, _, tx_effs)| tx_effs.iter().map(|(_tx, effs)| (effs.digest(), effs)));
 
         // Commit the transaction and effects
         let batch = self

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -48,7 +48,7 @@
 //! of the newly synchronized checkpoint so that it can help other peers synchronize.
 
 use anemo::{types::PeerEvent, PeerId, Request, Response, Result};
-use anyhow::anyhow;
+
 use futures::{FutureExt, StreamExt};
 use std::{
     collections::HashMap,
@@ -56,16 +56,16 @@ use std::{
     time::{Duration, SystemTime},
 };
 use sui_config::p2p::StateSyncConfig;
+use sui_types::messages_checkpoint::CertifiedCheckpointSummary;
 use sui_types::{
-    base_types::ExecutionDigests,
-    digests::{CheckpointContentsDigest, CheckpointDigest},
+    digests::{CheckpointDigest},
     message_envelope::Message,
     messages_checkpoint::{
         CertifiedCheckpointSummary as Checkpoint, CheckpointContents, CheckpointSequenceNumber,
         VerifiedCheckpoint,
     },
     storage::ReadStore,
-    storage::WriteStore,
+    storage::WriteStore, messages::{TransactionEffects, CertifiedTransaction},
 };
 use tap::{Pipe, TapFallible, TapOptional};
 use tokio::{
@@ -542,6 +542,7 @@ where
                 self.config.timeout(),
                 // The if condition should ensure that this is Some
                 highest_known_checkpoint.unwrap(),
+                self.weak_sender.clone(),
             )
             .map(|result| match result {
                 Ok(()) => {}
@@ -551,49 +552,6 @@ where
             });
             let task_handle = self.tasks.spawn(task);
             self.sync_checkpoint_summaries_task = Some(task_handle);
-        }
-    }
-
-    fn maybe_start_checkpoint_contents_sync_task(&mut self) {
-        // Only run one sync task at a time
-        if self.sync_checkpoint_contents_task.is_some() {
-            return;
-        }
-
-        let highest_verified_checkpoint = self
-            .store
-            .get_highest_verified_checkpoint()
-            .expect("store operation should not fail");
-        let highest_synced_checkpoint = self
-            .store
-            .get_highest_synced_checkpoint()
-            .expect("store operation should not fail");
-
-        if highest_verified_checkpoint.sequence_number()
-            > highest_synced_checkpoint.sequence_number()
-            // skip if we aren't connected to any peers that can help
-            && self
-                .peer_heights
-                .read()
-                .unwrap()
-                .highest_known_checkpoint_sequence_number()
-                > Some(highest_synced_checkpoint.sequence_number())
-        {
-            let task = sync_checkpoint_contents(
-                self.network.clone(),
-                self.store.clone(),
-                self.peer_heights.clone(),
-                self.weak_sender.clone(),
-                self.checkpoint_event_sender.clone(),
-                self.metrics.clone(),
-                self.config.transaction_download_concurrency(),
-                self.config.checkpoint_content_download_concurrency(),
-                self.config.timeout(),
-                highest_verified_checkpoint,
-            );
-
-            let task_handle = self.tasks.spawn(task);
-            self.sync_checkpoint_contents_task = Some(task_handle);
         }
     }
 
@@ -802,6 +760,7 @@ async fn sync_to_checkpoint<S>(
     checkpoint_event_sender: broadcast::Sender<VerifiedCheckpoint>,
     timeout: Duration,
     checkpoint: Checkpoint,
+    sender: mpsc::WeakSender<StateSyncMessage>,
 ) -> Result<()>
 where
     S: WriteStore,
@@ -821,14 +780,14 @@ where
     }
 
     // Define an epoch within which we are doing sync. After that we stop this
-    // sync and start again a sync for the next epoch. If the last verified checkpoint 
+    // sync and start again a sync for the next epoch. If the last verified checkpoint
     // is at an epoch boundary we are in the next epoch, otherwise we are in the same
     // epoch.
-    let sync_epoch = current.next_epoch_committee().map(|_| { 
-        current.epoch() + 1
-    }).unwrap_or(current.epoch());
+    let sync_epoch = current
+        .next_epoch_committee()
+        .map(|_| current.epoch() + 1)
+        .unwrap_or(current.epoch());
 
-    let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::from_entropy();
     // get a list of peers that can help
     let peers = peer_heights
         .read()
@@ -852,127 +811,12 @@ where
     let request_stream = (current.sequence_number().saturating_add(1)
         ..=checkpoint.sequence_number())
         .map(|next| {
-            let mut peers = peers
-                .iter()
-                // Filter out any peers who can't help with this particular checkpoint
-                .filter(|(_peer_id, info)| info.height >= next)
-                // Filter out any peers who we aren't connected with
-                .flat_map(|(peer_id, _height)| network.peer(*peer_id))
-                .map(StateSyncClient::new)
-                .collect::<Vec<_>>();
-
-            rand::seq::SliceRandom::shuffle(peers.as_mut_slice(), &mut rng);
-            let transaction_download_concurrency = 1_000;
-
-            // let peer_heights = peer_heights.clone();
-            async move {
-                let now = tokio::time::Instant::now();
-
-                // Iterate through our selected peers trying each one in turn until we're able to
-                // successfully get the target checkpoint
-                'outer_peer_loop: for mut peer in peers {
-                    let request = Request::new(GetCheckpointSummaryRequest::BySequenceNumber(next))
-                        .with_timeout(timeout);
-
-                    if let Some(checkpoint) = peer
-                        .get_checkpoint_summary(request)
-                        .await
-                        .tap_err(|e| trace!("{e:?}"))
-                        .ok()
-                        .and_then(Response::into_inner)
-                        .tap_none(|| trace!("peer unable to help sync"))
-                    {
-                        // peer didn't give us a checkpoint with the height that we requested
-                        if checkpoint.sequence_number() != next {
-                            continue 'outer_peer_loop;
-                        }
-
-                        // Now get the contents structure
-                        let request =
-                            Request::new(checkpoint.content_digest()).with_timeout(timeout);
-                        let contents = if let Some(contents) = peer
-                            .get_checkpoint_contents(request)
-                            .await
-                            .tap_err(|e| trace!("{e:?}"))
-                            .ok()
-                            .and_then(Response::into_inner)
-                            .tap_none(|| trace!("peer unable to help sync"))
-                        {
-                            if checkpoint.content_digest() != contents.digest() {
-                                continue 'outer_peer_loop;
-                            }
-
-                            contents
-                        } else {
-                            continue 'outer_peer_loop;
-                        };
-
-                        let num_txns = contents.size() as u64;
-
-                        // Sync transactions and effects
-                        let mut stream = contents
-                            .iter()
-                            .cloned()
-                            .into_iter()
-                            .map(|digests| {
-                                let digests = digests.clone();
-                                let mut peer = peer.clone();
-                                async move {
-                                    // Ask for all requests
-                                    let request = Request::new(digests).with_timeout(timeout);
-                                    if let Some((transaction, effects)) = peer
-                                        .get_transaction_and_effects(request)
-                                        .await
-                                        .tap_err(|e| trace!("{e:?}"))
-                                        .ok()
-                                        .and_then(Response::into_inner)
-                                        .tap_none(|| trace!("peer unable to help sync"))
-                                    {
-                                        if !(transaction.digest() == &digests.transaction
-                                            && effects.digest() == digests.effects
-                                            && effects.transaction_digest == digests.transaction)
-                                        {
-                                            return None;
-                                        }
-
-                                        Some((transaction, effects))
-                                    } else {
-                                        None
-                                    }
-                                }
-                            })
-                            .pipe(futures::stream::iter)
-                            .buffer_unordered(transaction_download_concurrency);
-
-                        let mut transaction_effects = Vec::with_capacity(num_txns as usize);
-                        while let Some(result) = stream.next().await {
-                            if let Some((transaction, effects)) = result {
-                                transaction_effects.push((transaction, effects));
-                            } else {
-                                continue 'outer_peer_loop;
-                            }
-                        }
-
-                        // Let go of the &stream reference
-                        drop(stream);
-
-                        trace!(
-                            "Full Sync: {} L: {}\t{}ms",
-                            checkpoint.sequence_number(),
-                            num_txns,
-                            now.elapsed().as_millis()
-                        );
-                        return (
-                            Some((checkpoint, contents, transaction_effects)),
-                            next,
-                            Some(peer.inner().peer_id()),
-                        );
-                    }
-                }
-
-                warn!("Failed to download checkpoint: {}", next);
-                (None, next, None)
-            }
+            download_full_checkpoint(
+                next,
+                peers.clone(),
+                &network,
+                timeout.clone(),
+            )
         })
         .pipe(futures::stream::iter)
         .buffered(checkpoint_header_download_concurrency);
@@ -982,7 +826,6 @@ where
 
     let mut now_net = tokio::time::Instant::now();
     while let Some(mut vec_checkpoints) = chucks_stream.next().await {
-
         let net_elapsed = now_net.elapsed().as_millis();
         total_on_net += net_elapsed;
         let now = tokio::time::Instant::now();
@@ -992,7 +835,7 @@ where
             .into_iter()
             .take_while(|item| item.0.is_some())
             .map(|item| {
-                let (opt_items, next, opt_peer) = item;
+                let (opt_items, _next, _opt_peer) = item;
                 let (checkpoint, contents, transaction_effects) = opt_items.unwrap(); // Safe due to take_whie check
 
                 // Change all transaction to be certified.
@@ -1099,7 +942,7 @@ where
 
             // Verify the checkpoint
             let checkpoint = {
-                let (checkpoint, contents, transaction_effects) = maybe_checkpoint
+                let (checkpoint, _contents, _transaction_effects) = maybe_checkpoint
                     .ok_or_else(|| anyhow::anyhow!("no peers were able to help sync"))?;
 
                 // Do the work for summary.
@@ -1139,6 +982,12 @@ where
 
         metrics.set_highest_verified_checkpoint(current.sequence_number());
         metrics.set_highest_synced_checkpoint(current.sequence_number());
+
+        // Notify event loop to notify our peers that we've synced to a new checkpoint height
+        if let Some(sender) = sender.upgrade() {
+            let message = StateSyncMessage::SyncedCheckpoint(Box::new(current.clone()));
+            let _ = sender.send(message).await;
+        }
 
         let now_db_elapsed = now_db.elapsed().as_millis();
 
@@ -1181,9 +1030,139 @@ where
     Ok(())
 }
 
+fn download_full_checkpoint(
+    next: u64,
+    peers: Vec<(PeerId, PeerStateSyncInfo)>,
+    network: &anemo::Network,
+    timeout: Duration,
+) -> impl core::future::Future<Output=(Option<(CertifiedCheckpointSummary, CheckpointContents, Vec<(CertifiedTransaction, TransactionEffects)>)>, u64, Option<PeerId>)> {
+    let mut peers = peers
+        .iter()
+        // Filter out any peers who can't help with this particular checkpoint
+        .filter(|(_peer_id, info)| info.height >= next)
+        // Filter out any peers who we aren't connected with
+        .flat_map(|(peer_id, _height)| network.peer(*peer_id).map(|c| (*peer_id, c)))
+        .map(|(peer_id, client)| (peer_id, StateSyncClient::new(client)))
+        .collect::<Vec<_>>();
+
+    let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::from_entropy();
+    rand::seq::SliceRandom::shuffle(peers.as_mut_slice(), &mut rng);
+    let transaction_download_concurrency = 1_000;
+
+    async move {
+        let now = tokio::time::Instant::now();
+
+        // Iterate through our selected peers trying each one in turn until we're able to
+        // successfully get the target checkpoint
+        // info!("Num peers: {}", peers.len());
+        'outer_peer_loop: for (peer_id, mut peer) in peers {
+            let request = Request::new(GetCheckpointSummaryRequest::BySequenceNumber(next))
+                .with_timeout(timeout);
+
+            if let Some(checkpoint) = peer
+                .get_checkpoint_summary(request)
+                .await
+                .tap_err(|e| error!("{e:?}"))
+                .ok()
+                .and_then(Response::into_inner)
+                .tap_none(|| warn!("Peer unable to help sync checkpoint {}", peer_id))
+            {
+                // peer didn't give us a checkpoint with the height that we requested
+                if checkpoint.sequence_number() != next {
+                    continue 'outer_peer_loop;
+                }
+
+                // Now get the contents structure
+                let request = Request::new(checkpoint.content_digest()).with_timeout(timeout);
+                let contents = if let Some(contents) = peer
+                    .get_checkpoint_contents(request)
+                    .await
+                    .tap_err(|e| error!("{e:?}"))
+                    .ok()
+                    .and_then(Response::into_inner)
+                    .tap_none(|| warn!("Peer unable to help sync contents {}", peer_id))
+                {
+                    if checkpoint.content_digest() != contents.digest() {
+                        continue 'outer_peer_loop;
+                    }
+
+                    contents
+                } else {
+                    continue 'outer_peer_loop;
+                };
+
+                let num_txns = contents.size() as u64;
+
+                // Sync transactions and effects
+                let mut stream = contents
+                    .iter()
+                    .cloned()
+                    .into_iter()
+                    .map(|digests| {
+                        let digests = digests.clone();
+                        let mut peer = peer.clone();
+                        async move {
+                            // Ask for all requests
+                            let request = Request::new(digests).with_timeout(timeout);
+                            if let Some((transaction, effects)) = peer
+                                .get_transaction_and_effects(request)
+                                .await
+                                .tap_err(|e| error!("{e:?}"))
+                                .ok()
+                                .and_then(Response::into_inner)
+                                .tap_none(|| warn!("Peer unable to help sync transaction {}", peer_id))
+                            {
+                                if !(transaction.digest() == &digests.transaction
+                                    && effects.digest() == digests.effects
+                                    && effects.transaction_digest == digests.transaction)
+                                {
+                                    return None;
+                                }
+
+                                Some((transaction, effects))
+                            } else {
+                                None
+                            }
+                        }
+                    })
+                    .pipe(futures::stream::iter)
+                    .buffer_unordered(transaction_download_concurrency);
+
+                let mut transaction_effects = Vec::with_capacity(num_txns as usize);
+                while let Some(result) = stream.next().await {
+                    if let Some((transaction, effects)) = result {
+                        transaction_effects.push((transaction, effects));
+                    } else {
+                        continue 'outer_peer_loop;
+                    }
+                }
+
+                // Let go of the &stream reference
+                drop(stream);
+
+                trace!(
+                    "Full Sync: {} L: {}\t{}ms",
+                    checkpoint.sequence_number(),
+                    num_txns,
+                    now.elapsed().as_millis()
+                );
+
+                return (
+                    Some((checkpoint, contents, transaction_effects)),
+                    next,
+                    Some(peer.inner().peer_id()),
+                );
+            }
+        }
+
+        warn!("Failed to download checkpoint: {}", next);
+        (None, next, None)
+    }
+}
+
 fn verify_checkpoint_not_certificate<S>(
     current: &VerifiedCheckpoint,
-    store: S,
+    _store: S,
     checkpoint: Checkpoint,
 ) -> Result<VerifiedCheckpoint, Checkpoint>
 where
@@ -1229,228 +1208,4 @@ where
     }
 
     Ok(VerifiedCheckpoint::new_unchecked(checkpoint))
-}
-
-async fn sync_checkpoint_contents<S>(
-    network: anemo::Network,
-    store: S,
-    peer_heights: Arc<RwLock<PeerHeights>>,
-    sender: mpsc::WeakSender<StateSyncMessage>,
-    checkpoint_event_sender: broadcast::Sender<VerifiedCheckpoint>,
-    metrics: Metrics,
-    transaction_download_concurrency: usize,
-    checkpoint_content_download_concurrency: usize,
-    timeout: Duration,
-    target_checkpoint: VerifiedCheckpoint,
-) where
-    S: WriteStore + Clone,
-    <S as ReadStore>::Error: std::error::Error,
-{
-    let mut highest_synced = store
-        .get_highest_synced_checkpoint()
-        .expect("store operation should not fail");
-
-    let start = highest_synced.sequence_number().saturating_add(1);
-
-    let mut checkpoint_contents_stream = (start..=target_checkpoint.sequence_number())
-        .map(|next| {
-            store
-                .get_checkpoint_by_sequence_number(next)
-                .expect("store operation should not fail")
-                .expect(
-                    "BUG: store should have all checkpoints older than highest_verified_checkpoint",
-                )
-        })
-        .map(|checkpoint| {
-            sync_one_checkpoint_contents(
-                network.clone(),
-                &store,
-                peer_heights.clone(),
-                transaction_download_concurrency,
-                timeout,
-                checkpoint,
-            )
-        })
-        .pipe(futures::stream::iter)
-        .buffered(checkpoint_content_download_concurrency);
-
-    while let Some(maybe_checkpoint) = checkpoint_contents_stream.next().await {
-        match maybe_checkpoint {
-            Ok((checkpoint, num_txns)) => {
-                // if this fails, there is a bug in checkpoint construction (or the chain is
-                // corrupted)
-                assert_eq!(
-                    highest_synced.summary.network_total_transactions + num_txns,
-                    checkpoint.summary.network_total_transactions
-                );
-
-                store
-                    .update_highest_synced_checkpoint(&checkpoint)
-                    .expect("store operation should not fail");
-                metrics.set_highest_synced_checkpoint(checkpoint.sequence_number());
-                // We don't care if no one is listening as this is a broadcast channel
-                let _ = checkpoint_event_sender.send(checkpoint.clone());
-                highest_synced = checkpoint;
-            }
-            Err(err) => {
-                debug!("unable to sync contents of checkpoint: {err}");
-                break;
-            }
-        }
-    }
-
-    // Notify event loop to notify our peers that we've synced to a new checkpoint height
-    if let Some(sender) = sender.upgrade() {
-        let message = StateSyncMessage::SyncedCheckpoint(Box::new(highest_synced));
-        let _ = sender.send(message).await;
-    }
-}
-
-async fn sync_one_checkpoint_contents<S>(
-    network: anemo::Network,
-    store: S,
-    peer_heights: Arc<RwLock<PeerHeights>>,
-    transaction_download_concurrency: usize,
-    timeout: Duration,
-    checkpoint: VerifiedCheckpoint,
-) -> Result<(VerifiedCheckpoint, u64)>
-where
-    S: WriteStore + Clone,
-    <S as ReadStore>::Error: std::error::Error,
-{
-    let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::from_entropy();
-    // get a list of peers that can help
-    let mut peers = peer_heights
-        .read()
-        .unwrap()
-        .peers_on_same_chain()
-        // Filter out any peers who can't help with this particular checkpoint
-        .filter(|(_peer_id, info)| info.height >= checkpoint.sequence_number())
-        // Filter out any peers who we aren't connected with
-        .flat_map(|(peer_id, _height)| network.peer(*peer_id))
-        .map(StateSyncClient::new)
-        .collect::<Vec<_>>();
-    rand::seq::SliceRandom::shuffle(peers.as_mut_slice(), &mut rng);
-
-    let Some(contents) = get_checkpoint_contents(&mut peers, &store, checkpoint.content_digest(), timeout).await else {
-        return Err(anyhow!("unable to sync checkpoint contents for checkpoint {}", checkpoint.sequence_number()));
-    };
-
-    let num_txns = contents.size() as u64;
-
-    // Sync transactions and effects
-    let mut stream = contents
-        .into_inner()
-        .into_iter()
-        .map(|digests| get_transaction_and_effects(peers.clone(), store.clone(), digests, timeout))
-        .pipe(futures::stream::iter)
-        .buffer_unordered(transaction_download_concurrency);
-
-    while let Some(result) = stream.next().await {
-        result?;
-    }
-
-    Ok((checkpoint, num_txns))
-}
-
-async fn get_checkpoint_contents<S>(
-    peers: &mut [StateSyncClient<anemo::Peer>],
-    store: S,
-    digest: CheckpointContentsDigest,
-    timeout: Duration,
-) -> Option<CheckpointContents>
-where
-    S: WriteStore,
-    <S as ReadStore>::Error: std::error::Error,
-{
-    if let Some(contents) = store
-        .get_checkpoint_contents(&digest)
-        .expect("store operation should not fail")
-    {
-        return Some(contents);
-    }
-
-    // Iterate through our selected peers trying each one in turn until we're able to
-    // successfully get the target checkpoint
-    for peer in peers.iter_mut() {
-        let request = Request::new(digest).with_timeout(timeout);
-        if let Some(contents) = peer
-            .get_checkpoint_contents(request)
-            .await
-            .tap_err(|e| trace!("{e:?}"))
-            .ok()
-            .and_then(Response::into_inner)
-            .tap_none(|| trace!("peer unable to help sync"))
-        {
-            if digest == contents.digest() {
-                store
-                    .insert_checkpoint_contents(contents.clone())
-                    .expect("store operation should not fail");
-                return Some(contents);
-            }
-        }
-    }
-
-    None
-}
-
-async fn get_transaction_and_effects<S>(
-    peers: Vec<StateSyncClient<anemo::Peer>>,
-    store: S,
-    digests: ExecutionDigests,
-    timeout: Duration,
-) -> Result<()>
-where
-    S: WriteStore,
-    <S as ReadStore>::Error: std::error::Error,
-{
-    if let (Some(_transaction), Some(_effects)) = (
-        store
-            .get_transaction(&digests.transaction)
-            .expect("store operation should not fail"),
-        store
-            .get_transaction_effects(&digests.effects)
-            .expect("store operation should not fail"),
-    ) {
-        return Ok(());
-    }
-
-    // Iterate through our selected peers trying each one in turn until we're able to
-    // successfully get the target checkpoint
-    for mut peer in peers {
-        let request = Request::new(digests).with_timeout(timeout);
-        if let Some((transaction, effects)) = peer
-            .get_transaction_and_effects(request)
-            .await
-            .tap_err(|e| trace!("{e:?}"))
-            .ok()
-            .and_then(Response::into_inner)
-            .tap_none(|| trace!("peer unable to help sync"))
-        {
-            if transaction.digest() == &digests.transaction
-                && effects.digest() == digests.effects
-                && effects.transaction_digest == digests.transaction
-            {
-                // TODO this should just be a bare Transaction type and not a TransactionCertificate
-                // since Certificates are intended to be ephemeral and thrown away at the end of an
-                // epoch
-                store
-                    .insert_transaction(sui_types::messages::VerifiedCertificate::new_unchecked(
-                        transaction,
-                    ))
-                    .expect("store operation should not fail");
-                store
-                    .insert_transaction_effects(effects)
-                    .expect("store operation should not fail");
-                // TODO: If the transaction has already been executed, we should check that the executed
-                // effects match. If they don't, it's a bug and we should panic.
-                return Ok(());
-            }
-        }
-    }
-
-    Err(anyhow!(
-        "unable to sync transaction {:?} from any of our peers",
-        digests.transaction
-    ))
 }

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -815,9 +815,9 @@ where
         .pipe(futures::stream::iter)
         .buffered(checkpoint_header_download_concurrency);
 
-    const MAX_CHECKPOINT_CHUNK : usize =  200; // This is an internal param, no need to expose as config
-    let mut chucks_stream =
-        request_stream.ready_chunks(checkpoint_header_download_concurrency.min(MAX_CHECKPOINT_CHUNK));
+    const MAX_CHECKPOINT_CHUNK: usize = 200; // This is an internal param, no need to expose as config
+    let mut chucks_stream = request_stream
+        .ready_chunks(checkpoint_header_download_concurrency.min(MAX_CHECKPOINT_CHUNK));
 
     while let Some(mut vec_checkpoints) = chucks_stream.next().await {
         let checkpoint_bundle: Vec<_> = vec_checkpoints
@@ -940,7 +940,7 @@ where
         // and return if it changes epoch, since we need the new epoch committee
         // to check the new epoch checkpoints. This is rare enough to not care.
         if current.summary().end_of_epoch_data.is_some() || vec_size == 0 {
-            info!("Sync interrupted at epoch boundary.");
+            debug!("Sync interrupted possibly at epoch boundary.");
             return Ok(());
         }
     }
@@ -1089,7 +1089,10 @@ fn download_full_checkpoint(
             }
         }
 
-        warn!("Failed to download checkpoint: {}", next);
+        debug!(
+            "Failed to download checkpoint despite trying all peers: {}",
+            next
+        );
         (None, next, None)
     }
 }
@@ -1097,8 +1100,7 @@ fn download_full_checkpoint(
 fn verify_checkpoint_not_certificate(
     current: &VerifiedCheckpoint,
     checkpoint: &Checkpoint,
-) -> Result<(), ()>
-{
+) -> Result<(), ()> {
     assert_eq!(
         checkpoint.sequence_number(),
         current.sequence_number().saturating_add(1)

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -430,12 +430,6 @@ impl SuiNode {
             // Set the max_frame_size to be 2 GB to work around the issue of there being too many
             // delegation events in the epoch change txn.
             anemo_config.max_frame_size = Some(2 << 30);
-            anemo_config.max_concurrent_connections = Some(10_000);
-            anemo_config.max_concurrent_outstanding_connecting_connections = Some(10_000);
-            let mut quic_config = anemo::QuicConfig::default();
-            quic_config.max_concurrent_bidi_streams = Some(10_000);
-            quic_config.max_concurrent_uni_streams = Some(10_000);
-            anemo_config.quic = Some(quic_config);
 
             let network = Network::bind(config.p2p_config.listen_address)
                 .server_name("sui")

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -430,6 +430,12 @@ impl SuiNode {
             // Set the max_frame_size to be 2 GB to work around the issue of there being too many
             // delegation events in the epoch change txn.
             anemo_config.max_frame_size = Some(2 << 30);
+            anemo_config.max_concurrent_connections = Some(10_000);
+            anemo_config.max_concurrent_outstanding_connecting_connections = Some(10_000);
+            let mut quic_config = anemo::QuicConfig::default();
+            quic_config.max_concurrent_bidi_streams = Some(10_000);
+            quic_config.max_concurrent_uni_streams = Some(10_000);
+            anemo_config.quic = Some(quic_config);
 
             let network = Network::bind(config.p2p_config.listen_address)
                 .server_name("sui")

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -13,6 +13,7 @@ use sui_telemetry::send_telemetry_event;
 use tokio::task;
 use tokio::time::sleep;
 use tracing::info;
+use tracing::log::debug;
 
 const GIT_REVISION: &str = {
     if let Some(revision) = option_env!("GIT_REVISION") {
@@ -68,6 +69,8 @@ async fn main() -> Result<()> {
         .with_env()
         .with_prom_registry(&prometheus_registry)
         .init();
+
+    debug!("Config: {:?}", config);
 
     info!("Sui Node version: {VERSION}");
     info!(

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -268,16 +268,15 @@ impl<T: ReadStore> ReadStore for &T {
     }
 }
 
+pub type CheckpointBundle = (
+    VerifiedCheckpoint,
+    CheckpointContents,
+    Vec<(VerifiedCertificate, TransactionEffects)>,
+);
+
 pub trait WriteStore: ReadStore {
     // Define how to commit a bundle of checkpoints to the DB
-    fn insert_full_bundle(
-        &self,
-        bundle: Vec<(
-            VerifiedCheckpoint,
-            CheckpointContents,
-            Vec<(VerifiedCertificate, TransactionEffects)>,
-        )>,
-    ) -> Result<(), Self::Error> {
+    fn insert_full_bundle(&self, bundle: Vec<CheckpointBundle>) -> Result<(), Self::Error> {
         for bundle_item in bundle {
             let (verified_checkpoint, contents, transaction_effects) = bundle_item;
             // Insert the newly verified checkpoint into our store, which will bump our highest

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -269,6 +269,34 @@ impl<T: ReadStore> ReadStore for &T {
 }
 
 pub trait WriteStore: ReadStore {
+    // Define how to commit a bundle of checkpoints to the DB
+    fn insert_full_bundle(
+        &self,
+        bundle: Vec<(
+            VerifiedCheckpoint,
+            CheckpointContents,
+            Vec<(VerifiedCertificate, TransactionEffects)>,
+        )>,
+    ) -> Result<(), Self::Error> {
+        for bundle_item in bundle {
+            let (verified_checkpoint, contents, transaction_effects) = bundle_item;
+            // Insert the newly verified checkpoint into our store, which will bump our highest
+            // verified checkpoint watermark as well.
+            self.insert_checkpoint(verified_checkpoint.clone())?;
+
+            // Do the work on contents
+            self.insert_checkpoint_contents(contents.clone())?;
+
+            // Do the work on transactions
+            for (transaction, effects) in transaction_effects {
+                self.insert_transaction(transaction)?;
+                self.insert_transaction_effects(effects)?;
+            }
+            self.update_highest_synced_checkpoint(&verified_checkpoint)?;
+        }
+        Ok(())
+    }
+
     fn insert_checkpoint(&self, checkpoint: VerifiedCheckpoint) -> Result<(), Self::Error>;
     fn update_highest_synced_checkpoint(
         &self,


### PR DESCRIPTION
This PR adds a facility for the checkpoint sync to read checkpoints from another Sui rocks DB database (just perpetual + checkpoints tables in read-only mode), and otherwise feed them in the normal sync path to observe bottlenecks. The aim of this PR is to benchmark, not to merge for the moment.