### PR TITLE
[sui-types] use bcs::serialized_size instead of bcs::to_bytes when on…

### DIFF
--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -3018,7 +3018,7 @@ impl TransactionEffects {
 
     pub fn summary_for_debug(&self) -> TransactionEffectsDebugSummary {
         TransactionEffectsDebugSummary {
-            bcs_size: bcs::to_bytes(self).unwrap().len(),
+            bcs_size: bcs::serialized_size(self).unwrap(),
             status: self.status.clone(),
             gas_used: self.gas_used.clone(),
             transaction_digest: self.transaction_digest,

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -294,11 +294,11 @@ impl MoveObject {
     /// This should not be very expensive since the type tag is usually simple, and
     /// we only do this once per object being mutated.
     pub fn object_size_for_gas_metering(&self) -> usize {
-        let seriealized_type_tag =
-            bcs::to_bytes(&self.type_).expect("Serializing type tag should not fail");
+        let serialized_type_tag_size =
+            bcs::serialized_size(&self.type_).expect("Serializing type tag should not fail");
         // + 1 for 'has_public_transfer'
         // + 8 for `version`
-        self.contents.len() + seriealized_type_tag.len() + 1 + 8
+        self.contents.len() + serialized_type_tag_size + 1 + 8
     }
 
     /// Get the total amount of SUI embedded in `self`. Intended for testing purposes


### PR DESCRIPTION
…ly size is needed

This is slightly cheaper, as @aschran noted elsewhere.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
