### PR TITLE
Remove handle_committee_info from validator gRPC API

### DIFF
--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -81,7 +81,7 @@ impl<S: SignatureVerifier + Default> ReconfigObserver<NetworkAuthorityClient, S>
                                 // Safe to unwrap, checked above
                                 Committee::new(
                                     committee.epoch,
-                                    BTreeMap::from_iter(committee.committee_info.into_iter())).unwrap_or_else(
+                                    BTreeMap::from_iter(committee.validators.into_iter())).unwrap_or_else(
                                     |e| panic!("Can't create a valid Committee given info returned from Full Node: {:?}", e)
                                 )
                             }

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -504,7 +504,7 @@ impl FullNodeProxy {
 
         let resp = sui_client.read_api().get_committee_info(None).await?;
         let epoch = resp.epoch;
-        let committee_vec = resp.committee_info;
+        let committee_vec = resp.validators;
         let committee_map =
             BTreeMap::from_iter(committee_vec.into_iter().map(|(name, stake)| (name, stake)));
         let committee = Committee::new(epoch, committee_map)?;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1489,28 +1489,6 @@ impl AuthorityState {
         })
     }
 
-    pub fn handle_committee_info_request(
-        &self,
-        request: &CommitteeInfoRequest,
-    ) -> SuiResult<CommitteeInfoResponse> {
-        let (epoch, committee) = match request.epoch {
-            Some(epoch) => (
-                epoch,
-                self.committee_store
-                    .get_committee(&epoch)?
-                    .ok_or(SuiError::MissingCommitteeAtEpoch(epoch))?,
-            ),
-            None => {
-                let committee = self.committee_store.get_latest_committee();
-                (committee.epoch, committee)
-            }
-        };
-        Ok(CommitteeInfoResponse {
-            epoch,
-            committee_info: committee.voting_rights,
-        })
-    }
-
     fn check_protocol_version(
         supported_protocol_versions: SupportedProtocolVersions,
         current_version: ProtocolVersion,

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -51,11 +51,6 @@ pub trait AuthorityAPI {
         request: CheckpointRequest,
     ) -> Result<CheckpointResponse, SuiError>;
 
-    async fn handle_committee_info_request(
-        &self,
-        request: CommitteeInfoRequest,
-    ) -> Result<CommitteeInfoResponse, SuiError>;
-
     // This API is exclusively used by the benchmark code.
     // Hence it's OK to return a fixed system state type.
     async fn handle_system_state_object(
@@ -150,17 +145,6 @@ impl AuthorityAPI for NetworkAuthorityClient {
     ) -> Result<CheckpointResponse, SuiError> {
         self.client()
             .checkpoint(request)
-            .await
-            .map(tonic::Response::into_inner)
-            .map_err(Into::into)
-    }
-
-    async fn handle_committee_info_request(
-        &self,
-        request: CommitteeInfoRequest,
-    ) -> Result<CommitteeInfoResponse, SuiError> {
-        self.client()
-            .committee_info(request)
             .await
             .map(tonic::Response::into_inner)
             .map_err(Into::into)

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -491,17 +491,6 @@ impl Validator for ValidatorService {
         return Ok(tonic::Response::new(response));
     }
 
-    async fn committee_info(
-        &self,
-        request: tonic::Request<CommitteeInfoRequest>,
-    ) -> Result<tonic::Response<CommitteeInfoResponse>, tonic::Status> {
-        let request = request.into_inner();
-
-        let response = self.state.handle_committee_info_request(&request)?;
-
-        return Ok(tonic::Response::new(response));
-    }
-
     async fn get_system_state_object(
         &self,
         _request: tonic::Request<SystemStateRequest>,

--- a/crates/sui-core/src/epoch/committee_store.rs
+++ b/crates/sui-core/src/epoch/committee_store.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use sui_storage::default_db_options;
 use sui_types::base_types::ObjectID;
 use sui_types::committee::{Committee, EpochId};
-use sui_types::error::SuiResult;
+use sui_types::error::{SuiError, SuiResult};
 use typed_store::rocks::{DBMap, DBOptions, MetricConf};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 
@@ -75,6 +75,16 @@ impl CommitteeStore {
             // when initializing the store.
             .unwrap()
             .1
+    }
+
+    /// Return the committee specified by `epoch`. If `epoch` is `None`, return the latest committee.
+    pub fn get_or_latest_committee(&self, epoch: Option<EpochId>) -> SuiResult<Committee> {
+        Ok(match epoch {
+            Some(epoch) => self
+                .get_committee(&epoch)?
+                .ok_or(SuiError::MissingCommitteeAtEpoch(epoch))?,
+            None => self.get_latest_committee(),
+        })
     }
 
     fn database_is_empty(&self) -> bool {

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -395,33 +395,6 @@ where
         Ok(transaction_info)
     }
 
-    pub async fn handle_committee_info_request(
-        &self,
-        request: CommitteeInfoRequest,
-    ) -> SuiResult<CommitteeInfoResponse> {
-        let requested_epoch = request.epoch;
-        let committee_info = self
-            .authority_client
-            .handle_committee_info_request(request)
-            .await?;
-        self.verify_committee_info_response(requested_epoch, &committee_info)?;
-        Ok(committee_info)
-    }
-
-    fn verify_committee_info_response(
-        &self,
-        requested_epoch: Option<EpochId>,
-        committee_info: &CommitteeInfoResponse,
-    ) -> SuiResult {
-        if let Some(epoch) = requested_epoch {
-            fp_ensure!(
-                committee_info.epoch == epoch,
-                SuiError::from("Committee info response epoch doesn't match requested epoch")
-            );
-        }
-        Ok(())
-    }
-
     fn verify_checkpoint_sequence(
         &self,
         expected_seq: Option<CheckpointSequenceNumber>,

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -16,9 +16,9 @@ use sui_types::{
     crypto::AuthorityKeyPair,
     error::SuiError,
     messages::{
-        CertifiedTransaction, CommitteeInfoRequest, CommitteeInfoResponse,
-        HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, SystemStateRequest,
-        Transaction, TransactionEffectsAPI, TransactionInfoRequest, TransactionInfoResponse,
+        CertifiedTransaction, HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse,
+        SystemStateRequest, Transaction, TransactionEffectsAPI, TransactionInfoRequest,
+        TransactionInfoResponse,
     },
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
 };
@@ -103,15 +103,6 @@ impl AuthorityAPI for LocalAuthorityClient {
         state.handle_checkpoint_request(&request)
     }
 
-    async fn handle_committee_info_request(
-        &self,
-        request: CommitteeInfoRequest,
-    ) -> Result<CommitteeInfoResponse, SuiError> {
-        let state = self.state.clone();
-
-        state.handle_committee_info_request(&request)
-    }
-
     async fn handle_system_state_object(
         &self,
         _request: SystemStateRequest,
@@ -186,7 +177,6 @@ impl LocalAuthorityClient {
 pub struct MockAuthorityApi {
     delay: Duration,
     count: Arc<Mutex<u32>>,
-    handle_committee_info_request_result: Option<SuiResult<CommitteeInfoResponse>>,
     handle_object_info_request_result: Option<SuiResult<ObjectInfoResponse>>,
 }
 
@@ -195,15 +185,8 @@ impl MockAuthorityApi {
         MockAuthorityApi {
             delay,
             count,
-            handle_committee_info_request_result: None,
             handle_object_info_request_result: None,
         }
-    }
-    pub fn set_handle_committee_info_request_result(
-        &mut self,
-        result: SuiResult<CommitteeInfoResponse>,
-    ) {
-        self.handle_committee_info_request_result = Some(result);
     }
 
     pub fn set_handle_object_info_request(&mut self, result: SuiResult<ObjectInfoResponse>) {
@@ -265,13 +248,6 @@ impl AuthorityAPI for MockAuthorityApi {
         unimplemented!();
     }
 
-    async fn handle_committee_info_request(
-        &self,
-        _request: CommitteeInfoRequest,
-    ) -> Result<CommitteeInfoResponse, SuiError> {
-        self.handle_committee_info_request_result.clone().unwrap()
-    }
-
     async fn handle_system_state_object(
         &self,
         _request: SystemStateRequest,
@@ -319,13 +295,6 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
         &self,
         _request: CheckpointRequest,
     ) -> Result<CheckpointResponse, SuiError> {
-        unimplemented!()
-    }
-
-    async fn handle_committee_info_request(
-        &self,
-        _request: CommitteeInfoRequest,
-    ) -> Result<CommitteeInfoResponse, SuiError> {
         unimplemented!()
     }
 

--- a/crates/sui-indexer/src/apis/governance_api.rs
+++ b/crates/sui-indexer/src/apis/governance_api.rs
@@ -7,11 +7,10 @@ use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::RpcModule;
 use sui_json_rpc::api::{GovernanceReadApiClient, GovernanceReadApiServer};
 use sui_json_rpc::SuiRpcModule;
-use sui_json_rpc_types::SuiSystemStateRpc;
+use sui_json_rpc_types::{SuiCommittee, SuiSystemStateRpc};
 use sui_open_rpc::Module;
 use sui_types::base_types::{EpochId, SuiAddress};
 use sui_types::governance::DelegatedStake;
-use sui_types::messages::CommitteeInfoResponse;
 use sui_types::sui_system_state::ValidatorMetadata;
 
 pub(crate) struct GovernanceReadApi {
@@ -36,7 +35,7 @@ impl GovernanceReadApiServer for GovernanceReadApi {
         self.fullnode.get_validators().await
     }
 
-    async fn get_committee_info(&self, epoch: Option<EpochId>) -> RpcResult<CommitteeInfoResponse> {
+    async fn get_committee_info(&self, epoch: Option<EpochId>) -> RpcResult<SuiCommittee> {
         self.fullnode.get_committee_info(epoch).await
     }
 

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -27,11 +27,11 @@ use serde_json::{json, Value};
 use serde_with::serde_as;
 use sui_json::SuiJsonValue;
 use sui_types::base_types::{
-    ObjectDigest, ObjectID, ObjectInfo, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
-    TransactionEffectsDigest,
+    AuthorityName, ObjectDigest, ObjectID, ObjectInfo, ObjectRef, SequenceNumber, SuiAddress,
+    TransactionDigest, TransactionEffectsDigest,
 };
 use sui_types::coin::CoinMetadata;
-use sui_types::committee::EpochId;
+use sui_types::committee::{Committee, EpochId, StakeUnit};
 use sui_types::crypto::SuiAuthorityStrongQuorumSignInfo;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::dynamic_field::DynamicFieldInfo;
@@ -2518,6 +2518,23 @@ impl From<SuiSystemStateRpc> for SuiSystemState {
     fn from(state: SuiSystemStateRpc) -> Self {
         match state {
             SuiSystemStateRpc::V1(state) => Self::V1(state),
+        }
+    }
+}
+
+/// RPC representation of the [Committee] type.
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(rename = "CommitteeInfo")]
+pub struct SuiCommittee {
+    pub epoch: EpochId,
+    pub validators: Vec<(AuthorityName, StakeUnit)>,
+}
+
+impl From<Committee> for SuiCommittee {
+    fn from(committee: Committee) -> Self {
+        Self {
+            epoch: committee.epoch,
+            validators: committee.voting_rights,
         }
     }
 }

--- a/crates/sui-json-rpc/src/api/governance.rs
+++ b/crates/sui-json-rpc/src/api/governance.rs
@@ -4,13 +4,12 @@
 use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 
-use sui_json_rpc_types::SuiSystemStateRpc;
+use sui_json_rpc_types::{SuiCommittee, SuiSystemStateRpc};
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::SuiAddress;
 
 use sui_types::committee::EpochId;
 use sui_types::governance::DelegatedStake;
-use sui_types::messages::CommitteeInfoResponse;
 
 use sui_types::sui_system_state::ValidatorMetadata;
 
@@ -31,7 +30,7 @@ pub trait GovernanceReadApi {
         &self,
         /// The epoch of interest. If None, default to the latest epoch
         epoch: Option<EpochId>,
-    ) -> RpcResult<CommitteeInfoResponse>;
+    ) -> RpcResult<SuiCommittee>;
 
     /// Return latest SUI system state object on-chain.
     #[method(name = "getSuiSystemState")]

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -4,7 +4,7 @@
 use jsonrpsee::core::RpcResult;
 use std::collections::HashMap;
 use std::sync::Arc;
-use sui_json_rpc_types::SuiSystemStateRpc;
+use sui_json_rpc_types::{SuiCommittee, SuiSystemStateRpc};
 
 use crate::api::GovernanceReadApiServer;
 use crate::error::Error;
@@ -16,7 +16,6 @@ use sui_open_rpc::Module;
 use sui_types::base_types::SuiAddress;
 use sui_types::committee::EpochId;
 use sui_types::governance::{DelegatedStake, Delegation, DelegationStatus, StakedSui};
-use sui_types::messages::{CommitteeInfoRequest, CommitteeInfoResponse};
 use sui_types::sui_system_state::{SuiSystemStateTrait, ValidatorMetadata};
 
 pub struct GovernanceReadApi {
@@ -79,10 +78,12 @@ impl GovernanceReadApiServer for GovernanceReadApi {
             .get_validator_metadata_vec())
     }
 
-    async fn get_committee_info(&self, epoch: Option<EpochId>) -> RpcResult<CommitteeInfoResponse> {
+    async fn get_committee_info(&self, epoch: Option<EpochId>) -> RpcResult<SuiCommittee> {
         Ok(self
             .state
-            .handle_committee_info_request(&CommitteeInfoRequest { epoch })
+            .committee_store()
+            .get_or_latest_committee(epoch)
+            .map(|committee| committee.into())
             .map_err(Error::from)?)
     }
 

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -69,15 +69,6 @@ fn main() -> Result<()> {
         )
         .method(
             Method::builder()
-                .name("committee_info")
-                .route_name("CommitteeInfo")
-                .input_type("sui_types::messages::CommitteeInfoRequest")
-                .output_type("sui_types::messages::CommitteeInfoResponse")
-                .codec_path(codec_path)
-                .build(),
-        )
-        .method(
-            Method::builder()
                 .name("get_system_state_object")
                 .route_name("GetSystemStateObject")
                 .input_type("sui_types::messages::SystemStateRequest")

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -794,10 +794,10 @@
         }
       ],
       "result": {
-        "name": "CommitteeInfoResponse",
+        "name": "SuiCommittee",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/CommitteeInfoResponse"
+          "$ref": "#/components/schemas/CommitteeInfo"
         }
       }
     },
@@ -3197,14 +3197,20 @@
           }
         }
       },
-      "CommitteeInfoResponse": {
+      "CommitteeInfo": {
+        "description": "RPC representation of the [Committee] type.",
         "type": "object",
         "required": [
-          "committee_info",
-          "epoch"
+          "epoch",
+          "validators"
         ],
         "properties": {
-          "committee_info": {
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "validators": {
             "type": "array",
             "items": {
               "type": "array",
@@ -3221,11 +3227,6 @@
               "maxItems": 2,
               "minItems": 2
             }
-          },
-          "epoch": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
           }
         }
       },

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -14,9 +14,10 @@ use std::time::{Duration, Instant};
 use sui_json_rpc::api::GovernanceReadApiClient;
 use sui_json_rpc_types::{
     Balance, Checkpoint, CheckpointId, Coin, CoinPage, DryRunTransactionResponse, DynamicFieldPage,
-    EventPage, SuiCoinMetadata, SuiEventEnvelope, SuiEventFilter, SuiMoveNormalizedModule,
-    SuiObjectDataOptions, SuiObjectInfo, SuiObjectResponse, SuiPastObjectResponse,
-    SuiSystemStateRpc, SuiTransactionEffectsAPI, SuiTransactionResponse, TransactionsPage,
+    EventPage, SuiCoinMetadata, SuiCommittee, SuiEventEnvelope, SuiEventFilter,
+    SuiMoveNormalizedModule, SuiObjectDataOptions, SuiObjectInfo, SuiObjectResponse,
+    SuiPastObjectResponse, SuiSystemStateRpc, SuiTransactionEffectsAPI, SuiTransactionResponse,
+    TransactionsPage,
 };
 use sui_types::balance::Supply;
 use sui_types::base_types::{
@@ -25,9 +26,7 @@ use sui_types::base_types::{
 use sui_types::committee::EpochId;
 use sui_types::error::TRANSACTION_NOT_FOUND_MSG_PREFIX;
 use sui_types::event::EventID;
-use sui_types::messages::{
-    CommitteeInfoResponse, ExecuteTransactionRequestType, TransactionData, VerifiedTransaction,
-};
+use sui_types::messages::{ExecuteTransactionRequestType, TransactionData, VerifiedTransaction};
 use sui_types::messages_checkpoint::{CheckpointSequenceNumber, CheckpointSummary};
 use sui_types::query::{EventQuery, TransactionQuery};
 use sui_types::sui_system_state::ValidatorMetadata;
@@ -109,10 +108,7 @@ impl ReadApi {
         Ok(self.api.http.get_transaction(digest).await?)
     }
 
-    pub async fn get_committee_info(
-        &self,
-        epoch: Option<EpochId>,
-    ) -> SuiRpcResult<CommitteeInfoResponse> {
+    pub async fn get_committee_info(&self, epoch: Option<EpochId>) -> SuiRpcResult<SuiCommittee> {
         Ok(self.api.http.get_committee_info(epoch).await?)
     }
 
@@ -492,10 +488,7 @@ impl GovernanceApi {
 
     /// Return the committee information for the asked `epoch`.
     /// `epoch`: The epoch of interest. If None, default to the latest epoch
-    pub async fn get_committee_info(
-        &self,
-        epoch: Option<EpochId>,
-    ) -> SuiRpcResult<CommitteeInfoResponse> {
+    pub async fn get_committee_info(&self, epoch: Option<EpochId>) -> SuiRpcResult<SuiCommittee> {
         Ok(self.api.http.get_committee_info(epoch).await?)
     }
 

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1461,7 +1461,6 @@ mod bcs_signable {
     impl BcsSignable for crate::messages_checkpoint::CheckpointSummary {}
     impl BcsSignable for crate::messages_checkpoint::CheckpointContents {}
 
-    impl BcsSignable for crate::messages::CommitteeInfoResponse {}
     impl BcsSignable for crate::messages::TransactionEffects {}
     impl BcsSignable for crate::messages::TransactionEvents {}
     impl BcsSignable for crate::messages::TransactionData {}

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -4,7 +4,7 @@
 
 use super::{base_types::*, committee::Committee, error::*, event::Event};
 use crate::certificate_proof::CertificateProof;
-use crate::committee::{EpochId, ProtocolVersion, StakeUnit};
+use crate::committee::{EpochId, ProtocolVersion};
 use crate::crypto::{
     sha3_hash, AuthoritySignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo,
     Ed25519SuiSignature, EmptySignInfo, Signature, Signer, SuiSignatureInner, ToFromBytes,
@@ -4022,27 +4022,6 @@ pub struct QuorumDriverRequest {
 pub struct QuorumDriverResponse {
     pub effects_cert: VerifiedCertifiedTransactionEffects,
     pub events: TransactionEvents,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct CommitteeInfoRequest {
-    pub epoch: Option<EpochId>,
-}
-
-#[derive(Serialize, Deserialize, Clone, schemars::JsonSchema, Debug)]
-pub struct CommitteeInfoResponse {
-    pub epoch: EpochId,
-    pub committee_info: Vec<(AuthorityName, StakeUnit)>,
-    // TODO: We could also return the certified checkpoint that contains this committee.
-    // This would allows a client to verify the authenticity of the committee.
-}
-
-pub type CommitteeInfoResponseDigest = [u8; 32];
-
-impl CommitteeInfoResponse {
-    pub fn digest(&self) -> CommitteeInfoResponseDigest {
-        sha3_hash(self)
-    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -149,7 +149,7 @@ export const DelegationStakingPool = object({
 export const CommitteeInfo = object({
   epoch: number(),
   /** Array of (validator public key, stake unit) tuple */
-  committee_info: optional(array(tuple([AuthorityName, number()]))),
+  validators: optional(array(tuple([AuthorityName, number()]))),
 });
 
 export const SystemParameters = object({

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -54,9 +54,9 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       expect(validators.length).greaterThan(0);
     });
 
-    it('test getCommiteeInfo', async () => {
-      const commiteeInfo = await toolbox.provider.getCommitteeInfo(0);
-      expect(commiteeInfo.committee_info?.length).greaterThan(0);
+    it('test getCommitteeInfo', async () => {
+      const committeeInfo = await toolbox.provider.getCommitteeInfo(0);
+      expect(committeeInfo.validators?.length).greaterThan(0);
     });
 
     it('test getSuiSystemState', async () => {


### PR DESCRIPTION
This API is not used and we shouldn't need it.
Also added a json-RPC dedicated type for committee for the sdk to use it.