### PR TITLE
Support display in SuiObjectData

### DIFF
--- a/.changeset/lemon-news-judge.md
+++ b/.changeset/lemon-news-judge.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Add `display` field in `SuiObjectResponse` for frontend rendering. See more details in https://forums.sui.io/t/nft-object-display-proposal/4872

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -522,7 +522,7 @@ impl ValidatorProxy for FullNodeProxy {
         match self
             .sui_client
             .read_api()
-            .get_object_with_options(object_id, Some(SuiObjectDataOptions::bcs_lossless()))
+            .get_object_with_options(object_id, SuiObjectDataOptions::bcs_lossless())
             .await?
         {
             SuiObjectResponse::Exists(sui_object) => sui_object.try_into(),

--- a/crates/sui-cluster-test/src/helper.rs
+++ b/crates/sui-cluster-test/src/helper.rs
@@ -78,12 +78,10 @@ impl ObjectChecker {
             .read_api()
             .get_object_with_options(
                 object_id,
-                Some(SuiObjectDataOptions {
-                    show_type: Some(true),
-                    show_owner: Some(true),
-                    show_bcs: Some(true),
-                    ..Default::default()
-                }),
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_bcs(),
             )
             .await
             .or_else(|err| bail!("Failed to get object info (id: {}), err: {err}", object_id))?;

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -192,12 +192,10 @@ impl SimpleFaucet {
             .read_api()
             .get_object_with_options(
                 coin_id,
-                Some(SuiObjectDataOptions {
-                    show_content: Some(true),
-                    show_owner: Some(true),
-                    show_type: Some(true),
-                    ..Default::default()
-                }),
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_content(),
             )
             .await?;
         Ok(match gas_obj {

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -364,13 +364,6 @@ where
     ) -> RpcResult<CheckpointContents> {
         self.fullnode.get_checkpoint_contents(sequence_number).await
     }
-
-    async fn get_display_deprecated(
-        &self,
-        object_id: ObjectID,
-    ) -> RpcResult<BTreeMap<String, String>> {
-        self.fullnode.get_display_deprecated(object_id).await
-    }
 }
 
 impl<S> SuiRpcModule for ReadApi<S>

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -200,13 +200,4 @@ pub trait ReadApi {
         &self,
         digest: CheckpointContentsDigest,
     ) -> RpcResult<CheckpointContents>;
-
-    // TODO: this will be replaced by the new queryObjects API
-    /// Return the Display string of a object
-    #[method(name = "getDisplayDeprecated")]
-    async fn get_display_deprecated(
-        &self,
-        /// the id of the object
-        object_id: ObjectID,
-    ) -> RpcResult<BTreeMap<String, String>>;
 }

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -66,7 +66,7 @@ impl DataReader for AuthorityStateDataReader {
     async fn get_object_with_options(
         &self,
         object_id: ObjectID,
-        options: Option<SuiObjectDataOptions>,
+        options: SuiObjectDataOptions,
     ) -> Result<SuiObjectResponse, anyhow::Error> {
         let result = self.0.get_object_read(&object_id).await?;
         Ok((result, options).try_into()?)

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -341,10 +341,7 @@ async fn test_get_object_info() -> Result<(), anyhow::Error> {
         let result = http_client
             .get_object_with_options(
                 oref.object_id,
-                Some(SuiObjectDataOptions {
-                    show_owner: Some(true),
-                    ..Default::default()
-                }),
+                Some(SuiObjectDataOptions::new().with_owner()),
             )
             .await?;
         assert!(

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -830,35 +830,6 @@
       }
     },
     {
-      "name": "sui_getDisplayDeprecated",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "description": "Return the Display string of a object",
-      "params": [
-        {
-          "name": "object_id",
-          "description": "the id of the object",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/ObjectID"
-          }
-        }
-      ],
-      "result": {
-        "name": "BTreeMap<String,String>",
-        "required": true,
-        "schema": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    {
       "name": "sui_getDynamicFieldObject",
       "tags": [
         {
@@ -1288,6 +1259,7 @@
                 "showType": true,
                 "showOwner": true,
                 "showPreviousTransaction": true,
+                "showDisplay": false,
                 "showContent": true,
                 "showBcs": false,
                 "showStorageRebate": true
@@ -4870,45 +4842,38 @@
         "properties": {
           "showBcs": {
             "description": "Whether to show the content in BCS format. Default to be False",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "default": false,
+            "type": "boolean"
           },
           "showContent": {
             "description": "Whether to show the content(i.e., package content or Move struct content) of the object. Default to be False",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "default": false,
+            "type": "boolean"
+          },
+          "showDisplay": {
+            "description": "Whether to show the Display metadata of the object for frontend rendering. Default to be False",
+            "default": false,
+            "type": "boolean"
           },
           "showOwner": {
             "description": "Whether to show the owner of the object. Default to be False",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "default": false,
+            "type": "boolean"
           },
           "showPreviousTransaction": {
             "description": "Whether to show the previous transaction digest of the object. Default to be False",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "default": false,
+            "type": "boolean"
           },
           "showStorageRebate": {
             "description": "Whether to show the storage rebate of the object. Default to be False",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "default": false,
+            "type": "boolean"
           },
           "showType": {
             "description": "Whether to show the type of the object. Default to be False",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -4949,6 +4914,16 @@
                 "$ref": "#/components/schemas/ObjectDigest"
               }
             ]
+          },
+          "display": {
+            "description": "The Display metadata for frontend UI rendering, default to be None unless SuiObjectDataOptions.showContent is set to true This can also be None if the struct type does not have Display defined See more details in <https://forums.sui.io/t/nft-object-display-proposal/4872>",
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "objectId": {
             "$ref": "#/components/schemas/ObjectID"

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -230,6 +230,7 @@ impl RpcExampleProvider {
             digest: ObjectDigest::new(self.rng.gen()),
             type_: Some(GasCoin::type_().to_string()),
             bcs: None,
+            display: None,
         });
 
         Examples::new(
@@ -268,6 +269,7 @@ impl RpcExampleProvider {
             digest: ObjectDigest::new(self.rng.gen()),
             type_: Some(GasCoin::type_().to_string()),
             bcs: None,
+            display: None,
         });
 
         Examples::new(

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -648,7 +648,7 @@ async fn get_balance(client: &SuiClient, address: SuiAddress) -> u64 {
         if coin.type_ == GasCoin::type_().to_string() {
             let object = client
                 .read_api()
-                .get_object_with_options(coin.object_id, Some(SuiObjectDataOptions::bcs_only()))
+                .get_object_with_options(coin.object_id, SuiObjectDataOptions::new().with_bcs())
                 .await
                 .unwrap();
             let coin: GasCoin = object

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -243,7 +243,7 @@ impl TicTacToe {
         let current_game = self
             .client
             .read_api()
-            .get_object_with_options(game_id, Some(SuiObjectDataOptions::bcs_only()))
+            .get_object_with_options(game_id, SuiObjectDataOptions::new().with_bcs())
             .await?;
         current_game
             .object()?

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -81,12 +81,12 @@ impl ReadApi {
     pub async fn get_object_with_options(
         &self,
         object_id: ObjectID,
-        options: Option<SuiObjectDataOptions>,
+        options: SuiObjectDataOptions,
     ) -> SuiRpcResult<SuiObjectResponse> {
         Ok(self
             .api
             .http
-            .get_object_with_options(object_id, options)
+            .get_object_with_options(object_id, Some(options))
             .await?)
     }
 

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -272,7 +272,7 @@ impl DataReader for ReadApi {
     async fn get_object_with_options(
         &self,
         object_id: ObjectID,
-        options: Option<SuiObjectDataOptions>,
+        options: SuiObjectDataOptions,
     ) -> Result<SuiObjectResponse, anyhow::Error> {
         Ok(self.get_object_with_options(object_id, options).await?)
     }

--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -236,7 +236,7 @@ impl<'a> BytecodeSourceVerifier<'a> {
         // batched object fetching should be added to the ReadApi & used here
         let obj_read = self
             .rpc_client
-            .get_object_with_options(obj_id, Some(SuiObjectDataOptions::bcs_only()))
+            .get_object_with_options(obj_id, SuiObjectDataOptions::new().with_bcs())
             .await
             .map_err(SourceVerificationError::DependencyObjectReadFailure)?;
 

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -52,7 +52,7 @@ pub trait DataReader {
     async fn get_object_with_options(
         &self,
         object_id: ObjectID,
-        options: Option<SuiObjectDataOptions>,
+        options: SuiObjectDataOptions,
     ) -> Result<SuiObjectResponse, anyhow::Error>;
 
     async fn get_reference_gas_price(&self) -> Result<u64, anyhow::Error>;
@@ -89,7 +89,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             for obj in gas_objs {
                 let response = self
                     .0
-                    .get_object_with_options(obj.object_id, Some(SuiObjectDataOptions::bcs_only()))
+                    .get_object_with_options(obj.object_id, SuiObjectDataOptions::new().with_bcs())
                     .await?;
                 let obj = response.object()?;
                 let gas: GasCoin = bcs::from_bytes(
@@ -335,7 +335,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
     ) -> Result<ObjectArg, anyhow::Error> {
         let response = self
             .0
-            .get_object_with_options(id, Some(SuiObjectDataOptions::bcs_lossless()))
+            .get_object_with_options(id, SuiObjectDataOptions::bcs_lossless())
             .await?;
 
         let obj: Object = response.into_object()?.try_into()?;
@@ -367,7 +367,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
     ) -> Result<Vec<CallArg>, anyhow::Error> {
         let object = self
             .0
-            .get_object_with_options(package_id, Some(SuiObjectDataOptions::bcs_lossless()))
+            .get_object_with_options(package_id, SuiObjectDataOptions::bcs_lossless())
             .await?
             .into_object()?;
         let package = object
@@ -454,7 +454,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
     ) -> anyhow::Result<TransactionData> {
         let coin = self
             .0
-            .get_object_with_options(coin_object_id, Some(SuiObjectDataOptions::bcs_lossless()))
+            .get_object_with_options(coin_object_id, SuiObjectDataOptions::bcs_lossless())
             .await?
             .into_object()?;
         let coin_object_ref = coin.object_ref();
@@ -492,7 +492,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
     ) -> anyhow::Result<TransactionData> {
         let coin = self
             .0
-            .get_object_with_options(coin_object_id, Some(SuiObjectDataOptions::bcs_lossless()))
+            .get_object_with_options(coin_object_id, SuiObjectDataOptions::bcs_lossless())
             .await?
             .into_object()?;
         let coin_object_ref = coin.object_ref();
@@ -530,7 +530,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
     ) -> anyhow::Result<TransactionData> {
         let coin = self
             .0
-            .get_object_with_options(primary_coin, Some(SuiObjectDataOptions::bcs_lossless()))
+            .get_object_with_options(primary_coin, SuiObjectDataOptions::bcs_lossless())
             .await?
             .into_object()?;
         let primary_coin_ref = coin.object_ref();
@@ -740,13 +740,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
     ) -> anyhow::Result<(ObjectRef, ObjectType)> {
         let object = self
             .0
-            .get_object_with_options(
-                object_id,
-                Some(SuiObjectDataOptions {
-                    show_type: Some(true),
-                    ..Default::default()
-                }),
-            )
+            .get_object_with_options(object_id, SuiObjectDataOptions::new().with_type())
             .await?
             .into_object()?;
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -534,13 +534,13 @@ impl SuiClientCommands {
                 if !bcs {
                     let object_read = client
                         .read_api()
-                        .get_object_with_options(id, Some(SuiObjectDataOptions::full_content()))
+                        .get_object_with_options(id, SuiObjectDataOptions::full_content())
                         .await?;
                     SuiClientCommandResult::Object(object_read)
                 } else {
                     let raw_object_read = client
                         .read_api()
-                        .get_object_with_options(id, Some(SuiObjectDataOptions::bcs_lossless()))
+                        .get_object_with_options(id, SuiObjectDataOptions::bcs_lossless())
                         .await?;
                     SuiClientCommandResult::RawObject(raw_object_read)
                 }
@@ -934,7 +934,7 @@ impl SuiClientCommands {
                 let client = context.get_client().await?;
                 let object_read = client
                     .read_api()
-                    .get_object_with_options(nft_id, Some(SuiObjectDataOptions::full_content()))
+                    .get_object_with_options(nft_id, SuiObjectDataOptions::full_content())
                     .await?;
                 SuiClientCommandResult::CreateExampleNFT(object_read)
             }
@@ -1130,7 +1130,7 @@ impl WalletContext {
         let client = self.get_client().await?;
         Ok(client
             .read_api()
-            .get_object_with_options(object_id, None)
+            .get_object_with_options(object_id, SuiObjectDataOptions::new())
             .await?
             .into_object()?
             .object_ref())
@@ -1153,7 +1153,7 @@ impl WalletContext {
         for oref in object_refs {
             let response = client
                 .read_api()
-                .get_object_with_options(oref.object_id, Some(SuiObjectDataOptions::full_content()))
+                .get_object_with_options(oref.object_id, SuiObjectDataOptions::full_content())
                 .await?;
             match response {
                 SuiObjectResponse::Exists(o) => {
@@ -1174,13 +1174,7 @@ impl WalletContext {
         let client = self.get_client().await?;
         let object = client
             .read_api()
-            .get_object_with_options(
-                *id,
-                Some(SuiObjectDataOptions {
-                    show_owner: Some(true),
-                    ..Default::default()
-                }),
-            )
+            .get_object_with_options(*id, SuiObjectDataOptions::new().with_owner())
             .await?
             .into_object()?;
         Ok(object

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -855,7 +855,7 @@ async fn get_object(id: ObjectID, context: &WalletContext) -> Option<SuiObjectDa
     let client = context.get_client().await.unwrap();
     let response = client
         .read_api()
-        .get_object_with_options(id, Some(SuiObjectDataOptions::full_content()))
+        .get_object_with_options(id, SuiObjectDataOptions::full_content())
         .await
         .unwrap();
     if let SuiObjectResponse::Exists(o) = response {

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -8,7 +8,6 @@ import {
   boolean,
   Infer,
   literal,
-  map,
   number,
   object,
   optional,
@@ -94,7 +93,7 @@ export type SuiRawMoveObject = Infer<typeof SuiRawMoveObject>;
 export const SuiRawMovePackage = object({
   id: ObjectId,
   /** A mapping from module name to Move bytecode enocded in base64*/
-  moduleMap: map(string(), string()),
+  moduleMap: record(string(), string()),
 });
 export type SuiRawMovePackage = Infer<typeof SuiRawMovePackage>;
 
@@ -142,6 +141,12 @@ export const SuiObjectData = object({
    * Default to be undefined unless SuiObjectDataOptions.showStorageRebate is set to true
    */
   storageRebate: optional(number()),
+  /**
+   * Display metadata for this object, default to be undefined unless SuiObjectDataOptions.showDisplay is set to true
+   * This can also be None if the struct type does not have Display defined
+   * See more details in https://forums.sui.io/t/nft-object-display-proposal/4872
+   */
+  display: optional(record(string(), string())),
 });
 export type SuiObjectData = Infer<typeof SuiObjectData>;
 
@@ -161,6 +166,8 @@ export const SuiObjectDataOptions = object({
   showPreviousTransaction: optional(boolean()),
   /* Whether to fetch the storage rebate, default to be false */
   showStorageRebate: optional(boolean()),
+  /* Whether to fetch the display metadata, default to be false */
+  showDisplay: optional(boolean()),
 });
 export type SuiObjectDataOptions = Infer<typeof SuiObjectDataOptions>;
 
@@ -271,6 +278,12 @@ export function getObjectOwner(
   resp: SuiObjectResponse,
 ): ObjectOwner | undefined {
   return getSuiObjectData(resp)?.owner;
+}
+
+export function getObjectDisplay(
+  resp: SuiObjectResponse,
+): Record<string, string> | undefined {
+  return getSuiObjectData(resp)?.display;
 }
 
 export function getSharedObjectInitialVersion(

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { LocalTxnDataSerializer, ObjectId, RawSigner } from '../../src';
+import {
+  LocalTxnDataSerializer,
+  ObjectId,
+  RawSigner,
+  getObjectDisplay,
+} from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test Object Display Standard', () => {
@@ -21,16 +26,16 @@ describe('Test Object Display Standard', () => {
     packageId = await publishPackage(signer, true, packagePath);
   });
 
-  it('Test getting Display Object', async () => {
+  it('Test getting Display fields', async () => {
     const boarId = (
       await toolbox.provider.getObjectsOwnedByAddress(
         toolbox.address(),
         `${packageId}::boars::Boar`,
       )
     )[0].objectId;
-    const display = await toolbox.provider.call('sui_getDisplayDeprecated', [
-      boarId,
-    ]);
+    const display = getObjectDisplay(
+      await toolbox.provider.getObject(boarId, { showDisplay: true }),
+    );
     expect(display).toEqual({
       age: '10',
       buyer: `0x${toolbox.address()}`,
@@ -43,5 +48,15 @@ describe('Test Object Display Standard', () => {
       full_url: 'https://get-a-boar.fullurl.com/',
       escape_syntax: '{name}',
     });
+  });
+
+  it('Test getting Display fields for object that has no display object', async () => {
+    const coinId = (
+      await toolbox.provider.getGasObjectsOwnedByAddress(toolbox.address())
+    )[0].objectId;
+    const display = getObjectDisplay(
+      await toolbox.provider.getObject(coinId, { showDisplay: true }),
+    );
+    expect(display).toEqual(undefined);
   });
 });

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -83,7 +83,6 @@ export async function publishPackage(
   tmp.setGracefulCleanup();
 
   const tmpobj = tmp.dirSync({ unsafeCleanup: true });
-  console.log('Dir: ', tmpobj.name);
 
   const compiledModules = JSON.parse(
     execSync(


### PR DESCRIPTION
## Description 

- Add `display` field in `SuiObjectResponse`
- Simplify the `SuiObjectDataOptions` logic

Example request
```
curl --location --request POST 'http://127.0.0.1:9000' \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc":"2.0",
    "id":1,
    "method":"sui_getObject",
    "params":["0xea55a257f903378574f6fd1cd1c58031c8bb652b1e29c4a11b2b24bddb53675e", {"showDisplay": true}]
}'
```
response
```
{
    "jsonrpc": "2.0",
    "result": {
        "status": "Exists",
        "details": {
            "objectId": "0xea55a257f903378574f6fd1cd1c58031c8bb652b1e29c4a11b2b24bddb53675e",
            "version": 3,
            "digest": "3MvgrCe5MGYEXsL7byB2HmHasE3FiN5se1sQfyycqZi2",
            "display": {
                "age": "10",
                "buyer": "0xbac5b67c7f35ee9006054976b2926c335eedbda97ef3a4f3ff8676e4f2f8d975",
                "creator": "Chris",
                "description": "Unique Boar from the Boars collection with First Boar and 0xea55a257f903378574f6fd1cd1c58031c8bb652b1e29c4a11b2b24bddb53675e",
                "escape_syntax": "{name}",
                "full_url": "https://get-a-boar.fullurl.com/",
                "img_url": "https://get-a-boar.com/first.png",
                "name": "First Boar",
                "price": "",
                "project_url": "https://get-a-boar.com/"
            }
        }
    },
    "id": 1
}

```

## Test Plan 

Rust test + TS e2e tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
[RPC] Add `display` field in `SuiObjectResponse` for frontend rendering. See more details in https://forums.sui.io/t/nft-object-display-proposal/4872