### PR TITLE
Deduplicate input objects from `TransactionKind`

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -11,6 +11,7 @@ use once_cell::sync::OnceCell;
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::collections::BTreeSet;
 use std::iter;
 use std::path::Path;
 use std::sync::Arc;
@@ -364,7 +365,7 @@ impl AuthorityStore {
         digest: &TransactionDigest,
         objects: &[InputObjectKind],
         epoch_store: &AuthorityPerEpochStore,
-    ) -> Vec<InputKey> {
+    ) -> BTreeSet<InputKey> {
         let mut shared_locks = HashMap::<ObjectID, SequenceNumber>::new();
         objects
             .iter()

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -14,7 +14,7 @@ use sui_types::{
 };
 use sui_types::{base_types::TransactionDigest, error::SuiResult};
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use crate::authority::{
     authority_per_epoch_store::AuthorityPerEpochStore, authority_store::InputKey,
@@ -138,6 +138,9 @@ impl TransactionManager {
                 &input_object_kinds,
                 epoch_store,
             );
+            if input_object_kinds.len() != input_object_keys.len() {
+                error!("Duplicated input objects: {:?}", input_object_kinds);
+            }
             pending.push(PendingCertificate {
                 certificate: cert,
                 missing: input_object_keys

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1239,12 +1239,14 @@ impl TransactionKind {
     }
 
     pub fn input_objects(&self) -> UserInputResult<Vec<InputObjectKind>> {
+        let mut seen = BTreeSet::new();
         let inputs: Vec<_> = self
             .single_transactions()
             .map(|s| s.input_objects())
             .collect::<UserInputResult<Vec<_>>>()?
             .into_iter()
             .flatten()
+            .filter(|kind| seen.insert(*kind))
             .collect();
         Ok(inputs)
     }


### PR DESCRIPTION
## Description 

The list of input objects from a `TransactionKind` is used (directly or directly) in number of places including checking locks, load shedding, execution scheduling etc. It is better to avoid duplicates in them.

Also, log an error instead of crashing if duplicates are found among input objects.

## Test Plan 

existing unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
