### PR TITLE
[docs] Update move-analyzer install instructions

### DIFF
--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -277,7 +277,7 @@ Use the `--help` flag to access helpful information for any of these binaries.
 
 ## Integrated development environment
 
-The recommended IDE for Move development is [Visual Studio Code](https://code.visualstudio.com/) with the move-analyzer extension. Follow the Visual Studio Marketplace instructions to install the [move-analyzer extension](https://marketplace.visualstudio.com/items?itemName=move.move-analyzer), then install the move-analyzer language server passing `address20` using the `--features` flag:
+The recommended IDE for Move development is [Visual Studio Code](https://code.visualstudio.com/) with the move-analyzer extension. Follow the Visual Studio Marketplace instructions to install the [move-analyzer extension](https://marketplace.visualstudio.com/items?itemName=move.move-analyzer), then install the move-analyzer language server passing `address20` using the `--features` flag and passing `sui-move` to the `branch` flag:
 
 ```shell
 cargo install --git https://github.com/move-language/move move-analyzer --branch sui-move --features "address32"

--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -280,7 +280,7 @@ Use the `--help` flag to access helpful information for any of these binaries.
 The recommended IDE for Move development is [Visual Studio Code](https://code.visualstudio.com/) with the move-analyzer extension. Follow the Visual Studio Marketplace instructions to install the [move-analyzer extension](https://marketplace.visualstudio.com/items?itemName=move.move-analyzer), then install the move-analyzer language server passing `address20` using the `--features` flag:
 
 ```shell
-cargo install --git https://github.com/move-language/move move-analyzer --features "address32"
+cargo install --git https://github.com/move-language/move move-analyzer --branch sui-move --features "address32"
 ```
 
 See more [IDE options](https://github.com/MystenLabs/awesome-move#ides) in the [Awesome Move](https://github.com/MystenLabs/awesome-move) documentation.

--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -280,7 +280,7 @@ Use the `--help` flag to access helpful information for any of these binaries.
 The recommended IDE for Move development is [Visual Studio Code](https://code.visualstudio.com/) with the move-analyzer extension. Follow the Visual Studio Marketplace instructions to install the [move-analyzer extension](https://marketplace.visualstudio.com/items?itemName=move.move-analyzer), then install the move-analyzer language server passing `address20` using the `--features` flag:
 
 ```shell
-cargo install --git https://github.com/move-language/move move-analyzer --features "address20"
+cargo install --git https://github.com/move-language/move move-analyzer --features "address32"
 ```
 
 See more [IDE options](https://github.com/MystenLabs/awesome-move#ides) in the [Awesome Move](https://github.com/MystenLabs/awesome-move) documentation.


### PR DESCRIPTION
## Description 

We recently changed the size of addresses used by Sui to be 32B instead of 20B and move-analyzer installation instructions need to be updated to reflect this.

## Test Plan 

Tested locally to confirm that the new install makes the address-related IDE errors go away.

