### PR TITLE
Add options to try_get_past_object

### DIFF
--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -309,8 +309,11 @@ where
         &self,
         object_id: ObjectID,
         version: SequenceNumber,
+        options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<SuiPastObjectResponse> {
-        self.fullnode.try_get_past_object(object_id, version).await
+        self.fullnode
+            .try_get_past_object(object_id, version, options)
+            .await
     }
 
     async fn get_latest_checkpoint_sequence_number(&self) -> RpcResult<CheckpointSequenceNumber> {

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -7,8 +7,8 @@ use mysten_metrics::spawn_monitored_task;
 use prometheus::Registry;
 use std::collections::BTreeMap;
 use sui_json_rpc_types::{
-    SuiObjectData, SuiParsedData, SuiTransactionDataAPI, SuiTransactionEffectsAPI,
-    SuiTransactionResponse,
+    SuiObjectData, SuiObjectDataOptions, SuiParsedData, SuiTransactionDataAPI,
+    SuiTransactionEffectsAPI, SuiTransactionResponse,
 };
 use sui_sdk::SuiClient;
 use tokio::task::JoinHandle;
@@ -150,9 +150,11 @@ where
         // TODO: Use multi get objects
         // TODO: Error handling.
         let new_objects = join_all(all_mutated.map(|(id, version)| {
-            self.rpc_client
-                .read_api()
-                .try_get_parsed_past_object(id, version)
+            self.rpc_client.read_api().try_get_parsed_past_object(
+                id,
+                version,
+                SuiObjectDataOptions::full_content(),
+            )
         }))
         .await
         .into_iter()

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -26,9 +26,7 @@ use sui_types::error::{UserInputError, UserInputResult};
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::MoveModulePublish;
 use sui_types::move_package::{disassemble_modules, MovePackage};
-use sui_types::object::{
-    Data, MoveObject, Object, ObjectFormatOptions, ObjectRead, Owner, PastObjectRead,
-};
+use sui_types::object::{Data, MoveObject, Object, ObjectFormatOptions, ObjectRead, Owner};
 use sui_types::parse_sui_struct_tag;
 
 use crate::{SuiMoveStruct, SuiMoveValue};
@@ -817,30 +815,6 @@ impl SuiPastObjectResponse {
                 asked_version,
                 latest_version,
             } => Err(UserInputError::ObjectSequenceNumberTooHigh {
-                object_id,
-                asked_version,
-                latest_version,
-            }),
-        }
-    }
-}
-
-impl TryFrom<PastObjectRead> for SuiPastObjectResponse {
-    type Error = anyhow::Error;
-
-    fn try_from(value: PastObjectRead) -> Result<Self, Self::Error> {
-        match value {
-            PastObjectRead::ObjectNotExists(id) => Ok(Self::ObjectNotExists(id)),
-            PastObjectRead::VersionFound(object_ref, o, layout) => Ok(Self::VersionFound(
-                (object_ref, o, layout, SuiObjectDataOptions::full_content()).try_into()?,
-            )),
-            PastObjectRead::ObjectDeleted(oref) => Ok(Self::ObjectDeleted(oref.into())),
-            PastObjectRead::VersionNotFound(id, seq_num) => Ok(Self::VersionNotFound(id, seq_num)),
-            PastObjectRead::VersionTooHigh {
-                object_id,
-                asked_version,
-                latest_version,
-            } => Ok(Self::VersionTooHigh {
                 object_id,
                 asked_version,
                 latest_version,

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -159,6 +159,8 @@ pub trait ReadApi {
         object_id: ObjectID,
         /// the version of the queried object. If None, default to the latest known version
         version: SequenceNumber,
+        /// options for specifying the content to be returned
+        options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<SuiPastObjectResponse>;
 
     /// Return the sequence number of the latest checkpoint that has been executed

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2827,6 +2827,13 @@
           "schema": {
             "$ref": "#/components/schemas/SequenceNumber"
           }
+        },
+        {
+          "name": "options",
+          "description": "options for specifying the content to be returned",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectContentOptions"
+          }
         }
       ],
       "result": {
@@ -2847,6 +2854,18 @@
             {
               "name": "version",
               "value": 4
+            },
+            {
+              "name": "options",
+              "value": {
+                "showType": true,
+                "showOwner": true,
+                "showPreviousTransaction": true,
+                "showDisplay": false,
+                "showContent": true,
+                "showBcs": false,
+                "showStorageRebate": true
+              }
             }
           ],
           "result": {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -276,7 +276,11 @@ impl RpcExampleProvider {
             "sui_tryGetPastObject",
             vec![ExamplePairing::new(
                 "Get Past Object data",
-                vec![("object_id", json!(object_id)), ("version", json!(4))],
+                vec![
+                    ("object_id", json!(object_id)),
+                    ("version", json!(4)),
+                    ("options", json!(SuiObjectDataOptions::full_content())),
+                ],
                 json!(result),
             )],
         )

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -69,11 +69,12 @@ impl ReadApi {
         &self,
         object_id: ObjectID,
         version: SequenceNumber,
+        options: SuiObjectDataOptions,
     ) -> SuiRpcResult<SuiPastObjectResponse> {
         Ok(self
             .api
             .http
-            .try_get_past_object(object_id, version)
+            .try_get_past_object(object_id, version, Some(options))
             .await?)
     }
 


### PR DESCRIPTION
## Description 

Add SuiObjectDataOptions to `try_get_past_object`

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Add SuiObjectDataOptions to try_get_past_object