### PR TITLE
indexer: Add move call table and txn query via move call

### DIFF
--- a/crates/sui-indexer/migrations/2023-03-05-165748_move_calls/down.sql
+++ b/crates/sui-indexer/migrations/2023-03-05-165748_move_calls/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE move_calls;

--- a/crates/sui-indexer/migrations/2023-03-05-165748_move_calls/up.sql
+++ b/crates/sui-indexer/migrations/2023-03-05-165748_move_calls/up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE move_calls (
+    id BIGSERIAL PRIMARY KEY,
+    transaction_digest VARCHAR(255) NOT NULL,
+    checkpoint_sequence_number BIGINT NOT NULL,
+    epoch BIGINT NOT NULL,
+    sender TEXT NOT NULL,
+    move_package TEXT NOT NULL,
+    move_module TEXT NOT NULL,
+    move_function TEXT NOT NULL
+);
+
+CREATE INDEX move_calls_transaction_digest ON move_calls (transaction_digest);
+CREATE INDEX move_calls_checkpoint_sequence_number ON move_calls (checkpoint_sequence_number);
+CREATE INDEX move_calls_epoch ON move_calls (epoch);
+CREATE INDEX move_calls_sender ON move_calls (sender);
+CREATE INDEX move_calls_move_package ON move_calls (move_package);
+CREATE INDEX move_calls_move_module ON move_calls (move_module);
+CREATE INDEX move_calls_move_function ON move_calls (move_function);

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -65,23 +65,32 @@ impl<S: IndexerStore> ReadApi<S> {
         descending_order: Option<bool>,
     ) -> RpcResult<TransactionsPage> {
         let limit = cap_page_limit(limit);
-        let indexer_seq_number = self.state.get_transaction_sequence_by_digest(
-            cursor.map(|digest| digest.to_string()),
-            descending_order.unwrap_or_default(),
-        )?;
+        let reverse = descending_order.unwrap_or_default();
+        let indexer_seq_number = self
+            .state
+            .get_transaction_sequence_by_digest(cursor.map(|digest| digest.to_string()), reverse)?;
+        let move_call_seq_number = self
+            .state
+            .get_move_call_sequence_by_digest(cursor.map(|digest| digest.to_string()), reverse)?;
 
         let digests_from_db = match query {
-            TransactionQuery::All => self.state.get_all_transaction_digest_page(
-                indexer_seq_number,
-                limit,
-                descending_order.unwrap_or_default(),
-            ),
+            TransactionQuery::All => {
+                self.state
+                    .get_all_transaction_digest_page(indexer_seq_number, limit, reverse)
+            }
             // TODO(gegaowp): implement Move call query handling.
             TransactionQuery::MoveFunction {
-                package: _,
-                module: _,
-                function: _,
-            } => Ok(vec![]),
+                package,
+                module,
+                function,
+            } => self.state.get_transaction_digest_page_by_move_call(
+                package.to_string(),
+                module,
+                function,
+                move_call_seq_number,
+                limit,
+                reverse,
+            ),
             // TODO(gegaowp): input objects are tricky to retrive from
             // SuiTransactionResponse, instead we should store the BCS
             // serialized transaction and retrive from there.
@@ -92,7 +101,7 @@ impl<S: IndexerStore> ReadApi<S> {
                     mutated_obj_id.to_string(),
                     indexer_seq_number,
                     limit + 1,
-                    descending_order.unwrap_or_default(),
+                    reverse,
                 )
             }
             TransactionQuery::FromAddress(sender_address) => {
@@ -100,7 +109,7 @@ impl<S: IndexerStore> ReadApi<S> {
                     sender_address.to_string(),
                     indexer_seq_number,
                     limit + 1,
-                    descending_order.unwrap_or_default(),
+                    reverse,
                 )
             }
             TransactionQuery::ToAddress(recipient_address) => {
@@ -108,7 +117,7 @@ impl<S: IndexerStore> ReadApi<S> {
                     recipient_address.to_string(),
                     indexer_seq_number,
                     limit + 1,
-                    descending_order.unwrap_or_default(),
+                    reverse,
                 )
             }
         }?;

--- a/crates/sui-indexer/src/models/mod.rs
+++ b/crates/sui-indexer/src/models/mod.rs
@@ -5,6 +5,7 @@ pub mod addresses;
 pub mod checkpoints;
 pub mod error_logs;
 pub mod events;
+pub mod move_calls;
 pub mod objects;
 pub mod owners;
 pub mod packages;

--- a/crates/sui-indexer/src/models/move_calls.rs
+++ b/crates/sui-indexer/src/models/move_calls.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::schema::move_calls;
+use diesel::prelude::*;
+
+#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[diesel(table_name = move_calls)]
+pub struct MoveCall {
+    pub id: Option<i64>,
+    pub transaction_digest: String,
+    pub checkpoint_sequence_number: i64,
+    pub epoch: i64,
+    pub sender: String,
+    pub move_package: String,
+    pub move_module: String,
+    pub move_function: String,
+}

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -64,6 +64,19 @@ diesel::table! {
 }
 
 diesel::table! {
+    move_calls (id) {
+        id -> Int8,
+        transaction_digest -> Varchar,
+        checkpoint_sequence_number -> Int8,
+        epoch -> Int8,
+        sender -> Text,
+        move_package -> Text,
+        move_module -> Text,
+        move_function -> Text,
+    }
+}
+
+diesel::table! {
     object_logs (last_processed_id) {
         last_processed_id -> Int8,
     }
@@ -173,6 +186,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     checkpoints,
     error_logs,
     events,
+    move_calls,
     object_logs,
     objects,
     owner_changes,

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -5,6 +5,7 @@ use crate::errors::IndexerError;
 use crate::models::addresses::Address;
 use crate::models::checkpoints::Checkpoint;
 use crate::models::events::Event;
+use crate::models::move_calls::MoveCall;
 use crate::models::objects::Object;
 use crate::models::owners::OwnerChange;
 use crate::models::packages::Package;
@@ -25,20 +26,21 @@ pub trait IndexerStore {
     // based on observations, thus `get_total_transaction_number` and
     // `get_latest_transaction_sequence_number` are not always equal.
     fn get_latest_transaction_sequence_number(&self) -> Result<i64, IndexerError>;
+    fn get_latest_move_call_sequence_number(&self) -> Result<i64, IndexerError>;
 
     // TODO: combine all get_transaction* methods
     fn get_transaction_by_digest(&self, txn_digest: String) -> Result<Transaction, IndexerError>;
     fn get_transaction_sequence_by_digest(
         &self,
         txn_digest: Option<String>,
-        reverse: bool,
+        is_descending: bool,
     ) -> Result<i64, IndexerError>;
 
     fn get_all_transaction_digest_page(
         &self,
         start_sequence: i64,
         limit: usize,
-        reverse: bool,
+        is_descending: bool,
     ) -> Result<Vec<String>, IndexerError>;
 
     fn get_transaction_digest_page_by_mutated_object(
@@ -46,7 +48,7 @@ pub trait IndexerStore {
         object_id: String,
         start_sequence: i64,
         limit: usize,
-        reverse: bool,
+        is_descending: bool,
     ) -> Result<Vec<String>, IndexerError>;
 
     fn get_transaction_digest_page_by_sender_address(
@@ -54,7 +56,7 @@ pub trait IndexerStore {
         sender_address: String,
         start_sequence: i64,
         limit: usize,
-        reverse: bool,
+        is_descending: bool,
     ) -> Result<Vec<String>, IndexerError>;
 
     fn get_transaction_digest_page_by_recipient_address(
@@ -62,8 +64,24 @@ pub trait IndexerStore {
         recipient_address: String,
         start_sequence: i64,
         limit: usize,
-        reverse: bool,
+        is_descending: bool,
     ) -> Result<Vec<String>, IndexerError>;
+
+    fn get_transaction_digest_page_by_move_call(
+        &self,
+        package: String,
+        module: Option<String>,
+        function: Option<String>,
+        start_sequence: i64,
+        limit: usize,
+        is_descending: bool,
+    ) -> Result<Vec<String>, IndexerError>;
+
+    fn get_move_call_sequence_by_digest(
+        &self,
+        txn_digest: Option<String>,
+        is_descending: bool,
+    ) -> Result<i64, IndexerError>;
 
     fn read_transactions(
         &self,
@@ -92,6 +110,7 @@ pub struct TemporaryCheckpointStore {
     pub owner_changes: Vec<OwnerChange>,
     pub addresses: Vec<Address>,
     pub packages: Vec<Package>,
+    pub move_calls: Vec<MoveCall>,
 }
 
 // Per epoch indexing

--- a/crates/sui-indexer/tests/indexer_tests.rs
+++ b/crates/sui-indexer/tests/indexer_tests.rs
@@ -81,6 +81,10 @@ impl IndexerStore for InMemoryIndexerStore {
         todo!()
     }
 
+    fn get_latest_move_call_sequence_number(&self) -> Result<i64, IndexerError> {
+        todo!()
+    }
+
     fn get_latest_transaction_sequence_number(&self) -> Result<i64, IndexerError> {
         todo!()
     }
@@ -92,7 +96,15 @@ impl IndexerStore for InMemoryIndexerStore {
     fn get_transaction_sequence_by_digest(
         &self,
         _txn_digest: Option<String>,
-        _reverse: bool,
+        _is_descending: bool,
+    ) -> Result<i64, IndexerError> {
+        todo!()
+    }
+
+    fn get_move_call_sequence_by_digest(
+        &self,
+        _txn_digest: Option<String>,
+        _is_descending: bool,
     ) -> Result<i64, IndexerError> {
         todo!()
     }
@@ -101,7 +113,7 @@ impl IndexerStore for InMemoryIndexerStore {
         &self,
         _start_sequence: i64,
         _limit: usize,
-        _reverse: bool,
+        _is_descending: bool,
     ) -> Result<Vec<String>, IndexerError> {
         todo!()
     }
@@ -111,7 +123,7 @@ impl IndexerStore for InMemoryIndexerStore {
         _object_id: String,
         _start_sequence: i64,
         _limit: usize,
-        _reverse: bool,
+        _is_descending: bool,
     ) -> Result<Vec<String>, IndexerError> {
         todo!()
     }
@@ -121,7 +133,19 @@ impl IndexerStore for InMemoryIndexerStore {
         _sender_address: String,
         _start_sequence: i64,
         _limit: usize,
-        _reverse: bool,
+        _is_descending: bool,
+    ) -> Result<Vec<String>, IndexerError> {
+        todo!()
+    }
+
+    fn get_transaction_digest_page_by_move_call(
+        &self,
+        _package: String,
+        _module: Option<String>,
+        _function: Option<String>,
+        _start_sequence: i64,
+        _limit: usize,
+        _is_descending: bool,
     ) -> Result<Vec<String>, IndexerError> {
         todo!()
     }
@@ -131,7 +155,7 @@ impl IndexerStore for InMemoryIndexerStore {
         _recipient_address: String,
         _start_sequence: i64,
         _limit: usize,
-        _reverse: bool,
+        _is_descending: bool,
     ) -> Result<Vec<String>, IndexerError> {
         todo!()
     }


### PR DESCRIPTION
## Description 

- add move_calls table, b/c in one txn, it might include multiple txn kinds, thus multiple move_calls; as a result 1) searching txn digest via move_call before this PR can only be done via search an element in move_calls array in a txn, which is very inefficient 2) even worse, PG index has length limit, if a txn calls many move calls, the column of move_calls array cannot be indexed
- support txn query via move call

## Test Plan 

- make sure move call table can be populated with NFT mint move calls

![Screenshot 2023-03-05 at 3 29 57 PM](https://user-images.githubusercontent.com/106119108/222984274-2be434f3-2497-41a5-b2f4-e022fe4d9f0e.png)

- verify that move call query results from FN and indexer are the same
```
curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{ "jsonrpc":"2.0", "id":1, "method":"sui_getTransactions", "params":[  {"MoveFunction": ["0x0000000000000000000000000000000000000000000000000000000000000002", "devnet_nft", "mint"] } , null, null, null]}'
{"jsonrpc":"2.0","result":{"data":["2igWgvpw3QZdPY3mMQMpuTuBiixMxGbVotmDKv4jkyPc","97aqRvMwFCthkAiFGZ7BfbjfvZPqUFK7BXSZK3Nu4aAS","Fp21PTZBEv9tvo3C5uQQo8y1Q5wqQakoqgRcRJnc8kpe","9XGsdfT515F9AYahUwoekW4k49uuMaimuG8FME3rVi7r","9WJy8bpefKAELkWjfFQsnvmaqvwqyJG4NDom7B9VuCAs","9uySVSf53UwF1SuS3BxRn2Zw1YJsFMy6r4NUWAtNn9gs","Cc92aAV2uJ9tSnXnFUwg6iLKaZAckpTbSyHRw2HL8yQu","ADPW5bsSfTgZS2NYMWXYNpmR1BSr1XLQQiLwj7nQmrae","8BA2A1hx4sQNEbkfKBsTnTLNvNjYuvmnR8Tz8arTKBgV"],"nextCursor":null},"id":1}%

curl --location --request POST http://127.0.0.1:9000 \
--header 'Content-Type: application/json' \
--data-raw '{ "jsonrpc":"2.0", "id":1, "method":"sui_getTransactions", "params":[  {"MoveFunction": ["0x0000000000000000000000000000000000000000000000000000000000000002", "devnet_nft", "mint"] } , null, null, null]}'
{"jsonrpc":"2.0","result":{"data":["2igWgvpw3QZdPY3mMQMpuTuBiixMxGbVotmDKv4jkyPc","97aqRvMwFCthkAiFGZ7BfbjfvZPqUFK7BXSZK3Nu4aAS","Fp21PTZBEv9tvo3C5uQQo8y1Q5wqQakoqgRcRJnc8kpe","9XGsdfT515F9AYahUwoekW4k49uuMaimuG8FME3rVi7r","9WJy8bpefKAELkWjfFQsnvmaqvwqyJG4NDom7B9VuCAs","9uySVSf53UwF1SuS3BxRn2Zw1YJsFMy6r4NUWAtNn9gs","Cc92aAV2uJ9tSnXnFUwg6iLKaZAckpTbSyHRw2HL8yQu","ADPW5bsSfTgZS2NYMWXYNpmR1BSr1XLQQiLwj7nQmrae","8BA2A1hx4sQNEbkfKBsTnTLNvNjYuvmnR8Tz8arTKBgV"],"nextCursor":null},"id":1}%
```

