### PR TITLE
[easy] indexer:batch fetch txns

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -125,15 +125,11 @@ where
             .get_checkpoint(seq.into())
             .await?;
 
-        let transactions = join_all(
-            checkpoint
-                .transactions
-                .iter()
-                .map(|tx_digest| self.rpc_client.read_api().get_transaction(*tx_digest)),
-        )
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>, _>>()?;
+        let transactions = self
+            .rpc_client
+            .read_api()
+            .multi_get_transactions(checkpoint.transactions.to_vec())
+            .await?;
 
         let all_mutated = transactions
             .iter()

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -109,6 +109,13 @@ impl ReadApi {
         Ok(self.api.http.get_transaction(digest).await?)
     }
 
+    pub async fn multi_get_transactions(
+        &self,
+        digests: Vec<TransactionDigest>,
+    ) -> SuiRpcResult<Vec<SuiTransactionResponse>> {
+        Ok(self.api.http.multi_get_transactions(digests).await?)
+    }
+
     pub async fn get_committee_info(&self, epoch: Option<EpochId>) -> SuiRpcResult<SuiCommittee> {
         Ok(self.api.http.get_committee_info(epoch).await?)
     }


### PR DESCRIPTION
## Description 

we now have `multi_get_transactions`, we can batch fetch txns w/o worrying about the connections indexer would take from a FN

## Test Plan 

CI

