### PR TITLE
Add SuiSystemStateSummary

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -37,6 +37,7 @@ use sui_types::intent::IntentScope;
 use sui_types::message_envelope::Message;
 use sui_types::parse_sui_struct_tag;
 use sui_types::sui_system_state::SuiSystemStateTrait;
+use sui_types::sui_system_state_summary::SuiSystemStateSummary;
 use sui_types::MOVE_STDLIB_OBJECT_ID;
 use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 use tap::TapFallible;
@@ -1655,7 +1656,10 @@ impl AuthorityState {
             &path.join("store"),
             None,
             EpochMetrics::new(&registry),
-            Some(Default::default()),
+            Some(EpochStartConfiguration {
+                system_state: SuiSystemStateSummary::new_for_testing(),
+                epoch_digest: Default::default(),
+            }),
             store.clone(),
             cache_metrics,
         );
@@ -1878,8 +1882,10 @@ impl AuthorityState {
     /// This function should be called once and exactly once during reconfiguration.
     /// Instead of this function use AuthorityEpochStore::epoch_start_configuration() to access this object everywhere
     /// besides when we are reading fields for the current epoch
-    pub fn get_sui_system_state_object_during_reconfig(&self) -> SuiResult<SuiSystemState> {
-        self.database.get_sui_system_state_object()
+    pub fn get_sui_system_state_summary_during_reconfig(&self) -> SuiResult<SuiSystemStateSummary> {
+        self.database
+            .get_sui_system_state_object()
+            .map(|s| s.into())
     }
 
     // This function is only used for testing.

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -29,6 +29,7 @@ use sui_types::messages::{
     VerifiedCertificate, VerifiedExecutableTransaction, VerifiedSignedTransaction,
 };
 use sui_types::signature::GenericSignature;
+use sui_types::sui_system_state_summary::SuiSystemStateSummary;
 use tracing::{debug, info, trace, warn};
 use typed_store::rocks::{DBBatch, DBMap, DBOptions, MetricConf, TypedStoreError};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
@@ -64,7 +65,6 @@ use sui_types::messages_checkpoint::{
     CheckpointSignatureMessage, CheckpointSummary, CheckpointTimestamp,
 };
 use sui_types::storage::{transaction_input_object_keys, ObjectKey, ParentSync};
-use sui_types::sui_system_state::{SuiSystemState, SuiSystemStateTrait};
 use sui_types::temporary_store::InnerTemporaryStore;
 use sui_types::{MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS};
 use tokio::time::Instant;
@@ -278,9 +278,9 @@ pub struct AuthorityEpochTables {
 }
 
 /// Parameters of the epoch fixed at epoch start.
-#[derive(Default, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct EpochStartConfiguration {
-    pub system_state: SuiSystemState,
+    pub system_state: SuiSystemStateSummary,
     /// epoch_digest is defined as following
     /// (1) For the genesis epoch it is set to 0
     /// (2) For all other epochs it is a digest of the last checkpoint of a previous epoch
@@ -500,12 +500,12 @@ impl AuthorityPerEpochStore {
             .insert(checkpoint, accumulator)?)
     }
 
-    pub fn system_state_object(&self) -> &SuiSystemState {
+    pub fn system_state_summary(&self) -> &SuiSystemStateSummary {
         &self.epoch_start_configuration.system_state
     }
 
     pub fn reference_gas_price(&self) -> u64 {
-        self.system_state_object().reference_gas_price()
+        self.system_state_summary().reference_gas_price()
     }
 
     pub fn protocol_version(&self) -> ProtocolVersion {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -506,10 +506,10 @@ impl Validator for ValidatorService {
         &self,
         _request: tonic::Request<SystemStateRequest>,
     ) -> Result<tonic::Response<SuiSystemStateInnerBenchmark>, tonic::Status> {
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
-        let response = epoch_store
-            .system_state_object()
-            .clone()
+        let response = self
+            .state
+            .database
+            .get_sui_system_state_object()?
             .into_benchmark_version();
 
         return Ok(tonic::Response::new(response));

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -223,8 +223,8 @@ pub async fn test_checkpoint_executor_cross_epoch() {
             SupportedProtocolVersions::SYSTEM_DEFAULT,
             second_committee.committee().clone(),
             EpochStartConfiguration {
-                system_state,
-                ..Default::default()
+                system_state: system_state.into(),
+                epoch_digest: Default::default(),
             },
         )
         .await

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -116,10 +116,10 @@ impl AuthorityAPI for LocalAuthorityClient {
         &self,
         _request: SystemStateRequest,
     ) -> Result<SuiSystemStateInnerBenchmark, SuiError> {
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
-        Ok(epoch_store
-            .system_state_object()
-            .clone()
+        Ok(self
+            .state
+            .database
+            .get_sui_system_state_object()?
             .into_benchmark_version())
     }
 }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1794,8 +1794,8 @@ async fn test_transaction_expiration() {
             SupportedProtocolVersions::SYSTEM_DEFAULT,
             committee,
             EpochStartConfiguration {
-                system_state,
-                ..Default::default()
+                system_state: system_state.into(),
+                epoch_digest: Default::default(),
             },
         )
         .await
@@ -2716,7 +2716,10 @@ async fn test_authority_persist() {
             &epoch_store_path,
             None,
             EpochMetrics::new(&registry),
-            Some(Default::default()),
+            Some(EpochStartConfiguration {
+                system_state: SuiSystemStateSummary::new_for_testing(),
+                epoch_digest: Default::default(),
+            }),
             store.clone(),
             cache_metrics,
         );
@@ -4716,7 +4719,10 @@ async fn test_tallying_rule_score_updates() {
         &path,
         None,
         metrics.clone(),
-        Some(Default::default()),
+        Some(EpochStartConfiguration {
+            system_state: SuiSystemStateSummary::new_for_testing(),
+            epoch_digest: Default::default(),
+        }),
         store,
         cache_metrics,
     );

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -52,6 +52,7 @@ pub mod signature;
 pub mod storage;
 pub mod sui_serde;
 pub mod sui_system_state;
+pub mod sui_system_state_summary;
 pub mod temporary_store;
 
 pub mod epoch_data;

--- a/crates/sui-types/src/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state_summary.rs
@@ -1,0 +1,196 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashMap};
+
+use anemo::PeerId;
+use multiaddr::Multiaddr;
+use narwhal_config::{WorkerCache, WorkerIndex};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sui_protocol_config::ProtocolVersion;
+
+use crate::{
+    base_types::{AuthorityName, SuiAddress},
+    committee::{Committee, CommitteeWithNetAddresses, StakeUnit},
+    sui_system_state::{SuiSystemState, SuiSystemStateTrait},
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+pub struct SuiValidatorSummary {
+    pub sui_address: SuiAddress,
+    #[schemars(with = "&[u8]")]
+    pub protocol_pubkey: narwhal_crypto::PublicKey,
+    #[schemars(with = "&[u8]")]
+    pub network_pubkey: narwhal_crypto::NetworkPublicKey,
+    #[schemars(with = "&[u8]")]
+    pub worker_pubkey: narwhal_crypto::NetworkPublicKey,
+    pub proof_of_possession_bytes: Vec<u8>,
+    pub name: String,
+    pub description: String,
+    pub image_url: String,
+    pub project_url: String,
+    #[schemars(with = "&[u8]")]
+    pub net_address: Multiaddr,
+    #[schemars(with = "&[u8]")]
+    pub p2p_address: Multiaddr,
+    #[schemars(with = "&[u8]")]
+    pub primary_address: Multiaddr,
+    #[schemars(with = "&[u8]")]
+    pub worker_address: Multiaddr,
+    pub voting_power: StakeUnit,
+    // TODO: Add more fields.
+}
+
+impl SuiValidatorSummary {
+    // Convenient method to get the public key of the validator as AuthorityName.
+    pub fn pubkey_bytes(&self) -> AuthorityName {
+        (&self.protocol_pubkey).into()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+pub struct SuiSystemStateSummary {
+    epoch: u64,
+    protocol_version: u64,
+    active_validators: Vec<SuiValidatorSummary>,
+    reference_gas_price: u64,
+    safe_mode: bool,
+    epoch_start_timestamp_ms: u64,
+    // TODO: Add more fields
+}
+
+impl SuiSystemStateSummary {
+    pub fn new_for_testing() -> Self {
+        Self {
+            epoch: 0,
+            protocol_version: ProtocolVersion::MIN.as_u64(),
+            active_validators: vec![],
+            reference_gas_price: 0,
+            safe_mode: false,
+            epoch_start_timestamp_ms: 0,
+        }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    pub fn protocol_version(&self) -> u64 {
+        self.protocol_version
+    }
+
+    pub fn reference_gas_price(&self) -> u64 {
+        self.reference_gas_price
+    }
+
+    pub fn safe_mode(&self) -> bool {
+        self.safe_mode
+    }
+
+    pub fn epoch_start_timestamp_ms(&self) -> u64 {
+        self.epoch_start_timestamp_ms
+    }
+
+    pub fn sui_committee(&self) -> Committee {
+        let voting_rights = self
+            .active_validators
+            .iter()
+            .map(|validator| (validator.pubkey_bytes(), validator.voting_power))
+            .collect();
+        Committee::new(self.epoch, voting_rights).expect("Committee information must be valid.")
+    }
+
+    pub fn sui_committee_with_net_addresses(&self) -> CommitteeWithNetAddresses {
+        let net_addresses = self
+            .active_validators
+            .iter()
+            // TODO: CommitteeWithNetAddresses should use Multiaddr instead of Vec<u8>.
+            .map(|validator| {
+                (
+                    validator.pubkey_bytes(),
+                    validator.net_address.clone().to_vec(),
+                )
+            })
+            .collect();
+        CommitteeWithNetAddresses {
+            committee: self.sui_committee(),
+            net_addresses,
+        }
+    }
+
+    #[allow(clippy::mutable_key_type)]
+    pub fn narwhal_committee(&self) -> narwhal_config::Committee {
+        let narwhal_committee = self
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let authority = narwhal_config::Authority {
+                    stake: validator.voting_power as narwhal_config::Stake,
+                    primary_address: validator.primary_address.clone(),
+                    network_key: validator.network_pubkey.clone(),
+                };
+                (validator.protocol_pubkey.clone(), authority)
+            })
+            .collect();
+
+        narwhal_config::Committee {
+            authorities: narwhal_committee,
+            epoch: self.epoch as narwhal_config::Epoch,
+        }
+    }
+
+    #[allow(clippy::mutable_key_type)]
+    pub fn narwhal_worker_cache(
+        &self,
+        transactions_address: &multiaddr::Multiaddr,
+    ) -> narwhal_config::WorkerCache {
+        let workers: BTreeMap<narwhal_crypto::PublicKey, WorkerIndex> = self
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let workers = [(
+                    0,
+                    narwhal_config::WorkerInfo {
+                        name: validator.worker_pubkey.clone(),
+                        transactions: transactions_address.clone(),
+                        worker_address: validator.worker_address.clone(),
+                    },
+                )]
+                .into_iter()
+                .collect();
+                let worker_index = WorkerIndex(workers);
+
+                (validator.protocol_pubkey.clone(), worker_index)
+            })
+            .collect();
+        WorkerCache {
+            workers,
+            epoch: self.epoch,
+        }
+    }
+
+    pub fn authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, anemo::PeerId> {
+        self.active_validators
+            .iter()
+            .map(|validator| {
+                let name = validator.pubkey_bytes();
+                let peer_id = PeerId(validator.network_pubkey.0.to_bytes());
+                (name, peer_id)
+            })
+            .collect()
+    }
+}
+
+impl From<SuiSystemState> for SuiSystemStateSummary {
+    fn from(state: SuiSystemState) -> Self {
+        Self {
+            epoch: state.epoch(),
+            protocol_version: state.protocol_version(),
+            active_validators: state.get_validator_summary_vec(),
+            reference_gas_price: state.reference_gas_price(),
+            safe_mode: state.safe_mode(),
+            epoch_start_timestamp_ms: state.epoch_start_timestamp_ms(),
+        }
+    }
+}


### PR DESCRIPTION
Add a flatten type to capture the sui system state.
It's also json-serializable so that we could eventually use it for json-RPC interface as well.
This will help decouple the EpochStartConfiguration type and the SuiSystemState type, and hence makes it a lot easier to evolve over time, and does not get affected much by the change to sui system state type.