### PR TITLE
[bug fix][framework] use new epoch for staking pool deactivation epoch

### DIFF
--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -752,7 +752,7 @@ this pool deactivation, the pool stops earning rewards. Only delegation
 withdraws can be made to the pool.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">deactivate_staking_pool</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">deactivate_staking_pool</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">staking_pool::StakingPool</a>, deactivation_epoch: u64)
 </code></pre>
 
 
@@ -761,10 +761,10 @@ withdraws can be made to the pool.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">deactivate_staking_pool</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, ctx: &<b>mut</b> TxContext) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">deactivate_staking_pool</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakingPool">StakingPool</a>, deactivation_epoch: u64) {
     // We can't deactivate an already deactivated pool.
     <b>assert</b>!(<a href="staking_pool.md#0x2_staking_pool_pool_active">pool_active</a>(pool), <a href="staking_pool.md#0x2_staking_pool_EDeactivationOfInactivePool">EDeactivationOfInactivePool</a>);
-    pool.deactivation_epoch = <a href="_some">option::some</a>(<a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx));
+    pool.deactivation_epoch = <a href="_some">option::some</a>(deactivation_epoch);
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -613,7 +613,7 @@ Invalid worker_pubkey_bytes field in ValidatorMetadata
 Deactivate this validator's staking pool
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deactivate">deactivate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deactivate">deactivate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">validator::Validator</a>, deactivation_epoch: u64)
 </code></pre>
 
 
@@ -622,8 +622,8 @@ Deactivate this validator's staking pool
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deactivate">deactivate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, ctx: &<b>mut</b> TxContext) {
-    <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">staking_pool::deactivate_staking_pool</a>(&<b>mut</b> self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, ctx)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_deactivate">deactivate</a>(self: &<b>mut</b> <a href="validator.md#0x2_validator_Validator">Validator</a>, deactivation_epoch: u64) {
+    <a href="staking_pool.md#0x2_staking_pool_deactivate_staking_pool">staking_pool::deactivate_staking_pool</a>(&<b>mut</b> self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, deactivation_epoch)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -1306,6 +1306,7 @@ is removed from <code>validators</code> and its staking pool is put into the <co
     self: &<b>mut</b> <a href="validator_set.md#0x2_validator_set_ValidatorSet">ValidatorSet</a>,
     ctx: &<b>mut</b> TxContext,
 ) {
+    <b>let</b> new_epoch = <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1;
     <a href="validator_set.md#0x2_validator_set_sort_removal_list">sort_removal_list</a>(&<b>mut</b> self.pending_removals);
     <b>while</b> (!<a href="_is_empty">vector::is_empty</a>(&self.pending_removals)) {
         <b>let</b> index = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> self.pending_removals);
@@ -1314,7 +1315,7 @@ is removed from <code>validators</code> and its staking pool is put into the <co
         <a href="table.md#0x2_table_remove">table::remove</a>(&<b>mut</b> self.staking_pool_mappings, validator_pool_id);
         self.total_stake = self.total_stake - <a href="validator.md#0x2_validator_total_stake_amount">validator::total_stake_amount</a>(&<a href="validator.md#0x2_validator">validator</a>);
         // Deactivate the <a href="validator.md#0x2_validator">validator</a> and its staking pool
-        <a href="validator.md#0x2_validator_deactivate">validator::deactivate</a>(&<b>mut</b> <a href="validator.md#0x2_validator">validator</a>, ctx);
+        <a href="validator.md#0x2_validator_deactivate">validator::deactivate</a>(&<b>mut</b> <a href="validator.md#0x2_validator">validator</a>, new_epoch);
         <a href="table.md#0x2_table_add">table::add</a>(&<b>mut</b> self.inactive_validators, validator_pool_id, <a href="validator.md#0x2_validator">validator</a>);
     }
 }

--- a/crates/sui-framework/sources/governance/staking_pool.move
+++ b/crates/sui-framework/sources/governance/staking_pool.move
@@ -281,10 +281,10 @@ module sui::staking_pool {
     /// Deactivate a staking pool by setting the `deactivation_epoch`. After
     /// this pool deactivation, the pool stops earning rewards. Only delegation
     /// withdraws can be made to the pool.
-    public(friend) fun deactivate_staking_pool(pool: &mut StakingPool, ctx: &mut TxContext) {
+    public(friend) fun deactivate_staking_pool(pool: &mut StakingPool, deactivation_epoch: u64) {
         // We can't deactivate an already deactivated pool.
         assert!(pool_active(pool), EDeactivationOfInactivePool);
-        pool.deactivation_epoch = option::some(tx_context::epoch(ctx));
+        pool.deactivation_epoch = option::some(deactivation_epoch);
     }
 
     // ==== getters and misc utility functions ====

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -247,8 +247,8 @@ module sui::validator {
     }
 
     /// Deactivate this validator's staking pool
-    public(friend) fun deactivate(self: &mut Validator, ctx: &mut TxContext) {
-        staking_pool::deactivate_staking_pool(&mut self.staking_pool, ctx)
+    public(friend) fun deactivate(self: &mut Validator, deactivation_epoch: u64) {
+        staking_pool::deactivate_staking_pool(&mut self.staking_pool, deactivation_epoch)
     }
 
     /// Process pending stake and pending withdraws, and update the gas price.

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -537,6 +537,7 @@ module sui::validator_set {
         self: &mut ValidatorSet,
         ctx: &mut TxContext,
     ) {
+        let new_epoch = tx_context::epoch(ctx) + 1;
         sort_removal_list(&mut self.pending_removals);
         while (!vector::is_empty(&self.pending_removals)) {
             let index = vector::pop_back(&mut self.pending_removals);
@@ -545,7 +546,7 @@ module sui::validator_set {
             table::remove(&mut self.staking_pool_mappings, validator_pool_id);
             self.total_stake = self.total_stake - validator::total_stake_amount(&validator);
             // Deactivate the validator and its staking pool
-            validator::deactivate(&mut validator, ctx);
+            validator::deactivate(&mut validator, new_epoch);
             table::add(&mut self.inactive_validators, validator_pool_id, validator);
         }
     }


### PR DESCRIPTION
## Description 

This PR fixes a small bug in our staking pool deactivation code. When a validator requests to leave the validator set at epoch X, they will still earn the rewards as epoch changes from epoch X to X + 1 and therefore their last entry in the exchange rate table will be keyed X + 1 so their deactivation epoch should be set to the new epoch number. 

## Test Plan 

Added a new test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
