### PR TITLE
Configure addresses

### DIFF
--- a/crates/sui-config/src/genesis_config.rs
+++ b/crates/sui-config/src/genesis_config.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::{IpAddr, SocketAddr},
+};
 
 use anyhow::Result;
 use multiaddr::Multiaddr;
@@ -106,6 +109,9 @@ pub struct ValidatorGenesisInfo {
     pub network_key_pair: NetworkKeyPair,
     pub network_address: Multiaddr,
     pub p2p_address: Multiaddr,
+    pub p2p_listen_address: Option<SocketAddr>,
+    pub metrics_address: SocketAddr,
+    pub narwhal_metrics_address: Multiaddr,
     pub gas_price: u64,
     pub commission_rate: u64,
     pub narwhal_primary_address: Multiaddr,
@@ -126,6 +132,9 @@ impl ValidatorGenesisInfo {
             network_key_pair,
             network_address: utils::new_tcp_network_address(),
             p2p_address: utils::new_udp_network_address(),
+            p2p_listen_address: None,
+            metrics_address: utils::available_local_socket_address(),
+            narwhal_metrics_address: utils::new_tcp_network_address(),
             gas_price: DEFAULT_GAS_PRICE,
             commission_rate: DEFAULT_COMMISSION_RATE,
             narwhal_primary_address: utils::new_udp_network_address(),
@@ -138,6 +147,7 @@ impl ValidatorGenesisInfo {
         worker_key_pair: NetworkKeyPair,
         account_key_pair: SuiKeyPair,
         network_key_pair: NetworkKeyPair,
+        p2p_listen_address: Option<IpAddr>,
         ip: String,
         // Port offset allows running many SuiNodes inside the same simulator node, which is
         // helpful for tests that don't use Swarm.
@@ -157,6 +167,9 @@ impl ValidatorGenesisInfo {
             network_key_pair,
             network_address: make_tcp_addr(1000 + port_offset),
             p2p_address: make_udp_addr(5000 + port_offset),
+            p2p_listen_address: p2p_listen_address.map(|x| SocketAddr::new(x, 4000 + port_offset)),
+            metrics_address: format!("127.0.0.1:{}", 6000 + port_offset).parse().unwrap(),
+            narwhal_metrics_address: make_tcp_addr(7000 + port_offset),
             gas_price: DEFAULT_GAS_PRICE,
             commission_rate: DEFAULT_COMMISSION_RATE,
             narwhal_primary_address: make_udp_addr(2000 + port_offset),


### PR DESCRIPTION
This Pr allows us to fix the metrics ports (both for Sui and for Narwhal) so the benchmarking tools can scrap metrics. It also allows to modify the p2p listen address that was previously set to the value of the external address. 