### PR TITLE
[sui-framework] Check test compilation with sui-specific verifier

### DIFF
--- a/crates/sui-framework-test/src/lib.rs
+++ b/crates/sui-framework-test/src/lib.rs
@@ -4,7 +4,6 @@
 #[cfg(test)]
 mod test {
     use move_cli::base::test::UnitTestResult;
-    use move_package::BuildConfig as MoveBuildConfig;
     use std::path::{Path, PathBuf};
     use sui_framework::build_move_package;
     use sui_framework_build::compiled_package::BuildConfig;
@@ -13,14 +12,11 @@ mod test {
     #[test]
     #[cfg_attr(msim, ignore)]
     fn run_framework_move_unit_tests() {
-        let path = {
+        check_move_unit_tests(&{
             let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             buf.extend(["..", "sui-framework"]);
             buf
-        };
-
-        BuildConfig::new_for_testing().build(path.clone()).unwrap();
-        check_move_unit_tests(&path);
+        });
     }
 
     #[test]
@@ -36,47 +32,39 @@ mod test {
             "nfts",
             "objects_tutorial",
         ] {
-            let path = {
+            check_move_unit_tests(&{
                 let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
                 buf.extend(["..", "..", "sui_programmability", "examples", example]);
                 buf
-            };
-            BuildConfig::new_for_testing().build(path.clone()).unwrap();
-            check_move_unit_tests(&path);
+            });
         }
     }
 
     #[test]
     #[cfg_attr(msim, ignore)]
     fn run_book_examples_move_unit_tests() {
-        let path = {
+        check_move_unit_tests(&{
             let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             buf.extend(["..", "..", "doc", "book", "examples"]);
             buf
-        };
-
-        BuildConfig::new_for_testing().build(path.clone()).unwrap();
-        check_move_unit_tests(&path);
+        });
     }
 
     fn check_move_unit_tests(path: &Path) {
+        let mut config = BuildConfig::new_for_testing();
+        // Make sure to verify tests
+        config.config.dev_mode = true;
+        config.config.test_mode = true;
+        config.run_bytecode_verifier = true;
+        config.print_diags_to_stderr = true;
+        let move_config = config.config.clone();
+
         // build tests first to enable Sui-specific test code verification
-        matches!(
-            build_move_package(
-                path,
-                BuildConfig {
-                    config: MoveBuildConfig {
-                        test_mode: true, // make sure to verify tests
-                        ..MoveBuildConfig::default()
-                    },
-                    run_bytecode_verifier: true,
-                    print_diags_to_stderr: true,
-                },
-            ),
-            Ok(_)
-        );
+        build_move_package(path, config)
+            .unwrap_or_else(|_| panic!("Building tests at {}", path.display()));
+
         assert_eq!(
-            run_move_unit_tests(path, MoveBuildConfig::default(), None, false).unwrap(),
+            run_move_unit_tests(path, move_config, None, false).unwrap(),
             UnitTestResult::Success
         );
     }

--- a/sui_programmability/examples/fungible_tokens/sources/treasury_lock.move
+++ b/sui_programmability/examples/fungible_tokens/sources/treasury_lock.move
@@ -166,6 +166,11 @@ module fungible_tokens::treasury_lock {
     }
 }
 
+/*
+
+// TODO Re-enable when it's possible to test code using one-time
+// witnesses in `test_scenario`.
+
 #[test_only]
 module fungible_tokens::treasury_lock_tests {
     use std::option;
@@ -443,3 +448,4 @@ module fungible_tokens::treasury_lock_tests {
         test_scenario::end(scenario_);
     }
 }
+*/

--- a/sui_programmability/examples/nfts/tests/auction_tests.move
+++ b/sui_programmability/examples/nfts/tests/auction_tests.move
@@ -27,7 +27,7 @@ module nfts::auction_tests {
     // Initializes the "state of the world" that mimics what should
     // be available in Sui genesis state (e.g., mints and distributes
     // coins to users).
-    fun init(ctx: &mut TxContext, bidders: vector<address>) {
+    fun init_bidders(ctx: &mut TxContext, bidders: vector<address>) {
         while (!vector::is_empty(&bidders)) {
             let bidder = vector::pop_back(&mut bidders);
             let coin = coin::mint_for_testing<SUI>(100, ctx);
@@ -48,7 +48,7 @@ module nfts::auction_tests {
             let bidders = vector::empty();
             vector::push_back(&mut bidders, bidder1);
             vector::push_back(&mut bidders, bidder2);
-            init(test_scenario::ctx(scenario), bidders);
+            init_bidders(test_scenario::ctx(scenario), bidders);
         };
 
         // a transaction by the item owner to put it for auction

--- a/sui_programmability/examples/nfts/tests/cross_chain_airdrop_tests.move
+++ b/sui_programmability/examples/nfts/tests/cross_chain_airdrop_tests.move
@@ -26,7 +26,7 @@ module nfts::cross_chain_airdrop_tests {
 
     #[test]
     fun test_claim_airdrop() {
-        let (scenario, oracle_address) = init();
+        let (scenario, oracle_address) = init_scenario();
 
         // claim a token
         claim_token(&mut scenario, oracle_address, SOURCE_TOKEN_ID);
@@ -39,7 +39,7 @@ module nfts::cross_chain_airdrop_tests {
     #[test]
     #[expected_failure(abort_code = cross_chain_airdrop::ETokenIDClaimed)]
     fun test_double_claim() {
-        let (scenario, oracle_address) = init();
+        let (scenario, oracle_address) = init_scenario();
 
         // claim a token
         claim_token(&mut scenario, oracle_address, SOURCE_TOKEN_ID);
@@ -49,7 +49,7 @@ module nfts::cross_chain_airdrop_tests {
         test_scenario::end(scenario);
     }
 
-    fun init(): (Scenario, address) {
+    fun init_scenario(): (Scenario, address) {
         let scenario = test_scenario::begin(ORACLE_ADDRESS);
         {
             let ctx = test_scenario::ctx(&mut scenario);

--- a/sui_programmability/examples/nfts/tests/shared_auction_tests.move
+++ b/sui_programmability/examples/nfts/tests/shared_auction_tests.move
@@ -31,7 +31,7 @@ module nfts::shared_auction_tests {
     // Initializes the "state of the world" that mimics what should
     // be available in Sui genesis state (e.g., mints and distributes
     // coins to users).
-    fun init(ctx: &mut TxContext, bidders: vector<address>) {
+    fun init_bidders(ctx: &mut TxContext, bidders: vector<address>) {
         while (!vector::is_empty(&bidders)) {
             let bidder = vector::pop_back(&mut bidders);
             let coin = coin::mint_for_testing<SUI>(COIN_VALUE, ctx);
@@ -52,7 +52,7 @@ module nfts::shared_auction_tests {
             let bidders = vector::empty();
             vector::push_back(&mut bidders, bidder1);
             vector::push_back(&mut bidders, bidder2);
-            init(test_scenario::ctx(scenario), bidders);
+            init_bidders(test_scenario::ctx(scenario), bidders);
         };
 
         // a transaction by the item owner to put it for auction

--- a/sui_programmability/examples/objects_tutorial/sources/color_object.move
+++ b/sui_programmability/examples/objects_tutorial/sources/color_object.move
@@ -73,11 +73,10 @@ module tutorial::color_object {
 }
 
 #[test_only]
-module tutorial::color_objectTests {
+module tutorial::color_object_tests {
     use sui::test_scenario;
     use tutorial::color_object::{Self, ColorObject};
     use sui::object;
-    use sui::transfer;
     use sui::tx_context;
 
     // == Tests covered in Chapter 1 ==
@@ -188,7 +187,7 @@ module tutorial::color_objectTests {
         test_scenario::next_tx(scenario, owner);
         {
             let object = test_scenario::take_from_sender<ColorObject>(scenario);
-            transfer::transfer(object, recipient);
+            color_object::transfer(object, recipient);
         };
         // Check that owner no longer owns the object.
         test_scenario::next_tx(scenario, owner);


### PR DESCRIPTION
## Description 

Previous implementation forgot to check the result of compiling tests with sui-specific verification enabled.

## Test Plan 

Run tests with some of the fixes in `.move` files rolled back, and the tests will actually fail.

```
sui-framework-test$ cargo nextest run
```
