### PR TITLE
[sui-framework] Add test native to create OTWs

### DIFF
--- a/crates/sui-framework/sources/test/test_utils.move
+++ b/crates/sui-framework/sources/test/test_utils.move
@@ -23,4 +23,6 @@ module sui::test_utils {
     }
 
     public native fun destroy<T>(x: T);
+
+    public native fun create_one_time_witness<T: drop>(): T;
 }

--- a/crates/sui-framework/src/natives/mod.rs
+++ b/crates/sui-framework/src/natives/mod.rs
@@ -287,6 +287,11 @@ pub fn all_natives(
             make_native!(validator::validate_metadata_bcs),
         ),
         ("test_utils", "destroy", make_native!(test_utils::destroy)),
+        (
+            "test_utils",
+            "create_one_time_witness",
+            make_native!(test_utils::create_one_time_witness),
+        ),
     ];
     sui_natives
         .iter()

--- a/crates/sui-framework/src/natives/test_utils.rs
+++ b/crates/sui-framework/src/natives/test_utils.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::legacy_test_cost;
+use crate::{legacy_test_cost, natives::types::is_otw_struct};
 use move_binary_format::errors::PartialVMResult;
+use move_core_types::{gas_algebra::InternalGas, value::MoveTypeLayout};
 use move_vm_runtime::native_functions::NativeContext;
 use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
@@ -17,4 +18,32 @@ pub fn destroy(
 ) -> PartialVMResult<NativeResult> {
     args.pop_back();
     Ok(NativeResult::ok(legacy_test_cost(), smallvec![]))
+}
+
+pub fn create_one_time_witness(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.is_empty());
+
+    let ty = ty_args.pop().unwrap();
+    let type_tag = context.type_to_type_tag(&ty)?;
+    let type_layout = context.type_to_type_layout(&ty)?;
+
+    let Some(MoveTypeLayout::Struct(struct_layout)) = type_layout else {
+        return Ok(NativeResult::err(InternalGas::new(1), 0))
+    };
+
+    if is_otw_struct(&struct_layout, &type_tag) {
+        Ok(NativeResult::ok(
+            legacy_test_cost(),
+            smallvec![Value::struct_(move_vm_types::values::Struct::pack(vec![
+                Value::bool(true)
+            ]))],
+        ))
+    } else {
+        Ok(NativeResult::err(InternalGas::new(1), 1))
+    }
 }

--- a/sui_programmability/examples/fungible_tokens/sources/treasury_lock.move
+++ b/sui_programmability/examples/fungible_tokens/sources/treasury_lock.move
@@ -166,11 +166,6 @@ module fungible_tokens::treasury_lock {
     }
 }
 
-/*
-
-// TODO Re-enable when it's possible to test code using one-time
-// witnesses in `test_scenario`.
-
 #[test_only]
 module fungible_tokens::treasury_lock_tests {
     use std::option;
@@ -179,6 +174,7 @@ module fungible_tokens::treasury_lock_tests {
     use sui::transfer;
     use sui::coin;
     use sui::object::{Self};
+    use sui::test_utils;
     use fungible_tokens::treasury_lock::{Self, TreasuryLock, LockAdminCap, MintCap, create_and_transfer_mint_cap, new_lock, mint_balance};
 
     const ADMIN: address = @0xABBA;
@@ -194,7 +190,8 @@ module fungible_tokens::treasury_lock_tests {
         // create a currency and lock it
         test_scenario::next_tx(scenario, ADMIN);
         {
-            let (treasury, metadata) = coin::create_currency(TREASURY_LOCK_TESTS {}, 0, b"", b"", b"", option::none(), test_scenario::ctx(scenario));
+            let treasury_lock_tests = test_utils::create_one_time_witness<TREASURY_LOCK_TESTS>();
+            let (treasury, metadata) = coin::create_currency(treasury_lock_tests, 0, b"", b"", b"", option::none(), test_scenario::ctx(scenario));
             transfer::freeze_object(metadata);
             let admin_cap = new_lock(treasury, test_scenario::ctx(scenario));
             transfer::transfer(
@@ -448,4 +445,3 @@ module fungible_tokens::treasury_lock_tests {
         test_scenario::end(scenario_);
     }
 }
-*/


### PR DESCRIPTION
This adds a native function to `test_utils` that allows the creation of one-time witnesses for testing purposes. This is then used to turn on a test that couldn't be run previously since we didn't have an easy way of creating OTWs.

## Test Plan 

Turns back on a test that needed to be turned off. 
