### PR TITLE
Split sui system state file

### DIFF
--- a/crates/sui-framework/src/natives/validator.rs
+++ b/crates/sui-framework/src/natives/validator.rs
@@ -10,7 +10,7 @@ use move_vm_types::{
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
-use sui_types::sui_system_state::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
 
 pub fn validate_metadata_bcs(
     _context: &mut NativeContext,

--- a/crates/sui-indexer/src/apis/governance_api.rs
+++ b/crates/sui-indexer/src/apis/governance_api.rs
@@ -11,7 +11,7 @@ use sui_json_rpc_types::{SuiCommittee, SuiSystemStateRpc};
 use sui_open_rpc::Module;
 use sui_types::base_types::{EpochId, SuiAddress};
 use sui_types::governance::DelegatedStake;
-use sui_types::sui_system_state::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
 
 pub(crate) struct GovernanceReadApi {
     fullnode: HttpClient,

--- a/crates/sui-json-rpc-types/src/sui_governance.rs
+++ b/crates/sui-json-rpc-types/src/sui_governance.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use sui_types::base_types::{AuthorityName, EpochId};
 use sui_types::committee::{Committee, StakeUnit};
-use sui_types::sui_system_state::{SuiSystemState, SuiSystemStateInnerV1};
+use sui_types::sui_system_state::sui_system_state_inner_v1::SuiSystemStateInnerV1;
+use sui_types::sui_system_state::SuiSystemState;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 #[serde(untagged, rename = "SuiSystemState")]

--- a/crates/sui-json-rpc/src/api/governance.rs
+++ b/crates/sui-json-rpc/src/api/governance.rs
@@ -11,7 +11,7 @@ use sui_types::base_types::SuiAddress;
 use sui_types::committee::EpochId;
 use sui_types::governance::DelegatedStake;
 
-use sui_types::sui_system_state::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
 
 #[open_rpc(namespace = "sui", tag = "Governance Read API")]
 #[rpc(server, client, namespace = "sui")]

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -5,6 +5,7 @@ use jsonrpsee::core::RpcResult;
 use std::collections::HashMap;
 use std::sync::Arc;
 use sui_json_rpc_types::{SuiCommittee, SuiSystemStateRpc};
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
 
 use crate::api::GovernanceReadApiServer;
 use crate::error::Error;
@@ -16,7 +17,7 @@ use sui_open_rpc::Module;
 use sui_types::base_types::SuiAddress;
 use sui_types::committee::EpochId;
 use sui_types::governance::{DelegatedStake, Delegation, DelegationStatus, StakedSui};
-use sui_types::sui_system_state::{SuiSystemStateTrait, ValidatorMetadata};
+use sui_types::sui_system_state::SuiSystemStateTrait;
 
 pub struct GovernanceReadApi {
     state: Arc<AuthorityState>,

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -28,7 +28,7 @@ use sui_types::gas_coin::GAS;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::object::Owner;
 use sui_types::query::{EventQuery, TransactionQuery};
-use sui_types::sui_system_state::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{parse_sui_struct_tag, parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS};
 use test_utils::network::TestClusterBuilder;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4678,7 +4678,7 @@
         ]
       },
       "MoveOption_for_uint64": {
-        "description": "Rust version of the Move std::option::Option type. Putting it in this file because it's only used here.",
+        "description": "Rust version of the Move std::option::Option type.",
         "type": "object",
         "required": [
           "vec"
@@ -6436,7 +6436,7 @@
         }
       },
       "Table": {
-        "description": "Rust version of the Move sui::table::Table type. Putting it here since we only use it in sui_system in the framework.",
+        "description": "Rust version of the Move sui::table::Table type.",
         "type": "object",
         "required": [
           "id",
@@ -6454,7 +6454,7 @@
         }
       },
       "TableVec": {
-        "description": "Rust version of the Move sui::table::Table type. Putting it here since we only use it in sui_system in the framework.",
+        "description": "Rust version of the Move sui::table::Table type.",
         "type": "object",
         "required": [
           "contents"

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -29,7 +29,7 @@ use sui_types::event::EventID;
 use sui_types::messages::{ExecuteTransactionRequestType, TransactionData, VerifiedTransaction};
 use sui_types::messages_checkpoint::{CheckpointSequenceNumber, CheckpointSummary};
 use sui_types::query::{EventQuery, TransactionQuery};
-use sui_types::sui_system_state::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
 
 use futures::StreamExt;
 use sui_json_rpc::api::{CoinReadApiClient, EventReadApiClient, ReadApiClient, WriteApiClient};

--- a/crates/sui-types/src/collection_types.rs
+++ b/crates/sui-types/src/collection_types.rs
@@ -4,6 +4,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::base_types::{ObjectID, SuiAddress};
+
 /// Rust version of the Move sui::vec_map::VecMap type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct VecMap<K, V> {
@@ -21,4 +23,69 @@ pub struct Entry<K, V> {
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct VecSet<T> {
     contents: Vec<T>,
+}
+
+/// Rust version of the Move std::option::Option type.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+pub struct MoveOption<T> {
+    pub vec: Vec<T>,
+}
+
+impl<T> MoveOption<T> {
+    pub fn empty() -> Self {
+        Self { vec: vec![] }
+    }
+}
+
+/// Rust version of the Move sui::table::Table type.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+pub struct TableVec {
+    pub contents: Table,
+}
+
+impl Default for TableVec {
+    fn default() -> Self {
+        TableVec {
+            contents: Table {
+                id: ObjectID::from(SuiAddress::ZERO),
+                size: 0,
+            },
+        }
+    }
+}
+
+/// Rust version of the Move sui::table::Table type.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+pub struct Table {
+    pub id: ObjectID,
+    pub size: u64,
+}
+
+impl Default for Table {
+    fn default() -> Self {
+        Table {
+            id: ObjectID::from(SuiAddress::ZERO),
+            size: 0,
+        }
+    }
+}
+
+/// Rust version of the Move sui::linked_table::LinkedTable type.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+pub struct LinkedTable<K> {
+    pub id: ObjectID,
+    pub size: u64,
+    pub head: MoveOption<K>,
+    pub tail: MoveOption<K>,
+}
+
+impl<K> Default for LinkedTable<K> {
+    fn default() -> Self {
+        LinkedTable {
+            id: ObjectID::from(SuiAddress::ZERO),
+            size: 0,
+            head: MoveOption { vec: vec![] },
+            tail: MoveOption { vec: vec![] },
+        }
+    }
 }

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -1,0 +1,195 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::base_types::{AuthorityName, SuiAddress};
+use crate::committee::{CommitteeWithNetAddresses, EpochId, ProtocolVersion};
+use crate::dynamic_field::{derive_dynamic_field_id, Field};
+use crate::error::SuiError;
+use crate::storage::ObjectStore;
+use crate::{id::UID, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID};
+use anemo::PeerId;
+use anyhow::Result;
+use enum_dispatch::enum_dispatch;
+use move_core_types::language_storage::TypeTag;
+use move_core_types::value::MoveTypeLayout;
+use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
+use move_vm_types::values::Value;
+use multiaddr::Multiaddr;
+use narwhal_config::{Committee as NarwhalCommittee, WorkerCache};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
+use tracing::error;
+
+use self::sui_system_state_inner_v1::{SuiSystemStateInnerV1, ValidatorMetadata};
+
+pub mod sui_system_state_inner_v1;
+
+const SUI_SYSTEM_STATE_WRAPPER_STRUCT_NAME: &IdentStr = ident_str!("SuiSystemState");
+
+pub const SUI_SYSTEM_MODULE_NAME: &IdentStr = ident_str!("sui_system");
+pub const ADVANCE_EPOCH_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch");
+pub const ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch_safe_mode");
+pub const CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME: &IdentStr =
+    ident_str!("consensus_commit_prologue");
+
+pub const INIT_SYSTEM_STATE_VERSION: u64 = 1;
+
+/// Rust version of the Move sui::sui_system::SuiSystemState type
+/// This repreents the object with 0x5 ID.
+/// In Rust, this type should be rarely used since it's just a thin
+/// wrapper used to access the inner object.
+/// Within this module, we use it to determine the current version of the system state inner object type,
+/// so that we could deserialize the inner object correctly.
+/// Outside of this module, we only use it in genesis snapshot and testing.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SuiSystemStateWrapper {
+    pub id: UID,
+    pub version: u64,
+}
+
+impl SuiSystemStateWrapper {
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            name: SUI_SYSTEM_STATE_WRAPPER_STRUCT_NAME.to_owned(),
+            module: SUI_SYSTEM_MODULE_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+}
+
+/// This is the standard API that all inner system state object type should implement.
+#[enum_dispatch]
+pub trait SuiSystemStateTrait {
+    fn epoch(&self) -> u64;
+    fn reference_gas_price(&self) -> u64;
+    fn protocol_version(&self) -> u64;
+    fn epoch_start_timestamp_ms(&self) -> u64;
+    fn safe_mode(&self) -> bool;
+    fn get_current_epoch_committee(&self) -> CommitteeWithNetAddresses;
+    fn get_current_epoch_narwhal_committee(&self) -> NarwhalCommittee;
+    fn get_current_epoch_narwhal_worker_cache(
+        &self,
+        transactions_address: &Multiaddr,
+    ) -> WorkerCache;
+    fn get_validator_metadata_vec(&self) -> Vec<ValidatorMetadata>;
+    fn get_current_epoch_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId>;
+    fn get_staking_pool_info(&self) -> BTreeMap<SuiAddress, (Vec<u8>, u64)>;
+}
+
+/// SuiSystemState provides an abstraction over multiple versions of the inner SuiSystemStateInner object.
+/// This should be the primary interface to the system state object in Rust.
+/// We use enum dispatch to dispatch all methods defined in SuiSystemStateTrait to the actual
+/// implementation in the inner types.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[enum_dispatch(SuiSystemStateTrait)]
+pub enum SuiSystemState {
+    V1(SuiSystemStateInnerV1),
+}
+
+/// This is the fixed type used by genesis.
+pub type SuiSystemStateInnerGenesis = SuiSystemStateInnerV1;
+
+/// This is the fixed type used by benchmarking.
+pub type SuiSystemStateInnerBenchmark = SuiSystemStateInnerV1;
+
+impl SuiSystemState {
+    pub fn new_genesis(inner: SuiSystemStateInnerGenesis) -> Self {
+        Self::V1(inner)
+    }
+
+    /// Always return the version that we will be using for genesis.
+    /// Genesis always uses this version regardless of the current version.
+    pub fn into_genesis_version(self) -> SuiSystemStateInnerGenesis {
+        match self {
+            SuiSystemState::V1(inner) => inner,
+        }
+    }
+
+    pub fn into_benchmark_version(self) -> SuiSystemStateInnerBenchmark {
+        match self {
+            SuiSystemState::V1(inner) => inner,
+        }
+    }
+
+    pub fn new_for_benchmarking(inner: SuiSystemStateInnerBenchmark) -> Self {
+        Self::V1(inner)
+    }
+
+    pub fn new_for_testing(epoch: EpochId) -> Self {
+        SuiSystemState::V1(SuiSystemStateInnerV1 {
+            epoch,
+            ..Default::default()
+        })
+    }
+}
+
+impl Default for SuiSystemState {
+    fn default() -> Self {
+        SuiSystemState::V1(SuiSystemStateInnerV1::default())
+    }
+}
+
+pub fn get_sui_system_state_wrapper<S>(object_store: &S) -> Result<SuiSystemStateWrapper, SuiError>
+where
+    S: ObjectStore,
+{
+    let sui_system_object = object_store
+        .get_object(&SUI_SYSTEM_STATE_OBJECT_ID)?
+        .ok_or(SuiError::SuiSystemStateNotFound)?;
+    let move_object = sui_system_object
+        .data
+        .try_as_move()
+        .ok_or(SuiError::SuiSystemStateNotFound)?;
+    let result = bcs::from_bytes::<SuiSystemStateWrapper>(move_object.contents())
+        .expect("Sui System State object deserialization cannot fail");
+    Ok(result)
+}
+
+// This version is used to support authority_tests::test_sui_system_state_nop_upgrade.
+pub const SUI_SYSTEM_STATE_TESTING_VERSION1: u64 = u64::MAX;
+
+pub fn get_sui_system_state<S>(object_store: &S) -> Result<SuiSystemState, SuiError>
+where
+    S: ObjectStore,
+{
+    let wrapper = get_sui_system_state_wrapper(object_store)?;
+    let inner_id = derive_dynamic_field_id(
+        wrapper.id.id.bytes,
+        &TypeTag::U64,
+        &MoveTypeLayout::U64,
+        &Value::u64(wrapper.version),
+    )
+    .expect("Sui System State object must exist");
+    let inner = object_store
+        .get_object(&inner_id)?
+        .ok_or(SuiError::SuiSystemStateNotFound)?;
+    let move_object = inner
+        .data
+        .try_as_move()
+        .ok_or(SuiError::SuiSystemStateNotFound)?;
+    match wrapper.version {
+        1 => {
+            let result =
+                bcs::from_bytes::<Field<u64, SuiSystemStateInnerV1>>(move_object.contents())
+                    .expect("Sui System State object deserialization cannot fail");
+            Ok(SuiSystemState::V1(result.value))
+        }
+        // The following case is for sim_test only to support authority_tests::test_sui_system_state_nop_upgrade.
+        #[cfg(msim)]
+        SUI_SYSTEM_STATE_TESTING_VERSION1 => {
+            let result =
+                bcs::from_bytes::<Field<u64, SuiSystemStateInnerV1>>(move_object.contents())
+                    .expect("Sui System State object deserialization cannot fail");
+            Ok(SuiSystemState::V1(result.value))
+        }
+        _ => {
+            error!("Unsupported Sui System State version: {}", wrapper.version);
+            Err(SuiError::SuiSystemStateUnexpectedVersion)
+        }
+    }
+}
+
+pub fn get_sui_system_state_version(_protocol_version: ProtocolVersion) -> u64 {
+    INIT_SYSTEM_STATE_VERSION
+}


### PR DESCRIPTION
A few more refactoring is coming.
Before that, first split the growing sui system state file into a dedicated sub module with multiple files:
1. Put a few common Move types such as Table into collection_types.rs
2. Put all the V1 data structures in a dedicated V1 file.
