### PR TITLE
Add new RPC type and API for sui system state

### DIFF
--- a/crates/sui-indexer/src/apis/governance_api.rs
+++ b/crates/sui-indexer/src/apis/governance_api.rs
@@ -12,6 +12,7 @@ use sui_open_rpc::Module;
 use sui_types::base_types::{EpochId, SuiAddress};
 use sui_types::governance::DelegatedStake;
 use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
 pub(crate) struct GovernanceReadApi {
     fullnode: HttpClient,
@@ -41,6 +42,10 @@ impl GovernanceReadApiServer for GovernanceReadApi {
 
     async fn get_sui_system_state(&self) -> RpcResult<SuiSystemStateRpc> {
         self.fullnode.get_sui_system_state().await
+    }
+
+    async fn get_latest_sui_system_state(&self) -> RpcResult<SuiSystemStateSummary> {
+        self.fullnode.get_latest_sui_system_state().await
     }
 
     async fn get_reference_gas_price(&self) -> RpcResult<u64> {

--- a/crates/sui-json-rpc/src/api/governance.rs
+++ b/crates/sui-json-rpc/src/api/governance.rs
@@ -12,6 +12,7 @@ use sui_types::committee::EpochId;
 use sui_types::governance::DelegatedStake;
 
 use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
 #[open_rpc(namespace = "sui", tag = "Governance Read API")]
 #[rpc(server, client, namespace = "sui")]
@@ -32,9 +33,14 @@ pub trait GovernanceReadApi {
         epoch: Option<EpochId>,
     ) -> RpcResult<SuiCommittee>;
 
-    /// Return latest SUI system state object on-chain.
-    #[method(name = "getSuiSystemState")]
+    /// (Deprecated) Return latest SUI system state object on-chain.
+    /// This is now deprecated in favor of get_latest_sui_system_state.
+    #[method(name = "getSuiSystemState", deprecated)]
     async fn get_sui_system_state(&self) -> RpcResult<SuiSystemStateRpc>;
+
+    /// Return the latest SUI system state object on-chain.
+    #[method(name = "getLatestSuiSystemState")]
+    async fn get_latest_sui_system_state(&self) -> RpcResult<SuiSystemStateSummary>;
 
     /// Return the reference gas price for the network
     #[method(name = "getReferenceGasPrice")]

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use sui_json_rpc_types::{SuiCommittee, SuiSystemStateRpc};
 use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
 use crate::api::GovernanceReadApiServer;
 use crate::error::Error;
@@ -95,6 +96,15 @@ impl GovernanceReadApiServer for GovernanceReadApi {
             .get_sui_system_state_object()
             .map_err(Error::from)?
             .into())
+    }
+
+    async fn get_latest_sui_system_state(&self) -> RpcResult<SuiSystemStateSummary> {
+        Ok(self
+            .state
+            .database
+            .get_sui_system_state_object()
+            .map_err(Error::from)?
+            .into_sui_system_state_summary())
     }
 
     async fn get_reference_gas_price(&self) -> RpcResult<u64> {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1034,6 +1034,23 @@
       }
     },
     {
+      "name": "sui_getLatestSuiSystemState",
+      "tags": [
+        {
+          "name": "Governance Read API"
+        }
+      ],
+      "description": "Return the latest SUI system state object on-chain.",
+      "params": [],
+      "result": {
+        "name": "SuiSystemStateSummary",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/SuiSystemStateSummary"
+        }
+      }
+    },
+    {
       "name": "sui_getMoveFunctionArgTypes",
       "tags": [
         {
@@ -1408,7 +1425,7 @@
           "name": "Governance Read API"
         }
       ],
-      "description": "Return latest SUI system state object on-chain.",
+      "description": "(Deprecated) Return latest SUI system state object on-chain. This is now deprecated in favor of get_latest_sui_system_state.",
       "params": [],
       "result": {
         "name": "SuiSystemStateRpc",
@@ -1416,7 +1433,8 @@
         "schema": {
           "$ref": "#/components/schemas/SuiSystemState"
         }
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "sui_getTotalSupply",
@@ -6298,6 +6316,97 @@
           }
         }
       },
+      "SuiSystemStateSummary": {
+        "description": "This is the JSON-RPC type for the SUI system state object. It flatterns all fields to make them top-level fields such that it as minimum dependencies to the internal data structures of the SUI system state type.",
+        "type": "object",
+        "required": [
+          "active_validators",
+          "epoch",
+          "epoch_start_timestamp_ms",
+          "governance_start_epoch",
+          "max_validator_candidate_count",
+          "min_validator_stake",
+          "protocol_version",
+          "reference_gas_price",
+          "safe_mode",
+          "stake_subsidy_balance",
+          "stake_subsidy_current_epoch_amount",
+          "stake_subsidy_epoch_counter",
+          "storage_fund",
+          "total_stake"
+        ],
+        "properties": {
+          "active_validators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SuiValidatorSummary"
+            }
+          },
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "epoch_start_timestamp_ms": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "governance_start_epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "max_validator_candidate_count": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "min_validator_stake": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "protocol_version": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "reference_gas_price": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "safe_mode": {
+            "type": "boolean"
+          },
+          "stake_subsidy_balance": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "stake_subsidy_current_epoch_amount": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "stake_subsidy_epoch_counter": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "storage_fund": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "total_stake": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      },
       "SuiTBlsSignObjectCommitmentType": {
         "oneOf": [
           {
@@ -6393,6 +6502,280 @@
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
+          }
+        }
+      },
+      "SuiValidatorSummary": {
+        "description": "This is the JSON-RPC type for the SUI validator. It flattens all inner strucutures to top-level fields so that they are decoupled from the internal definitions.",
+        "type": "object",
+        "required": [
+          "commission_rate",
+          "description",
+          "gas_price",
+          "image_url",
+          "name",
+          "net_address",
+          "network_pubkey_bytes",
+          "next_epoch_commission_rate",
+          "next_epoch_gas_price",
+          "next_epoch_stake",
+          "p2p_address",
+          "pending_delegation",
+          "pending_pool_token_withdraw",
+          "pending_total_sui_withdraw",
+          "pool_token_balance",
+          "primary_address",
+          "project_url",
+          "proof_of_possession_bytes",
+          "protocol_pubkey_bytes",
+          "rewards_pool",
+          "starting_epoch",
+          "sui_address",
+          "sui_balance",
+          "voting_power",
+          "worker_address",
+          "worker_pubkey_bytes"
+        ],
+        "properties": {
+          "commission_rate": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "deactivation_epoch": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "description": {
+            "type": "string"
+          },
+          "gas_price": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "image_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "net_address": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "network_pubkey_bytes": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_commission_rate": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "next_epoch_gas_price": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "next_epoch_net_address": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_network_pubkey_bytes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_p2p_address": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_primary_address": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_proof_of_possession": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_protocol_pubkey_bytes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_stake": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "next_epoch_worker_address": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "next_epoch_worker_pubkey_bytes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "p2p_address": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "pending_delegation": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "pending_pool_token_withdraw": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "pending_total_sui_withdraw": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "pool_token_balance": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "primary_address": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "project_url": {
+            "type": "string"
+          },
+          "proof_of_possession_bytes": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "protocol_pubkey_bytes": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "rewards_pool": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "starting_epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "sui_address": {
+            "$ref": "#/components/schemas/SuiAddress"
+          },
+          "sui_balance": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "voting_power": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "worker_address": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "worker_pubkey_bytes": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
           }
         }
       },

--- a/crates/sui-types/src/collection_types.rs
+++ b/crates/sui-types/src/collection_types.rs
@@ -35,6 +35,11 @@ impl<T> MoveOption<T> {
     pub fn empty() -> Self {
         Self { vec: vec![] }
     }
+
+    pub fn into_option(self) -> Option<T> {
+        let Self { mut vec } = self;
+        vec.pop()
+    }
 }
 
 /// Rust version of the Move sui::table::Table type.

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -21,8 +21,10 @@ use std::collections::{BTreeMap, HashMap};
 use tracing::error;
 
 use self::sui_system_state_inner_v1::{SuiSystemStateInnerV1, ValidatorMetadata};
+use self::sui_system_state_summary::SuiSystemStateSummary;
 
 pub mod sui_system_state_inner_v1;
+pub mod sui_system_state_summary;
 
 const SUI_SYSTEM_STATE_WRAPPER_STRUCT_NAME: &IdentStr = ident_str!("SuiSystemState");
 
@@ -75,6 +77,7 @@ pub trait SuiSystemStateTrait {
     fn get_validator_metadata_vec(&self) -> Vec<ValidatorMetadata>;
     fn get_current_epoch_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId>;
     fn get_staking_pool_info(&self) -> BTreeMap<SuiAddress, (Vec<u8>, u64)>;
+    fn into_sui_system_state_summary(self) -> SuiSystemStateSummary;
 }
 
 /// SuiSystemState provides an abstraction over multiple versions of the inner SuiSystemStateInner object.

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -15,6 +15,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
+use super::sui_system_state_summary::{SuiSystemStateSummary, SuiValidatorSummary};
 use super::SuiSystemStateTrait;
 
 const E_METADATA_INVALID_PUBKEY: u64 = 1;
@@ -437,6 +438,66 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
 
     fn safe_mode(&self) -> bool {
         self.safe_mode
+    }
+
+    fn into_sui_system_state_summary(self) -> SuiSystemStateSummary {
+        SuiSystemStateSummary {
+            epoch: self.epoch,
+            protocol_version: self.protocol_version,
+            storage_fund: self.storage_fund.value(),
+            reference_gas_price: self.reference_gas_price,
+            safe_mode: self.safe_mode,
+            epoch_start_timestamp_ms: self.epoch_start_timestamp_ms,
+            min_validator_stake: self.parameters.min_validator_stake,
+            max_validator_candidate_count: self.parameters.max_validator_candidate_count,
+            governance_start_epoch: self.parameters.governance_start_epoch,
+            stake_subsidy_epoch_counter: self.stake_subsidy.epoch_counter,
+            stake_subsidy_balance: self.stake_subsidy.balance.value(),
+            stake_subsidy_current_epoch_amount: self.stake_subsidy.current_epoch_amount,
+            total_stake: self.validators.total_stake,
+            active_validators: self
+                .validators
+                .active_validators
+                .into_iter()
+                .map(|v| SuiValidatorSummary {
+                    sui_address: v.metadata.sui_address,
+                    protocol_pubkey_bytes: v.metadata.protocol_pubkey_bytes,
+                    network_pubkey_bytes: v.metadata.network_pubkey_bytes,
+                    worker_pubkey_bytes: v.metadata.worker_pubkey_bytes,
+                    proof_of_possession_bytes: v.metadata.proof_of_possession_bytes,
+                    name: v.metadata.name,
+                    description: v.metadata.description,
+                    image_url: v.metadata.image_url,
+                    project_url: v.metadata.project_url,
+                    net_address: v.metadata.net_address,
+                    p2p_address: v.metadata.p2p_address,
+                    primary_address: v.metadata.primary_address,
+                    worker_address: v.metadata.worker_address,
+                    next_epoch_protocol_pubkey_bytes: v.metadata.next_epoch_protocol_pubkey_bytes,
+                    next_epoch_proof_of_possession: v.metadata.next_epoch_proof_of_possession,
+                    next_epoch_network_pubkey_bytes: v.metadata.next_epoch_network_pubkey_bytes,
+                    next_epoch_worker_pubkey_bytes: v.metadata.next_epoch_worker_pubkey_bytes,
+                    next_epoch_net_address: v.metadata.next_epoch_net_address,
+                    next_epoch_p2p_address: v.metadata.next_epoch_p2p_address,
+                    next_epoch_primary_address: v.metadata.next_epoch_primary_address,
+                    next_epoch_worker_address: v.metadata.next_epoch_worker_address,
+                    voting_power: v.voting_power,
+                    gas_price: v.gas_price,
+                    commission_rate: v.commission_rate,
+                    next_epoch_stake: v.next_epoch_stake,
+                    next_epoch_gas_price: v.next_epoch_gas_price,
+                    next_epoch_commission_rate: v.next_epoch_commission_rate,
+                    starting_epoch: v.staking_pool.starting_epoch,
+                    deactivation_epoch: v.staking_pool.deactivation_epoch.into_option(),
+                    sui_balance: v.staking_pool.sui_balance,
+                    rewards_pool: v.staking_pool.rewards_pool.value(),
+                    pool_token_balance: v.staking_pool.pool_token_balance,
+                    pending_delegation: v.staking_pool.pending_delegation,
+                    pending_total_sui_withdraw: v.staking_pool.pending_total_sui_withdraw,
+                    pending_pool_token_withdraw: v.staking_pool.pending_pool_token_withdraw,
+                })
+                .collect(),
+        }
     }
 }
 

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::base_types::SuiAddress;
+
+/// This is the JSON-RPC type for the SUI system state object.
+/// It flatterns all fields to make them top-level fields such that it as minimum
+/// dependencies to the internal data structures of the SUI system state type.
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct SuiSystemStateSummary {
+    pub epoch: u64,
+    pub protocol_version: u64,
+    pub storage_fund: u64,
+    pub reference_gas_price: u64,
+    pub safe_mode: bool,
+    pub epoch_start_timestamp_ms: u64,
+
+    // System parameters
+    pub min_validator_stake: u64,
+    pub max_validator_candidate_count: u64,
+    pub governance_start_epoch: u64,
+
+    // Stake subsidy information
+    pub stake_subsidy_epoch_counter: u64,
+    pub stake_subsidy_balance: u64,
+    pub stake_subsidy_current_epoch_amount: u64,
+
+    // Validator set
+    pub total_stake: u64,
+    pub active_validators: Vec<SuiValidatorSummary>,
+}
+
+/// This is the JSON-RPC type for the SUI validator. It flattens all inner strucutures
+/// to top-level fields so that they are decoupled from the internal definitions.
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct SuiValidatorSummary {
+    // Metadata
+    pub sui_address: SuiAddress,
+    pub protocol_pubkey_bytes: Vec<u8>,
+    pub network_pubkey_bytes: Vec<u8>,
+    pub worker_pubkey_bytes: Vec<u8>,
+    pub proof_of_possession_bytes: Vec<u8>,
+    pub name: String,
+    pub description: String,
+    pub image_url: String,
+    pub project_url: String,
+    pub net_address: Vec<u8>,
+    pub p2p_address: Vec<u8>,
+    pub primary_address: Vec<u8>,
+    pub worker_address: Vec<u8>,
+    pub next_epoch_protocol_pubkey_bytes: Option<Vec<u8>>,
+    pub next_epoch_proof_of_possession: Option<Vec<u8>>,
+    pub next_epoch_network_pubkey_bytes: Option<Vec<u8>>,
+    pub next_epoch_worker_pubkey_bytes: Option<Vec<u8>>,
+    pub next_epoch_net_address: Option<Vec<u8>>,
+    pub next_epoch_p2p_address: Option<Vec<u8>>,
+    pub next_epoch_primary_address: Option<Vec<u8>>,
+    pub next_epoch_worker_address: Option<Vec<u8>>,
+
+    pub voting_power: u64,
+    pub gas_price: u64,
+    pub commission_rate: u64,
+    pub next_epoch_stake: u64,
+    pub next_epoch_gas_price: u64,
+    pub next_epoch_commission_rate: u64,
+
+    // Staking pool information
+    pub starting_epoch: u64,
+    pub deactivation_epoch: Option<u64>,
+    pub sui_balance: u64,
+    pub rewards_pool: u64,
+    pub pool_token_balance: u64,
+    pub pending_delegation: u64,
+    pub pending_total_sui_withdraw: u64,
+    pub pending_pool_token_withdraw: u64,
+}


### PR DESCRIPTION
This PR adds a new type called SuiSystemStateSummary.
It's a flatten type of SuiSystemState with minimum number of data structure dependencies.
Added a new RPC API to return the latest state.