### PR TITLE
Log integrity hash every 1000th transaction, along with index

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -75,11 +75,11 @@ fn update_hash(
     previous_hash.hash(&mut hasher);
     v.hash(&mut hasher);
     let hash = hasher.finish();
-    // Log hash every 100th transaction of the subdag
-    if index.transaction_index % 100 == 0 {
+    // Log hash every 1000th transaction of the subdag
+    if index.transaction_index % 1000 == 0 {
         debug!(
-            "Integrity hash for consensus output at subdag {} is {:016x}",
-            index.sub_dag_index, hash
+            "Integrity hash for consensus output at subdag {} transaction {} is {:016x}",
+            index.sub_dag_index, index.transaction_index, hash
         );
     }
     let last_seen = ExecutionIndicesWithHash { index, hash };


### PR DESCRIPTION
## Description 

Logging every 100th transaction seems a bit noisy. Also sometimes the log lines from the same subdag are reordered, so include the transaction index in the log messages as well.

## Test Plan 

n/a

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
