### PR TITLE
Move EpochStartConfiguration to perpetual db

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2716,7 +2716,7 @@ async fn test_authority_persist() {
             &epoch_store_path,
             None,
             EpochMetrics::new(&registry),
-            Some(Default::default()),
+            Default::default(),
             store.clone(),
             cache_metrics,
         );
@@ -4716,7 +4716,7 @@ async fn test_tallying_rule_score_updates() {
         &path,
         None,
         metrics.clone(),
-        Some(Default::default()),
+        Default::default(),
         store,
         cache_metrics,
     );

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -180,14 +180,9 @@ impl SuiNode {
         let committee = committee_store
             .get_committee(&cur_epoch)?
             .expect("Committee of the current epoch must exist");
-        let epoch_start_configuration = if cur_epoch == genesis.epoch() {
-            Some(EpochStartConfiguration {
-                system_state: SuiSystemState::new_genesis(genesis.sui_system_object()),
-                epoch_digest: genesis.checkpoint().digest(),
-            })
-        } else {
-            None
-        };
+        let epoch_start_configuration = store
+            .get_epoch_start_configuration()?
+            .expect("EpochStartConfiguration of the current epoch must exist");
         let cache_metrics = Arc::new(ResolverMetrics::new(&prometheus_registry));
         let epoch_store = AuthorityPerEpochStore::new(
             config.protocol_public_key(),


### PR DESCRIPTION
## Description 

We are moving EpochStartConfiguration from epoch store to perpetual as that simplifies db checkpoints (we already checkpoint perpetual db with this it and does not require us to checkpoint epoch start configuration explicitly) and restore.

## Test Plan 

Existing tests
