### PR TITLE
Support for extensible committment schemes

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -773,6 +773,7 @@ fn create_genesis_checkpoint(
         end_of_epoch_data: None,
         timestamp_ms: parameters.timestamp_ms,
         version_specific_data: Vec::new(),
+        checkpoint_commitments: Default::default(),
     };
 
     (checkpoint, contents)

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use fastcrypto::hash::MultisetHash;
 use fastcrypto::traits::KeyPair;
 use tempfile::tempdir;
 
@@ -10,8 +9,8 @@ use std::{sync::Arc, time::Duration};
 
 use broadcast::{Receiver, Sender};
 use sui_protocol_config::SupportedProtocolVersions;
-use sui_types::messages_checkpoint::VerifiedCheckpoint;
-use sui_types::{accumulator::Accumulator, committee::ProtocolVersion};
+use sui_types::committee::ProtocolVersion;
+use sui_types::messages_checkpoint::{ECMHLiveObjectSetDigest, VerifiedCheckpoint};
 use tokio::{sync::broadcast, time::timeout};
 
 use crate::authority::authority_per_epoch_store::EpochStartConfiguration;
@@ -426,7 +425,7 @@ fn sync_end_of_epoch_checkpoint(
         Some(EndOfEpochData {
             next_epoch_committee: new_committee.committee().voting_rights.clone(),
             next_epoch_protocol_version: ProtocolVersion::MIN,
-            root_state_digest: Accumulator::default().digest(),
+            epoch_commitments: vec![ECMHLiveObjectSetDigest::default().into()],
         }),
     );
     sync_checkpoint(&checkpoint, checkpoint_store, sender);

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -8,11 +8,11 @@ use typed_store::Map;
 
 use std::sync::Arc;
 
-use fastcrypto::hash::{Digest, MultisetHash};
+use fastcrypto::hash::MultisetHash;
 use sui_types::accumulator::Accumulator;
 use sui_types::error::SuiResult;
 use sui_types::messages::{TransactionEffects, TransactionEffectsAPI};
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::messages_checkpoint::{CheckpointSequenceNumber, ECMHLiveObjectSetDigest};
 use typed_store::rocks::TypedStoreError;
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
@@ -160,10 +160,11 @@ impl StateAccumulator {
         epoch: &EpochId,
         last_checkpoint_of_epoch: CheckpointSequenceNumber,
         epoch_store: Arc<AuthorityPerEpochStore>,
-    ) -> Result<Digest<32>, TypedStoreError> {
+    ) -> Result<ECMHLiveObjectSetDigest, TypedStoreError> {
         Ok(self
             .accumulate_epoch(epoch, last_checkpoint_of_epoch, epoch_store)
             .await?
-            .digest())
+            .digest()
+            .into())
     }
 }

--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -101,6 +101,7 @@ impl TryFrom<Checkpoint> for RpcCheckpoint {
             network_total_transactions: checkpoint.total_transactions_from_genesis as u64,
             timestamp_ms: checkpoint.timestamp_ms as u64,
             transactions: parsed_txn_digests,
+            checkpoint_commitments: vec![],
         })
     }
 }

--- a/crates/sui-json-rpc-types/src/sui_checkpoint.rs
+++ b/crates/sui-json-rpc-types/src/sui_checkpoint.rs
@@ -8,8 +8,8 @@ use sui_types::committee::EpochId;
 use sui_types::digests::CheckpointDigest;
 use sui_types::gas::GasCostSummary;
 use sui_types::messages_checkpoint::{
-    CheckpointContents, CheckpointSequenceNumber, CheckpointSummary, CheckpointTimestamp,
-    EndOfEpochData,
+    CheckpointCommitment, CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
+    CheckpointTimestamp, EndOfEpochData,
 };
 
 #[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
@@ -37,6 +37,9 @@ pub struct Checkpoint {
     pub end_of_epoch_data: Option<EndOfEpochData>,
     /// Transaction digests
     pub transactions: Vec<TransactionDigest>,
+
+    /// Commitments to checkpoint state
+    pub checkpoint_commitments: Vec<CheckpointCommitment>,
 }
 
 impl From<(CheckpointSummary, CheckpointContents)> for Checkpoint {
@@ -63,6 +66,10 @@ impl From<(CheckpointSummary, CheckpointContents)> for Checkpoint {
             timestamp_ms,
             end_of_epoch_data,
             transactions: contents.iter().map(|digest| digest.transaction).collect(),
+            // TODO: populate commitment for rpc clients. Most likely, rpc clients don't need this
+            // info (if they need it, they need to get signed BCS data anyway in order to trust
+            // it).
+            checkpoint_commitments: Default::default(),
         }
     }
 }

--- a/crates/sui-network/src/state_sync/test_utils.rs
+++ b/crates/sui-network/src/state_sync/test_utils.rs
@@ -70,6 +70,7 @@ impl CommitteeFixture {
             end_of_epoch_data: None,
             timestamp_ms: 0,
             version_specific_data: Vec::new(),
+            checkpoint_commitments: Default::default(),
         };
 
         self.create_certified_checkpoint(checkpoint)
@@ -134,6 +135,7 @@ impl CommitteeFixture {
                 end_of_epoch_data: None,
                 timestamp_ms: 0,
                 version_specific_data: Vec::new(),
+                checkpoint_commitments: Default::default(),
             };
 
             let checkpoint = self.create_certified_checkpoint(summary);
@@ -181,6 +183,7 @@ impl CommitteeFixture {
             end_of_epoch_data,
             timestamp_ms: 0,
             version_specific_data: Vec::new(),
+            checkpoint_commitments: Default::default(),
         };
 
         let checkpoint = self.create_certified_checkpoint(summary);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -589,7 +589,8 @@
               "endOfEpochData": null,
               "transactions": [
                 "BhbWpBeESxuRWvmvLMyb2JNUuFa6j4aG1T4WUiPgKAHm"
-              ]
+              ],
+              "checkpointCommitments": []
             }
           }
         }
@@ -2855,6 +2856,7 @@
       "Checkpoint": {
         "type": "object",
         "required": [
+          "checkpointCommitments",
           "digest",
           "epoch",
           "epochRollingGasCostSummary",
@@ -2864,6 +2866,13 @@
           "transactions"
         ],
         "properties": {
+          "checkpointCommitments": {
+            "description": "Commitments to checkpoint state",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CheckpointCommitment"
+            }
+          },
           "digest": {
             "description": "Checkpoint digest",
             "allOf": [
@@ -2934,6 +2943,22 @@
             }
           }
         }
+      },
+      "CheckpointCommitment": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "ECMHLiveObjectSetDigest"
+            ],
+            "properties": {
+              "ECMHLiveObjectSetDigest": {
+                "$ref": "#/components/schemas/ECMHLiveObjectSetDigest"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "CheckpointDigest": {
         "description": "Representation of a Checkpoint's digest",
@@ -3284,6 +3309,25 @@
           "DynamicObject"
         ]
       },
+      "ECMHLiveObjectSetDigest": {
+        "description": "The Sha256 digest of an EllipticCurveMultisetHash committing to the live object set.",
+        "type": "object",
+        "required": [
+          "digest"
+        ],
+        "properties": {
+          "digest": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            },
+            "maxItems": 32,
+            "minItems": 32
+          }
+        }
+      },
       "Ed25519SuiSignature": {
         "$ref": "#/components/schemas/Base64"
       },
@@ -3332,11 +3376,18 @@
       "EndOfEpochData": {
         "type": "object",
         "required": [
+          "epoch_commitments",
           "next_epoch_committee",
-          "next_epoch_protocol_version",
-          "root_state_digest"
+          "next_epoch_protocol_version"
         ],
         "properties": {
+          "epoch_commitments": {
+            "description": "Commitments to epoch specific state (e.g. live object set)",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CheckpointCommitment"
+            }
+          },
           "next_epoch_committee": {
             "description": "next_epoch_committee is `Some` if and only if the current checkpoint is the last checkpoint of an epoch. Therefore next_epoch_committee can be used to pick the last checkpoint of an epoch, which is often useful to get epoch level summary stats like total gas cost of an epoch, or the total number of transactions from genesis to the end of an epoch. The committee is stored as a vector of validator pub key and stake pairs. The vector should be sorted based on the Committee data structure.",
             "type": "array",
@@ -3363,17 +3414,6 @@
                 "$ref": "#/components/schemas/ProtocolVersion"
               }
             ]
-          },
-          "root_state_digest": {
-            "description": "The digest of the union of all checkpoint accumulators, representing the state of the system at the end of the epoch.",
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            },
-            "maxItems": 32,
-            "minItems": 32
           }
         }
       },

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -297,6 +297,7 @@ impl RpcExampleProvider {
             timestamp_ms: 1676911928,
             end_of_epoch_data: None,
             transactions: vec![TransactionDigest::new(self.rng.gen())],
+            checkpoint_commitments: vec![],
         };
 
         Examples::new(

--- a/sdk/typescript/src/types/checkpoints.ts
+++ b/sdk/typescript/src/types/checkpoints.ts
@@ -10,7 +10,6 @@ import {
   string,
   union,
   tuple,
-  optional,
 } from 'superstruct';
 
 import { TransactionDigest, TransactionEffectsDigest } from './common';
@@ -28,11 +27,18 @@ export type CheckPointContentsDigest = Infer<typeof CheckPointContentsDigest>;
 export const CheckpointDigest = string();
 export type CheckpointDigest = Infer<typeof CheckpointDigest>;
 
+export const ECMHLiveObjectSetDigest = object({
+  digest: array(number()),
+});
+export type ECMHLiveObjectSetDigest = Infer<typeof ECMHLiveObjectSetDigest>;
+
+export const CheckpointCommitment = union([ECMHLiveObjectSetDigest]);
+export type CheckpointCommitment = Infer<typeof CheckpointCommitment>;
+
 export const EndOfEpochData = object({
   next_epoch_committee: array(tuple([string(), number()])),
   next_epoch_protocol_version: number(),
-  // Need to remove optional after we hit the next network version
-  root_state_digest: optional(array(number())),
+  checkpoint_commitments: array(CheckpointCommitment),
 });
 export type EndOfEpochData = Infer<typeof EndOfEpochData>;
 
@@ -51,5 +57,6 @@ export const Checkpoint = object({
   timestampMs: union([number(), literal(null)]),
   endOfEpochData: union([EndOfEpochData, literal(null)]),
   transactions: array(TransactionDigest),
+  checkpointCommitments: array(CheckpointCommitment),
 });
 export type Checkpoint = Infer<typeof Checkpoint>;


### PR DESCRIPTION
## Description 

Allows multiple commitments to be added per checkpoint, and allows new commitment types to be added in a forward compatible way.

Actually using multiple commitments will require consensus among validators as to which commitment schemes should be used. That work is TBD.

## Test Plan 

```cargo simtest```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
