### PR TITLE
[ts-sdk] Execute TS SDK transactions with the builder

### DIFF
--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -35,18 +35,21 @@ export async function mint(address: string) {
         keypair.getPublicKey().toSuiAddress()
     );
 
-    const tx = await signer.executeMoveCall({
-        packageObjectId: '0x2',
-        module: 'devnet_nft',
-        function: 'mint',
-        typeArguments: [],
-        arguments: [
-            'Example NFT',
-            'An example NFT.',
-            'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
-        ],
-        gasPayment: gasPayment.objectId,
-        gasBudget: 30000,
+    const tx = await signer.signAndExecuteTransaction({
+        kind: 'moveCall',
+        data: {
+            packageObjectId: '0x2',
+            module: 'devnet_nft',
+            function: 'mint',
+            typeArguments: [],
+            arguments: [
+                'Example NFT',
+                'An example NFT.',
+                'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+            ],
+            gasPayment: gasPayment.objectId,
+            gasBudget: 30000,
+        },
     });
 
     assert(tx, SuiTransactionResponse);

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -52,10 +52,13 @@ function TransferCoinPage() {
 
                 // Use payAllSui if sendMax is true and the token type is SUI
                 if (formData.isPayAllSui && coinType === SUI_TYPE_ARG) {
-                    return signer.payAllSui({
-                        recipient: formData.to,
-                        gasBudget: formData.gasBudget,
-                        inputCoins: formData.coinIds,
+                    return signer.signAndExecuteTransaction({
+                        kind: 'payAllSui',
+                        data: {
+                            recipient: formData.to,
+                            gasBudget: formData.gasBudget,
+                            inputCoins: formData.coinIds,
+                        },
                     });
                 }
 

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -107,18 +107,21 @@ export class Coin {
         });
 
         try {
-            return await signer.executeMoveCall({
-                packageObjectId: '0x2',
-                module: 'sui_system',
-                function: 'request_add_delegation_mul_coin',
-                typeArguments: [],
-                arguments: [
-                    SUI_SYSTEM_STATE_OBJECT_ID,
-                    [stakeCoin],
-                    [String(amount)],
-                    validator,
-                ],
-                gasBudget: DEFAULT_GAS_BUDGET_FOR_STAKE,
+            return await signer.signAndExecuteTransaction({
+                kind: 'moveCall',
+                data: {
+                    packageObjectId: '0x2',
+                    module: 'sui_system',
+                    function: 'request_add_delegation_mul_coin',
+                    typeArguments: [],
+                    arguments: [
+                        SUI_SYSTEM_STATE_OBJECT_ID,
+                        [stakeCoin],
+                        [String(amount)],
+                        validator,
+                    ],
+                    gasBudget: DEFAULT_GAS_BUDGET_FOR_STAKE,
+                },
             });
         } finally {
             span.finish();
@@ -133,17 +136,20 @@ export class Coin {
     ): Promise<SuiTransactionResponse> {
         const transaction = Sentry.startTransaction({ name: 'unstake' });
         try {
-            return await signer.executeMoveCall({
-                packageObjectId: '0x2',
-                module: 'sui_system',
-                function: 'request_withdraw_delegation',
-                typeArguments: [],
-                arguments: [
-                    SUI_SYSTEM_STATE_OBJECT_ID,
-                    delegation,
-                    stakedSuiId,
-                ],
-                gasBudget: DEFAULT_GAS_BUDGET_FOR_STAKE,
+            return await signer.signAndExecuteTransaction({
+                kind: 'moveCall',
+                data: {
+                    packageObjectId: '0x2',
+                    module: 'sui_system',
+                    function: 'request_withdraw_delegation',
+                    typeArguments: [],
+                    arguments: [
+                        SUI_SYSTEM_STATE_OBJECT_ID,
+                        delegation,
+                        stakedSuiId,
+                    ],
+                    gasBudget: DEFAULT_GAS_BUDGET_FOR_STAKE,
+                },
             });
         } finally {
             transaction.finish();
@@ -173,16 +179,19 @@ export class Coin {
 
             const address = await signer.getAddress();
 
-            const result = await signer.paySui({
-                // NOTE: We reverse the order here so that the highest coin is in the front
-                // so that it is used as the gas coin.
-                inputCoins: [...inputCoins]
-                    .reverse()
-                    .map((coin) => Coin.getID(coin as SuiMoveObject)),
-                recipients: [address, address],
-                // TODO: Update SDK to accept bigint
-                amounts: [Number(amount), Number(gasFee)],
-                gasBudget,
+            const result = await signer.signAndExecuteTransaction({
+                kind: 'paySui',
+                data: {
+                    // NOTE: We reverse the order here so that the highest coin is in the front
+                    // so that it is used as the gas coin.
+                    inputCoins: [...inputCoins]
+                        .reverse()
+                        .map((coin) => Coin.getID(coin as SuiMoveObject)),
+                    recipients: [address, address],
+                    // TODO: Update SDK to accept bigint
+                    amounts: [Number(amount), Number(gasFee)],
+                    gasBudget,
+                },
             });
 
             const effects = getTransactionEffects(result);

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
@@ -22,17 +22,20 @@ export class ExampleNFT {
         description?: string,
         imageUrl?: string
     ): Promise<SuiTransactionResponse> {
-        return await signer.executeMoveCall({
-            packageObjectId: '0x2',
-            module: 'devnet_nft',
-            function: 'mint',
-            typeArguments: [],
-            arguments: [
-                name || 'Example NFT',
-                description || 'An NFT created by Sui Wallet',
-                imageUrl || DEFAULT_NFT_IMAGE,
-            ],
-            gasBudget: 2000,
+        return await signer.signAndExecuteTransaction({
+            kind: 'moveCall',
+            data: {
+                packageObjectId: '0x2',
+                module: 'devnet_nft',
+                function: 'mint',
+                typeArguments: [],
+                arguments: [
+                    name || 'Example NFT',
+                    description || 'An NFT created by Sui Wallet',
+                    imageUrl || DEFAULT_NFT_IMAGE,
+                ],
+                gasBudget: 2000,
+            },
         });
     }
 }

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
@@ -132,7 +132,10 @@ export const transferNFT = createAsyncThunk<
             throw new Error('Error, active address is not defined');
         }
         const signer = api.getSignerInstance(activeAddress, background);
-        const txn = await signer.transferObject(data);
+        const txn = await signer.signAndExecuteTransaction({
+            kind: 'transferObject',
+            data,
+        });
         await dispatch(fetchAllOwnedAndRequiredObjects());
         const txnResp = {
             timestampMs: getTimestampFromTransactionResponse(txn),

--- a/sdk/typescript/src/builder/TransactionData.ts
+++ b/sdk/typescript/src/builder/TransactionData.ts
@@ -80,7 +80,7 @@ export class TransactionDataBuilder {
     this.commands = clone?.commands ?? [];
   }
 
-  build() {
+  build({ size }: { size?: number } = {}) {
     if (!this.gasConfig.budget) {
       throw new Error('Missing gas budget');
     }
@@ -122,7 +122,9 @@ export class TransactionDataBuilder {
       },
     };
 
-    return builder.ser('TransactionData', { V1: transactionData }).toBytes();
+    return builder
+      .ser('TransactionData', { V1: transactionData }, size)
+      .toBytes();
   }
 
   snapshot(): SerializedTransactionDataBuilder {

--- a/sdk/typescript/test/e2e/coin-metadata.test.ts
+++ b/sdk/typescript/test/e2e/coin-metadata.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeAll } from 'vitest';
-import { LocalTxnDataSerializer, ObjectId, RawSigner } from '../../src';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectId, RawSigner } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test Coin Metadata', () => {
@@ -10,13 +10,9 @@ describe('Test Coin Metadata', () => {
   let signer: RawSigner;
   let packageId: ObjectId;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     toolbox = await setup();
-    signer = new RawSigner(
-      toolbox.keypair,
-      toolbox.provider,
-      new LocalTxnDataSerializer(toolbox.provider),
-    );
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath = __dirname + '/./data/coin_metadata';
     packageId = await publishPackage(signer, packagePath);
   });

--- a/sdk/typescript/test/e2e/coin-metadata.test.ts
+++ b/sdk/typescript/test/e2e/coin-metadata.test.ts
@@ -18,7 +18,7 @@ describe('Test Coin Metadata', () => {
       new LocalTxnDataSerializer(toolbox.provider),
     );
     const packagePath = __dirname + '/./data/coin_metadata';
-    packageId = await publishPackage(signer, true, packagePath);
+    packageId = await publishPackage(signer, packagePath);
   });
 
   it('Test accessing coin metadata', async () => {

--- a/sdk/typescript/test/e2e/coin-read.test.ts
+++ b/sdk/typescript/test/e2e/coin-read.test.ts
@@ -2,80 +2,71 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { LocalTxnDataSerializer, RawSigner } from '../../src';
+import { RawSigner } from '../../src';
 
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
-describe.each([{ useLocalTxnBuilder: true }])(
-  'CoinRead API',
-  ({ useLocalTxnBuilder }) => {
-    let toolbox: TestToolbox;
-    let signer: RawSigner;
-    let packageId: string;
-    let testType: string;
+describe('CoinRead API', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+  let packageId: string;
+  let testType: string;
 
-    beforeAll(async () => {
-      toolbox = await setup();
-      signer = new RawSigner(
-        toolbox.keypair,
-        toolbox.provider,
-        useLocalTxnBuilder
-          ? new LocalTxnDataSerializer(toolbox.provider)
-          : undefined,
-      );
-      const packagePath = __dirname + '/./data/coin_metadata';
-      packageId = await publishPackage(signer, useLocalTxnBuilder, packagePath);
-      testType = packageId + '::test::TEST';
-    });
+  beforeAll(async () => {
+    toolbox = await setup();
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
+    const packagePath = __dirname + '/./data/coin_metadata';
+    packageId = await publishPackage(signer, packagePath);
+    testType = packageId + '::test::TEST';
+  });
 
-    it('Get coins with/without type', async () => {
-      const suiCoins = await toolbox.provider.getCoins(toolbox.address());
-      expect(suiCoins.data.length).toEqual(5);
+  it('Get coins with/without type', async () => {
+    const suiCoins = await toolbox.provider.getCoins(toolbox.address());
+    expect(suiCoins.data.length).toEqual(5);
 
-      const testCoins = await toolbox.provider.getCoins(
-        toolbox.address(),
-        testType,
-      );
-      expect(testCoins.data.length).toEqual(2);
+    const testCoins = await toolbox.provider.getCoins(
+      toolbox.address(),
+      testType,
+    );
+    expect(testCoins.data.length).toEqual(2);
 
-      const allCoins = await toolbox.provider.getAllCoins(toolbox.address());
-      expect(allCoins.data.length).toEqual(7);
-      expect(allCoins.nextCursor).toBeNull();
+    const allCoins = await toolbox.provider.getAllCoins(toolbox.address());
+    expect(allCoins.data.length).toEqual(7);
+    expect(allCoins.nextCursor).toBeNull();
 
-      //test paging with limit
-      const someSuiCoins = await toolbox.provider.getCoins(
-        toolbox.address(),
-        null,
-        null,
-        3,
-      );
-      expect(someSuiCoins.data.length).toEqual(3);
-      expect(someSuiCoins.nextCursor).toBeTruthy();
-    });
+    //test paging with limit
+    const someSuiCoins = await toolbox.provider.getCoins(
+      toolbox.address(),
+      null,
+      null,
+      3,
+    );
+    expect(someSuiCoins.data.length).toEqual(3);
+    expect(someSuiCoins.nextCursor).toBeTruthy();
+  });
 
-    it('Get balance with/without type', async () => {
-      const suiBalance = await toolbox.provider.getBalance(toolbox.address());
-      expect(suiBalance.coinType).toEqual('0x2::sui::SUI');
-      expect(suiBalance.coinObjectCount).toEqual(5);
-      expect(suiBalance.totalBalance).toBeGreaterThan(0);
+  it('Get balance with/without type', async () => {
+    const suiBalance = await toolbox.provider.getBalance(toolbox.address());
+    expect(suiBalance.coinType).toEqual('0x2::sui::SUI');
+    expect(suiBalance.coinObjectCount).toEqual(5);
+    expect(suiBalance.totalBalance).toBeGreaterThan(0);
 
-      const testBalance = await toolbox.provider.getBalance(
-        toolbox.address(),
-        testType,
-      );
-      expect(testBalance.coinType).toEqual(testType);
-      expect(testBalance.coinObjectCount).toEqual(2);
-      expect(testBalance.totalBalance).toEqual(11);
+    const testBalance = await toolbox.provider.getBalance(
+      toolbox.address(),
+      testType,
+    );
+    expect(testBalance.coinType).toEqual(testType);
+    expect(testBalance.coinObjectCount).toEqual(2);
+    expect(testBalance.totalBalance).toEqual(11);
 
-      const allBalances = await toolbox.provider.getAllBalances(
-        toolbox.address(),
-      );
-      expect(allBalances.length).toEqual(2);
-    });
+    const allBalances = await toolbox.provider.getAllBalances(
+      toolbox.address(),
+    );
+    expect(allBalances.length).toEqual(2);
+  });
 
-    it('Get total supply', async () => {
-      const testSupply = await toolbox.provider.getTotalSupply(testType);
-      expect(testSupply.value).toEqual(11);
-    });
-  },
-);
+  it('Get total supply', async () => {
+    const testSupply = await toolbox.provider.getTotalSupply(testType);
+    expect(testSupply.value).toEqual(11);
+  });
+});

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
   Coin,
   getObjectId,
-  LocalTxnDataSerializer,
   normalizeSuiObjectId,
   ObjectId,
   RawSigner,
@@ -25,21 +24,20 @@ describe('Coin related API', () => {
 
   beforeAll(async () => {
     toolbox = await setup();
-    signer = new RawSigner(
-      toolbox.keypair,
-      toolbox.provider,
-      new LocalTxnDataSerializer(toolbox.provider),
-    );
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
       toolbox.address(),
     );
     coinToSplit = coins[0].objectId;
     // split coins into desired amount
-    await signer.splitCoin({
-      coinObjectId: coinToSplit,
-      splitAmounts: SPLIT_AMOUNTS.map((s) => Number(s)),
-      gasBudget: DEFAULT_GAS_BUDGET,
-      gasPayment: coins[1].objectId,
+    await signer.signAndExecuteTransaction({
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: coinToSplit,
+        splitAmounts: SPLIT_AMOUNTS.map((s) => Number(s)),
+        gasBudget: DEFAULT_GAS_BUDGET,
+        gasPayment: coins[1].objectId,
+      },
     });
     coinsAfterSplit = await toolbox.provider.getGasObjectsOwnedByAddress(
       toolbox.address(),

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
   getObjectId,
   getNewlyCreatedCoinRefsAfterSplit,
-  LocalTxnDataSerializer,
   RawSigner,
   UnserializedSignableTransaction,
 } from '../../src';
@@ -17,104 +16,95 @@ import {
   TestToolbox,
 } from './utils/setup';
 
-describe.each([{ useLocalTxnBuilder: false }, { useLocalTxnBuilder: true }])(
-  'Test dev inspect',
-  ({ useLocalTxnBuilder }) => {
-    let toolbox: TestToolbox;
-    let signer: RawSigner;
-    let packageId: string;
+describe('Test dev inspect', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+  let packageId: string;
 
-    beforeAll(async () => {
-      toolbox = await setup();
-      //const version = await toolbox.provider.getRpcApiVersion();
-      signer = new RawSigner(
-        toolbox.keypair,
-        toolbox.provider,
-        useLocalTxnBuilder
-          ? new LocalTxnDataSerializer(toolbox.provider)
-          : undefined,
-      );
-      const packagePath = __dirname + '/./data/serializer';
-      packageId = await publishPackage(signer, useLocalTxnBuilder, packagePath);
-    });
+  beforeAll(async () => {
+    toolbox = await setup();
+    //const version = await toolbox.provider.getRpcApiVersion();
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
+    const packagePath = __dirname + '/./data/serializer';
+    packageId = await publishPackage(signer, packagePath);
+  });
 
-    it('Dev inspect transaction with Pay', async () => {
-      const gasBudget = 1000;
-      const coins =
-        await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
-          toolbox.address(),
-          BigInt(DEFAULT_GAS_BUDGET),
-        );
-
-      const splitTxn = await signer.splitCoin({
-        coinObjectId: getObjectId(coins[0]),
-        splitAmounts: [2000, 2000, 2000],
-        gasBudget: gasBudget,
-        gasPayment: getObjectId(coins[1]),
-      });
-      const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
-        getObjectId(c),
-      );
-
-      await validateDevInspectTransaction(
-        signer,
-        {
-          kind: 'pay',
-          data: {
-            inputCoins: splitCoins,
-            recipients: [DEFAULT_RECIPIENT],
-            amounts: [4000],
-            gasBudget: gasBudget,
-          },
-        },
-        'success',
-      );
-    });
-
-    it('Move Call that returns struct', async () => {
-      const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+  it('Dev inspect transaction with Pay', async () => {
+    const gasBudget = 1000;
+    const coins =
+      await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
         toolbox.address(),
+        BigInt(DEFAULT_GAS_BUDGET),
       );
-      const moveCall = {
-        packageObjectId: packageId,
-        module: 'serializer_tests',
-        function: 'return_struct',
-        typeArguments: ['0x2::coin::Coin<0x2::sui::SUI>'],
-        arguments: [coins[0].objectId],
-        gasBudget: DEFAULT_GAS_BUDGET,
-      };
 
-      await validateDevInspectTransaction(
-        signer,
-        {
-          kind: 'moveCall',
-          data: moveCall,
-        },
-        'success',
-      );
+    const splitTxn = await signer.splitCoin({
+      coinObjectId: getObjectId(coins[0]),
+      splitAmounts: [2000, 2000, 2000],
+      gasBudget: gasBudget,
+      gasPayment: getObjectId(coins[1]),
     });
+    const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
+      getObjectId(c),
+    );
 
-    it('Move Call that aborts', async () => {
-      const moveCall = {
-        packageObjectId: packageId,
-        module: 'serializer_tests',
-        function: 'test_abort',
-        typeArguments: [],
-        arguments: [],
-        gasBudget: DEFAULT_GAS_BUDGET,
-      };
-
-      await validateDevInspectTransaction(
-        signer,
-        {
-          kind: 'moveCall',
-          data: moveCall,
+    await validateDevInspectTransaction(
+      signer,
+      {
+        kind: 'pay',
+        data: {
+          inputCoins: splitCoins,
+          recipients: [DEFAULT_RECIPIENT],
+          amounts: [4000],
+          gasBudget: gasBudget,
         },
-        'failure',
-      );
-    });
-  },
-);
+      },
+      'success',
+    );
+  });
+
+  it('Move Call that returns struct', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address(),
+    );
+    const moveCall = {
+      packageObjectId: packageId,
+      module: 'serializer_tests',
+      function: 'return_struct',
+      typeArguments: ['0x2::coin::Coin<0x2::sui::SUI>'],
+      arguments: [coins[0].objectId],
+      gasBudget: DEFAULT_GAS_BUDGET,
+    };
+
+    await validateDevInspectTransaction(
+      signer,
+      {
+        kind: 'moveCall',
+        data: moveCall,
+      },
+      'success',
+    );
+  });
+
+  it('Move Call that aborts', async () => {
+    const moveCall = {
+      packageObjectId: packageId,
+      module: 'serializer_tests',
+      function: 'test_abort',
+      typeArguments: [],
+      arguments: [],
+      gasBudget: DEFAULT_GAS_BUDGET,
+    };
+
+    await validateDevInspectTransaction(
+      signer,
+      {
+        kind: 'moveCall',
+        data: moveCall,
+      },
+      'failure',
+    );
+  });
+});
 
 async function validateDevInspectTransaction(
   signer: RawSigner,

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -37,11 +37,14 @@ describe('Test dev inspect', () => {
         BigInt(DEFAULT_GAS_BUDGET),
       );
 
-    const splitTxn = await signer.splitCoin({
-      coinObjectId: getObjectId(coins[0]),
-      splitAmounts: [2000, 2000, 2000],
-      gasBudget: gasBudget,
-      gasPayment: getObjectId(coins[1]),
+    const splitTxn = await signer.signAndExecuteTransaction({
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: getObjectId(coins[0]),
+        splitAmounts: [2000, 2000, 2000],
+        gasBudget: gasBudget,
+        gasPayment: getObjectId(coins[1]),
+      },
     });
     const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
       getObjectId(c),

--- a/sdk/typescript/test/e2e/dynamic-fields.test.ts
+++ b/sdk/typescript/test/e2e/dynamic-fields.test.ts
@@ -2,83 +2,74 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { LocalTxnDataSerializer, RawSigner } from '../../src';
+import { RawSigner } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
-describe.each([{ useLocalTxnBuilder: true }])(
-  'Dynamic Fields Reading API',
-  ({ useLocalTxnBuilder }) => {
-    let toolbox: TestToolbox;
-    let signer: RawSigner;
-    let packageId: string;
-    let parentObjectId: string;
+describe('Dynamic Fields Reading API', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+  let packageId: string;
+  let parentObjectId: string;
 
-    beforeAll(async () => {
-      toolbox = await setup();
-      signer = new RawSigner(
-        toolbox.keypair,
-        toolbox.provider,
-        useLocalTxnBuilder
-          ? new LocalTxnDataSerializer(toolbox.provider)
-          : undefined,
-      );
-      const packagePath = __dirname + '/./data/dynamic_fields';
-      packageId = await publishPackage(signer, useLocalTxnBuilder, packagePath);
+  beforeAll(async () => {
+    toolbox = await setup();
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
+    const packagePath = __dirname + '/./data/dynamic_fields';
+    packageId = await publishPackage(signer, packagePath);
 
-      await toolbox.provider
-        .getObjectsOwnedByAddress(toolbox.address())
-        .then(function (objects) {
-          const obj = objects.filter(
-            (o) => o.type === `${packageId}::dynamic_fields_test::Test`,
-          );
-          parentObjectId = obj[0].objectId;
-        });
-    });
+    await toolbox.provider
+      .getObjectsOwnedByAddress(toolbox.address())
+      .then(function (objects) {
+        const obj = objects.filter(
+          (o) => o.type === `${packageId}::dynamic_fields_test::Test`,
+        );
+        parentObjectId = obj[0].objectId;
+      });
+  });
 
-    it('get all dynamic fields', async () => {
-      const dynamicFields = await toolbox.provider.getDynamicFields(
-        parentObjectId,
-        null,
-        null,
-      );
-      expect(dynamicFields.data.length).toEqual(2);
-    });
-    it('limit response in page', async () => {
-      const dynamicFields = await toolbox.provider.getDynamicFields(
-        parentObjectId,
-        null,
-        1,
-      );
-      expect(dynamicFields.data.length).toEqual(1);
-      expect(dynamicFields.nextCursor).not.toEqual(null);
-    });
-    it('go to next cursor', async () => {
-      return await toolbox.provider
-        .getDynamicFields(parentObjectId, null, 1)
-        .then(async function (dynamicFields) {
-          expect(dynamicFields.nextCursor).not.toEqual(null);
+  it('get all dynamic fields', async () => {
+    const dynamicFields = await toolbox.provider.getDynamicFields(
+      parentObjectId,
+      null,
+      null,
+    );
+    expect(dynamicFields.data.length).toEqual(2);
+  });
+  it('limit response in page', async () => {
+    const dynamicFields = await toolbox.provider.getDynamicFields(
+      parentObjectId,
+      null,
+      1,
+    );
+    expect(dynamicFields.data.length).toEqual(1);
+    expect(dynamicFields.nextCursor).not.toEqual(null);
+  });
+  it('go to next cursor', async () => {
+    return await toolbox.provider
+      .getDynamicFields(parentObjectId, null, 1)
+      .then(async function (dynamicFields) {
+        expect(dynamicFields.nextCursor).not.toEqual(null);
 
-          const dynamicFieldsCursor = await toolbox.provider.getDynamicFields(
-            parentObjectId,
-            dynamicFields.nextCursor,
-            null,
-          );
-          expect(dynamicFieldsCursor.data.length).greaterThanOrEqual(0);
-        });
-    });
-    it('get dynamic object field', async () => {
-      const dynamicFields = await toolbox.provider.getDynamicFields(
-        parentObjectId,
-        null,
-        null,
-      );
-      const objDofName = dynamicFields.data[1].name;
+        const dynamicFieldsCursor = await toolbox.provider.getDynamicFields(
+          parentObjectId,
+          dynamicFields.nextCursor,
+          null,
+        );
+        expect(dynamicFieldsCursor.data.length).greaterThanOrEqual(0);
+      });
+  });
+  it('get dynamic object field', async () => {
+    const dynamicFields = await toolbox.provider.getDynamicFields(
+      parentObjectId,
+      null,
+      null,
+    );
+    const objDofName = dynamicFields.data[1].name;
 
-      const dynamicObjectField = await toolbox.provider.getDynamicFieldObject(
-        parentObjectId,
-        objDofName,
-      );
-      expect(dynamicObjectField.status).toEqual('Exists');
-    });
-  },
-);
+    const dynamicObjectField = await toolbox.provider.getDynamicFieldObject(
+      parentObjectId,
+      objDofName,
+    );
+    expect(dynamicObjectField.status).toEqual('Exists');
+  });
+});

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import {
-  getExecutionStatusType,
-  LocalTxnDataSerializer,
-  ObjectId,
-  RawSigner,
-} from '../../src';
+import { getExecutionStatusType, ObjectId, RawSigner } from '../../src';
 import {
   DEFAULT_GAS_BUDGET,
   publishPackage,
@@ -15,50 +10,41 @@ import {
   TestToolbox,
 } from './utils/setup';
 
-describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
-  'Test Move call with strings',
-  ({ useLocalTxnBuilder }) => {
-    let toolbox: TestToolbox;
-    let signer: RawSigner;
-    let packageId: ObjectId;
+describe('Test Move call with strings', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+  let packageId: ObjectId;
 
-    async function callWithString(str: string | string[], funcName: string) {
-      const txn = await signer.executeMoveCall({
-        packageObjectId: packageId,
-        module: 'entry_point_string',
-        function: funcName,
-        typeArguments: [],
-        arguments: [str],
-        gasBudget: DEFAULT_GAS_BUDGET,
-      });
-      expect(getExecutionStatusType(txn)).toEqual('success');
-    }
-
-    beforeAll(async () => {
-      toolbox = await setup();
-      signer = new RawSigner(
-        toolbox.keypair,
-        toolbox.provider,
-        useLocalTxnBuilder
-          ? new LocalTxnDataSerializer(toolbox.provider)
-          : undefined,
-      );
-      const packagePath =
-        __dirname +
-        '/../../../../crates/sui-core/src/unit_tests/data/entry_point_string';
-      packageId = await publishPackage(signer, useLocalTxnBuilder, packagePath);
+  async function callWithString(str: string | string[], funcName: string) {
+    const txn = await signer.executeMoveCall({
+      packageObjectId: packageId,
+      module: 'entry_point_string',
+      function: funcName,
+      typeArguments: [],
+      arguments: [str],
+      gasBudget: DEFAULT_GAS_BUDGET,
     });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  }
 
-    it('Test ascii', async () => {
-      await callWithString('SomeString', 'ascii_arg');
-    });
+  beforeAll(async () => {
+    toolbox = await setup();
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
+    const packagePath =
+      __dirname +
+      '/../../../../crates/sui-core/src/unit_tests/data/entry_point_string';
+    packageId = await publishPackage(signer, packagePath);
+  });
 
-    it('Test utf8', async () => {
-      await callWithString('çå∞≠¢õß∂ƒ∫', 'utf8_arg');
-    });
+  it('Test ascii', async () => {
+    await callWithString('SomeString', 'ascii_arg');
+  });
 
-    it('Test string vec', async () => {
-      await callWithString(['çå∞≠¢', 'õß∂ƒ∫'], 'utf8_vec_arg');
-    });
-  },
-);
+  it('Test utf8', async () => {
+    await callWithString('çå∞≠¢õß∂ƒ∫', 'utf8_arg');
+  });
+
+  it('Test string vec', async () => {
+    await callWithString(['çå∞≠¢', 'õß∂ƒ∫'], 'utf8_vec_arg');
+  });
+});

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -16,13 +16,16 @@ describe('Test Move call with strings', () => {
   let packageId: ObjectId;
 
   async function callWithString(str: string | string[], funcName: string) {
-    const txn = await signer.executeMoveCall({
-      packageObjectId: packageId,
-      module: 'entry_point_string',
-      function: funcName,
-      typeArguments: [],
-      arguments: [str],
-      gasBudget: DEFAULT_GAS_BUDGET,
+    const txn = await signer.signAndExecuteTransaction({
+      kind: 'moveCall',
+      data: {
+        packageObjectId: packageId,
+        module: 'entry_point_string',
+        function: funcName,
+        typeArguments: [],
+        arguments: [str],
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
     });
     expect(getExecutionStatusType(txn)).toEqual('success');
   }

--- a/sdk/typescript/test/e2e/event-subscription.test.ts
+++ b/sdk/typescript/test/e2e/event-subscription.test.ts
@@ -33,10 +33,13 @@ describe('Event Subscription API', () => {
       toolbox.address(),
     );
 
-    await signer.payAllSui({
-      inputCoins: inputCoins.map((o) => o.objectId),
-      recipient: DEFAULT_RECIPIENT,
-      gasBudget: DEFAULT_GAS_BUDGET,
+    await signer.signAndExecuteTransaction({
+      kind: 'payAllSui',
+      data: {
+        inputCoins: inputCoins.map((o) => o.objectId),
+        recipient: DEFAULT_RECIPIENT,
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
     });
 
     const subFoundAndRemoved = await toolbox.provider.unsubscribeEvent(

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -2,46 +2,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import {
-  getExecutionStatusType,
-  LocalTxnDataSerializer,
-  ObjectId,
-  RawSigner,
-} from '../../src';
+import { getExecutionStatusType, ObjectId, RawSigner } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
-describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
-  'Test ID as args to entry functions',
-  ({ useLocalTxnBuilder }) => {
-    let toolbox: TestToolbox;
-    let signer: RawSigner;
-    let packageId: ObjectId;
+describe('Test ID as args to entry functions', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+  let packageId: ObjectId;
 
-    beforeAll(async () => {
-      toolbox = await setup();
-      signer = new RawSigner(
-        toolbox.keypair,
-        toolbox.provider,
-        useLocalTxnBuilder
-          ? new LocalTxnDataSerializer(toolbox.provider)
-          : undefined,
-      );
-      const packagePath = __dirname + '/./data/id_entry_args';
-      packageId = await publishPackage(signer, useLocalTxnBuilder, packagePath);
-    });
+  beforeAll(async () => {
+    toolbox = await setup();
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
+    const packagePath = __dirname + '/./data/id_entry_args';
+    packageId = await publishPackage(signer, packagePath);
+  });
 
-    it('Test ID as arg to entry functions', async () => {
-      const txn = await signer.executeMoveCall({
-        packageObjectId: packageId,
-        module: 'test',
-        function: 'test_id',
-        typeArguments: [],
-        arguments: [
-          '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
-        ],
-        gasBudget: 2000,
-      });
-      expect(getExecutionStatusType(txn)).toEqual('success');
+  it('Test ID as arg to entry functions', async () => {
+    const txn = await signer.executeMoveCall({
+      packageObjectId: packageId,
+      module: 'test',
+      function: 'test_id',
+      typeArguments: [],
+      arguments: [
+        '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
+      ],
+      gasBudget: 2000,
     });
-  },
-);
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+});

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -18,15 +18,18 @@ describe('Test ID as args to entry functions', () => {
   });
 
   it('Test ID as arg to entry functions', async () => {
-    const txn = await signer.executeMoveCall({
-      packageObjectId: packageId,
-      module: 'test',
-      function: 'test_id',
-      typeArguments: [],
-      arguments: [
-        '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
-      ],
-      gasBudget: 2000,
+    const txn = await signer.signAndExecuteTransaction({
+      kind: 'moveCall',
+      data: {
+        packageObjectId: packageId,
+        module: 'test',
+        function: 'test_id',
+        typeArguments: [],
+        arguments: [
+          '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
+        ],
+        gasBudget: 2000,
+      },
     });
     expect(getExecutionStatusType(txn)).toEqual('success');
   });

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -23,7 +23,7 @@ describe('Test Object Display Standard', () => {
       new LocalTxnDataSerializer(toolbox.provider),
     );
     const packagePath = __dirname + '/./data/display_test';
-    packageId = await publishPackage(signer, true, packagePath);
+    packageId = await publishPackage(signer, packagePath);
   });
 
   it('Test getting Display fields', async () => {

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import {
-  LocalTxnDataSerializer,
-  ObjectId,
-  RawSigner,
-  getObjectDisplay,
-} from '../../src';
+import { ObjectId, RawSigner, getObjectDisplay } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test Object Display Standard', () => {
@@ -17,11 +12,7 @@ describe('Test Object Display Standard', () => {
 
   beforeAll(async () => {
     toolbox = await setup();
-    signer = new RawSigner(
-      toolbox.keypair,
-      toolbox.provider,
-      new LocalTxnDataSerializer(toolbox.provider),
-    );
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath = __dirname + '/./data/display_test';
     packageId = await publishPackage(signer, packagePath);
   });

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -6,7 +6,6 @@ import {
   Coin,
   getCreatedObjects,
   getExecutionStatusType,
-  LocalTxnDataSerializer,
   ObjectId,
   RawSigner,
   SUI_FRAMEWORK_ADDRESS,
@@ -18,71 +17,62 @@ import {
   TestToolbox,
 } from './utils/setup';
 
-describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
-  'Test Move call with a vector of objects as input',
-  ({ useLocalTxnBuilder }) => {
-    let toolbox: TestToolbox;
-    let signer: RawSigner;
-    let packageId: ObjectId;
+describe('Test Move call with a vector of objects as input', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+  let packageId: ObjectId;
 
-    async function mintObject(val: number) {
-      const txn = await signer.executeMoveCall({
-        packageObjectId: packageId,
-        module: 'entry_point_vector',
-        function: 'mint',
-        typeArguments: [],
-        arguments: [val.toString()],
-        gasBudget: DEFAULT_GAS_BUDGET,
-      });
-      expect(getExecutionStatusType(txn)).toEqual('success');
-      return getCreatedObjects(txn)![0].reference.objectId;
-    }
-
-    async function destroyObjects(objects: ObjectId[]) {
-      const txn = await signer.executeMoveCall({
-        packageObjectId: packageId,
-        module: 'entry_point_vector',
-        function: 'two_obj_vec_destroy',
-        typeArguments: [],
-        arguments: [objects],
-        gasBudget: DEFAULT_GAS_BUDGET,
-      });
-      expect(getExecutionStatusType(txn)).toEqual('success');
-    }
-
-    beforeAll(async () => {
-      toolbox = await setup();
-      signer = new RawSigner(
-        toolbox.keypair,
-        toolbox.provider,
-        useLocalTxnBuilder
-          ? new LocalTxnDataSerializer(toolbox.provider)
-          : undefined,
-      );
-      const packagePath =
-        __dirname +
-        '/../../../../crates/sui-core/src/unit_tests/data/entry_point_vector';
-      packageId = await publishPackage(signer, useLocalTxnBuilder, packagePath);
+  async function mintObject(val: number) {
+    const txn = await signer.executeMoveCall({
+      packageObjectId: packageId,
+      module: 'entry_point_vector',
+      function: 'mint',
+      typeArguments: [],
+      arguments: [val.toString()],
+      gasBudget: DEFAULT_GAS_BUDGET,
     });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+    return getCreatedObjects(txn)![0].reference.objectId;
+  }
 
-    it('Test object vector', async () => {
-      await destroyObjects([await mintObject(7), await mintObject(42)]);
+  async function destroyObjects(objects: ObjectId[]) {
+    const txn = await signer.executeMoveCall({
+      packageObjectId: packageId,
+      module: 'entry_point_vector',
+      function: 'two_obj_vec_destroy',
+      typeArguments: [],
+      arguments: [objects],
+      gasBudget: DEFAULT_GAS_BUDGET,
     });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  }
 
-    it('Test regular arg mixed with object vector arg', async () => {
-      const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-        toolbox.address(),
-      );
-      const coinIDs = coins.map((coin) => Coin.getID(coin));
-      const txn = await signer.executeMoveCall({
-        packageObjectId: SUI_FRAMEWORK_ADDRESS,
-        module: 'pay',
-        function: 'join_vec',
-        typeArguments: ['0x2::sui::SUI'],
-        arguments: [coinIDs[0], [coinIDs[1], coinIDs[2]]],
-        gasBudget: DEFAULT_GAS_BUDGET,
-      });
-      expect(getExecutionStatusType(txn)).toEqual('success');
+  beforeAll(async () => {
+    toolbox = await setup();
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
+    const packagePath =
+      __dirname +
+      '/../../../../crates/sui-core/src/unit_tests/data/entry_point_vector';
+    packageId = await publishPackage(signer, packagePath);
+  });
+
+  it('Test object vector', async () => {
+    await destroyObjects([await mintObject(7), await mintObject(42)]);
+  });
+
+  it('Test regular arg mixed with object vector arg', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address(),
+    );
+    const coinIDs = coins.map((coin) => Coin.getID(coin));
+    const txn = await signer.executeMoveCall({
+      packageObjectId: SUI_FRAMEWORK_ADDRESS,
+      module: 'pay',
+      function: 'join_vec',
+      typeArguments: ['0x2::sui::SUI'],
+      arguments: [coinIDs[0], [coinIDs[1], coinIDs[2]]],
+      gasBudget: DEFAULT_GAS_BUDGET,
     });
-  },
-);
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+});

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -17,32 +17,38 @@ import {
   TestToolbox,
 } from './utils/setup';
 
-describe('Test Move call with a vector of objects as input', () => {
+describe.skip('Test Move call with a vector of objects as input (skipped due to move vector requirement)', () => {
   let toolbox: TestToolbox;
   let signer: RawSigner;
   let packageId: ObjectId;
 
   async function mintObject(val: number) {
-    const txn = await signer.executeMoveCall({
-      packageObjectId: packageId,
-      module: 'entry_point_vector',
-      function: 'mint',
-      typeArguments: [],
-      arguments: [val.toString()],
-      gasBudget: DEFAULT_GAS_BUDGET,
+    const txn = await signer.signAndExecuteTransaction({
+      kind: 'moveCall',
+      data: {
+        packageObjectId: packageId,
+        module: 'entry_point_vector',
+        function: 'mint',
+        typeArguments: [],
+        arguments: [val.toString()],
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
     });
     expect(getExecutionStatusType(txn)).toEqual('success');
     return getCreatedObjects(txn)![0].reference.objectId;
   }
 
   async function destroyObjects(objects: ObjectId[]) {
-    const txn = await signer.executeMoveCall({
-      packageObjectId: packageId,
-      module: 'entry_point_vector',
-      function: 'two_obj_vec_destroy',
-      typeArguments: [],
-      arguments: [objects],
-      gasBudget: DEFAULT_GAS_BUDGET,
+    const txn = await signer.signAndExecuteTransaction({
+      kind: 'moveCall',
+      data: {
+        packageObjectId: packageId,
+        module: 'entry_point_vector',
+        function: 'two_obj_vec_destroy',
+        typeArguments: [],
+        arguments: [objects],
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
     });
     expect(getExecutionStatusType(txn)).toEqual('success');
   }
@@ -65,13 +71,16 @@ describe('Test Move call with a vector of objects as input', () => {
       toolbox.address(),
     );
     const coinIDs = coins.map((coin) => Coin.getID(coin));
-    const txn = await signer.executeMoveCall({
-      packageObjectId: SUI_FRAMEWORK_ADDRESS,
-      module: 'pay',
-      function: 'join_vec',
-      typeArguments: ['0x2::sui::SUI'],
-      arguments: [coinIDs[0], [coinIDs[1], coinIDs[2]]],
-      gasBudget: DEFAULT_GAS_BUDGET,
+    const txn = await signer.signAndExecuteTransaction({
+      kind: 'moveCall',
+      data: {
+        packageObjectId: SUI_FRAMEWORK_ADDRESS,
+        module: 'pay',
+        function: 'join_vec',
+        typeArguments: ['0x2::sui::SUI'],
+        arguments: [coinIDs[0], [coinIDs[1], coinIDs[2]]],
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
     });
     expect(getExecutionStatusType(txn)).toEqual('success');
   });

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   getExecutionStatusType,
   getNewlyCreatedCoinRefsAfterSplit,
@@ -23,7 +23,7 @@ describe('Transaction Builders', () => {
   let toolbox: TestToolbox;
   let signer: RawSigner;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     toolbox = await setup();
     signer = new RawSigner(toolbox.keypair, toolbox.provider);
   });
@@ -142,11 +142,14 @@ describe('Transaction Builders', () => {
       );
 
     // get some new coins with small amount
-    const splitTxn = await signer.splitCoin({
-      coinObjectId: getObjectId(coins[0]),
-      splitAmounts: [1, 2, 3],
-      gasBudget: DEFAULT_GAS_BUDGET,
-      gasPayment: getObjectId(coins[1]),
+    const splitTxn = await signer.signAndExecuteTransaction({
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: getObjectId(coins[0]),
+        splitAmounts: [1, 2, 3],
+        gasBudget: DEFAULT_GAS_BUDGET,
+        gasPayment: getObjectId(coins[1]),
+      },
     });
     const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
       getObjectId(c),
@@ -173,11 +176,14 @@ describe('Transaction Builders', () => {
         BigInt(DEFAULT_GAS_BUDGET),
       );
 
-    const splitTxn = await signer.splitCoin({
-      coinObjectId: getObjectId(coins[0]),
-      splitAmounts: [2000, 2000, 2000],
-      gasBudget: gasBudget,
-      gasPayment: getObjectId(coins[1]),
+    const splitTxn = await signer.signAndExecuteTransaction({
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: getObjectId(coins[0]),
+        splitAmounts: [2000, 2000, 2000],
+        gasBudget: gasBudget,
+        gasPayment: getObjectId(coins[1]),
+      },
     });
     const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
       getObjectId(c),
@@ -202,11 +208,14 @@ describe('Transaction Builders', () => {
         BigInt(DEFAULT_GAS_BUDGET),
       );
 
-    const splitTxn = await signer.splitCoin({
-      coinObjectId: getObjectId(coins[0]),
-      splitAmounts: [2000, 2000, 2000],
-      gasBudget: gasBudget,
-      gasPayment: getObjectId(coins[1]),
+    const splitTxn = await signer.signAndExecuteTransaction({
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: getObjectId(coins[0]),
+        splitAmounts: [2000, 2000, 2000],
+        gasBudget: gasBudget,
+        gasPayment: getObjectId(coins[1]),
+      },
     });
     const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
       getObjectId(c),

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -7,7 +7,6 @@ import {
   getNewlyCreatedCoinRefsAfterSplit,
   getObjectId,
   getTransactionDigest,
-  LocalTxnDataSerializer,
   RawSigner,
   SignableTransaction,
   SUI_SYSTEM_STATE_OBJECT_ID,
@@ -20,217 +19,208 @@ import {
   DEFAULT_RECIPIENT_2,
 } from './utils/setup';
 
-describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
-  'Transaction Builders',
-  ({ useLocalTxnBuilder }) => {
-    let toolbox: TestToolbox;
-    let signer: RawSigner;
+describe('Transaction Builders', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
 
-    beforeAll(async () => {
-      toolbox = await setup();
-      signer = new RawSigner(
-        toolbox.keypair,
-        toolbox.provider,
-        useLocalTxnBuilder
-          ? new LocalTxnDataSerializer(toolbox.provider)
-          : undefined,
-      );
-    });
+  beforeAll(async () => {
+    toolbox = await setup();
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
+  });
 
-    it('Split coin', async () => {
-      const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-        toolbox.address(),
-      );
-      await validateTransaction(signer, {
-        kind: 'splitCoin',
-        data: {
-          coinObjectId: coins[0].objectId,
-          splitAmounts: [DEFAULT_GAS_BUDGET * 2],
-          gasBudget: DEFAULT_GAS_BUDGET,
-        },
-      });
-    });
-
-    it('Merge coin', async () => {
-      const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-        toolbox.address(),
-      );
-      await validateTransaction(signer, {
-        kind: 'mergeCoin',
-        data: {
-          primaryCoin: coins[0].objectId,
-          coinToMerge: coins[1].objectId,
-          gasBudget: DEFAULT_GAS_BUDGET,
-        },
-      });
-    });
-
-    it('Move Call', async () => {
-      const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-        toolbox.address(),
-      );
-      await validateTransaction(signer, {
-        kind: 'moveCall',
-        data: {
-          packageObjectId: '0x2',
-          module: 'devnet_nft',
-          function: 'mint',
-          typeArguments: [],
-          arguments: [
-            'Example NFT',
-            'An NFT created by the wallet Command Line Tool',
-            'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
-          ],
-          gasBudget: DEFAULT_GAS_BUDGET,
-          gasPayment: coins[0].objectId,
-        },
-      });
-    });
-
-    it('Move Shared Object Call', async () => {
-      const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-        toolbox.address(),
-      );
-
-      const [{ sui_address: validator_address }] =
-        await toolbox.getActiveValidators();
-
-      await validateTransaction(signer, {
-        kind: 'moveCall',
-        data: {
-          packageObjectId: '0x2',
-          module: 'sui_system',
-          function: 'request_add_delegation',
-          typeArguments: [],
-          arguments: [
-            SUI_SYSTEM_STATE_OBJECT_ID,
-            coins[2].objectId,
-            validator_address,
-          ],
-          gasBudget: DEFAULT_GAS_BUDGET,
-          gasPayment: coins[3].objectId,
-        },
-      });
-    });
-
-    it('Transfer Sui', async () => {
-      const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-        toolbox.address(),
-      );
-      await validateTransaction(signer, {
-        kind: 'transferSui',
-        data: {
-          suiObjectId: coins[0].objectId,
-          gasBudget: DEFAULT_GAS_BUDGET,
-          recipient: DEFAULT_RECIPIENT,
-          amount: 100,
-        },
-      });
-    });
-
-    it('Transfer Object', async () => {
-      const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-        toolbox.address(),
-      );
-      await validateTransaction(signer, {
-        kind: 'transferObject',
-        data: {
-          objectId: coins[0].objectId,
-          gasBudget: DEFAULT_GAS_BUDGET,
-          recipient: DEFAULT_RECIPIENT,
-          gasPayment: coins[1].objectId,
-        },
-      });
-    });
-
-    it('Pay', async () => {
-      const coins =
-        await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
-          toolbox.address(),
-          BigInt(DEFAULT_GAS_BUDGET),
-        );
-
-      // get some new coins with small amount
-      const splitTxn = await signer.splitCoin({
-        coinObjectId: getObjectId(coins[0]),
-        splitAmounts: [1, 2, 3],
+  it('Split coin', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address(),
+    );
+    await validateTransaction(signer, {
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: coins[0].objectId,
+        splitAmounts: [DEFAULT_GAS_BUDGET * 2],
         gasBudget: DEFAULT_GAS_BUDGET,
-        gasPayment: getObjectId(coins[1]),
-      });
-      const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
-        getObjectId(c),
+      },
+    });
+  });
+
+  it('Merge coin', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address(),
+    );
+    await validateTransaction(signer, {
+      kind: 'mergeCoin',
+      data: {
+        primaryCoin: coins[0].objectId,
+        coinToMerge: coins[1].objectId,
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
+    });
+  });
+
+  it('Move Call', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address(),
+    );
+    await validateTransaction(signer, {
+      kind: 'moveCall',
+      data: {
+        packageObjectId: '0x2',
+        module: 'devnet_nft',
+        function: 'mint',
+        typeArguments: [],
+        arguments: [
+          'Example NFT',
+          'An NFT created by the wallet Command Line Tool',
+          'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+        ],
+        gasBudget: DEFAULT_GAS_BUDGET,
+        gasPayment: coins[0].objectId,
+      },
+    });
+  });
+
+  it('Move Shared Object Call', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address(),
+    );
+
+    const [{ sui_address: validator_address }] =
+      await toolbox.getActiveValidators();
+
+    await validateTransaction(signer, {
+      kind: 'moveCall',
+      data: {
+        packageObjectId: '0x2',
+        module: 'sui_system',
+        function: 'request_add_delegation',
+        typeArguments: [],
+        arguments: [
+          SUI_SYSTEM_STATE_OBJECT_ID,
+          coins[2].objectId,
+          validator_address,
+        ],
+        gasBudget: DEFAULT_GAS_BUDGET,
+        gasPayment: coins[3].objectId,
+      },
+    });
+  });
+
+  it('Transfer Sui', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address(),
+    );
+    await validateTransaction(signer, {
+      kind: 'transferSui',
+      data: {
+        suiObjectId: coins[0].objectId,
+        gasBudget: DEFAULT_GAS_BUDGET,
+        recipient: DEFAULT_RECIPIENT,
+        amount: 100,
+      },
+    });
+  });
+
+  it('Transfer Object', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address(),
+    );
+    await validateTransaction(signer, {
+      kind: 'transferObject',
+      data: {
+        objectId: coins[0].objectId,
+        gasBudget: DEFAULT_GAS_BUDGET,
+        recipient: DEFAULT_RECIPIENT,
+        gasPayment: coins[1].objectId,
+      },
+    });
+  });
+
+  it('Pay', async () => {
+    const coins =
+      await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
+        toolbox.address(),
+        BigInt(DEFAULT_GAS_BUDGET),
       );
 
-      // use the newly created coins as the input coins for the pay transaction
-      await validateTransaction(signer, {
-        kind: 'pay',
-        data: {
-          inputCoins: splitCoins,
-          gasBudget: DEFAULT_GAS_BUDGET,
-          recipients: [DEFAULT_RECIPIENT, DEFAULT_RECIPIENT_2],
-          amounts: [4, 2],
-          gasPayment: getObjectId(coins[2]),
-        },
-      });
+    // get some new coins with small amount
+    const splitTxn = await signer.splitCoin({
+      coinObjectId: getObjectId(coins[0]),
+      splitAmounts: [1, 2, 3],
+      gasBudget: DEFAULT_GAS_BUDGET,
+      gasPayment: getObjectId(coins[1]),
     });
+    const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
+      getObjectId(c),
+    );
 
-    it('PaySui', async () => {
-      const gasBudget = 1000;
-      const coins =
-        await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
-          toolbox.address(),
-          BigInt(DEFAULT_GAS_BUDGET),
-        );
+    // use the newly created coins as the input coins for the pay transaction
+    await validateTransaction(signer, {
+      kind: 'pay',
+      data: {
+        inputCoins: splitCoins,
+        gasBudget: DEFAULT_GAS_BUDGET,
+        recipients: [DEFAULT_RECIPIENT, DEFAULT_RECIPIENT_2],
+        amounts: [4, 2],
+        gasPayment: getObjectId(coins[2]),
+      },
+    });
+  });
 
-      const splitTxn = await signer.splitCoin({
-        coinObjectId: getObjectId(coins[0]),
-        splitAmounts: [2000, 2000, 2000],
+  it('PaySui', async () => {
+    const gasBudget = 1000;
+    const coins =
+      await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
+        toolbox.address(),
+        BigInt(DEFAULT_GAS_BUDGET),
+      );
+
+    const splitTxn = await signer.splitCoin({
+      coinObjectId: getObjectId(coins[0]),
+      splitAmounts: [2000, 2000, 2000],
+      gasBudget: gasBudget,
+      gasPayment: getObjectId(coins[1]),
+    });
+    const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
+      getObjectId(c),
+    );
+
+    await validateTransaction(signer, {
+      kind: 'paySui',
+      data: {
+        inputCoins: splitCoins,
+        recipients: [DEFAULT_RECIPIENT, DEFAULT_RECIPIENT_2],
+        amounts: [1000, 1000],
         gasBudget: gasBudget,
-        gasPayment: getObjectId(coins[1]),
-      });
-      const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
-        getObjectId(c),
+      },
+    });
+  });
+
+  it('PayAllSui', async () => {
+    const gasBudget = 1000;
+    const coins =
+      await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
+        toolbox.address(),
+        BigInt(DEFAULT_GAS_BUDGET),
       );
 
-      await validateTransaction(signer, {
-        kind: 'paySui',
-        data: {
-          inputCoins: splitCoins,
-          recipients: [DEFAULT_RECIPIENT, DEFAULT_RECIPIENT_2],
-          amounts: [1000, 1000],
-          gasBudget: gasBudget,
-        },
-      });
+    const splitTxn = await signer.splitCoin({
+      coinObjectId: getObjectId(coins[0]),
+      splitAmounts: [2000, 2000, 2000],
+      gasBudget: gasBudget,
+      gasPayment: getObjectId(coins[1]),
     });
-
-    it('PayAllSui', async () => {
-      const gasBudget = 1000;
-      const coins =
-        await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
-          toolbox.address(),
-          BigInt(DEFAULT_GAS_BUDGET),
-        );
-
-      const splitTxn = await signer.splitCoin({
-        coinObjectId: getObjectId(coins[0]),
-        splitAmounts: [2000, 2000, 2000],
+    const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
+      getObjectId(c),
+    );
+    await validateTransaction(signer, {
+      kind: 'payAllSui',
+      data: {
+        inputCoins: splitCoins,
+        recipient: DEFAULT_RECIPIENT,
         gasBudget: gasBudget,
-        gasPayment: getObjectId(coins[1]),
-      });
-      const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
-        getObjectId(c),
-      );
-      await validateTransaction(signer, {
-        kind: 'payAllSui',
-        data: {
-          inputCoins: splitCoins,
-          recipient: DEFAULT_RECIPIENT,
-          gasBudget: gasBudget,
-        },
-      });
+      },
     });
-  },
-);
+  });
+});
 
 async function validateTransaction(
   signer: RawSigner,

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -45,7 +45,7 @@ describe('Transaction Serialization and deserialization', () => {
     );
     const signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath = __dirname + '/./data/serializer';
-    packageId = await publishPackage(signer, false, packagePath);
+    packageId = await publishPackage(signer, packagePath);
   });
 
   async function serializeAndDeserialize(

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -89,9 +89,12 @@ export async function publishPackage(
       { encoding: 'utf-8' },
     ),
   );
-  const publishTxn = await signer.publish({
-    compiledModules: compiledModules.map((m: any) => Array.from(fromB64(m))),
-    gasBudget: DEFAULT_GAS_BUDGET,
+  const publishTxn = await signer.signAndExecuteTransaction({
+    kind: 'publish',
+    data: {
+      compiledModules: compiledModules.map((m: any) => Array.from(fromB64(m))),
+      gasBudget: DEFAULT_GAS_BUDGET,
+    },
   });
   expect(getExecutionStatusType(publishTxn)).toEqual('success');
 

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -74,7 +74,6 @@ export async function setup() {
 
 export async function publishPackage(
   signer: RawSigner,
-  useLocalTxnBuilder: boolean,
   packagePath: string,
 ): Promise<ObjectId> {
   const { execSync } = require('child_process');
@@ -91,9 +90,7 @@ export async function publishPackage(
     ),
   );
   const publishTxn = await signer.publish({
-    compiledModules: useLocalTxnBuilder
-      ? compiledModules.map((m: any) => Array.from(fromB64(m)))
-      : compiledModules,
+    compiledModules: compiledModules.map((m: any) => Array.from(fromB64(m))),
     gasBudget: DEFAULT_GAS_BUDGET,
   });
   expect(getExecutionStatusType(publishTxn)).toEqual('success');


### PR DESCRIPTION
## Description 

The new transaction builder API (which will be used in all paths) does not support variable serialization patterns, so removing the variability in tests for now.

## Test Plan 

Tests should continue to pass, I'll do more cleanup once the transaction serializers are completely worked out of code.