### PR TITLE
[ts-sdk] Remove legacy transaction builders

### DIFF
--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -35,18 +35,21 @@ export async function mint(address: string) {
         keypair.getPublicKey().toSuiAddress()
     );
 
-    const tx = await signer.executeMoveCall({
-        packageObjectId: '0x2',
-        module: 'devnet_nft',
-        function: 'mint',
-        typeArguments: [],
-        arguments: [
-            'Example NFT',
-            'An example NFT.',
-            'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
-        ],
-        gasPayment: gasPayment.objectId,
-        gasBudget: 30000,
+    const tx = await signer.signAndExecuteTransaction({
+        kind: 'moveCall',
+        data: {
+            packageObjectId: '0x2',
+            module: 'devnet_nft',
+            function: 'mint',
+            typeArguments: [],
+            arguments: [
+                'Example NFT',
+                'An example NFT.',
+                'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+            ],
+            gasPayment: gasPayment.objectId,
+            gasBudget: 30000,
+        },
     });
 
     assert(tx, SuiTransactionResponse);

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -52,10 +52,13 @@ function TransferCoinPage() {
 
                 // Use payAllSui if sendMax is true and the token type is SUI
                 if (formData.isPayAllSui && coinType === SUI_TYPE_ARG) {
-                    return signer.payAllSui({
-                        recipient: formData.to,
-                        gasBudget: formData.gasBudget,
-                        inputCoins: formData.coinIds,
+                    return signer.signAndExecuteTransaction({
+                        kind: 'payAllSui',
+                        data: {
+                            recipient: formData.to,
+                            gasBudget: formData.gasBudget,
+                            inputCoins: formData.coinIds,
+                        },
                     });
                 }
 

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -107,18 +107,21 @@ export class Coin {
         });
 
         try {
-            return await signer.executeMoveCall({
-                packageObjectId: '0x2',
-                module: 'sui_system',
-                function: 'request_add_delegation_mul_coin',
-                typeArguments: [],
-                arguments: [
-                    SUI_SYSTEM_STATE_OBJECT_ID,
-                    [stakeCoin],
-                    [String(amount)],
-                    validator,
-                ],
-                gasBudget: DEFAULT_GAS_BUDGET_FOR_STAKE,
+            return await signer.signAndExecuteTransaction({
+                kind: 'moveCall',
+                data: {
+                    packageObjectId: '0x2',
+                    module: 'sui_system',
+                    function: 'request_add_delegation_mul_coin',
+                    typeArguments: [],
+                    arguments: [
+                        SUI_SYSTEM_STATE_OBJECT_ID,
+                        [stakeCoin],
+                        [String(amount)],
+                        validator,
+                    ],
+                    gasBudget: DEFAULT_GAS_BUDGET_FOR_STAKE,
+                },
             });
         } finally {
             span.finish();
@@ -133,17 +136,20 @@ export class Coin {
     ): Promise<SuiTransactionResponse> {
         const transaction = Sentry.startTransaction({ name: 'unstake' });
         try {
-            return await signer.executeMoveCall({
-                packageObjectId: '0x2',
-                module: 'sui_system',
-                function: 'request_withdraw_delegation',
-                typeArguments: [],
-                arguments: [
-                    SUI_SYSTEM_STATE_OBJECT_ID,
-                    delegation,
-                    stakedSuiId,
-                ],
-                gasBudget: DEFAULT_GAS_BUDGET_FOR_STAKE,
+            return await signer.signAndExecuteTransaction({
+                kind: 'moveCall',
+                data: {
+                    packageObjectId: '0x2',
+                    module: 'sui_system',
+                    function: 'request_withdraw_delegation',
+                    typeArguments: [],
+                    arguments: [
+                        SUI_SYSTEM_STATE_OBJECT_ID,
+                        delegation,
+                        stakedSuiId,
+                    ],
+                    gasBudget: DEFAULT_GAS_BUDGET_FOR_STAKE,
+                },
             });
         } finally {
             transaction.finish();
@@ -173,16 +179,19 @@ export class Coin {
 
             const address = await signer.getAddress();
 
-            const result = await signer.paySui({
-                // NOTE: We reverse the order here so that the highest coin is in the front
-                // so that it is used as the gas coin.
-                inputCoins: [...inputCoins]
-                    .reverse()
-                    .map((coin) => Coin.getID(coin as SuiMoveObject)),
-                recipients: [address, address],
-                // TODO: Update SDK to accept bigint
-                amounts: [Number(amount), Number(gasFee)],
-                gasBudget,
+            const result = await signer.signAndExecuteTransaction({
+                kind: 'paySui',
+                data: {
+                    // NOTE: We reverse the order here so that the highest coin is in the front
+                    // so that it is used as the gas coin.
+                    inputCoins: [...inputCoins]
+                        .reverse()
+                        .map((coin) => Coin.getID(coin as SuiMoveObject)),
+                    recipients: [address, address],
+                    // TODO: Update SDK to accept bigint
+                    amounts: [Number(amount), Number(gasFee)],
+                    gasBudget,
+                },
             });
 
             const effects = getTransactionEffects(result);

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
@@ -22,17 +22,20 @@ export class ExampleNFT {
         description?: string,
         imageUrl?: string
     ): Promise<SuiTransactionResponse> {
-        return await signer.executeMoveCall({
-            packageObjectId: '0x2',
-            module: 'devnet_nft',
-            function: 'mint',
-            typeArguments: [],
-            arguments: [
-                name || 'Example NFT',
-                description || 'An NFT created by Sui Wallet',
-                imageUrl || DEFAULT_NFT_IMAGE,
-            ],
-            gasBudget: 2000,
+        return await signer.signAndExecuteTransaction({
+            kind: 'moveCall',
+            data: {
+                packageObjectId: '0x2',
+                module: 'devnet_nft',
+                function: 'mint',
+                typeArguments: [],
+                arguments: [
+                    name || 'Example NFT',
+                    description || 'An NFT created by Sui Wallet',
+                    imageUrl || DEFAULT_NFT_IMAGE,
+                ],
+                gasBudget: 2000,
+            },
         });
     }
 }

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
@@ -132,7 +132,10 @@ export const transferNFT = createAsyncThunk<
             throw new Error('Error, active address is not defined');
         }
         const signer = api.getSignerInstance(activeAddress, background);
-        const txn = await signer.transferObject(data);
+        const txn = await signer.signAndExecuteTransaction({
+            kind: 'transferObject',
+            data,
+        });
         await dispatch(fetchAllOwnedAndRequiredObjects());
         const txnResp = {
             timestampMs: getTimestampFromTransactionResponse(txn),

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -24,16 +24,7 @@ import { IntentScope, messageWithIntent } from '../utils/intent';
 import { Signer } from './signer';
 import { RpcTxnDataSerializer } from './txn-data-serializers/rpc-txn-data-serializer';
 import {
-  MoveCallTransaction,
-  MergeCoinTransaction,
-  PayTransaction,
-  PaySuiTransaction,
-  PayAllSuiTransaction,
-  SplitCoinTransaction,
-  TransferObjectTransaction,
-  TransferSuiTransaction,
   TxnDataSerializer,
-  PublishTransaction,
   SignableTransaction,
   UnserializedSignableTransaction,
   SignedTransaction,
@@ -104,6 +95,13 @@ export abstract class SignerWithProvider implements Signer {
     };
   }
 
+  /** @deprecated Instead of using `SignableTransaction`, pass a `Transaction` instance instead. */
+  async signTransaction(
+    transaction: SignableTransaction,
+  ): Promise<SignedTransaction>;
+  async signTransaction(
+    transaction: Uint8Array | Transaction,
+  ): Promise<SignedTransaction>;
   /**
    * Sign a transaction.
    */
@@ -146,6 +144,15 @@ export abstract class SignerWithProvider implements Signer {
     };
   }
 
+  /** @deprecated Instead of using `SignableTransaction`, pass a `Transaction` instance instead. */
+  async signAndExecuteTransaction(
+    transaction: SignableTransaction,
+    requestType?: ExecuteTransactionRequestType,
+  ): Promise<SuiTransactionResponse>;
+  async signAndExecuteTransaction(
+    transaction: Uint8Array | Transaction,
+    requestType?: ExecuteTransactionRequestType,
+  ): Promise<SuiTransactionResponse>;
   /**
    * Sign a transaction and submit to the Fullnode for execution.
    */
@@ -154,7 +161,8 @@ export abstract class SignerWithProvider implements Signer {
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
   ): Promise<SuiTransactionResponse> {
     const { transactionBytes, signature } = await this.signTransaction(
-      transaction,
+      // TODO: Remove this refinement when the deprecated overload goes away
+      transaction as Uint8Array | Transaction,
     );
 
     return await this.provider.executeTransaction(
@@ -246,153 +254,6 @@ export abstract class SignerWithProvider implements Signer {
       }
     }
     return this.provider.dryRunTransaction(dryRunTxBytes);
-  }
-
-  /**
-   *
-   * Serialize and sign a `TransferObject` transaction and submit to the Fullnode
-   * for execution
-   *
-   * @deprecated Use `Transaction` builder API instead.
-   */
-  async transferObject(
-    transaction: TransferObjectTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiTransactionResponse> {
-    return this.signAndExecuteTransaction(
-      { kind: 'transferObject', data: transaction },
-      requestType,
-    );
-  }
-
-  /**
-   *
-   * Serialize and sign a `TransferSui` transaction and submit to the Fullnode
-   * for execution
-   *
-   * @deprecated Use `Transaction` builder API instead.
-   */
-  async transferSui(
-    transaction: TransferSuiTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiTransactionResponse> {
-    return this.signAndExecuteTransaction(
-      { kind: 'transferSui', data: transaction },
-      requestType,
-    );
-  }
-
-  /**
-   *
-   * Serialize and Sign a `Pay` transaction and submit to the fullnode for execution
-   *
-   * @deprecated Use `Transaction` builder API instead.
-   */
-  async pay(
-    transaction: PayTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiTransactionResponse> {
-    return this.signAndExecuteTransaction(
-      { kind: 'pay', data: transaction },
-      requestType,
-    );
-  }
-
-  /**
-   * Serialize and Sign a `PaySui` transaction and submit to the fullnode for execution
-   *
-   * @deprecated Use `Transaction` builder API instead.
-   */
-  async paySui(
-    transaction: PaySuiTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiTransactionResponse> {
-    return this.signAndExecuteTransaction(
-      { kind: 'paySui', data: transaction },
-      requestType,
-    );
-  }
-
-  /**
-   * Serialize and Sign a `PayAllSui` transaction and submit to the fullnode for execution
-   *
-   * @deprecated Use `Transaction` builder API instead.
-   */
-  async payAllSui(
-    transaction: PayAllSuiTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiTransactionResponse> {
-    return this.signAndExecuteTransaction(
-      { kind: 'payAllSui', data: transaction },
-      requestType,
-    );
-  }
-
-  /**
-   *
-   * Serialize and sign a `MergeCoin` transaction and submit to the Fullnode
-   * for execution
-   *
-   * @deprecated Use `Transaction` builder API instead.
-   */
-  async mergeCoin(
-    transaction: MergeCoinTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiTransactionResponse> {
-    return this.signAndExecuteTransaction(
-      { kind: 'mergeCoin', data: transaction },
-      requestType,
-    );
-  }
-
-  /**
-   *
-   * Serialize and sign a `SplitCoin` transaction and submit to the Fullnode
-   * for execution
-   *
-   * @deprecated Use `Transaction` builder API instead.
-   */
-  async splitCoin(
-    transaction: SplitCoinTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiTransactionResponse> {
-    return this.signAndExecuteTransaction(
-      { kind: 'splitCoin', data: transaction },
-      requestType,
-    );
-  }
-
-  /**
-   * Serialize and sign a `MoveCall` transaction and submit to the Fullnode
-   * for execution
-   *
-   * @deprecated Use `Transaction` builder API instead.
-   */
-  async executeMoveCall(
-    transaction: MoveCallTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiTransactionResponse> {
-    return this.signAndExecuteTransaction(
-      { kind: 'moveCall', data: transaction },
-      requestType,
-    );
-  }
-
-  /**
-   *
-   * Serialize and sign a `Publish` transaction and submit to the Fullnode
-   * for execution
-   *
-   * @deprecated Use `Transaction` builder API instead.
-   */
-  async publish(
-    transaction: PublishTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
-  ): Promise<SuiTransactionResponse> {
-    return this.signAndExecuteTransaction(
-      { kind: 'publish', data: transaction },
-      requestType,
-    );
   }
 
   /**

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -30,11 +30,14 @@ describe('Coin related API', () => {
     );
     coinToSplit = coins[0].objectId;
     // split coins into desired amount
-    await signer.splitCoin({
-      coinObjectId: coinToSplit,
-      splitAmounts: SPLIT_AMOUNTS.map((s) => Number(s)),
-      gasBudget: DEFAULT_GAS_BUDGET,
-      gasPayment: coins[1].objectId,
+    await signer.signAndExecuteTransaction({
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: coinToSplit,
+        splitAmounts: SPLIT_AMOUNTS.map((s) => Number(s)),
+        gasBudget: DEFAULT_GAS_BUDGET,
+        gasPayment: coins[1].objectId,
+      },
     });
     coinsAfterSplit = await toolbox.provider.getGasObjectsOwnedByAddress(
       toolbox.address(),

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -37,11 +37,14 @@ describe('Test dev inspect', () => {
         BigInt(DEFAULT_GAS_BUDGET),
       );
 
-    const splitTxn = await signer.splitCoin({
-      coinObjectId: getObjectId(coins[0]),
-      splitAmounts: [2000, 2000, 2000],
-      gasBudget: gasBudget,
-      gasPayment: getObjectId(coins[1]),
+    const splitTxn = await signer.signAndExecuteTransaction({
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: getObjectId(coins[0]),
+        splitAmounts: [2000, 2000, 2000],
+        gasBudget: gasBudget,
+        gasPayment: getObjectId(coins[1]),
+      },
     });
     const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
       getObjectId(c),

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -16,13 +16,16 @@ describe('Test Move call with strings', () => {
   let packageId: ObjectId;
 
   async function callWithString(str: string | string[], funcName: string) {
-    const txn = await signer.executeMoveCall({
-      packageObjectId: packageId,
-      module: 'entry_point_string',
-      function: funcName,
-      typeArguments: [],
-      arguments: [str],
-      gasBudget: DEFAULT_GAS_BUDGET,
+    const txn = await signer.signAndExecuteTransaction({
+      kind: 'moveCall',
+      data: {
+        packageObjectId: packageId,
+        module: 'entry_point_string',
+        function: funcName,
+        typeArguments: [],
+        arguments: [str],
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
     });
     expect(getExecutionStatusType(txn)).toEqual('success');
   }

--- a/sdk/typescript/test/e2e/event-subscription.test.ts
+++ b/sdk/typescript/test/e2e/event-subscription.test.ts
@@ -33,10 +33,13 @@ describe('Event Subscription API', () => {
       toolbox.address(),
     );
 
-    await signer.payAllSui({
-      inputCoins: inputCoins.map((o) => o.objectId),
-      recipient: DEFAULT_RECIPIENT,
-      gasBudget: DEFAULT_GAS_BUDGET,
+    await signer.signAndExecuteTransaction({
+      kind: 'payAllSui',
+      data: {
+        inputCoins: inputCoins.map((o) => o.objectId),
+        recipient: DEFAULT_RECIPIENT,
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
     });
 
     const subFoundAndRemoved = await toolbox.provider.unsubscribeEvent(

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -18,15 +18,18 @@ describe('Test ID as args to entry functions', () => {
   });
 
   it('Test ID as arg to entry functions', async () => {
-    const txn = await signer.executeMoveCall({
-      packageObjectId: packageId,
-      module: 'test',
-      function: 'test_id',
-      typeArguments: [],
-      arguments: [
-        '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
-      ],
-      gasBudget: 2000,
+    const txn = await signer.signAndExecuteTransaction({
+      kind: 'moveCall',
+      data: {
+        packageObjectId: packageId,
+        module: 'test',
+        function: 'test_id',
+        typeArguments: [],
+        arguments: [
+          '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
+        ],
+        gasBudget: 2000,
+      },
     });
     expect(getExecutionStatusType(txn)).toEqual('success');
   });

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -23,26 +23,32 @@ describe.skip('Test Move call with a vector of objects as input (skipped due to 
   let packageId: ObjectId;
 
   async function mintObject(val: number) {
-    const txn = await signer.executeMoveCall({
-      packageObjectId: packageId,
-      module: 'entry_point_vector',
-      function: 'mint',
-      typeArguments: [],
-      arguments: [val.toString()],
-      gasBudget: DEFAULT_GAS_BUDGET,
+    const txn = await signer.signAndExecuteTransaction({
+      kind: 'moveCall',
+      data: {
+        packageObjectId: packageId,
+        module: 'entry_point_vector',
+        function: 'mint',
+        typeArguments: [],
+        arguments: [val.toString()],
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
     });
     expect(getExecutionStatusType(txn)).toEqual('success');
     return getCreatedObjects(txn)![0].reference.objectId;
   }
 
   async function destroyObjects(objects: ObjectId[]) {
-    const txn = await signer.executeMoveCall({
-      packageObjectId: packageId,
-      module: 'entry_point_vector',
-      function: 'two_obj_vec_destroy',
-      typeArguments: [],
-      arguments: [objects],
-      gasBudget: DEFAULT_GAS_BUDGET,
+    const txn = await signer.signAndExecuteTransaction({
+      kind: 'moveCall',
+      data: {
+        packageObjectId: packageId,
+        module: 'entry_point_vector',
+        function: 'two_obj_vec_destroy',
+        typeArguments: [],
+        arguments: [objects],
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
     });
     expect(getExecutionStatusType(txn)).toEqual('success');
   }
@@ -65,13 +71,16 @@ describe.skip('Test Move call with a vector of objects as input (skipped due to 
       toolbox.address(),
     );
     const coinIDs = coins.map((coin) => Coin.getID(coin));
-    const txn = await signer.executeMoveCall({
-      packageObjectId: SUI_FRAMEWORK_ADDRESS,
-      module: 'pay',
-      function: 'join_vec',
-      typeArguments: ['0x2::sui::SUI'],
-      arguments: [coinIDs[0], [coinIDs[1], coinIDs[2]]],
-      gasBudget: DEFAULT_GAS_BUDGET,
+    const txn = await signer.signAndExecuteTransaction({
+      kind: 'moveCall',
+      data: {
+        packageObjectId: SUI_FRAMEWORK_ADDRESS,
+        module: 'pay',
+        function: 'join_vec',
+        typeArguments: ['0x2::sui::SUI'],
+        arguments: [coinIDs[0], [coinIDs[1], coinIDs[2]]],
+        gasBudget: DEFAULT_GAS_BUDGET,
+      },
     });
     expect(getExecutionStatusType(txn)).toEqual('success');
   });

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -142,11 +142,14 @@ describe('Transaction Builders', () => {
       );
 
     // get some new coins with small amount
-    const splitTxn = await signer.splitCoin({
-      coinObjectId: getObjectId(coins[0]),
-      splitAmounts: [1, 2, 3],
-      gasBudget: DEFAULT_GAS_BUDGET,
-      gasPayment: getObjectId(coins[1]),
+    const splitTxn = await signer.signAndExecuteTransaction({
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: getObjectId(coins[0]),
+        splitAmounts: [1, 2, 3],
+        gasBudget: DEFAULT_GAS_BUDGET,
+        gasPayment: getObjectId(coins[1]),
+      },
     });
     const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
       getObjectId(c),
@@ -173,11 +176,14 @@ describe('Transaction Builders', () => {
         BigInt(DEFAULT_GAS_BUDGET),
       );
 
-    const splitTxn = await signer.splitCoin({
-      coinObjectId: getObjectId(coins[0]),
-      splitAmounts: [2000, 2000, 2000],
-      gasBudget: gasBudget,
-      gasPayment: getObjectId(coins[1]),
+    const splitTxn = await signer.signAndExecuteTransaction({
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: getObjectId(coins[0]),
+        splitAmounts: [2000, 2000, 2000],
+        gasBudget: gasBudget,
+        gasPayment: getObjectId(coins[1]),
+      },
     });
     const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
       getObjectId(c),
@@ -202,11 +208,14 @@ describe('Transaction Builders', () => {
         BigInt(DEFAULT_GAS_BUDGET),
       );
 
-    const splitTxn = await signer.splitCoin({
-      coinObjectId: getObjectId(coins[0]),
-      splitAmounts: [2000, 2000, 2000],
-      gasBudget: gasBudget,
-      gasPayment: getObjectId(coins[1]),
+    const splitTxn = await signer.signAndExecuteTransaction({
+      kind: 'splitCoin',
+      data: {
+        coinObjectId: getObjectId(coins[0]),
+        splitAmounts: [2000, 2000, 2000],
+        gasBudget: gasBudget,
+        gasPayment: getObjectId(coins[1]),
+      },
     });
     const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
       getObjectId(c),

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -89,9 +89,12 @@ export async function publishPackage(
       { encoding: 'utf-8' },
     ),
   );
-  const publishTxn = await signer.publish({
-    compiledModules: compiledModules.map((m: any) => Array.from(fromB64(m))),
-    gasBudget: DEFAULT_GAS_BUDGET,
+  const publishTxn = await signer.signAndExecuteTransaction({
+    kind: 'publish',
+    data: {
+      compiledModules: compiledModules.map((m: any) => Array.from(fromB64(m))),
+      gasBudget: DEFAULT_GAS_BUDGET,
+    },
   });
   expect(getExecutionStatusType(publishTxn)).toEqual('success');
 


### PR DESCRIPTION
## Description 

Remove the previous transaction builder helpers, and migrate them to just define the deprecated `SignableTransaction` interface directly. Eventually we'll move these to use the transaction builder itself.

## Test Plan 

Tests should continue to pass.