### PR TITLE
[Consensus] recover above GC round instead of min committed

### DIFF
--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -65,6 +65,7 @@ async fn commit_one() {
 
     let _consensus_handle = Consensus::spawn(
         committee,
+        gc_depth,
         store,
         cert_store,
         tx_shutdown.subscribe(),
@@ -141,6 +142,7 @@ async fn dead_node() {
 
     let _consensus_handle = Consensus::spawn(
         committee,
+        gc_depth,
         store,
         cert_store,
         tx_shutdown.subscribe(),
@@ -284,6 +286,7 @@ async fn not_enough_support() {
 
     let _consensus_handle = Consensus::spawn(
         committee,
+        gc_depth,
         store,
         cert_store,
         tx_shutdown.subscribe(),
@@ -397,6 +400,7 @@ async fn missing_leader() {
 
     let _consensus_handle = Consensus::spawn(
         committee,
+        gc_depth,
         store,
         cert_store,
         tx_shutdown.subscribe(),
@@ -478,6 +482,7 @@ async fn committed_round_after_restart() {
 
         let handle = Consensus::spawn(
             committee.clone(),
+            gc_depth,
             store.clone(),
             cert_store.clone(),
             tx_shutdown.subscribe(),
@@ -753,6 +758,7 @@ async fn restart_with_new_committee() {
 
         let handle = Consensus::spawn(
             committee.clone(),
+            gc_depth,
             store,
             cert_store,
             tx_shutdown.subscribe(),

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -72,6 +72,7 @@ async fn test_consensus_recovery_with_bullshark() {
 
     let consensus_handle = Consensus::spawn(
         committee.clone(),
+        gc_depth,
         consensus_store.clone(),
         certificate_store.clone(),
         tx_shutdown.subscribe(),
@@ -166,6 +167,7 @@ async fn test_consensus_recovery_with_bullshark() {
 
     let consensus_handle = Consensus::spawn(
         committee.clone(),
+        gc_depth,
         consensus_store.clone(),
         certificate_store.clone(),
         tx_shutdown.subscribe(),
@@ -234,6 +236,7 @@ async fn test_consensus_recovery_with_bullshark() {
 
     let _consensus_handle = Consensus::spawn(
         committee.clone(),
+        gc_depth,
         consensus_store.clone(),
         certificate_store.clone(),
         tx_shutdown.subscribe(),

--- a/narwhal/consensus/src/tests/tusk_tests.rs
+++ b/narwhal/consensus/src/tests/tusk_tests.rs
@@ -50,6 +50,7 @@ async fn commit_one() {
 
     let _consensus_handle = Consensus::spawn(
         committee,
+        gc_depth,
         store,
         cert_store,
         tx_shutdown.subscribe(),
@@ -115,6 +116,7 @@ async fn dead_node() {
 
     let _consensus_handle = Consensus::spawn(
         committee,
+        gc_depth,
         store,
         cert_store,
         tx_shutdown.subscribe(),
@@ -234,6 +236,7 @@ async fn not_enough_support() {
 
     let _consensus_handle = Consensus::spawn(
         committee,
+        gc_depth,
         store,
         cert_store,
         tx_shutdown.subscribe(),
@@ -322,6 +325,7 @@ async fn missing_leader() {
 
     let _consensus_handle = Consensus::spawn(
         committee,
+        gc_depth,
         store,
         cert_store,
         tx_shutdown.subscribe(),
@@ -384,6 +388,7 @@ async fn restart_with_new_committee() {
 
         let handle = Consensus::spawn(
             committee.clone(),
+            gc_depth,
             store,
             cert_store,
             tx_shutdown.subscribe(),

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -68,6 +68,7 @@ async fn test_recovery() {
 
     let _consensus_handle = Consensus::spawn(
         committee,
+        GC_DEPTH,
         consensus_store.clone(),
         certificate_store.clone(),
         tx_shutdown.subscribe(),

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -333,6 +333,7 @@ impl PrimaryNodeInner {
         );
         let consensus_handles = Consensus::spawn(
             committee.clone(),
+            parameters.gc_depth,
             store.consensus_store.clone(),
             store.certificate_store.clone(),
             shutdown_receivers.pop().unwrap(),

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -97,6 +97,8 @@ pub struct CommittedSubDagShell {
     pub certificates: Vec<CertificateDigest>,
     /// The leader certificate's digest responsible of committing this sub-dag.
     pub leader: CertificateDigest,
+    // The round of the leader
+    pub leader_round: Round,
     /// Sequence number of the CommittedSubDag
     pub sub_dag_index: SequenceNumber,
     /// The so far calculated reputation score for nodes
@@ -108,6 +110,7 @@ impl CommittedSubDagShell {
         Self {
             certificates: sub_dag.certificates.iter().map(|x| x.digest()).collect(),
             leader: sub_dag.leader.digest(),
+            leader_round: sub_dag.leader.round(),
             sub_dag_index: sub_dag.sub_dag_index,
             reputation_score: sub_dag.reputation_score.clone(),
         }


### PR DESCRIPTION
## Description 

A node can be down for hours or have never participated in the epoch. Recovering consensus from 
min committed round among all nodes can be very slow, and unnecessary since consensus has already committed to the `last_committed_round`. Instead, recover only from `gc_round`.

## Test Plan 

Deploy to private testnet

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
