### PR TITLE
Remove legacy checkpoint APIs

### DIFF
--- a/.changeset/popular-oranges-report.md
+++ b/.changeset/popular-oranges-report.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Remove deprecated `getCheckpointContents`, `getCheckpointContentsByDigest`, `getCheckpointSummary` and `getCheckpointSummaryByDigest` methods.

--- a/apps/explorer/src/pages/checkpoints/CheckpointDetail.tsx
+++ b/apps/explorer/src/pages/checkpoints/CheckpointDetail.tsx
@@ -21,33 +21,22 @@ function CheckpointDetail() {
     const { digest } = useParams<{ digest: string }>();
     const rpc = useRpcClient();
 
-    const checkpointQuery = useQuery(['checkpoints', digest], () =>
+    const { data, isError, isLoading } = useQuery(['checkpoints', digest], () =>
         rpc.getCheckpoint(digest!)
     );
 
-    // todo: add user_signatures to combined `getCheckpoint` endpoint
-    const contentsQuery = useQuery(
-        ['checkpoints', digest, 'contents'],
-        () => rpc.getCheckpointContents(checkpoint.sequenceNumber),
-        { enabled: !!checkpointQuery.data }
-    );
-
-    if (checkpointQuery.isError)
+    if (isError)
         return (
             <Banner variant="error" fullWidth>
                 There was an issue retrieving data for checkpoint: {digest}
             </Banner>
         );
 
-    if (checkpointQuery.isLoading) return <LoadingSpinner />;
-
-    const {
-        data: { epochRollingGasCostSummary, ...checkpoint },
-    } = checkpointQuery;
+    if (isLoading) return <LoadingSpinner />;
 
     return (
         <div className="flex flex-col space-y-12">
-            <PageHeader title={checkpoint.digest} type="Checkpoint" />
+            <PageHeader title={data.digest} type="Checkpoint" />
             <div className="space-y-8">
                 <TabGroup as="div" size="lg">
                     <TabList>
@@ -62,7 +51,7 @@ function CheckpointDetail() {
                                         variant="p1/medium"
                                         color="steel-darker"
                                     >
-                                        {checkpoint.sequenceNumber}
+                                        {data.sequenceNumber}
                                     </Text>
                                 </DescriptionItem>
                                 <DescriptionItem title="Epoch">
@@ -70,7 +59,7 @@ function CheckpointDetail() {
                                         variant="p1/medium"
                                         color="steel-darker"
                                     >
-                                        {checkpoint.epoch}
+                                        {data.epoch}
                                     </Text>
                                 </DescriptionItem>
                                 <DescriptionItem title="Checkpoint Timestamp">
@@ -78,9 +67,9 @@ function CheckpointDetail() {
                                         variant="p1/medium"
                                         color="steel-darker"
                                     >
-                                        {checkpoint.timestampMs
+                                        {data.timestampMs
                                             ? convertNumberToDate(
-                                                  checkpoint.timestampMs
+                                                  data.timestampMs
                                               )
                                             : '--'}
                                     </Text>
@@ -88,7 +77,8 @@ function CheckpointDetail() {
                             </DescriptionList>
                         </TabPanel>
                         <TabPanel>
-                            <DescriptionList>
+                            {/* TODO: Get validator signatures */}
+                            {/* <DescriptionList>
                                 {contentsQuery.data?.user_signatures.map(
                                     ([signature]) => (
                                         <DescriptionItem
@@ -104,7 +94,7 @@ function CheckpointDetail() {
                                         </DescriptionItem>
                                     )
                                 )}
-                            </DescriptionList>
+                            </DescriptionList> */}
                         </TabPanel>
                     </TabPanels>
                 </TabGroup>
@@ -117,18 +107,25 @@ function CheckpointDetail() {
                             <DescriptionItem title="Computation Fee">
                                 <Text variant="p1/medium" color="steel-darker">
                                     {
-                                        epochRollingGasCostSummary.computation_cost
+                                        data.epochRollingGasCostSummary
+                                            .computation_cost
                                     }
                                 </Text>
                             </DescriptionItem>
                             <DescriptionItem title="Storage Fee">
                                 <Text variant="p1/medium" color="steel-darker">
-                                    {epochRollingGasCostSummary.storage_cost}
+                                    {
+                                        data.epochRollingGasCostSummary
+                                            .storage_cost
+                                    }
                                 </Text>
                             </DescriptionItem>
                             <DescriptionItem title="Storage Rebate">
                                 <Text variant="p1/medium" color="steel-darker">
-                                    {epochRollingGasCostSummary.storage_rebate}
+                                    {
+                                        data.epochRollingGasCostSummary
+                                            .storage_rebate
+                                    }
                                 </Text>
                             </DescriptionItem>
                         </DescriptionList>
@@ -142,8 +139,8 @@ function CheckpointDetail() {
                     <TabPanels>
                         <div className="mt-4">
                             <CheckpointTransactions
-                                digest={checkpoint.digest}
-                                transactions={checkpoint.transactions || []}
+                                digest={data.digest}
+                                transactions={data.transactions || []}
                             />
                         </div>
                     </TabPanels>

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -18,11 +18,9 @@ use sui_json_rpc_types::{
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress, TxSequenceNumber};
-use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest, TransactionDigest};
+use sui_types::digests::TransactionDigest;
 use sui_types::dynamic_field::DynamicFieldName;
-use sui_types::messages_checkpoint::{
-    CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
-};
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::query::TransactionQuery;
 
 pub(crate) struct ReadApi<S> {
@@ -343,38 +341,6 @@ where
             return self.fullnode.get_checkpoint(id).await;
         }
         Ok(self.get_checkpoint(id).await?)
-    }
-
-    // NOTE: checkpoint APIs below will be deprecated,
-    // thus skipping them regarding indexer native implementations.
-    async fn get_checkpoint_summary_by_digest(
-        &self,
-        digest: CheckpointDigest,
-    ) -> RpcResult<CheckpointSummary> {
-        self.fullnode.get_checkpoint_summary_by_digest(digest).await
-    }
-
-    async fn get_checkpoint_summary(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> RpcResult<CheckpointSummary> {
-        self.fullnode.get_checkpoint_summary(sequence_number).await
-    }
-
-    async fn get_checkpoint_contents_by_digest(
-        &self,
-        digest: CheckpointContentsDigest,
-    ) -> RpcResult<CheckpointContents> {
-        self.fullnode
-            .get_checkpoint_contents_by_digest(digest)
-            .await
-    }
-
-    async fn get_checkpoint_contents(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> RpcResult<CheckpointContents> {
-        self.fullnode.get_checkpoint_contents(sequence_number).await
     }
 }
 

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -13,11 +13,8 @@ use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{
     ObjectID, SequenceNumber, SuiAddress, TransactionDigest, TxSequenceNumber,
 };
-use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest};
 use sui_types::dynamic_field::DynamicFieldName;
-use sui_types::messages_checkpoint::{
-    CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
-};
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::query::TransactionQuery;
 
 #[open_rpc(namespace = "sui", tag = "Read API")]
@@ -174,32 +171,4 @@ pub trait ReadApi {
         /// Checkpoint identifier, can use either checkpoint digest, or checkpoint sequence number as input.
         id: CheckpointId,
     ) -> RpcResult<Checkpoint>;
-
-    /// Return a checkpoint summary based on a checkpoint sequence number
-    #[method(name = "getCheckpointSummary")]
-    async fn get_checkpoint_summary(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> RpcResult<CheckpointSummary>;
-
-    /// Return a checkpoint summary based on checkpoint digest
-    #[method(name = "getCheckpointSummaryByDigest")]
-    async fn get_checkpoint_summary_by_digest(
-        &self,
-        digest: CheckpointDigest,
-    ) -> RpcResult<CheckpointSummary>;
-
-    /// Return contents of a checkpoint, namely a list of execution digests
-    #[method(name = "getCheckpointContents")]
-    async fn get_checkpoint_contents(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> RpcResult<CheckpointContents>;
-
-    /// Return contents of a checkpoint based on checkpoint content digest
-    #[method(name = "getCheckpointContentsByDigest")]
-    async fn get_checkpoint_contents_by_digest(
-        &self,
-        digest: CheckpointContentsDigest,
-    ) -> RpcResult<CheckpointContents>;
 }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -32,10 +32,7 @@ use sui_types::base_types::{
 };
 use sui_types::crypto::sha3_hash;
 use sui_types::messages::{TransactionData, TransactionEffectsAPI};
-use sui_types::messages_checkpoint::{
-    CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
-    CheckpointSummary,
-};
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::move_package::normalize_modules;
 use sui_types::object::{Data, Object, ObjectRead, PastObjectRead};
 use sui_types::query::{EventQuery, TransactionQuery};
@@ -449,49 +446,6 @@ impl ReadApiServer for ReadApi {
 
     async fn get_checkpoint(&self, id: CheckpointId) -> RpcResult<Checkpoint> {
         Ok(self.get_checkpoint_internal(id)?)
-    }
-
-    async fn get_checkpoint_summary_by_digest(
-        &self,
-        digest: CheckpointDigest,
-    ) -> RpcResult<CheckpointSummary> {
-        Ok(self
-            .state
-            .get_checkpoint_summary_by_digest(digest)
-            .map_err(|e| {
-                anyhow!(
-                    "Checkpoint summary based on digest: {digest:?} were not found with error: {e}"
-                )
-            })?)
-    }
-
-    async fn get_checkpoint_summary(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> RpcResult<CheckpointSummary> {
-        Ok(self.state.get_checkpoint_summary_by_sequence_number(sequence_number)
-            .map_err(|e| anyhow!("Checkpoint summary based on sequence number: {sequence_number} was not found with error :{e}"))?)
-    }
-
-    async fn get_checkpoint_contents_by_digest(
-        &self,
-        digest: CheckpointContentsDigest,
-    ) -> RpcResult<CheckpointContents> {
-        Ok(self.state.get_checkpoint_contents(digest).map_err(|e| {
-            anyhow!(
-                "Checkpoint contents based on digest: {digest:?} were not found with error: {e}"
-            )
-        })?)
-    }
-
-    async fn get_checkpoint_contents(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> RpcResult<CheckpointContents> {
-        Ok(self
-            .state
-            .get_checkpoint_contents_by_sequence_number(sequence_number)
-            .map_err(|e| anyhow!("Checkpoint contents based on seq number: {sequence_number} were not found with error: {e}"))?)
     }
 }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -596,110 +596,6 @@
       ]
     },
     {
-      "name": "sui_getCheckpointContents",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "description": "Return contents of a checkpoint, namely a list of execution digests",
-      "params": [
-        {
-          "name": "sequence_number",
-          "required": true,
-          "schema": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          }
-        }
-      ],
-      "result": {
-        "name": "CheckpointContents",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/CheckpointContents"
-        }
-      }
-    },
-    {
-      "name": "sui_getCheckpointContentsByDigest",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "description": "Return contents of a checkpoint based on checkpoint content digest",
-      "params": [
-        {
-          "name": "digest",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/CheckpointContentsDigest"
-          }
-        }
-      ],
-      "result": {
-        "name": "CheckpointContents",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/CheckpointContents"
-        }
-      }
-    },
-    {
-      "name": "sui_getCheckpointSummary",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "description": "Return a checkpoint summary based on a checkpoint sequence number",
-      "params": [
-        {
-          "name": "sequence_number",
-          "required": true,
-          "schema": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          }
-        }
-      ],
-      "result": {
-        "name": "CheckpointSummary",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/CheckpointSummary"
-        }
-      }
-    },
-    {
-      "name": "sui_getCheckpointSummaryByDigest",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "description": "Return a checkpoint summary based on checkpoint digest",
-      "params": [
-        {
-          "name": "digest",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/CheckpointDigest"
-          }
-        }
-      ],
-      "result": {
-        "name": "CheckpointSummary",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/CheckpointSummary"
-        }
-      }
-    },
-    {
       "name": "sui_getCoinMetadata",
       "tags": [
         {
@@ -3039,35 +2935,6 @@
           }
         }
       },
-      "CheckpointContents": {
-        "description": "CheckpointContents are the transactions included in an upcoming checkpoint. They must have already been causally ordered. Since the causal order algorithm is the same among validators, we expect all honest validators to come up with the same order for each checkpoint content.",
-        "type": "object",
-        "required": [
-          "transactions",
-          "user_signatures"
-        ],
-        "properties": {
-          "transactions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExecutionDigests"
-            }
-          },
-          "user_signatures": {
-            "description": "This field 'pins' user signatures for the checkpoint The length of this vector is same as length of transactions vector System transactions has empty signatures",
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GenericSignature"
-              }
-            }
-          }
-        }
-      },
-      "CheckpointContentsDigest": {
-        "$ref": "#/components/schemas/Sha3Digest"
-      },
       "CheckpointDigest": {
         "description": "Representation of a Checkpoint's digest",
         "allOf": [
@@ -3087,83 +2954,6 @@
             "$ref": "#/components/schemas/CheckpointDigest"
           }
         ]
-      },
-      "CheckpointSummary": {
-        "type": "object",
-        "required": [
-          "content_digest",
-          "epoch",
-          "epoch_rolling_gas_cost_summary",
-          "network_total_transactions",
-          "sequence_number",
-          "timestamp_ms",
-          "version_specific_data"
-        ],
-        "properties": {
-          "content_digest": {
-            "$ref": "#/components/schemas/CheckpointContentsDigest"
-          },
-          "end_of_epoch_data": {
-            "description": "Present only on the final checkpoint of the epoch.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/EndOfEpochData"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "epoch": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "epoch_rolling_gas_cost_summary": {
-            "description": "The running total gas costs of all transactions included in the current epoch so far until this checkpoint.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/GasCostSummary"
-              }
-            ]
-          },
-          "network_total_transactions": {
-            "description": "Total number of transactions committed since genesis, including those in this checkpoint.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "previous_digest": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/CheckpointDigest"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "sequence_number": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "timestamp_ms": {
-            "description": "Timestamp of the checkpoint - number of milliseconds from the Unix epoch Checkpoint timestamps are monotonic, but not strongly monotonic - subsequent checkpoints can have same timestamp if they originate from the same underlining consensus commit",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "version_specific_data": {
-            "description": "CheckpointSummary is not an evolvable structure - it must be readable by any version of the code. Therefore, in order to allow extensions to be added to CheckpointSummary, we allow opaque data to be added to checkpoints which can be deserialized based on the current protocol version.",
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          }
-        }
       },
       "Coin": {
         "type": "object",
@@ -4394,21 +4184,6 @@
           "WaitForEffectsCert",
           "WaitForLocalExecution"
         ]
-      },
-      "ExecutionDigests": {
-        "type": "object",
-        "required": [
-          "effects",
-          "transaction"
-        ],
-        "properties": {
-          "effects": {
-            "$ref": "#/components/schemas/TransactionEffectsDigest"
-          },
-          "transaction": {
-            "$ref": "#/components/schemas/TransactionDigest"
-          }
-        }
       },
       "ExecutionStatus": {
         "oneOf": [

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -27,7 +27,7 @@ use sui_types::committee::EpochId;
 use sui_types::error::TRANSACTION_NOT_FOUND_MSG_PREFIX;
 use sui_types::event::EventID;
 use sui_types::messages::{ExecuteTransactionRequestType, TransactionData, VerifiedTransaction};
-use sui_types::messages_checkpoint::{CheckpointSequenceNumber, CheckpointSummary};
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::query::{EventQuery, TransactionQuery};
 use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
 
@@ -137,14 +137,6 @@ impl ReadApi {
     /// Return a checkpoint
     pub async fn get_checkpoint(&self, id: CheckpointId) -> SuiRpcResult<Checkpoint> {
         Ok(self.api.http.get_checkpoint(id).await?)
-    }
-
-    /// Return a checkpoint summary based on a checkpoint sequence number
-    pub async fn get_checkpoint_summary(
-        &self,
-        seq_number: CheckpointSequenceNumber,
-    ) -> SuiRpcResult<CheckpointSummary> {
-        Ok(self.api.http.get_checkpoint_summary(seq_number).await?)
     }
 
     /// Return the sequence number of the latest checkpoint that has been executed

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -49,11 +49,8 @@ import {
   SuiSystemState,
   CoinBalance,
   CoinSupply,
-  CheckpointSummary,
-  CheckpointContents,
   CheckpointDigest,
   Checkpoint,
-  CheckPointContentsDigest,
   CommitteeInfo,
   DryRunTransactionResponse,
   SuiObjectDataOptions,
@@ -906,78 +903,6 @@ export class JsonRpcProvider extends Provider {
     } catch (err) {
       throw new Error(
         `Error fetching latest checkpoint sequence number: ${err}`,
-      );
-    }
-  }
-
-  async getCheckpointSummary(
-    sequence_number: number,
-  ): Promise<CheckpointSummary> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_getCheckpointSummary',
-        [sequence_number],
-        CheckpointSummary,
-        this.options.skipDataValidation,
-      );
-      return resp;
-    } catch (err) {
-      throw new Error(
-        `Error getting checkpoint summary with request type: ${err} for sequence number: ${sequence_number}.`,
-      );
-    }
-  }
-
-  async getCheckpointSummaryByDigest(
-    digest: CheckpointDigest,
-  ): Promise<CheckpointSummary> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_getCheckpointSummaryByDigest',
-        [digest],
-        CheckpointSummary,
-        this.options.skipDataValidation,
-      );
-      return resp;
-    } catch (err) {
-      throw new Error(
-        `Error getting checkpoint summary with request type: ${err} for digest: ${digest}.`,
-      );
-    }
-  }
-
-  async getCheckpointContents(
-    sequence_number: number | CheckPointContentsDigest,
-  ): Promise<CheckpointContents> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_getCheckpointContents',
-        [sequence_number],
-        CheckpointContents,
-        this.options.skipDataValidation,
-      );
-      return resp;
-    } catch (err) {
-      throw new Error(
-        `Error getting checkpoint contents with request type: ${err} for sequence number: ${sequence_number}.`,
-      );
-    }
-  }
-
-  async getCheckpointContentsByDigest(
-    digest: CheckPointContentsDigest,
-  ): Promise<CheckpointContents> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_getCheckpointContentsByDigest',
-        [digest],
-        CheckpointContents,
-        this.options.skipDataValidation,
-      );
-      return resp;
-    } catch (err) {
-      throw new Error(
-        `Error getting checkpoint summary with request type: ${err} for digest: ${digest}.`,
       );
     }
   }

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -39,10 +39,7 @@ import {
   PaginatedCoins,
   CoinBalance,
   CoinSupply,
-  CheckpointSummary,
-  CheckpointContents,
   CheckpointDigest,
-  CheckPointContentsDigest,
   Checkpoint,
   CommitteeInfo,
   DryRunTransactionResponse,
@@ -394,41 +391,6 @@ export abstract class Provider {
    * Get the sequence number of the latest checkpoint that has been executed
    */
   abstract getLatestCheckpointSequenceNumber(): Promise<number>;
-
-  /**
-   * Returns checkpoint summary based on a checkpoint sequence number
-   * @param sequence_number - The sequence number of the desired checkpoint summary
-   * @deprecated - Prefer `getCheckpoint` instead
-   */
-  abstract getCheckpointSummary(
-    sequenceNumber: number,
-  ): Promise<CheckpointSummary>;
-
-  /**
-   * Returns checkpoint summary based on a checkpoint digest
-   * @param digest - The checkpoint digest
-   * @deprecated - Prefer `getCheckpoint` instead
-   */
-  abstract getCheckpointSummaryByDigest(
-    digest: CheckpointDigest,
-  ): Promise<CheckpointSummary>;
-
-  /**
-   * Return contents of a checkpoint, namely a list of execution digests
-   * @param sequence_number - The sequence number of the desired checkpoint contents
-   * @deprecated - Prefer `getCheckpoint` instead
-   */
-  abstract getCheckpointContents(
-    sequenceNumber: number,
-  ): Promise<CheckpointContents>;
-
-  /**
-   * Returns checkpoint summary based on a checkpoint content digest
-   * @param digest - The checkpoint summary digest
-   */
-  abstract getCheckpointContentsByDigest(
-    digest: CheckPointContentsDigest,
-  ): Promise<CheckpointContents>;
 
   /**
    * Returns information about a given checkpoint

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -37,10 +37,7 @@ import {
   PaginatedCoins,
   CoinBalance,
   CoinSupply,
-  CheckpointSummary,
-  CheckpointContents,
   CheckpointDigest,
-  CheckPointContentsDigest,
   CommitteeInfo,
   Checkpoint,
   DryRunTransactionResponse,
@@ -306,32 +303,8 @@ export class VoidProvider extends Provider {
     throw this.newError('getLatestCheckpointSequenceNumber');
   }
 
-  async getCheckpointSummary(
-    _sequenceNumber: number,
-  ): Promise<CheckpointSummary> {
-    throw this.newError('getCheckpointSummary');
-  }
-
-  async getCheckpointSummaryByDigest(
-    _digest: CheckpointDigest,
-  ): Promise<CheckpointSummary> {
-    throw this.newError('getCheckpointSummaryByDigest');
-  }
-
   async getCheckpoint(_id: CheckpointDigest | number): Promise<Checkpoint> {
     throw this.newError('getCheckpoint');
-  }
-
-  async getCheckpointContents(
-    _sequenceNumber: number,
-  ): Promise<CheckpointContents> {
-    throw this.newError('getCheckpointContents');
-  }
-
-  async getCheckpointContentsByDigest(
-    _digest: CheckPointContentsDigest,
-  ): Promise<CheckpointContents> {
-    throw this.newError('getCheckpointContentsByDigest');
   }
 
   async getCommitteeInfo(_epoch?: number): Promise<CommitteeInfo> {

--- a/sdk/typescript/src/types/checkpoints.ts
+++ b/sdk/typescript/src/types/checkpoints.ts
@@ -36,27 +36,9 @@ export const EndOfEpochData = object({
 });
 export type EndOfEpochData = Infer<typeof EndOfEpochData>;
 
-export const CheckpointSummary = object({
-  epoch: number(),
-  sequence_number: number(),
-  network_total_transactions: number(),
-  content_digest: CheckPointContentsDigest,
-  previous_digest: union([CheckpointDigest, literal(null)]),
-  epoch_rolling_gas_cost_summary: GasCostSummary,
-  end_of_epoch_data: union([EndOfEpochData, literal(null)]),
-  timestamp_ms: union([number(), literal(null)]),
-  version_specific_data: optional(array(number())),
-});
-export type CheckpointSummary = Infer<typeof CheckpointSummary>;
-
 export const ExecutionDigests = object({
   transaction: TransactionDigest,
   effects: TransactionEffectsDigest,
-});
-
-export const CheckpointContents = object({
-  transactions: array(ExecutionDigests),
-  user_signatures: array(array(string())),
 });
 
 export const Checkpoint = object({
@@ -71,5 +53,3 @@ export const Checkpoint = object({
   transactions: array(TransactionDigest),
 });
 export type Checkpoint = Infer<typeof Checkpoint>;
-
-export type CheckpointContents = Infer<typeof CheckpointContents>;

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -12,11 +12,4 @@ export * from './faucet';
 export * from './normalized';
 export * from './validator';
 export * from './coin';
-export {
-  GasCostSummary,
-  CheckpointSummary,
-  CheckpointContents,
-  CheckpointDigest,
-  CheckPointContentsDigest,
-  Checkpoint,
-} from './checkpoints';
+export { GasCostSummary, CheckpointDigest, Checkpoint } from './checkpoints';

--- a/sdk/typescript/test/e2e/checkpoint.test.ts
+++ b/sdk/typescript/test/e2e/checkpoint.test.ts
@@ -17,43 +17,21 @@ describe('Checkpoints Reading API', () => {
     expect(checkpointSequenceNumber).to.greaterThan(0);
   });
 
-  it('Get checkpoint summary', async () => {
-    const resp = await toolbox.provider.getCheckpointSummary(0);
-    expect(resp.epoch).not.toBeNull();
-    expect(resp.sequence_number).not.toBeNull();
-    expect(resp.network_total_transactions).not.toBeNull();
-    expect(resp.content_digest).not.toBeNull();
-    expect(resp.epoch_rolling_gas_cost_summary).not.toBeNull();
-    expect(resp.timestamp_ms).not.toBeNull();
-  });
-
-  it('get checkpoint summary by digest', async () => {
-    const checkpoint_resp = await toolbox.provider.getCheckpointSummary(1);
-    const digest = checkpoint_resp.previous_digest;
-    expect(digest).not.toBeNull();
-    const resp = await toolbox.provider.getCheckpointSummaryByDigest(digest!);
-    expect(resp.epoch).not.toBeNull();
-    expect(resp.sequence_number).not.toBeNull();
-    expect(resp.network_total_transactions).not.toBeNull();
-    expect(resp.content_digest).not.toBeNull();
-    expect(resp.epoch_rolling_gas_cost_summary).not.toBeNull();
-    expect(resp.timestamp_ms).not.toBeNull();
-  });
-
-  it('get checkpoint contents', async () => {
-    const resp = await toolbox.provider.getCheckpointContents(0);
-    expect(resp.transactions.length).greaterThan(0);
-  });
-
   it('gets checkpoint by id', async () => {
     const resp = await toolbox.provider.getCheckpoint(0);
     expect(resp.digest.length).greaterThan(0);
+    expect(resp.transactions.length).greaterThan(0);
+    expect(resp.epoch).not.toBeNull();
+    expect(resp.sequenceNumber).not.toBeNull();
+    expect(resp.networkTotalTransactions).not.toBeNull();
+    expect(resp.epochRollingGasCostSummary).not.toBeNull();
+    expect(resp.timestampMs).not.toBeNull();
   });
 
   it('get checkpoint contents by digest', async () => {
-    const checkpoint_resp = await toolbox.provider.getCheckpointSummary(0);
-    const digest = checkpoint_resp.content_digest;
-    const resp = await toolbox.provider.getCheckpointContentsByDigest(digest);
-    expect(resp.transactions.length).greaterThan(0);
+    const checkpoint_resp = await toolbox.provider.getCheckpoint(0);
+    const digest = checkpoint_resp.digest;
+    const resp = await toolbox.provider.getCheckpoint(digest);
+    expect(checkpoint_resp).toEqual(resp);
   });
 });


### PR DESCRIPTION
## Description 

Saw these APIs and figured we can move forward to deprecate and keep things simple for next release.

## Test Plan 

Tests should continue to pass, updated SDK checkpoint tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Unified all RPC checkpoint methods onto `getCheckpoint`.
