### PR TITLE
indexer: separate recipients table for txn query

### DIFF
--- a/crates/sui-indexer/migrations/2023-03-05-165748_move_calls/down.sql
+++ b/crates/sui-indexer/migrations/2023-03-05-165748_move_calls/down.sql
@@ -1,1 +1,0 @@
-DROP TABLE move_calls;

--- a/crates/sui-indexer/migrations/2023-03-05-165748_transaction_index/down.sql
+++ b/crates/sui-indexer/migrations/2023-03-05-165748_transaction_index/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS move_calls;
+DROP TABLE IF EXISTS recipients;

--- a/crates/sui-indexer/migrations/2023-03-05-165748_transaction_index/up.sql
+++ b/crates/sui-indexer/migrations/2023-03-05-165748_transaction_index/up.sql
@@ -16,3 +16,16 @@ CREATE INDEX move_calls_sender ON move_calls (sender);
 CREATE INDEX move_calls_move_package ON move_calls (move_package);
 CREATE INDEX move_calls_move_module ON move_calls (move_module);
 CREATE INDEX move_calls_move_function ON move_calls (move_function);
+
+CREATE TABLE recipients (
+    id BIGSERIAL PRIMARY KEY,
+    transaction_digest VARCHAR(255) NOT NULL,
+    checkpoint_sequence_number BIGINT NOT NULL,
+    epoch BIGINT NOT NULL,
+    recipient VARCHAR(255) NOT NULL
+);
+
+CREATE INDEX recipients_transaction_digest ON recipients (transaction_digest);
+CREATE INDEX recipients_checkpoint_sequence_number ON recipients (checkpoint_sequence_number);
+CREATE INDEX recipients_epoch ON recipients (epoch);
+CREATE INDEX recipients_recipient ON recipients (recipient);

--- a/crates/sui-indexer/src/models/mod.rs
+++ b/crates/sui-indexer/src/models/mod.rs
@@ -9,4 +9,5 @@ pub mod move_calls;
 pub mod objects;
 pub mod owners;
 pub mod packages;
+pub mod recipients;
 pub mod transactions;

--- a/crates/sui-indexer/src/models/recipients.rs
+++ b/crates/sui-indexer/src/models/recipients.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::schema::recipients;
+use diesel::prelude::*;
+
+#[derive(Queryable, Insertable, Debug, Clone, Default)]
+pub struct Recipient {
+    pub id: Option<i64>,
+    pub transaction_digest: String,
+    pub checkpoint_sequence_number: i64,
+    pub epoch: i64,
+    pub recipient: String,
+}

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -169,6 +169,16 @@ diesel::table! {
 }
 
 diesel::table! {
+    recipients (id) {
+        id -> Int8,
+        transaction_digest -> Varchar,
+        checkpoint_sequence_number -> Int8,
+        epoch -> Int8,
+        recipient -> Varchar,
+    }
+}
+
+diesel::table! {
     transactions (id) {
         id -> Int8,
         transaction_digest -> Varchar,
@@ -210,5 +220,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     owner_history,
     package_logs,
     packages,
+    recipients,
     transactions,
 );

--- a/crates/sui-indexer/tests/indexer_tests.rs
+++ b/crates/sui-indexer/tests/indexer_tests.rs
@@ -79,14 +79,6 @@ impl IndexerStore for InMemoryIndexerStore {
         todo!()
     }
 
-    fn get_latest_move_call_sequence_number(&self) -> Result<i64, IndexerError> {
-        todo!()
-    }
-
-    fn get_latest_transaction_sequence_number(&self) -> Result<i64, IndexerError> {
-        todo!()
-    }
-
     fn get_transaction_by_digest(&self, _txn_digest: String) -> Result<Transaction, IndexerError> {
         todo!()
     }
@@ -95,7 +87,15 @@ impl IndexerStore for InMemoryIndexerStore {
         &self,
         _txn_digest: Option<String>,
         _is_descending: bool,
-    ) -> Result<i64, IndexerError> {
+    ) -> Result<Option<i64>, IndexerError> {
+        todo!()
+    }
+
+    fn get_recipient_sequence_by_digest(
+        &self,
+        _txn_digest: Option<String>,
+        _is_descending: bool,
+    ) -> Result<Option<i64>, IndexerError> {
         todo!()
     }
 
@@ -103,13 +103,13 @@ impl IndexerStore for InMemoryIndexerStore {
         &self,
         _txn_digest: Option<String>,
         _is_descending: bool,
-    ) -> Result<i64, IndexerError> {
+    ) -> Result<Option<i64>, IndexerError> {
         todo!()
     }
 
     fn get_all_transaction_digest_page(
         &self,
-        _start_sequence: i64,
+        _start_sequence: Option<i64>,
         _limit: usize,
         _is_descending: bool,
     ) -> Result<Vec<String>, IndexerError> {
@@ -119,7 +119,7 @@ impl IndexerStore for InMemoryIndexerStore {
     fn get_transaction_digest_page_by_mutated_object(
         &self,
         _object_id: String,
-        _start_sequence: i64,
+        _start_sequence: Option<i64>,
         _limit: usize,
         _is_descending: bool,
     ) -> Result<Vec<String>, IndexerError> {
@@ -129,7 +129,7 @@ impl IndexerStore for InMemoryIndexerStore {
     fn get_transaction_digest_page_by_sender_address(
         &self,
         _sender_address: String,
-        _start_sequence: i64,
+        _start_sequence: Option<i64>,
         _limit: usize,
         _is_descending: bool,
     ) -> Result<Vec<String>, IndexerError> {
@@ -141,7 +141,7 @@ impl IndexerStore for InMemoryIndexerStore {
         _package: String,
         _module: Option<String>,
         _function: Option<String>,
-        _start_sequence: i64,
+        _start_sequence: Option<i64>,
         _limit: usize,
         _is_descending: bool,
     ) -> Result<Vec<String>, IndexerError> {
@@ -151,7 +151,7 @@ impl IndexerStore for InMemoryIndexerStore {
     fn get_transaction_digest_page_by_recipient_address(
         &self,
         _recipient_address: String,
-        _start_sequence: i64,
+        _start_sequence: Option<i64>,
         _limit: usize,
         _is_descending: bool,
     ) -> Result<Vec<String>, IndexerError> {


### PR DESCRIPTION
## Description 

Add a separate recipients table for txn query via recipient address, because `recipients` is an array in `transactions` table, it cannot be safely indexed b/c of b-tree entry size limit, also array contain check for each row is highly inefficient.

Also fixed a `distinct` issue from previous PR.

## Test Plan 

```
curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{ "jsonrpc":"2.0", "id":1, "method":"sui_getTransactions", "params":[  {"ToAddress": "0x8867068daf9111ee013450eea1b1e10ffd62fc874329f0eadadd62b5617011e4" } , null, null, true]}'
{"jsonrpc":"2.0","result":{"data":["FJwuhGK17wCfk9PyQthrKSnAVh63e19j2MW7nsMkgemJ","4hCmXYjwm96vZUom4AUJDdB5LixRcTR1LnyQfJb3RJLr","8DesDfoVmJcDs3CHE71z9xxhJSNP2nFx6LcBqtZcmLy7","D3CRhQd2737NG7wAgyfw7sNTUNxu7wdFYWWbyTFrRCQZ","5id1ncYSwaFioLdZrkpn2eAyM4syQkm116XxaETsL97t"],"nextCursor":null},"id":1}%     
curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{ "jsonrpc":"2.0", "id":1, "method":"sui_getTransactions", "params":[  {"ToAddress": "0x8867068daf9111ee013450eea1b1e10ffd62fc874329f0eadadd62b5617011e4" } , null, null, null]}'
{"jsonrpc":"2.0","result":{"data":["5id1ncYSwaFioLdZrkpn2eAyM4syQkm116XxaETsL97t","D3CRhQd2737NG7wAgyfw7sNTUNxu7wdFYWWbyTFrRCQZ","8DesDfoVmJcDs3CHE71z9xxhJSNP2nFx6LcBqtZcmLy7","4hCmXYjwm96vZUom4AUJDdB5LixRcTR1LnyQfJb3RJLr","FJwuhGK17wCfk9PyQthrKSnAVh63e19j2MW7nsMkgemJ"],"nextCursor":null},"id":1}%                                                                            
curl --location --request POST http://127.0.0.1:9000 \
--header 'Content-Type: application/json' \
--data-raw '{ "jsonrpc":"2.0", "id":1, "method":"sui_getTransactions", "params":[  {"ToAddress": "0x8867068daf9111ee013450eea1b1e10ffd62fc874329f0eadadd62b5617011e4" } , null, null, null]}'
{"jsonrpc":"2.0","result":{"data":["5id1ncYSwaFioLdZrkpn2eAyM4syQkm116XxaETsL97t","D3CRhQd2737NG7wAgyfw7sNTUNxu7wdFYWWbyTFrRCQZ","8DesDfoVmJcDs3CHE71z9xxhJSNP2nFx6LcBqtZcmLy7","4hCmXYjwm96vZUom4AUJDdB5LixRcTR1LnyQfJb3RJLr","FJwuhGK17wCfk9PyQthrKSnAVh63e19j2MW7nsMkgemJ"],"nextCursor":null},"id":1}%                                                                            
curl --location --request POST http://127.0.0.1:9000 \
--header 'Content-Type: application/json' \
--data-raw '{ "jsonrpc":"2.0", "id":1, "method":"sui_getTransactions", "params":[  {"ToAddress": "0x8867068daf9111ee013450eea1b1e10ffd62fc874329f0eadadd62b5617011e4" } , null, null, true]}'
{"jsonrpc":"2.0","result":{"data":["FJwuhGK17wCfk9PyQthrKSnAVh63e19j2MW7nsMkgemJ","4hCmXYjwm96vZUom4AUJDdB5LixRcTR1LnyQfJb3RJLr","8DesDfoVmJcDs3CHE71z9xxhJSNP2nFx6LcBqtZcmLy7","D3CRhQd2737NG7wAgyfw7sNTUNxu7wdFYWWbyTFrRCQZ","5id1ncYSwaFioLdZrkpn2eAyM4syQkm116XxaETsL97t"],"nextCursor":null},"id":1}%     
```
