### PR TITLE
Add failpoint before epoch db start in reconfig simtest with crashes

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -57,7 +57,7 @@ use sui_json_rpc_types::{
     type_and_fields_from_move_struct, DevInspectResults, DryRunTransactionResponse, SuiEvent,
     SuiEventEnvelope, SuiMoveValue, SuiTransactionEvents,
 };
-use sui_macros::nondeterministic;
+use sui_macros::{fail_point, nondeterministic};
 use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use sui_storage::indexes::{ObjectIndexChanges, MAX_GET_OWNED_OBJECT_SIZE};
 use sui_storage::write_ahead_log::WriteAheadLog;
@@ -3092,6 +3092,7 @@ impl AuthorityState {
         self.db()
             .set_epoch_start_configuration(&epoch_start_configuration)
             .await?;
+        fail_point!("before-open-new-epoch-store");
         let new_epoch_store = cur_epoch_store.new_at_next_epoch(
             self.name,
             new_committee,


### PR DESCRIPTION
### Description 

This PR adds a failpoint in the reconfig test which crashes the node before epoch db is started. This is to test the scenario discussed in https://github.com/MystenLabs/sui/pull/8910.

### Test Plan 

I ran the test `MSIM_TEST_NUM=20 cargo simtest test_simulated_load_reconfig_crashes` and found it to not fail
