### PR TITLE
State sync: download complete checkpoint contents in one RPC

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -102,13 +102,6 @@ pub struct StateSyncConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint_content_download_concurrency: Option<usize>,
 
-    /// Set the upper bound on the number of transactions to be downloaded concurrently from a
-    /// single checkpoint.
-    ///
-    /// If unspecified, this will default to `100`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction_download_concurrency: Option<usize>,
-
     /// Set the timeout that should be used when sending state-sync RPC requests.
     ///
     /// If unspecified, this will default to `10,000` milliseconds.
@@ -132,12 +125,6 @@ pub struct StateSyncConfig {
     /// If unspecified, this will default to no limit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub get_checkpoint_contents_rate_limit: Option<NonZeroU32>,
-
-    /// Per-peer rate-limit (in requests/sec) for the GetTransactionAndEffects RPC.
-    ///
-    /// If unspecified, this will default to no limit.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub get_transaction_and_effects_rate_limit: Option<NonZeroU32>,
 }
 
 impl StateSyncConfig {
@@ -172,13 +159,6 @@ impl StateSyncConfig {
 
         self.checkpoint_content_download_concurrency
             .unwrap_or(CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY)
-    }
-
-    pub fn transaction_download_concurrency(&self) -> usize {
-        const TRANSACTION_DOWNLOAD_CONCURRENCY: usize = 100;
-
-        self.transaction_download_concurrency
-            .unwrap_or(TRANSACTION_DOWNLOAD_CONCURRENCY)
     }
 
     pub fn timeout(&self) -> Duration {

--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -102,11 +102,17 @@ pub struct StateSyncConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint_content_download_concurrency: Option<usize>,
 
-    /// Set the timeout that should be used when sending state-sync RPC requests.
+    /// Set the timeout that should be used when sending most state-sync RPC requests.
     ///
     /// If unspecified, this will default to `10,000` milliseconds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
+
+    /// Set the timeout that should be used when sending RPC requests to sync checkpoint contents.
+    ///
+    /// If unspecified, this will default to `10,000` milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint_content_timeout_ms: Option<u64>,
 
     /// Per-peer rate-limit (in requests/sec) for the PushCheckpointSummary RPC.
     ///
@@ -165,6 +171,14 @@ impl StateSyncConfig {
         const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
         self.timeout_ms
+            .map(Duration::from_millis)
+            .unwrap_or(DEFAULT_TIMEOUT)
+    }
+
+    pub fn checkpoint_content_timeout(&self) -> Duration {
+        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+
+        self.checkpoint_content_timeout_ms
             .map(Duration::from_millis)
             .unwrap_or(DEFAULT_TIMEOUT)
     }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -447,7 +447,7 @@ fn sync_checkpoint(
         .insert_verified_checkpoint(checkpoint.clone())
         .unwrap();
     checkpoint_store
-        .insert_checkpoint_contents(empty_contents())
+        .insert_checkpoint_contents(empty_contents().into_inner().into_checkpoint_contents())
         .unwrap();
     checkpoint_store
         .update_highest_synced_checkpoint(checkpoint)

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -573,6 +573,9 @@ impl CheckpointBuilder {
             .zip(signatures.into_iter())
         {
             // Roll over to a new chunk after either max count or max size is reached.
+            // The size calculation here is intended to estimate the size of the
+            // FullCheckpointContents struct. If this code is modified, that struct
+            // should also be updated accordingly.
             let size = transaction_size
                 + bcs::serialized_size(&effects)?
                 + bcs::serialized_size(&signatures)?;

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -9,12 +9,13 @@ use sui_types::committee::EpochId;
 use sui_types::digests::{TransactionEffectsDigest, TransactionEventsDigest};
 use sui_types::messages::VerifiedTransaction;
 use sui_types::messages::{TransactionEffects, TransactionEvents};
-use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::messages_checkpoint::CheckpointContentsDigest;
 use sui_types::messages_checkpoint::CheckpointDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::messages_checkpoint::EndOfEpochData;
+use sui_types::messages_checkpoint::FullCheckpointContents;
 use sui_types::messages_checkpoint::VerifiedCheckpoint;
+use sui_types::messages_checkpoint::VerifiedCheckpointContents;
 use sui_types::storage::ReadStore;
 use sui_types::storage::WriteStore;
 use typed_store::Map;
@@ -80,11 +81,14 @@ impl ReadStore for RocksDbStore {
             })
     }
 
-    fn get_checkpoint_contents(
+    fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
-    ) -> Result<Option<CheckpointContents>, Self::Error> {
-        self.checkpoint_store.get_checkpoint_contents(digest)
+    ) -> Result<Option<FullCheckpointContents>, Self::Error> {
+        self.checkpoint_store
+            .get_checkpoint_contents(digest)?
+            .map(|contents| FullCheckpointContents::from_checkpoint_contents(&self, contents))
+            .transpose()
     }
 
     fn get_committee(&self, epoch: EpochId) -> Result<Option<Committee>, Self::Error> {
@@ -137,8 +141,14 @@ impl WriteStore for RocksDbStore {
             .update_highest_synced_checkpoint(checkpoint)
     }
 
-    fn insert_checkpoint_contents(&self, contents: CheckpointContents) -> Result<(), Self::Error> {
-        self.checkpoint_store.insert_checkpoint_contents(contents)
+    fn insert_checkpoint_contents(
+        &self,
+        contents: VerifiedCheckpointContents,
+    ) -> Result<(), Self::Error> {
+        self.authority_store
+            .multi_insert_transaction_and_effects(contents.iter())?;
+        self.checkpoint_store
+            .insert_checkpoint_contents(contents.into_inner().into_checkpoint_contents())
     }
 
     fn insert_committee(&self, new_committee: Committee) -> Result<(), Self::Error> {
@@ -146,14 +156,5 @@ impl WriteStore for RocksDbStore {
             .insert_new_committee(&new_committee)
             .unwrap();
         Ok(())
-    }
-
-    fn insert_transaction_and_effects(
-        &self,
-        transaction: VerifiedTransaction,
-        transaction_effects: TransactionEffects,
-    ) -> Result<(), Self::Error> {
-        self.authority_store
-            .insert_transaction_and_effects(&transaction, &transaction_effects)
     }
 }

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -133,16 +133,7 @@ fn build_anemo_services(out_dir: &Path) {
                 .name("get_checkpoint_contents")
                 .route_name("GetCheckpointContents")
                 .request_type("sui_types::messages_checkpoint::CheckpointContentsDigest")
-                .response_type("Option<sui_types::messages_checkpoint::CheckpointContents>")
-                .codec_path(codec_path)
-                .build(),
-        )
-        .method(
-            anemo_build::manual::Method::builder()
-                .name("get_transaction_and_effects")
-                .route_name("GetTransactionAndEffects")
-                .request_type("sui_types::base_types::ExecutionDigests")
-                .response_type("Option<(sui_types::messages::Transaction, sui_types::messages::TransactionEffects)>")
+                .response_type("Option<sui_types::messages_checkpoint::FullCheckpointContents>")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/crates/sui-network/src/state_sync/builder.rs
+++ b/crates/sui-network/src/state_sync/builder.rs
@@ -93,14 +93,6 @@ where
                 )),
             );
         }
-        if let Some(limit) = state_sync_config.get_transaction_and_effects_rate_limit {
-            state_sync_server = state_sync_server.add_layer_for_get_transaction_and_effects(
-                InboundRequestLayer::new(rate_limit::RateLimitLayer::new(
-                    governor::Quota::per_second(limit),
-                    rate_limit::WaitMode::Block,
-                )),
-            );
-        }
 
         (builder, state_sync_server)
     }

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -567,7 +567,7 @@ where
                 self.checkpoint_event_sender.clone(),
                 self.metrics.clone(),
                 self.config.checkpoint_content_download_concurrency(),
-                self.config.timeout(),
+                self.config.checkpoint_content_timeout(),
                 highest_verified_checkpoint,
             );
 

--- a/crates/sui-network/src/state_sync/server.rs
+++ b/crates/sui-network/src/state_sync/server.rs
@@ -6,11 +6,9 @@ use anemo::{rpc::Status, Request, Response, Result};
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, RwLock};
 use sui_types::{
-    base_types::ExecutionDigests,
     digests::{CheckpointContentsDigest, CheckpointDigest},
-    messages::{Transaction, TransactionEffects},
     messages_checkpoint::{
-        CertifiedCheckpointSummary as Checkpoint, CheckpointContents, CheckpointSequenceNumber,
+        CertifiedCheckpointSummary as Checkpoint, CheckpointSequenceNumber, FullCheckpointContents,
         VerifiedCheckpoint,
     },
     storage::ReadStore,
@@ -98,40 +96,11 @@ where
     async fn get_checkpoint_contents(
         &self,
         request: Request<CheckpointContentsDigest>,
-    ) -> Result<Response<Option<CheckpointContents>>, Status> {
+    ) -> Result<Response<Option<FullCheckpointContents>>, Status> {
         let contents = self
             .store
-            .get_checkpoint_contents(request.inner())
+            .get_full_checkpoint_contents(request.inner())
             .map_err(|e| Status::internal(e.to_string()))?;
-
         Ok(Response::new(contents))
-    }
-
-    async fn get_transaction_and_effects(
-        &self,
-        request: Request<ExecutionDigests>,
-    ) -> Result<Response<Option<(Transaction, TransactionEffects)>>, Status> {
-        let ExecutionDigests {
-            transaction: tx_digest,
-            effects: effects_digest,
-        } = request.into_inner();
-
-        let Some(transaction) = self
-            .store
-            .get_transaction(&tx_digest)
-            .map_err(|e| Status::internal(e.to_string()))? else
-        {
-            return Ok(Response::new(None));
-        };
-
-        let Some(effects) = self
-            .store
-            .get_transaction_effects(&effects_digest)
-            .map_err(|e| Status::internal(e.to_string()))? else
-        {
-            return Ok(Response::new(None));
-        };
-
-        Ok(Response::new(Some((transaction.into_inner(), effects))))
     }
 }

--- a/crates/sui-network/src/state_sync/test_utils.rs
+++ b/crates/sui-network/src/state_sync/test_utils.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::intent::{Intent, IntentMessage, IntentScope};
+use sui_types::messages_checkpoint::{FullCheckpointContents, VerifiedCheckpointContents};
 use sui_types::{
     base_types::AuthorityName,
     committee::{Committee, EpochId, StakeUnit},
@@ -12,8 +13,8 @@ use sui_types::{
         SuiAuthoritySignature,
     },
     messages_checkpoint::{
-        CertifiedCheckpointSummary, CheckpointContents, CheckpointDigest, CheckpointSequenceNumber,
-        CheckpointSummary, EndOfEpochData, VerifiedCheckpoint,
+        CertifiedCheckpointSummary, CheckpointDigest, CheckpointSequenceNumber, CheckpointSummary,
+        EndOfEpochData, VerifiedCheckpoint,
     },
 };
 
@@ -60,7 +61,10 @@ impl CommitteeFixture {
             epoch: 0,
             sequence_number: 0,
             network_total_transactions: 0,
-            content_digest: empty_contents().digest(),
+            content_digest: empty_contents()
+                .into_inner()
+                .into_checkpoint_contents()
+                .digest(),
             previous_digest: None,
             epoch_rolling_gas_cost_summary: Default::default(),
             end_of_epoch_data: None,
@@ -121,7 +125,10 @@ impl CommitteeFixture {
                 epoch: self.epoch,
                 sequence_number: prev.summary.sequence_number + 1,
                 network_total_transactions: 0,
-                content_digest: empty_contents().digest(),
+                content_digest: empty_contents()
+                    .into_inner()
+                    .into_checkpoint_contents()
+                    .digest(),
                 previous_digest: Some(prev.summary.digest()),
                 epoch_rolling_gas_cost_summary: Default::default(),
                 end_of_epoch_data: None,
@@ -165,7 +172,10 @@ impl CommitteeFixture {
             epoch: self.epoch,
             sequence_number: previous_checkpoint.summary.sequence_number + 1,
             network_total_transactions: 0,
-            content_digest: empty_contents().digest(),
+            content_digest: empty_contents()
+                .into_inner()
+                .into_checkpoint_contents()
+                .digest(),
             previous_digest: Some(previous_checkpoint.summary.digest()),
             epoch_rolling_gas_cost_summary: Default::default(),
             end_of_epoch_data,
@@ -183,6 +193,8 @@ impl CommitteeFixture {
     }
 }
 
-pub fn empty_contents() -> CheckpointContents {
-    CheckpointContents::new_with_causally_ordered_transactions(std::iter::empty())
+pub fn empty_contents() -> VerifiedCheckpointContents {
+    VerifiedCheckpointContents::new_unchecked(
+        FullCheckpointContents::new_with_causally_ordered_transactions(std::iter::empty()),
+    )
 }

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -26,8 +26,6 @@ async fn server_push_checkpoint() {
     store.inner_mut().insert_genesis_state(
         ordered_checkpoints.first().cloned().unwrap(),
         empty_contents(),
-        vec![],
-        vec![],
         committee.committee().to_owned(),
     );
 
@@ -101,8 +99,6 @@ async fn server_get_checkpoint() {
     builder.store.inner_mut().insert_genesis_state(
         ordered_checkpoints.first().cloned().unwrap(),
         empty_contents(),
-        vec![],
-        vec![],
         committee.committee().to_owned(),
     );
 
@@ -193,15 +189,11 @@ async fn isolated_sync_job() {
     event_loop_1.store.inner_mut().insert_genesis_state(
         ordered_checkpoints.first().cloned().unwrap(),
         empty_contents(),
-        vec![],
-        vec![],
         committee.committee().to_owned(),
     );
     event_loop_2.store.inner_mut().insert_genesis_state(
         ordered_checkpoints.first().cloned().unwrap(),
         empty_contents(),
-        vec![],
-        vec![],
         committee.committee().to_owned(),
     );
 
@@ -282,15 +274,11 @@ async fn sync_with_checkpoints_being_inserted() {
     event_loop_1.store.inner_mut().insert_genesis_state(
         ordered_checkpoints.first().cloned().unwrap(),
         empty_contents(),
-        vec![],
-        vec![],
         committee.committee().to_owned(),
     );
     event_loop_2.store.inner_mut().insert_genesis_state(
         ordered_checkpoints.first().cloned().unwrap(),
         empty_contents(),
-        vec![],
-        vec![],
         committee.committee().to_owned(),
     );
 

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -523,14 +523,6 @@ pub(crate) fn make_anemo_config() -> anemo_cli::Config {
                         get_checkpoint_contents,
                         sui_types::messages_checkpoint::CheckpointContentsDigest
                     ),
-                )
-                .add_method(
-                    "GetTransactionAndEffects",
-                    anemo_cli::ron_method!(
-                        StateSyncClient,
-                        get_transaction_and_effects,
-                        sui_types::base_types::ExecutionDigests
-                    ),
                 ),
         )
 }

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -13,6 +13,10 @@ use crate::error::ExecutionErrorKind;
 use crate::error::SuiError;
 use crate::error::{ExecutionError, SuiResult};
 use crate::gas_coin::GasCoin;
+use crate::messages::Transaction;
+use crate::messages::TransactionEffects;
+use crate::messages::TransactionEffectsAPI;
+use crate::messages::VerifiedTransaction;
 use crate::messages_checkpoint::CheckpointTimestamp;
 use crate::multisig::MultiSigPublicKey;
 use crate::object::{Object, Owner};
@@ -359,6 +363,60 @@ impl ExecutionDigests {
             transaction: TransactionDigest::random(),
             effects: TransactionEffectsDigest::random(),
         }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+pub struct ExecutionData {
+    pub transaction: Transaction,
+    pub effects: TransactionEffects,
+}
+
+impl ExecutionData {
+    pub fn new(transaction: Transaction, effects: TransactionEffects) -> ExecutionData {
+        debug_assert_eq!(transaction.digest(), effects.transaction_digest());
+        Self {
+            transaction,
+            effects,
+        }
+    }
+
+    pub fn digests(&self) -> ExecutionDigests {
+        self.effects.execution_digests()
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct VerifiedExecutionData {
+    pub transaction: VerifiedTransaction,
+    pub effects: TransactionEffects,
+}
+
+impl VerifiedExecutionData {
+    pub fn new(transaction: VerifiedTransaction, effects: TransactionEffects) -> Self {
+        debug_assert_eq!(transaction.digest(), effects.transaction_digest());
+        Self {
+            transaction,
+            effects,
+        }
+    }
+
+    pub fn new_unchecked(data: ExecutionData) -> Self {
+        Self {
+            transaction: VerifiedTransaction::new_unchecked(data.transaction),
+            effects: data.effects,
+        }
+    }
+
+    pub fn into_inner(self) -> ExecutionData {
+        ExecutionData {
+            transaction: self.transaction.into_inner(),
+            effects: self.effects,
+        }
+    }
+
+    pub fn digests(&self) -> ExecutionDigests {
+        self.effects.execution_digests()
     }
 }
 

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -6,19 +6,22 @@ use std::fmt::{Debug, Display, Formatter};
 use std::slice::Iter;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crate::base_types::ExecutionDigests;
+use crate::base_types::{ExecutionData, ExecutionDigests, VerifiedExecutionData};
 use crate::committee::{EpochId, ProtocolVersion, StakeUnit};
 use crate::crypto::{AuthoritySignInfo, AuthoritySignInfoTrait, AuthorityStrongQuorumSignInfo};
 use crate::error::SuiResult;
 use crate::gas::GasCostSummary;
 use crate::intent::{Intent, IntentScope};
+use crate::messages::TransactionEffectsAPI;
 use crate::signature::GenericSignature;
+use crate::storage::ReadStore;
 use crate::{
     base_types::AuthorityName,
     committee::Committee,
     crypto::{sha3_hash, AuthoritySignature, VerificationObligation},
     error::SuiError,
 };
+use anyhow::Result;
 use fastcrypto::traits::Signer;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
@@ -410,6 +413,12 @@ pub struct CheckpointSignatureMessage {
     pub summary: SignedCheckpointSummary,
 }
 
+impl CheckpointSignatureMessage {
+    pub fn verify(&self, committee: &Committee) -> SuiResult {
+        self.summary.verify(committee, None)
+    }
+}
+
 /// CheckpointContents are the transactions included in an upcoming checkpoint.
 /// They must have already been causally ordered. Since the causal order algorithm
 /// is the same among validators, we expect all honest validators to come up with
@@ -421,12 +430,6 @@ pub struct CheckpointContents {
     /// The length of this vector is same as length of transactions vector
     /// System transactions has empty signatures
     user_signatures: Vec<Vec<GenericSignature>>,
-}
-
-impl CheckpointSignatureMessage {
-    pub fn verify(&self, committee: &Committee) -> SuiResult {
-        self.summary.verify(committee, None)
-    }
 }
 
 impl CheckpointContents {
@@ -461,6 +464,14 @@ impl CheckpointContents {
         self.transactions.iter()
     }
 
+    pub fn into_iter_with_signatures(
+        self,
+    ) -> impl Iterator<Item = (ExecutionDigests, Vec<GenericSignature>)> {
+        self.transactions
+            .into_iter()
+            .zip(self.user_signatures.into_iter())
+    }
+
     /// Return an iterator that enumerates the transactions in the contents.
     /// The iterator item is a tuple of (sequence_number, &ExecutionDigests),
     /// where the sequence_number indicates the index of the transaction in the
@@ -486,6 +497,140 @@ impl CheckpointContents {
 
     pub fn digest(&self) -> CheckpointContentsDigest {
         CheckpointContentsDigest::new(sha3_hash(self))
+    }
+}
+
+/// Same as CheckpointContents, but contains full contents of all Transactions and
+/// TransactionEffects associated with the checkpoint.
+// NOTE: This data structure is used for state sync of checkpoints. Therefore we attempt
+// to estimate its size in CheckpointBuilder in order to limit the maximum serialized
+// size of a checkpoint sent over the network. If this struct is modified,
+// CheckpointBuilder::split_checkpoint_chunks should also be updated accordingly.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FullCheckpointContents {
+    transactions: Vec<ExecutionData>,
+    /// This field 'pins' user signatures for the checkpoint
+    /// The length of this vector is same as length of transactions vector
+    /// System transactions has empty signatures
+    user_signatures: Vec<Vec<GenericSignature>>,
+}
+
+impl FullCheckpointContents {
+    pub fn new_with_causally_ordered_transactions<T>(contents: T) -> Self
+    where
+        T: IntoIterator<Item = ExecutionData>,
+    {
+        let transactions: Vec<_> = contents.into_iter().collect();
+        let user_signatures = transactions.iter().map(|_| vec![]).collect();
+        Self {
+            transactions,
+            user_signatures,
+        }
+    }
+
+    pub fn from_checkpoint_contents<S>(
+        store: S,
+        contents: CheckpointContents,
+    ) -> Result<Self, <S as ReadStore>::Error>
+    where
+        S: ReadStore,
+    {
+        let mut transactions = Vec::with_capacity(contents.size());
+        for tx in contents.transactions {
+            let t = store.get_transaction(&tx.transaction)?.unwrap();
+            let e = store.get_transaction_effects(&tx.effects)?.unwrap();
+            transactions.push(ExecutionData::new(t.into_inner(), e))
+        }
+        Ok(Self {
+            transactions,
+            user_signatures: contents.user_signatures,
+        })
+    }
+
+    pub fn iter(&self) -> Iter<'_, ExecutionData> {
+        self.transactions.iter()
+    }
+
+    /// Verifies that this checkpoint's digest matches the given digest, and that all internal
+    /// Transaction and TransactionEffects digests are consistent.
+    pub fn verify_digests(&self, digest: CheckpointContentsDigest) -> Result<()> {
+        let self_digest = self.checkpoint_contents().digest();
+        fp_ensure!(
+            digest == self_digest,
+            anyhow::anyhow!(
+                "checkpoint contents digest {self_digest} does not match expected digest {digest}"
+            )
+        );
+        for tx in self.iter() {
+            let transaction_digest = tx.transaction.digest();
+            fp_ensure!(
+                tx.effects.transaction_digest() == transaction_digest,
+                anyhow::anyhow!(
+                    "transaction digest {transaction_digest} does not match expected digest {}",
+                    tx.effects.transaction_digest()
+                )
+            );
+        }
+        Ok(())
+    }
+
+    pub fn checkpoint_contents(&self) -> CheckpointContents {
+        CheckpointContents {
+            transactions: self.transactions.iter().map(|tx| tx.digests()).collect(),
+            user_signatures: self.user_signatures.clone(),
+        }
+    }
+
+    pub fn into_checkpoint_contents(self) -> CheckpointContents {
+        CheckpointContents {
+            transactions: self
+                .transactions
+                .into_iter()
+                .map(|tx| tx.digests())
+                .collect(),
+            user_signatures: self.user_signatures,
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        self.transactions.len()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedCheckpointContents {
+    transactions: Vec<VerifiedExecutionData>,
+    /// This field 'pins' user signatures for the checkpoint
+    /// The length of this vector is same as length of transactions vector
+    /// System transactions has empty signatures
+    user_signatures: Vec<Vec<GenericSignature>>,
+}
+
+impl VerifiedCheckpointContents {
+    pub fn new_unchecked(contents: FullCheckpointContents) -> Self {
+        Self {
+            transactions: contents
+                .transactions
+                .into_iter()
+                .map(VerifiedExecutionData::new_unchecked)
+                .collect(),
+            user_signatures: contents.user_signatures,
+        }
+    }
+
+    pub fn iter(&self) -> Iter<'_, VerifiedExecutionData> {
+        self.transactions.iter()
+    }
+
+    pub fn into_inner(self) -> FullCheckpointContents {
+        FullCheckpointContents {
+            transactions: self
+                .transactions
+                .into_iter()
+                .map(|tx| tx.into_inner())
+                .collect(),
+            user_signatures: self.user_signatures,
+        }
     }
 }
 


### PR DESCRIPTION
## Description 

As above

## Test Plan 

Updated tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Changes state sync service to download all contents associated with a checkpoint in one RPC.