### PR TITLE
[Consensus] treat GC round as the highest garbage collected round

### DIFF
--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -101,7 +101,7 @@ impl ConsensusState {
     ) -> Result<Dag, ConsensusError> {
         let mut dag: Dag = BTreeMap::new();
 
-        info!("Recreating dag from last GC round: {}", gc_round,);
+        info!("Recreating dag from last GC round: {}", gc_round);
 
         // get all certificates at rounds > gc_round
         let certificates = cert_store.after_round(gc_round + 1).unwrap();
@@ -187,7 +187,7 @@ impl ConsensusState {
 
         // Purge all certificates past the gc depth.
         self.dag
-            .retain(|r, _| r + gc_depth >= self.last_committed_round);
+            .retain(|r, _| r + gc_depth > self.last_committed_round);
         // Also purge this certificate, and other certificates at the same origin below its round.
         self.dag.retain(|r, authorities| {
             if r <= &certificate.round() {

--- a/narwhal/consensus/src/utils.rs
+++ b/narwhal/consensus/src/utils.rs
@@ -63,7 +63,6 @@ pub fn order_dag(
 ) -> Vec<Certificate> {
     debug!("Processing sub-dag of {:?}", leader);
     assert!(leader.round() > 0);
-    let gc_round = leader.round().saturating_sub(gc_depth);
 
     let mut ordered = Vec::new();
     let mut already_ordered = HashSet::new();
@@ -72,9 +71,6 @@ pub fn order_dag(
     while let Some(x) = buffer.pop() {
         debug!("Sequencing {:?}", x);
         ordered.push(x.clone());
-        if x.round() == gc_round + 1 {
-            continue;
-        }
         for parent in &x.header.parents {
             let (digest, certificate) = match state
                 .dag


### PR DESCRIPTION
## Description 

It seems in parts of Consensus, certificates at GC round are kept. This is inconsistent with other parts of the codebase, which treat GC round as the highest round to garbage collect.

Update consensus to use GC round the same way as other components.

## Test Plan 

existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
