### PR TITLE
Add Validator Operation Capability

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -238,6 +238,7 @@ validators:
         next_epoch_primary_address: ~
         next_epoch_worker_address: ~
       voting_power: 10000
+      operation_cap_id: "0x18b8140c8a6ea340142f128061016fc4bd8220ec88875a8e573a5f72a85a15c1"
       gas_price: 1
       staking_pool:
         id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f65e4b0dea15829e3157962e1"
@@ -259,17 +260,17 @@ validators:
       next_epoch_commission_rate: 0
   pending_active_validators:
     contents:
-      id: "0x628ffd0e51e9a6ea32c13c2739a31a8f344b557d3429e057b377a9c499b9bb13"
+      id: "0x1ace65f54d65a96251b3f46bfa720ab65a7ebe0174caa9fa1dc0d65a56ae7872"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x18b8140c8a6ea340142f128061016fc4bd8220ec88875a8e573a5f72a85a15c1"
+    id: "0x628ffd0e51e9a6ea32c13c2739a31a8f344b557d3429e057b377a9c499b9bb13"
     size: 1
   inactive_pools:
-    id: "0x1ace65f54d65a96251b3f46bfa720ab65a7ebe0174caa9fa1dc0d65a56ae7872"
+    id: "0x9dc97c4be6f1d0e61fbdf2cc9d78f9df04cdff7a473e2ec3a65853766dca1177"
     size: 0
   validator_candidates:
-    id: "0x9dc97c4be6f1d0e61fbdf2cc9d78f9df04cdff7a473e2ec3a65853766dca1177"
+    id: "0x6d3ffc5213ed4df6802cd4535d3c18f66d85bab5e9f004a7087a005e2f8dc455"
     size: 0
 storage_fund:
   value: 0

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -24,6 +24,9 @@
 -  [Function `request_withdraw_delegation`](#0x2_sui_system_request_withdraw_delegation)
 -  [Function `report_validator`](#0x2_sui_system_report_validator)
 -  [Function `undo_report_validator`](#0x2_sui_system_undo_report_validator)
+-  [Function `report_validator_impl`](#0x2_sui_system_report_validator_impl)
+-  [Function `undo_report_validator_impl`](#0x2_sui_system_undo_report_validator_impl)
+-  [Function `rotate_operation_cap`](#0x2_sui_system_rotate_operation_cap)
 -  [Function `update_validator_name`](#0x2_sui_system_update_validator_name)
 -  [Function `update_validator_description`](#0x2_sui_system_update_validator_description)
 -  [Function `update_validator_image_url`](#0x2_sui_system_update_validator_image_url)
@@ -74,6 +77,7 @@
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="url.md#0x2_url">0x2::url</a>;
 <b>use</b> <a href="validator.md#0x2_validator">0x2::validator</a>;
+<b>use</b> <a href="validator_cap.md#0x2_validator_cap">0x2::validator_cap</a>;
 <b>use</b> <a href="validator_set.md#0x2_validator_set">0x2::validator_set</a>;
 <b>use</b> <a href="vec_map.md#0x2_vec_map">0x2::vec_map</a>;
 <b>use</b> <a href="vec_set.md#0x2_vec_set">0x2::vec_set</a>;
@@ -344,6 +348,24 @@ the epoch advancement transaction.
 
 
 <pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>: u128 = 10000;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_ACTIVE_OR_PENDING_VALIDATOR"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ACTIVE_OR_PENDING_VALIDATOR">ACTIVE_OR_PENDING_VALIDATOR</a>: bool = <b>false</b>;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_ACTIVE_VALIDATOR_ONLY"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_ACTIVE_VALIDATOR_ONLY">ACTIVE_VALIDATOR_ONLY</a>: bool = <b>true</b>;
 </code></pre>
 
 
@@ -652,7 +674,7 @@ A validator can call this entry function to submit a new gas price quote, to be
 used for the reference gas price calculation at the end of the epoch.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_set_gas_price">request_set_gas_price</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_gas_price: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_set_gas_price">request_set_gas_price</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, cap: &<a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, new_gas_price: u64)
 </code></pre>
 
 
@@ -663,15 +685,16 @@ used for the reference gas price calculation at the end of the epoch.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_set_gas_price">request_set_gas_price</a>(
     wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    cap: &UnverifiedValidatorOperationCap,
     new_gas_price: u64,
-    ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="validator_set.md#0x2_validator_set_request_set_gas_price">validator_set::request_set_gas_price</a>(
-        &<b>mut</b> self.validators,
-        new_gas_price,
-        ctx
-    )
+
+    // Verify the represented <b>address</b> is an active or pending <a href="validator.md#0x2_validator">validator</a>, and the capability is still valid.
+    <b>let</b> verified_cap = <a href="validator_set.md#0x2_validator_set_verify_cap">validator_set::verify_cap</a>(&self.validators, cap, <a href="sui_system.md#0x2_sui_system_ACTIVE_OR_PENDING_VALIDATOR">ACTIVE_OR_PENDING_VALIDATOR</a>);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_verified_cap">validator_set::get_validator_mut_with_verified_cap</a>(&<b>mut</b> self.validators, &verified_cap);
+
+    <a href="validator.md#0x2_validator_request_set_gas_price">validator::request_set_gas_price</a>(<a href="validator.md#0x2_validator">validator</a>, verified_cap, new_gas_price);
 }
 </code></pre>
 
@@ -892,11 +915,14 @@ Withdraw some portion of a delegation from a validator's staking pool.
 ## Function `report_validator`
 
 Report a validator as a bad or non-performant actor in the system.
-Succeeds iff both the sender and the input <code>validator_addr</code> are active validators
-and they are not the same address. This function is idempotent.
+Succeeds if all the following are satisfied:
+1. both the reporter in <code>cap</code> and the input <code>reportee_addr</code> are active validators.
+2. reporter and reportee not the same address.
+3. the cap object is still valid.
+This function is idempotent.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_report_validator">report_validator</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, validator_addr: <b>address</b>, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_report_validator">report_validator</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, cap: &<a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, reportee_addr: <b>address</b>)
 </code></pre>
 
 
@@ -907,24 +933,15 @@ and they are not the same address. This function is idempotent.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_report_validator">report_validator</a>(
     wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
-    validator_addr: <b>address</b>,
-    ctx: &TxContext,
+    cap: &UnverifiedValidatorOperationCap,
+    reportee_addr: <b>address</b>,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <b>let</b> sender = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
-    // Both the reporter and the reported have <b>to</b> be validators.
-    <b>assert</b>!(<a href="validator_set.md#0x2_validator_set_is_active_validator_by_sui_address">validator_set::is_active_validator_by_sui_address</a>(&self.validators, sender), <a href="sui_system.md#0x2_sui_system_ENotValidator">ENotValidator</a>);
-    <b>assert</b>!(<a href="validator_set.md#0x2_validator_set_is_active_validator_by_sui_address">validator_set::is_active_validator_by_sui_address</a>(&self.validators, validator_addr), <a href="sui_system.md#0x2_sui_system_ENotValidator">ENotValidator</a>);
-    <b>assert</b>!(sender != validator_addr, <a href="sui_system.md#0x2_sui_system_ECannotReportOneself">ECannotReportOneself</a>);
-
-    <b>if</b> (!<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.validator_report_records, &validator_addr)) {
-        <a href="vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(&<b>mut</b> self.validator_report_records, validator_addr, <a href="vec_set.md#0x2_vec_set_singleton">vec_set::singleton</a>(sender));
-    } <b>else</b> {
-        <b>let</b> reporters = <a href="vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(&<b>mut</b> self.validator_report_records, &validator_addr);
-        <b>if</b> (!<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &sender)) {
-            <a href="vec_set.md#0x2_vec_set_insert">vec_set::insert</a>(reporters, sender);
-        }
-    }
+    // Reportee needs <b>to</b> be an active <a href="validator.md#0x2_validator">validator</a>
+    <b>assert</b>!(<a href="validator_set.md#0x2_validator_set_is_active_validator_by_sui_address">validator_set::is_active_validator_by_sui_address</a>(&self.validators, reportee_addr), <a href="sui_system.md#0x2_sui_system_ENotValidator">ENotValidator</a>);
+    // Verify the represented reporter <b>address</b> is an active <a href="validator.md#0x2_validator">validator</a>, and the capability is still valid.
+    <b>let</b> verified_cap = <a href="validator_set.md#0x2_validator_set_verify_cap">validator_set::verify_cap</a>(&self.validators, cap, <a href="sui_system.md#0x2_sui_system_ACTIVE_VALIDATOR_ONLY">ACTIVE_VALIDATOR_ONLY</a>);
+    <a href="sui_system.md#0x2_sui_system_report_validator_impl">report_validator_impl</a>(verified_cap, reportee_addr, &<b>mut</b> self.validator_report_records);
 }
 </code></pre>
 
@@ -936,11 +953,13 @@ and they are not the same address. This function is idempotent.
 
 ## Function `undo_report_validator`
 
-Undo a <code>report_validator</code> action. Aborts if the sender has not previously reported the
-<code>validator_addr</code>.
+Undo a <code>report_validator</code> action. Aborts if
+1. the reportee is not a currently active validator or
+2. the sender has not previously reported the <code>reportee_addr</code>, or
+3. the cap is not valid
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_undo_report_validator">undo_report_validator</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, validator_addr: <b>address</b>, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_undo_report_validator">undo_report_validator</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, cap: &<a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, reportee_addr: <b>address</b>)
 </code></pre>
 
 
@@ -951,19 +970,118 @@ Undo a <code>report_validator</code> action. Aborts if the sender has not previo
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_undo_report_validator">undo_report_validator</a>(
     wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
-    validator_addr: <b>address</b>,
-    ctx: &TxContext,
+    cap: &UnverifiedValidatorOperationCap,
+    reportee_addr: <b>address</b>,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <b>let</b> sender = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
 
-    <b>assert</b>!(<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.validator_report_records, &validator_addr), <a href="sui_system.md#0x2_sui_system_EReportRecordNotFound">EReportRecordNotFound</a>);
-    <b>let</b> reporters = <a href="vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(&<b>mut</b> self.validator_report_records, &validator_addr);
-    <b>assert</b>!(<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &sender), <a href="sui_system.md#0x2_sui_system_EReportRecordNotFound">EReportRecordNotFound</a>);
-    <a href="vec_set.md#0x2_vec_set_remove">vec_set::remove</a>(reporters, &sender);
-    <b>if</b> (<a href="vec_set.md#0x2_vec_set_is_empty">vec_set::is_empty</a>(reporters)) {
-        <a href="vec_map.md#0x2_vec_map_remove">vec_map::remove</a>(&<b>mut</b> self.validator_report_records, &validator_addr);
+    <b>let</b> verified_cap = <a href="validator_set.md#0x2_validator_set_verify_cap">validator_set::verify_cap</a>(&self.validators, cap, <a href="sui_system.md#0x2_sui_system_ACTIVE_VALIDATOR_ONLY">ACTIVE_VALIDATOR_ONLY</a>);
+    <a href="sui_system.md#0x2_sui_system_undo_report_validator_impl">undo_report_validator_impl</a>(verified_cap, reportee_addr, &<b>mut</b> self.validator_report_records);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_report_validator_impl"></a>
+
+## Function `report_validator_impl`
+
+
+
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_report_validator_impl">report_validator_impl</a>(verified_cap: <a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">validator_cap::ValidatorOperationCap</a>, reportee_addr: <b>address</b>, validator_report_records: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_report_validator_impl">report_validator_impl</a>(
+    verified_cap: ValidatorOperationCap,
+    reportee_addr: <b>address</b>,
+    validator_report_records: &<b>mut</b> VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
+) {
+    <b>let</b> reporter_address = *<a href="validator_cap.md#0x2_validator_cap_verified_operation_cap_address">validator_cap::verified_operation_cap_address</a>(&verified_cap);
+    <b>assert</b>!(reporter_address != reportee_addr, <a href="sui_system.md#0x2_sui_system_ECannotReportOneself">ECannotReportOneself</a>);
+    <b>if</b> (!<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(validator_report_records, &reportee_addr)) {
+        <a href="vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(validator_report_records, reportee_addr, <a href="vec_set.md#0x2_vec_set_singleton">vec_set::singleton</a>(reporter_address));
+    } <b>else</b> {
+        <b>let</b> reporters = <a href="vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(validator_report_records, &reportee_addr);
+        <b>if</b> (!<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &reporter_address)) {
+            <a href="vec_set.md#0x2_vec_set_insert">vec_set::insert</a>(reporters, reporter_address);
+        }
     }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_undo_report_validator_impl"></a>
+
+## Function `undo_report_validator_impl`
+
+
+
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_undo_report_validator_impl">undo_report_validator_impl</a>(verified_cap: <a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">validator_cap::ValidatorOperationCap</a>, reportee_addr: <b>address</b>, validator_report_records: &<b>mut</b> <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_undo_report_validator_impl">undo_report_validator_impl</a>(
+    verified_cap: ValidatorOperationCap,
+    reportee_addr: <b>address</b>,
+    validator_report_records: &<b>mut</b> VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
+) {
+    <b>assert</b>!(<a href="vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(validator_report_records, &reportee_addr), <a href="sui_system.md#0x2_sui_system_EReportRecordNotFound">EReportRecordNotFound</a>);
+    <b>let</b> reporters = <a href="vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(validator_report_records, &reportee_addr);
+
+    <b>let</b> reporter_addr = *<a href="validator_cap.md#0x2_validator_cap_verified_operation_cap_address">validator_cap::verified_operation_cap_address</a>(&verified_cap);
+    <b>assert</b>!(<a href="vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &reporter_addr), <a href="sui_system.md#0x2_sui_system_EReportRecordNotFound">EReportRecordNotFound</a>);
+
+    <a href="vec_set.md#0x2_vec_set_remove">vec_set::remove</a>(reporters, &reporter_addr);
+    <b>if</b> (<a href="vec_set.md#0x2_vec_set_is_empty">vec_set::is_empty</a>(reporters)) {
+        <a href="vec_map.md#0x2_vec_map_remove">vec_map::remove</a>(validator_report_records, &reportee_addr);
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_sui_system_rotate_operation_cap"></a>
+
+## Function `rotate_operation_cap`
+
+Create a new <code>UnverifiedValidatorOperationCap</code>, transfer it to the
+validator and registers it. The original object is thus revoked.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_rotate_operation_cap">rotate_operation_cap</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_rotate_operation_cap">rotate_operation_cap</a>(
+    self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
+    ctx: &<b>mut</b> TxContext,
+) {
+    <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
+    <a href="validator.md#0x2_validator_new_unverified_validator_operation_cap_and_transfer">validator::new_unverified_validator_operation_cap_and_transfer</a>(<a href="validator.md#0x2_validator">validator</a>, ctx);
 }
 </code></pre>
 
@@ -993,7 +1111,7 @@ Update a validator's name.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_name">validator::update_name</a>(<a href="validator.md#0x2_validator">validator</a>, <a href="_from_ascii">string::from_ascii</a>(<a href="_string">ascii::string</a>(name)));
 }
 </code></pre>
@@ -1024,7 +1142,7 @@ Update a validator's description
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_description">validator::update_description</a>(<a href="validator.md#0x2_validator">validator</a>, <a href="_from_ascii">string::from_ascii</a>(<a href="_string">ascii::string</a>(description)));
 }
 </code></pre>
@@ -1055,7 +1173,7 @@ Update a validator's image url
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_image_url">validator::update_image_url</a>(<a href="validator.md#0x2_validator">validator</a>, <a href="url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(image_url));
 }
 </code></pre>
@@ -1086,7 +1204,7 @@ Update a validator's project url
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_project_url">validator::update_project_url</a>(<a href="validator.md#0x2_validator">validator</a>, <a href="url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(project_url));
 }
 </code></pre>
@@ -1118,7 +1236,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_next_epoch_network_address">validator::update_next_epoch_network_address</a>(<a href="validator.md#0x2_validator">validator</a>, network_address);
 }
 </code></pre>
@@ -1150,7 +1268,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_next_epoch_p2p_address">validator::update_next_epoch_p2p_address</a>(<a href="validator.md#0x2_validator">validator</a>, p2p_address);
 }
 </code></pre>
@@ -1182,7 +1300,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_next_epoch_primary_address">validator::update_next_epoch_primary_address</a>(<a href="validator.md#0x2_validator">validator</a>, primary_address);
 }
 </code></pre>
@@ -1214,7 +1332,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_next_epoch_worker_address">validator::update_next_epoch_worker_address</a>(<a href="validator.md#0x2_validator">validator</a>, worker_address);
 }
 </code></pre>
@@ -1247,7 +1365,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_next_epoch_protocol_pubkey">validator::update_next_epoch_protocol_pubkey</a>(<a href="validator.md#0x2_validator">validator</a>, protocol_pubkey, proof_of_possession);
 }
 </code></pre>
@@ -1279,7 +1397,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_next_epoch_worker_pubkey">validator::update_next_epoch_worker_pubkey</a>(<a href="validator.md#0x2_validator">validator</a>, worker_pubkey);
 }
 </code></pre>
@@ -1311,7 +1429,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_active_or_pending_validator_mut">validator_set::get_active_or_pending_validator_mut</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x2_validator">validator</a> = <a href="validator_set.md#0x2_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
     <a href="validator.md#0x2_validator_update_next_epoch_network_pubkey">validator::update_next_epoch_network_pubkey</a>(<a href="validator.md#0x2_validator">validator</a>, network_pubkey);
 }
 </code></pre>

--- a/crates/sui-framework/docs/validator_cap.md
+++ b/crates/sui-framework/docs/validator_cap.md
@@ -1,0 +1,214 @@
+
+<a name="0x2_validator_cap"></a>
+
+# Module `0x2::validator_cap`
+
+
+
+-  [Resource `UnverifiedValidatorOperationCap`](#0x2_validator_cap_UnverifiedValidatorOperationCap)
+-  [Struct `ValidatorOperationCap`](#0x2_validator_cap_ValidatorOperationCap)
+-  [Function `unverified_operation_cap_address`](#0x2_validator_cap_unverified_operation_cap_address)
+-  [Function `verified_operation_cap_address`](#0x2_validator_cap_verified_operation_cap_address)
+-  [Function `new_unverified_validator_operation_cap_and_transfer`](#0x2_validator_cap_new_unverified_validator_operation_cap_and_transfer)
+-  [Function `new_from_unverified`](#0x2_validator_cap_new_from_unverified)
+
+
+<pre><code><b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x2_validator_cap_UnverifiedValidatorOperationCap"></a>
+
+## Resource `UnverifiedValidatorOperationCap`
+
+The capability object is created when creating a new <code>Validator</code> or when the
+validator explicitly creates a new capability object for rotation/revocation.
+The holder address of this object can perform some validator operations on behalf of
+the authorizer validator. Thus, if a validator wants to separate the keys for operation
+(such as reference gas price setting or tallying rule reporting) from fund/staking, it
+could transfer this capability object to another address.
+To facilitate rotating/revocation, <code>Validator</code> stores the ID of currently valid
+<code><a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">UnverifiedValidatorOperationCap</a></code>. Thus, before converting <code><a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">UnverifiedValidatorOperationCap</a></code>
+to <code><a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">ValidatorOperationCap</a></code>, verification needs to be done to make sure
+the cap object is still valid.
+
+
+<pre><code><b>struct</b> <a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">UnverifiedValidatorOperationCap</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>authorizer_validator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_validator_cap_ValidatorOperationCap"></a>
+
+## Struct `ValidatorOperationCap`
+
+Privileged operations require <code><a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">ValidatorOperationCap</a></code> for permission check.
+This is only constructed after successful verification.
+
+
+<pre><code><b>struct</b> <a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">ValidatorOperationCap</a> <b>has</b> drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>authorizer_validator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_validator_cap_unverified_operation_cap_address"></a>
+
+## Function `unverified_operation_cap_address`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_cap.md#0x2_validator_cap_unverified_operation_cap_address">unverified_operation_cap_address</a>(cap: &<a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>): &<b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_cap.md#0x2_validator_cap_unverified_operation_cap_address">unverified_operation_cap_address</a>(cap: &<a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">UnverifiedValidatorOperationCap</a>): &<b>address</b> {
+    &cap.authorizer_validator_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_cap_verified_operation_cap_address"></a>
+
+## Function `verified_operation_cap_address`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_cap.md#0x2_validator_cap_verified_operation_cap_address">verified_operation_cap_address</a>(cap: &<a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">validator_cap::ValidatorOperationCap</a>): &<b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_cap.md#0x2_validator_cap_verified_operation_cap_address">verified_operation_cap_address</a>(cap: &<a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">ValidatorOperationCap</a>): &<b>address</b> {
+    &cap.authorizer_validator_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_cap_new_unverified_validator_operation_cap_and_transfer"></a>
+
+## Function `new_unverified_validator_operation_cap_and_transfer`
+
+Should be only called by the friend modules when adding a <code>Validator</code>
+or rotating an existing validaotr's <code>operation_cap_id</code>.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_cap.md#0x2_validator_cap_new_unverified_validator_operation_cap_and_transfer">new_unverified_validator_operation_cap_and_transfer</a>(validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_cap.md#0x2_validator_cap_new_unverified_validator_operation_cap_and_transfer">new_unverified_validator_operation_cap_and_transfer</a>(
+    validator_address: <b>address</b>,
+    ctx: &<b>mut</b> TxContext,
+): ID {
+    // TODO: <b>update</b> all tests <b>to</b> <b>use</b> @0x0 <b>to</b> create validators so we can
+    // enforce the <b>assert</b> below.
+    // This function needs <b>to</b> be called only by the <a href="validator.md#0x2_validator">validator</a> itself, <b>except</b>
+    // 1. in <a href="genesis.md#0x2_genesis">genesis</a> <b>where</b> all valdiators are created by @0x0
+    // 2. in tests <b>where</b> @0x0 could be used <b>to</b> simplify the setup
+    // <b>let</b> sender_address = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    // <b>assert</b>!(sender_address == @0x0 || sender_address == validator_address, 0);
+
+    <b>let</b> operation_cap = <a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">UnverifiedValidatorOperationCap</a> {
+        id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
+        authorizer_validator_address: validator_address,
+    };
+    <b>let</b> operation_cap_id = <a href="object.md#0x2_object_id">object::id</a>(&operation_cap);
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(operation_cap, validator_address);
+    operation_cap_id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_validator_cap_new_from_unverified"></a>
+
+## Function `new_from_unverified`
+
+Convert an <code><a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">UnverifiedValidatorOperationCap</a></code> to <code><a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">ValidatorOperationCap</a></code>.
+Should only be called by <code><a href="validator_set.md#0x2_validator_set">validator_set</a></code> module AFTER verification.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_cap.md#0x2_validator_cap_new_from_unverified">new_from_unverified</a>(cap: &<a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>): <a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">validator_cap::ValidatorOperationCap</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_cap.md#0x2_validator_cap_new_from_unverified">new_from_unverified</a>(
+    cap: &<a href="validator_cap.md#0x2_validator_cap_UnverifiedValidatorOperationCap">UnverifiedValidatorOperationCap</a>,
+): <a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">ValidatorOperationCap</a> {
+    <a href="validator_cap.md#0x2_validator_cap_ValidatorOperationCap">ValidatorOperationCap</a> {
+        authorizer_validator_address: cap.authorizer_validator_address
+    }
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework/sources/governance/validator_cap.move
+++ b/crates/sui-framework/sources/governance/validator_cap.move
@@ -1,0 +1,79 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::validator_cap {
+    use sui::object::{Self, ID, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+    friend sui::sui_system;
+    friend sui::validator;
+    friend sui::validator_set;
+
+    #[test_only]
+    friend sui::sui_system_tests;
+    #[test_only]
+    friend sui::rewards_distribution_tests;
+
+    /// The capability object is created when creating a new `Validator` or when the
+    /// validator explicitly creates a new capability object for rotation/revocation.
+    /// The holder address of this object can perform some validator operations on behalf of
+    /// the authorizer validator. Thus, if a validator wants to separate the keys for operation
+    /// (such as reference gas price setting or tallying rule reporting) from fund/staking, it
+    /// could transfer this capability object to another address.
+
+    /// To facilitate rotating/revocation, `Validator` stores the ID of currently valid
+    /// `UnverifiedValidatorOperationCap`. Thus, before converting `UnverifiedValidatorOperationCap`
+    /// to `ValidatorOperationCap`, verification needs to be done to make sure
+    /// the cap object is still valid.
+    struct UnverifiedValidatorOperationCap has key, store {
+        id: UID,
+        authorizer_validator_address: address,
+    }
+
+    /// Privileged operations require `ValidatorOperationCap` for permission check.
+    /// This is only constructed after successful verification.
+    struct ValidatorOperationCap has drop {
+        authorizer_validator_address: address,
+    }
+
+    public(friend) fun unverified_operation_cap_address(cap: &UnverifiedValidatorOperationCap): &address {
+        &cap.authorizer_validator_address
+    }
+
+    public(friend) fun verified_operation_cap_address(cap: &ValidatorOperationCap): &address {
+        &cap.authorizer_validator_address
+    }
+
+    /// Should be only called by the friend modules when adding a `Validator`
+    /// or rotating an existing validaotr's `operation_cap_id`.
+    public(friend) fun new_unverified_validator_operation_cap_and_transfer(
+        validator_address: address,
+        ctx: &mut TxContext,
+    ): ID {
+        // TODO: update all tests to use @0x0 to create validators so we can
+        // enforce the assert below.
+        // This function needs to be called only by the validator itself, except
+        // 1. in genesis where all valdiators are created by @0x0
+        // 2. in tests where @0x0 could be used to simplify the setup
+        // let sender_address = tx_context::sender(ctx);
+        // assert!(sender_address == @0x0 || sender_address == validator_address, 0);
+
+        let operation_cap = UnverifiedValidatorOperationCap {
+            id: object::new(ctx),
+            authorizer_validator_address: validator_address,
+        };
+        let operation_cap_id = object::id(&operation_cap);
+        transfer::transfer(operation_cap, validator_address);
+        operation_cap_id
+    }
+
+    /// Convert an `UnverifiedValidatorOperationCap` to `ValidatorOperationCap`.
+    /// Should only be called by `validator_set` module AFTER verification.
+    public(friend) fun new_from_unverified(
+        cap: &UnverifiedValidatorOperationCap,
+    ): ValidatorOperationCap {
+        ValidatorOperationCap {
+            authorizer_validator_address: cap.authorizer_validator_address
+        }
+    }
+}

--- a/crates/sui-framework/tests/rewards_distribution_tests.move
+++ b/crates/sui-framework/tests/rewards_distribution_tests.move
@@ -6,6 +6,7 @@ module sui::rewards_distribution_tests {
     use sui::test_scenario::{Self, Scenario};
     use sui::sui_system::{Self, SuiSystemState};
 
+    use sui::validator_cap::UnverifiedValidatorOperationCap;
     use sui::governance_test_utils::{
         Self,
         advance_epoch,
@@ -362,8 +363,9 @@ module sui::rewards_distribution_tests {
     fun report_validator(reporter: address, reportee: address, scenario: &mut Scenario) {
         test_scenario::next_tx(scenario, reporter);
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let ctx = test_scenario::ctx(scenario);
-        sui_system::report_validator(&mut system_state, reportee, ctx);
+        let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
+        sui_system::report_validator(&mut system_state, &cap, reportee);
+        test_scenario::return_to_sender(scenario, cap);
         test_scenario::return_shared(system_state);
     }
 }

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -872,8 +872,9 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
         )
         .await
         .unwrap();
-    // 17 events created by this test + 44 Genesis event
-    assert_eq!(61, page2.data.len());
+
+    // 17 events created by this test + 48 Genesis event
+    assert_eq!(65, page2.data.len());
     assert!(!page2.has_next_page);
 
     // test get sender events

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6538,6 +6538,7 @@
           "next_epoch_commission_rate",
           "next_epoch_gas_price",
           "next_epoch_stake",
+          "operation_cap_id",
           "p2p_address",
           "pending_delegation",
           "pending_pool_token_withdraw",
@@ -6707,6 +6708,9 @@
               "format": "uint8",
               "minimum": 0.0
             }
+          },
+          "operation_cap_id": {
+            "$ref": "#/components/schemas/ObjectID"
           },
           "p2p_address": {
             "type": "array",

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -8,6 +8,7 @@ use crate::committee::{
     Committee, CommitteeWithNetworkMetadata, NetworkMetadata, ProtocolVersion, StakeUnit,
 };
 use crate::crypto::AuthorityPublicKeyBytes;
+use crate::id::ID;
 use crate::sui_system_state::epoch_start_sui_system_state::{
     EpochStartSystemState, EpochStartValidatorInfo,
 };
@@ -213,6 +214,7 @@ impl ValidatorMetadataV1 {
 pub struct ValidatorV1 {
     pub metadata: ValidatorMetadataV1,
     pub voting_power: u64,
+    pub operation_cap_id: ID,
     pub gas_price: u64,
     pub staking_pool: StakingPoolV1,
     pub commission_rate: u64,
@@ -269,6 +271,7 @@ impl ValidatorV1 {
                     next_epoch_worker_address,
                 },
             voting_power,
+            operation_cap_id,
             gas_price,
             staking_pool:
                 StakingPoolV1 {
@@ -315,6 +318,7 @@ impl ValidatorV1 {
             next_epoch_primary_address,
             next_epoch_worker_address,
             voting_power,
+            operation_cap_id,
             gas_price,
             staking_pool_id,
             staking_pool_activation_epoch,

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 
 use crate::base_types::{AuthorityName, ObjectID, SuiAddress};
 use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata};
+use crate::id::ID;
 
 /// This is the JSON-RPC type for the SUI system state object.
 /// It flattens all fields to make them top-level fields such that it as minimum
@@ -126,6 +127,7 @@ pub struct SuiValidatorSummary {
     pub next_epoch_worker_address: Option<Vec<u8>>,
 
     pub voting_power: u64,
+    pub operation_cap_id: ID,
     pub gas_price: u64,
     pub commission_rate: u64,
     pub next_epoch_stake: u64,

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -133,6 +133,7 @@ export const SuiValidatorSummary = object({
   network_pubkey_bytes: array(number()),
   worker_pubkey_bytes: array(number()),
   proof_of_possession_bytes: array(number()),
+  operation_cap_id: string(),
   name: string(),
   description: string(),
   image_url: string(),


### PR DESCRIPTION
## Description 

This PR enables a validator to delegate its operation ability to a separate sui account. With this they are able to separate the keys to move funds and normal validator operations such as gas price setting and tallying rule. 
1. This is achieved by introducing `UnverifiedValidatorOperationCap`. This cap is created when a `Validator` is created. By default, this object is transferred to the validator. The validator could transfer it to another address afterwards. The holder of this object has the permission to set gas price and report validators on behalf of the authorizer validator.
2. To facilitate rotation/revocation of this capability, we register the currently valid cap object id in the `operation_cap_id` field of `Validator`. In the event of lost/compromised key, the validator could call `sui_system::create_new_operation_cap` to create a new cap object, register it, and thus voiding the previous cap's validity.
3. Therefore, `UnverifiedValidatorOperationCap` itself is not enough to present full eligibility, it needs to be verified first and then becomes a `VerifiedValidatorOperationCap`. `VerifiedValidatorOperationCap` uses hot potato pattern. Privileged functions should consume `VerifiedValidatorOperationCap`.


## Test Plan 

added tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
Validators can delegate its operation ability to a separate sui account. With this they are able to separate the keys to move funds and normal validator operations such as gas price setting and tallying rule. 