### PR TITLE
Re-config channel send epoch start state

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1633,7 +1633,7 @@ impl AuthorityState {
             &path.join("store"),
             None,
             EpochMetrics::new(&registry),
-            Default::default(),
+            EpochStartConfiguration::new_for_testing(),
             store.clone(),
             cache_metrics,
         );
@@ -3085,10 +3085,7 @@ impl AuthorityState {
     ) -> SuiResult<Arc<AuthorityPerEpochStore>> {
         let new_epoch = new_committee.epoch;
         info!(new_epoch = ?new_epoch, "re-opening AuthorityEpochTables for new epoch");
-        assert_eq!(
-            epoch_start_configuration.system_state.epoch(),
-            new_committee.epoch
-        );
+        assert_eq!(epoch_start_configuration.epoch(), new_committee.epoch);
         self.db()
             .set_epoch_start_configuration(&epoch_start_configuration)
             .await?;

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -64,7 +64,7 @@ use sui_types::messages_checkpoint::{
     CheckpointSignatureMessage, CheckpointSummary, CheckpointTimestamp,
 };
 use sui_types::storage::{transaction_input_object_keys, ObjectKey, ParentSync};
-use sui_types::sui_system_state::{SuiSystemState, SuiSystemStateTrait};
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use sui_types::temporary_store::InnerTemporaryStore;
 use sui_types::{MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS};
 use tokio::time::Instant;
@@ -148,6 +148,69 @@ pub struct AuthorityPerEpochStore {
 
     /// Execution state that has to restart at each epoch change
     execution_component: ExecutionComponents,
+}
+
+/// Parameters of the epoch fixed at epoch start.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct EpochStartConfiguration {
+    system_state: EpochStartSystemState,
+    /// epoch_digest is defined as following
+    /// (1) For the genesis epoch it is set to 0
+    /// (2) For all other epochs it is a digest of the last checkpoint of a previous epoch
+    /// Note that this is in line with how epoch start timestamp is defined
+    epoch_digest: CheckpointDigest,
+}
+
+impl EpochStartConfiguration {
+    pub fn new(system_state: EpochStartSystemState, epoch_digest: CheckpointDigest) -> Self {
+        Self {
+            system_state,
+            epoch_digest,
+        }
+    }
+
+    pub fn new_for_testing() -> Self {
+        Self::new(
+            EpochStartSystemState::new_for_testing(),
+            CheckpointDigest::default(),
+        )
+    }
+
+    pub fn epoch_data(&self) -> EpochData {
+        EpochData::new(
+            self.epoch(),
+            self.epoch_start_timestamp_ms(),
+            self.epoch_digest(),
+        )
+    }
+
+    pub fn epoch_digest(&self) -> CheckpointDigest {
+        self.epoch_digest
+    }
+
+    pub fn epoch(&self) -> EpochId {
+        self.system_state.epoch
+    }
+
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        ProtocolVersion::new(self.system_state.protocol_version)
+    }
+
+    pub fn reference_gas_price(&self) -> u64 {
+        self.system_state.reference_gas_price
+    }
+
+    pub fn safe_mode(&self) -> bool {
+        self.system_state.safe_mode
+    }
+
+    pub fn epoch_start_timestamp_ms(&self) -> u64 {
+        self.system_state.epoch_start_timestamp_ms
+    }
+
+    pub fn epoch_start_state(&self) -> &EpochStartSystemState {
+        &self.system_state
+    }
 }
 
 /// AuthorityEpochTables contains tables that contain data that is only valid within an epoch.
@@ -274,23 +337,6 @@ pub struct AuthorityEpochTables {
     authority_capabilities: DBMap<AuthorityName, AuthorityCapabilities>,
 }
 
-/// Parameters of the epoch fixed at epoch start.
-#[derive(Default, Serialize, Deserialize, Debug, Eq, PartialEq)]
-pub struct EpochStartConfiguration {
-    pub system_state: SuiSystemState,
-    /// epoch_digest is defined as following
-    /// (1) For the genesis epoch it is set to 0
-    /// (2) For all other epochs it is a digest of the last checkpoint of a previous epoch
-    /// Note that this is in line with how epoch start timestamp is defined
-    pub epoch_digest: CheckpointDigest,
-}
-
-impl EpochStartConfiguration {
-    pub fn protocol_version(&self) -> ProtocolVersion {
-        ProtocolVersion::new(self.system_state.protocol_version())
-    }
-}
-
 impl AuthorityEpochTables {
     pub fn open(epoch: EpochId, parent_path: &Path, db_options: Option<Options>) -> Self {
         Self::open_tables_transactional(
@@ -363,7 +409,7 @@ impl AuthorityPerEpochStore {
                 }
             })
             .collect();
-        assert_eq!(epoch_start_configuration.epoch_id(), epoch_id);
+        assert_eq!(epoch_start_configuration.epoch(), epoch_id);
         let epoch_start_configuration = Arc::new(epoch_start_configuration);
         metrics.current_epoch.set(epoch_id as i64);
         metrics
@@ -465,16 +511,16 @@ impl AuthorityPerEpochStore {
             .insert(checkpoint, accumulator)?)
     }
 
-    pub fn system_state_object(&self) -> &SuiSystemState {
-        &self.epoch_start_configuration.system_state
+    pub fn epoch_start_config(&self) -> &EpochStartConfiguration {
+        &self.epoch_start_configuration
     }
 
     pub fn reference_gas_price(&self) -> u64 {
-        self.system_state_object().reference_gas_price()
+        self.epoch_start_config().reference_gas_price()
     }
 
     pub fn protocol_version(&self) -> ProtocolVersion {
-        self.epoch_start_configuration.protocol_version()
+        self.epoch_start_config().protocol_version()
     }
 
     pub fn module_cache(&self) -> &Arc<SyncModuleCache<ResolverWrapper<AuthorityStore>>> {
@@ -1954,28 +2000,6 @@ impl AuthorityPerEpochStore {
 
 fn transactions_table_default_config() -> DBOptions {
     default_db_options(None, None).1
-}
-
-impl EpochStartConfiguration {
-    pub fn epoch_data(&self) -> EpochData {
-        EpochData::new(
-            self.epoch_id(),
-            self.epoch_start_timestamp_ms(),
-            self.epoch_digest(),
-        )
-    }
-
-    pub fn epoch_id(&self) -> EpochId {
-        self.system_state.epoch()
-    }
-
-    pub fn epoch_start_timestamp_ms(&self) -> CheckpointTimestamp {
-        self.system_state.epoch_start_timestamp_ms()
-    }
-
-    pub fn epoch_digest(&self) -> CheckpointDigest {
-        self.epoch_digest
-    }
 }
 
 impl ExecutionComponents {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -71,10 +71,10 @@ impl AuthorityStore {
     ) -> SuiResult<Self> {
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(path, db_options.clone()));
         if perpetual_tables.database_is_empty()? {
-            let epoch_start_configuration = EpochStartConfiguration {
-                system_state: SuiSystemState::new_genesis(genesis.sui_system_object()),
-                epoch_digest: genesis.checkpoint().digest(),
-            };
+            let epoch_start_configuration = EpochStartConfiguration::new(
+                genesis.sui_system_object().into_epoch_start_state(),
+                genesis.checkpoint().digest(),
+            );
             perpetual_tables
                 .set_epoch_start_configuration(&epoch_start_configuration)
                 .await?;

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -166,7 +166,7 @@ impl AuthorityPerpetualTables {
             .epoch_start_configuration
             .get(&())?
             .expect("Must have current epoch.")
-            .epoch_id())
+            .epoch())
     }
 
     pub async fn set_epoch_start_configuration(

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -495,10 +495,10 @@ impl Validator for ValidatorService {
         &self,
         _request: tonic::Request<SystemStateRequest>,
     ) -> Result<tonic::Response<SuiSystemStateInnerBenchmark>, tonic::Status> {
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
-        let response = epoch_store
-            .system_state_object()
-            .clone()
+        let response = self
+            .state
+            .database
+            .get_sui_system_state_object()?
             .into_benchmark_version();
 
         return Ok(tonic::Response::new(response));

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -107,10 +107,10 @@ impl AuthorityAPI for LocalAuthorityClient {
         &self,
         _request: SystemStateRequest,
     ) -> Result<SuiSystemStateInnerBenchmark, SuiError> {
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
-        Ok(epoch_store
-            .system_state_object()
-            .clone()
+        Ok(self
+            .state
+            .database
+            .get_sui_system_state_object()?
             .into_benchmark_version())
     }
 }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -53,6 +53,7 @@ use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::epoch_data::EpochData;
 use sui_types::object::Data;
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use sui_types::sui_system_state::{SuiSystemStateWrapper, SUI_SYSTEM_STATE_TESTING_VERSION1};
 use sui_types::{
     base_types::dbg_addr,
@@ -61,7 +62,6 @@ use sui_types::{
     messages::TransactionExpiration,
     messages::VerifiedTransaction,
     object::{Owner, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION},
-    sui_system_state::SuiSystemState,
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use tracing::info;
@@ -1786,17 +1786,14 @@ async fn test_transaction_expiration() {
         .committee()
         .to_owned();
     committee.epoch = 1;
-    let system_state = SuiSystemState::new_for_testing(1);
+    let system_state = EpochStartSystemState::new_for_testing_with_epoch(1);
 
     authority_state
         .reconfigure(
             &authority_state.epoch_store_for_testing(),
             SupportedProtocolVersions::SYSTEM_DEFAULT,
             committee,
-            EpochStartConfiguration {
-                system_state,
-                ..Default::default()
-            },
+            EpochStartConfiguration::new(system_state, Default::default()),
         )
         .await
         .unwrap();
@@ -2716,7 +2713,7 @@ async fn test_authority_persist() {
             &epoch_store_path,
             None,
             EpochMetrics::new(&registry),
-            Default::default(),
+            EpochStartConfiguration::new_for_testing(),
             store.clone(),
             cache_metrics,
         );
@@ -4716,7 +4713,7 @@ async fn test_tallying_rule_score_updates() {
         &path,
         None,
         metrics.clone(),
-        Default::default(),
+        EpochStartConfiguration::new_for_testing(),
         store,
         cache_metrics,
     );

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -99,11 +99,12 @@ async fn test_narwhal_manager() {
 
         let system_state = state
             .get_sui_system_state_object_for_testing()
-            .expect("Reading Sui system state object cannot fail");
+            .expect("Reading Sui system state object cannot fail")
+            .into_epoch_start_state();
 
         let transactions_addr = &config.consensus_config.as_ref().unwrap().address;
-        let narwhal_committee = system_state.get_current_epoch_narwhal_committee();
-        let worker_cache = system_state.get_current_epoch_narwhal_worker_cache(transactions_addr);
+        let narwhal_committee = system_state.get_narwhal_committee();
+        let worker_cache = system_state.get_narwhal_worker_cache(transactions_addr);
 
         let execution_state = Arc::new(NoOpExecutionState {
             epoch: narwhal_committee.epoch,
@@ -174,11 +175,10 @@ async fn test_narwhal_manager() {
 
         let system_state = state
             .get_sui_system_state_object_for_testing()
-            .expect("Reading Sui system state object cannot fail");
-
-        let mut narwhal_committee = system_state.get_current_epoch_narwhal_committee();
-        let mut worker_cache =
-            system_state.get_current_epoch_narwhal_worker_cache(&transactions_addr);
+            .expect("Reading Sui system state object cannot fail")
+            .into_epoch_start_state();
+        let mut narwhal_committee = system_state.get_narwhal_committee();
+        let mut worker_cache = system_state.get_narwhal_worker_cache(&transactions_addr);
 
         // advance epoch
         narwhal_committee.epoch = 1;

--- a/crates/sui-network/src/discovery/builder.rs
+++ b/crates/sui-network/src/discovery/builder.rs
@@ -10,6 +10,7 @@ use std::{
 };
 use sui_config::p2p::P2pConfig;
 use sui_types::committee::{CommitteeWithNetworkMetadata, ProtocolVersion};
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use tap::Pipe;
 use tokio::{
     sync::{broadcast::Receiver, oneshot},
@@ -19,14 +20,12 @@ use tokio::{
 /// Discovery Service Builder.
 pub struct Builder {
     config: Option<P2pConfig>,
-    reconfig_receiver: Receiver<(CommitteeWithNetworkMetadata, ProtocolVersion)>,
+    reconfig_receiver: Receiver<EpochStartSystemState>,
 }
 
 impl Builder {
     #[allow(clippy::new_without_default)]
-    pub fn new(
-        reconfig_receiver: Receiver<(CommitteeWithNetworkMetadata, ProtocolVersion)>,
-    ) -> Self {
+    pub fn new(reconfig_receiver: Receiver<EpochStartSystemState>) -> Self {
         Self {
             config: None,
             reconfig_receiver,
@@ -102,7 +101,7 @@ pub struct UnstartedDiscovery {
     pub(super) config: P2pConfig,
     pub(super) shutdown_handle: oneshot::Receiver<()>,
     pub(super) state: Arc<RwLock<State>>,
-    pub(super) reconfig_receiver: Receiver<(CommitteeWithNetworkMetadata, ProtocolVersion)>,
+    pub(super) reconfig_receiver: Receiver<EpochStartSystemState>,
 }
 
 impl UnstartedDiscovery {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -88,6 +88,7 @@ use sui_json_rpc::threshold_bls_api::ThresholdBlsApi;
 use sui_types::base_types::{AuthorityName, EpochId, TransactionDigest};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{AuthorityCapabilities, ConsensusTransaction};
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 
 pub struct ValidatorComponents {
     validator_server_handle: JoinHandle<Result<()>>,
@@ -102,7 +103,6 @@ pub struct ValidatorComponents {
     sui_tx_validator_metrics: Arc<SuiTxValidatorMetrics>,
 }
 use sui_json_rpc::governance_api::GovernanceReadApi;
-use sui_types::sui_system_state::SuiSystemState;
 
 pub struct SuiNode {
     config: NodeConfig,
@@ -306,8 +306,8 @@ impl SuiNode {
 
         let authority_names_to_peer_ids = epoch_store
             .epoch_start_configuration()
-            .system_state
-            .get_current_epoch_authority_names_to_peer_ids();
+            .epoch_start_state()
+            .get_authority_names_to_peer_ids();
 
         let network_connection_metrics =
             NetworkConnectionMetrics::new("sui", &registry_service.default_registry());
@@ -592,15 +592,15 @@ impl SuiNode {
             state.metrics.clone(),
         ));
 
-        let system_state = epoch_store.system_state_object();
-        let committee = system_state.get_current_epoch_narwhal_committee();
+        let new_epoch_start_state = epoch_store.epoch_start_config().epoch_start_state();
+        let committee = new_epoch_start_state.get_narwhal_committee();
 
         let transactions_addr = &config
             .consensus_config
             .as_ref()
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?
             .address;
-        let worker_cache = system_state.get_current_epoch_narwhal_worker_cache(transactions_addr);
+        let worker_cache = new_epoch_start_state.get_narwhal_worker_cache(transactions_addr);
 
         narwhal_manager
             .start(
@@ -829,17 +829,17 @@ impl SuiNode {
             }
 
             checkpoint_executor.run_epoch(cur_epoch_store.clone()).await;
-            let system_state = self
+            let new_system_state = self
                 .state
                 .get_sui_system_state_object_during_reconfig()
                 .expect("Read Sui System State object cannot fail");
-            let next_epoch_committee = system_state.get_current_epoch_committee();
+            let next_epoch_committee = new_system_state.get_current_epoch_committee();
             let next_epoch = next_epoch_committee.epoch();
             assert_eq!(cur_epoch_store.epoch() + 1, next_epoch);
 
             // If we eventually add tests that exercise safe mode, we will need a configurable way of
             // guarding against unexpected safe_mode.
-            debug_assert!(!system_state.safe_mode());
+            debug_assert!(!new_system_state.safe_mode());
 
             info!(
                 next_epoch,
@@ -850,16 +850,17 @@ impl SuiNode {
             // so that we don't need to restart the connection monitor every epoch.
             //  Update the mappings that will be used by the consensus adapter if it exists or is
             // about to be created.
-            let authority_names_to_peer_ids =
-                system_state.get_current_epoch_authority_names_to_peer_ids();
+            let new_system_state = new_system_state.into_epoch_start_state();
+            let authority_names_to_peer_ids = new_system_state.get_authority_names_to_peer_ids();
             self.connection_monitor_status
                 .update_mapping_for_epoch(authority_names_to_peer_ids);
 
             cur_epoch_store.record_epoch_reconfig_start_time_metric();
             let _ = self.end_of_epoch_channel.send((
                 next_epoch_committee.clone(),
-                ProtocolVersion::new(system_state.protocol_version()),
+                ProtocolVersion::new(new_system_state.protocol_version),
             ));
+            let next_epoch_committee = next_epoch_committee.committee;
 
             // The following code handles 4 different cases, depending on whether the node
             // was a validator in the previous epoch, and whether the node is a validator
@@ -881,11 +882,7 @@ impl SuiNode {
                 narwhal_manager.shutdown().await;
 
                 let new_epoch_store = self
-                    .reconfigure_state(
-                        &cur_epoch_store,
-                        next_epoch_committee.committee,
-                        system_state,
-                    )
+                    .reconfigure_state(&cur_epoch_store, next_epoch_committee, new_system_state)
                     .await;
 
                 narwhal_epoch_data_remover
@@ -917,11 +914,7 @@ impl SuiNode {
                 }
             } else {
                 let new_epoch_store = self
-                    .reconfigure_state(
-                        &cur_epoch_store,
-                        next_epoch_committee.committee,
-                        system_state,
-                    )
+                    .reconfigure_state(&cur_epoch_store, next_epoch_committee, new_system_state)
                     .await;
 
                 if self.state.is_validator(&new_epoch_store) {
@@ -953,7 +946,7 @@ impl SuiNode {
         &self,
         cur_epoch_store: &AuthorityPerEpochStore,
         next_epoch_committee: Committee,
-        system_state: SuiSystemState,
+        next_epoch_start_system_state: EpochStartSystemState,
     ) -> Arc<AuthorityPerEpochStore> {
         let next_epoch = next_epoch_committee.epoch();
 
@@ -962,10 +955,8 @@ impl SuiNode {
             .get_epoch_last_checkpoint(cur_epoch_store.epoch())
             .expect("Error loading last checkpoint for current epoch")
             .expect("Could not load last checkpoint for current epoch");
-        let epoch_start_configuration = EpochStartConfiguration {
-            system_state,
-            epoch_digest: last_checkpoint.digest(),
-        };
+        let epoch_start_configuration =
+            EpochStartConfiguration::new(next_epoch_start_system_state, last_checkpoint.digest());
 
         let new_epoch_store = self
             .state

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -1,0 +1,135 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashMap};
+
+use crate::base_types::{AuthorityName, EpochId, SuiAddress};
+use crate::committee::{Committee, StakeUnit};
+use anemo::PeerId;
+use multiaddr::Multiaddr;
+use narwhal_config::{Committee as NarwhalCommittee, WorkerCache, WorkerIndex};
+use serde::{Deserialize, Serialize};
+use sui_protocol_config::ProtocolVersion;
+
+/// This type captures the minimum amount of information from SuiSystemState needed by a validator
+/// to run the protocol. This allows us to decouple from the actual SuiSystemState type, and hence
+/// do not need to evolve it when we upgrade the SuiSystemState type.
+/// Evolving EpochStartSystemState is also a lot easier in that we could add optional fields
+/// and fill them with None for older versions. When we absolutely must delete fields, we could
+/// also add new db tables to store the new version. This is OK because we only store one copy of
+/// this as part of EpochStartConfiguration for the most recent epoch in the db.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct EpochStartSystemState {
+    pub epoch: EpochId,
+    pub protocol_version: u64,
+    pub reference_gas_price: u64,
+    pub safe_mode: bool,
+    pub epoch_start_timestamp_ms: u64,
+    pub active_validators: Vec<EpochStartValidatorInfo>,
+}
+
+impl EpochStartSystemState {
+    pub fn new_for_testing() -> Self {
+        Self::new_for_testing_with_epoch(0)
+    }
+
+    pub fn new_for_testing_with_epoch(epoch: EpochId) -> Self {
+        Self {
+            epoch,
+            protocol_version: ProtocolVersion::MIN.as_u64(),
+            reference_gas_price: 1,
+            safe_mode: false,
+            epoch_start_timestamp_ms: 0,
+            active_validators: vec![],
+        }
+    }
+
+    pub fn get_sui_committee(&self) -> Committee {
+        let voting_rights = self
+            .active_validators
+            .iter()
+            .map(|validator| (validator.authority_name(), validator.voting_power))
+            .collect();
+        Committee::new(self.epoch, voting_rights)
+            .expect("Committee information should have been verified on-chain")
+    }
+
+    #[allow(clippy::mutable_key_type)]
+    pub fn get_narwhal_committee(&self) -> NarwhalCommittee {
+        let narwhal_committee = self
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let authority = narwhal_config::Authority {
+                    stake: validator.voting_power as narwhal_config::Stake,
+                    primary_address: validator.narwhal_primary_address.clone(),
+                    network_key: validator.narwhal_network_pubkey.clone(),
+                };
+                (validator.protocol_pubkey.clone(), authority)
+            })
+            .collect();
+
+        narwhal_config::Committee {
+            authorities: narwhal_committee,
+            epoch: self.epoch as narwhal_config::Epoch,
+        }
+    }
+
+    pub fn get_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId> {
+        self.active_validators
+            .iter()
+            .map(|validator| {
+                let name = validator.authority_name();
+                let peer_id = PeerId(validator.narwhal_network_pubkey.0.to_bytes());
+
+                (name, peer_id)
+            })
+            .collect()
+    }
+
+    #[allow(clippy::mutable_key_type)]
+    pub fn get_narwhal_worker_cache(&self, transactions_address: &Multiaddr) -> WorkerCache {
+        let workers: BTreeMap<narwhal_crypto::PublicKey, WorkerIndex> = self
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let workers = [(
+                    0,
+                    narwhal_config::WorkerInfo {
+                        name: validator.narwhal_worker_pubkey.clone(),
+                        transactions: transactions_address.clone(),
+                        worker_address: validator.narwhal_worker_address.clone(),
+                    },
+                )]
+                .into_iter()
+                .collect();
+                let worker_index = WorkerIndex(workers);
+
+                (validator.protocol_pubkey.clone(), worker_index)
+            })
+            .collect();
+        WorkerCache {
+            workers,
+            epoch: self.epoch,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct EpochStartValidatorInfo {
+    pub sui_address: SuiAddress,
+    pub protocol_pubkey: narwhal_crypto::PublicKey,
+    pub narwhal_network_pubkey: narwhal_crypto::NetworkPublicKey,
+    pub narwhal_worker_pubkey: narwhal_crypto::NetworkPublicKey,
+    pub sui_net_address: Multiaddr,
+    pub p2p_address: Multiaddr,
+    pub narwhal_primary_address: Multiaddr,
+    pub narwhal_worker_address: Multiaddr,
+    pub voting_power: StakeUnit,
+}
+
+impl EpochStartValidatorInfo {
+    pub fn authority_name(&self) -> AuthorityName {
+        (&self.protocol_pubkey).into()
+    }
+}

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -1,28 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::base_types::{AuthorityName, SuiAddress};
+use crate::base_types::SuiAddress;
 use crate::committee::{CommitteeWithNetworkMetadata, EpochId, ProtocolVersion};
 use crate::dynamic_field::{derive_dynamic_field_id, Field};
 use crate::error::SuiError;
 use crate::storage::ObjectStore;
+use crate::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use crate::{id::UID, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID};
-use anemo::PeerId;
 use anyhow::Result;
 use enum_dispatch::enum_dispatch;
 use move_core_types::language_storage::TypeTag;
 use move_core_types::value::MoveTypeLayout;
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use move_vm_types::values::Value;
-use multiaddr::Multiaddr;
-use narwhal_config::{Committee as NarwhalCommittee, WorkerCache};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use tracing::error;
 
 use self::sui_system_state_inner_v1::{SuiSystemStateInnerV1, ValidatorMetadata};
 use self::sui_system_state_summary::SuiSystemStateSummary;
 
+pub mod epoch_start_sui_system_state;
 pub mod sui_system_state_inner_v1;
 pub mod sui_system_state_summary;
 
@@ -69,14 +68,9 @@ pub trait SuiSystemStateTrait {
     fn epoch_start_timestamp_ms(&self) -> u64;
     fn safe_mode(&self) -> bool;
     fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata;
-    fn get_current_epoch_narwhal_committee(&self) -> NarwhalCommittee;
-    fn get_current_epoch_narwhal_worker_cache(
-        &self,
-        transactions_address: &Multiaddr,
-    ) -> WorkerCache;
     fn get_validator_metadata_vec(&self) -> Vec<ValidatorMetadata>;
-    fn get_current_epoch_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId>;
     fn get_staking_pool_info(&self) -> BTreeMap<SuiAddress, (Vec<u8>, u64)>;
+    fn into_epoch_start_state(self) -> EpochStartSystemState;
     fn into_sui_system_state_summary(self) -> SuiSystemStateSummary;
 }
 

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -398,7 +398,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
                     EpochStartValidatorInfo {
                         sui_address: metadata.sui_address,
                         protocol_pubkey: metadata.protocol_pubkey,
-                        narwhal_network_pubkey: metadata.network_pubkey,
+                        network_pubkey: metadata.network_pubkey,
                         narwhal_worker_pubkey: metadata.worker_pubkey,
                         sui_net_address: metadata.net_address,
                         p2p_address: metadata.p2p_address,


### PR DESCRIPTION
### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
