### PR TITLE
[cli/move] Expose --Xdebug flag for sui move disassemble

### DIFF
--- a/crates/sui-move/src/disassemble.rs
+++ b/crates/sui-move/src/disassemble.rs
@@ -51,7 +51,7 @@ impl Disassemble {
         // disassembling a bytecode file with no source info
         assert!(
             Path::new(&self.module_path).exists(),
-            "Bath path to .mv file"
+            "Bad path to .mv file"
         );
 
         let mut bytes = Vec::new();


### PR DESCRIPTION
## Description

Replicates a change to the `move` CLI, where the `--Xdebug` flag dumps a compiled module in its most raw form -- the `Debug` format of the `CompiledModule` type in Rust.

This helps to see what's going on in the module's pools which are otherwise hidden in the disassembly output.

## Test Plan

First call to disassemble will forward to the move CLI's `debug` command and print both a source-mapped disassembly, and the raw output, and the second call will print just the raw output:

```
sui$ cargo build
sui$ target/debug/sui move disassemble --Xdebug crates/sui-framework/build/Sui/bytecode_modules/pay.mv
sui$ cp crates/sui-framework/build/Sui/bytecode_modules/pay.mv /tmp/
sui$ target/debug/sui move disassemble --Xdebug /tmp/pay.mv
```