### PR TITLE
[objects] switch to partial merge in subsequent writes + locking to avoid race with pruner

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -461,6 +461,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     metrics: None,
                     supported_protocol_versions: Some(supported_protocol_versions),
                     db_checkpoint_config: self.db_checkpoint_config.clone(),
+                    indirect_objects_threshold: usize::MAX,
                 }
             })
             .collect();

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -101,6 +101,9 @@ pub struct NodeConfig {
 
     #[serde(default)]
     pub db_checkpoint_config: DBCheckpointConfig,
+
+    #[serde(default)]
+    pub indirect_objects_threshold: usize,
 }
 
 fn default_authority_store_pruning_config() -> AuthorityStorePruningConfig {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -279,6 +279,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             metrics: None,
             supported_protocol_versions: Some(supported_protocol_versions),
             db_checkpoint_config: self.db_checkpoint_config,
+            indirect_objects_threshold: usize::MAX,
         })
     }
 }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -74,6 +74,7 @@ validator_configs:
       local-execution-timeout-sec: 10
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
+    indirect-objects-threshold: 18446744073709551615
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -145,6 +146,7 @@ validator_configs:
       local-execution-timeout-sec: 10
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
+    indirect-objects-threshold: 18446744073709551615
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -216,6 +218,7 @@ validator_configs:
       local-execution-timeout-sec: 10
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
+    indirect-objects-threshold: 18446744073709551615
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -287,6 +290,7 @@ validator_configs:
       local-execution-timeout-sec: 10
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
+    indirect-objects-threshold: 18446744073709551615
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -358,6 +362,7 @@ validator_configs:
       local-execution-timeout-sec: 10
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
+    indirect-objects-threshold: 18446744073709551615
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -429,6 +434,7 @@ validator_configs:
       local-execution-timeout-sec: 10
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
+    indirect-objects-threshold: 18446744073709551615
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -500,6 +506,7 @@ validator_configs:
       local-execution-timeout-sec: 10
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
+    indirect-objects-threshold: 18446744073709551615
 account_keys:
   - 10wECHkYvXqL5/CY6WhjbfFPotZb5tjEbpmumqbRxuk=
   - ZTWBfKEmFOyYM9oBU9dNfREBuAU5fm2OBhg/vPtI00c=

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1552,6 +1552,7 @@ impl AuthorityState {
         let _objects_pruner = AuthorityStorePruner::new(
             store.perpetual_tables.clone(),
             checkpoint_store.clone(),
+            store.objects_lock_table.clone(),
             pruning_config,
             epoch_duration_ms,
         );
@@ -1620,6 +1621,7 @@ impl AuthorityState {
                 None,
                 &genesis_committee,
                 genesis,
+                0,
             )
             .await
             .unwrap(),

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -15,7 +15,6 @@ use std::iter;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use sui_storage::default_db_options;
-use sui_storage::mutex_table::LockGuard;
 use sui_storage::write_ahead_log::{DBWriteAheadLog, TxGuard, WriteAheadLog};
 use sui_types::accumulator::Accumulator;
 use sui_types::base_types::{AuthorityName, EpochId, ObjectID, SequenceNumber, TransactionDigest};
@@ -57,6 +56,7 @@ use prometheus::IntCounter;
 use std::cmp::Ordering as CmpOrdering;
 use sui_adapter::adapter;
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+use sui_storage::mutex_table::MutexGuard;
 use sui_types::epoch_data::EpochData;
 use sui_types::message_envelope::TrustedEnvelope;
 use sui_types::messages_checkpoint::{
@@ -78,7 +78,7 @@ const RECONFIG_STATE_INDEX: u64 = 0;
 const FINAL_EPOCH_CHECKPOINT_INDEX: u64 = 0;
 pub const EPOCH_DB_PREFIX: &str = "epoch_";
 
-pub struct CertLockGuard(LockGuard);
+pub struct CertLockGuard(MutexGuard);
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ExecutionIndicesWithHash {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -4,7 +4,9 @@
 use super::authority_notify_read::NotifyRead;
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
-use crate::authority::authority_store_types::StoreObjectPair;
+use crate::authority::authority_store_types::{
+    get_store_object_pair, ObjectContentDigest, StoreObjectPair,
+};
 use either::Either;
 use move_core_types::resolver::ModuleResolver;
 use once_cell::sync::OnceCell;
@@ -15,7 +17,7 @@ use std::collections::BTreeSet;
 use std::iter;
 use std::path::Path;
 use std::sync::Arc;
-use sui_storage::mutex_table::{LockGuard, MutexTable};
+use sui_storage::mutex_table::{MutexGuard, MutexTable, RwLockGuard, RwLockTable};
 use sui_types::accumulator::Accumulator;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::error::UserInputError;
@@ -55,6 +57,11 @@ pub struct AuthorityStore {
     /// Reconfiguration acquires write lock, changes the epoch and revert all transactions
     /// from previous epoch that are executed but did not make into checkpoint.
     execution_lock: RwLock<EpochId>,
+
+    /// Guards reference count updates to `indirect_move_objects` table
+    pub(crate) objects_lock_table: Arc<RwLockTable<ObjectContentDigest>>,
+
+    indirect_objects_threshold: usize,
 }
 
 pub type ExecutionLockReadGuard<'a> = RwLockReadGuard<'a, EpochId>;
@@ -68,6 +75,7 @@ impl AuthorityStore {
         db_options: Option<Options>,
         genesis: &Genesis,
         committee_store: &Arc<CommitteeStore>,
+        indirect_objects_threshold: usize,
     ) -> SuiResult<Self> {
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(path, db_options.clone()));
         if perpetual_tables.database_is_empty()? {
@@ -83,7 +91,13 @@ impl AuthorityStore {
         let committee = committee_store
             .get_committee(&cur_epoch)?
             .expect("Committee of the current epoch must exist");
-        Self::open_inner(genesis, perpetual_tables, committee).await
+        Self::open_inner(
+            genesis,
+            perpetual_tables,
+            committee,
+            indirect_objects_threshold,
+        )
+        .await
     }
 
     pub async fn open_with_committee_for_testing(
@@ -91,18 +105,26 @@ impl AuthorityStore {
         db_options: Option<Options>,
         committee: &Committee,
         genesis: &Genesis,
+        indirect_objects_threshold: usize,
     ) -> SuiResult<Self> {
         // TODO: Since we always start at genesis, the committee should be technically the same
         // as the genesis committee.
         assert_eq!(committee.epoch, 0);
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(path, db_options.clone()));
-        Self::open_inner(genesis, perpetual_tables, committee.clone()).await
+        Self::open_inner(
+            genesis,
+            perpetual_tables,
+            committee.clone(),
+            indirect_objects_threshold,
+        )
+        .await
     }
 
     async fn open_inner(
         genesis: &Genesis,
         perpetual_tables: Arc<AuthorityPerpetualTables>,
         committee: Committee,
+        indirect_objects_threshold: usize,
     ) -> SuiResult<Self> {
         let epoch = committee.epoch;
 
@@ -113,6 +135,8 @@ impl AuthorityStore {
             root_state_notify_read:
                 NotifyRead::<EpochId, (CheckpointSequenceNumber, Accumulator)>::new(),
             execution_lock: RwLock::new(epoch),
+            objects_lock_table: Arc::new(RwLockTable::new(NUM_SHARDS, SHARD_SIZE)),
+            indirect_objects_threshold,
         };
         // Only initialize an empty database.
         if store
@@ -310,7 +334,7 @@ impl AuthorityStore {
     }
 
     /// A function that acquires all locks associated with the objects (in order to avoid deadlocks).
-    async fn acquire_locks(&self, input_objects: &[ObjectRef]) -> Vec<LockGuard> {
+    async fn acquire_locks(&self, input_objects: &[ObjectRef]) -> Vec<MutexGuard> {
         self.mutex_table
             .acquire_locks(input_objects.iter().map(|(_, _, digest)| *digest))
             .await
@@ -551,7 +575,8 @@ impl AuthorityStore {
         let mut write_batch = self.perpetual_tables.objects.batch();
 
         // Insert object
-        let StoreObjectPair(store_object, indirect_object) = object.clone().into();
+        let StoreObjectPair(store_object, indirect_object) =
+            get_store_object_pair(object.clone(), self.indirect_objects_threshold);
         write_batch = write_batch.insert_batch(
             &self.perpetual_tables.objects,
             std::iter::once((ObjectKey::from(object_ref), store_object)),
@@ -596,14 +621,15 @@ impl AuthorityStore {
                 ref_and_objects.iter().map(|(oref, o)| {
                     (
                         ObjectKey::from(oref),
-                        StoreObjectPair::from((**o).clone()).0,
+                        get_store_object_pair((**o).clone(), self.indirect_objects_threshold).0,
                     )
                 }),
             )?
             .insert_batch(
                 &self.perpetual_tables.indirect_move_objects,
                 ref_and_objects.iter().filter_map(|(_, o)| {
-                    let StoreObjectPair(_, indirect_object) = (**o).clone().into();
+                    let StoreObjectPair(_, indirect_object) =
+                        get_store_object_pair((**o).clone(), self.indirect_objects_threshold);
                     indirect_object.map(|obj| (obj.digest(), obj))
                 }),
             )?
@@ -655,6 +681,9 @@ impl AuthorityStore {
         transaction: &VerifiedTransaction,
         effects: &TransactionEffects,
     ) -> SuiResult {
+        let _locks = self
+            .acquire_read_locks_for_indirect_objects(&inner_temporary_store)
+            .await;
         // Extract the new state from the execution
         // TODO: events are already stored in the TxDigest -> TransactionEffects store. Is that enough?
         let mut write_batch = self.perpetual_tables.transactions.batch();
@@ -695,6 +724,31 @@ impl AuthorityStore {
             .notify(transaction_digest, effects);
 
         Ok(())
+    }
+
+    /// Acquires read locks for affected indirect objects
+    async fn acquire_read_locks_for_indirect_objects(
+        &self,
+        inner_temporary_store: &InnerTemporaryStore,
+    ) -> Vec<RwLockGuard> {
+        // locking is required to avoid potential race conditions with the pruner
+        // potential race:
+        //   - transaction execution branches to reference count increment
+        //   - pruner decrements ref count to 0
+        //   - compaction job compresses existing merge values to an empty vector
+        //   - tx executor commits ref count increment instead of the full value making object inaccessible
+        // read locks are sufficient because ref count increments are safe,
+        // concurrent transaction executions produce independent ref count increments and don't corrupt the state
+        let digests = inner_temporary_store
+            .written
+            .iter()
+            .filter_map(|(_, (_, object, _))| {
+                let StoreObjectPair(_, indirect_object) =
+                    get_store_object_pair(object.clone(), self.indirect_objects_threshold);
+                indirect_object.map(|obj| obj.digest())
+            })
+            .collect();
+        self.objects_lock_table.acquire_read_locks(digests).await
     }
 
     /// Helper function for updating the objects and locks in the state
@@ -753,7 +807,8 @@ impl AuthorityStore {
             .iter()
             .map(|(_, (obj_ref, new_object, _))| {
                 debug!(?obj_ref, "writing object");
-                let StoreObjectPair(store_object, indirect_object) = new_object.clone().into();
+                let StoreObjectPair(store_object, indirect_object) =
+                    get_store_object_pair(new_object.clone(), self.indirect_objects_threshold);
                 (
                     (ObjectKey::from(obj_ref), store_object),
                     indirect_object.map(|obj| (obj.digest(), obj)),
@@ -761,12 +816,34 @@ impl AuthorityStore {
             })
             .unzip();
 
-        write_batch = write_batch
-            .insert_batch(&self.perpetual_tables.objects, new_objects.into_iter())?
-            .merge_batch(
+        let indirect_objects: Vec<_> = new_indirect_move_objects.into_iter().flatten().collect();
+        let existing_digests = self
+            .perpetual_tables
+            .indirect_move_objects
+            .multi_get(indirect_objects.iter().map(|(digest, _)| digest))?;
+        // split updates to existing and new indirect objects
+        // for new objects full merge needs to be triggered. For existing ref count increment is sufficient
+        let (existing_indirect_objects, new_indirect_objects): (Vec<_>, Vec<_>) = indirect_objects
+            .into_iter()
+            .enumerate()
+            .partition(|(idx, _)| existing_digests[*idx].is_some());
+
+        write_batch =
+            write_batch.insert_batch(&self.perpetual_tables.objects, new_objects.into_iter())?;
+        if !new_indirect_objects.is_empty() {
+            write_batch = write_batch.merge_batch(
                 &self.perpetual_tables.indirect_move_objects,
-                new_indirect_move_objects.into_iter().flatten(),
+                new_indirect_objects.into_iter().map(|(_, pair)| pair),
             )?;
+        }
+        if !existing_indirect_objects.is_empty() {
+            write_batch = write_batch.partial_merge_batch(
+                &self.perpetual_tables.indirect_move_objects,
+                existing_indirect_objects
+                    .into_iter()
+                    .map(|(_, (digest, _))| (digest, 1_u64.to_le_bytes())),
+            )?;
+        }
 
         write_batch =
             write_batch.insert_batch(&self.perpetual_tables.events, [(events.digest(), events)])?;

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -1,15 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::authority_store_types::StoreData;
+use crate::authority::authority_store_types::{ObjectContentDigest, StoreData};
 use crate::checkpoints::CheckpointStore;
 use mysten_metrics::monitored_scope;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::{sync::Arc, time::Duration};
 use sui_config::node::AuthorityStorePruningConfig;
-use sui_types::digests::CheckpointDigest;
+use sui_storage::mutex_table::RwLockTable;
 use sui_types::messages::{TransactionEffects, TransactionEffectsAPI};
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::{
     base_types::{ObjectID, VersionNumber},
     storage::ObjectKey,
@@ -33,9 +34,11 @@ enum DeletionMethod {
 
 impl AuthorityStorePruner {
     /// prunes old versions of objects based on transaction effects
-    fn prune_effects(
+    async fn prune_effects(
         transaction_effects: Vec<TransactionEffects>,
         perpetual_db: &Arc<AuthorityPerpetualTables>,
+        objects_lock_table: &Arc<RwLockTable<ObjectContentDigest>>,
+        checkpoint_number: CheckpointSequenceNumber,
         deletion_method: DeletionMethod,
     ) -> anyhow::Result<()> {
         let _scope = monitored_scope("ObjectsLivePruner");
@@ -82,18 +85,24 @@ impl AuthorityStorePruner {
         }
         if !indirect_objects.is_empty() {
             let ref_count_update = indirect_objects
-                .into_iter()
+                .iter()
                 .map(|(digest, delta)| (digest, delta.to_le_bytes()));
             wb = wb.partial_merge_batch(&perpetual_db.indirect_move_objects, ref_count_update)?;
         }
+        wb = perpetual_db.set_highest_pruned_checkpoint(wb, checkpoint_number)?;
+
+        let _locks = objects_lock_table
+            .acquire_locks(indirect_objects.into_keys())
+            .await;
         wb.write()?;
         Ok(())
     }
 
     /// Prunes old object versions based on effects from all checkpoints from epochs eligible for pruning
-    fn prune_objects_for_eligible_epochs(
+    async fn prune_objects_for_eligible_epochs(
         perpetual_db: &Arc<AuthorityPerpetualTables>,
         checkpoint_store: &Arc<CheckpointStore>,
+        objects_lock_table: &Arc<RwLockTable<ObjectContentDigest>>,
         config: AuthorityStorePruningConfig,
     ) -> anyhow::Result<()> {
         let deletion_method = if config.use_range_deletion {
@@ -101,10 +110,7 @@ impl AuthorityStorePruner {
         } else {
             DeletionMethod::PointDelete
         };
-        let mut checkpoint_number = checkpoint_store
-            .get_highest_pruned_checkpoint_seq_number()?
-            .unwrap_or_default();
-        let mut checkpoint_digest = CheckpointDigest::random();
+        let mut checkpoint_number = perpetual_db.get_highest_pruned_checkpoint()?;
         let current_epoch = checkpoint_store
             .get_highest_executed_checkpoint()?
             .map(|c| c.epoch())
@@ -130,7 +136,6 @@ impl AuthorityStorePruner {
                 break;
             }
             checkpoint_number = *checkpoint.sequence_number();
-            checkpoint_digest = *checkpoint.digest();
             checkpoints_in_batch += 1;
             if network_total_transactions == checkpoint.network_total_transactions {
                 continue;
@@ -152,17 +157,27 @@ impl AuthorityStorePruner {
             if batch_effects.len() >= config.max_transactions_in_batch
                 || checkpoints_in_batch >= config.max_checkpoints_in_batch
             {
-                Self::prune_effects(batch_effects, perpetual_db, deletion_method)?;
-                checkpoint_store
-                    .update_highest_pruned_checkpoint(checkpoint_number, checkpoint_digest)?;
+                Self::prune_effects(
+                    batch_effects,
+                    perpetual_db,
+                    objects_lock_table,
+                    checkpoint_number,
+                    deletion_method,
+                )
+                .await?;
                 batch_effects = vec![];
                 checkpoints_in_batch = 0;
             }
         }
         if !batch_effects.is_empty() {
-            Self::prune_effects(batch_effects, perpetual_db, deletion_method)?;
-            checkpoint_store
-                .update_highest_pruned_checkpoint(checkpoint_number, checkpoint_digest)?;
+            Self::prune_effects(
+                batch_effects,
+                perpetual_db,
+                objects_lock_table,
+                checkpoint_number,
+                deletion_method,
+            )
+            .await?;
         }
         debug!(
             "Finished pruner iteration. Latest pruned checkpoint: {}",
@@ -176,6 +191,7 @@ impl AuthorityStorePruner {
         epoch_duration_ms: u64,
         perpetual_db: Arc<AuthorityPerpetualTables>,
         checkpoint_store: Arc<CheckpointStore>,
+        objects_lock_table: Arc<RwLockTable<ObjectContentDigest>>,
     ) -> Sender<()> {
         let (sender, mut recv) = tokio::sync::oneshot::channel();
         debug!(
@@ -196,7 +212,7 @@ impl AuthorityStorePruner {
             loop {
                 tokio::select! {
                     _ = prune_interval.tick(), if config.num_epochs_to_retain != u64::MAX => {
-                        if let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, config) {
+                        if let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, &objects_lock_table, config).await {
                             error!("Failed to prune objects: {:?}", err);
                         }
                     },
@@ -209,6 +225,7 @@ impl AuthorityStorePruner {
     pub fn new(
         perpetual_db: Arc<AuthorityPerpetualTables>,
         checkpoint_store: Arc<CheckpointStore>,
+        objects_lock_table: Arc<RwLockTable<ObjectContentDigest>>,
         pruning_config: AuthorityStorePruningConfig,
         epoch_duration_ms: u64,
     ) -> Self {
@@ -218,6 +235,7 @@ impl AuthorityStorePruner {
                 epoch_duration_ms,
                 perpetual_db,
                 checkpoint_store,
+                objects_lock_table,
             ),
         }
     }
@@ -234,9 +252,12 @@ mod tests {
 
     use crate::authority::authority_store_pruner::DeletionMethod;
     use crate::authority::authority_store_tables::AuthorityPerpetualTables;
-    use crate::authority::authority_store_types::{StoreData, StoreObject, StoreObjectPair};
+    use crate::authority::authority_store_types::{
+        get_store_object_pair, ObjectContentDigest, StoreData, StoreObject, StoreObjectPair,
+    };
     #[cfg(not(target_env = "msvc"))]
     use pprof::Symbol;
+    use sui_storage::mutex_table::RwLockTable;
     use sui_types::base_types::{ObjectDigest, VersionNumber};
     use sui_types::messages::{TransactionEffects, TransactionEffectsAPI};
     use sui_types::{
@@ -304,7 +325,7 @@ mod tests {
         let ids = ObjectID::in_range(ObjectID::ZERO, total_unique_object_ids)?;
         for id in ids {
             for i in (0..num_versions_per_object).rev() {
-                let StoreObjectPair(obj, _) = Object::immutable_with_id_for_testing(id).into();
+                let obj = get_store_object_pair(Object::immutable_with_id_for_testing(id), 0).0;
                 objects.insert(&ObjectKey(id, SequenceNumber::from(i)), &obj)?;
                 if i < num_versions_per_object - num_versions_to_keep {
                     to_delete.push((id, SequenceNumber::from(i)));
@@ -350,7 +371,7 @@ mod tests {
                     to_delete.push(object_key);
                 }
                 let StoreObjectPair(obj, indirect_obj) =
-                    Object::immutable_with_id_for_testing(id).into();
+                    get_store_object_pair(Object::immutable_with_id_for_testing(id), 1);
                 batch = batch.insert_batch(
                     &db.objects,
                     [(ObjectKey(id, SequenceNumber::from(i)), obj.clone())],
@@ -372,6 +393,10 @@ mod tests {
         Ok((to_keep, to_delete))
     }
 
+    fn lock_table() -> Arc<RwLockTable<ObjectContentDigest>> {
+        Arc::new(RwLockTable::new(1, 10))
+    }
+
     async fn run_pruner(
         path: &Path,
         num_versions_per_object: u64,
@@ -391,7 +416,15 @@ mod tests {
             let mut effects = TransactionEffects::default();
             *effects.modified_at_versions_mut_for_testing() =
                 to_delete.into_iter().map(|o| (o.0, o.1)).collect();
-            AuthorityStorePruner::prune_effects(vec![effects], &db, deletion_method).unwrap();
+            AuthorityStorePruner::prune_effects(
+                vec![effects],
+                &db,
+                &lock_table(),
+                0,
+                deletion_method,
+            )
+            .await
+            .unwrap();
             to_keep
         };
         tokio::time::sleep(Duration::from_secs(3)).await;
@@ -459,7 +492,7 @@ mod tests {
                 if i < num_versions_per_object - 2 {
                     to_delete.push((id, SequenceNumber::from(i)));
                 }
-                let StoreObjectPair(obj, _) = Object::immutable_with_id_for_testing(id).into();
+                let obj = get_store_object_pair(Object::immutable_with_id_for_testing(id), 0).0;
                 perpetual_db
                     .objects
                     .insert(&ObjectKey(id, SequenceNumber::from(i)), &obj)?;
@@ -473,8 +506,11 @@ mod tests {
         let total_pruned = AuthorityStorePruner::prune_effects(
             vec![effects],
             &perpetual_db,
+            &lock_table(),
+            0,
             DeletionMethod::RangeDelete,
-        );
+        )
+        .await;
         info!("Total pruned keys = {:?}", total_pruned);
         let start = ObjectKey(ObjectID::ZERO, SequenceNumber::MIN);
         let end = ObjectKey(ObjectID::MAX, SequenceNumber::MAX);
@@ -504,8 +540,11 @@ mod tests {
         AuthorityStorePruner::prune_effects(
             vec![effects],
             &perpetual_db,
+            &lock_table(),
+            0,
             DeletionMethod::RangeDelete,
-        )?;
+        )
+        .await?;
         let guard = pprof::ProfilerGuardBuilder::default()
             .frequency(1000)
             .build()
@@ -533,8 +572,11 @@ mod tests {
         AuthorityStorePruner::prune_effects(
             vec![effects],
             &perpetual_db,
+            &lock_table(),
+            0,
             DeletionMethod::RangeDelete,
-        )?;
+        )
+        .await?;
         if let Ok(()) = perpetual_db.objects.flush() {
             info!("Completed flushing objects table");
         } else {

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -249,15 +249,6 @@ impl CheckpointStore {
         self.get_checkpoint_by_digest(&highest_executed.1)
     }
 
-    pub fn get_highest_pruned_checkpoint_seq_number(
-        &self,
-    ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
-        self.watermarks
-            .get(&CheckpointWatermark::HighestPruned)?
-            .map(|(sequence_number, _)| Ok(sequence_number))
-            .transpose()
-    }
-
     pub fn get_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
@@ -333,17 +324,6 @@ impl CheckpointStore {
         }
     }
 
-    pub fn update_highest_pruned_checkpoint(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-        digest: CheckpointDigest,
-    ) -> Result<(), TypedStoreError> {
-        self.watermarks.insert(
-            &CheckpointWatermark::HighestPruned,
-            &(sequence_number, digest),
-        )
-    }
-
     pub fn insert_checkpoint_contents(
         &self,
         contents: CheckpointContents,
@@ -403,7 +383,6 @@ pub enum CheckpointWatermark {
     HighestVerified,
     HighestSynced,
     HighestExecuted,
-    HighestPruned,
 }
 
 pub struct CheckpointBuilder {

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2765,7 +2765,7 @@ async fn test_authority_persist() {
 
     // Create an authority
     let store = Arc::new(
-        AuthorityStore::open_with_committee_for_testing(&path, None, &committee, &genesis)
+        AuthorityStore::open_with_committee_for_testing(&path, None, &committee, &genesis, 0)
             .await
             .unwrap(),
     );
@@ -2791,7 +2791,7 @@ async fn test_authority_persist() {
     let (genesis, authority_key) = init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     let committee = genesis.committee().unwrap();
     let store = Arc::new(
-        AuthorityStore::open_with_committee_for_testing(&path, None, &committee, &genesis)
+        AuthorityStore::open_with_committee_for_testing(&path, None, &committee, &genesis, 0)
             .await
             .unwrap(),
     );
@@ -4769,7 +4769,7 @@ async fn test_tallying_rule_score_updates() {
         .build();
     let genesis = network_config.genesis;
     let store = Arc::new(
-        AuthorityStore::open_with_committee_for_testing(&path, None, &committee, &genesis)
+        AuthorityStore::open_with_committee_for_testing(&path, None, &committee, &genesis, 0)
             .await
             .unwrap(),
     );

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -179,6 +179,7 @@ impl SuiNode {
                 None,
                 genesis,
                 &committee_store,
+                config.indirect_objects_threshold,
             )
             .await?,
         );

--- a/crates/sui-storage/src/write_ahead_log.rs
+++ b/crates/sui-storage/src/write_ahead_log.rs
@@ -7,7 +7,7 @@
 
 use async_trait::async_trait;
 
-use crate::mutex_table::{LockGuard, MutexTable};
+use crate::mutex_table::{MutexGuard, MutexTable};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::Debug;
 use std::path::PathBuf;
@@ -112,7 +112,7 @@ pub struct DBTxGuard<
 > {
     tx: TransactionDigest,
     retry_num: u32,
-    _mutex_guard: LockGuard,
+    _mutex_guard: MutexGuard,
     wal: &'a DBWriteAheadLog<C, ExecutionOutput>,
     dead: bool,
 }
@@ -125,7 +125,7 @@ where
     fn new(
         tx: &TransactionDigest,
         retry_num: u32,
-        _mutex_guard: LockGuard,
+        _mutex_guard: MutexGuard,
         wal: &'a DBWriteAheadLog<C, ExecutionOutput>,
     ) -> Self {
         Self {
@@ -331,7 +331,7 @@ where
     ExecutionOutput: Serialize + DeserializeOwned + Debug + Send + Sync,
 {
     type Guard = DBTxGuard<'a, C, ExecutionOutput>;
-    type LockGuard = LockGuard;
+    type LockGuard = MutexGuard;
 
     #[instrument(level = "debug", name = "begin_tx", skip_all)]
     async fn begin_tx<'b>(


### PR DESCRIPTION
PR includes following changes:
* transaction execution splits indirect objects updates into two groups: existing objects and new objects. For latter full merge operation is used. For existing objects we only perform ref count increments
* to avoid potential race conditions with pruner rwlocks are used. Pruner has to grab exclusive write lock because ref count decrements are dangerous in general(see potential race condition described in comments). Actors that execute transactions have to grab read lock to avoid conflict with the pruner. They don't really conflict with each other. Concurrent transaction executions will produce either ref count increments or full merge operands
* to support following scenario `MutexTable` was modified to support both mutexes and rwlocks
* highest pruned checkpoint was moved to perpetual db. We need to execute all pruner operations in a single atomic write batch to ensure decrement correctness