### PR TITLE
indexer: rpc concurrency limit patch

### DIFF
--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -25,7 +25,6 @@ use errors::IndexerError;
 pub async fn new_rpc_client(http_url: String) -> Result<SuiClient, IndexerError> {
     info!("Getting new RPC client...");
     SuiClientBuilder::default()
-        .max_concurrent_requests(5)
         .build(http_url)
         .await
         .map_err(|e| {


### PR DESCRIPTION
## Description 

Path to loose limit of indexer RPC connections limit