### PR TITLE
[rpc] More efficient gas reference price query

### DIFF
--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -108,12 +108,8 @@ impl GovernanceReadApiServer for GovernanceReadApi {
     }
 
     async fn get_reference_gas_price(&self) -> RpcResult<u64> {
-        Ok(self
-            .state
-            .database
-            .get_sui_system_state_object()
-            .map_err(Error::from)?
-            .reference_gas_price())
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        Ok(epoch_store.reference_gas_price())
     }
 }
 


### PR DESCRIPTION
The reference gas price doesn't change during the epoch and can be obtained from in-memory cache