### PR TITLE
[rpc] Deprecate getValidators

### DIFF
--- a/crates/sui-json-rpc/src/api/governance.rs
+++ b/crates/sui-json-rpc/src/api/governance.rs
@@ -22,7 +22,8 @@ pub trait GovernanceReadApi {
     async fn get_delegated_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>>;
 
     /// Return all validators available for stake delegation.
-    #[method(name = "getValidators")]
+    /// This is now deprecated in favor of extracting it from getLatestSuiSystemState.
+    #[method(name = "getValidators", deprecated)]
     async fn get_validators(&self) -> RpcResult<Vec<ValidatorMetadata>>;
 
     /// Return the committee information for the asked `epoch`.

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1656,7 +1656,7 @@
           "name": "Governance Read API"
         }
       ],
-      "description": "Return all validators available for stake delegation.",
+      "description": "Return all validators available for stake delegation. This is now deprecated in favor of extracting it from getLatestSuiSystemState.",
       "params": [],
       "result": {
         "name": "Vec<ValidatorMetadata>",
@@ -1667,7 +1667,8 @@
             "$ref": "#/components/schemas/ValidatorMetadata"
           }
         }
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "sui_mergeCoins",


### PR DESCRIPTION
We can always extract it from sui system state.