### PR TITLE
[ts-sdk] Remove getValidators and getSuiSystemState references

### DIFF
--- a/.changeset/lemon-kids-sit.md
+++ b/.changeset/lemon-kids-sit.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Remove `getSuiSystemState` method. Use `getLatestSuiSystemState` method instead.

--- a/.changeset/soft-fishes-greet.md
+++ b/.changeset/soft-fishes-greet.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Remove `getValidators` API. Use `getLatestSuiSystemState` instead.

--- a/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type Validator } from '@mysten/sui.js';
+import { type SuiValidatorSummary } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
 import { ReactComponent as ArrowRight } from '../../assets/SVGIcons/12px/ArrowRight.svg';
@@ -18,17 +18,17 @@ import { Text } from '~/ui/Text';
 
 const NUMBER_OF_VALIDATORS = 10;
 
-export function processValidators(set: Validator[]) {
+export function processValidators(set: SuiValidatorSummary[]) {
     return set.map((av) => ({
-        name: av.metadata.name,
-        address: av.metadata.sui_address,
-        stake: av.staking_pool.sui_balance,
-        logo: av.metadata.image_url,
+        name: av.name,
+        address: av.sui_address,
+        stake: av.staking_pool_sui_balance,
+        logo: av.image_url,
     }));
 }
 
 const validatorsTable = (
-    validatorsData: Validator[],
+    validatorsData: SuiValidatorSummary[],
     limit?: number,
     showIcon?: boolean
 ) => {
@@ -93,11 +93,7 @@ export function TopValidatorsCard({ limit, showIcon }: TopValidatorsCardProps) {
     const tableData = useMemo(
         () =>
             data
-                ? validatorsTable(
-                      data.validators.active_validators,
-                      limit,
-                      showIcon
-                  )
+                ? validatorsTable(data.active_validators, limit, showIcon)
                 : null,
         [data, limit, showIcon]
     );

--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ArrowUpRight12 } from '@mysten/icons';
-import { toB64, type Validator } from '@mysten/sui.js';
+import { toB64, type SuiValidatorSummary } from '@mysten/sui.js';
 
 import { StakeButton } from './StakeButton';
 
@@ -13,18 +13,18 @@ import { AddressLink } from '~/ui/InternalLink';
 import { Text } from '~/ui/Text';
 
 type ValidatorMetaProps = {
-    validatorData: Validator;
+    validatorData: SuiValidatorSummary;
 };
 
 export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
     const validatorPublicKey = toB64(
-        new Uint8Array(validatorData.metadata.protocol_pubkey_bytes)
+        new Uint8Array(validatorData.protocol_pubkey_bytes)
     );
 
-    const validatorName = validatorData.metadata.name;
-    const logo = validatorData.metadata.image_url;
-    const description = validatorData.metadata.description;
-    const projectUrl = validatorData.metadata.project_url;
+    const validatorName = validatorData.name;
+    const logo = validatorData.image_url;
+    const description = validatorData.description;
+    const projectUrl = validatorData.project_url;
 
     return (
         <>
@@ -69,7 +69,7 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
                     </DescriptionItem>
                     <DescriptionItem title="Address">
                         <AddressLink
-                            address={validatorData.metadata.sui_address}
+                            address={validatorData.sui_address}
                             noTruncate
                         />
                     </DescriptionItem>

--- a/apps/explorer/src/components/validator/ValidatorStats.tsx
+++ b/apps/explorer/src/components/validator/ValidatorStats.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type Validator } from '@mysten/sui.js';
+import { type SuiValidatorSummary } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
 import { DelegationAmount } from './DelegationAmount';
@@ -12,7 +12,7 @@ import { Heading } from '~/ui/Heading';
 import { Stats } from '~/ui/Stats';
 
 type StatsCardProps = {
-    validatorData: Validator;
+    validatorData: SuiValidatorSummary;
     epoch: number | string;
     epochRewards: string;
 };
@@ -33,9 +33,9 @@ export function ValidatorStats({
         () => calculateAPY(validatorData, +epoch),
         [validatorData, epoch]
     );
-    const totalStake = +validatorData.staking_pool.sui_balance;
+    const totalStake = +validatorData.staking_pool_sui_balance;
     const commission = +validatorData.commission_rate / 100;
-    const rewardsPoolBalance = +validatorData.staking_pool.rewards_pool;
+    const rewardsPoolBalance = +validatorData.rewards_pool;
 
     return (
         <div className="flex flex-col items-stretch gap-5 md:flex-row">

--- a/apps/explorer/src/components/validator/calculateAPY.ts
+++ b/apps/explorer/src/components/validator/calculateAPY.ts
@@ -1,24 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Validator } from '@mysten/sui.js';
+import type { SuiValidatorSummary } from '@mysten/sui.js';
 
 import { roundFloat } from '~/utils/roundFloat';
 
 const APY_DECIMALS = 4;
 
 // TODO: share code with `calculateAPY` for wallet?
-export function calculateAPY(validator: Validator, epoch: number) {
+export function calculateAPY(validator: SuiValidatorSummary, epoch: number) {
     let apy;
-    const { sui_balance, activation_epoch, pool_token_balance } =
-        validator.staking_pool;
+    const {
+        staking_pool_sui_balance,
+        staking_pool_activation_epoch,
+        pool_token_balance,
+    } = validator;
 
     // If the staking pool is active then we calculate its APY.
-    if (activation_epoch.vec.length > 0) {
-        const num_epochs_participated = +epoch - +activation_epoch.vec[0];
+    if (staking_pool_activation_epoch) {
+        const num_epochs_participated = +epoch - +staking_pool_activation_epoch;
         apy =
             Math.pow(
-                1 + (+sui_balance - +pool_token_balance) / +pool_token_balance,
+                1 +
+                    (+staking_pool_sui_balance - +pool_token_balance) /
+                        +pool_token_balance,
                 365 / num_epochs_participated
             ) - 1;
     } else {

--- a/apps/explorer/src/hooks/useGetObject.ts
+++ b/apps/explorer/src/hooks/useGetObject.ts
@@ -7,7 +7,7 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 export function useGetSystemObject() {
     const rpc = useRpcClient();
-    return useQuery(['system', 'state'], () => rpc.getSuiSystemState());
+    return useQuery(['system', 'state'], () => rpc.getLatestSuiSystemState());
 }
 
 export function useGetObject(

--- a/apps/explorer/src/hooks/useGetObject.ts
+++ b/apps/explorer/src/hooks/useGetObject.ts
@@ -5,11 +5,6 @@ import { useRpcClient } from '@mysten/core';
 import { type SuiObjectResponse, normalizeSuiAddress } from '@mysten/sui.js';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
-export function useGetValidators() {
-    const rpc = useRpcClient();
-    return useQuery(['system', 'validators'], () => rpc.getValidators());
-}
-
 export function useGetSystemObject() {
     const rpc = useRpcClient();
     return useQuery(['system', 'state'], () => rpc.getSuiSystemState());

--- a/apps/explorer/src/pages/epochs/EpochDetail.tsx
+++ b/apps/explorer/src/pages/epochs/EpochDetail.tsx
@@ -28,15 +28,13 @@ function EpochDetail() {
 
     const { data, isError, isLoading } = useGetSystemObject();
 
-    const { active, pending, atRisk } = {
-        active: data?.validators.active_validators.length,
-        pending: data?.validators.pending_active_validators.contents.size,
-        atRisk: data?.validators.pending_removals.length,
-    };
+    const active = data?.active_validators.length;
+    const pending = 0; // data?.pending_active_validators.contents.size;
+    const atRisk = 0; // data?.pending_removals.length;
 
     const { data: validatorEvents, isLoading: validatorsEventsLoading } =
         useGetValidatorsEvents({
-            limit: data?.validators.active_validators.length || 0,
+            limit: data?.active_validators.length || 0,
             order: 'descending',
         });
 
@@ -51,10 +49,10 @@ function EpochDetail() {
     if (!data || !validatorEvents) return null;
 
     const validatorsTable = validatorsTableData(
-        data.validators.active_validators,
+        data.active_validators,
         data.epoch,
         validatorEvents?.data,
-        data.parameters.min_validator_stake
+        data.min_validator_stake
     );
 
     return (
@@ -80,7 +78,7 @@ function EpochDetail() {
                 <EpochStats label="Rewards">
                     <Stats label="Stake Subsidies" tooltip="Stake Subsidies">
                         <SuiAmount
-                            amount={data.stake_subsidy.current_epoch_amount}
+                            amount={data.stake_subsidy_current_epoch_amount}
                         />
                     </Stats>
                     <Stats label="Total Rewards" tooltip="Total Rewards">

--- a/apps/explorer/src/pages/validator/ValidatorDetails.tsx
+++ b/apps/explorer/src/pages/validator/ValidatorDetails.tsx
@@ -20,14 +20,11 @@ function ValidatorDetails() {
     const validatorData = useMemo(() => {
         if (!data) return null;
         return (
-            data.validators.active_validators.find(
-                (av) => av.metadata.sui_address === id
-            ) || null
+            data.active_validators.find((av) => av.sui_address === id) || null
         );
     }, [id, data]);
 
-    const numberOfValidators =
-        data?.validators.active_validators.length ?? null;
+    const numberOfValidators = data?.active_validators.length ?? null;
 
     const { data: validatorEvents, isLoading: validatorsEventsLoading } =
         useGetValidatorsEvents({

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type Validator, type SuiEventEnvelope } from '@mysten/sui.js';
+import {
+    type SuiValidatorSummary,
+    type SuiEventEnvelope,
+} from '@mysten/sui.js';
 import { lazy, Suspense, useMemo } from 'react';
 
 import { ErrorBoundary } from '~/components/error-boundary/ErrorBoundary';
@@ -28,32 +31,32 @@ const APY_DECIMALS = 3;
 const NodeMap = lazy(() => import('../../components/node-map'));
 
 export function validatorsTableData(
-    validators: Validator[],
+    validators: SuiValidatorSummary[],
     epoch: number,
     validatorsEvents: SuiEventEnvelope[],
     minimumStake: number
 ) {
     return {
         data: validators.map((validator) => {
-            const validatorName = validator.metadata.name;
-            const totalStake = validator.staking_pool.sui_balance;
-            const img = validator.metadata.image_url;
+            const validatorName = validator.name;
+            const totalStake = validator.staking_pool_sui_balance;
+            const img = validator.image_url;
 
             const event = getValidatorMoveEvent(
                 validatorsEvents,
-                validator.metadata.sui_address
+                validator.sui_address
             );
 
             return {
                 name: {
                     name: validatorName,
-                    logo: validator.metadata.image_url,
+                    logo: validator.image_url,
                 },
                 stake: totalStake,
                 apy: calculateAPY(validator, epoch),
                 commission: +validator.commission_rate / 100,
                 img: img,
-                address: validator.metadata.sui_address,
+                address: validator.sui_address,
                 lastReward: event?.fields.stake_rewards || 0,
                 atRisk: totalStake < minimumStake,
             };
@@ -176,7 +179,7 @@ function ValidatorPageResult() {
     const { data, isLoading, isSuccess, isError } = useGetSystemObject();
 
     const numberOfValidators = useMemo(
-        () => data?.validators.active_validators.length || null,
+        () => data?.active_validators.length || null,
         [data]
     );
 
@@ -191,17 +194,17 @@ function ValidatorPageResult() {
 
     const totalStaked = useMemo(() => {
         if (!data) return 0;
-        const validators = data.validators.active_validators;
+        const validators = data.active_validators;
 
         return validators.reduce(
-            (acc, cur) => acc + +cur.staking_pool.sui_balance,
+            (acc, cur) => acc + +cur.staking_pool_sui_balance,
             0
         );
     }, [data]);
 
     const averageAPY = useMemo(() => {
         if (!data) return 0;
-        const validators = data.validators.active_validators;
+        const validators = data.active_validators;
 
         const validatorsApy = validators.map((av) =>
             calculateAPY(av, +data.epoch)
@@ -230,13 +233,13 @@ function ValidatorPageResult() {
     const validatorsTable = useMemo(() => {
         if (!data || !validatorEvents) return null;
 
-        const validators = data.validators.active_validators;
+        const validators = data.active_validators;
 
         return validatorsTableData(
             validators,
             +data.epoch,
             validatorEvents.data,
-            data.parameters.min_validator_stake
+            data.min_validator_stake
         );
     }, [validatorEvents, data]);
 

--- a/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
@@ -45,9 +45,8 @@ export function StakeTxnCard({ txnEffects, events }: StakeTxnCardProps) {
     const validatorData = useMemo(() => {
         if (!system || !stakingData || !stakingData.fields.validator_address)
             return null;
-        return system.validators.active_validators.find(
-            (av) =>
-                av.metadata.sui_address === stakingData.fields.validator_address
+        return system.active_validators.find(
+            (av) => av.sui_address === stakingData.fields.validator_address
         );
     }, [stakingData, system]);
 

--- a/apps/wallet/src/ui/app/shared/delegated-apy/index.tsx
+++ b/apps/wallet/src/ui/app/shared/delegated-apy/index.tsx
@@ -22,12 +22,12 @@ export function DelegatedAPY({ stakedValidators }: DelegatedAPYProps) {
 
     const averageNetworkAPY = useMemo(() => {
         if (!data) return 0;
-        const validators = data.validators.active_validators;
+        const validators = data.active_validators;
 
         let stakedAPYs = 0;
 
         validators.forEach((validator) => {
-            if (stakedValidators.includes(validator.metadata.sui_address)) {
+            if (stakedValidators.includes(validator.sui_address)) {
                 stakedAPYs += calculateAPY(validator, +data.epoch);
             }
         });

--- a/apps/wallet/src/ui/app/staking/calculateAPY.ts
+++ b/apps/wallet/src/ui/app/staking/calculateAPY.ts
@@ -1,23 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type Validator } from '@mysten/sui.js';
+import { type SuiValidatorSummary } from '@mysten/sui.js';
 
 import { roundFloat } from '_helpers';
 
 const APY_DECIMALS = 4;
 
-export function calculateAPY(validator: Validator, epoch: number) {
+export function calculateAPY(validator: SuiValidatorSummary, epoch: number) {
     let apy;
-    const { sui_balance, activation_epoch, pool_token_balance } =
-        validator.staking_pool;
+    const {
+        staking_pool_sui_balance,
+        staking_pool_activation_epoch,
+        pool_token_balance,
+    } = validator;
 
     // If the staking pool is active then we calculate its APY.
-    if (activation_epoch.vec.length > 0) {
-        const num_epochs_participated = +epoch - +activation_epoch.vec[0];
+    if (staking_pool_activation_epoch) {
+        const num_epochs_participated = +epoch - +staking_pool_activation_epoch;
         apy =
             Math.pow(
-                1 + (+sui_balance - +pool_token_balance) / +pool_token_balance,
+                1 +
+                    (+staking_pool_sui_balance - +pool_token_balance) /
+                        +pool_token_balance,
                 365 / num_epochs_participated
             ) - 1;
     } else {

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -47,8 +47,8 @@ export function DelegationDetailCard({
 
     const validatorData = useMemo(() => {
         if (!system) return null;
-        return system.validators.active_validators.find(
-            (av) => av.metadata.sui_address === validatorAddress
+        return system.active_validators.find(
+            (av) => av.sui_address === validatorAddress
         );
     }, [validatorAddress, system]);
 
@@ -64,10 +64,7 @@ export function DelegationDetailCard({
 
     const suiEarned = useMemo(() => {
         if (!system || !delegationData) return 0n;
-        return getStakingRewards(
-            system.validators.active_validators,
-            delegationData
-        );
+        return getStakingRewards(system.active_validators, delegationData);
     }, [delegationData, system]);
 
     const apy = useMemo(() => {

--- a/apps/wallet/src/ui/app/staking/getStakingRewards.ts
+++ b/apps/wallet/src/ui/app/staking/getStakingRewards.ts
@@ -3,10 +3,10 @@
 
 import BigNumber from 'bignumber.js';
 
-import type { Validator, DelegatedStake } from '@mysten/sui.js';
+import type { SuiValidatorSummary, DelegatedStake } from '@mysten/sui.js';
 
 export function getStakingRewards(
-    activeValidators: Validator[],
+    activeValidators: SuiValidatorSummary[],
     delegation: DelegatedStake
 ) {
     if (
@@ -17,7 +17,7 @@ export function getStakingRewards(
         return 0;
     const pool_id = delegation.staked_sui.pool_id;
     const validator = activeValidators.find(
-        (validator) => validator.staking_pool.id === pool_id
+        (validator) => validator.staking_pool_id === pool_id
     );
 
     if (!validator) return 0;
@@ -25,10 +25,8 @@ export function getStakingRewards(
     const poolTokens = new BigNumber(
         delegation.delegation_status.Active.pool_tokens.value
     );
-    const delegationTokenSupply = new BigNumber(
-        validator.staking_pool.pool_token_balance
-    );
-    const suiBalance = new BigNumber(validator.staking_pool.sui_balance);
+    const delegationTokenSupply = new BigNumber(validator.pool_token_balance);
+    const suiBalance = new BigNumber(validator.staking_pool_sui_balance);
     const pricipalAmout = new BigNumber(
         delegation.delegation_status.Active.principal_sui_amount
     );

--- a/apps/wallet/src/ui/app/staking/home/DelegationCard.tsx
+++ b/apps/wallet/src/ui/app/staking/home/DelegationCard.tsx
@@ -11,7 +11,7 @@ import { ValidatorLogo } from '../validators/ValidatorLogo';
 import { Text } from '_src/ui/app/shared/text';
 import { IconTooltip } from '_src/ui/app/shared/tooltip';
 
-import type { Validator, DelegatedStake } from '@mysten/sui.js';
+import type { SuiValidatorSummary, DelegatedStake } from '@mysten/sui.js';
 
 export enum DelegationState {
     WARM_UP = 'WARM_UP',
@@ -21,7 +21,7 @@ export enum DelegationState {
 
 interface DelegationCardProps {
     delegationObject: DelegatedStake;
-    activeValidators: Validator[];
+    activeValidators: SuiValidatorSummary[];
     currentEpoch: number;
 }
 

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -95,10 +95,7 @@ function StakingCard() {
 
     const suiEarned = useMemo(() => {
         if (!system || !delegationData) return 0;
-        return getStakingRewards(
-            system.validators.active_validators,
-            delegationData
-        );
+        return getStakingRewards(system.active_validators, delegationData);
     }, [delegationData, system]);
 
     const [coinDecimals] = useCoinDecimals(coinType);

--- a/apps/wallet/src/ui/app/staking/stake/ValidatorFormDetail.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/ValidatorFormDetail.tsx
@@ -44,12 +44,12 @@ export function ValidatorFormDetail({
 
     const validatorData = useMemo(() => {
         if (!system) return null;
-        return system.validators.active_validators.find(
-            (av) => av.metadata.sui_address === validatorAddress
+        return system.active_validators.find(
+            (av) => av.sui_address === validatorAddress
         );
     }, [validatorAddress, system]);
 
-    const totalValidatorStake = validatorData?.staking_pool.sui_balance || 0;
+    const totalValidatorStake = validatorData?.staking_pool_sui_balance || 0;
 
     const totalStake = useMemo(() => {
         if (!allDelegation) return 0n;

--- a/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
+++ b/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
@@ -4,7 +4,7 @@
 import { useRpcClient } from '@mysten/core';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
-import type { ValidatorMetaData, DelegatedStake } from '@mysten/sui.js';
+import type { DelegatedStake } from '@mysten/sui.js';
 
 export function useGetDelegatedStake(
     address: string
@@ -13,15 +13,4 @@ export function useGetDelegatedStake(
     return useQuery(['validator', address], () =>
         rpc.getDelegatedStakes(address)
     );
-}
-
-export function useGetValidatorMetaData(): UseQueryResult<
-    ValidatorMetaData[],
-    Error
-> {
-    const rpc = useRpcClient();
-    // keeping the query parent key the same to invalidate all related queries
-    return useQuery(['validator', 'all'], async () => {
-        return rpc.getValidators();
-    });
 }

--- a/apps/wallet/src/ui/app/staking/useSystemState.tsx
+++ b/apps/wallet/src/ui/app/staking/useSystemState.tsx
@@ -6,5 +6,5 @@ import { useQuery } from '@tanstack/react-query';
 
 export function useSystemState() {
     const rpc = useRpcClient();
-    return useQuery(['system', 'state'], () => rpc.getSuiSystemState());
+    return useQuery(['system', 'state'], () => rpc.getLatestSuiSystemState());
 }

--- a/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
@@ -43,8 +43,8 @@ export function SelectValidatorCard() {
 
     const totalStake = useMemo(() => {
         if (!data) return 0;
-        return data.validators.active_validators.reduce(
-            (acc, curr) => (acc += BigInt(curr.staking_pool.sui_balance)),
+        return data.active_validators.reduce(
+            (acc, curr) => (acc += BigInt(curr.staking_pool_sui_balance)),
             0n
         );
     }, [data]);
@@ -52,16 +52,16 @@ export function SelectValidatorCard() {
     const validatorList = useMemo(() => {
         if (!data) return [];
 
-        const sortedAsc = data.validators.active_validators
+        const sortedAsc = data.active_validators
             .map((validator) => ({
-                name: validator.metadata.name,
-                address: validator.metadata.sui_address,
+                name: validator.name,
+                address: validator.sui_address,
                 apy: calculateAPY(validator, +data.epoch),
                 stakeShare: calculateStakeShare(
-                    BigInt(validator.staking_pool.sui_balance),
+                    BigInt(validator.staking_pool_sui_balance),
                     BigInt(totalStake)
                 ),
-                logo: validator.metadata.image_url,
+                logo: validator.image_url,
             }))
             .sort((a, b) => {
                 if (sortKey === 'name') {

--- a/apps/wallet/src/ui/app/staking/validators/ValidatorLogo.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/ValidatorLogo.tsx
@@ -34,14 +34,14 @@ export function ValidatorLogo({
     const validatorMeta = useMemo(() => {
         if (!data) return null;
 
-        const validator = data.validators.active_validators.find(
-            ({ metadata }) => metadata.sui_address === validatorAddress
+        const validator = data.active_validators.find(
+            (validator) => validator.sui_address === validatorAddress
         );
         if (!validator) return null;
 
         return {
-            name: validator.metadata.name,
-            logo: validator.metadata.image_url,
+            name: validator.name,
+            logo: validator.image_url,
         };
     }, [validatorAddress, data]);
 

--- a/apps/wallet/src/ui/app/staking/validators/ValidatorLogo.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/ValidatorLogo.tsx
@@ -5,7 +5,7 @@ import { formatAddress, type SuiAddress } from '@mysten/sui.js';
 import cl from 'classnames';
 import { useMemo } from 'react';
 
-import { useGetValidatorMetaData } from '../useGetDelegatedStake';
+import { useSystemState } from '../useSystemState';
 import { Heading } from '_app/shared/heading';
 import { ImageIcon } from '_app/shared/image-icon';
 import { Text } from '_app/shared/text';
@@ -29,23 +29,21 @@ export function ValidatorLogo({
     size,
     stacked,
 }: ValidatorLogoProps) {
-    const { data: validatorsData, isLoading } = useGetValidatorMetaData();
+    const { data, isLoading } = useSystemState();
 
     const validatorMeta = useMemo(() => {
-        if (!validatorsData) return null;
+        if (!data) return null;
 
-        const validator = validatorsData.find(
-            ({ sui_address }) => sui_address === validatorAddress
+        const validator = data.validators.active_validators.find(
+            ({ metadata }) => metadata.sui_address === validatorAddress
         );
         if (!validator) return null;
 
-        const logo = validator.image_url;
-
         return {
-            name: validator.name,
-            logo: logo,
+            name: validator.metadata.name,
+            logo: validator.metadata.image_url,
         };
-    }, [validatorAddress, validatorsData]);
+    }, [validatorAddress, data]);
 
     if (isLoading) {
         return <div className="flex justify-center items-center">...</div>;

--- a/apps/wallet/src/ui/app/staking/validators/ValidatorsCard.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/ValidatorsCard.tsx
@@ -33,12 +33,12 @@ export function ValidatorsCard() {
 
     const { data: system } = useSystemState();
 
-    const activeValidators = system?.validators.active_validators;
+    const activeValidators = system?.active_validators;
     // Total earn token for all delegations
     const totalEarnToken = useMemo(() => {
         if (!delegations || !system) return 0;
 
-        const activeValidators = system.validators.active_validators;
+        const activeValidators = system.active_validators;
 
         return delegations.reduce(
             (acc, delegation) =>

--- a/dapps/frenemies/src/components/Validators/Validator.tsx
+++ b/dapps/frenemies/src/components/Validators/Validator.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ValidatorMetaData } from "@mysten/sui.js";
+import { SuiValidatorSummary } from "@mysten/sui.js";
 import clsx from "clsx";
 import { FormEvent, useState } from "react";
 import { useScorecard } from "../../network/queries/scorecard";
@@ -17,7 +17,7 @@ import { Target } from "./Target";
 
 interface Props {
   index: number;
-  validator: ValidatorMetaData;
+  validator: SuiValidatorSummary;
   stake: ObjectData<StakedSui>;
   delegation?: ObjectData<Delegation>;
 }
@@ -32,9 +32,7 @@ export function ValidatorItem({ index, validator, stake, delegation }: Props) {
     setAmount(evt.currentTarget.value);
   };
 
-  const delegatedStake = BigInt(validator.next_epoch_delegation);
-  const selfStake = BigInt(validator.next_epoch_stake);
-  const totalStake = selfStake + delegatedStake;
+  const totalStake = BigInt(validator.next_epoch_stake);
 
   return (
     <GridItem

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -45,7 +45,6 @@ import {
   SuiObjectResponse,
   GetOwnedObjectsResponse,
   DelegatedStake,
-  ValidatorMetaData,
   SuiSystemState,
   CoinBalance,
   CoinSupply,
@@ -719,20 +718,6 @@ export class JsonRpcProvider extends Provider {
       return resp;
     } catch (err) {
       throw new Error(`Error in getDelegatedStake: ${err}`);
-    }
-  }
-
-  async getValidators(): Promise<ValidatorMetaData[]> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_getValidators',
-        [],
-        array(ValidatorMetaData),
-        this.options.skipDataValidation,
-      );
-      return resp;
-    } catch (err) {
-      throw new Error(`Error in getValidators: ${err}`);
     }
   }
 

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -45,7 +45,6 @@ import {
   SuiObjectResponse,
   GetOwnedObjectsResponse,
   DelegatedStake,
-  SuiSystemState,
   CoinBalance,
   CoinSupply,
   CheckpointDigest,
@@ -718,20 +717,6 @@ export class JsonRpcProvider extends Provider {
       return resp;
     } catch (err) {
       throw new Error(`Error in getDelegatedStake: ${err}`);
-    }
-  }
-
-  async getSuiSystemState(): Promise<SuiSystemState> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_getSuiSystemState',
-        [],
-        SuiSystemState,
-        this.options.skipDataValidation,
-      );
-      return resp;
-    } catch (err) {
-      throw new Error(`Error in getSuiSystemState: ${err}`);
     }
   }
 

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -33,7 +33,6 @@ import {
   Order,
   CoinMetadata,
   DevInspectResults,
-  SuiSystemState,
   DelegatedStake,
   PaginatedCoins,
   CoinBalance,
@@ -370,11 +369,6 @@ export abstract class Provider {
    * Return the delegated stakes for an address
    */
   abstract getDelegatedStakes(address: SuiAddress): Promise<DelegatedStake[]>;
-
-  /**
-   * Return the content of `0x5` object
-   */
-  abstract getSuiSystemState(): Promise<SuiSystemState>;
 
   /**
    * Return the latest system state content.

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -35,7 +35,6 @@ import {
   DevInspectResults,
   SuiSystemState,
   DelegatedStake,
-  ValidatorMetaData,
   PaginatedCoins,
   CoinBalance,
   CoinSupply,
@@ -371,11 +370,6 @@ export abstract class Provider {
    * Return the delegated stakes for an address
    */
   abstract getDelegatedStakes(address: SuiAddress): Promise<DelegatedStake[]>;
-
-  /**
-   * Return all validators available for stake delegation.
-   */
-  abstract getValidators(): Promise<ValidatorMetaData[]>;
 
   /**
    * Return the content of `0x5` object

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -33,7 +33,6 @@ import {
   DevInspectResults,
   SuiSystemState,
   DelegatedStake,
-  ValidatorMetaData,
   PaginatedCoins,
   CoinBalance,
   CoinSupply,
@@ -73,10 +72,6 @@ export class VoidProvider extends Provider {
 
   async getDelegatedStakes(_address: SuiAddress): Promise<DelegatedStake[]> {
     throw this.newError('getDelegatedStakes');
-  }
-
-  async getValidators(): Promise<ValidatorMetaData[]> {
-    throw this.newError('getValidators');
   }
 
   // Faucet

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -31,7 +31,6 @@ import {
   Order,
   CoinMetadata,
   DevInspectResults,
-  SuiSystemState,
   DelegatedStake,
   PaginatedCoins,
   CoinBalance,
@@ -60,10 +59,6 @@ export class VoidProvider extends Provider {
   // Governance
   async getReferenceGasPrice(): Promise<number> {
     throw this.newError('getReferenceGasPrice');
-  }
-
-  async getSuiSystemState(): Promise<SuiSystemState> {
-    throw this.newError('getSuiSystemState');
   }
 
   async getLatestSuiSystemState(): Promise<SuiSystemStateSummary> {

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -19,32 +19,7 @@ import { AuthorityName } from './transactions';
 
 /* -------------- Types for the SuiSystemState Rust definition -------------- */
 
-export const ValidatorMetaData = object({
-  sui_address: SuiAddress,
-  protocol_pubkey_bytes: array(number()),
-  network_pubkey_bytes: array(number()),
-  worker_pubkey_bytes: array(number()),
-  proof_of_possession_bytes: array(number()),
-  name: string(),
-  description: string(),
-  image_url: string(),
-  project_url: string(),
-  p2p_address: array(number()),
-  net_address: array(number()),
-  primary_address: array(number()),
-  worker_address: array(number()),
-  next_epoch_protocol_pubkey_bytes: nullable(array(number())),
-  next_epoch_proof_of_possession: nullable(array(number())),
-  next_epoch_network_pubkey_bytes: nullable(array(number())),
-  next_epoch_worker_pubkey_bytes: nullable(array(number())),
-  next_epoch_net_address: nullable(array(number())),
-  next_epoch_p2p_address: nullable(array(number())),
-  next_epoch_primary_address: nullable(array(number())),
-  next_epoch_worker_address: nullable(array(number())),
-});
-
 export type DelegatedStake = Infer<typeof DelegatedStake>;
-export type ValidatorMetaData = Infer<typeof ValidatorMetaData>;
 export type CommitteeInfo = Infer<typeof CommitteeInfo>;
 
 // Staking
@@ -151,69 +126,6 @@ export const CommitteeInfo = object({
   /** Array of (validator public key, stake unit) tuple */
   validators: optional(array(tuple([AuthorityName, number()]))),
 });
-
-export const SystemParameters = object({
-  min_validator_stake: number(),
-  max_validator_count: number(),
-  governance_start_epoch: number(),
-  storage_gas_price: optional(number()),
-});
-
-export const Validator = object({
-  metadata: ValidatorMetaData,
-  voting_power: number(),
-  gas_price: number(),
-  staking_pool: DelegationStakingPoolFields,
-  commission_rate: number(),
-  next_epoch_stake: number(),
-  next_epoch_gas_price: number(),
-  next_epoch_commission_rate: number(),
-});
-export type Validator = Infer<typeof Validator>;
-
-export const ValidatorPair = object({
-  from: SuiAddress,
-  to: SuiAddress,
-});
-
-export const ValidatorSet = object({
-  total_stake: number(),
-  active_validators: array(Validator),
-  pending_active_validators: object({
-    contents: object({
-      id: string(),
-      size: number(),
-    }),
-  }),
-  pending_removals: array(number()),
-  staking_pool_mappings: object({
-    id: string(),
-    size: number(),
-  }),
-  inactive_pools: object({
-    id: string(),
-    size: number(),
-  }),
-  validator_candidates: object({
-    id: string(),
-    size: number(),
-  }),
-});
-
-export const SuiSystemState = object({
-  epoch: number(),
-  protocol_version: number(),
-  validators: ValidatorSet,
-  storage_fund: Balance,
-  parameters: SystemParameters,
-  reference_gas_price: number(),
-  validator_report_records: object({ contents: array() }),
-  stake_subsidy: StakeSubsidyFields,
-  safe_mode: boolean(),
-  epoch_start_timestamp_ms: optional(number()),
-});
-
-export type SuiSystemState = Infer<typeof SuiSystemState>;
 
 export const SuiValidatorSummary = object({
   sui_address: SuiAddress,

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -44,10 +44,6 @@ describe('Governance API', () => {
     expect(committeeInfo.validators?.length).greaterThan(0);
   });
 
-  it('test getSuiSystemState', async () => {
-    await toolbox.provider.getSuiSystemState();
-  });
-
   it('test getLatestSuiSystemState', async () => {
     await toolbox.provider.getLatestSuiSystemState();
   });
@@ -61,14 +57,14 @@ async function addDelegation(signer: RawSigner) {
     null,
   );
 
-  const system = await signer.provider.getSuiSystemState();
-  const validators = system.validators.active_validators;
+  const system = await signer.provider.getLatestSuiSystemState();
+  const validators = system.active_validators;
 
   const tx = await SuiSystemStateUtil.newRequestAddDelegationTxn(
     signer.provider,
     [coins.data[0].coinObjectId],
     BigInt(DEFAULT_STAKED_AMOUNT),
-    validators[0].metadata.sui_address,
+    validators[0].sui_address,
   );
 
   tx.setGasBudget(DEFAULT_GAS_BUDGET);

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -39,11 +39,6 @@ describe('Governance API', () => {
     // TODO: implement this
   });
 
-  it('test getValidators', async () => {
-    const validators = await toolbox.provider.getValidators();
-    expect(validators.length).greaterThan(0);
-  });
-
   it('test getCommitteeInfo', async () => {
     const committeeInfo = await toolbox.provider.getCommitteeInfo(0);
     expect(committeeInfo.validators?.length).greaterThan(0);
@@ -66,13 +61,14 @@ async function addDelegation(signer: RawSigner) {
     null,
   );
 
-  const validators = await signer.provider.getValidators();
+  const system = await signer.provider.getSuiSystemState();
+  const validators = system.validators.active_validators;
 
   const tx = await SuiSystemStateUtil.newRequestAddDelegationTxn(
     signer.provider,
     [coins.data[0].coinObjectId],
     BigInt(DEFAULT_STAKED_AMOUNT),
-    validators[0].sui_address,
+    validators[0].metadata.sui_address,
   );
 
   tx.setGasBudget(DEFAULT_GAS_BUDGET);

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -71,11 +71,8 @@ describe('Transaction Builders', () => {
   it('MoveCall Shared Object', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
 
-    const [
-      {
-        metadata: { sui_address: validator_address },
-      },
-    ] = await toolbox.getActiveValidators();
+    const [{ sui_address: validator_address }] =
+      await toolbox.getActiveValidators();
 
     const tx = new Transaction();
     tx.add(

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -71,8 +71,11 @@ describe('Transaction Builders', () => {
   it('MoveCall Shared Object', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
 
-    const [{ sui_address: validator_address }] =
-      await toolbox.getActiveValidators();
+    const [
+      {
+        metadata: { sui_address: validator_address },
+      },
+    ] = await toolbox.getActiveValidators();
 
     const tx = new Transaction();
     tx.add(

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -125,8 +125,11 @@ describe('Transaction Serialization and deserialization', () => {
   it('Move Shared Object Call', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
 
-    const [{ sui_address: validator_address }] =
-      await toolbox.getActiveValidators();
+    const [
+      {
+        metadata: { sui_address: validator_address },
+      },
+    ] = await toolbox.getActiveValidators();
 
     const moveCall = {
       packageObjectId:

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -125,11 +125,8 @@ describe('Transaction Serialization and deserialization', () => {
   it('Move Shared Object Call', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
 
-    const [
-      {
-        metadata: { sui_address: validator_address },
-      },
-    ] = await toolbox.getActiveValidators();
+    const [{ sui_address: validator_address }] =
+      await toolbox.getActiveValidators();
 
     const moveCall = {
       packageObjectId:

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -49,7 +49,8 @@ export class TestToolbox {
   }
 
   public async getActiveValidators() {
-    return this.provider.getValidators();
+    return (await this.provider.getSuiSystemState()).validators
+      .active_validators;
   }
 }
 

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -49,8 +49,7 @@ export class TestToolbox {
   }
 
   public async getActiveValidators() {
-    return (await this.provider.getSuiSystemState()).validators
-      .active_validators;
+    return (await this.provider.getLatestSuiSystemState()).active_validators;
   }
 }
 


### PR DESCRIPTION
## Description 

Remove all usage of the deprecated `getValidators` and `getSuiSystemState` functions, and fully remove them from the TS SDK.

## Test Plan 

Tests should continue to pass.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Removed `getValidators` and `getSuiSystemState` functions from the TypeScript SDK. Use `getLatestSuiSystemState` instead.
