### PR TITLE
Rename all V1 system state types with V1 suffix

### DIFF
--- a/crates/sui-framework/src/natives/validator.rs
+++ b/crates/sui-framework/src/natives/validator.rs
@@ -10,7 +10,7 @@ use move_vm_types::{
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
-use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadataV1;
 
 pub fn validate_metadata_bcs(
     _context: &mut NativeContext,
@@ -21,7 +21,7 @@ pub fn validate_metadata_bcs(
     debug_assert!(args.len() == 1);
     let metadata_bytes = pop_arg!(args, Vec<u8>);
     let validator_metadata =
-        bcs::from_bytes::<ValidatorMetadata>(&metadata_bytes).map_err(|_| {
+        bcs::from_bytes::<ValidatorMetadataV1>(&metadata_bytes).map_err(|_| {
             PartialVMError::new(StatusCode::MALFORMED).with_message(
                 "ValidateMetadata Move struct does not much internal ValidateMetadata struct"
                     .to_string(),

--- a/crates/sui-indexer/src/apis/governance_api.rs
+++ b/crates/sui-indexer/src/apis/governance_api.rs
@@ -11,7 +11,7 @@ use sui_json_rpc_types::{SuiCommittee, SuiSystemStateRpc};
 use sui_open_rpc::Module;
 use sui_types::base_types::{EpochId, SuiAddress};
 use sui_types::governance::DelegatedStake;
-use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadataV1;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
 pub(crate) struct GovernanceReadApi {
@@ -32,7 +32,7 @@ impl GovernanceReadApiServer for GovernanceReadApi {
         self.fullnode.get_delegated_stakes(owner).await
     }
 
-    async fn get_validators(&self) -> RpcResult<Vec<ValidatorMetadata>> {
+    async fn get_validators(&self) -> RpcResult<Vec<ValidatorMetadataV1>> {
         self.fullnode.get_validators().await
     }
 

--- a/crates/sui-json-rpc/src/api/governance.rs
+++ b/crates/sui-json-rpc/src/api/governance.rs
@@ -11,7 +11,7 @@ use sui_types::base_types::SuiAddress;
 use sui_types::committee::EpochId;
 use sui_types::governance::DelegatedStake;
 
-use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadataV1;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
 #[open_rpc(namespace = "sui", tag = "Governance Read API")]
@@ -23,7 +23,7 @@ pub trait GovernanceReadApi {
 
     /// Return all validators available for stake delegation.
     #[method(name = "getValidators")]
-    async fn get_validators(&self) -> RpcResult<Vec<ValidatorMetadata>>;
+    async fn get_validators(&self) -> RpcResult<Vec<ValidatorMetadataV1>>;
 
     /// Return the committee information for the asked `epoch`.
     #[method(name = "getCommitteeInfo")]

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -5,7 +5,7 @@ use jsonrpsee::core::RpcResult;
 use std::collections::HashMap;
 use std::sync::Arc;
 use sui_json_rpc_types::{SuiCommittee, SuiSystemStateRpc};
-use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadataV1;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
 use crate::api::GovernanceReadApiServer;
@@ -70,7 +70,7 @@ impl GovernanceReadApiServer for GovernanceReadApi {
             .collect())
     }
 
-    async fn get_validators(&self) -> RpcResult<Vec<ValidatorMetadata>> {
+    async fn get_validators(&self) -> RpcResult<Vec<ValidatorMetadataV1>> {
         // TODO: include pending validators as well when the necessary changes are made in move.
         Ok(self
             .state

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -28,7 +28,7 @@ use sui_types::gas_coin::GAS;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::object::Owner;
 use sui_types::query::{EventQuery, TransactionQuery};
-use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadataV1;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{parse_sui_struct_tag, parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS};
 use test_utils::network::TestClusterBuilder;
@@ -1002,7 +1002,7 @@ async fn test_delegation() -> Result<(), anyhow::Error> {
     let staked_sui: Vec<DelegatedStake> = http_client.get_delegated_stakes(*address).await?;
     assert!(staked_sui.is_empty());
 
-    let validators: Vec<ValidatorMetadata> = http_client.get_validators().await?;
+    let validators: Vec<ValidatorMetadataV1> = http_client.get_validators().await?;
 
     // Delegate some SUI
     let transaction_bytes: TransactionBytes = http_client
@@ -1057,7 +1057,7 @@ async fn test_delegation_multiple_coins() -> Result<(), anyhow::Error> {
     let staked_sui: Vec<DelegatedStake> = http_client.get_delegated_stakes(*address).await?;
     assert!(staked_sui.is_empty());
 
-    let validators: Vec<ValidatorMetadata> = http_client.get_validators().await?;
+    let validators: Vec<ValidatorMetadataV1> = http_client.get_validators().await?;
 
     // Delegate some SUI
     let transaction_bytes: TransactionBytes = http_client
@@ -1155,7 +1155,7 @@ async fn test_delegation_with_locked_sui() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let validators: Vec<ValidatorMetadata> = http_client.get_validators().await?;
+    let validators: Vec<ValidatorMetadataV1> = http_client.get_validators().await?;
 
     // Delegate some locked SUI
     let coins: CoinPage = http_client.get_coins(*address, None, None, None).await?;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1659,7 +1659,7 @@
       "description": "Return all validators available for stake delegation.",
       "params": [],
       "result": {
-        "name": "Vec<ValidatorMetadata>",
+        "name": "Vec<ValidatorMetadataV1>",
         "required": true,
         "schema": {
           "type": "array",

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -29,7 +29,7 @@ use sui_types::event::EventID;
 use sui_types::messages::{ExecuteTransactionRequestType, TransactionData, VerifiedTransaction};
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::query::{EventQuery, TransactionQuery};
-use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadata;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadataV1;
 
 use futures::StreamExt;
 use sui_json_rpc::api::{CoinReadApiClient, EventReadApiClient, ReadApiClient, WriteApiClient};
@@ -482,7 +482,7 @@ impl GovernanceApi {
     }
 
     /// Return all validators available for stake delegation.
-    pub async fn get_validators(&self) -> SuiRpcResult<Vec<ValidatorMetadata>> {
+    pub async fn get_validators(&self) -> SuiRpcResult<Vec<ValidatorMetadataV1>> {
         Ok(self.api.http.get_validators().await?)
     }
 

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use tracing::error;
 
-use self::sui_system_state_inner_v1::{SuiSystemStateInnerV1, ValidatorMetadata};
+use self::sui_system_state_inner_v1::{SuiSystemStateInnerV1, ValidatorMetadataV1};
 use self::sui_system_state_summary::SuiSystemStateSummary;
 
 pub mod epoch_start_sui_system_state;
@@ -68,7 +68,7 @@ pub trait SuiSystemStateTrait {
     fn epoch_start_timestamp_ms(&self) -> u64;
     fn safe_mode(&self) -> bool;
     fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata;
-    fn get_validator_metadata_vec(&self) -> Vec<ValidatorMetadata>;
+    fn get_validator_metadata_vec(&self) -> Vec<ValidatorMetadataV1>;
     fn get_staking_pool_info(&self) -> BTreeMap<SuiAddress, (Vec<u8>, u64)>;
     fn into_epoch_start_state(self) -> EpochStartSystemState;
     fn into_sui_system_state_summary(self) -> SuiSystemStateSummary;

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -31,14 +31,18 @@ const E_METADATA_INVALID_WORKER_ADDR: u64 = 7;
 
 /// Rust version of the Move sui::sui_system::SystemParameters type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
-pub struct SystemParameters {
+// TODO: Get rid of json schema once we deprecate getSuiSystemState RPC API.
+#[serde(rename = "SystemParameters")]
+pub struct SystemParametersV1 {
     pub min_validator_stake: u64,
     pub max_validator_candidate_count: u64,
     pub governance_start_epoch: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
-pub struct ValidatorMetadata {
+// TODO: Get rid of json schema once we deprecate getSuiSystemState RPC API.
+#[serde(rename = "ValidatorMetadata")]
+pub struct ValidatorMetadataV1 {
     pub sui_address: SuiAddress,
     pub protocol_pubkey_bytes: Vec<u8>,
     pub network_pubkey_bytes: Vec<u8>,
@@ -63,7 +67,7 @@ pub struct ValidatorMetadata {
 }
 
 #[derive(Debug, Clone)]
-pub struct VerifiedValidatorMetadata {
+pub struct VerifiedValidatorMetadataV1 {
     pub sui_address: SuiAddress,
     pub protocol_pubkey: narwhal_crypto::PublicKey,
     pub network_pubkey: narwhal_crypto::NetworkPublicKey,
@@ -87,9 +91,9 @@ pub struct VerifiedValidatorMetadata {
     pub next_epoch_worker_address: Option<Multiaddr>,
 }
 
-impl ValidatorMetadata {
+impl ValidatorMetadataV1 {
     /// Verify validator metadata and return a verified version (on success) or error code (on failure)
-    pub fn verify(&self) -> Result<VerifiedValidatorMetadata, u64> {
+    pub fn verify(&self) -> Result<VerifiedValidatorMetadataV1, u64> {
         // TODO: move the proof of possession verification here
 
         let protocol_pubkey =
@@ -163,7 +167,7 @@ impl ValidatorMetadata {
             )),
         }?;
 
-        Ok(VerifiedValidatorMetadata {
+        Ok(VerifiedValidatorMetadataV1 {
             sui_address: self.sui_address,
             protocol_pubkey,
             network_pubkey,
@@ -189,7 +193,7 @@ impl ValidatorMetadata {
     }
 }
 
-impl ValidatorMetadata {
+impl ValidatorMetadataV1 {
     pub fn network_address(&self) -> Result<Multiaddr> {
         Multiaddr::try_from(self.net_address.clone()).map_err(Into::into)
     }
@@ -201,18 +205,20 @@ impl ValidatorMetadata {
 
 /// Rust version of the Move sui::validator::Validator type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
-pub struct Validator {
-    pub metadata: ValidatorMetadata,
+// TODO: Get rid of json schema once we deprecate getSuiSystemState RPC API.
+#[serde(rename = "Validator")]
+pub struct ValidatorV1 {
+    pub metadata: ValidatorMetadataV1,
     pub voting_power: u64,
     pub gas_price: u64,
-    pub staking_pool: StakingPool,
+    pub staking_pool: StakingPoolV1,
     pub commission_rate: u64,
     pub next_epoch_stake: u64,
     pub next_epoch_gas_price: u64,
     pub next_epoch_commission_rate: u64,
 }
 
-impl Validator {
+impl ValidatorV1 {
     pub fn to_stake_and_network_metadata(&self) -> (AuthorityName, StakeUnit, NetworkMetadata) {
         (
             // TODO: Make sure we are actually verifying this on-chain.
@@ -242,25 +248,11 @@ impl Validator {
     }
 }
 
-/// Rust version of the Move sui::staking_pool::PendingDelegationEntry type.
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
-pub struct PendingDelegationEntry {
-    pub delegator: SuiAddress,
-    pub sui_amount: u64,
-    pub staked_sui_id: ObjectID,
-}
-
-/// Rust version of the Move sui::staking_pool::PendingWithdrawEntry type.
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
-pub struct PendingWithdrawEntry {
-    delegator: SuiAddress,
-    principal_withdraw_amount: u64,
-    withdrawn_pool_tokens: Balance,
-}
-
 /// Rust version of the Move sui::staking_pool::StakingPool type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
-pub struct StakingPool {
+// TODO: Get rid of json schema once we deprecate getSuiSystemState RPC API.
+#[serde(rename = "StakingPool")]
+pub struct StakingPoolV1 {
     pub id: ObjectID,
     pub starting_epoch: u64,
     pub deactivation_epoch: MoveOption<u64>,
@@ -273,18 +265,13 @@ pub struct StakingPool {
     pub pending_pool_token_withdraw: u64,
 }
 
-/// Rust version of the Move sui::validator_set::ValidatorPair type
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
-pub struct ValidatorPair {
-    from: SuiAddress,
-    to: SuiAddress,
-}
-
 /// Rust version of the Move sui::validator_set::ValidatorSet type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
-pub struct ValidatorSet {
+// TODO: Get rid of json schema once we deprecate getSuiSystemState RPC API.
+#[serde(rename = "ValidatorSet")]
+pub struct ValidatorSetV1 {
     pub total_stake: u64,
-    pub active_validators: Vec<Validator>,
+    pub active_validators: Vec<ValidatorV1>,
     pub pending_validators: TableVec,
     pub pending_removals: Vec<u64>,
     pub staking_pool_mappings: Table,
@@ -297,19 +284,21 @@ pub struct ValidatorSet {
 pub struct SuiSystemStateInnerV1 {
     pub epoch: u64,
     pub protocol_version: u64,
-    pub validators: ValidatorSet,
+    pub validators: ValidatorSetV1,
     pub storage_fund: Balance,
-    pub parameters: SystemParameters,
+    pub parameters: SystemParametersV1,
     pub reference_gas_price: u64,
     pub validator_report_records: VecMap<SuiAddress, VecSet<SuiAddress>>,
-    pub stake_subsidy: StakeSubsidy,
+    pub stake_subsidy: StakeSubsidyV1,
     pub safe_mode: bool,
     pub epoch_start_timestamp_ms: u64,
     // TODO: Use getters instead of all pub.
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
-pub struct StakeSubsidy {
+// TODO: Get rid of json schema once we deprecate getSuiSystemState RPC API.
+#[serde(rename = "StakeSubsidy")]
+pub struct StakeSubsidyV1 {
     pub epoch_counter: u64,
     pub balance: Balance,
     pub current_epoch_amount: u64,
@@ -353,7 +342,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
         }
     }
 
-    fn get_validator_metadata_vec(&self) -> Vec<ValidatorMetadata> {
+    fn get_validator_metadata_vec(&self) -> Vec<ValidatorMetadataV1> {
         self.validators
             .active_validators
             .iter()
@@ -478,7 +467,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
 // The default implementation for tests
 impl Default for SuiSystemStateInnerV1 {
     fn default() -> Self {
-        let validator_set = ValidatorSet {
+        let validator_set = ValidatorSetV1 {
             total_stake: 2,
             active_validators: vec![],
             pending_validators: TableVec::default(),
@@ -491,14 +480,14 @@ impl Default for SuiSystemStateInnerV1 {
             protocol_version: ProtocolVersion::MIN.as_u64(),
             validators: validator_set,
             storage_fund: Balance::new(0),
-            parameters: SystemParameters {
+            parameters: SystemParametersV1 {
                 min_validator_stake: 1,
                 max_validator_candidate_count: 100,
                 governance_start_epoch: 0,
             },
             reference_gas_price: 1,
             validator_report_records: VecMap { contents: vec![] },
-            stake_subsidy: StakeSubsidy {
+            stake_subsidy: StakeSubsidyV1 {
                 epoch_counter: 0,
                 balance: Balance::new(0),
                 current_epoch_amount: 0,


### PR DESCRIPTION
For clarity
Also removed a few types from Rust, such as PendingDelegationEntry/Withdraw