### PR TITLE
[indexer] - store bcs bytes for object and packages instead of raw json

### DIFF
--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/down.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/down.sql
@@ -3,3 +3,4 @@ DROP TABLE IF EXISTS objects_history;
 
 DROP TYPE IF EXISTS owner_type;
 DROP TYPE IF EXISTS change_type;
+DROP TYPE IF EXISTS bcs_bytes;

--- a/crates/sui-indexer/migrations/2022-12-02-202249_packages/down.sql
+++ b/crates/sui-indexer/migrations/2022-12-02-202249_packages/down.sql
@@ -1,2 +1,1 @@
 DROP TABLE IF EXISTS packages;
-DROP TABLE IF EXISTS package_logs;

--- a/crates/sui-indexer/migrations/2022-12-02-202249_packages/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-02-202249_packages/up.sql
@@ -1,17 +1,12 @@
-CREATE TABLE packages (
-    id BIGSERIAL PRIMARY KEY,
-    package_id TEXT NOT NULL UNIQUE,
-    author TEXT NOT NULL,
+CREATE TABLE packages
+(
+    package_id address     NOT NULL,
+    version    BIGINT      NOT NULL,
+    author     address     NOT NULL,
     -- means the column cannot be null,
     -- the element in the array can still be null
-    module_names TEXT[] NOT NULL,
-    package_content TEXT NOT NULL
+    data       bcs_bytes[] NOT NULL,
+    CONSTRAINT packages_pk PRIMARY KEY (package_id, version)
 );
 
 CREATE INDEX packages_package_id ON packages (package_id);
-
-CREATE TABLE package_logs (
-    last_processed_id BIGINT PRIMARY KEY
-);
-
-INSERT INTO package_logs (last_processed_id) VALUES (0);

--- a/crates/sui-indexer/src/models/packages.rs
+++ b/crates/sui-indexer/src/models/packages.rs
@@ -6,37 +6,31 @@ use crate::schema::packages;
 
 use diesel::prelude::*;
 
-use sui_json_rpc_types::SuiMovePackage;
-use sui_types::base_types::{ObjectID, SuiAddress};
+use crate::models::objects::NamedBcsBytes;
+use sui_json_rpc_types::SuiRawMovePackage;
+use sui_types::base_types::SuiAddress;
 
 #[derive(Queryable, Insertable, Debug, Identifiable)]
-#[diesel(table_name = packages)]
+#[diesel(table_name = packages, primary_key(package_id, version))]
 pub struct Package {
-    pub id: Option<i64>,
     pub package_id: String,
+    pub version: i64,
     pub author: String,
-    pub module_names: Vec<String>,
-    pub package_content: String,
+    pub data: Vec<NamedBcsBytes>,
 }
 
 impl Package {
-    pub fn try_from(
-        id: ObjectID,
-        sender: SuiAddress,
-        package: &SuiMovePackage,
-    ) -> Result<Self, IndexerError> {
+    pub fn try_from(sender: SuiAddress, package: &SuiRawMovePackage) -> Result<Self, IndexerError> {
         Ok(Self {
-            id: None,
-            package_id: id.to_hex(),
+            package_id: package.id.to_string(),
+            version: package.version.value() as i64,
             author: sender.to_string(),
-            module_names: package.disassembled.keys().cloned().collect(),
-            // TODO: store raw package bytes instead when object refactoring is done.
-            package_content: serde_json::to_string(&package.disassembled).map_err(|err| {
-                IndexerError::InsertableParsingError(format!(
-                    "Failed converting package module map to JSON with error: {:?}",
-                    err
-                ))
-            })?,
+            data: package
+                .module_map
+                .clone()
+                .into_iter()
+                .map(|(k, v)| NamedBcsBytes(k, v))
+                .collect(),
         })
     }
 }

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -4,6 +4,10 @@
 
 pub mod sql_types {
     #[derive(diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "bcs_bytes"))]
+    pub struct BcsBytes;
+
+    #[derive(diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "object_status"))]
     pub struct ObjectStatus;
 
@@ -80,6 +84,7 @@ diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::OwnerType;
     use super::sql_types::ObjectStatus;
+    use super::sql_types::BcsBytes;
 
     objects (object_id) {
         epoch -> Int8,
@@ -93,6 +98,7 @@ diesel::table! {
         previous_transaction -> Varchar,
         object_type -> Varchar,
         object_status -> ObjectStatus,
+        bcs -> Array<Nullable<BcsBytes>>,
     }
 }
 
@@ -100,6 +106,7 @@ diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::OwnerType;
     use super::sql_types::ObjectStatus;
+    use super::sql_types::BcsBytes;
 
     objects_history (epoch, object_id, version) {
         epoch -> Int8,
@@ -113,6 +120,7 @@ diesel::table! {
         previous_transaction -> Varchar,
         object_type -> Varchar,
         object_status -> ObjectStatus,
+        bcs -> Array<Nullable<BcsBytes>>,
     }
 }
 
@@ -153,18 +161,14 @@ diesel::table! {
 }
 
 diesel::table! {
-    package_logs (last_processed_id) {
-        last_processed_id -> Int8,
-    }
-}
+    use diesel::sql_types::*;
+    use super::sql_types::BcsBytes;
 
-diesel::table! {
-    packages (id) {
-        id -> Int8,
-        package_id -> Text,
-        author -> Text,
-        module_names -> Array<Nullable<Text>>,
-        package_content -> Text,
+    packages (package_id, version) {
+        package_id -> Varchar,
+        version -> Int8,
+        author -> Varchar,
+        data -> Array<Nullable<BcsBytes>>,
     }
 }
 
@@ -218,7 +222,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     objects_history,
     owner,
     owner_history,
-    package_logs,
     packages,
     recipients,
     transactions,

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -740,6 +740,7 @@ impl SuiRawMoveObject {
 #[serde(rename = "RawMovePackage", rename_all = "camelCase")]
 pub struct SuiRawMovePackage {
     pub id: ObjectID,
+    pub version: SequenceNumber,
     #[schemars(with = "BTreeMap<String, Base64>")]
     #[serde_as(as = "BTreeMap<_, Base64>")]
     pub module_map: BTreeMap<String, Vec<u8>>,
@@ -749,6 +750,7 @@ impl From<MovePackage> for SuiRawMovePackage {
     fn from(p: MovePackage) -> Self {
         Self {
             id: p.id(),
+            version: p.version(),
             module_map: p.serialized_module_map().clone(),
         }
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5342,7 +5342,8 @@
             "required": [
               "dataType",
               "id",
-              "moduleMap"
+              "moduleMap",
+              "version"
             ],
             "properties": {
               "dataType": {
@@ -5359,6 +5360,9 @@
                 "additionalProperties": {
                   "$ref": "#/components/schemas/Base64"
                 }
+              },
+              "version": {
+                "$ref": "#/components/schemas/SequenceNumber"
               }
             }
           }


### PR DESCRIPTION
## Description 

store bcs bytes for object and packages instead of raw json

## Test Plan 

Manual tested locally confirming object bytes is written into the database
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/1888654/223546975-0a141213-2317-49a7-94ee-f32e5b8e0fda.png">
