### PR TITLE
[Consensus] do not remove certificates from DAG until GC 

### DIFF
--- a/narwhal/consensus/src/lib.rs
+++ b/narwhal/consensus/src/lib.rs
@@ -43,8 +43,7 @@ pub enum ConsensusError {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Outcome {
-    // Certificate has not been inserted to DAG since it's bellow the latest commit round
-    // for this authority.
+    // Certificate is not processed, since it's below the latest committed round for its origin.
     CertificateBelowCommitRound,
 
     // Certificate processed is of an even round, so the previous one is an odd round and

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -219,8 +219,9 @@ mod tests {
         // -- support level 1 (for L4)
         // -- support level 2 (for L4)
         //
-        let n = state.dag.len();
-        assert!(n <= 6, "DAG size: {}", n);
+        let n = state.last_committed.values().max().unwrap()
+            - state.last_committed.values().min().unwrap();
+        assert!(n <= 6, "Uncommitted depth: {}", n);
     }
 
     #[tokio::test]
@@ -255,7 +256,8 @@ mod tests {
         }
 
         // with "less optimal" certificates (see `make_certificates`), we should keep at most gc_depth rounds lookbehind
-        let n = state.dag.len();
-        assert!(n <= gc_depth as usize, "DAG size: {}", n);
+        let n = state.last_committed.values().max().unwrap()
+            - state.last_committed.values().min().unwrap();
+        assert!(n <= gc_depth, "DAG size: {}", n);
     }
 }


### PR DESCRIPTION
## Description 

Avoid adding certificate without parent into the DAG, and panic if it happens. This helps to detect issues when certificates are not sent to consensus in causal order.

## Test Plan 

existing simtests and unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
