### PR TITLE
Support for override buffer stake to allow upgrades with as little as 2f+1 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9408,6 +9408,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "prometheus",
  "reqwest",
+ "serde 1.0.152",
  "sui-config",
  "sui-core",
  "sui-json-rpc",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -24,7 +24,7 @@ use prometheus::{
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use tap::TapFallible;
+use tap::{TapFallible, TapOptional};
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::oneshot;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
@@ -47,7 +47,7 @@ use sui_json_rpc_types::{
     SuiObjectDataFilter, SuiTransactionEvents,
 };
 use sui_macros::{fail_point, nondeterministic};
-use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
+use sui_protocol_config::SupportedProtocolVersions;
 use sui_storage::indexes::{ObjectIndexChanges, MAX_GET_OWNED_OBJECT_SIZE};
 use sui_storage::write_ahead_log::WriteAheadLog;
 use sui_storage::{
@@ -2839,6 +2839,24 @@ impl AuthorityState {
         self.database.get_latest_parent_entry(object_id)
     }
 
+    /// Ordinarily, protocol upgrades occur when 2f + 1 + (f *
+    /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps) vote for the upgrade.
+    ///
+    /// This method can be used to dynamic adjust the amount of buffer. If set to 0, the upgrade
+    /// will go through with only 2f+1 votes.
+    ///
+    /// IMPORTANT: If this is used, it must be used on >=2f+1 validators (all should have the same
+    /// value), or you risk halting the chain.
+    pub fn set_override_protocol_upgrade_buffer_stake(&self, buffer_stake_bps: u64) -> SuiResult {
+        let epoch_store = self.load_epoch_store_one_call_per_task();
+        epoch_store.set_override_protocol_upgrade_buffer_stake(buffer_stake_bps)
+    }
+
+    pub fn clear_override_protocol_upgrade_buffer_stake(&self) -> SuiResult {
+        let epoch_store = self.load_epoch_store_one_call_per_task();
+        epoch_store.clear_override_protocol_upgrade_buffer_stake()
+    }
+
     /// Get the set of system packages that are compiled in to this build, if those packages are
     /// compatible with the current versions of those packages on-chain.
     pub async fn get_available_system_packages(&self) -> Vec<ObjectRef> {
@@ -3008,10 +3026,15 @@ impl AuthorityState {
     fn choose_protocol_version_and_system_packages(
         current_protocol_version: ProtocolVersion,
         committee: &Committee,
-        protocol_config: &ProtocolConfig,
         capabilities: Vec<AuthorityCapabilities>,
+        mut buffer_stake_bps: u64,
     ) -> (ProtocolVersion, Vec<ObjectRef>) {
         let next_protocol_version = current_protocol_version + 1;
+
+        if buffer_stake_bps > 10000 {
+            warn!("clamping buffer_stake_bps to 10000");
+            buffer_stake_bps = 10000;
+        }
 
         // For each validator, gather the protocol version and system packages that it would like
         // to upgrade to in the next epoch.
@@ -3061,15 +3084,15 @@ impl AuthorityState {
                 let total_votes = stake_aggregator.total_votes();
                 let quorum_threshold = committee.quorum_threshold();
                 let f = committee.total_votes - committee.quorum_threshold();
-                let buffer_bps = protocol_config.buffer_stake_for_protocol_upgrade_bps();
-                // multiple by buffer_bps / 10000, rounded up.
-                let buffer_stake = (f * buffer_bps + 9999) / 10000;
+
+                // multiple by buffer_stake_bps / 10000, rounded up.
+                let buffer_stake = (f * buffer_stake_bps + 9999) / 10000;
                 let effective_threshold = quorum_threshold + buffer_stake;
 
                 info!(
                     ?total_votes,
                     ?quorum_threshold,
-                    ?buffer_bps,
+                    ?buffer_stake_bps,
                     ?effective_threshold,
                     ?next_protocol_version,
                     ?packages,
@@ -3102,12 +3125,21 @@ impl AuthorityState {
     ) -> anyhow::Result<(SuiSystemState, TransactionEffects)> {
         let next_epoch = epoch_store.epoch() + 1;
 
+        let buffer_stake_bps = epoch_store
+            .get_override_protocol_upgrade_buffer_stake()
+            .tap_some(|b| warn!("using overrided buffer stake value of {}", b))
+            .unwrap_or_else(|| {
+                epoch_store
+                    .protocol_config()
+                    .buffer_stake_for_protocol_upgrade_bps()
+            });
+
         let (next_epoch_protocol_version, next_epoch_system_packages) =
             Self::choose_protocol_version_and_system_packages(
                 epoch_store.protocol_version(),
                 epoch_store.committee(),
-                epoch_store.protocol_config(),
                 epoch_store.get_capabilities(),
+                buffer_stake_bps,
             );
 
         let Some(next_epoch_system_package_bytes) = self.get_system_package_bytes(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2847,13 +2847,36 @@ impl AuthorityState {
     ///
     /// IMPORTANT: If this is used, it must be used on >=2f+1 validators (all should have the same
     /// value), or you risk halting the chain.
-    pub fn set_override_protocol_upgrade_buffer_stake(&self, buffer_stake_bps: u64) -> SuiResult {
+    pub fn set_override_protocol_upgrade_buffer_stake(
+        &self,
+        expected_epoch: EpochId,
+        buffer_stake_bps: u64,
+    ) -> SuiResult {
         let epoch_store = self.load_epoch_store_one_call_per_task();
+        let actual_epoch = epoch_store.epoch();
+        if actual_epoch != expected_epoch {
+            return Err(SuiError::WrongEpoch {
+                expected_epoch,
+                actual_epoch,
+            });
+        }
+
         epoch_store.set_override_protocol_upgrade_buffer_stake(buffer_stake_bps)
     }
 
-    pub fn clear_override_protocol_upgrade_buffer_stake(&self) -> SuiResult {
+    pub fn clear_override_protocol_upgrade_buffer_stake(
+        &self,
+        expected_epoch: EpochId,
+    ) -> SuiResult {
         let epoch_store = self.load_epoch_store_one_call_per_task();
+        let actual_epoch = epoch_store.epoch();
+        if actual_epoch != expected_epoch {
+            return Err(SuiError::WrongEpoch {
+                expected_epoch,
+                actual_epoch,
+            });
+        }
+
         epoch_store.clear_override_protocol_upgrade_buffer_stake()
     }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::{debug, info, trace};
 
+use sui_protocol_config::ProtocolConfig;
 use sui_storage::mutex_table::{MutexGuard, MutexTable, RwLockGuard, RwLockTable};
 use sui_types::accumulator::Accumulator;
 use sui_types::digests::TransactionEventsDigest;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4985,8 +4985,8 @@ fn test_choose_next_system_packages() {
         AuthorityState::choose_protocol_version_and_system_packages(
             ProtocolVersion::MIN,
             &committee,
-            &protocol_config,
-            capabilities
+            capabilities,
+            protocol_config.buffer_stake_for_protocol_upgrade_bps(),
         )
     );
 
@@ -5003,8 +5003,8 @@ fn test_choose_next_system_packages() {
         AuthorityState::choose_protocol_version_and_system_packages(
             ProtocolVersion::MIN,
             &committee,
-            &protocol_config,
             capabilities.clone(),
+            protocol_config.buffer_stake_for_protocol_upgrade_bps(),
         )
     );
 
@@ -5016,8 +5016,8 @@ fn test_choose_next_system_packages() {
         AuthorityState::choose_protocol_version_and_system_packages(
             ProtocolVersion::MIN,
             &committee,
-            &protocol_config,
-            capabilities
+            capabilities,
+            protocol_config.buffer_stake_for_protocol_upgrade_bps(),
         )
     );
 
@@ -5034,8 +5034,8 @@ fn test_choose_next_system_packages() {
         AuthorityState::choose_protocol_version_and_system_packages(
             ProtocolVersion::MIN,
             &committee,
-            &protocol_config,
             capabilities,
+            protocol_config.buffer_stake_for_protocol_upgrade_bps(),
         )
     );
 
@@ -5052,8 +5052,8 @@ fn test_choose_next_system_packages() {
         AuthorityState::choose_protocol_version_and_system_packages(
             ProtocolVersion::MIN,
             &committee,
-            &protocol_config,
-            capabilities
+            capabilities,
+            protocol_config.buffer_stake_for_protocol_upgrade_bps(),
         )
     );
 
@@ -5070,8 +5070,8 @@ fn test_choose_next_system_packages() {
         AuthorityState::choose_protocol_version_and_system_packages(
             ProtocolVersion::MIN,
             &committee,
-            &protocol_config,
-            capabilities
+            capabilities,
+            protocol_config.buffer_stake_for_protocol_upgrade_bps(),
         )
     );
 
@@ -5088,8 +5088,8 @@ fn test_choose_next_system_packages() {
         AuthorityState::choose_protocol_version_and_system_packages(
             ProtocolVersion::MIN,
             &committee,
-            &protocol_config,
-            capabilities
+            capabilities,
+            protocol_config.buffer_stake_for_protocol_upgrade_bps(),
         )
     );
 }

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -25,6 +25,7 @@ git-version = "0.3.5"
 const-str = "0.5.3"
 reqwest = { version = "0.11.13", default_features= false, features = ["blocking", "json", "rustls-tls"] }
 tap = "1.0.1"
+serde = { version = "1.0.144", features = ["derive"] }
 
 sui-tls = { path = "../sui-tls" }
 sui-config = { path = "../sui-config" }

--- a/crates/sui-node/src/admin.rs
+++ b/crates/sui-node/src/admin.rs
@@ -1,26 +1,48 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::SuiNode;
 use axum::{
-    extract::Extension,
+    extract::State,
     http::StatusCode,
     routing::{get, post},
     Router,
 };
 use mysten_metrics::spawn_monitored_task;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
 use telemetry_subscribers::FilterHandle;
 use tracing::info;
 
 const LOGGING_ROUTE: &str = "/logging";
+const SET_BUFFER_STAKE_ROUTE: &str = "/set-override-buffer-stake";
+const CLEAR_BUFFER_STAKE_ROUTE: &str = "/clear-override-buffer-stake";
 
-pub fn start_admin_server(port: u16, filter_handle: FilterHandle) {
+struct AppState {
+    node: Arc<SuiNode>,
+    filter_handle: FilterHandle,
+}
+
+pub fn start_admin_server(node: Arc<SuiNode>, port: u16, filter_handle: FilterHandle) {
     let filter = filter_handle.get().unwrap();
+
+    let app_state = AppState {
+        node,
+        filter_handle,
+    };
 
     let app = Router::new()
         .route(LOGGING_ROUTE, get(get_filter))
         .route(LOGGING_ROUTE, post(set_filter))
-        .layer(Extension(filter_handle));
+        .route(
+            SET_BUFFER_STAKE_ROUTE,
+            post(set_override_protocol_upgrade_buffer_stake),
+        )
+        .route(
+            CLEAR_BUFFER_STAKE_ROUTE,
+            post(clear_override_protocol_upgrade_buffer_stake),
+        )
+        .with_state(Arc::new(app_state));
 
     let socket_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
     info!(
@@ -37,22 +59,58 @@ pub fn start_admin_server(port: u16, filter_handle: FilterHandle) {
     });
 }
 
-async fn get_filter(Extension(filter_handle): Extension<FilterHandle>) -> (StatusCode, String) {
-    match filter_handle.get() {
+async fn get_filter(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
+    match state.filter_handle.get() {
         Ok(filter) => (StatusCode::OK, filter),
         Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
     }
 }
 
 async fn set_filter(
-    Extension(filter_handle): Extension<FilterHandle>,
+    State(state): State<Arc<AppState>>,
     new_filter: String,
 ) -> (StatusCode, String) {
-    match filter_handle.update(&new_filter) {
+    match state.filter_handle.update(&new_filter) {
         Ok(()) => {
             info!(filter =% new_filter, "Log filter updated");
             (StatusCode::OK, "".into())
         }
         Err(err) => (StatusCode::BAD_REQUEST, err.to_string()),
+    }
+}
+
+async fn clear_override_protocol_upgrade_buffer_stake(
+    State(state): State<Arc<AppState>>,
+    _body: String,
+) -> (StatusCode, String) {
+    match state.node.clear_override_protocol_upgrade_buffer_stake() {
+        Ok(()) => (
+            StatusCode::OK,
+            "protocol upgrade buffer stake cleared".to_string(),
+        ),
+        Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+    }
+}
+
+async fn set_override_protocol_upgrade_buffer_stake(
+    State(state): State<Arc<AppState>>,
+    buffer_bps: String,
+) -> (StatusCode, String) {
+    let Ok(buffer_bps) = buffer_bps.parse::<u64>() else {
+        return (
+            StatusCode::BAD_REQUEST,
+            "argument must be a positive integer".to_string(),
+        );
+    };
+
+    match state
+        .node
+        .set_override_protocol_upgrade_buffer_stake(buffer_bps)
+    {
+        Ok(()) => (
+            StatusCode::OK,
+            format!("protocol upgrade buffer stake set to '{}'", buffer_bps),
+        ),
+        Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
     }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -437,13 +437,18 @@ impl SuiNode {
         Ok(())
     }
 
-    pub fn clear_override_protocol_upgrade_buffer_stake(&self) -> SuiResult {
-        self.state.clear_override_protocol_upgrade_buffer_stake()
+    pub fn clear_override_protocol_upgrade_buffer_stake(&self, epoch: EpochId) -> SuiResult {
+        self.state
+            .clear_override_protocol_upgrade_buffer_stake(epoch)
     }
 
-    pub fn set_override_protocol_upgrade_buffer_stake(&self, buffer_stake_bps: u64) -> SuiResult {
+    pub fn set_override_protocol_upgrade_buffer_stake(
+        &self,
+        epoch: EpochId,
+        buffer_stake_bps: u64,
+    ) -> SuiResult {
         self.state
-            .set_override_protocol_upgrade_buffer_stake(buffer_stake_bps)
+            .set_override_protocol_upgrade_buffer_stake(epoch, buffer_stake_bps)
     }
 
     // Testing-only API to start epoch close process.

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -423,6 +423,15 @@ impl SuiNode {
         Ok(())
     }
 
+    pub fn clear_override_protocol_upgrade_buffer_stake(&self) -> SuiResult {
+        self.state.clear_override_protocol_upgrade_buffer_stake()
+    }
+
+    pub fn set_override_protocol_upgrade_buffer_stake(&self, buffer_stake_bps: u64) -> SuiResult {
+        self.state
+            .set_override_protocol_upgrade_buffer_stake(buffer_stake_bps)
+    }
+
     // Testing-only API to start epoch close process.
     // For production code, please use the non-testing version.
     pub async fn close_epoch_for_testing(&self) -> SuiResult {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -209,6 +209,20 @@ impl SuiNode {
             batch_verifier_metrics,
         );
 
+        if let Some(override_buffer_stake) =
+            epoch_store.get_override_protocol_upgrade_buffer_stake()
+        {
+            let default_buffer_stake = epoch_store
+                .protocol_config()
+                .buffer_stake_for_protocol_upgrade_bps();
+
+            warn!(
+                ?override_buffer_stake,
+                ?default_buffer_stake,
+                "buffer_stake_for_protocol_upgrade_bps is currently overridden"
+            );
+        }
+
         let checkpoint_store = CheckpointStore::new(&config.db_path().join("checkpoints"));
         checkpoint_store.insert_genesis_checkpoint(
             genesis.checkpoint(),

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -94,9 +94,9 @@ async fn main() -> Result<()> {
         }
     });
 
-    sui_node::admin::start_admin_server(config.admin_interface_port, filter_handle);
+    let node = sui_node::SuiNode::start(&config, registry_service).await?;
+    sui_node::admin::start_admin_server(node.clone(), config.admin_interface_port, filter_handle);
 
-    let _node = sui_node::SuiNode::start(&config, registry_service).await?;
     // TODO: Do we want to provide a way for the node to gracefully shutdown?
     loop {
         tokio::time::sleep(Duration::from_secs(1000)).await;

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -251,7 +251,10 @@ mod sim_only_tests {
 
         test_cluster.swarm.validators().for_each(|v| {
             let node_handle = v.get_node_handle().expect("node should be running");
-            node_handle.with(|node| node.set_override_protocol_upgrade_buffer_stake(0).unwrap());
+            node_handle.with(|node| {
+                node.set_override_protocol_upgrade_buffer_stake(0, 0)
+                    .unwrap()
+            });
         });
 
         // Verify that clearing the override is respected.

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -224,7 +224,10 @@ mod sim_only_tests {
 
         test_cluster.swarm.validators().for_each(|v| {
             let node_handle = v.get_node_handle().expect("node should be running");
-            node_handle.with(|node| node.set_override_protocol_upgrade_buffer_stake(0).unwrap());
+            node_handle.with(|node| {
+                node.set_override_protocol_upgrade_buffer_stake(0, 0)
+                    .unwrap()
+            });
         });
 
         // upgrade happens with only 3 votes
@@ -260,7 +263,10 @@ mod sim_only_tests {
         // Verify that clearing the override is respected.
         test_cluster.swarm.validators().for_each(|v| {
             let node_handle = v.get_node_handle().expect("node should be running");
-            node_handle.with(|node| node.clear_override_protocol_upgrade_buffer_stake().unwrap());
+            node_handle.with(|node| {
+                node.clear_override_protocol_upgrade_buffer_stake(0)
+                    .unwrap()
+            });
         });
 
         // default buffer stake is in effect, we do not advance to version 2.

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -205,7 +205,72 @@ mod sim_only_tests {
     }
 
     #[sim_test]
+    async fn test_protocol_version_upgrade_forced() {
+        ProtocolConfig::poison_get_for_min_version();
+
+        let test_cluster = TestClusterBuilder::new()
+            .with_epoch_duration_ms(20000)
+            .with_supported_protocol_version_callback(Arc::new(|idx, name| {
+                if name.is_some() && idx == 0 {
+                    // first validator only does not support version 2.
+                    SupportedProtocolVersions::new_for_testing(1, 1)
+                } else {
+                    SupportedProtocolVersions::new_for_testing(1, 2)
+                }
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        test_cluster.swarm.validators().for_each(|v| {
+            let node_handle = v.get_node_handle().expect("node should be running");
+            node_handle.with(|node| node.set_override_protocol_upgrade_buffer_stake(0).unwrap());
+        });
+
+        // upgrade happens with only 3 votes
+        monitor_version_change(&test_cluster, 2 /* expected proto version */).await;
+    }
+
+    #[sim_test]
+    async fn test_protocol_version_upgrade_no_override_cleared() {
+        ProtocolConfig::poison_get_for_min_version();
+
+        let test_cluster = TestClusterBuilder::new()
+            .with_epoch_duration_ms(20000)
+            .with_supported_protocol_version_callback(Arc::new(|idx, name| {
+                if name.is_some() && idx == 0 {
+                    // first validator only does not support version 2.
+                    SupportedProtocolVersions::new_for_testing(1, 1)
+                } else {
+                    SupportedProtocolVersions::new_for_testing(1, 2)
+                }
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        test_cluster.swarm.validators().for_each(|v| {
+            let node_handle = v.get_node_handle().expect("node should be running");
+            node_handle.with(|node| node.set_override_protocol_upgrade_buffer_stake(0).unwrap());
+        });
+
+        // Verify that clearing the override is respected.
+        test_cluster.swarm.validators().for_each(|v| {
+            let node_handle = v.get_node_handle().expect("node should be running");
+            node_handle.with(|node| node.clear_override_protocol_upgrade_buffer_stake().unwrap());
+        });
+
+        // default buffer stake is in effect, we do not advance to version 2.
+        monitor_version_change(&test_cluster, 1 /* expected proto version */).await;
+    }
+
+    #[sim_test]
     async fn test_protocol_version_upgrade_no_quorum() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_buffer_stake_for_protocol_upgrade_bps_for_testing(0);
+            config
+        });
+
         ProtocolConfig::poison_get_for_min_version();
 
         let test_cluster = TestClusterBuilder::new()


### PR DESCRIPTION
This also adds support for calling close_epoch() via admin server