### PR TITLE
[programmable transactions] Add support for publishing `UpgradeCap` during transactional tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/publish/publish_with_upgrade.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/publish_with_upgrade.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 1 'publish'. lines 6-10:
+created: object(104), object(105)
+written: object(103)
+
+task 2 'view-object'. lines 12-12:
+Owner: Account Address ( _ )
+Version: 2
+Contents: sui::package::UpgradeCap {id: sui::object::UID {id: sui::object::ID {bytes: fake(105)}}, package: sui::object::ID {bytes: Test}, version: 1u64, policy: 0u8}

--- a/crates/sui-adapter-transactional-tests/tests/publish/publish_with_upgrade.move
+++ b/crates/sui-adapter-transactional-tests/tests/publish/publish_with_upgrade.move
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0
+
+//# publish --upgradeable
+module Test::M1 {
+    use sui::tx_context::TxContext;
+    fun init(_ctx: &mut TxContext) { }
+}
+
+//# view-object 105

--- a/crates/sui-adapter-transactional-tests/tests/shared/upgrade.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/upgrade.move
@@ -5,7 +5,7 @@
 
 //# init --addresses t=0x0 --accounts A
 
-//# publish
+//# publish --sender A
 
 module t::m {
     use sui::object::{Self, UID};

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -336,7 +336,7 @@ where
     pub fn new_package(
         &mut self,
         modules: Vec<move_binary_format::CompiledModule>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<ObjectID, ExecutionError> {
         // wrap the modules in an object, write it to the store
         let package_object = Object::new_package(
             modules,
@@ -344,8 +344,9 @@ where
             self.tx_context.digest(),
             self.protocol_config.max_move_package_size(),
         )?;
+        let id = package_object.id();
         self.new_packages.push(package_object);
-        Ok(())
+        Ok(id)
     }
 
     /// Finish a command: clearing the borrows and adding the results to the result vector

--- a/crates/sui-framework/docs/package.md
+++ b/crates/sui-framework/docs/package.md
@@ -236,7 +236,7 @@ Add new functions or types, or change dependencies, existing
 functions can't change.
 
 
-<pre><code><b>const</b> <a href="package.md#0x2_package_ADDITIVE">ADDITIVE</a>: u8 = 1;
+<pre><code><b>const</b> <a href="package.md#0x2_package_ADDITIVE">ADDITIVE</a>: u8 = 128;
 </code></pre>
 
 
@@ -257,7 +257,7 @@ functions or types, change dependencies)
 Only be able to change dependencies.
 
 
-<pre><code><b>const</b> <a href="package.md#0x2_package_DEP_ONLY">DEP_ONLY</a>: u8 = 2;
+<pre><code><b>const</b> <a href="package.md#0x2_package_DEP_ONLY">DEP_ONLY</a>: u8 = 192;
 </code></pre>
 
 

--- a/crates/sui-framework/sources/package.move
+++ b/crates/sui-framework/sources/package.move
@@ -28,9 +28,9 @@ module sui::package {
     const COMPATIBLE: u8 = 0;
     /// Add new functions or types, or change dependencies, existing
     /// functions can't change.
-    const ADDITIVE: u8 = 1;
+    const ADDITIVE: u8 = 128;
     /// Only be able to change dependencies.
-    const DEP_ONLY: u8 = 2;
+    const DEP_ONLY: u8 = 192;
 
     /// This type can only be created in the transaction that
     /// generates a module, by consuming its one-time witness, so it

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -27,6 +27,8 @@ pub struct SuiRunArgs {
 pub struct SuiPublishArgs {
     #[clap(long = "sender")]
     pub sender: Option<String>,
+    #[clap(long = "upgradeable", action = clap::ArgAction::SetTrue)]
+    pub upgradeable: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -300,7 +300,10 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         gas_budget: Option<u64>,
         extra: Self::ExtraPublishArgs,
     ) -> anyhow::Result<(Option<String>, CompiledModule)> {
-        let SuiPublishArgs { sender } = extra;
+        let SuiPublishArgs {
+            sender,
+            upgradeable,
+        } = extra;
         let module_name = module.self_id().name().to_string();
         let module_bytes = {
             let mut buf = vec![];
@@ -310,7 +313,16 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let gas_budget = gas_budget.unwrap_or(GAS_VALUE_FOR_TESTING);
         let data = |sender, gas| {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder.publish(vec![module_bytes]);
+            if upgradeable {
+                builder.publish_and_handle_capability_with(vec![module_bytes], |builder, cap| {
+                    // TODO(tzakian): Don't use `sender` here but use `Argument::Sender` once that
+                    // is added.
+                    let receiver_arg = builder.pure(sender).unwrap();
+                    sui_types::messages::Command::TransferObjects(vec![cap], receiver_arg)
+                });
+            } else {
+                builder.publish(vec![module_bytes]);
+            };
             let pt = builder.finish();
             TransactionData::new_programmable_with_dummy_gas_price(sender, gas, pt, gas_budget)
         };

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -43,7 +43,6 @@ use sui_types::epoch_data::EpochData;
 use sui_types::gas::SuiCostTable;
 use sui_types::id::UID;
 use sui_types::in_memory_storage::InMemoryStorage;
-use sui_types::messages::Command;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -311,7 +311,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let gas_budget = gas_budget.unwrap_or(GAS_VALUE_FOR_TESTING);
         let data = |sender, gas| {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder.command(Command::Publish(vec![module_bytes]));
+            builder.publish(vec![module_bytes]);
             let pt = builder.finish();
             TransactionData::new_programmable_with_dummy_gas_price(sender, gas, pt, gas_budget)
         };

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -16,6 +16,7 @@ use crate::{
         ProgrammableMoveCall, ProgrammableTransaction, SingleTransactionKind, TransactionData,
         TransactionDataAPI, TransactionKind, TransferObject, TransferSui,
     },
+    move_package::PACKAGE_MODULE_NAME,
     SUI_FRAMEWORK_OBJECT_ID,
 };
 
@@ -172,7 +173,7 @@ impl ProgrammableTransactionBuilder {
         self.commands
             .push(Command::MoveCall(Box::new(ProgrammableMoveCall {
                 package: SUI_FRAMEWORK_OBJECT_ID,
-                module: ident_str!("package").to_owned(),
+                module: PACKAGE_MODULE_NAME.to_owned(),
                 function: ident_str!("make_immutable").to_owned(),
                 type_arguments: vec![],
                 arguments: vec![cap],


### PR DESCRIPTION
This adds the `--upgradeable` flag to transaction tests that, when present, will transfer the returned `UpgradeCap` that is returned from publishing a package to the sender of the transaction.

This adds a new entrypoinp `ProgrammableTransaction::publish_and_handle_capability_with` to support this -- you can pass a capability handler which given a capability will return a command (and may perhaps add more commands) that will be  placed immediately after the publish command.

This PR is stacked on #8825 

## Testing

Added a new transactional test with the `--upgradeable` flag that makes sure the `UpgradeCap` is published under the sender of the transaction.