### PR TITLE
[ts-sdk] Rewrite more SDK usage onto programmable tx

### DIFF
--- a/apps/explorer/src/components/ownedobjects/views/OwnedCoinView.tsx
+++ b/apps/explorer/src/components/ownedobjects/views/OwnedCoinView.tsx
@@ -63,10 +63,7 @@ function SingleCoinView({
     const totalBalance =
         subObjList[0]._isCoin &&
         subObjList.every((el) => el.balance !== undefined)
-            ? subObjList.reduce(
-                  (prev, current) => prev + current.balance!,
-                  Coin.getZero()
-              )
+            ? subObjList.reduce((prev, current) => prev + current.balance!, 0n)
             : null;
 
     const extractedCoinType = Coin.getCoinType(coinType);

--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -230,22 +230,6 @@ export class Transaction {
       throw new Error('Missing gas budget');
     }
 
-    if (!this.#transactionData.gasConfig.payment) {
-      const coins = await expectProvider(provider).getCoins(
-        this.#transactionData.sender,
-        SUI_TYPE_ARG,
-        null,
-        null,
-      );
-
-      // TODO: Pick coins better, this is just a temporary hack.
-      this.#transactionData.gasConfig.payment = coins.data.map((coin) => ({
-        objectId: coin.coinObjectId,
-        digest: coin.digest,
-        version: coin.version,
-      }));
-    }
-
     if (!this.#transactionData.gasConfig.price) {
       this.#transactionData.gasConfig.price = String(
         await expectProvider(provider).getReferenceGasPrice(),
@@ -424,6 +408,46 @@ export class Transaction {
           input.value = Inputs.ObjectRef(getObjectReference(object)!);
         }
       });
+    }
+
+    if (!this.#transactionData.gasConfig.payment) {
+      const coins = await expectProvider(provider).getCoins(
+        this.#transactionData.sender,
+        SUI_TYPE_ARG,
+        null,
+        null,
+      );
+
+      // TODO: Allow consumers to define coin selection logic, and refine the default behavior.
+      // The current default is just picking _all_ coins which may not be ideal.
+      this.#transactionData.gasConfig.payment = coins.data
+        // Filter out coins that are also used as input:
+        .filter((coin) => {
+          const matchingInput = this.#transactionData.inputs.find((input) => {
+            if (
+              is(input.value, BuilderCallArg) &&
+              'Object' in input.value &&
+              'ImmOrOwned' in input.value.Object
+            ) {
+              return (
+                coin.coinObjectId === input.value.Object.ImmOrOwned.objectId
+              );
+            }
+
+            return false;
+          });
+
+          return !matchingInput;
+        })
+        .map((coin) => ({
+          objectId: coin.coinObjectId,
+          digest: coin.digest,
+          version: coin.version,
+        }));
+
+      if (!this.#transactionData.gasConfig.payment.length) {
+        throw new Error('No valid gas coins found for the transaction.');
+      }
     }
 
     return this.#transactionData.build({ size });

--- a/sdk/typescript/src/framework/framework.ts
+++ b/sdk/typescript/src/framework/framework.ts
@@ -109,25 +109,6 @@ export class Coin {
   }
 
   /**
-   * Convenience method for select an arbitrary coin object that has a balance greater than or
-   * equal to `amount`
-   *
-   * @param amount coin balance
-   * @param exclude object ids of the coins to exclude
-   * @return an arbitrary coin with balance greater than or equal to `amount
-   */
-  static selectCoinWithBalanceGreaterThanOrEqual(
-    coins: CoinStruct[],
-    amount: bigint,
-    exclude: ObjectId[] = [],
-  ): CoinStruct | undefined {
-    return coins.find(
-      ({ coinObjectId, balance }) =>
-        !exclude.includes(coinObjectId) && BigInt(balance) >= amount,
-    );
-  }
-
-  /**
    * Convenience method for select a minimal set of coin objects that has a balance greater than
    * or equal to `amount`. The output can be used for `PayTransaction`
    *
@@ -204,10 +185,6 @@ export class Coin {
     }
     const balance = getObjectFields(data)?.balance;
     return BigInt(balance);
-  }
-
-  static getZero(): bigint {
-    return BigInt(0);
   }
 
   private static getType(data: ObjectData): string | undefined {

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -428,13 +428,6 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async getGasObjectsOwnedByAddress(
-    address: SuiAddress,
-  ): Promise<SuiObjectInfo[]> {
-    const objects = await this.getObjectsOwnedByAddress(address);
-    return objects.filter((obj: SuiObjectInfo) => Coin.isSUI(obj));
-  }
-
   async selectCoinsWithBalanceGreaterThanOrEqual(
     address: SuiAddress,
     amount: bigint,

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -150,13 +150,6 @@ export abstract class Provider {
   ): Promise<SuiObjectInfo[]>;
 
   /**
-   * Convenience method for getting all gas objects(SUI Tokens) owned by an address
-   */
-  abstract getGasObjectsOwnedByAddress(
-    _address: string,
-  ): Promise<SuiObjectInfo[]>;
-
-  /**
    * Convenience method for select coin objects that has a balance greater than or equal to `amount`
    *
    * @param amount coin balance

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -137,12 +137,6 @@ export class VoidProvider extends Provider {
     throw this.newError('getObjectsOwnedByAddress');
   }
 
-  async getGasObjectsOwnedByAddress(
-    _address: string,
-  ): Promise<SuiObjectInfo[]> {
-    throw this.newError('getGasObjectsOwnedByAddress');
-  }
-
   async selectCoinsWithBalanceGreaterThanOrEqual(
     _address: string,
     _amount: bigint,

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -26,9 +26,7 @@ describe('Coin related API', () => {
   beforeAll(async () => {
     toolbox = await setup();
     signer = new RawSigner(toolbox.keypair, toolbox.provider);
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     coinToSplit = coins[0].objectId;
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
@@ -40,15 +38,11 @@ describe('Coin related API', () => {
 
     // split coins into desired amount
     await signer.signAndExecuteTransaction(tx);
-    coinsAfterSplit = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    coinsAfterSplit = await toolbox.getGasObjectsOwnedByAddress();
   });
 
   it('test Coin utility functions', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     coins.forEach((c) => {
       expect(Coin.isCoin(c)).toBeTruthy();
       expect(Coin.isSUI(c)).toBeTruthy();
@@ -62,9 +56,7 @@ describe('Coin related API', () => {
       name: 'SUI',
       typeParams: [],
     };
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     const coinTypeArg: string = Coin.getCoinTypeArg(coins[0])!;
     expect(Coin.getCoinStructTag(coinTypeArg)).toStrictEqual(exampleStructTag);
   });

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -66,9 +66,7 @@ describe('Test dev inspect', () => {
   });
 
   it('Move Call that returns struct', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     const moveCall = {
       packageObjectId: packageId,
       module: 'serializer_tests',

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { getExecutionStatusType, ObjectId, RawSigner } from '../../src';
+import {
+  Commands,
+  getExecutionStatusType,
+  ObjectId,
+  RawSigner,
+  Transaction,
+} from '../../src';
 import {
   DEFAULT_GAS_BUDGET,
   publishPackage,
@@ -16,18 +22,17 @@ describe('Test Move call with strings', () => {
   let packageId: ObjectId;
 
   async function callWithString(str: string | string[], funcName: string) {
-    const txn = await signer.signAndExecuteTransaction({
-      kind: 'moveCall',
-      data: {
-        packageObjectId: packageId,
-        module: 'entry_point_string',
-        function: funcName,
+    const tx = new Transaction();
+    tx.setGasBudget(DEFAULT_GAS_BUDGET);
+    tx.add(
+      Commands.MoveCall({
+        target: `${packageId}::entry_point_string::${funcName}`,
         typeArguments: [],
-        arguments: [str],
-        gasBudget: DEFAULT_GAS_BUDGET,
-      },
-    });
-    expect(getExecutionStatusType(txn)).toEqual('success');
+        arguments: [tx.input(str)],
+      }),
+    );
+    const result = await signer.signAndExecuteTransaction(tx);
+    expect(getExecutionStatusType(result)).toEqual('success');
   }
 
   beforeAll(async () => {

--- a/sdk/typescript/test/e2e/event-subscription.test.ts
+++ b/sdk/typescript/test/e2e/event-subscription.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll, vi } from 'vitest';
-import { RawSigner, SuiEventEnvelope } from '../../src';
+import { Commands, RawSigner, SuiEventEnvelope, Transaction } from '../../src';
 import {
   DEFAULT_GAS_BUDGET,
   DEFAULT_RECIPIENT,
@@ -29,18 +29,10 @@ describe('Event Subscription API', () => {
       mockCallback,
     );
 
-    const inputCoins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
-
-    await signer.signAndExecuteTransaction({
-      kind: 'payAllSui',
-      data: {
-        inputCoins: inputCoins.map((o) => o.objectId),
-        recipient: DEFAULT_RECIPIENT,
-        gasBudget: DEFAULT_GAS_BUDGET,
-      },
-    });
+    const tx = new Transaction();
+    tx.setGasBudget(DEFAULT_GAS_BUDGET);
+    tx.add(Commands.TransferObjects([tx.gas], tx.input(DEFAULT_RECIPIENT)));
+    await signer.signAndExecuteTransaction(tx);
 
     const subFoundAndRemoved = await toolbox.provider.unsubscribeEvent(
       subscriptionId,

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -6,6 +6,7 @@ import {
   RawSigner,
   getExecutionStatusType,
   SuiSystemStateUtil,
+  SUI_TYPE_ARG,
 } from '../../src';
 import { DEFAULT_GAS_BUDGET, setup, TestToolbox } from './utils/setup';
 
@@ -58,15 +59,18 @@ describe('Governance API', () => {
 });
 
 async function addDelegation(signer: RawSigner) {
-  const coins = await signer.provider.getGasObjectsOwnedByAddress(
+  const coins = await signer.provider.getCoins(
     await signer.getAddress(),
+    SUI_TYPE_ARG,
+    null,
+    null,
   );
 
   const validators = await signer.provider.getValidators();
 
   const tx = await SuiSystemStateUtil.newRequestAddDelegationTxn(
     signer.provider,
-    [coins[0].objectId],
+    [coins.data[0].coinObjectId],
     BigInt(DEFAULT_STAKED_AMOUNT),
     validators[0].sui_address,
   );

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { getExecutionStatusType, ObjectId, RawSigner } from '../../src';
+import {
+  Commands,
+  getExecutionStatusType,
+  ObjectId,
+  RawSigner,
+  Transaction,
+} from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test ID as args to entry functions', () => {
@@ -18,19 +24,20 @@ describe('Test ID as args to entry functions', () => {
   });
 
   it('Test ID as arg to entry functions', async () => {
-    const txn = await signer.signAndExecuteTransaction({
-      kind: 'moveCall',
-      data: {
-        packageObjectId: packageId,
-        module: 'test',
-        function: 'test_id',
+    const tx = new Transaction();
+    tx.setGasBudget(2000);
+    tx.add(
+      Commands.MoveCall({
+        target: `${packageId}::test::test_id`,
         typeArguments: [],
         arguments: [
-          '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
+          tx.input(
+            '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
+          ),
         ],
-        gasBudget: 2000,
-      },
-    });
-    expect(getExecutionStatusType(txn)).toEqual('success');
+      }),
+    );
+    const result = await signer.signAndExecuteTransaction(tx);
+    expect(getExecutionStatusType(result)).toEqual('success');
   });
 });

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -42,9 +42,7 @@ describe('Test Object Display Standard', () => {
   });
 
   it('Test getting Display fields for object that has no display object', async () => {
-    const coinId = (
-      await toolbox.provider.getGasObjectsOwnedByAddress(toolbox.address())
-    )[0].objectId;
+    const coinId = (await toolbox.getGasObjectsOwnedByAddress())[0].objectId;
     const display = getObjectDisplay(
       await toolbox.provider.getObject(coinId, { showDisplay: true }),
     );

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -67,9 +67,7 @@ describe.skip('Test Move call with a vector of objects as input (skipped due to 
   });
 
   it('Test regular arg mixed with object vector arg', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     const coinIDs = coins.map((coin) => Coin.getID(coin));
     const txn = await signer.signAndExecuteTransaction({
       kind: 'moveCall',

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -20,9 +20,7 @@ describe('Object Reading API', () => {
   });
 
   it('Get Object', async () => {
-    const gasObjects = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const gasObjects = await toolbox.getGasObjectsOwnedByAddress();
     expect(gasObjects.length).to.greaterThan(0);
     const objectInfos = await Promise.all(
       gasObjects.map((gasObject) =>

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -29,9 +29,7 @@ describe('Transaction Builders', () => {
   });
 
   it('Split coin', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     await validateTransaction(signer, {
       kind: 'splitCoin',
       data: {
@@ -43,9 +41,7 @@ describe('Transaction Builders', () => {
   });
 
   it('Merge coin', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     await validateTransaction(signer, {
       kind: 'mergeCoin',
       data: {
@@ -57,9 +53,7 @@ describe('Transaction Builders', () => {
   });
 
   it('Move Call', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     await validateTransaction(signer, {
       kind: 'moveCall',
       data: {
@@ -79,9 +73,7 @@ describe('Transaction Builders', () => {
   });
 
   it('Move Shared Object Call', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
 
     const [{ sui_address: validator_address }] =
       await toolbox.getActiveValidators();
@@ -105,9 +97,7 @@ describe('Transaction Builders', () => {
   });
 
   it('Transfer Sui', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     await validateTransaction(signer, {
       kind: 'transferSui',
       data: {
@@ -120,9 +110,7 @@ describe('Transaction Builders', () => {
   });
 
   it('Transfer Object', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     await validateTransaction(signer, {
       kind: 'transferObject',
       data: {

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -3,20 +3,18 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
+  Commands,
   getExecutionStatusType,
-  getNewlyCreatedCoinRefsAfterSplit,
-  getObjectId,
   getTransactionDigest,
   RawSigner,
-  SignableTransaction,
   SUI_SYSTEM_STATE_OBJECT_ID,
+  Transaction,
 } from '../../src';
 import {
   DEFAULT_RECIPIENT,
   DEFAULT_GAS_BUDGET,
   setup,
   TestToolbox,
-  DEFAULT_RECIPIENT_2,
 } from './utils/setup';
 
 describe('Transaction Builders', () => {
@@ -28,203 +26,100 @@ describe('Transaction Builders', () => {
     signer = new RawSigner(toolbox.keypair, toolbox.provider);
   });
 
-  it('Split coin', async () => {
+  it('SplitCoin + TransferObjects', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
-    await validateTransaction(signer, {
-      kind: 'splitCoin',
-      data: {
-        coinObjectId: coins[0].objectId,
-        splitAmounts: [DEFAULT_GAS_BUDGET * 2],
-        gasBudget: DEFAULT_GAS_BUDGET,
-      },
-    });
+    const tx = new Transaction();
+    const coin = tx.add(
+      Commands.SplitCoin(
+        tx.input(coins[0].objectId),
+        tx.input(DEFAULT_GAS_BUDGET * 2),
+      ),
+    );
+    tx.add(Commands.TransferObjects([coin], tx.input(toolbox.address())));
+    await validateTransaction(signer, tx);
   });
 
-  it('Merge coin', async () => {
+  it('MergeCoins', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
-    await validateTransaction(signer, {
-      kind: 'mergeCoin',
-      data: {
-        primaryCoin: coins[0].objectId,
-        coinToMerge: coins[1].objectId,
-        gasBudget: DEFAULT_GAS_BUDGET,
-      },
-    });
+    const tx = new Transaction();
+    tx.add(
+      Commands.MergeCoins(tx.input(coins[0].objectId), [
+        tx.input(coins[1].objectId),
+      ]),
+    );
+    await validateTransaction(signer, tx);
   });
 
-  it('Move Call', async () => {
-    const coins = await toolbox.getGasObjectsOwnedByAddress();
-    await validateTransaction(signer, {
-      kind: 'moveCall',
-      data: {
-        packageObjectId: '0x2',
-        module: 'devnet_nft',
-        function: 'mint',
+  it('MoveCall', async () => {
+    const tx = new Transaction();
+    tx.add(
+      Commands.MoveCall({
+        target: '0x2::devnet_nft::mint',
         typeArguments: [],
         arguments: [
-          'Example NFT',
-          'An NFT created by the wallet Command Line Tool',
-          'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+          tx.input('Example NFT'),
+          tx.input('An NFT created by the wallet Command Line Tool'),
+          tx.input(
+            'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+          ),
         ],
-        gasBudget: DEFAULT_GAS_BUDGET,
-        gasPayment: coins[0].objectId,
-      },
-    });
+      }),
+    );
+    await validateTransaction(signer, tx);
   });
 
-  it('Move Shared Object Call', async () => {
+  it('MoveCall Shared Object', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
 
     const [{ sui_address: validator_address }] =
       await toolbox.getActiveValidators();
 
-    await validateTransaction(signer, {
-      kind: 'moveCall',
-      data: {
-        packageObjectId: '0x2',
-        module: 'sui_system',
-        function: 'request_add_delegation',
+    const tx = new Transaction();
+    tx.add(
+      Commands.MoveCall({
+        target: '0x2::sui_system::request_add_delegation',
         typeArguments: [],
         arguments: [
-          SUI_SYSTEM_STATE_OBJECT_ID,
-          coins[2].objectId,
-          validator_address,
+          tx.input(SUI_SYSTEM_STATE_OBJECT_ID),
+          tx.input(coins[2].objectId),
+          tx.input(validator_address),
         ],
-        gasBudget: DEFAULT_GAS_BUDGET,
-        gasPayment: coins[3].objectId,
-      },
-    });
+      }),
+    );
+
+    await validateTransaction(signer, tx);
   });
 
-  it('Transfer Sui', async () => {
+  it('SplitCoin from gas object + TransferObjects', async () => {
+    const tx = new Transaction();
+    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(1)));
+    tx.add(Commands.TransferObjects([coin], tx.input(DEFAULT_RECIPIENT)));
+    await validateTransaction(signer, tx);
+  });
+
+  it('TransferObjects gas object', async () => {
+    const tx = new Transaction();
+    tx.add(Commands.TransferObjects([tx.gas], tx.input(DEFAULT_RECIPIENT)));
+    await validateTransaction(signer, tx);
+  });
+
+  it('TransferObject', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
-    await validateTransaction(signer, {
-      kind: 'transferSui',
-      data: {
-        suiObjectId: coins[0].objectId,
-        gasBudget: DEFAULT_GAS_BUDGET,
-        recipient: DEFAULT_RECIPIENT,
-        amount: 100,
-      },
-    });
-  });
-
-  it('Transfer Object', async () => {
-    const coins = await toolbox.getGasObjectsOwnedByAddress();
-    await validateTransaction(signer, {
-      kind: 'transferObject',
-      data: {
-        objectId: coins[0].objectId,
-        gasBudget: DEFAULT_GAS_BUDGET,
-        recipient: DEFAULT_RECIPIENT,
-        gasPayment: coins[1].objectId,
-      },
-    });
-  });
-
-  it('Pay', async () => {
-    const coins =
-      await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
-        toolbox.address(),
-        BigInt(DEFAULT_GAS_BUDGET),
-      );
-
-    // get some new coins with small amount
-    const splitTxn = await signer.signAndExecuteTransaction({
-      kind: 'splitCoin',
-      data: {
-        coinObjectId: coins[0].coinObjectId,
-        splitAmounts: [1, 2, 3],
-        gasBudget: DEFAULT_GAS_BUDGET,
-        gasPayment: coins[1].coinObjectId,
-      },
-    });
-    const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
-      getObjectId(c),
+    const tx = new Transaction();
+    tx.add(
+      Commands.TransferObjects(
+        [tx.input(coins[0].objectId)],
+        tx.input(DEFAULT_RECIPIENT),
+      ),
     );
-
-    // use the newly created coins as the input coins for the pay transaction
-    await validateTransaction(signer, {
-      kind: 'pay',
-      data: {
-        inputCoins: splitCoins,
-        gasBudget: DEFAULT_GAS_BUDGET,
-        recipients: [DEFAULT_RECIPIENT, DEFAULT_RECIPIENT_2],
-        amounts: [4, 2],
-        gasPayment: coins[2].coinObjectId,
-      },
-    });
-  });
-
-  it('PaySui', async () => {
-    const gasBudget = 1000;
-    const coins =
-      await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
-        toolbox.address(),
-        BigInt(DEFAULT_GAS_BUDGET),
-      );
-
-    const splitTxn = await signer.signAndExecuteTransaction({
-      kind: 'splitCoin',
-      data: {
-        coinObjectId: coins[0].coinObjectId,
-        splitAmounts: [2000, 2000, 2000],
-        gasBudget: gasBudget,
-        gasPayment: coins[1].coinObjectId,
-      },
-    });
-    const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
-      getObjectId(c),
-    );
-
-    await validateTransaction(signer, {
-      kind: 'paySui',
-      data: {
-        inputCoins: splitCoins,
-        recipients: [DEFAULT_RECIPIENT, DEFAULT_RECIPIENT_2],
-        amounts: [1000, 1000],
-        gasBudget: gasBudget,
-      },
-    });
-  });
-
-  it('PayAllSui', async () => {
-    const gasBudget = 1000;
-    const coins =
-      await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
-        toolbox.address(),
-        BigInt(DEFAULT_GAS_BUDGET),
-      );
-
-    const splitTxn = await signer.signAndExecuteTransaction({
-      kind: 'splitCoin',
-      data: {
-        coinObjectId: coins[0].coinObjectId,
-        splitAmounts: [2000, 2000, 2000],
-        gasBudget: gasBudget,
-        gasPayment: coins[1].coinObjectId,
-      },
-    });
-    const splitCoins = getNewlyCreatedCoinRefsAfterSplit(splitTxn)!.map((c) =>
-      getObjectId(c),
-    );
-    await validateTransaction(signer, {
-      kind: 'payAllSui',
-      data: {
-        inputCoins: splitCoins,
-        recipient: DEFAULT_RECIPIENT,
-        gasBudget: gasBudget,
-      },
-    });
+    await validateTransaction(signer, tx);
   });
 });
 
-async function validateTransaction(
-  signer: RawSigner,
-  txn: SignableTransaction,
-) {
-  const localDigest = await signer.getTransactionDigest(txn);
-  const result = await signer.signAndExecuteTransaction(txn);
+async function validateTransaction(signer: RawSigner, tx: Transaction) {
+  tx.setGasBudget(DEFAULT_GAS_BUDGET);
+  const localDigest = await signer.getTransactionDigest(tx);
+  const result = await signer.signAndExecuteTransaction(tx);
   expect(localDigest).toEqual(getTransactionDigest(result));
   expect(getExecutionStatusType(result)).toEqual('success');
 }

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -88,9 +88,7 @@ describe('Transaction Serialization and deserialization', () => {
   }
 
   it('Move Call', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     const moveCall = {
       packageObjectId:
         '0000000000000000000000000000000000000000000000000000000000000002',
@@ -112,9 +110,7 @@ describe('Transaction Serialization and deserialization', () => {
   });
 
   it('Move Call With Type Tags', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     const moveCall = {
       packageObjectId: packageId,
       module: 'serializer_tests',
@@ -127,9 +123,7 @@ describe('Transaction Serialization and deserialization', () => {
   });
 
   it('Move Shared Object Call', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
 
     const [{ sui_address: validator_address }] =
       await toolbox.getActiveValidators();
@@ -159,9 +153,7 @@ describe('Transaction Serialization and deserialization', () => {
   });
 
   it('Move Call with Pure Arg', async () => {
-    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const coins = await toolbox.getGasObjectsOwnedByAddress();
     const moveCallExpected = {
       packageObjectId: '0x2',
       module: 'devnet_nft',

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -12,6 +12,7 @@ import {
   fromB64,
   localnetConnection,
   Connection,
+  Coin,
 } from '../../../src';
 import { retry } from 'ts-retry-promise';
 import { FaucetRateLimitError } from '../../../src/rpc/faucet-client';
@@ -37,6 +38,14 @@ export class TestToolbox {
 
   address() {
     return this.keypair.getPublicKey().toSuiAddress();
+  }
+
+  async getGasObjectsOwnedByAddress() {
+    const objects = await this.provider.getObjectsOwnedByAddress(
+      this.address(),
+    );
+
+    return objects.filter((obj) => Coin.isSUI(obj));
   }
 
   public async getActiveValidators() {


### PR DESCRIPTION
## Description 

This rewrites some of the usage of `SignableTransaction` to programmable transactions in the SDK.

This also removes the `getGasObjectsOwnedByAddress` method, which shouldn't be used anymore, and moves to a new internal helper for tests.

This PR also tweaks gas selection a little bit:
- Change gas selection to happen after input and command resolution. 
- Gas object selection now takes inputs into account, leading to less transaction errors when using Sui gas objects. This is mostly useful for the existing transactions, generally we'd recommend using the gas object + split though.

## Test Plan 

Updated e2e tests.
