### PR TITLE
Update voting weights in Committee to be normalized constants

### DIFF
--- a/crates/sui-benchmark/src/authority_aggregator_builder.rs
+++ b/crates/sui-benchmark/src/authority_aggregator_builder.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_core::authority_client::{make_authority_clients, NetworkAuthorityClient};
+use sui_config::genesis::Genesis;
+use sui_config::{NetworkConfig};
+use sui_network::{
+    DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_REQUEST_TIMEOUT_SEC,
+};
+use sui_types::crypto::{AuthorityPublicKeyBytes};
+use sui_types::committee::{Committee, ProtocolVersion};
+
+use prometheus::{Registry};
+use std::collections::{BTreeMap};
+use std::sync::Arc;
+
+use sui_core::authority_aggregator::AuthorityAggregator;
+use sui_core::epoch::committee_store::CommitteeStore;
+use sui_core::signature_verifier::{SignatureVerifier};
+
+pub struct AuthorityAggregatorBuilder<'a> {
+    network_config: Option<&'a NetworkConfig>,
+    genesis: Option<&'a Genesis>,
+    committee_store: Option<Arc<CommitteeStore>>,
+    registry: Option<&'a Registry>,
+    protocol_version: ProtocolVersion,
+}
+
+impl<'a> AuthorityAggregatorBuilder<'a> {
+    pub fn from_network_config(config: &'a NetworkConfig) -> Self {
+        Self {
+            network_config: Some(config),
+            genesis: None,
+            committee_store: None,
+            registry: None,
+            protocol_version: ProtocolVersion::MIN,
+        }
+    }
+
+    pub fn from_genesis(genesis: &'a Genesis) -> Self {
+        Self {
+            network_config: None,
+            genesis: Some(genesis),
+            committee_store: None,
+            registry: None,
+            protocol_version: ProtocolVersion::MIN,
+        }
+    }
+
+    pub fn with_protocol_version(mut self, new_version: ProtocolVersion) -> Self {
+        self.protocol_version = new_version;
+        self
+    }
+
+    pub fn with_committee_store(mut self, committee_store: Arc<CommitteeStore>) -> Self {
+        self.committee_store = Some(committee_store);
+        self
+    }
+
+    pub fn with_registry(mut self, registry: &'a Registry) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    pub fn build<S: SignatureVerifier + Default>(
+        self,
+    ) -> anyhow::Result<(
+        AuthorityAggregator<NetworkAuthorityClient, S>,
+        BTreeMap<AuthorityPublicKeyBytes, NetworkAuthorityClient>,
+    )> {
+        let validator_info = if let Some(network_config) = self.network_config {
+            network_config.validator_set()
+        } else if let Some(genesis) = self.genesis {
+            genesis.validator_set()
+        } else {
+            anyhow::bail!("need either NetworkConfig or Genesis.");
+        };
+        let committee = Committee::normalize_from_weights_for_testing(
+            0,
+            validator_info.iter().map(|validator| (validator.protocol_key(), 1)).collect())?;
+        let mut registry = &prometheus::Registry::new();
+        if self.registry.is_some() {
+            registry = self.registry.unwrap();
+        }
+
+        let auth_clients = make_authority_clients(
+            &validator_info,
+            DEFAULT_CONNECT_TIMEOUT_SEC,
+            DEFAULT_REQUEST_TIMEOUT_SEC,
+        );
+        let committee_store = if let Some(committee_store) = self.committee_store {
+            committee_store
+        } else {
+            Arc::new(CommitteeStore::new_for_testing(&committee))
+        };
+        Ok((
+            AuthorityAggregator::new(committee, committee_store, auth_clients.clone(), registry),
+            auth_clients,
+        ))
+    }
+}

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -11,7 +11,6 @@ use once_cell::sync::OnceCell;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -421,14 +420,6 @@ impl ValidatorInfo {
 
     pub fn p2p_address(&self) -> &Multiaddr {
         &self.p2p_address
-    }
-
-    //TODO remove this
-    pub fn voting_rights(validator_set: &[Self]) -> BTreeMap<AuthorityPublicKeyBytes, u64> {
-        validator_set
-            .iter()
-            .map(|validator| (validator.protocol_key(), 1))
-            .collect()
     }
 }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -66,7 +66,7 @@ use sui_storage::{
     write_ahead_log::{DBTxGuard, TxGuard},
     IndexStore,
 };
-use sui_types::committee::{EpochId, ProtocolVersion};
+use sui_types::committee::{self, EpochId, ProtocolVersion};
 use sui_types::crypto::{sha3_hash, AuthorityKeyPair, NetworkKeyPair, Signer};
 use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType};
 use sui_types::event::{Event, EventID};
@@ -2906,8 +2906,8 @@ impl AuthorityState {
                 }
 
                 let total_votes = stake_aggregator.total_votes();
-                let quorum_threshold = committee.quorum_threshold();
-                let f = committee.total_votes - committee.quorum_threshold();
+                let quorum_threshold = committee::QUORUM_THRESHOLD;
+                let f = committee::VALIDITY_THRESHOLD - 1;
                 let buffer_bps = protocol_config.buffer_stake_for_protocol_upgrade_bps();
                 // multiple by buffer_bps / 10000, rounded up.
                 let buffer_stake = (f * buffer_bps + 9999) / 10000;

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -19,7 +19,7 @@ use sui_storage::mutex_table::LockGuard;
 use sui_storage::write_ahead_log::{DBWriteAheadLog, TxGuard, WriteAheadLog};
 use sui_types::accumulator::Accumulator;
 use sui_types::base_types::{AuthorityName, EpochId, ObjectID, SequenceNumber, TransactionDigest};
-use sui_types::committee::Committee;
+use sui_types::committee::{self, Committee};
 use sui_types::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
@@ -415,7 +415,9 @@ impl AuthorityPerEpochStore {
         metrics
             .current_voting_right
             .set(committee.weight(&name) as i64);
-        metrics.epoch_total_votes.set(committee.total_votes as i64);
+        metrics
+            .epoch_total_votes
+            .set(committee::TOTAL_VOTING_POWER as i64);
         let protocol_version = epoch_start_configuration.protocol_version();
         let protocol_config = ProtocolConfig::get_for_version(protocol_version);
         let execution_component = ExecutionComponents::new(&protocol_config, store, cache_metrics);

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -167,7 +167,7 @@ pub fn make_network_authority_client_sets_from_committee(
     network_config: &Config,
 ) -> anyhow::Result<BTreeMap<AuthorityName, NetworkAuthorityClient>> {
     let mut authority_clients = BTreeMap::new();
-    for (name, _stakes) in &committee.committee.voting_rights {
+    for (name, _stakes) in &committee.committee.voting_weights {
         let address = &committee
             .network_metadata
             .get(name)

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -423,7 +423,7 @@ fn sync_end_of_epoch_checkpoint(
     let (_sequence_number, _digest, checkpoint) = committee.make_end_of_epoch_checkpoint(
         previous_checkpoint,
         Some(EndOfEpochData {
-            next_epoch_committee: new_committee.committee().voting_rights.clone(),
+            next_epoch_committee: new_committee.committee().voting_weights.clone(),
             next_epoch_protocol_version: ProtocolVersion::MIN,
             epoch_commitments: vec![ECMHLiveObjectSetDigest::default().into()],
         }),

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -744,7 +744,7 @@ impl CheckpointBuilder {
                 info!("Epoch {epoch} root state hash digest: {root_state_digest:?}");
 
                 Some(EndOfEpochData {
-                    next_epoch_committee: committee.voting_rights,
+                    next_epoch_committee: committee.voting_weights,
                     next_epoch_protocol_version: ProtocolVersion::new(
                         system_state_obj.protocol_version(),
                     ),

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -587,7 +587,7 @@ pub fn order_validators_for_submission(
 
     // permute the validators deterministically, based on the digest
     let mut rng = StdRng::from_seed(digest_bytes);
-    committee.shuffle_by_stake_with_rng(None, None, &mut rng)
+    committee.shuffle_by_weight_with_rng(None, None, &mut rng)
 }
 
 impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
@@ -737,7 +737,9 @@ mod adapter_tests {
                 )
             })
             .collect::<Vec<_>>();
-        let committee = Committee::new(0, authorities.iter().cloned().collect()).unwrap();
+        let committee =
+            Committee::normalize_from_weights_for_testing(0, authorities.iter().cloned().collect())
+                .unwrap();
 
         // generate random transaction digests, and account for validator selection
         const NUM_TEST_TRANSACTIONS: usize = 1000;

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -13,6 +13,7 @@ use crate::{
 use std::time::Duration;
 use std::{collections::BTreeMap, sync::Arc};
 use sui_types::base_types::SuiAddress;
+use sui_types::committee;
 use sui_types::crypto::get_key_pair;
 use sui_types::crypto::{deterministic_random_account_key, AccountKeyPair};
 use sui_types::messages::{TransactionEffectsAPI, VerifiedTransaction};
@@ -408,11 +409,7 @@ async fn test_quorum_driver_not_retry_on_object_locked() -> Result<(), anyhow::E
     .start();
 
     let quorum_driver = quorum_driver_handler.clone_quorum_driver();
-    let validity = quorum_driver
-        .authority_aggregator()
-        .load()
-        .committee
-        .validity_threshold();
+    let validity = committee::VALIDITY_THRESHOLD;
 
     assert_eq!(auth_agg.clone_inner_clients().keys().cloned().count(), 4);
 

--- a/crates/sui-core/src/stake_aggregator.rs
+++ b/crates/sui-core/src/stake_aggregator.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
 use std::sync::Arc;
 use sui_types::base_types::AuthorityName;
-use sui_types::committee::{Committee, StakeUnit};
+use sui_types::committee::{Committee, VoteUnit};
 use sui_types::crypto::{AuthorityQuorumSignInfo, AuthoritySignInfo};
 use sui_types::error::SuiError;
 
@@ -15,7 +15,7 @@ use sui_types::error::SuiError;
 #[derive(Debug)]
 pub struct StakeAggregator<S, const STRENGTH: bool> {
     data: HashMap<AuthorityName, S>,
-    total_votes: StakeUnit,
+    total_votes: VoteUnit,
     committee: Arc<Committee>,
 }
 
@@ -84,7 +84,7 @@ impl<S: Clone + Eq, const STRENGTH: bool> StakeAggregator<S, STRENGTH> {
         &self.committee
     }
 
-    pub fn total_votes(&self) -> StakeUnit {
+    pub fn total_votes(&self) -> VoteUnit {
         self.total_votes
     }
 
@@ -160,7 +160,7 @@ impl<K, V, const STRENGTH: bool> MultiStakeAggregator<K, V, STRENGTH> {
         self.stake_maps.len()
     }
 
-    pub fn total_votes(&self) -> StakeUnit {
+    pub fn total_votes(&self) -> VoteUnit {
         self.stake_maps
             .values()
             .map(|(_, stake_aggregator)| stake_aggregator.total_votes())
@@ -198,7 +198,7 @@ impl<K, V, const STRENGTH: bool> MultiStakeAggregator<K, V, STRENGTH>
 where
     K: Clone + Ord,
 {
-    pub fn get_all_unique_values(&self) -> BTreeMap<K, (Vec<AuthorityName>, StakeUnit)> {
+    pub fn get_all_unique_values(&self) -> BTreeMap<K, (Vec<AuthorityName>, VoteUnit)> {
         self.stake_maps
             .iter()
             .map(|(k, (_, s))| (k.clone(), (s.data.keys().copied().collect(), s.total_votes)))

--- a/crates/sui-core/src/tbls/tbls_ids.rs
+++ b/crates/sui-core/src/tbls/tbls_ids.rs
@@ -7,7 +7,7 @@ use std::num::NonZeroU32;
 use std::ops::Range;
 use std::unreachable;
 use sui_types::base_types::AuthorityName;
-use sui_types::committee::StakeUnit;
+use sui_types::committee::VoteUnit;
 
 /// Threshold BLS (tBLS) requires unique integer "share IDs". (tBLS will be used soon by the
 /// randomness beacon.)
@@ -30,7 +30,7 @@ type TBlsId = NonZeroU32;
 const MAX_NUM_OF_SHARES: u16 = 1000;
 
 impl TBlsIds {
-    pub fn new(stakes: &[(AuthorityName, StakeUnit)]) -> Self {
+    pub fn new(stakes: &[(AuthorityName, VoteUnit)]) -> Self {
         let total_stake: u64 = stakes.iter().map(|(_name, stake)| stake).sum();
         let deltas = stakes
             .iter()

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3901,7 +3901,6 @@ pub async fn init_state() -> Arc<AuthorityState> {
     let keypair = network_config.validator_configs[0]
         .protocol_key_pair()
         .copy();
-
     init_state_with_committee(&genesis, &keypair).await
 }
 
@@ -4837,7 +4836,7 @@ fn test_choose_next_system_packages() {
     }
 
     let committee = Committee::new_simple_test_committee().0;
-    let v = &committee.voting_rights;
+    let v = &committee.voting_weights;
     let mut protocol_config = ProtocolConfig::get_for_max_version();
 
     // all validators agree on new system packages, but without a new protocol version, so no

--- a/crates/sui-core/src/unit_tests/tbls_tests.rs
+++ b/crates/sui-core/src/unit_tests/tbls_tests.rs
@@ -6,7 +6,7 @@ use fastcrypto::traits::{ToFromBytes, VerifyingKey};
 use std::num::NonZeroU32;
 use std::ops::Range;
 use sui_types::base_types::AuthorityName;
-use sui_types::committee::StakeUnit;
+use sui_types::committee::VoteUnit;
 use sui_types::crypto::{AuthorityPublicKey, AuthorityPublicKeyBytes};
 
 fn get_key(id: u16) -> AuthorityName {
@@ -24,7 +24,7 @@ fn get_range(begin: u16, end: u16) -> Range<NonZeroU32> {
 
 #[test]
 fn test_1000_validators_with_1000_stake() {
-    let stakes: Vec<(AuthorityName, StakeUnit)> =
+    let stakes: Vec<(AuthorityName, VoteUnit)> =
         (1..=1000).into_iter().map(|i| (get_key(i), 1)).collect();
 
     let tbls_ids = TBlsIds::new(&stakes);
@@ -37,7 +37,7 @@ fn test_1000_validators_with_1000_stake() {
 
 #[test]
 fn test_1000_validators_with_100000_stake() {
-    let stakes: Vec<(AuthorityName, StakeUnit)> =
+    let stakes: Vec<(AuthorityName, VoteUnit)> =
         (1..=1000).into_iter().map(|i| (get_key(i), 100)).collect();
 
     let tbls_ids = TBlsIds::new(&stakes);
@@ -48,7 +48,7 @@ fn test_1000_validators_with_100000_stake() {
 
 #[test]
 fn test_100_validators_one_with_large_stake() {
-    let mut stakes: Vec<(AuthorityName, StakeUnit)> =
+    let mut stakes: Vec<(AuthorityName, VoteUnit)> =
         (1..=100).into_iter().map(|i| (get_key(i), 1)).collect();
     stakes.get_mut(0).unwrap().1 = 900;
 
@@ -59,7 +59,7 @@ fn test_100_validators_one_with_large_stake() {
 
 #[test]
 fn test_unsorted_100_validators_with_1000_stake() {
-    let mut stakes: Vec<(AuthorityName, StakeUnit)> = (1..=100)
+    let mut stakes: Vec<(AuthorityName, VoteUnit)> = (1..=100)
         .into_iter()
         .map(|i| (get_key(101 - i), 1))
         .collect();
@@ -75,7 +75,7 @@ fn test_unsorted_100_validators_with_1000_stake() {
 
 #[test]
 fn test_validator_without_shares() {
-    let mut stakes: Vec<(AuthorityName, StakeUnit)> =
+    let mut stakes: Vec<(AuthorityName, VoteUnit)> =
         (1..=10).into_iter().map(|i| (get_key(i), 100)).collect();
     // The next validator should not receive any id.
     stakes.push((get_key(11), 1));

--- a/crates/sui-json-rpc-types/src/sui_governance.rs
+++ b/crates/sui-json-rpc-types/src/sui_governance.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use sui_types::base_types::{AuthorityName, EpochId};
-use sui_types::committee::{Committee, StakeUnit};
+use sui_types::committee::{Committee, VoteUnit};
 use sui_types::sui_system_state::sui_system_state_inner_v1::SuiSystemStateInnerV1;
 use sui_types::sui_system_state::SuiSystemState;
 
@@ -36,14 +36,14 @@ impl From<SuiSystemStateRpc> for SuiSystemState {
 #[serde(rename = "CommitteeInfo")]
 pub struct SuiCommittee {
     pub epoch: EpochId,
-    pub validators: Vec<(AuthorityName, StakeUnit)>,
+    pub validators: Vec<(AuthorityName, VoteUnit)>,
 }
 
 impl From<Committee> for SuiCommittee {
     fn from(committee: Committee) -> Self {
         Self {
             epoch: committee.epoch,
-            validators: committee.voting_rights,
+            validators: committee.voting_weights,
         }
     }
 }

--- a/crates/sui-network/src/discovery/tests.rs
+++ b/crates/sui-network/src/discovery/tests.rs
@@ -7,7 +7,7 @@ use anemo::Result;
 use fastcrypto::ed25519::Ed25519PublicKey;
 use futures::stream::FuturesUnordered;
 use std::collections::{BTreeMap, HashSet};
-use sui_types::committee::{Committee, NetworkMetadata};
+use sui_types::committee::{self, Committee, NetworkMetadata};
 use sui_types::crypto::get_authority_key_pair;
 use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::crypto::KeypairTraits;
@@ -253,7 +253,11 @@ async fn peers_are_added_from_reocnfig_channel() -> Result<()> {
     let (mut subscriber_2, _) = network_2.subscribe()?;
 
     // We send peer 1 a new committee info (peer 2) from the reconfig channel.
-    let committee = Committee::new(1, BTreeMap::from([(authority_name_2, 1)])).unwrap();
+    let committee = Committee::new(
+        1,
+        BTreeMap::from([(authority_name_2, committee::TOTAL_VOTING_POWER)]),
+    )
+    .unwrap();
     let peer_2_network_pubkey =
         Ed25519PublicKey(ed25519_consensus::VerificationKey::try_from(peer_id_2.0).unwrap());
     end_of_epoch_channel_1

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -8,13 +8,11 @@ use crate::crypto::{
 };
 use crate::error::{SuiError, SuiResult};
 use fastcrypto::traits::KeyPair;
-use itertools::Itertools;
 use multiaddr::Multiaddr;
 use rand::rngs::ThreadRng;
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::borrow::Borrow;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Write;
 use std::fmt::{Display, Formatter};
@@ -23,18 +21,30 @@ pub use sui_protocol_config::ProtocolVersion;
 
 pub type EpochId = u64;
 
-// TODO: the stake and voting power of a validator can be different so
-// in some places when we are actually referring to the voting power, we
-// should use a different type alias, field name, etc.
-pub type StakeUnit = u64;
+pub type VoteUnit = u64;
 
 pub type CommitteeDigest = [u8; 32];
+
+// The voting power, quorum threshold and max voting power are defined in the `voting_power.move` module.
+// We're following the very same convention in the validator binaries.
+
+/// Set total_voting_power as 10_000 by convention. Individual voting powers can be interpreted
+/// as easily understandable basis points (e.g., voting_power: 100 = 1%, voting_power: 1 = 0.01%).
+/// Fixing the total voting power allows clients to hardcode the quorum threshold and total_voting power rather
+/// than recomputing these.
+pub const TOTAL_VOTING_POWER: VoteUnit = 10_000;
+
+/// Quorum threshold for our fixed voting power--any message signed by this much voting power can be trusted
+/// up to BFT assumptions
+pub const QUORUM_THRESHOLD: VoteUnit = 6_667;
+
+/// Validity threshold defined by f+1
+pub const VALIDITY_THRESHOLD: VoteUnit = 3_334;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq)]
 pub struct Committee {
     pub epoch: EpochId,
-    pub voting_rights: Vec<(AuthorityName, StakeUnit)>,
-    pub total_votes: StakeUnit,
+    pub voting_weights: Vec<(AuthorityName, VoteUnit)>,
     #[serde(skip)]
     expanded_keys: HashMap<AuthorityName, AuthorityPublicKey>,
     #[serde(skip)]
@@ -46,60 +56,103 @@ pub struct Committee {
 impl Committee {
     pub fn new(
         epoch: EpochId,
-        voting_rights: BTreeMap<AuthorityName, StakeUnit>,
+        voting_weights: BTreeMap<AuthorityName, VoteUnit>,
     ) -> SuiResult<Self> {
-        let mut voting_rights: Vec<(AuthorityName, StakeUnit)> =
-            voting_rights.iter().map(|(a, s)| (*a, *s)).collect();
+        let mut voting_weights: Vec<(AuthorityName, VoteUnit)> =
+            voting_weights.iter().map(|(a, s)| (*a, *s)).collect();
 
         fp_ensure!(
             // Actual committee size is enforced in sui_system.move.
             // This is just to ensure that choose_multiple_weighted can't fail.
-            voting_rights.len() < u32::MAX.try_into().unwrap(),
+            voting_weights.len() < u32::MAX.try_into().unwrap(),
             SuiError::InvalidCommittee("committee has too many members".into())
         );
 
         fp_ensure!(
-            !voting_rights.is_empty(),
+            !voting_weights.is_empty(),
             SuiError::InvalidCommittee("committee has 0 members".into())
         );
 
         fp_ensure!(
-            voting_rights.iter().any(|(_, s)| *s != 0),
+            voting_weights.iter().any(|(_, s)| *s != 0),
             SuiError::InvalidCommittee(
-                "at least one committee member must have non-zero stake.".into()
+                "at least one committee member must have non-zero voting power.".into()
             )
         );
 
-        voting_rights.sort_by_key(|(a, _)| *a);
-        let total_votes = voting_rights.iter().map(|(_, votes)| *votes).sum();
+        voting_weights.sort_by_key(|(a, _)| *a);
 
-        let (expanded_keys, index_map) = Self::load_inner(&voting_rights);
+        let total_votes: VoteUnit = voting_weights.iter().map(|(_, votes)| *votes).sum();
+        fp_ensure!(
+            total_votes == TOTAL_VOTING_POWER,
+            SuiError::InvalidCommittee(format!(
+                "total voting power of a committee is {}, must be {}",
+                total_votes, TOTAL_VOTING_POWER
+            ))
+        );
+
+        let (expanded_keys, index_map) = Self::load_inner(&voting_weights);
 
         Ok(Committee {
             epoch,
-            voting_rights,
-            total_votes,
+            voting_weights,
             expanded_keys,
             index_map,
             loaded: true,
         })
     }
 
+    /// Normalize the given weights to TOTAL_VOTING_POWER and create the committee.
+    /// Used for testing only: a production system is using the voting weights
+    /// of the Sui System object.
+    pub fn normalize_from_weights_for_testing(
+        epoch: EpochId,
+        mut voting_weights: BTreeMap<AuthorityName, VoteUnit>,
+    ) -> SuiResult<Self> {
+        fp_ensure!(
+            !voting_weights.is_empty(),
+            SuiError::InvalidCommittee("committee has 0 members".into())
+        );
+
+        let num_nodes = voting_weights.len();
+        let total_votes: VoteUnit = voting_weights.iter().map(|(_, votes)| *votes).sum();
+
+        fp_ensure!(
+            total_votes != 0,
+            SuiError::InvalidCommittee(
+                "at least one committee member must have non-zero voting power.".into()
+            )
+        );
+        let normalization_coef = TOTAL_VOTING_POWER as f64 / total_votes as f64;
+        let mut total_sum = 0;
+        for (idx, (_auth, weight)) in voting_weights.iter_mut().enumerate() {
+            if idx < num_nodes - 1 {
+                *weight = (*weight as f64 * normalization_coef).floor() as u64; // adjust the weights following the normalization coef
+                total_sum += *weight;
+            } else {
+                // the last element is taking all the rest
+                *weight = TOTAL_VOTING_POWER - total_sum;
+            }
+        }
+
+        Self::new(epoch, voting_weights)
+    }
+
     // We call this if these have not yet been computed
     pub fn load_inner(
-        voting_rights: &[(AuthorityName, StakeUnit)],
+        voting_weights: &[(AuthorityName, VoteUnit)],
     ) -> (
         HashMap<AuthorityName, AuthorityPublicKey>,
         HashMap<AuthorityName, usize>,
     ) {
-        let expanded_keys: HashMap<AuthorityName, AuthorityPublicKey> = voting_rights
+        let expanded_keys: HashMap<AuthorityName, AuthorityPublicKey> = voting_weights
             .iter()
             // TODO: Verify all code path to make sure we always have valid public keys.
             // e.g. when a new validator is registering themself on-chain.
             .map(|(addr, _)| (*addr, (*addr).try_into().expect("Invalid Authority Key")))
             .collect();
 
-        let index_map: HashMap<AuthorityName, usize> = voting_rights
+        let index_map: HashMap<AuthorityName, usize> = voting_weights
             .iter()
             .enumerate()
             .map(|(index, (addr, _))| (*addr, index))
@@ -108,7 +161,7 @@ impl Committee {
     }
 
     pub fn reload_fields(&mut self) {
-        let (expanded_keys, index_map) = Committee::load_inner(&self.voting_rights);
+        let (expanded_keys, index_map) = Committee::load_inner(&self.voting_weights);
         self.expanded_keys = expanded_keys;
         self.index_map = index_map;
         self.loaded = true;
@@ -117,7 +170,7 @@ impl Committee {
     pub fn authority_index(&self, author: &AuthorityName) -> Option<u32> {
         if !self.loaded {
             return self
-                .voting_rights
+                .voting_weights
                 .iter()
                 .position(|(a, _)| a == author)
                 .map(|i| i as u32);
@@ -126,7 +179,9 @@ impl Committee {
     }
 
     pub fn authority_by_index(&self, index: u32) -> Option<&AuthorityName> {
-        self.voting_rights.get(index as usize).map(|(name, _)| name)
+        self.voting_weights
+            .get(index as usize)
+            .map(|(name, _)| name)
     }
 
     pub fn epoch(&self) -> EpochId {
@@ -146,13 +201,13 @@ impl Committee {
     /// Samples authorities by weight
     pub fn sample(&self) -> &AuthorityName {
         // unwrap safe unless committee is empty
-        Self::choose_multiple_weighted(&self.voting_rights[..], 1, &mut ThreadRng::default())
+        Self::choose_multiple_weighted(&self.voting_weights[..], 1, &mut ThreadRng::default())
             .next()
             .unwrap()
     }
 
     fn choose_multiple_weighted<'a>(
-        slice: &'a [(AuthorityName, StakeUnit)],
+        slice: &'a [(AuthorityName, VoteUnit)],
         count: usize,
         rng: &mut impl Rng,
     ) -> impl Iterator<Item = &'a AuthorityName> {
@@ -165,17 +220,17 @@ impl Committee {
             .map(|(a, _)| a)
     }
 
-    pub fn shuffle_by_stake(
+    pub fn shuffle_by_weight(
         &self,
         // try these authorities first
         preferences: Option<&BTreeSet<AuthorityName>>,
         // only attempt from these authorities.
         restrict_to: Option<&BTreeSet<AuthorityName>>,
     ) -> Vec<AuthorityName> {
-        self.shuffle_by_stake_with_rng(preferences, restrict_to, &mut ThreadRng::default())
+        self.shuffle_by_weight_with_rng(preferences, restrict_to, &mut ThreadRng::default())
     }
 
-    pub fn shuffle_by_stake_with_rng(
+    pub fn shuffle_by_weight_with_rng(
         &self,
         // try these authorities first
         preferences: Option<&BTreeSet<AuthorityName>>,
@@ -184,7 +239,7 @@ impl Committee {
         rng: &mut impl Rng,
     ) -> Vec<AuthorityName> {
         let restricted = self
-            .voting_rights
+            .voting_weights
             .iter()
             .filter(|(name, _)| {
                 if let Some(restrict_to) = restrict_to {
@@ -207,96 +262,52 @@ impl Committee {
             .collect()
     }
 
-    pub fn weight(&self, author: &AuthorityName) -> StakeUnit {
-        match self.voting_rights.binary_search_by_key(author, |(a, _)| *a) {
+    pub fn weight(&self, author: &AuthorityName) -> VoteUnit {
+        match self
+            .voting_weights
+            .binary_search_by_key(author, |(a, _)| *a)
+        {
             Err(_) => 0,
-            Ok(idx) => self.voting_rights[idx].1,
+            Ok(idx) => self.voting_weights[idx].1,
         }
-    }
-
-    pub fn quorum_threshold(&self) -> StakeUnit {
-        // If N = 3f + 1 + k (0 <= k < 3)
-        // then (2 N + 3) / 3 = 2f + 1 + (2k + 2)/3 = 2f + 1 + k = N - f
-        2 * self.total_votes / 3 + 1
-    }
-
-    pub fn validity_threshold(&self) -> StakeUnit {
-        // If N = 3f + 1 + k (0 <= k < 3)
-        // then (N + 2) / 3 = f + 1 + k/3 = f + 1
-        validity_threshold(self.total_votes)
     }
 
     #[inline]
-    pub fn threshold<const STRENGTH: bool>(&self) -> StakeUnit {
+    pub fn threshold<const STRENGTH: bool>(&self) -> VoteUnit {
         if STRENGTH {
-            self.quorum_threshold()
+            QUORUM_THRESHOLD
         } else {
-            self.validity_threshold()
+            VALIDITY_THRESHOLD
         }
-    }
-
-    /// Given a sequence of (AuthorityName, value) for values, provide the
-    /// value at the particular threshold by stake. This orders all provided values
-    /// in ascending order and pick the appropriate value that has under it threshold
-    /// stake. You may use the function `validity_threshold` or `quorum_threshold` to
-    /// pick the f+1 (1/3 stake) or 2f+1 (2/3 stake) thresholds respectively.
-    ///
-    /// This function may be used in a number of settings:
-    /// - When we pass in a set of values produced by authorities with at least 2/3 stake
-    ///   and pick a validity_threshold it ensures that the resulting value is either itself
-    ///   or is in between values provided by an honest node.
-    /// - When we pass in values associated with the totality of stake and set a threshold
-    ///   of quorum_threshold, we ensure that at least a majority of honest nodes (ie >1/3
-    ///   out of the 2/3 threshold) have a value smaller than the value returned.
-    pub fn robust_value<A, V>(
-        &self,
-        items: impl Iterator<Item = (A, V)>,
-        threshold: StakeUnit,
-    ) -> (AuthorityName, V)
-    where
-        A: Borrow<AuthorityName> + Ord,
-        V: Ord,
-    {
-        debug_assert!(threshold < self.total_votes);
-
-        let items = items
-            .map(|(a, v)| (v, self.weight(a.borrow()), *a.borrow()))
-            .sorted();
-        let mut total = 0;
-        for (v, s, a) in items {
-            total += s;
-            if threshold <= total {
-                return (a, v);
-            }
-        }
-        unreachable!();
     }
 
     pub fn num_members(&self) -> usize {
-        self.voting_rights.len()
+        self.voting_weights.len()
     }
 
-    pub fn members(&self) -> impl Iterator<Item = &(AuthorityName, StakeUnit)> {
-        self.voting_rights.iter()
+    pub fn members(&self) -> impl Iterator<Item = &(AuthorityName, VoteUnit)> {
+        self.voting_weights.iter()
     }
 
     pub fn names(&self) -> impl Iterator<Item = &AuthorityName> {
-        self.voting_rights.iter().map(|(name, _)| name)
+        self.voting_weights.iter().map(|(name, _)| name)
     }
 
-    pub fn stakes(&self) -> impl Iterator<Item = StakeUnit> + '_ {
-        self.voting_rights.iter().map(|(_, stake)| *stake)
+    pub fn voting_rights(&self) -> impl Iterator<Item = VoteUnit> + '_ {
+        self.voting_weights
+            .iter()
+            .map(|(_, voting_power)| *voting_power)
     }
 
     pub fn authority_exists(&self, name: &AuthorityName) -> bool {
-        self.voting_rights
+        self.voting_weights
             .binary_search_by_key(name, |(a, _)| *a)
             .is_ok()
     }
 
     // ===== Testing-only methods =====
 
-    /// Generate a simple committee with 4 validators each with equal voting stake of 1.
+    /// Generate a simple committee with 4 validators each with equal voting power of 2_500.
     pub fn new_simple_test_committee() -> (Self, Vec<AuthorityKeyPair>) {
         let key_pairs: Vec<_> = random_committee_key_pairs().into_iter().collect();
         let committee = Self::new(
@@ -304,7 +315,10 @@ impl Committee {
             key_pairs
                 .iter()
                 .map(|key| {
-                    (AuthorityName::from(key.public()), /* voting right */ 1)
+                    (
+                        AuthorityName::from(key.public()),
+                        /* voting right */ 2_500,
+                    )
                 })
                 .collect(),
         )
@@ -315,24 +329,21 @@ impl Committee {
 
 impl PartialEq for Committee {
     fn eq(&self, other: &Self) -> bool {
-        self.epoch == other.epoch
-            && self.voting_rights == other.voting_rights
-            && self.total_votes == other.total_votes
+        self.epoch == other.epoch && self.voting_weights == other.voting_weights
     }
 }
 
 impl Hash for Committee {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.epoch.hash(state);
-        self.voting_rights.hash(state);
-        self.total_votes.hash(state);
+        self.voting_weights.hash(state);
     }
 }
 
 impl Display for Committee {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut voting_rights = String::new();
-        for (name, vote) in &self.voting_rights {
+        for (name, vote) in &self.voting_weights {
             write!(voting_rights, "{}: {}, ", name.concise(), vote)?;
         }
         write!(
@@ -341,12 +352,6 @@ impl Display for Committee {
             self.epoch, voting_rights
         )
     }
-}
-
-pub fn validity_threshold(total_stake: StakeUnit) -> StakeUnit {
-    // If N = 3f + 1 + k (0 <= k < 3)
-    // then (N + 2) / 3 = f + 1 + k/3 = f + 1
-    (total_stake + 2) / 3
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -398,9 +403,9 @@ mod test {
         authorities.insert(a2, 1);
         authorities.insert(a3, 1);
 
-        let committee = Committee::new(0, authorities).unwrap();
+        let committee = Committee::normalize_from_weights_for_testing(0, authorities).unwrap();
 
-        assert_eq!(committee.shuffle_by_stake(None, None).len(), 3);
+        assert_eq!(committee.shuffle_by_weight(None, None).len(), 3);
 
         let mut pref = BTreeSet::new();
         pref.insert(a2);
@@ -410,7 +415,7 @@ mod test {
             assert_eq!(
                 a2,
                 *committee
-                    .shuffle_by_stake(Some(&pref), None)
+                    .shuffle_by_weight(Some(&pref), None)
                     .first()
                     .unwrap()
             );
@@ -420,46 +425,16 @@ mod test {
         restrict.insert(a2);
 
         for _ in 0..100 {
-            let res = committee.shuffle_by_stake(None, Some(&restrict));
+            let res = committee.shuffle_by_weight(None, Some(&restrict));
             assert_eq!(1, res.len());
             assert_eq!(a2, res[0]);
         }
 
         // empty preferences are valid
-        let res = committee.shuffle_by_stake(Some(&BTreeSet::new()), None);
+        let res = committee.shuffle_by_weight(Some(&BTreeSet::new()), None);
         assert_eq!(3, res.len());
 
-        let res = committee.shuffle_by_stake(None, Some(&BTreeSet::new()));
+        let res = committee.shuffle_by_weight(None, Some(&BTreeSet::new()));
         assert_eq!(0, res.len());
-    }
-
-    #[test]
-    fn test_robust_value() {
-        let (_, sec1): (_, AuthorityKeyPair) = get_key_pair();
-        let (_, sec2): (_, AuthorityKeyPair) = get_key_pair();
-        let (_, sec3): (_, AuthorityKeyPair) = get_key_pair();
-        let (_, sec4): (_, AuthorityKeyPair) = get_key_pair();
-        let a1: AuthorityName = sec1.public().into();
-        let a2: AuthorityName = sec2.public().into();
-        let a3: AuthorityName = sec3.public().into();
-        let a4: AuthorityName = sec4.public().into();
-
-        let mut authorities = BTreeMap::new();
-        authorities.insert(a1, 1);
-        authorities.insert(a2, 1);
-        authorities.insert(a3, 1);
-        authorities.insert(a4, 1);
-        let committee = Committee::new(0, authorities).unwrap();
-        let items = vec![(a1, 666), (a2, 1), (a3, 2), (a4, 0)];
-        assert_eq!(
-            committee.robust_value(items.into_iter(), committee.quorum_threshold()),
-            (a3, 2)
-        );
-
-        let items = vec![(a1, "a"), (a2, "b"), (a3, "c"), (a4, "d")];
-        assert_eq!(
-            committee.robust_value(items.into_iter(), committee.quorum_threshold()),
-            (a3, "c")
-        );
     }
 }

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -35,7 +35,7 @@ use std::str::FromStr;
 use strum::EnumString;
 
 use crate::base_types::{AuthorityName, ObjectID, SuiAddress};
-use crate::committee::{Committee, EpochId, StakeUnit};
+use crate::committee::{Committee, EpochId, VoteUnit};
 use crate::error::{SuiError, SuiResult};
 use crate::intent::{Intent, IntentMessage};
 use crate::sui_serde::{Readable, SuiBitmap};
@@ -1343,7 +1343,7 @@ impl<const STRONG_THRESHOLD: bool> AuthorityQuorumSignInfo<STRONG_THRESHOLD> {
                 error: "All signatures must be from the same epoch as the committee".to_string()
             }
         );
-        let total_stake: StakeUnit = auth_sign_infos
+        let total_stake: VoteUnit = auth_sign_infos
             .iter()
             .map(|a| committee.weight(&a.authority))
             .sum();
@@ -1394,7 +1394,7 @@ impl<const STRONG_THRESHOLD: bool> AuthorityQuorumSignInfo<STRONG_THRESHOLD> {
         })
     }
 
-    pub fn quorum_threshold(committee: &Committee) -> StakeUnit {
+    pub fn quorum_threshold(committee: &Committee) -> VoteUnit {
         committee.threshold::<STRONG_THRESHOLD>()
     }
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     base_types::*,
-    committee::{Committee, EpochId, StakeUnit},
+    committee::{Committee, EpochId, VoteUnit},
     messages::{CommandIndex, ExecutionFailureStatus, MoveLocation},
     object::Owner,
 };
@@ -240,7 +240,7 @@ pub enum SuiError {
         "Failed to get a quorum of signed effects when processing transaction: {effects_map:?}"
     )]
     QuorumFailedToGetEffectsQuorumWhenProcessingTransaction {
-        effects_map: BTreeMap<TransactionEffectsDigest, (Vec<AuthorityName>, StakeUnit)>,
+        effects_map: BTreeMap<TransactionEffectsDigest, (Vec<AuthorityName>, VoteUnit)>,
     },
     #[error("System Transaction not accepted")]
     InvalidSystemTransaction,

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::accumulator::Accumulator;
 use crate::base_types::{ExecutionData, ExecutionDigests, VerifiedExecutionData};
-use crate::committee::{EpochId, ProtocolVersion, StakeUnit};
+use crate::committee::{EpochId, ProtocolVersion, VoteUnit};
 use crate::crypto::{AuthoritySignInfo, AuthoritySignInfoTrait, AuthorityStrongQuorumSignInfo};
 use crate::error::SuiResult;
 use crate::gas::GasCostSummary;
@@ -95,7 +95,7 @@ pub struct EndOfEpochData {
     /// or the total number of transactions from genesis to the end of an epoch.
     /// The committee is stored as a vector of validator pub key and stake pairs. The vector
     /// should be sorted based on the Committee data structure.
-    pub next_epoch_committee: Vec<(AuthorityName, StakeUnit)>,
+    pub next_epoch_committee: Vec<(AuthorityName, VoteUnit)>,
 
     /// The protocol version that is in effect during the epoch that starts immediately after this
     /// checkpoint.
@@ -222,7 +222,7 @@ impl<S> CheckpointSummaryEnvelope<S> {
         self.summary.previous_digest
     }
 
-    pub fn next_epoch_committee(&self) -> Option<&[(AuthorityName, StakeUnit)]> {
+    pub fn next_epoch_committee(&self) -> Option<&[(AuthorityName, VoteUnit)]> {
         self.summary
             .end_of_epoch_data
             .as_ref()

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -5,7 +5,7 @@
 use std::collections::BTreeMap;
 
 use crate::base_types::{AuthorityName, ObjectRef, TransactionDigest};
-use crate::committee::StakeUnit;
+use crate::committee::VoteUnit;
 use crate::error::SuiError;
 use crate::messages::{QuorumDriverResponse, VerifiedTransaction};
 use serde::{Deserialize, Serialize};
@@ -32,7 +32,7 @@ pub enum QuorumDriverError {
         retried_tx_success
     )]
     ObjectsDoubleUsed {
-        conflicting_txes: BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
+        conflicting_txes: BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, VoteUnit)>,
         retried_tx: Option<TransactionDigest>,
         retried_tx_success: Option<bool>,
     },
@@ -42,6 +42,6 @@ pub enum QuorumDriverError {
     FailedWithTransientErrorAfterMaximumAttempts { total_attempts: u8 },
     #[error("Transaction has non recoverable errors from at least 1/3 of validators: {errors:?}.")]
     NonRecoverableTransactionError {
-        errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
+        errors: Vec<(SuiError, Vec<AuthorityName>, VoteUnit)>,
     },
 }

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -4,7 +4,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use crate::base_types::{AuthorityName, EpochId, SuiAddress};
-use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata, StakeUnit};
+use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata, VoteUnit};
 use anemo::PeerId;
 use multiaddr::Multiaddr;
 use narwhal_config::{Committee as NarwhalCommittee, WorkerCache, WorkerIndex};
@@ -132,11 +132,11 @@ pub struct EpochStartValidatorInfo {
     pub p2p_address: Multiaddr,
     pub narwhal_primary_address: Multiaddr,
     pub narwhal_worker_address: Multiaddr,
-    pub voting_power: StakeUnit,
+    pub voting_power: VoteUnit,
 }
 
 impl EpochStartValidatorInfo {
-    pub fn to_stake_and_network_metadata(&self) -> (AuthorityName, StakeUnit, NetworkMetadata) {
+    pub fn to_stake_and_network_metadata(&self) -> (AuthorityName, VoteUnit, NetworkMetadata) {
         (
             (&self.protocol_pubkey).into(),
             self.voting_power,

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -5,7 +5,7 @@ use crate::balance::Balance;
 use crate::base_types::{AuthorityName, ObjectID, SuiAddress};
 use crate::collection_types::{MoveOption, Table, TableVec, VecMap, VecSet};
 use crate::committee::{
-    Committee, CommitteeWithNetworkMetadata, NetworkMetadata, ProtocolVersion, StakeUnit,
+    Committee, CommitteeWithNetworkMetadata, NetworkMetadata, ProtocolVersion, VoteUnit,
 };
 use crate::crypto::AuthorityPublicKeyBytes;
 use crate::sui_system_state::epoch_start_sui_system_state::{
@@ -219,7 +219,7 @@ pub struct ValidatorV1 {
 }
 
 impl ValidatorV1 {
-    pub fn to_stake_and_network_metadata(&self) -> (AuthorityName, StakeUnit, NetworkMetadata) {
+    pub fn to_stake_and_network_metadata(&self) -> (AuthorityName, VoteUnit, NetworkMetadata) {
         (
             // TODO: Make sure we are actually verifying this on-chain.
             AuthorityPublicKeyBytes::from_bytes(self.metadata.protocol_pubkey_bytes.as_ref())

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -43,7 +43,7 @@ fn test_signed_values() {
         /* address */ AuthorityPublicKeyBytes::from(sec2.public()),
         /* voting right */ 0,
     );
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities).unwrap();
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -120,7 +120,7 @@ fn test_certificates() {
         /* address */ AuthorityPublicKeyBytes::from(sec2.public()),
         /* voting right */ 1,
     );
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities).unwrap();
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -193,7 +193,7 @@ fn test_new_with_signatures() {
     let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
     authorities.insert(AuthorityPublicKeyBytes::from(sec.public()), 1);
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities.clone()).unwrap();
     let quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures.clone(), &committee)
             .unwrap();
@@ -240,7 +240,7 @@ fn test_handle_reject_malicious_signature() {
         };
     }
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities.clone()).unwrap();
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
     {
@@ -321,7 +321,7 @@ fn test_bitmap_out_of_range() {
         ));
     }
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities.clone()).unwrap();
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
 
@@ -362,7 +362,7 @@ fn test_reject_extra_public_key() {
         signatures[3].clone(),
     ];
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities.clone()).unwrap();
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(used_signatures, &committee)
             .unwrap();
@@ -400,7 +400,7 @@ fn test_reject_reuse_signatures() {
         signatures[2].clone(),
     ];
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities.clone()).unwrap();
     let quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(used_signatures, &committee)
             .unwrap();
@@ -429,7 +429,7 @@ fn test_empty_bitmap() {
         ));
     }
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities.clone()).unwrap();
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
     quorum.signers_map = RoaringBitmap::new();
@@ -453,7 +453,7 @@ fn test_digest_caching() {
     authorities.insert(sec1.public().into(), 1);
     authorities.insert(sec2.public().into(), 0);
 
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities).unwrap();
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -620,7 +620,7 @@ fn test_user_signature_committed_in_signed_transactions() {
     // Ensure that signed tx verifies against the transaction with a correct user signature.
     let mut authorities: BTreeMap<AuthorityPublicKeyBytes, u64> = BTreeMap::new();
     authorities.insert(AuthorityPublicKeyBytes::from(sec1.public()), 1);
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities.clone()).unwrap();
     assert!(signed_tx_a
         .auth_sig()
         .verify_secure(
@@ -898,7 +898,7 @@ fn verify_sender_signature_correctly_with_flag() {
     let (_, sec2): (_, AuthorityKeyPair) = get_key_pair();
     authorities.insert(sec1.public().into(), 1);
     authorities.insert(sec2.public().into(), 0);
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities).unwrap();
 
     // create a receiver keypair with Secp256k1
     let receiver_kp = SuiKeyPair::Secp256k1(get_key_pair().1);

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -44,7 +44,7 @@ where
         keys.push(inner_authority_key);
     }
 
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::normalize_from_weights_for_testing(0, authorities).unwrap();
     (keys, committee)
 }
 

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -14,6 +14,7 @@ use sui_core::signature_verifier::DefaultSignatureVerifier;
 use sui_core::test_utils::make_transfer_sui_transaction;
 use sui_macros::sim_test;
 use sui_node::SuiNodeHandle;
+use sui_types::committee;
 use sui_types::crypto::ToFromBytes;
 use sui_types::crypto::{generate_proof_of_possession, get_account_key_pair};
 use sui_types::gas::GasCostSummary;
@@ -505,7 +506,7 @@ async fn trigger_reconfiguration(authorities: &[SuiNodeHandle]) {
                 cur_stake += cur_committee.weight(&node.state().name);
             })
             .await;
-        if cur_stake >= cur_committee.quorum_threshold() {
+        if cur_stake >= committee::QUORUM_THRESHOLD {
             break;
         }
     }


### PR DESCRIPTION
In Move we normalize the weights to sum up to a predefined constant 10_000. We now update the Rust world to follow the same rules:
* Sum of authority weights is 10_000
* Quorum threshold is 6_667
* Validity threshold is 3_334

Had to update a number of tests in order to make this to work.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
