### PR TITLE
Add state sync new trusted peer event

### DIFF
--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use std::sync::Arc;
 use sui_protocol_config::ProtocolVersion;
-use sui_types::committee::CommitteeWithNetworkMetadata;
+use sui_types::committee::Committee;
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{info, warn};
 
@@ -28,7 +28,7 @@ pub trait ReconfigObserver<A, S = DefaultSignatureVerifier> {
 /// A ReconfigObserver that subscribes to a reconfig channel of new committee.
 /// This is used in TransactionOrchestrator.
 pub struct OnsiteReconfigObserver {
-    reconfig_rx: tokio::sync::broadcast::Receiver<(CommitteeWithNetworkMetadata, ProtocolVersion)>,
+    reconfig_rx: tokio::sync::broadcast::Receiver<(Committee, ProtocolVersion)>,
     authority_store: Arc<AuthorityStore>,
     committee_store: Arc<CommitteeStore>,
     safe_client_metrics_base: SafeClientMetricsBase,
@@ -37,10 +37,7 @@ pub struct OnsiteReconfigObserver {
 
 impl OnsiteReconfigObserver {
     pub fn new(
-        reconfig_rx: tokio::sync::broadcast::Receiver<(
-            CommitteeWithNetworkMetadata,
-            ProtocolVersion,
-        )>,
+        reconfig_rx: tokio::sync::broadcast::Receiver<(Committee, ProtocolVersion)>,
         authority_store: Arc<AuthorityStore>,
         committee_store: Arc<CommitteeStore>,
         safe_client_metrics_base: SafeClientMetricsBase,

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -26,7 +26,7 @@ use std::time::Duration;
 use sui_protocol_config::ProtocolVersion;
 use sui_storage::write_path_pending_tx_log::WritePathPendingTransactionLog;
 use sui_types::base_types::TransactionDigest;
-use sui_types::committee::CommitteeWithNetworkMetadata;
+use sui_types::committee::Committee;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
@@ -62,7 +62,7 @@ pub struct TransactiondOrchestrator<A> {
 impl TransactiondOrchestrator<NetworkAuthorityClient> {
     pub async fn new_with_network_clients(
         validator_state: Arc<AuthorityState>,
-        reconfig_channel: Receiver<(CommitteeWithNetworkMetadata, ProtocolVersion)>,
+        reconfig_channel: Receiver<(Committee, ProtocolVersion)>,
         parent_path: &Path,
         prometheus_registry: &Registry,
     ) -> anyhow::Result<Self> {

--- a/crates/sui-network/src/discovery/tests.rs
+++ b/crates/sui-network/src/discovery/tests.rs
@@ -3,22 +3,17 @@
 
 use super::*;
 use crate::utils::build_network;
+use anemo::types::PeerAffinity;
 use anemo::Result;
 use fastcrypto::ed25519::Ed25519PublicKey;
 use futures::stream::FuturesUnordered;
-use std::collections::{BTreeMap, HashSet};
-use sui_types::committee::{Committee, NetworkMetadata};
-use sui_types::crypto::get_authority_key_pair;
-use sui_types::crypto::AuthorityPublicKeyBytes;
-use sui_types::crypto::KeypairTraits;
-use tokio::{sync::broadcast, time::timeout};
+use std::collections::HashSet;
+use tokio::time::timeout;
 
 #[tokio::test]
 async fn get_known_peers() -> Result<()> {
-    let (end_of_epoch_channel, _) =
-        broadcast::channel::<(CommitteeWithNetworkMetadata, ProtocolVersion)>(100);
     let config = P2pConfig::default();
-    let (UnstartedDiscovery { state, .. }, server) = Builder::new(end_of_epoch_channel.subscribe())
+    let (UnstartedDiscovery { state, .. }, server) = Builder::new(create_test_channel().1)
         .config(config)
         .build_internal();
 
@@ -64,12 +59,8 @@ async fn get_known_peers() -> Result<()> {
 
 #[tokio::test]
 async fn make_connection_to_seed_peer() -> Result<()> {
-    let (end_of_epoch_channel, _) =
-        broadcast::channel::<(CommitteeWithNetworkMetadata, ProtocolVersion)>(100);
     let config = P2pConfig::default();
-    let (builder, server) = Builder::new(end_of_epoch_channel.subscribe())
-        .config(config)
-        .build();
+    let (builder, server) = Builder::new(create_test_channel().1).config(config).build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (_event_loop_1, _handle_1) = builder.build(network_1.clone());
 
@@ -78,9 +69,7 @@ async fn make_connection_to_seed_peer() -> Result<()> {
         peer_id: None,
         address: format!("/dns/localhost/udp/{}", network_1.local_addr().port()).parse()?,
     });
-    let (builder, server) = Builder::new(end_of_epoch_channel.subscribe())
-        .config(config)
-        .build();
+    let (builder, server) = Builder::new(create_test_channel().1).config(config).build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (mut event_loop_2, _handle_2) = builder.build(network_2.clone());
 
@@ -103,12 +92,8 @@ async fn make_connection_to_seed_peer() -> Result<()> {
 
 #[tokio::test]
 async fn make_connection_to_seed_peer_with_peer_id() -> Result<()> {
-    let (end_of_epoch_channel, _) =
-        broadcast::channel::<(CommitteeWithNetworkMetadata, ProtocolVersion)>(100);
     let config = P2pConfig::default();
-    let (builder, server) = Builder::new(end_of_epoch_channel.subscribe())
-        .config(config)
-        .build();
+    let (builder, server) = Builder::new(create_test_channel().1).config(config).build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (_event_loop_1, _handle_1) = builder.build(network_1.clone());
 
@@ -117,9 +102,7 @@ async fn make_connection_to_seed_peer_with_peer_id() -> Result<()> {
         peer_id: Some(network_1.peer_id()),
         address: format!("/dns/localhost/udp/{}", network_1.local_addr().port()).parse()?,
     });
-    let (builder, server) = Builder::new(end_of_epoch_channel.subscribe())
-        .config(config)
-        .build();
+    let (builder, server) = Builder::new(create_test_channel().1).config(config).build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (mut event_loop_2, _handle_2) = builder.build(network_2.clone());
 
@@ -143,12 +126,8 @@ async fn make_connection_to_seed_peer_with_peer_id() -> Result<()> {
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn three_nodes_can_connect_via_discovery() -> Result<()> {
     // Setup the peer that will be the seed for the other two
-    let (end_of_epoch_channel, _) =
-        broadcast::channel::<(CommitteeWithNetworkMetadata, ProtocolVersion)>(100);
     let config = P2pConfig::default();
-    let (builder, server) = Builder::new(end_of_epoch_channel.subscribe())
-        .config(config)
-        .build();
+    let (builder, server) = Builder::new(create_test_channel().1).config(config).build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_1, _handle_1) = builder.build(network_1.clone());
 
@@ -157,7 +136,7 @@ async fn three_nodes_can_connect_via_discovery() -> Result<()> {
         peer_id: Some(network_1.peer_id()),
         address: format!("/dns/localhost/udp/{}", network_1.local_addr().port()).parse()?,
     });
-    let (builder, server) = Builder::new(end_of_epoch_channel.subscribe())
+    let (builder, server) = Builder::new(create_test_channel().1)
         .config(config.clone())
         .build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
@@ -166,9 +145,7 @@ async fn three_nodes_can_connect_via_discovery() -> Result<()> {
     event_loop_2.config.external_address =
         Some(format!("/dns/localhost/udp/{}", network_2.local_addr().port()).parse()?);
 
-    let (builder, server) = Builder::new(end_of_epoch_channel.subscribe())
-        .config(config)
-        .build();
+    let (builder, server) = Builder::new(create_test_channel().1).config(config).build();
     let network_3 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_3, _handle_3) = builder.build(network_3.clone());
 
@@ -212,24 +189,17 @@ async fn three_nodes_can_connect_via_discovery() -> Result<()> {
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn peers_are_added_from_reocnfig_channel() -> Result<()> {
-    let (end_of_epoch_channel_1, _) =
-        broadcast::channel::<(CommitteeWithNetworkMetadata, ProtocolVersion)>(100);
+    let (tx_1, rx_1) = create_test_channel();
     let config = P2pConfig::default();
-    let (builder, server) = Builder::new(end_of_epoch_channel_1.subscribe())
-        .config(config.clone())
-        .build();
+    let (builder, server) = Builder::new(rx_1).config(config.clone()).build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_1, _handle_1) = builder.build(network_1.clone());
 
-    let (end_of_epoch_channel_2, _) =
-        broadcast::channel::<(CommitteeWithNetworkMetadata, ProtocolVersion)>(100);
-    let (builder, server) = Builder::new(end_of_epoch_channel_2.subscribe())
+    let (builder, server) = Builder::new(create_test_channel().1)
         .config(config.clone())
         .build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, _handle_2) = builder.build(network_2.clone());
-
-    let authority_name_2 = get_authority_pub_key_bytes();
 
     let (mut subscriber_1, _) = network_1.subscribe()?;
     let (mut subscriber_2, _) = network_2.subscribe()?;
@@ -252,37 +222,20 @@ async fn peers_are_added_from_reocnfig_channel() -> Result<()> {
     let (mut subscriber_1, _) = network_1.subscribe()?;
     let (mut subscriber_2, _) = network_2.subscribe()?;
 
-    // We send peer 1 a new committee info (peer 2) from the reconfig channel.
-    let committee = Committee::new(1, BTreeMap::from([(authority_name_2, 1)])).unwrap();
+    // We send peer 1 a new peer info (peer 2) in the channel.
     let peer_2_network_pubkey =
         Ed25519PublicKey(ed25519_consensus::VerificationKey::try_from(peer_id_2.0).unwrap());
-    end_of_epoch_channel_1
-        .send((
-            CommitteeWithNetworkMetadata {
-                committee,
-                network_metadata: BTreeMap::from([(
-                    authority_name_2,
-                    NetworkMetadata {
-                        network_pubkey: peer_2_network_pubkey,
-                        // network_address does not matter here
-                        network_address: format!(
-                            "/dns/localhost/udp/{}",
-                            network_2.local_addr().port()
-                        )
-                        .parse()
-                        .unwrap(),
-                        p2p_address: format!(
-                            "/dns/localhost/udp/{}",
-                            network_2.local_addr().port()
-                        )
-                        .parse()
-                        .unwrap(),
-                    },
-                )]),
-            },
-            ProtocolVersion::new(1),
-        ))
+    let peer2_addr: Multiaddr = format!("/dns/localhost/udp/{}", network_2.local_addr().port())
+        .parse()
         .unwrap();
+    tx_1.send(TrustedPeerChangeEvent {
+        new_peers: vec![PeerInfo {
+            peer_id: PeerId(peer_2_network_pubkey.0.to_bytes()),
+            affinity: PeerAffinity::High,
+            address: vec![multiaddr_to_anemo_address(&peer2_addr).unwrap()],
+        }],
+    })
+    .unwrap();
 
     // Now peer 1 and peer 2 are connected.
     let new_peer_for_1 = unwrap_new_peer_event(subscriber_1.recv().await.unwrap());
@@ -300,7 +253,10 @@ fn unwrap_new_peer_event(event: PeerEvent) -> PeerId {
     }
 }
 
-pub fn get_authority_pub_key_bytes() -> AuthorityPublicKeyBytes {
-    let (_val0_addr, val0_kp) = get_authority_key_pair();
-    AuthorityPublicKeyBytes::from(val0_kp.public())
+fn create_test_channel() -> (
+    watch::Sender<TrustedPeerChangeEvent>,
+    watch::Receiver<TrustedPeerChangeEvent>,
+) {
+    let (tx, rx) = watch::channel(TrustedPeerChangeEvent { new_peers: vec![] });
+    (tx, rx)
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -42,10 +42,8 @@ use sui_json_rpc::{JsonRpcServerBuilder, ServerHandle};
 use sui_network::api::ValidatorServer;
 use sui_network::discovery;
 use sui_network::{state_sync, DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_HTTP2_KEEPALIVE_SEC};
-use sui_types::committee::CommitteeWithNetworkMetadata;
 use sui_types::sui_system_state::SuiSystemStateTrait;
-use tokio::sync::broadcast::Receiver;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion, SupportedProtocolVersions};
 
@@ -105,6 +103,7 @@ pub struct ValidatorComponents {
     sui_tx_validator_metrics: Arc<SuiTxValidatorMetrics>,
 }
 use sui_json_rpc::governance_api::GovernanceReadApi;
+use sui_network::discovery::TrustedPeerChangeEvent;
 
 pub struct SuiNode {
     config: NodeConfig,
@@ -120,8 +119,11 @@ pub struct SuiNode {
     accumulator: Arc<StateAccumulator>,
     connection_monitor_status: Arc<ConnectionMonitorStatus>,
 
-    /// Broadcast channel to send the committee and protocol version for the next epoch.
-    end_of_epoch_channel: broadcast::Sender<(CommitteeWithNetworkMetadata, ProtocolVersion)>,
+    /// Broadcast channel to send the starting system state for the next epoch.
+    end_of_epoch_channel: broadcast::Sender<(Committee, ProtocolVersion)>,
+
+    /// Broadcast channel to notify state-sync for new validator peers.
+    trusted_peer_change_tx: watch::Sender<TrustedPeerChangeEvent>,
 
     #[cfg(msim)]
     sim_node: sui_simulator::runtime::NodeHandle,
@@ -233,17 +235,19 @@ impl SuiNode {
             None
         };
 
-        let (end_of_epoch_channel, end_of_epoch_receiver) =
-            broadcast::channel::<(CommitteeWithNetworkMetadata, ProtocolVersion)>(
-                config.end_of_epoch_broadcast_channel_capacity,
-            );
-
         // Create network
+        // TODO only configure validators as seed/preferred peers for validators and not for
+        // fullnodes once we've had a chance to re-work fullnode configuration generation.
+        let (trusted_peer_change_tx, trusted_peer_change_rx) =
+            watch::channel(TrustedPeerChangeEvent {
+                new_peers: epoch_store
+                    .epoch_start_state()
+                    .get_validator_as_p2p_peers(config.protocol_public_key()),
+            });
         let (p2p_network, discovery_handle, state_sync_handle) = Self::create_p2p_network(
             &config,
-            epoch_store.epoch_start_state(),
             state_sync_store,
-            end_of_epoch_channel.subscribe(),
+            trusted_peer_change_rx,
             &prometheus_registry,
         )?;
 
@@ -289,6 +293,9 @@ impl SuiNode {
                 .await
                 .unwrap();
         }
+
+        let (end_of_epoch_channel, end_of_epoch_receiver) =
+            broadcast::channel(config.end_of_epoch_broadcast_channel_capacity);
 
         let transaction_orchestrator = if is_full_node {
             Some(Arc::new(
@@ -372,6 +379,7 @@ impl SuiNode {
             accumulator,
             end_of_epoch_channel,
             connection_monitor_status,
+            trusted_peer_change_tx,
 
             #[cfg(msim)]
             sim_node: sui_simulator::runtime::NodeHandle::current(),
@@ -385,9 +393,7 @@ impl SuiNode {
         Ok(node)
     }
 
-    pub fn subscribe_to_epoch_change(
-        &self,
-    ) -> broadcast::Receiver<(CommitteeWithNetworkMetadata, ProtocolVersion)> {
+    pub fn subscribe_to_epoch_change(&self) -> broadcast::Receiver<(Committee, ProtocolVersion)> {
         self.end_of_epoch_channel.subscribe()
     }
 
@@ -430,9 +436,8 @@ impl SuiNode {
 
     fn create_p2p_network(
         config: &NodeConfig,
-        sui_system: &EpochStartSystemState,
         state_sync_store: RocksDbStore,
-        reconfig_channel: Receiver<(CommitteeWithNetworkMetadata, ProtocolVersion)>,
+        trusted_peer_change_rx: watch::Receiver<TrustedPeerChangeEvent>,
         prometheus_registry: &Registry,
     ) -> Result<(Network, discovery::Handle, state_sync::Handle)> {
         let (state_sync, state_sync_server) = state_sync::Builder::new()
@@ -441,26 +446,8 @@ impl SuiNode {
             .with_metrics(prometheus_registry)
             .build();
 
-        // TODO only configure validators as seed/preferred peers for validators and not for
-        // fullnodes once we've had a chance to re-work fullnode configuration generation.
-        let mut p2p_config = config.p2p_config.clone();
-        let network_kp = config.network_key_pair();
-        let our_network_public_key = network_kp.public();
-        let other_validators = sui_system
-            .get_sui_committee()
-            .network_metadata
-            .into_iter()
-            .filter(|(_name, network_metadata)| {
-                &network_metadata.network_pubkey != our_network_public_key
-            })
-            .map(|(_name, network_metadata)| sui_config::p2p::SeedPeer {
-                peer_id: Some(anemo::PeerId(network_metadata.network_pubkey.0.to_bytes())),
-                address: network_metadata.p2p_address,
-            });
-        p2p_config.seed_peers.extend(other_validators);
-
-        let (discovery, discovery_server) = discovery::Builder::new(reconfig_channel)
-            .config(p2p_config)
+        let (discovery, discovery_server) = discovery::Builder::new(trusted_peer_change_rx)
+            .config(config.p2p_config.clone())
             .build();
 
         let p2p_network = {
@@ -515,6 +502,7 @@ impl SuiNode {
 
         let discovery_handle = discovery.start(p2p_network.clone());
         let state_sync_handle = state_sync.start(p2p_network.clone());
+
         Ok((p2p_network, discovery_handle, state_sync_handle))
     }
 
@@ -846,17 +834,18 @@ impl SuiNode {
             }
 
             checkpoint_executor.run_epoch(cur_epoch_store.clone()).await;
-            let new_system_state = self
+            let new_epoch_start_state = self
                 .state
                 .get_sui_system_state_object_during_reconfig()
-                .expect("Read Sui System State object cannot fail");
-            let next_epoch_committee = new_system_state.get_current_epoch_committee();
+                .expect("Read Sui System State object cannot fail")
+                .into_epoch_start_state();
+            let next_epoch_committee = new_epoch_start_state.get_sui_committee();
             let next_epoch = next_epoch_committee.epoch();
             assert_eq!(cur_epoch_store.epoch() + 1, next_epoch);
 
             // If we eventually add tests that exercise safe mode, we will need a configurable way of
             // guarding against unexpected safe_mode.
-            debug_assert!(!new_system_state.safe_mode());
+            debug_assert!(!new_epoch_start_state.safe_mode);
 
             info!(
                 next_epoch,
@@ -865,19 +854,27 @@ impl SuiNode {
 
             // We save the connection monitor status map regardless of validator / fullnode status
             // so that we don't need to restart the connection monitor every epoch.
-            //  Update the mappings that will be used by the consensus adapter if it exists or is
+            // Update the mappings that will be used by the consensus adapter if it exists or is
             // about to be created.
-            let new_system_state = new_system_state.into_epoch_start_state();
-            let authority_names_to_peer_ids = new_system_state.get_authority_names_to_peer_ids();
+            let authority_names_to_peer_ids =
+                new_epoch_start_state.get_authority_names_to_peer_ids();
             self.connection_monitor_status
                 .update_mapping_for_epoch(authority_names_to_peer_ids);
 
             cur_epoch_store.record_epoch_reconfig_start_time_metric();
             let _ = self.end_of_epoch_channel.send((
                 next_epoch_committee.clone(),
-                ProtocolVersion::new(new_system_state.protocol_version),
+                ProtocolVersion::new(new_epoch_start_state.protocol_version),
             ));
-            let next_epoch_committee = next_epoch_committee.committee;
+            if let Err(err) = self.trusted_peer_change_tx.send(TrustedPeerChangeEvent {
+                new_peers: new_epoch_start_state
+                    .get_validator_as_p2p_peers(self.config.protocol_public_key()),
+            }) {
+                warn!(
+                    "Failed to send validator peer information to state sync: {:?}",
+                    err
+                );
+            }
 
             // The following code handles 4 different cases, depending on whether the node
             // was a validator in the previous epoch, and whether the node is a validator
@@ -899,7 +896,11 @@ impl SuiNode {
                 narwhal_manager.shutdown().await;
 
                 let new_epoch_store = self
-                    .reconfigure_state(&cur_epoch_store, next_epoch_committee, new_system_state)
+                    .reconfigure_state(
+                        &cur_epoch_store,
+                        next_epoch_committee,
+                        new_epoch_start_state,
+                    )
                     .await;
 
                 narwhal_epoch_data_remover
@@ -931,7 +932,11 @@ impl SuiNode {
                 }
             } else {
                 let new_epoch_store = self
-                    .reconfigure_state(&cur_epoch_store, next_epoch_committee, new_system_state)
+                    .reconfigure_state(
+                        &cur_epoch_store,
+                        next_epoch_committee,
+                        new_epoch_start_state,
+                    )
                     .await;
 
                 if self.state.is_validator(&new_epoch_store) {

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::base_types::*;
-use crate::crypto::{
-    random_committee_key_pairs, AuthorityKeyPair, AuthorityPublicKey, NetworkPublicKey,
-};
+use crate::crypto::{random_committee_key_pairs, AuthorityKeyPair, AuthorityPublicKey};
 use crate::error::{SuiError, SuiResult};
 use fastcrypto::traits::KeyPair;
 use itertools::Itertools;
@@ -351,9 +349,7 @@ pub fn validity_threshold(total_stake: StakeUnit) -> StakeUnit {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NetworkMetadata {
-    pub network_pubkey: NetworkPublicKey,
     pub network_address: Multiaddr,
-    pub p2p_address: Multiaddr,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -4,7 +4,9 @@
 use std::collections::{BTreeMap, HashMap};
 
 use crate::base_types::{AuthorityName, EpochId, SuiAddress};
-use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata, StakeUnit};
+use crate::committee::{Committee, StakeUnit};
+use crate::sui_system_state::multiaddr_to_anemo_address;
+use anemo::types::{PeerAffinity, PeerInfo};
 use anemo::PeerId;
 use multiaddr::Multiaddr;
 use narwhal_config::{Committee as NarwhalCommittee, WorkerCache, WorkerIndex};
@@ -44,21 +46,16 @@ impl EpochStartSystemState {
         }
     }
 
-    pub fn get_sui_committee(&self) -> CommitteeWithNetworkMetadata {
-        let mut voting_rights = BTreeMap::new();
-        let mut network_metadata = BTreeMap::new();
-        for validator in &self.active_validators {
-            let (name, voting_stake, metadata) = validator.to_stake_and_network_metadata();
-            voting_rights.insert(name, voting_stake);
-            network_metadata.insert(name, metadata);
-        }
-        CommitteeWithNetworkMetadata {
-            committee: Committee::new(self.epoch, voting_rights)
-                // unwrap is safe because we should have verified the committee on-chain.
-                // TODO: Make sure we actually verify it.
-                .unwrap(),
-            network_metadata,
-        }
+    pub fn get_sui_committee(&self) -> Committee {
+        let voting_rights = self
+            .active_validators
+            .iter()
+            .map(|validator| (validator.authority_name(), validator.voting_power))
+            .collect();
+        Committee::new(self.epoch, voting_rights)
+            // unwrap is safe because we should have verified the committee on-chain.
+            // TODO: Make sure we actually verify it.
+            .unwrap()
     }
 
     #[allow(clippy::mutable_key_type)]
@@ -80,6 +77,19 @@ impl EpochStartSystemState {
             authorities: narwhal_committee,
             epoch: self.epoch as narwhal_config::Epoch,
         }
+    }
+
+    pub fn get_validator_as_p2p_peers(&self, excluding_self: AuthorityName) -> Vec<PeerInfo> {
+        self.active_validators
+            .iter()
+            .filter(|validator| validator.authority_name() != excluding_self)
+            .map(|validator| PeerInfo {
+                peer_id: PeerId(validator.narwhal_network_pubkey.0.to_bytes()),
+                affinity: PeerAffinity::High,
+                address: vec![multiaddr_to_anemo_address(&validator.p2p_address)
+                    .expect("p2p address must be valid anemo address and verified on-chain")],
+            })
+            .collect()
     }
 
     pub fn get_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId> {
@@ -136,17 +146,6 @@ pub struct EpochStartValidatorInfo {
 }
 
 impl EpochStartValidatorInfo {
-    pub fn to_stake_and_network_metadata(&self) -> (AuthorityName, StakeUnit, NetworkMetadata) {
-        (
-            (&self.protocol_pubkey).into(),
-            self.voting_power,
-            NetworkMetadata {
-                network_pubkey: self.narwhal_network_pubkey.clone(),
-                network_address: self.sui_net_address.clone(),
-                p2p_address: self.p2p_address.clone(),
-            },
-        )
-    }
     pub fn authority_name(&self) -> AuthorityName {
         (&self.protocol_pubkey).into()
     }

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -229,18 +229,10 @@ impl ValidatorV1 {
                 .expect("Validity of public key bytes should be verified on-chain"),
             self.voting_power,
             NetworkMetadata {
-                network_pubkey: narwhal_crypto::NetworkPublicKey::from_bytes(
-                    &self.metadata.network_pubkey_bytes,
-                )
-                .expect("Validity of network public key should be verified on-chain"),
                 network_address: self
                     .metadata
                     .network_address()
                     .expect("Validity of network address should be verified on-chain"),
-                p2p_address: self
-                    .metadata
-                    .p2p_address()
-                    .expect("Validity of p2p address should be verified on-chain"),
             },
         )
     }

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -3,7 +3,6 @@
 
 use fastcrypto::traits::ToFromBytes;
 use multiaddr::Multiaddr;
-use narwhal_crypto::NetworkPublicKey;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -88,10 +87,7 @@ impl SuiSystemStateSummary {
             network_metadata.insert(
                 name,
                 NetworkMetadata {
-                    network_pubkey: NetworkPublicKey::from_bytes(&validator.network_pubkey_bytes)
-                        .unwrap(),
                     network_address: Multiaddr::try_from(validator.net_address.clone()).unwrap(),
-                    p2p_address: Multiaddr::try_from(validator.p2p_address.clone()).unwrap(),
                 },
             );
         }


### PR DESCRIPTION
Introduce a new event for state sync called TrustedPeerChangeEvent. We send this event to state-sync whenever the validator set changes and hence we have new information about the p2p addresses of the new committee.
This decouples the type of the message from the committee+protocol version which are not needed by state-sync. Specifically, this brings a few benefits:
1. It makes it easy to optimize the event in the future, e.g. if we want to capture node leaving
2. It allows us to use watch channel instead of broadcast channel
3. It fixes a minor bug where we may include self node during reconfiguration when notifying state-sync about the next committee peers
4. Simplified committee with network metadata 