### PR TITLE
[13/x][programmable transactions] Migrate move calls and publish

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/sui/move_call_args_type_mismatch.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/move_call_args_type_mismatch.exp
@@ -5,8 +5,8 @@ created: object(104)
 written: object(103)
 
 task 2 'run'. lines 14-16:
-Error: Transaction Effects Status: Entry Argument Error. Error for argument at index 1: Mismatch between the number of actual versus expected arguments.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 1, kind: ArityMismatch }), source: Some("Expected 2 arguments calling function 'create', but found 1"), command: Some(0) } }
+Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 2 arguments calling function 'create', but found 1"), command: Some(0) } }
 
 task 3 'run'. lines 17-17:
 Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.

--- a/crates/sui-adapter/src/lib.rs
+++ b/crates/sui-adapter/src/lib.rs
@@ -3,6 +3,9 @@
 
 macro_rules! invariant_violation {
     ($msg:expr) => {{
+        if cfg!(debug_assertions) {
+            panic!("{}", $msg)
+        }
         return Err(sui_types::error::ExecutionError::new_with_source(
             sui_types::error::ExecutionErrorKind::InvariantViolation,
             $msg,

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -62,7 +62,7 @@ pub fn make_split_coin_tx(
         ],
         1000000,
         gas_price.unwrap_or(DUMMY_GAS_PRICE),
-    );
+    )?;
     let verified_tx = to_sender_signed_transaction(split_coin, keypair);
     Ok(verified_tx)
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1161,9 +1161,11 @@ impl AuthorityState {
             cert.data()
                 .intent_message
                 .value
-                .legacy_move_calls()
-                .iter()
-                .map(|mc| (mc.package, mc.module.clone(), mc.function.clone())),
+                .move_calls()
+                .into_iter()
+                .map(|(package, module, function)| {
+                    (*package, module.to_owned(), function.to_owned())
+                }),
             changes,
             digest,
             timestamp_ms,

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -84,7 +84,8 @@ pub fn transfer_object_move_transaction(
             gas_object_ref,
             args,
             GAS_VALUE_FOR_TESTING / 2,
-        ),
+        )
+        .unwrap(),
         secret,
     )
 }
@@ -113,7 +114,8 @@ pub fn create_object_move_transaction(
             gas_object_ref,
             arguments,
             GAS_VALUE_FOR_TESTING / 2,
-        ),
+        )
+        .unwrap(),
         secret,
     )
 }
@@ -135,7 +137,8 @@ pub fn delete_object_move_transaction(
             gas_object_ref,
             vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(object_ref))],
             GAS_VALUE_FOR_TESTING / 2,
-        ),
+        )
+        .unwrap(),
         secret,
     )
 }
@@ -163,7 +166,8 @@ pub fn set_object_move_transaction(
             gas_object_ref,
             args,
             GAS_VALUE_FOR_TESTING / 2,
-        ),
+        )
+        .unwrap(),
         secret,
     )
 }

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -4,7 +4,10 @@
 use super::*;
 use crate::authority::authority_tests::init_state_with_ids_and_object_basics;
 use bcs;
-use sui_types::utils::to_sender_signed_transaction;
+use sui_types::{
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    utils::to_sender_signed_transaction,
+};
 
 use authority_tests::{init_state_with_ids, send_and_confirm_transaction};
 use move_binary_format::file_format;
@@ -27,37 +30,39 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
         [sender; TOTAL].into_iter().zip(all_ids.clone().into_iter()),
     )
     .await;
-    let mut transactions = vec![];
+    let mut builder = ProgrammableTransactionBuilder::new();
     for obj_id in all_ids.iter().take(N) {
-        transactions.push(SingleTransactionKind::TransferObject(TransferObject {
+        builder.transfer_object(
             recipient,
-            object_ref: authority_state
+            authority_state
                 .get_object(obj_id)
                 .await?
                 .unwrap()
                 .compute_object_reference(),
-        }));
+        )
     }
     for _ in 0..N {
-        transactions.push(SingleTransactionKind::Call(MoveCall {
-            package: package.0,
-            module: ident_str!("object_basics").to_owned(),
-            function: ident_str!("create").to_owned(),
-            type_arguments: vec![],
-            arguments: vec![
-                CallArg::Pure(16u64.to_le_bytes().to_vec()),
-                CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
-            ],
-        }));
+        builder
+            .move_call(
+                package.0,
+                ident_str!("object_basics").to_owned(),
+                ident_str!("create").to_owned(),
+                vec![],
+                vec![
+                    CallArg::Pure(16u64.to_le_bytes().to_vec()),
+                    CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
+                ],
+            )
+            .unwrap();
     }
-    let data = TransactionData::new_with_dummy_gas_price(
-        TransactionKind::Batch(transactions),
+    let data = TransactionData::new_programmable_with_dummy_gas_price(
         sender,
-        authority_state
+        vec![authority_state
             .get_object(&all_ids[N])
             .await?
             .unwrap()
-            .compute_object_reference(),
+            .compute_object_reference()],
+        builder.finish(),
         1000000,
     );
 

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -68,7 +68,8 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
                 CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
             ],
             /* max_gas */ 10_000,
-        );
+        )
+        .unwrap();
 
         let transaction = to_sender_signed_transaction(data, &keypair);
 

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -307,7 +307,12 @@ async fn test_publish_gas() -> anyhow::Result<()> {
         .next()
         .unwrap()
     {
-        SingleTransactionKind::Publish(p) => &p.modules,
+        SingleTransactionKind::ProgrammableTransaction(pt) => {
+            match pt.commands.iter().next().unwrap() {
+                Command::Publish(modules) => modules,
+                _ => unreachable!(),
+            }
+        }
         _ => unreachable!(),
     };
 
@@ -420,7 +425,8 @@ async fn test_move_call_gas() -> SuiResult {
         gas_object.compute_object_reference(),
         args.clone(),
         GAS_VALUE_FOR_TESTING,
-    );
+    )
+    .unwrap();
 
     let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
@@ -488,7 +494,8 @@ async fn test_move_call_gas() -> SuiResult {
             created_object_ref,
         ))],
         expected_gas_balance,
-    );
+    )
+    .unwrap();
 
     let transaction = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, transaction).await?;
@@ -514,7 +521,8 @@ async fn test_move_call_gas() -> SuiResult {
         gas_object.compute_object_reference(),
         args,
         budget,
-    );
+    )
+    .unwrap();
 
     let transaction = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, transaction).await?;

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -307,12 +307,10 @@ async fn test_publish_gas() -> anyhow::Result<()> {
         .next()
         .unwrap()
     {
-        SingleTransactionKind::ProgrammableTransaction(pt) => {
-            match pt.commands.iter().next().unwrap() {
-                Command::Publish(modules) => modules,
-                _ => unreachable!(),
-            }
-        }
+        SingleTransactionKind::ProgrammableTransaction(pt) => match pt.commands.first().unwrap() {
+            Command::Publish(modules) => modules,
+            _ => unreachable!(),
+        },
         _ => unreachable!(),
     };
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1088,7 +1088,7 @@ impl From<Command> for SuiCommand {
 }
 
 /// An argument to a programmable transaction command
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub enum SuiArgument {
     /// The gas coin. The gas coin can only be used by-ref, except for with
     /// `TransferObjects`, which can use it by-value.

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -221,9 +221,7 @@ pub async fn metadata(
                 .into_iter()
                 .map(|coin| coin.object_ref())
                 .collect::<Vec<_>>();
-            // gas is always the first coin for pay_sui
-            let gas = sender_coins[0];
-            (TransactionMetadata::PaySui(sender_coins), gas, 1000)
+            (TransactionMetadata::PaySui, sender_coins, 1000)
         }
         InternalOperation::Delegation {
             sender,
@@ -258,7 +256,7 @@ pub async fn metadata(
                     coins,
                     locked_until_epoch: *locked_until_epoch,
                 },
-                data.gas()[0],
+                data.gas().to_vec(),
                 13000,
             )
         }
@@ -270,7 +268,7 @@ pub async fn metadata(
         .try_into_data(ConstructionMetadata {
             tx_metadata: tx_metadata.clone(),
             sender,
-            gas,
+            gas: gas.clone(),
             gas_price: 1,
             budget,
         })?;

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -3,14 +3,18 @@
 
 use anyhow::anyhow;
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::vec;
+use sui_json_rpc_types::SuiArgument;
+use sui_json_rpc_types::SuiCommand;
+use sui_json_rpc_types::SuiProgrammableMoveCall;
+use sui_json_rpc_types::SuiProgrammableTransaction;
+use sui_sdk::json::SuiJsonValue;
 
 use serde::Deserialize;
 use serde::Serialize;
 use sui_sdk::rpc_types::{
-    SuiEvent, SuiMoveCall, SuiPaySui, SuiTransactionData, SuiTransactionDataAPI,
-    SuiTransactionEffectsAPI, SuiTransactionKind, SuiTransactionResponse,
+    SuiEvent, SuiTransactionData, SuiTransactionDataAPI, SuiTransactionEffectsAPI,
+    SuiTransactionKind, SuiTransactionResponse,
 };
 
 use sui_types::base_types::{SequenceNumber, SuiAddress};
@@ -129,13 +133,18 @@ impl Operations {
         self,
         locked_until_epoch: Option<EpochId>,
     ) -> Result<InternalOperation, Error> {
-        if self.0.len() != 1 {
+        let mut ops = self
+            .0
+            .into_iter()
+            .filter(|op| op.type_ == OperationType::Delegation)
+            .collect::<Vec<_>>();
+        if ops.len() != 1 {
             return Err(Error::MalformedOperationError(
                 "Delegation should only have one operation.".into(),
             ));
         }
         // Checked above, safe to unwrap.
-        let op = self.into_iter().next().unwrap();
+        let op = ops.pop().unwrap();
         let sender = op
             .account
             .ok_or_else(|| Error::MissingInput("Sender address".to_string()))?
@@ -168,83 +177,183 @@ impl Operations {
         status: Option<OperationStatus>,
     ) -> Result<Vec<Operation>, Error> {
         Ok(match tx {
-            SuiTransactionKind::PaySui(tx) => Self::parse_pay_sui_operations(sender, tx, status),
-            SuiTransactionKind::Call(tx) => Self::parse_call_operations(sender, status, tx)?,
+            SuiTransactionKind::ProgrammableTransaction(pt) => {
+                Self::parse_programmable_transaction(sender, status, pt)?
+            }
             _ => vec![Operation::generic_op(status, sender, tx)],
         })
     }
 
-    fn parse_call_operations(
+    fn parse_programmable_transaction(
         sender: SuiAddress,
         status: Option<OperationStatus>,
-        tx: SuiMoveCall,
+        pt: SuiProgrammableTransaction,
     ) -> Result<Vec<Operation>, Error> {
-        if Self::is_delegation_call(&tx) {
-            let (amount, validator) = match &tx.arguments[..] {
+        enum KnownValue {
+            GasCoin(u64),
+        }
+        macro_rules! bcs_json_to_value {
+            ($value:expr) => {
+                $value.to_json_value().as_array().and_then(|v| {
+                    // value is a byte array
+                    let bytes = v
+                        .iter()
+                        .flat_map(|v| v.as_u64().map(|n| n as u8))
+                        .collect::<Vec<_>>();
+                    bcs::from_bytes(&bytes).ok()
+                })
+            };
+        }
+        fn resolve_result(
+            known_results: &[Vec<KnownValue>],
+            i: u16,
+            j: u16,
+        ) -> Option<&KnownValue> {
+            known_results
+                .get(i as usize)
+                .and_then(|inner| inner.get(j as usize))
+        }
+        fn split_coin(
+            inputs: &[SuiJsonValue],
+            _known_results: &[Vec<KnownValue>],
+            _coin: SuiArgument,
+            amount: SuiArgument,
+        ) -> Option<Vec<KnownValue>> {
+            let amount: u64 = match amount {
+                SuiArgument::Input(i) => bcs_json_to_value!(&inputs[i as usize])?,
+                SuiArgument::GasCoin | SuiArgument::Result(_) | SuiArgument::NestedResult(_, _) => {
+                    return None
+                }
+            };
+            Some(vec![KnownValue::GasCoin(amount)])
+        }
+        fn transfer_object(
+            aggregated_recipients: &mut HashMap<SuiAddress, u64>,
+            inputs: &[SuiJsonValue],
+            known_results: &[Vec<KnownValue>],
+            objs: &[SuiArgument],
+            recipient: SuiArgument,
+        ) -> Option<Vec<KnownValue>> {
+            let addr = match recipient {
+                SuiArgument::Input(i) => inputs[i as usize].to_sui_address().ok()?,
+                SuiArgument::GasCoin | SuiArgument::Result(_) | SuiArgument::NestedResult(_, _) => {
+                    return None
+                }
+            };
+            for obj in objs {
+                let value = match *obj {
+                    SuiArgument::Result(i) => {
+                        let KnownValue::GasCoin(value) = resolve_result(known_results, i, 0)?;
+                        value
+                    }
+                    SuiArgument::NestedResult(i, j) => {
+                        let KnownValue::GasCoin(value) = resolve_result(known_results, i, j)?;
+                        value
+                    }
+                    SuiArgument::GasCoin | SuiArgument::Input(_) => return None,
+                };
+                let aggregate = aggregated_recipients.entry(addr).or_default();
+                *aggregate += value;
+            }
+            Some(vec![])
+        }
+        fn delegation_call(
+            inputs: &[SuiJsonValue],
+            _known_results: &[Vec<KnownValue>],
+            call: &SuiProgrammableMoveCall,
+        ) -> Result<Option<(Option<u64>, SuiAddress)>, Error> {
+            let SuiProgrammableMoveCall { arguments, .. } = call;
+            let (amount, validator) = match &arguments[..] {
                 [_, _, amount, validator] => {
-                    let amount = amount.to_json_value().as_array().and_then(|v| {
-                        // value is a byte array
-                        let bytes = v.iter().flat_map(|v| v.as_u64().map(|n| n as u8)).collect::<Vec<_>>();
-                        if let Ok(Some(amount)) = bcs::from_bytes::<Option<u64>>(&bytes) {
-                            Some(amount as u128)
-                        } else { None }
-                    });
-                    let validator = validator
-                        .to_json_value()
-                        .as_str()
-                        .map(SuiAddress::from_str)
-                        .transpose()?
-                        .ok_or_else(|| Error::InternalError(anyhow!("Error parsing Validator address from call arg.")))?;
+                    let amount = match amount {
+                        SuiArgument::Input(i) => match bcs_json_to_value!(&inputs[*i as usize]){
+                            Some(amount) => amount,
+                            None => return Ok(None),
+                        },
+                        SuiArgument::GasCoin |
+                        SuiArgument::Result(_) |
+                        SuiArgument::NestedResult(_, _) => return Ok(None),
+                    };
+                    let validator = match validator {
+                        SuiArgument::Input(i) => inputs[*i as usize].to_sui_address(),
+                        SuiArgument::GasCoin |
+                        SuiArgument::Result(_) |
+                        SuiArgument::NestedResult(_, _) => return Ok(None),
+                    };
                     (amount, validator)
                 },
-                _ => return Err(Error::InternalError(anyhow!("Error encountered when extracting arguments from move call, expecting 4 elements, got {}", tx.arguments.len()))),
+                _ => return Err(Error::InternalError(anyhow!("Error encountered when extracting arguments from move call, expecting 4 elements, got {}", arguments.len()))),
             };
-
-            let amount = amount.map(|amount| Amount::new(-(amount as i128)));
-
-            return Ok(vec![Operation {
-                operation_identifier: Default::default(),
-                type_: OperationType::Delegation,
-                status,
-                account: Some(sender.into()),
-                amount,
-                coin_change: None,
-                metadata: Some(OperationMetadata::Delegation { validator }),
-            }]);
+            let validator = validator.map_err(|_| {
+                Error::InternalError(anyhow!("Error parsing Validator address from call arg."))
+            })?;
+            Ok(Some((amount, validator)))
         }
-        Ok(vec![Operation::generic_op(
-            status,
-            sender,
-            SuiTransactionKind::Call(tx),
-        )])
+
+        let SuiProgrammableTransaction { inputs, commands } = &pt;
+        let mut known_results: Vec<Vec<KnownValue>> = vec![];
+        let mut aggregated_recipients: HashMap<SuiAddress, u64> = HashMap::new();
+        let mut needs_generic = false;
+        let mut operations = vec![];
+        for command in commands {
+            let result = match command {
+                SuiCommand::SplitCoin(coin, amount) => {
+                    split_coin(inputs, &known_results, *coin, *amount)
+                }
+                SuiCommand::TransferObjects(objs, addr) => transfer_object(
+                    &mut aggregated_recipients,
+                    inputs,
+                    &known_results,
+                    objs,
+                    *addr,
+                ),
+                SuiCommand::MoveCall(m) if Self::is_delegation_call(m) => {
+                    delegation_call(inputs, &known_results, m)?.map(|(amount, validator)| {
+                        let amount = amount.map(|amount| Amount::new(-(amount as i128)));
+                        operations.push(Operation {
+                            operation_identifier: Default::default(),
+                            type_: OperationType::Delegation,
+                            status,
+                            account: Some(sender.into()),
+                            amount,
+                            coin_change: None,
+                            metadata: Some(OperationMetadata::Delegation { validator }),
+                        });
+                        vec![]
+                    })
+                }
+                _ => None,
+            };
+            if let Some(result) = result {
+                known_results.push(result)
+            } else {
+                needs_generic = true;
+                known_results.push(vec![])
+            }
+        }
+
+        let total_paid: u64 = aggregated_recipients.values().copied().sum();
+        operations.extend(
+            aggregated_recipients
+                .into_iter()
+                .map(|(recipient, amount)| Operation::pay_sui(status, recipient, amount.into())),
+        );
+        operations.push(Operation::pay_sui(status, sender, -(total_paid as i128)));
+        if needs_generic {
+            operations.push(Operation::generic_op(
+                status,
+                sender,
+                SuiTransactionKind::ProgrammableTransaction(pt),
+            ))
+        }
+        Ok(operations)
     }
 
-    fn is_delegation_call(tx: &SuiMoveCall) -> bool {
+    fn is_delegation_call(tx: &SuiProgrammableMoveCall) -> bool {
         tx.package == SUI_FRAMEWORK_OBJECT_ID
             && tx.module == SUI_SYSTEM_MODULE_NAME.as_str()
             && (tx.function == ADD_DELEGATION_LOCKED_COIN_FUN_NAME.as_str()
                 || tx.function == ADD_DELEGATION_MUL_COIN_FUN_NAME.as_str())
-    }
-
-    fn parse_pay_sui_operations(
-        sender: SuiAddress,
-        tx: SuiPaySui,
-        status: Option<OperationStatus>,
-    ) -> Vec<Operation> {
-        let recipients = tx.recipients.iter().zip(&tx.amounts);
-        let mut aggregated_recipients: HashMap<SuiAddress, u64> = HashMap::new();
-
-        for (recipient, amount) in recipients {
-            *aggregated_recipients.entry(*recipient).or_default() += *amount
-        }
-
-        let mut pay_operations = aggregated_recipients
-            .into_iter()
-            .map(|(recipient, amount)| Operation::pay_sui(status, recipient, amount.into()))
-            .collect::<Vec<_>>();
-        let total_paid = tx.amounts.iter().sum::<u64>();
-        pay_operations.push(Operation::pay_sui(status, sender, -(total_paid as i128)));
-        pay_operations
     }
 
     fn get_balance_operation_from_events(

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -556,7 +556,7 @@ pub enum PreprocessMetadata {
 impl From<TransactionMetadata> for PreprocessMetadata {
     fn from(tx_metadata: TransactionMetadata) -> Self {
         match tx_metadata {
-            TransactionMetadata::PaySui(_) => Self::PaySui,
+            TransactionMetadata::PaySui => Self::PaySui,
             TransactionMetadata::Delegation {
                 locked_until_epoch, ..
             } => Self::Delegation { locked_until_epoch },
@@ -608,7 +608,7 @@ pub struct ConstructionMetadataResponse {
 pub struct ConstructionMetadata {
     pub tx_metadata: TransactionMetadata,
     pub sender: SuiAddress,
-    pub gas: ObjectRef,
+    pub gas: Vec<ObjectRef>,
     pub gas_price: u64,
     pub budget: u64,
 }
@@ -620,7 +620,7 @@ impl IntoResponse for ConstructionMetadataResponse {
 }
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum TransactionMetadata {
-    PaySui(Vec<ObjectRef>),
+    PaySui,
     Delegation {
         coins: Vec<ObjectRef>,
         locked_until_epoch: Option<EpochId>,
@@ -893,10 +893,10 @@ impl InternalOperation {
                     amounts,
                     ..
                 },
-                TransactionMetadata::PaySui(coins),
+                TransactionMetadata::PaySui,
             ) => {
                 let mut builder = ProgrammableTransactionBuilder::new();
-                builder.pay(coins, recipients, amounts)?;
+                builder.pay_sui(recipients, amounts)?;
                 builder.finish()
             }
             (
@@ -945,7 +945,7 @@ impl InternalOperation {
 
         Ok(TransactionData::new_programmable(
             metadata.sender,
-            vec![metadata.gas],
+            metadata.gas,
             pt,
             metadata.budget,
             metadata.gas_price,

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -24,9 +24,9 @@ use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::gas_coin::GasCoin;
 use sui_types::intent::Intent;
 use sui_types::messages::{
-    CallArg, ExecuteTransactionRequestType, InputObjectKind, MoveCall, MoveModulePublish,
-    ObjectArg, SingleTransactionKind, Transaction, TransactionData, TransactionDataAPI,
-    TransactionKind, DUMMY_GAS_PRICE,
+    CallArg, ExecuteTransactionRequestType, InputObjectKind, ObjectArg, ProgrammableTransaction,
+    SingleTransactionKind, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
+    DUMMY_GAS_PRICE,
 };
 use test_utils::network::TestClusterBuilder;
 
@@ -47,13 +47,12 @@ async fn test_transfer_sui() {
         builder.transfer_sui(recipient, Some(50000));
         builder.finish()
     };
-    let tx = SingleTransactionKind::ProgrammableTransaction(pt);
     test_transaction(
         &client,
         keystore,
         vec![recipient],
         sender,
-        tx,
+        pt,
         vec![],
         10000,
         false,
@@ -75,13 +74,12 @@ async fn test_transfer_sui_whole_coin() {
         builder.transfer_sui(recipient, None);
         builder.finish()
     };
-    let tx = SingleTransactionKind::ProgrammableTransaction(pt);
     test_transaction(
         &client,
         keystore,
         vec![recipient],
         sender,
-        tx,
+        pt,
         vec![],
         10000,
         false,
@@ -104,13 +102,12 @@ async fn test_transfer_object() {
         builder.transfer_object(recipient, object_ref);
         builder.finish()
     };
-    let tx = SingleTransactionKind::ProgrammableTransaction(pt);
     test_transaction(
         &client,
         keystore,
         vec![recipient],
         sender,
-        tx,
+        pt,
         vec![],
         10000,
         false,
@@ -138,11 +135,13 @@ async fn test_publish_and_move_call() {
         })
         .collect::<Vec<_>>();
 
-    let tx = SingleTransactionKind::Publish(MoveModulePublish {
-        modules: compiled_module,
-    });
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.publish(compiled_module);
+        builder.finish()
+    };
     let response =
-        test_transaction(&client, keystore, vec![], sender, tx, vec![], 10000, false).await;
+        test_transaction(&client, keystore, vec![], sender, pt, vec![], 10000, false).await;
     let events = response.events;
 
     // Test move call (reuse published module from above test)
@@ -160,21 +159,28 @@ async fn test_publish_and_move_call() {
         .unwrap();
 
     // TODO: Improve tx response to make it easier to find objects.
-    let treasury = find_module_object(&effect, &events, "managed", "TreasuryCap");
+    let treasury = find_module_object(&effect, &events, "::TreasuryCap");
     let treasury = treasury.clone().reference.to_object_ref();
     let recipient = *network.accounts.choose(&mut OsRng::default()).unwrap();
-    let tx = SingleTransactionKind::Call(MoveCall {
-        package: *package,
-        module: Identifier::from_str("managed").unwrap(),
-        function: Identifier::from_str("mint").unwrap(),
-        type_arguments: vec![],
-        arguments: vec![
-            CallArg::Object(ObjectArg::ImmOrOwnedObject(treasury)),
-            CallArg::Pure(bcs::to_bytes(&10000u64).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&recipient).unwrap()),
-        ],
-    });
-    test_transaction(&client, keystore, vec![], sender, tx, vec![], 10000, false).await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .move_call(
+                *package,
+                Identifier::from_str("managed").unwrap(),
+                Identifier::from_str("mint").unwrap(),
+                vec![],
+                vec![
+                    CallArg::Object(ObjectArg::ImmOrOwnedObject(treasury)),
+                    CallArg::Pure(bcs::to_bytes(&10000u64).unwrap()),
+                    CallArg::Pure(bcs::to_bytes(&recipient).unwrap()),
+                ],
+            )
+            .unwrap();
+        builder.finish()
+    };
+
+    test_transaction(&client, keystore, vec![], sender, pt, vec![], 10000, false).await;
 }
 
 #[tokio::test]
@@ -191,8 +197,11 @@ async fn test_split_coin() {
         .split_coin(sender, coin.0, vec![100000], None, 10000)
         .await
         .unwrap();
-    let tx = tx.into_kind().single_transactions().next().unwrap().clone();
-    test_transaction(&client, keystore, vec![], sender, tx, vec![], 10000, false).await;
+    let pt = match tx.into_kind() {
+        TransactionKind::Single(SingleTransactionKind::ProgrammableTransaction(pt)) => pt,
+        _ => unreachable!(),
+    };
+    test_transaction(&client, keystore, vec![], sender, pt, vec![], 10000, false).await;
 }
 
 #[tokio::test]
@@ -210,8 +219,11 @@ async fn test_merge_coin() {
         .merge_coins(sender, coin.0, coin2.0, None, 10000)
         .await
         .unwrap();
-    let tx = tx.into_kind().single_transactions().next().unwrap().clone();
-    test_transaction(&client, keystore, vec![], sender, tx, vec![], 10000, false).await;
+    let pt = match tx.into_kind() {
+        TransactionKind::Single(SingleTransactionKind::ProgrammableTransaction(pt)) => pt,
+        _ => unreachable!(),
+    };
+    test_transaction(&client, keystore, vec![], sender, pt, vec![], 10000, false).await;
 }
 
 #[tokio::test]
@@ -231,13 +243,12 @@ async fn test_pay() {
             .unwrap();
         builder.finish()
     };
-    let tx = SingleTransactionKind::ProgrammableTransaction(pt);
     test_transaction(
         &client,
         keystore,
         vec![recipient],
         sender,
-        tx,
+        pt,
         vec![],
         10000,
         false,
@@ -268,13 +279,12 @@ async fn test_pay_multiple_coin_multiple_recipient() {
             .unwrap();
         builder.finish()
     };
-    let tx = SingleTransactionKind::ProgrammableTransaction(pt);
     test_transaction(
         &client,
         keystore,
         vec![recipient1, recipient2],
         sender,
-        tx,
+        pt,
         vec![],
         10000,
         false,
@@ -303,13 +313,12 @@ async fn test_pay_sui_multiple_coin_same_recipient() {
             .unwrap();
         builder.finish()
     };
-    let tx = SingleTransactionKind::ProgrammableTransaction(pt);
     test_transaction(
         &client,
         keystore,
         vec![recipient1],
         sender,
-        tx,
+        pt,
         vec![coin1, coin2],
         10000,
         false,
@@ -336,13 +345,12 @@ async fn test_pay_sui() {
             .unwrap();
         builder.finish()
     };
-    let tx = SingleTransactionKind::ProgrammableTransaction(pt);
     test_transaction(
         &client,
         keystore,
         vec![recipient1, recipient2],
         sender,
-        tx,
+        pt,
         vec![coin1, coin2],
         10000,
         false,
@@ -369,13 +377,12 @@ async fn test_failed_pay_sui() {
             .unwrap();
         builder.finish()
     };
-    let tx = SingleTransactionKind::ProgrammableTransaction(pt);
     test_transaction(
         &client,
         keystore,
         vec![],
         sender,
-        tx,
+        pt,
         vec![coin1, coin2],
         110,
         true,
@@ -407,9 +414,11 @@ async fn test_delegate_sui() {
         )
         .await
         .unwrap();
-    let tx = tx.into_kind().into_single_transactions().next().unwrap();
-
-    test_transaction(&client, keystore, vec![], sender, tx, vec![], 10000, false).await;
+    let pt = match tx.into_kind() {
+        TransactionKind::Single(SingleTransactionKind::ProgrammableTransaction(pt)) => pt,
+        _ => unreachable!(),
+    };
+    test_transaction(&client, keystore, vec![], sender, pt, vec![], 10000, false).await;
 }
 
 #[tokio::test]
@@ -436,9 +445,11 @@ async fn test_delegate_sui_with_none_amount() {
         )
         .await
         .unwrap();
-    let tx = tx.into_kind().into_single_transactions().next().unwrap();
-
-    test_transaction(&client, keystore, vec![], sender, tx, vec![], 10000, false).await;
+    let pt = match tx.into_kind() {
+        TransactionKind::Single(SingleTransactionKind::ProgrammableTransaction(pt)) => pt,
+        _ => unreachable!(),
+    };
+    test_transaction(&client, keystore, vec![], sender, pt, vec![], 10000, false).await;
 }
 
 #[tokio::test]
@@ -457,13 +468,12 @@ async fn test_pay_all_sui() {
         builder.pay_all_sui(recipient);
         builder.finish()
     };
-    let tx = SingleTransactionKind::ProgrammableTransaction(pt);
     test_transaction(
         &client,
         keystore,
         vec![recipient],
         sender,
-        tx,
+        pt,
         vec![coin1, coin2],
         10000,
         false,
@@ -515,7 +525,6 @@ async fn test_delegation_parsing() -> Result<(), anyhow::Error> {
 fn find_module_object(
     effects: &SuiTransactionEffects,
     events: &SuiTransactionEvents,
-    module: &str,
     object_type_name: &str,
 ) -> OwnedObjectRef {
     let mut results: Vec<_> = events
@@ -523,13 +532,12 @@ fn find_module_object(
         .iter()
         .filter_map(|event| {
             if let SuiEvent::NewObject {
-                transaction_module,
                 object_id,
                 object_type,
                 ..
             } = event
             {
-                if transaction_module == module && object_type.contains(object_type_name) {
+                if object_type.contains(object_type_name) {
                     return effects
                         .created()
                         .iter()
@@ -552,7 +560,7 @@ async fn test_transaction(
     keystore: &Keystore,
     addr_to_check: Vec<SuiAddress>,
     sender: SuiAddress,
-    tx: SingleTransactionKind,
+    tx: ProgrammableTransaction,
     gas: Vec<ObjectRef>,
     budget: u64,
     expect_fail: bool,
@@ -576,7 +584,7 @@ async fn test_transaction(
     };
 
     let data = TransactionData::new_with_gas_coins(
-        TransactionKind::Single(tx.clone()),
+        TransactionKind::programmable(tx.clone()),
         sender,
         gas,
         budget,

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -510,7 +510,7 @@ async fn test_delegation_parsing() -> Result<(), anyhow::Error> {
             locked_until_epoch: None,
         },
         sender,
-        gas,
+        gas: vec![gas],
         gas_price: client.read_api().get_reference_gas_price().await?,
         budget: 10000,
     };

--- a/crates/sui-rosetta/src/unit_tests/operations_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/operations_tests.rs
@@ -21,11 +21,7 @@ async fn test_operation_data_parsing() -> Result<(), anyhow::Error> {
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder
-            .pay(
-                vec![gas],
-                vec![SuiAddress::random_for_testing_only()],
-                vec![10000],
-            )
+            .pay_sui(vec![SuiAddress::random_for_testing_only()], vec![10000])
             .unwrap();
         builder.finish()
     };
@@ -33,9 +29,9 @@ async fn test_operation_data_parsing() -> Result<(), anyhow::Error> {
 
     let ops: Operations = data.clone().try_into()?;
     let metadata = ConstructionMetadata {
-        tx_metadata: TransactionMetadata::PaySui(vec![gas]),
+        tx_metadata: TransactionMetadata::PaySui,
         sender,
-        gas,
+        gas: vec![gas],
         gas_price: 1,
         budget: 1000,
     };

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -464,7 +464,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             .select_gas(signer, gas, gas_budget, vec![coin_object_id], gas_price)
             .await?;
 
-        Ok(TransactionData::new_move_call(
+        TransactionData::new_move_call(
             signer,
             SUI_FRAMEWORK_OBJECT_ID,
             coin::PAY_MODULE_NAME.to_owned(),
@@ -477,7 +477,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             ],
             gas_budget,
             gas_price,
-        ))
+        )
     }
 
     // TODO: consolidate this with Pay transactions
@@ -502,7 +502,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             .select_gas(signer, gas, gas_budget, vec![coin_object_id], gas_price)
             .await?;
 
-        Ok(TransactionData::new_move_call(
+        TransactionData::new_move_call(
             signer,
             SUI_FRAMEWORK_OBJECT_ID,
             coin::PAY_MODULE_NAME.to_owned(),
@@ -515,7 +515,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             ],
             gas_budget,
             gas_price,
-        ))
+        )
     }
 
     // TODO: consolidate this with Pay transactions
@@ -547,7 +547,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             )
             .await?;
 
-        Ok(TransactionData::new_move_call(
+        TransactionData::new_move_call(
             signer,
             SUI_FRAMEWORK_OBJECT_ID,
             coin::PAY_MODULE_NAME.to_owned(),
@@ -560,7 +560,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             ],
             gas_budget,
             gas_price,
-        ))
+        )
     }
 
     pub async fn batch_transaction(
@@ -671,7 +671,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         }
         .to_owned();
 
-        Ok(TransactionData::new_move_call(
+        TransactionData::new_move_call(
             signer,
             SUI_FRAMEWORK_OBJECT_ID,
             SUI_SYSTEM_MODULE_NAME.to_owned(),
@@ -690,7 +690,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             ],
             gas_budget,
             gas_price,
-        ))
+        )
     }
 
     pub async fn request_withdraw_delegation(
@@ -706,7 +706,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let gas = self
             .select_gas(signer, gas, gas_budget, vec![], gas_price)
             .await?;
-        Ok(TransactionData::new_move_call(
+        TransactionData::new_move_call(
             signer,
             SUI_FRAMEWORK_OBJECT_ID,
             SUI_SYSTEM_MODULE_NAME.to_owned(),
@@ -723,7 +723,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             ],
             gas_budget,
             gas_price,
-        ))
+        )
     }
 
     // TODO: we should add retrial to reduce the transaction building error rate

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -178,6 +178,23 @@ impl ProgrammableTransactionBuilder {
         Ok(())
     }
 
+    pub fn programmable_move_call(
+        &mut self,
+        package: ObjectID,
+        module: Identifier,
+        function: Identifier,
+        type_arguments: Vec<TypeTag>,
+        arguments: Vec<Argument>,
+    ) -> Argument {
+        self.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
+            package,
+            module,
+            function,
+            type_arguments,
+            arguments,
+        })))
+    }
+
     pub fn publish(&mut self, modules: Vec<Vec<u8>>) {
         self.commands.push(Command::Publish(modules))
     }

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -402,7 +402,8 @@ async fn test_reconfig_with_committee_change_basic() {
             CallArg::Pure(bcs::to_bytes(&0u64).unwrap()), // commission_rate
         ],
         10000,
-    );
+    )
+    .unwrap();
     let transaction =
         to_sender_signed_transaction(candidate_tx_data, new_node_config.account_key_pair());
     let effects = execute_transaction(&authorities, transaction)
@@ -453,7 +454,8 @@ async fn test_reconfig_with_committee_change_basic() {
             mutable: true,
         })],
         10000,
-    );
+    )
+    .unwrap();
     let transaction =
         to_sender_signed_transaction(activation_tx_data, new_node_config.account_key_pair());
     let effects = execute_transaction(&authorities, transaction)

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -430,7 +430,8 @@ async fn test_reconfig_with_committee_change_basic() {
             CallArg::Pure(bcs::to_bytes(&new_validator_address).unwrap()),
         ],
         10000,
-    );
+    )
+    .unwrap();
     let transaction =
         to_sender_signed_transaction(delegation_tx_data, new_node_config.account_key_pair());
     let effects = execute_transaction(&authorities, transaction)
@@ -517,7 +518,8 @@ async fn test_reconfig_with_committee_change_basic() {
             mutable: true,
         })],
         10000,
-    );
+    )
+    .unwrap();
     let transaction = to_sender_signed_transaction(tx_data, new_node_config.account_key_pair());
     let effects = execute_transaction(&authorities, transaction)
         .await

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -6,8 +6,8 @@ use std::time::{Duration, SystemTime};
 use sui_core::authority_client::AuthorityAPI;
 use sui_core::consensus_adapter::position_submit_certificate;
 use sui_types::messages::{
-    CallArg, EntryArgumentError, EntryArgumentErrorKind, ExecutionFailureStatus, ExecutionStatus,
-    ObjectArg, ObjectInfoRequest, TransactionEffectsAPI,
+    CallArg, CommandArgumentError, ExecutionFailureStatus, ExecutionStatus, ObjectArg,
+    ObjectInfoRequest, TransactionEffectsAPI,
 };
 use test_utils::authority::get_client;
 use test_utils::transaction::{
@@ -193,16 +193,16 @@ async fn call_shared_object_contract() {
         .await
         .unwrap();
     // Transaction fails
-    assert!(matches!(
+    assert_eq!(
         effects.status(),
-        ExecutionStatus::Failure {
-            error: ExecutionFailureStatus::EntryArgumentError(EntryArgumentError {
-                kind: EntryArgumentErrorKind::ObjectMutabilityMismatch,
-                ..
-            }),
-            ..
+        &ExecutionStatus::Failure {
+            error: ExecutionFailureStatus::CommandArgumentError {
+                arg_idx: 0,
+                kind: CommandArgumentError::InvalidObjectByMutRef,
+            },
+            command: Some(0),
         }
-    ));
+    );
     assert_eq!(effects.dependencies().len(), 2);
     assert!(effects
         .dependencies()

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -196,7 +196,8 @@ pub async fn make_counter_increment_transaction_with_wallet_context(
             mutable: true,
         })],
         MAX_GAS,
-    );
+    )
+    .unwrap();
     to_sender_signed_transaction(data, context.config.keystore.get_key(&sender).unwrap())
 }
 
@@ -271,7 +272,8 @@ pub fn test_shared_object_transactions() -> Vec<VerifiedTransaction> {
                 CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
             ],
             MAX_GAS,
-        );
+        )
+        .unwrap();
         transactions.push(to_sender_signed_transaction(data, &keypair));
     }
     transactions
@@ -361,7 +363,8 @@ pub fn make_counter_create_transaction(
         vec![],
         MAX_GAS,
         gas_price.unwrap_or(DUMMY_GAS_PRICE),
-    );
+    )
+    .unwrap();
     to_sender_signed_transaction(data, keypair)
 }
 
@@ -388,7 +391,8 @@ pub fn make_counter_increment_transaction(
         })],
         MAX_GAS,
         gas_price.unwrap_or(1),
-    );
+    )
+    .unwrap();
     to_sender_signed_transaction(data, keypair)
 }
 
@@ -418,7 +422,8 @@ pub fn make_delegation_transaction(
         ],
         MAX_DELEGATION_GAS,
         gas_price.unwrap_or(DUMMY_GAS_PRICE),
-    );
+    )
+    .unwrap();
     to_sender_signed_transaction(data, keypair)
 }
 
@@ -454,7 +459,8 @@ pub fn move_transaction_with_type_tags(
         gas_object.compute_object_reference(),
         arguments,
         MAX_GAS,
-    );
+    )
+    .unwrap();
     to_sender_signed_transaction(data, &keypair)
 }
 

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -384,7 +384,8 @@ pub async fn delete_devnet_nft(
         gas,
         vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(nft_to_delete))],
         MAX_GAS,
-    );
+    )
+    .unwrap();
 
     let signature = context
         .config


### PR DESCRIPTION
Stacked on on #8881 

## Description 

- Migrated most MoveCalls and Publishes to programmable transactions
- Fixed a few bugs in programmable transactions
- Had to rewrite sui-rosetta operations parsing, and it is a bit brittle

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [X] breaking change for a client SDKs
- [X] breaking change for FNs (FN binary must upgrade)
- [X] breaking change for validators or node operators (must upgrade binaries)
- [X] breaking change for on-chain data layout
- [X] necessitate either a data wipe or data migration

### Release notes
