### PR TITLE
use different gas objects in dynamic committee test

### DIFF
--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -19,7 +19,7 @@ use crate::options::Opts;
 use crate::util::get_ed25519_keypair_from_keystore;
 use crate::workloads::Gas;
 use crate::{FullNodeProxy, LocalValidatorAggregatorProxy, ValidatorProxy};
-use sui_types::object::{generate_test_gas_objects_with_owner, Owner};
+use sui_types::object::{generate_max_test_gas_objects_with_owner, Owner};
 use test_utils::authority::test_and_configure_authority_configs;
 use test_utils::authority::{spawn_fullnode, spawn_test_authorities};
 use tokio::runtime::Builder;
@@ -109,7 +109,7 @@ impl Env {
         let config = Arc::new(network_config);
         // bring up servers ..
         let (owner, keypair): (SuiAddress, AccountKeyPair) = deterministic_random_account_key();
-        let generated_gas = generate_test_gas_objects_with_owner(2, owner);
+        let generated_gas = generate_max_test_gas_objects_with_owner(2, owner);
         let primary_gas = generated_gas
             .get(0)
             .context("No gas found at index 0")?

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2382,6 +2382,15 @@ impl AuthorityState {
             .expect("Cannot insert genesis object")
     }
 
+    pub async fn insert_genesis_objects(&self, objects: &[Object]) {
+        futures::future::join_all(
+            objects
+                .iter()
+                .map(|o| self.insert_genesis_object(o.clone())),
+        )
+        .await;
+    }
+
     pub fn get_certified_transaction(
         &self,
         tx_digest: &TransactionDigest,

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -812,6 +812,16 @@ pub fn generate_test_gas_objects_with_owner(count: usize, owner: SuiAddress) -> 
     (0..count)
         .map(|_i| {
             let gas_object_id = ObjectID::random();
+            Object::with_id_owner_gas_for_testing(gas_object_id, owner, GAS_VALUE_FOR_TESTING)
+        })
+        .collect()
+}
+
+/// Make a few test gas objects (all with the same owner) with max u64 balance.
+pub fn generate_max_test_gas_objects_with_owner(count: usize, owner: SuiAddress) -> Vec<Object> {
+    (0..count)
+        .map(|_i| {
+            let gas_object_id = ObjectID::random();
             Object::with_id_owner_gas_for_testing(gas_object_id, owner, u64::MAX)
         })
         .collect()


### PR DESCRIPTION
## Description 

This test sometimes fails because we are sending multiple txns using the same gas object and we may be hit with `ObjectVersionUnavailableForConsumption ` error when the authority we are querying hasn't executed the previous txn yet. Using different gas objects solves the issue.

## Test Plan 

it's a test itself

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
