### PR TITLE
JSON RPC: improve Page definition

### DIFF
--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -147,12 +147,14 @@ impl<S: IndexerStore> ReadApi<S> {
             })
             .collect::<Result<Vec<TransactionDigest>, IndexerError>>()?;
 
-        let next_cursor = txn_digests.get(limit).cloned();
+        let has_next_page = txn_digests.len() > limit;
         txn_digests.truncate(limit);
+        let next_cursor = txn_digests.last().cloned().map_or(cursor, Some);
 
         Ok(Page {
             data: txn_digests,
             next_cursor,
+            has_next_page,
         })
     }
 

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -293,9 +293,9 @@ impl IndexerStore for PgIndexerStore {
                 }
                 if let Some(start_sequence) = start_sequence {
                     if is_descending {
-                        builder = builder.filter(move_calls_dsl::id.le(start_sequence));
+                        builder = builder.filter(move_calls_dsl::id.lt(start_sequence));
                     } else {
-                        builder = builder.filter(move_calls_dsl::id.ge(start_sequence));
+                        builder = builder.filter(move_calls_dsl::id.gt(start_sequence));
                     }
                 }
 
@@ -334,10 +334,10 @@ impl IndexerStore for PgIndexerStore {
                 if let Some(start_sequence) = start_sequence {
                     if is_descending {
                         boxed_query = boxed_query
-                            .filter(dsl::id.le(start_sequence));
+                            .filter(dsl::id.lt(start_sequence));
                     } else {
                         boxed_query = boxed_query
-                            .filter(dsl::id.ge(start_sequence));
+                            .filter(dsl::id.gt(start_sequence));
                     }
                 }
 
@@ -380,10 +380,10 @@ impl IndexerStore for PgIndexerStore {
                     if let Some(start_sequence) = start_sequence {
                         if is_descending {
                             boxed_query = boxed_query
-                                .filter(dsl::id.le(start_sequence));
+                                .filter(dsl::id.lt(start_sequence));
                         } else {
                             boxed_query = boxed_query
-                                .filter(dsl::id.ge(start_sequence));
+                                .filter(dsl::id.gt(start_sequence));
                         }
                     }
 
@@ -433,9 +433,9 @@ impl IndexerStore for PgIndexerStore {
                     recipient_address.clone(),
                     if let Some(start_sequence) = start_sequence {
                         if is_descending {
-                            format!("AND id <= {}", start_sequence)
+                            format!("AND id < {}", start_sequence)
                         } else {
-                            format!("AND id >= {}", start_sequence)
+                            format!("AND id > {}", start_sequence)
                         }
                     } else {
                         "".to_string()

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -31,10 +31,13 @@ mod sui_object;
 mod sui_transaction;
 
 pub type DynamicFieldPage = Page<DynamicFieldInfo, ObjectID>;
-
+/// `next_cursor` points to the last item in the page;
+/// Reading with `next_cursor` will start from the next item after `next_cursor`,
+/// if `next_cursor` is `Some`, otherwise it will start from the first item.
 #[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Page<T, C> {
     pub data: Vec<T>,
     pub next_cursor: Option<C>,
+    pub has_next_page: bool,
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -918,7 +918,8 @@
               "nextCursor": {
                 "txDigest": "11a72GCQ5hGNpWGh2QhQkkusTEGS6EDqifJqxr7nSYX",
                 "eventSeq": 5
-              }
+              },
+              "hasNextPage": false
             }
           }
         }
@@ -1624,9 +1625,11 @@
               "data": [
                 "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi",
                 "9BQobwxQvJ1JxSXNn8v8htZPTu8FEzJJGgcD4kgLUuMd",
-                "GUPcK4cmRmgsTFr52ab9f6fnzNVg3Lz6hF2aXFcsRzaD"
+                "GUPcK4cmRmgsTFr52ab9f6fnzNVg3Lz6hF2aXFcsRzaD",
+                "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2"
               ],
-              "nextCursor": "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2"
+              "nextCursor": "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2",
+              "hasNextPage": false
             }
           }
         }
@@ -5037,9 +5040,11 @@
         ]
       },
       "Page_for_Coin_and_ObjectID": {
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor`, if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
-          "data"
+          "data",
+          "hasNextPage"
         ],
         "properties": {
           "data": {
@@ -5047,6 +5052,9 @@
             "items": {
               "$ref": "#/components/schemas/Coin"
             }
+          },
+          "hasNextPage": {
+            "type": "boolean"
           },
           "nextCursor": {
             "anyOf": [
@@ -5061,9 +5069,11 @@
         }
       },
       "Page_for_DynamicFieldInfo_and_ObjectID": {
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor`, if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
-          "data"
+          "data",
+          "hasNextPage"
         ],
         "properties": {
           "data": {
@@ -5071,6 +5081,9 @@
             "items": {
               "$ref": "#/components/schemas/DynamicFieldInfo"
             }
+          },
+          "hasNextPage": {
+            "type": "boolean"
           },
           "nextCursor": {
             "anyOf": [
@@ -5085,9 +5098,11 @@
         }
       },
       "Page_for_EventEnvelope_and_EventID": {
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor`, if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
-          "data"
+          "data",
+          "hasNextPage"
         ],
         "properties": {
           "data": {
@@ -5095,6 +5110,9 @@
             "items": {
               "$ref": "#/components/schemas/EventEnvelope"
             }
+          },
+          "hasNextPage": {
+            "type": "boolean"
           },
           "nextCursor": {
             "anyOf": [
@@ -5109,9 +5127,11 @@
         }
       },
       "Page_for_TransactionDigest_and_TransactionDigest": {
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor`, if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
-          "data"
+          "data",
+          "hasNextPage"
         ],
         "properties": {
           "data": {
@@ -5119,6 +5139,9 @@
             "items": {
               "$ref": "#/components/schemas/TransactionDigest"
             }
+          },
+          "hasNextPage": {
+            "type": "boolean"
           },
           "nextCursor": {
             "anyOf": [

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -367,9 +367,15 @@ impl RpcExampleProvider {
 
     fn get_transactions(&mut self) -> Examples {
         let mut data = self.get_transaction_digests(5..9);
-        let next_cursor = data.pop();
+        let has_next_page = data.len() > (9 - 5);
+        data.truncate(9 - 5);
+        let next_cursor = data.last().cloned();
 
-        let result = TransactionsPage { data, next_cursor };
+        let result = TransactionsPage {
+            data,
+            next_cursor,
+            has_next_page,
+        };
         Examples::new(
             "sui_getTransactions",
             vec![ExamplePairing::new(
@@ -502,6 +508,7 @@ impl RpcExampleProvider {
         let page = EventPage {
             data: events.clone(),
             next_cursor: Some((tx_dig, 5).into()),
+            has_next_page: false,
         };
         Examples::new(
             "sui_getEvents",

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -251,16 +251,14 @@ impl IndexStore {
         reverse: bool,
     ) -> Result<Vec<TransactionDigest>, anyhow::Error> {
         // Lookup TransactionDigest sequence number,
-        // also default cursor to 0 or the current sequence number depends on ordering.
         let cursor = if let Some(cursor) = cursor {
-            self.get_transaction_seq(&cursor)?
-                .ok_or_else(|| anyhow!("Transaction [{cursor:?}] not found."))?
-        } else if reverse {
-            TxSequenceNumber::MAX
+            Some(
+                self.get_transaction_seq(&cursor)?
+                    .ok_or_else(|| anyhow!("Transaction [{cursor:?}] not found."))?,
+            )
         } else {
-            TxSequenceNumber::MIN
+            None
         };
-
         Ok(match query {
             TransactionQuery::MoveFunction {
                 package,
@@ -286,8 +284,9 @@ impl IndexStore {
 
                 if reverse {
                     let iter = iter
-                        .skip_prior_to(&cursor)?
+                        .skip_prior_to(&cursor.unwrap_or(TxSequenceNumber::MAX))?
                         .reverse()
+                        .skip(usize::from(cursor.is_some()))
                         .map(|(_, digest)| digest);
                     if let Some(limit) = limit {
                         iter.take(limit).collect()
@@ -295,7 +294,10 @@ impl IndexStore {
                         iter.collect()
                     }
                 } else {
-                    let iter = iter.skip_to(&cursor)?.map(|(_, digest)| digest);
+                    let iter = iter
+                        .skip_to(&cursor.unwrap_or(TxSequenceNumber::MIN))?
+                        .skip(usize::from(cursor.is_some()))
+                        .map(|(_, digest)| digest);
                     if let Some(limit) = limit {
                         iter.take(limit).collect()
                     } else {
@@ -382,15 +384,17 @@ impl IndexStore {
     fn get_transactions_from_index<KeyT: Clone + Serialize + DeserializeOwned + PartialEq>(
         index: &DBMap<(KeyT, TxSequenceNumber), TransactionDigest>,
         key: KeyT,
-        cursor: TxSequenceNumber,
+        cursor: Option<TxSequenceNumber>,
         limit: Option<usize>,
         reverse: bool,
     ) -> SuiResult<Vec<TransactionDigest>> {
         Ok(if reverse {
             let iter = index
                 .iter()
-                .skip_prior_to(&(key.clone(), cursor))?
+                .skip_prior_to(&(key.clone(), cursor.unwrap_or(TxSequenceNumber::MAX)))?
                 .reverse()
+                // skip one more if exclusive cursor is Some
+                .skip(usize::from(cursor.is_some()))
                 .take_while(|((id, _), _)| *id == key)
                 .map(|(_, digest)| digest);
             if let Some(limit) = limit {
@@ -401,7 +405,9 @@ impl IndexStore {
         } else {
             let iter = index
                 .iter()
-                .skip_to(&(key.clone(), cursor))?
+                .skip_to(&(key.clone(), cursor.unwrap_or(TxSequenceNumber::MIN)))?
+                // skip one more if exclusive cursor is Some
+                .skip(usize::from(cursor.is_some()))
                 .take_while(|((id, _), _)| *id == key)
                 .map(|(_, digest)| digest);
             if let Some(limit) = limit {
@@ -415,7 +421,7 @@ impl IndexStore {
     pub fn get_transactions_by_input_object(
         &self,
         input_object: ObjectID,
-        cursor: TxSequenceNumber,
+        cursor: Option<TxSequenceNumber>,
         limit: Option<usize>,
         reverse: bool,
     ) -> SuiResult<Vec<TransactionDigest>> {
@@ -431,7 +437,7 @@ impl IndexStore {
     pub fn get_transactions_by_mutated_object(
         &self,
         mutated_object: ObjectID,
-        cursor: TxSequenceNumber,
+        cursor: Option<TxSequenceNumber>,
         limit: Option<usize>,
         reverse: bool,
     ) -> SuiResult<Vec<TransactionDigest>> {
@@ -447,7 +453,7 @@ impl IndexStore {
     pub fn get_transactions_from_addr(
         &self,
         addr: SuiAddress,
-        cursor: TxSequenceNumber,
+        cursor: Option<TxSequenceNumber>,
         limit: Option<usize>,
         reverse: bool,
     ) -> SuiResult<Vec<TransactionDigest>> {
@@ -465,21 +471,29 @@ impl IndexStore {
         package: ObjectID,
         module: Option<String>,
         function: Option<String>,
-        cursor: TxSequenceNumber,
+        cursor: Option<TxSequenceNumber>,
         limit: Option<usize>,
         reverse: bool,
     ) -> SuiResult<Vec<TransactionDigest>> {
+        let cursor_val = cursor.unwrap_or(if reverse {
+            TxSequenceNumber::MAX
+        } else {
+            TxSequenceNumber::MIN
+        });
+
         let key = (
             package,
             module.clone().unwrap_or_default(),
             function.clone().unwrap_or_default(),
-            cursor,
+            cursor_val,
         );
         let iter = self.tables.transactions_by_move_function.iter();
         Ok(if reverse {
             let iter = iter
                 .skip_prior_to(&key)?
                 .reverse()
+                // skip one more if exclusive cursor is Some
+                .skip(usize::from(cursor.is_some()))
                 .take_while(|((id, m, f, _), _)| {
                     *id == package
                         && module.as_ref().map(|x| x == m).unwrap_or(true)
@@ -494,6 +508,8 @@ impl IndexStore {
         } else {
             let iter = iter
                 .skip_to(&key)?
+                // skip one more if exclusive cursor is Some
+                .skip(usize::from(cursor.is_some()))
                 .take_while(|((id, m, f, _), _)| {
                     *id == package
                         && module.as_ref().map(|x| x == m).unwrap_or(true)
@@ -511,7 +527,7 @@ impl IndexStore {
     pub fn get_transactions_to_addr(
         &self,
         addr: SuiAddress,
-        cursor: TxSequenceNumber,
+        cursor: Option<TxSequenceNumber>,
         limit: Option<usize>,
         reverse: bool,
     ) -> SuiResult<Vec<TransactionDigest>> {
@@ -538,13 +554,14 @@ impl IndexStore {
         limit: usize,
     ) -> SuiResult<Vec<DynamicFieldInfo>> {
         debug!(?object, "get_dynamic_fields");
-        let cursor = cursor.unwrap_or(ObjectID::ZERO);
         Ok(self
             .tables
             .dynamic_field_index
             .iter()
             // The object id 0 is the smallest possible
-            .skip_to(&(object, cursor))?
+            .skip_to(&(object, cursor.unwrap_or(ObjectID::ZERO)))?
+            // skip an extra b/c the cursor is exclusive
+            .skip(usize::from(cursor.is_some()))
             .take_while(|((object_owner, _), _)| (object_owner == &object))
             .map(|(_, object_info)| object_info)
             .take(limit)

--- a/sdk/typescript/src/types/coin.ts
+++ b/sdk/typescript/src/types/coin.ts
@@ -3,6 +3,7 @@
 
 import {
   array,
+  boolean,
   Infer,
   literal,
   nullable,
@@ -29,6 +30,7 @@ export type CoinStruct = Infer<typeof CoinStruct>;
 export const PaginatedCoins = object({
   data: array(CoinStruct),
   nextCursor: union([ObjectId, literal(null)]),
+  hasNextPage: boolean(),
 });
 
 export type PaginatedCoins = Infer<typeof PaginatedCoins>;

--- a/sdk/typescript/src/types/dynamic_fields.ts
+++ b/sdk/typescript/src/types/dynamic_fields.ts
@@ -4,6 +4,7 @@
 import {
   any,
   array,
+  boolean,
   Infer,
   literal,
   number,
@@ -38,5 +39,6 @@ export type DynamicFieldInfo = Infer<typeof DynamicFieldInfo>;
 export const DynamicFieldPage = object({
   data: array(DynamicFieldInfo),
   nextCursor: union([ObjectId, literal(null)]),
+  hasNextPage: boolean(),
 });
 export type DynamicFieldPage = Infer<typeof DynamicFieldPage>;

--- a/sdk/typescript/src/types/events.ts
+++ b/sdk/typescript/src/types/events.ts
@@ -13,6 +13,7 @@ import {
   record,
   any,
   optional,
+  boolean,
 } from 'superstruct';
 import {
   ObjectId,
@@ -192,6 +193,7 @@ export type SuiEvents = SuiEventEnvelope[];
 export const PaginatedEvents = object({
   data: array(SuiEventEnvelope),
   nextCursor: union([EventId, literal(null)]),
+  hasNextPage: boolean(),
 });
 export type PaginatedEvents = Infer<typeof PaginatedEvents>;
 

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -252,6 +252,7 @@ export type GetTxnDigestsResponse = Infer<typeof GetTxnDigestsResponse>;
 export const PaginatedTransactionDigests = object({
   data: array(TransactionDigest),
   nextCursor: union([TransactionDigest, literal(null)]),
+  hasNextPage: boolean(),
 });
 export type PaginatedTransactionDigests = Infer<
   typeof PaginatedTransactionDigests

--- a/sdk/typescript/test/e2e/coin-read.test.ts
+++ b/sdk/typescript/test/e2e/coin-read.test.ts
@@ -34,13 +34,13 @@ describe('CoinRead API', () => {
       owner: toolbox.address(),
     });
     expect(allCoins.data.length).toEqual(5);
-    expect(allCoins.nextCursor).toBeNull();
+    expect(allCoins.hasNextPage).toEqual(false);
 
     const publisherAllCoins = await toolbox.provider.getAllCoins({
       owner: publishToolbox.address(),
     });
     expect(publisherAllCoins.data.length).toEqual(3);
-    expect(publisherAllCoins.nextCursor).toBeNull();
+    expect(publisherAllCoins.hasNextPage).toEqual(false);
 
     //test paging with limit
     const someSuiCoins = await toolbox.provider.getCoins({


### PR DESCRIPTION
## Description 

Change Page definition, the cursor is now exclusive cursor and we have a separate `has_next_page` field

## Test Plan 

Cargo test
Test on on local FN and indexer ports

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
