### PR TITLE
Check p2p address as valid anemo address

### DIFF
--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -37,6 +37,7 @@ pub use generated::{
     discovery_server::{Discovery, DiscoveryServer},
 };
 pub use server::GetKnownPeersResponse;
+use sui_types::sui_system_state::multiaddr_to_anemo_address;
 
 /// The internal discovery state shared between the main event loop and the request handler
 struct State {
@@ -449,27 +450,6 @@ fn update_known_peers(state: Arc<RwLock<State>>, found_peers: Vec<NodeInfo>) {
             Entry::Vacant(v) => {
                 v.insert(peer);
             }
-        }
-    }
-}
-
-pub fn multiaddr_to_anemo_address(multiaddr: &Multiaddr) -> Option<anemo::types::Address> {
-    use multiaddr::Protocol;
-    let mut iter = multiaddr.iter();
-
-    match (iter.next(), iter.next(), iter.next()) {
-        (Some(Protocol::Ip4(ipaddr)), Some(Protocol::Udp(port)), None) => {
-            Some((ipaddr, port).into())
-        }
-        (Some(Protocol::Ip6(ipaddr)), Some(Protocol::Udp(port)), None) => {
-            Some((ipaddr, port).into())
-        }
-        (Some(Protocol::Dns(hostname)), Some(Protocol::Udp(port)), None) => {
-            Some((hostname.as_ref(), port).into())
-        }
-        _ => {
-            tracing::warn!("unsupported p2p multiaddr: '{multiaddr}'");
-            None
         }
     }
 }

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -109,6 +109,10 @@ impl ValidatorMetadataV1 {
             .map_err(|_| E_METADATA_INVALID_NET_ADDR)?;
         let p2p_address = Multiaddr::try_from(self.p2p_address.clone())
             .map_err(|_| E_METADATA_INVALID_P2P_ADDR)?;
+        // Also make sure that the p2p address is a valid anemo address.
+        // TODO: This will trigger a bunch of Move test failures today since we did not give proper
+        // value for p2p address.
+        // multiaddr_to_anemo_address(&p2p_address).ok_or(E_METADATA_INVALID_P2P_ADDR)?;
         let primary_address = Multiaddr::try_from(self.primary_address.clone())
             .map_err(|_| E_METADATA_INVALID_PRIMARY_ADDR)?;
         let worker_address = Multiaddr::try_from(self.worker_address.clone())


### PR DESCRIPTION
Add extra check in validator metadata verification.
Unfortunately we have a lot of Move tests that use wrong p2p address. I am not quite familiar with all those tests so the check is currently disabled. Would be good if someone familiar could help fix the tests as follow up.