### PR TITLE
Defaults for metrics_address during genesis

### DIFF
--- a/crates/sui-config/src/genesis_config.rs
+++ b/crates/sui-config/src/genesis_config.rs
@@ -110,12 +110,25 @@ pub struct ValidatorGenesisInfo {
     pub network_address: Multiaddr,
     pub p2p_address: Multiaddr,
     pub p2p_listen_address: Option<SocketAddr>,
+    #[serde(default = "default_socket_address")]
     pub metrics_address: SocketAddr,
+    #[serde(default = "default_multiaddr_address")]
     pub narwhal_metrics_address: Multiaddr,
     pub gas_price: u64,
     pub commission_rate: u64,
     pub narwhal_primary_address: Multiaddr,
     pub narwhal_worker_address: Multiaddr,
+}
+
+fn default_socket_address() -> SocketAddr {
+    utils::available_local_socket_address()
+}
+
+fn default_multiaddr_address() -> Multiaddr {
+    let addr = utils::available_local_socket_address();
+    format!("/ip4/{:?}/tcp/{}/http", addr.ip(), addr.port())
+        .parse()
+        .unwrap()
 }
 
 impl ValidatorGenesisInfo {


### PR DESCRIPTION
## Description 

https://github.com/MystenLabs/sui/pull/8885 is breaking sui-operations deploys with the following error:
```
$ sui genesis --from-config /data/generate/target/genesis.yaml --working-dir generate/z -f

validator_config_info[0].genesis_info: missing field `metrics_address` at line 23 column 21
```

Rather than set `metrics_address` and `narwhal_metrics_address` on every validator's `genesis_info`, it should be reasonable to use a default.
## Test Plan 

Tested locally, `sui genesis` succeeds:
```
./target/debug/sui genesis --from-config ../sui-operations/genesis.yaml --working-dir z -f                                                                                                                                [10:23:10]
2023-03-08T18:40:14.634219Z  INFO sui_config::genesis_config: Creating accounts and gas objects...
2023-03-08T18:40:16.330088Z  INFO sui::sui_commands: Network genesis completed.
```

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
