### PR TITLE
[SuiCommand] fail when committee and validator_config_info sizes do not match

### DIFF
--- a/crates/sui-config/src/genesis_config.rs
+++ b/crates/sui-config/src/genesis_config.rs
@@ -199,7 +199,7 @@ pub struct AccountConfig {
 }
 
 pub const DEFAULT_GAS_AMOUNT: u64 = 30_000_000_000_000_000;
-const DEFAULT_NUMBER_OF_AUTHORITIES: usize = 4;
+pub const DEFAULT_NUMBER_OF_AUTHORITIES: usize = 4;
 const DEFAULT_NUMBER_OF_ACCOUNT: usize = 5;
 pub const DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT: usize = 5;
 
@@ -354,7 +354,7 @@ impl Default for GenesisConfig {
         Self {
             validator_config_info: None,
             parameters: Default::default(),
-            committee_size: DEFAULT_NUMBER_OF_AUTHORITIES,
+            committee_size: 0, // default value indicates the field is not set
             grpc_load_shed: None,
             grpc_concurrency_limit: Some(DEFAULT_GRPC_CONCURRENCY_LIMIT),
             accounts: vec![],

--- a/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -12,7 +12,7 @@ parameters:
   stake_subsidy_initial_distribution_amount: 1000000000000000
   stake_subsidy_period_length: 30
   stake_subsidy_decrease_rate: 10000
-committee_size: 4
+committee_size: 0
 grpc_load_shed: ~
 grpc_concurrency_limit: 20000000000
 accounts:


### PR DESCRIPTION
## Description 

Otherwise, a genesis config can have different committee_size and number of validators, which is confusing.

## Test Plan 

n/a

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
