### PR TITLE
Add all fields to sui system state summary

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -241,11 +241,8 @@ validators:
       gas_price: 1
       staking_pool:
         id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f65e4b0dea15829e3157962e1"
-        activation_epoch:
-          vec:
-            - 0
-        deactivation_epoch:
-          vec: []
+        activation_epoch: 0
+        deactivation_epoch: ~
         sui_balance: 25000000000000000
         rewards_pool:
           value: 0

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4546,23 +4546,6 @@
           }
         ]
       },
-      "MoveOption_for_uint64": {
-        "description": "Rust version of the Move std::option::Option type.",
-        "type": "object",
-        "required": [
-          "vec"
-        ],
-        "properties": {
-          "vec": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            }
-          }
-        }
-      },
       "MovePackage": {
         "type": "object",
         "required": [
@@ -5568,8 +5551,6 @@
         "description": "Rust version of the Move sui::staking_pool::StakingPool type",
         "type": "object",
         "required": [
-          "activation_epoch",
-          "deactivation_epoch",
           "exchange_rates",
           "id",
           "pending_delegation",
@@ -5581,10 +5562,20 @@
         ],
         "properties": {
           "activation_epoch": {
-            "$ref": "#/components/schemas/MoveOption_for_uint64"
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
           },
           "deactivation_epoch": {
-            "$ref": "#/components/schemas/MoveOption_for_uint64"
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
           },
           "exchange_rates": {
             "$ref": "#/components/schemas/Table"
@@ -6446,86 +6437,195 @@
           "epoch",
           "epoch_start_timestamp_ms",
           "governance_start_epoch",
-          "max_validator_candidate_count",
+          "inactive_pools_id",
+          "inactive_pools_size",
+          "max_validator_count",
           "min_validator_stake",
+          "pending_active_validators_id",
+          "pending_active_validators_size",
+          "pending_removals",
           "protocol_version",
           "reference_gas_price",
           "safe_mode",
           "stake_subsidy_balance",
           "stake_subsidy_current_epoch_amount",
           "stake_subsidy_epoch_counter",
+          "staking_pool_mappings_id",
+          "staking_pool_mappings_size",
           "storage_fund",
-          "total_stake"
+          "total_stake",
+          "validator_candidates_id",
+          "validator_candidates_size",
+          "validator_report_records"
         ],
         "properties": {
           "active_validators": {
+            "description": "The list of active validators in the current epoch.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SuiValidatorSummary"
             }
           },
           "epoch": {
+            "description": "The current epoch ID, starting from 0.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "epoch_start_timestamp_ms": {
+            "description": "Unix timestamp of the current epoch start",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "governance_start_epoch": {
+            "description": "The starting epoch in which various on-chain governance features take effect.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
-          "max_validator_candidate_count": {
+          "inactive_pools_id": {
+            "description": "ID of the object that maps from a staking pool ID to the inactive validator that has that pool as its staking pool.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            ]
+          },
+          "inactive_pools_size": {
+            "description": "Number of inactive staking pools.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "max_validator_count": {
+            "description": "Maximum number of active validators at any moment. We do not allow the number of validators in any epoch to go above this.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "min_validator_stake": {
+            "description": "Lower-bound on the amount of stake required to become a validator.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
+          "pending_active_validators_id": {
+            "description": "ID of the object that contains the list of new validators that will join at the end of the epoch.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            ]
+          },
+          "pending_active_validators_size": {
+            "description": "Number of new validators that will join at the end of the epoch.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "pending_removals": {
+            "description": "Removal requests from the validators. Each element is an index pointing to `active_validators`.",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
           "protocol_version": {
+            "description": "The current protocol version, starting from 1.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "reference_gas_price": {
+            "description": "The reference gas price for the current epoch.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "safe_mode": {
+            "description": "Whether the system is running in a downgraded safe mode due to a non-recoverable bug. This is set whenever we failed to execute advance_epoch, and ended up executing advance_epoch_safe_mode. It can be reset once we are able to successfully execute advance_epoch.",
             "type": "boolean"
           },
           "stake_subsidy_balance": {
+            "description": "Balance of SUI set aside for stake subsidies that will be drawn down over time.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "stake_subsidy_current_epoch_amount": {
+            "description": "The amount of stake subsidy to be drawn down per epoch. This amount decays and decreases over time.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "stake_subsidy_epoch_counter": {
+            "description": "This counter may be different from the current epoch number if in some epochs we decide to skip the subsidy.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "staking_pool_mappings_id": {
+            "description": "ID of the object that maps from staking pool's ID to the sui address of a validator.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            ]
+          },
+          "staking_pool_mappings_size": {
+            "description": "Number of staking pool mappings.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "storage_fund": {
+            "description": "The storage fund balance.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "total_stake": {
+            "description": "Total amount of stake from all active validators at the beginning of the epoch.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
+          },
+          "validator_candidates_id": {
+            "description": "ID of the object that stores preactive validators, mapping their addresses to their `Validator ` structs.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            ]
+          },
+          "validator_candidates_size": {
+            "description": "Number of preactive validators.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "validator_report_records": {
+            "description": "A map storing the records of validator reporting each other.",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/components/schemas/SuiAddress"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SuiAddress"
+                  }
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
           }
         }
       },
@@ -6633,6 +6733,8 @@
         "required": [
           "commission_rate",
           "description",
+          "exchange_rates_id",
+          "exchange_rates_size",
           "gas_price",
           "image_url",
           "name",
@@ -6666,6 +6768,20 @@
           },
           "description": {
             "type": "string"
+          },
+          "exchange_rates_id": {
+            "description": "ID of the exchange rate table object.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            ]
+          },
+          "exchange_rates_size": {
+            "description": "Number of exchange rates in the table.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "gas_price": {
             "type": "integer",
@@ -6806,21 +6922,25 @@
             }
           },
           "pending_delegation": {
+            "description": "Pending delegation amount for this epoch.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "pending_pool_token_withdraw": {
+            "description": "Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "pending_total_sui_withdraw": {
+            "description": "Pending delegation withdrawn during the current epoch, emptied at epoch boundaries.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "pool_token_balance": {
+            "description": "Total number of pool tokens issued by the pool.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
@@ -6853,11 +6973,13 @@
             }
           },
           "rewards_pool": {
+            "description": "The epoch delegation rewards will be added here at the end of each epoch.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
           },
           "staking_pool_activation_epoch": {
+            "description": "The epoch at which this pool became active.",
             "type": [
               "integer",
               "null"
@@ -6866,6 +6988,7 @@
             "minimum": 0.0
           },
           "staking_pool_deactivation_epoch": {
+            "description": "The epoch at which this staking pool ceased to be active. `None` = {pre-active, active},",
             "type": [
               "integer",
               "null"
@@ -6874,9 +6997,15 @@
             "minimum": 0.0
           },
           "staking_pool_id": {
-            "$ref": "#/components/schemas/ObjectID"
+            "description": "ID of the staking pool object.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            ]
           },
           "staking_pool_sui_balance": {
+            "description": "The total number of SUI tokens in this pool.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0

--- a/crates/sui-types/src/collection_types.rs
+++ b/crates/sui-types/src/collection_types.rs
@@ -22,24 +22,7 @@ pub struct Entry<K, V> {
 /// Rust version of the Move sui::vec_set::VecSet type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct VecSet<T> {
-    contents: Vec<T>,
-}
-
-/// Rust version of the Move std::option::Option type.
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
-pub struct MoveOption<T> {
-    pub vec: Vec<T>,
-}
-
-impl<T> MoveOption<T> {
-    pub fn empty() -> Self {
-        Self { vec: vec![] }
-    }
-
-    pub fn into_option(self) -> Option<T> {
-        let Self { mut vec } = self;
-        vec.pop()
-    }
+    pub contents: Vec<T>,
 }
 
 /// Rust version of the Move sui::table::Table type.
@@ -80,8 +63,8 @@ impl Default for Table {
 pub struct LinkedTable<K> {
     pub id: ObjectID,
     pub size: u64,
-    pub head: MoveOption<K>,
-    pub tail: MoveOption<K>,
+    pub head: Option<K>,
+    pub tail: Option<K>,
 }
 
 impl<K> Default for LinkedTable<K> {
@@ -89,8 +72,8 @@ impl<K> Default for LinkedTable<K> {
         LinkedTable {
             id: ObjectID::from(SuiAddress::ZERO),
             size: 0,
-            head: MoveOption { vec: vec![] },
-            tail: MoveOption { vec: vec![] },
+            head: None,
+            tail: None,
         }
     }
 }

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -11,26 +11,66 @@ use crate::base_types::{ObjectID, SuiAddress};
 /// dependencies to the internal data structures of the SUI system state type.
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct SuiSystemStateSummary {
+    /// The current epoch ID, starting from 0.
     pub epoch: u64,
+    /// The current protocol version, starting from 1.
     pub protocol_version: u64,
+    /// The storage fund balance.
     pub storage_fund: u64,
+    /// The reference gas price for the current epoch.
     pub reference_gas_price: u64,
+    /// Whether the system is running in a downgraded safe mode due to a non-recoverable bug.
+    /// This is set whenever we failed to execute advance_epoch, and ended up executing advance_epoch_safe_mode.
+    /// It can be reset once we are able to successfully execute advance_epoch.
     pub safe_mode: bool,
+    /// Unix timestamp of the current epoch start
     pub epoch_start_timestamp_ms: u64,
 
     // System parameters
+    /// Lower-bound on the amount of stake required to become a validator.
     pub min_validator_stake: u64,
-    pub max_validator_candidate_count: u64,
+    /// Maximum number of active validators at any moment.
+    /// We do not allow the number of validators in any epoch to go above this.
+    pub max_validator_count: u64,
+    /// The starting epoch in which various on-chain governance features take effect.
     pub governance_start_epoch: u64,
 
     // Stake subsidy information
+    /// This counter may be different from the current epoch number if
+    /// in some epochs we decide to skip the subsidy.
     pub stake_subsidy_epoch_counter: u64,
+    /// Balance of SUI set aside for stake subsidies that will be drawn down over time.
     pub stake_subsidy_balance: u64,
+    /// The amount of stake subsidy to be drawn down per epoch.
+    /// This amount decays and decreases over time.
     pub stake_subsidy_current_epoch_amount: u64,
 
     // Validator set
+    /// Total amount of stake from all active validators at the beginning of the epoch.
     pub total_stake: u64,
+    /// The list of active validators in the current epoch.
     pub active_validators: Vec<SuiValidatorSummary>,
+    /// ID of the object that contains the list of new validators that will join at the end of the epoch.
+    pub pending_active_validators_id: ObjectID,
+    /// Number of new validators that will join at the end of the epoch.
+    pub pending_active_validators_size: u64,
+    /// Removal requests from the validators. Each element is an index
+    /// pointing to `active_validators`.
+    pub pending_removals: Vec<u64>,
+    /// ID of the object that maps from staking pool's ID to the sui address of a validator.
+    pub staking_pool_mappings_id: ObjectID,
+    /// Number of staking pool mappings.
+    pub staking_pool_mappings_size: u64,
+    /// ID of the object that maps from a staking pool ID to the inactive validator that has that pool as its staking pool.
+    pub inactive_pools_id: ObjectID,
+    /// Number of inactive staking pools.
+    pub inactive_pools_size: u64,
+    /// ID of the object that stores preactive validators, mapping their addresses to their `Validator ` structs.
+    pub validator_candidates_id: ObjectID,
+    /// Number of preactive validators.
+    pub validator_candidates_size: u64,
+    /// A map storing the records of validator reporting each other.
+    pub validator_report_records: Vec<(SuiAddress, Vec<SuiAddress>)>,
 }
 
 /// This is the JSON-RPC type for the SUI validator. It flattens all inner strucutures
@@ -68,13 +108,26 @@ pub struct SuiValidatorSummary {
     pub next_epoch_commission_rate: u64,
 
     // Staking pool information
+    /// ID of the staking pool object.
     pub staking_pool_id: ObjectID,
+    /// The epoch at which this pool became active.
     pub staking_pool_activation_epoch: Option<u64>,
+    /// The epoch at which this staking pool ceased to be active. `None` = {pre-active, active},
     pub staking_pool_deactivation_epoch: Option<u64>,
+    /// The total number of SUI tokens in this pool.
     pub staking_pool_sui_balance: u64,
+    /// The epoch delegation rewards will be added here at the end of each epoch.
     pub rewards_pool: u64,
+    /// Total number of pool tokens issued by the pool.
     pub pool_token_balance: u64,
+    /// Pending delegation amount for this epoch.
     pub pending_delegation: u64,
+    /// Pending delegation withdrawn during the current epoch, emptied at epoch boundaries.
     pub pending_total_sui_withdraw: u64,
+    /// Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
     pub pending_pool_token_withdraw: u64,
+    /// ID of the exchange rate table object.
+    pub exchange_rates_id: ObjectID,
+    /// Number of exchange rates in the table.
+    pub exchange_rates_size: u64,
 }

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -164,6 +164,8 @@ export const SuiValidatorSummary = object({
   pending_delegation: number(),
   pending_pool_token_withdraw: number(),
   pending_total_sui_withdraw: number(),
+  exchange_rates_id: string(),
+  exchange_rates_size: number(),
 });
 
 export type SuiValidatorSummary = Infer<typeof SuiValidatorSummary>;
@@ -176,13 +178,23 @@ export const SuiSystemStateSummary = object({
   safe_mode: boolean(),
   epoch_start_timestamp_ms: number(),
   min_validator_stake: number(),
-  max_validator_candidate_count: number(),
+  max_validator_count: number(),
   governance_start_epoch: number(),
   stake_subsidy_epoch_counter: number(),
   stake_subsidy_balance: number(),
   stake_subsidy_current_epoch_amount: number(),
   total_stake: number(),
   active_validators: array(SuiValidatorSummary),
+  pending_active_validators_id: string(),
+  pending_active_validators_size: number(),
+  pending_removals: array(number()),
+  staking_pool_mappings_id: string(),
+  staking_pool_mappings_size: number(),
+  inactive_pools_id: string(),
+  inactive_pools_size: number(),
+  validator_candidates_id: string(),
+  validator_candidates_size: number(),
+  validator_report_records: array(tuple([SuiAddress, array(SuiAddress)])),
 });
 
 export type SuiSystemStateSummary = Infer<typeof SuiSystemStateSummary>;


### PR DESCRIPTION
This PR adds all fields from sui system state to sui system state summary.
I changed the way we construct the summary to help ensure we don't miss any fields: we first destruct all fields, hence if any field is unused, Rust will complain.
Also removed MotionOption since it's not needed.