### PR TITLE
[clock] Add ability to create a Clock for testing

### DIFF
--- a/crates/sui-framework/sources/clock.move
+++ b/crates/sui-framework/sources/clock.move
@@ -52,6 +52,17 @@ module sui::clock {
     }
 
     #[test_only]
+    /// Expose the functionality of `create()` (usually only done during
+    /// genesis) for tests that want to create a Clock.
+    public fun create_for_testing(ctx: &mut sui::tx_context::TxContext) {
+        transfer::share_object(Clock {
+            id: object::new(ctx),
+            timestamp_ms: 0,
+        })
+    }
+
+
+    #[test_only]
     public fun increment_for_testing(clock: &mut Clock, tick: u64) {
         clock.timestamp_ms = clock.timestamp_ms + tick;
     }

--- a/crates/sui-framework/tests/clock_tests.move
+++ b/crates/sui-framework/tests/clock_tests.move
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::clock_tests {
+    use std::vector;
+    use sui::clock::{Self, Clock};
+    use sui::test_scenario as ts;
+
+    #[test]
+    fun creating_a_clock_and_incrementing_it() {
+        let ts = ts::begin(@0x1);
+        let ctx = ts::ctx(&mut ts);
+        clock::create_for_testing(ctx);
+
+        let eff = ts::next_tx(&mut ts, @0x2);
+        // Make sure the clock was created
+        assert!(vector::length(&ts::shared(&eff)) == 1, 0);
+
+        // ...and that we can fetch it and update it
+        let clock = ts::take_shared<Clock>(&ts);
+        clock::increment_for_testing(&mut clock, 42);
+        ts::return_shared(clock);
+
+        ts::next_tx(&mut ts, @0x3);
+        let clock = ts::take_shared<Clock>(&ts);
+        // ...and read the updates
+        assert!(clock::timestamp_ms(&clock) == 42, 1);
+        ts::return_shared(clock);
+        ts::end(ts);
+    }
+}


### PR DESCRIPTION
## Description

Add new `#[test_only]` move function to create a `Clock` for tests, and a test to demonstrate how to use it.  Also update the docs to explain how to use it.

## Test Plan

```
sui-framework-test$ cargo nextest run
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes

Adds `sui::clock::create_for_testing(ctx: &mut TxContext)` to create a `Clock` for tests.
