### PR TITLE
[ts-sdk] Rework package publishing onto programmable tx

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,7 @@ importers:
       '@scure/bip39': ^1.1.1
       '@size-limit/preset-small-lib': ^8.2.4
       '@suchipi/femver': ^1.0.0
+      '@types/tmp': ^0.2.3
       cross-env: ^7.0.3
       cross-fetch: ^3.1.5
       eslint: ^8.35.0
@@ -545,6 +546,7 @@ importers:
       tweetnacl: 1.0.3
     devDependencies:
       '@size-limit/preset-small-lib': 8.2.4_size-limit@8.2.4
+      '@types/tmp': 0.2.3
       cross-env: 7.0.3
       eslint: 8.35.0
       eslint-config-prettier: 8.6.0_eslint@8.35.0
@@ -7299,6 +7301,10 @@ packages:
 
   /@types/throttle-debounce/5.0.0:
     resolution: {integrity: sha512-Pb7k35iCGFcGPECoNE4DYp3Oyf2xcTd3FbFQxXUI9hEYKUl6YX+KLf7HrBmgVcD05nl50LIH6i+80js4iYmWbw==}
+    dev: true
+
+  /@types/tmp/0.2.3:
+    resolution: {integrity: sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==}
     dev: true
 
   /@types/topojson-client/3.1.1:

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -72,6 +72,7 @@
   ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^8.2.4",
+    "@types/tmp": "^0.2.3",
     "cross-env": "^7.0.3",
     "eslint": "^8.35.0",
     "eslint-config-prettier": "^8.6.0",

--- a/sdk/typescript/src/builder/bcs.ts
+++ b/sdk/typescript/src/builder/bcs.ts
@@ -74,7 +74,7 @@ export const builder = new BCS(bcs)
     /**
      * Publish a Move module.
      */
-    Publish: [VECTOR, [VECTOR, BCS.U8]],
+    Publish: { modules: [VECTOR, [VECTOR, BCS.U8]] },
     /**
      * Build a vector of objects using the input arguments.
      * It is impossible to construct a `vector<T: key>` otherwise,

--- a/sdk/typescript/src/builder/legacy.ts
+++ b/sdk/typescript/src/builder/legacy.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { fromB64 } from '@mysten/bcs';
 import { Provider } from '../providers/provider';
-import { LocalTxnDataSerializer } from '../signers/txn-data-serializers/local-txn-data-serializer';
 import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
 import { TypeTagSerializer } from '../signers/txn-data-serializers/type-tag-serializer';
 import { getObjectReference, getObjectType, SUI_TYPE_ARG } from '../types';
@@ -127,20 +127,13 @@ export async function convertToTransactionBuilder(
       );
       break;
     case 'publish': {
-      // TODO: Fix publish transactions:
-      const serializer = new LocalTxnDataSerializer(provider);
-      return await serializer.serializeToBytes(
-        sender,
-        { kind: 'publish', data },
-        'Commit',
+      const modules = Array.from(data.compiledModules as ArrayLike<any>).map(
+        (data: string | ArrayLike<number>) => [
+          ...(typeof data === 'string' ? fromB64(data) : Array.from(data)),
+        ],
       );
-      // const modules = Array.from(data.compiledModules as ArrayLike<any>).map(
-      //   (data: string | ArrayLike<number>) => [
-      //     ...(typeof data === 'string' ? fromB64(data) : Array.from(data)),
-      //   ],
-      // );
-      // tx.add(Commands.Publish(modules));
-      // break;
+      tx.add(Commands.Publish(modules));
+      break;
     }
     case 'pay': {
       const [coin, ...coins] = data.inputCoins;

--- a/sdk/typescript/test/e2e/coin-metadata.test.ts
+++ b/sdk/typescript/test/e2e/coin-metadata.test.ts
@@ -2,23 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { ObjectId, RawSigner } from '../../src';
+import { ObjectId } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test Coin Metadata', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
   let packageId: ObjectId;
 
   beforeEach(async () => {
     toolbox = await setup();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath = __dirname + '/./data/coin_metadata';
-    packageId = await publishPackage(signer, packagePath);
+    packageId = await publishPackage(packagePath);
   });
 
   it('Test accessing coin metadata', async () => {
-    const coinMetadata = await signer.provider.getCoinMetadata({
+    const coinMetadata = await toolbox.signer.provider.getCoinMetadata({
       coinType: `${packageId}::test::TEST`,
     });
     expect(coinMetadata.decimals).to.equal(2);

--- a/sdk/typescript/test/e2e/coin-read.test.ts
+++ b/sdk/typescript/test/e2e/coin-read.test.ts
@@ -2,21 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { RawSigner } from '../../src';
 
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('CoinRead API', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
+  let publishToolbox: TestToolbox;
   let packageId: string;
   let testType: string;
 
   beforeAll(async () => {
-    toolbox = await setup();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
+    [toolbox, publishToolbox] = await Promise.all([setup(), setup()]);
     const packagePath = __dirname + '/./data/coin_metadata';
-    packageId = await publishPackage(signer, packagePath);
+    packageId = await publishPackage(packagePath, publishToolbox);
     testType = packageId + '::test::TEST';
   });
 
@@ -27,7 +25,7 @@ describe('CoinRead API', () => {
     expect(suiCoins.data.length).toEqual(5);
 
     const testCoins = await toolbox.provider.getCoins({
-      owner: toolbox.address(),
+      owner: publishToolbox.address(),
       coinType: testType,
     });
     expect(testCoins.data.length).toEqual(2);
@@ -35,8 +33,14 @@ describe('CoinRead API', () => {
     const allCoins = await toolbox.provider.getAllCoins({
       owner: toolbox.address(),
     });
-    expect(allCoins.data.length).toEqual(7);
+    expect(allCoins.data.length).toEqual(5);
     expect(allCoins.nextCursor).toBeNull();
+
+    const publisherAllCoins = await toolbox.provider.getAllCoins({
+      owner: publishToolbox.address(),
+    });
+    expect(publisherAllCoins.data.length).toEqual(3);
+    expect(publisherAllCoins.nextCursor).toBeNull();
 
     //test paging with limit
     const someSuiCoins = await toolbox.provider.getCoins({
@@ -56,7 +60,7 @@ describe('CoinRead API', () => {
     expect(suiBalance.totalBalance).toBeGreaterThan(0);
 
     const testBalance = await toolbox.provider.getBalance({
-      owner: toolbox.address(),
+      owner: publishToolbox.address(),
       coinType: testType,
     });
     expect(testBalance.coinType).toEqual(testType);
@@ -64,7 +68,7 @@ describe('CoinRead API', () => {
     expect(testBalance.totalBalance).toEqual(11);
 
     const allBalances = await toolbox.provider.getAllBalances({
-      owner: toolbox.address(),
+      owner: publishToolbox.address(),
     });
     expect(allBalances.length).toEqual(2);
   });

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -7,7 +7,6 @@ import {
   Commands,
   normalizeSuiObjectId,
   ObjectId,
-  RawSigner,
   SuiObjectInfo,
   SUI_TYPE_ARG,
   Transaction,
@@ -19,13 +18,11 @@ const SPLIT_AMOUNTS = [BigInt(1), BigInt(2), BigInt(3)];
 
 describe('Coin related API', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
   let coinToSplit: ObjectId;
   let coinsAfterSplit: SuiObjectInfo[];
 
   beforeAll(async () => {
     toolbox = await setup();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const coins = await toolbox.getGasObjectsOwnedByAddress();
     coinToSplit = coins[0].objectId;
     const tx = new Transaction();
@@ -37,7 +34,7 @@ describe('Coin related API', () => {
     });
 
     // split coins into desired amount
-    await signer.signAndExecuteTransaction(tx);
+    await toolbox.signer.signAndExecuteTransaction(tx);
     coinsAfterSplit = await toolbox.getGasObjectsOwnedByAddress();
   });
 

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -18,15 +18,12 @@ import {
 
 describe('Test dev inspect', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
   let packageId: string;
 
   beforeAll(async () => {
     toolbox = await setup();
-    //const version = await toolbox.provider.getRpcApiVersion();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath = __dirname + '/./data/serializer';
-    packageId = await publishPackage(signer, packagePath);
+    packageId = await publishPackage(packagePath);
   });
 
   it('Dev inspect transaction with Pay', async () => {
@@ -37,7 +34,7 @@ describe('Test dev inspect', () => {
         BigInt(DEFAULT_GAS_BUDGET),
       );
 
-    const splitTxn = await signer.signAndExecuteTransaction({
+    const splitTxn = await toolbox.signer.signAndExecuteTransaction({
       kind: 'splitCoin',
       data: {
         coinObjectId: coins[0].coinObjectId,
@@ -51,7 +48,7 @@ describe('Test dev inspect', () => {
     );
 
     await validateDevInspectTransaction(
-      signer,
+      toolbox.signer,
       {
         kind: 'pay',
         data: {
@@ -77,7 +74,7 @@ describe('Test dev inspect', () => {
     };
 
     await validateDevInspectTransaction(
-      signer,
+      toolbox.signer,
       {
         kind: 'moveCall',
         data: moveCall,
@@ -97,7 +94,7 @@ describe('Test dev inspect', () => {
     };
 
     await validateDevInspectTransaction(
-      signer,
+      toolbox.signer,
       {
         kind: 'moveCall',
         data: moveCall,

--- a/sdk/typescript/test/e2e/dynamic-fields.test.ts
+++ b/sdk/typescript/test/e2e/dynamic-fields.test.ts
@@ -2,20 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { RawSigner } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Dynamic Fields Reading API', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
   let packageId: string;
   let parentObjectId: string;
 
   beforeAll(async () => {
     toolbox = await setup();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath = __dirname + '/./data/dynamic_fields';
-    packageId = await publishPackage(signer, packagePath);
+    packageId = await publishPackage(packagePath, toolbox);
 
     await toolbox.provider
       .getObjectsOwnedByAddress(toolbox.address())

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -6,7 +6,6 @@ import {
   Commands,
   getExecutionStatusType,
   ObjectId,
-  RawSigner,
   Transaction,
 } from '../../src';
 import {
@@ -18,7 +17,6 @@ import {
 
 describe('Test Move call with strings', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
   let packageId: ObjectId;
 
   async function callWithString(str: string | string[], funcName: string) {
@@ -31,17 +29,16 @@ describe('Test Move call with strings', () => {
         arguments: [tx.input(str)],
       }),
     );
-    const result = await signer.signAndExecuteTransaction(tx);
+    const result = await toolbox.signer.signAndExecuteTransaction(tx);
     expect(getExecutionStatusType(result)).toEqual('success');
   }
 
   beforeAll(async () => {
     toolbox = await setup();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath =
       __dirname +
       '/../../../../crates/sui-core/src/unit_tests/data/entry_point_string';
-    packageId = await publishPackage(signer, packagePath);
+    packageId = await publishPackage(packagePath);
   });
 
   it('Test ascii', async () => {

--- a/sdk/typescript/test/e2e/event-subscription.test.ts
+++ b/sdk/typescript/test/e2e/event-subscription.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll, vi } from 'vitest';
-import { Commands, RawSigner, SuiEventEnvelope, Transaction } from '../../src';
+import { Commands, SuiEventEnvelope, Transaction } from '../../src';
 import {
   DEFAULT_GAS_BUDGET,
   DEFAULT_RECIPIENT,
@@ -12,11 +12,9 @@ import {
 
 describe('Event Subscription API', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
 
   beforeAll(async () => {
     toolbox = await setup();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
   });
 
   const mockCallback = vi.fn((_: SuiEventEnvelope) =>
@@ -32,7 +30,7 @@ describe('Event Subscription API', () => {
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
     tx.add(Commands.TransferObjects([tx.gas], tx.input(DEFAULT_RECIPIENT)));
-    await signer.signAndExecuteTransaction(tx);
+    await toolbox.signer.signAndExecuteTransaction(tx);
 
     const subFoundAndRemoved = await toolbox.provider.unsubscribeEvent(
       subscriptionId,

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -6,21 +6,18 @@ import {
   Commands,
   getExecutionStatusType,
   ObjectId,
-  RawSigner,
   Transaction,
 } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test ID as args to entry functions', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
   let packageId: ObjectId;
 
   beforeAll(async () => {
     toolbox = await setup();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath = __dirname + '/./data/id_entry_args';
-    packageId = await publishPackage(signer, packagePath);
+    packageId = await publishPackage(packagePath);
   });
 
   it('Test ID as arg to entry functions', async () => {
@@ -37,7 +34,7 @@ describe('Test ID as args to entry functions', () => {
         ],
       }),
     );
-    const result = await signer.signAndExecuteTransaction(tx);
+    const result = await toolbox.signer.signAndExecuteTransaction(tx);
     expect(getExecutionStatusType(result)).toEqual('success');
   });
 });

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -2,19 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { ObjectId, RawSigner, getObjectDisplay } from '../../src';
+import { ObjectId, getObjectDisplay } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test Object Display Standard', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
   let packageId: ObjectId;
 
   beforeAll(async () => {
     toolbox = await setup();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath = __dirname + '/./data/display_test';
-    packageId = await publishPackage(signer, packagePath);
+    packageId = await publishPackage(packagePath, toolbox);
   });
 
   it('Test getting Display fields', async () => {

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -7,7 +7,6 @@ import {
   getCreatedObjects,
   getExecutionStatusType,
   ObjectId,
-  RawSigner,
   SUI_FRAMEWORK_ADDRESS,
 } from '../../src';
 import {
@@ -19,11 +18,10 @@ import {
 
 describe.skip('Test Move call with a vector of objects as input (skipped due to move vector requirement)', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
   let packageId: ObjectId;
 
   async function mintObject(val: number) {
-    const txn = await signer.signAndExecuteTransaction({
+    const txn = await toolbox.signer.signAndExecuteTransaction({
       kind: 'moveCall',
       data: {
         packageObjectId: packageId,
@@ -39,7 +37,7 @@ describe.skip('Test Move call with a vector of objects as input (skipped due to 
   }
 
   async function destroyObjects(objects: ObjectId[]) {
-    const txn = await signer.signAndExecuteTransaction({
+    const txn = await toolbox.signer.signAndExecuteTransaction({
       kind: 'moveCall',
       data: {
         packageObjectId: packageId,
@@ -55,11 +53,10 @@ describe.skip('Test Move call with a vector of objects as input (skipped due to 
 
   beforeAll(async () => {
     toolbox = await setup();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath =
       __dirname +
       '/../../../../crates/sui-core/src/unit_tests/data/entry_point_vector';
-    packageId = await publishPackage(signer, packagePath);
+    packageId = await publishPackage(packagePath);
   });
 
   it('Test object vector', async () => {
@@ -69,7 +66,7 @@ describe.skip('Test Move call with a vector of objects as input (skipped due to 
   it('Test regular arg mixed with object vector arg', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
     const coinIDs = coins.map((coin) => Coin.getID(coin));
-    const txn = await signer.signAndExecuteTransaction({
+    const txn = await toolbox.signer.signAndExecuteTransaction({
       kind: 'moveCall',
       data: {
         packageObjectId: SUI_FRAMEWORK_ADDRESS,

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -19,11 +19,9 @@ import {
 
 describe('Transaction Builders', () => {
   let toolbox: TestToolbox;
-  let signer: RawSigner;
 
   beforeEach(async () => {
     toolbox = await setup();
-    signer = new RawSigner(toolbox.keypair, toolbox.provider);
   });
 
   it('SplitCoin + TransferObjects', async () => {
@@ -36,7 +34,7 @@ describe('Transaction Builders', () => {
       ),
     );
     tx.add(Commands.TransferObjects([coin], tx.input(toolbox.address())));
-    await validateTransaction(signer, tx);
+    await validateTransaction(toolbox.signer, tx);
   });
 
   it('MergeCoins', async () => {
@@ -47,7 +45,7 @@ describe('Transaction Builders', () => {
         tx.input(coins[1].objectId),
       ]),
     );
-    await validateTransaction(signer, tx);
+    await validateTransaction(toolbox.signer, tx);
   });
 
   it('MoveCall', async () => {
@@ -65,7 +63,7 @@ describe('Transaction Builders', () => {
         ],
       }),
     );
-    await validateTransaction(signer, tx);
+    await validateTransaction(toolbox.signer, tx);
   });
 
   it('MoveCall Shared Object', async () => {
@@ -87,20 +85,20 @@ describe('Transaction Builders', () => {
       }),
     );
 
-    await validateTransaction(signer, tx);
+    await validateTransaction(toolbox.signer, tx);
   });
 
   it('SplitCoin from gas object + TransferObjects', async () => {
     const tx = new Transaction();
     const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(1)));
     tx.add(Commands.TransferObjects([coin], tx.input(DEFAULT_RECIPIENT)));
-    await validateTransaction(signer, tx);
+    await validateTransaction(toolbox.signer, tx);
   });
 
   it('TransferObjects gas object', async () => {
     const tx = new Transaction();
     tx.add(Commands.TransferObjects([tx.gas], tx.input(DEFAULT_RECIPIENT)));
-    await validateTransaction(signer, tx);
+    await validateTransaction(toolbox.signer, tx);
   });
 
   it('TransferObject', async () => {
@@ -112,7 +110,7 @@ describe('Transaction Builders', () => {
         tx.input(DEFAULT_RECIPIENT),
       ),
     );
-    await validateTransaction(signer, tx);
+    await validateTransaction(toolbox.signer, tx);
   });
 });
 

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -9,7 +9,6 @@ import {
   MoveCallTransaction,
   PaySuiTx,
   PureArg,
-  RawSigner,
   SUI_SYSTEM_STATE_OBJECT_ID,
   UnserializedSignableTransaction,
   TransactionData,
@@ -36,9 +35,8 @@ describe('Transaction Serialization and deserialization', () => {
   beforeAll(async () => {
     toolbox = await setup();
     localSerializer = new LocalTxnDataSerializer(toolbox.provider);
-    const signer = new RawSigner(toolbox.keypair, toolbox.provider);
     const packagePath = __dirname + '/./data/serializer';
-    packageId = await publishPackage(signer, packagePath);
+    packageId = await publishPackage(packagePath);
   });
 
   async function serializeAndDeserialize(

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -2,17 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect } from 'vitest';
+import { execSync } from 'child_process';
+import tmp from 'tmp';
+
 import {
   Ed25519Keypair,
   getEvents,
   getExecutionStatusType,
   JsonRpcProvider,
-  ObjectId,
-  RawSigner,
   fromB64,
   localnetConnection,
   Connection,
   Coin,
+  Transaction,
+  Commands,
+  RawSigner,
 } from '../../../src';
 import { retry } from 'ts-retry-promise';
 import { FaucetRateLimitError } from '../../../src/rpc/faucet-client';
@@ -31,10 +35,15 @@ export const DEFAULT_RECIPIENT_2 =
 export const DEFAULT_GAS_BUDGET = 10000;
 
 export class TestToolbox {
-  constructor(
-    public keypair: Ed25519Keypair,
-    public provider: JsonRpcProvider,
-  ) {}
+  keypair: Ed25519Keypair;
+  provider: JsonRpcProvider;
+  signer: RawSigner;
+
+  constructor(keypair: Ed25519Keypair, provider: JsonRpcProvider) {
+    this.keypair = keypair;
+    this.provider = provider;
+    this.signer = new RawSigner(this.keypair, this.provider);
+  }
 
   address() {
     return this.keypair.getPublicKey().toSuiAddress();
@@ -82,11 +91,14 @@ export async function setup() {
 }
 
 export async function publishPackage(
-  signer: RawSigner,
   packagePath: string,
-): Promise<ObjectId> {
-  const { execSync } = require('child_process');
-  const tmp = require('tmp');
+  toolbox?: TestToolbox,
+) {
+  // TODO: We create a unique publish address per publish, but we really could share one for all publishes.
+  if (!toolbox) {
+    toolbox = await setup();
+  }
+
   // remove all controlled temporary objects on process exit
   tmp.setGracefulCleanup();
 
@@ -98,13 +110,12 @@ export async function publishPackage(
       { encoding: 'utf-8' },
     ),
   );
-  const publishTxn = await signer.signAndExecuteTransaction({
-    kind: 'publish',
-    data: {
-      compiledModules: compiledModules.map((m: any) => Array.from(fromB64(m))),
-      gasBudget: DEFAULT_GAS_BUDGET,
-    },
-  });
+  const tx = new Transaction();
+  tx.setGasBudget(DEFAULT_GAS_BUDGET);
+  tx.add(
+    Commands.Publish(compiledModules.map((m: any) => Array.from(fromB64(m)))),
+  );
+  const publishTxn = await toolbox.signer.signAndExecuteTransaction(tx);
   expect(getExecutionStatusType(publishTxn)).toEqual('success');
 
   const publishEvent = getEvents(publishTxn)?.find((e) => 'publish' in e);
@@ -112,7 +123,8 @@ export async function publishPackage(
   // @ts-ignore: Publish not narrowed:
   const packageId = publishEvent?.publish.packageId.replace(/^(0x)(0+)/, '0x');
   console.info(
-    `Published package ${packageId} from address ${await signer.getAddress()}}`,
+    `Published package ${packageId} from address ${await toolbox.signer.getAddress()}}`,
   );
+
   return packageId;
 }


### PR DESCRIPTION
## Description 

Changes the package publishing to use programmable transactions. Updates some tests to account for changes related to different coin selection logic.

## Test Plan 

Tests pass.
