### PR TITLE
[sui-framework] Add validator candidacy to stress tests

### DIFF
--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -835,4 +835,13 @@ module sui::sui_system {
         let self = load_system_state_mut(wrapper);
         self.epoch = epoch_num
     }
+
+    #[test_only]
+    public fun request_add_validator_candidate_for_testing(
+        wrapper: &mut SuiSystemState,
+        testing_validator: Validator,
+    ) {
+        let self = load_system_state_mut(wrapper);
+        validator_set::request_add_validator_candidate(&mut self.validators, testing_validator);
+    }
 }

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -32,6 +32,8 @@ module sui::validator {
     friend sui::sui_system_tests;
     #[test_only]
     friend sui::governance_test_utils;
+    #[test_only]
+    friend sui::delegation_stress_tests;
 
     /// Invalid proof_of_possesion field in ValidatorMetadata
     const EInvalidProofOfPossession: u64 = 0;

--- a/crates/sui-framework/sources/test/test_random.move
+++ b/crates/sui-framework/sources/test/test_random.move
@@ -52,6 +52,20 @@ module sui::test_random {
         output
     }
 
+    /// Use the given pseudorandom generator to generate a vector with `l` random
+    /// bytes where each byte is a valid ascii character.
+    public fun next_ascii_bytes(random: &mut Random, l: u64): vector<u8> {
+        let vec = next_bytes(random, l);
+        let i = 0;
+        let len = vector::length(&vec);
+        while (i < len) {
+            let char = vector::borrow_mut(&mut vec, i);
+            *char = *char % 0x7F;
+            i = i + 1;
+        };
+        vec
+    }
+
     /// Use the given pseudorandom generator to generate a random `u256` integer.
     public fun next_u256(random: &mut Random): u256 {
         let bytes = next_digest(random);


### PR DESCRIPTION
This adds validator candidacy and tracking of the candidate validator's stake amount to the stress test. A candidate validator can be both delegated to and withdrawn from. Candidate validators cannot yet become active validators, but that will be the next PR in this stack.

## Test Plan 

This is tested as part of the smoke test in this file.

