### PR TITLE
Adding FN call for multiget objects

### DIFF
--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -201,6 +201,17 @@ where
             .await
     }
 
+    async fn multi_get_object_with_options(
+        &self,
+        object_ids: Vec<ObjectID>,
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<Vec<SuiObjectResponse>> {
+        return self
+            .fullnode
+            .multi_get_object_with_options(object_ids, options)
+            .await;
+    }
+
     async fn get_dynamic_field_object(
         &self,
         parent_object_id: ObjectID,
@@ -273,7 +284,7 @@ where
     ) -> RpcResult<Vec<SuiTransactionResponse>> {
         if self
             .method_to_be_forwarded
-            .contains(&"muti_get_transactions".to_string())
+            .contains(&"multi_get_transactions".to_string())
         {
             return self
                 .fullnode

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -75,6 +75,16 @@ pub trait ReadApi {
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<SuiObjectResponse>;
 
+    /// Return the object data for a list of objects
+    #[method(name = "multiGetObjects")]
+    async fn multi_get_object_with_options(
+        &self,
+        /// the IDs of the queried objects
+        object_ids: Vec<ObjectID>,
+        /// options for specifying the content to be returned
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<Vec<SuiObjectResponse>>;
+
     /// Return the dynamic field object information for a specified object
     #[method(name = "getDynamicFieldObject")]
     async fn get_dynamic_field_object(

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -46,6 +46,14 @@ async fn test_get_objects() -> Result<(), anyhow::Error> {
 
     let objects = http_client.get_objects_owned_by_address(*address).await?;
     assert_eq!(5, objects.len());
+
+    // Multiget objectIDs test
+    let object_digests = objects.iter().map(|o| o.object_id).collect();
+
+    let object_resp = http_client
+        .multi_get_object_with_options(object_digests, None)
+        .await?;
+    assert_eq!(5, object_resp.len());
     Ok(())
 }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1832,6 +1832,45 @@
       }
     },
     {
+      "name": "sui_multiGetObjects",
+      "tags": [
+        {
+          "name": "Read API"
+        }
+      ],
+      "description": "Return the object data for a list of objects",
+      "params": [
+        {
+          "name": "object_ids",
+          "description": "the IDs of the queried objects",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectID"
+            }
+          }
+        },
+        {
+          "name": "options",
+          "description": "options for specifying the content to be returned",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectDataOptions"
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec<SuiObjectResponse>",
+        "required": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/ObjectRead"
+          }
+        }
+      }
+    },
+    {
       "name": "sui_multiGetTransactions",
       "tags": [
         {


### PR DESCRIPTION
## Description 

Adding FN api call for multiGet objects
## Test Plan 

unit testing
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
