### PR TITLE
wallet-ext: split mnemonic input to multiple ones

### DIFF
--- a/apps/core/tailwind.config.js
+++ b/apps/core/tailwind.config.js
@@ -36,6 +36,7 @@ module.exports = {
                 DEFAULT: '#6fbcf0',
                 bright: '#2A38EB',
                 light: '#E1F3FF',
+                lightest: '#F1F8FD',
                 dark: '#1F6493',
             },
 

--- a/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ArrowRight16 } from '@mysten/icons';
-import { Field, Formik, Form, ErrorMessage } from 'formik';
+import { Formik, Form, ErrorMessage } from 'formik';
 import { toast } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 import { object, string as YupString } from 'yup';
@@ -13,7 +13,7 @@ import { Button } from '_src/ui/app/shared/ButtonUI';
 import { Link } from '_src/ui/app/shared/Link';
 import FieldLabel from '_src/ui/app/shared/field-label';
 import { Heading } from '_src/ui/app/shared/heading';
-import PasswordInput from '_src/ui/app/shared/input/password';
+import { PasswordInputField } from '_src/ui/app/shared/input/password';
 import { Text } from '_src/ui/app/shared/text';
 
 const validation = object({
@@ -65,7 +65,7 @@ export function PasswordInputDialog({
                     </Heading>
                     <div className="self-stretch flex-1">
                         <FieldLabel txt="Enter Wallet Password to Continue">
-                            <Field name="password" component={PasswordInput} />
+                            <PasswordInputField name="password" />
                             <ErrorMessage
                                 render={(error) => <Alert>{error}</Alert>}
                                 name="password"

--- a/apps/wallet/src/ui/app/index.tsx
+++ b/apps/wallet/src/ui/app/index.tsx
@@ -24,7 +24,7 @@ import HomePage, {
 import InitializePage from '_pages/initialize';
 import BackupPage from '_pages/initialize/backup';
 import CreatePage from '_pages/initialize/create';
-import ImportPage from '_pages/initialize/import';
+import { ImportPage } from '_pages/initialize/import';
 import SelectPage from '_pages/initialize/select';
 import SiteConnectPage from '_pages/site-connect';
 import WelcomePage from '_pages/welcome';

--- a/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Button from '_app/shared/button';
-import CardLayout from '_app/shared/card-layout';
+import { CardLayout } from '_app/shared/card-layout';
 import { Text } from '_app/shared/text';
 import { useLockedGuard } from '_app/wallet/hooks';
 import Alert from '_components/alert';

--- a/apps/wallet/src/ui/app/pages/initialize/create/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/create/index.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { createMnemonicValidation } from './validation';
 import Button from '_app/shared/button';
-import CardLayout from '_app/shared/card-layout';
+import { CardLayout } from '_app/shared/card-layout';
 import { Text } from '_app/shared/text';
 import ExternalLink from '_components/external-link';
 import Icon, { SuiIcons } from '_components/icon';

--- a/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 
 import StepOne from './steps/StepOne';
 import StepTwo from './steps/StepTwo';
-import CardLayout from '_app/shared/card-layout';
+import { CardLayout } from '_app/shared/card-layout';
 import { useAppDispatch } from '_hooks';
 import { createVault, logout } from '_redux/slices/account';
 import { MAIN_UI_URL } from '_shared/utils';
@@ -66,7 +66,6 @@ export function ImportPage({ mode = 'import' }: ImportPageProps) {
                     ? 'Import an Existing Wallet'
                     : 'Reset Password for This Wallet'
             }
-            mode={mode === 'import' ? 'box' : 'plain'}
         >
             {StepForm ? (
                 <div className="mt-7.5 flex flex-col flex-nowrap items-stretch flex-1 flex-grow w-full">

--- a/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
@@ -13,7 +13,7 @@ import { MAIN_UI_URL } from '_shared/utils';
 import { entropyToSerialized, mnemonicToEntropy } from '_shared/utils/bip39';
 
 const initialValues = {
-    mnemonic: '',
+    mnemonic: Array.from({ length: 12 }, () => ''),
     password: '',
     confirmPassword: '',
 };
@@ -24,7 +24,7 @@ export type ImportValuesType = typeof initialValues;
 export type ImportPageProps = {
     mode?: 'import' | 'forgot';
 };
-const ImportPage = ({ mode = 'import' }: ImportPageProps) => {
+export function ImportPage({ mode = 'import' }: ImportPageProps) {
     const [data, setData] = useState<ImportValuesType>(initialValues);
     const [step, setStep] = useState(0);
     const dispatch = useAppDispatch();
@@ -39,7 +39,7 @@ const ImportPage = ({ mode = 'import' }: ImportPageProps) => {
                 await dispatch(
                     createVault({
                         importedEntropy: entropyToSerialized(
-                            mnemonicToEntropy(mnemonic)
+                            mnemonicToEntropy(mnemonic.join(' '))
                         ),
                         password,
                     })
@@ -89,6 +89,4 @@ const ImportPage = ({ mode = 'import' }: ImportPageProps) => {
             ) : null}
         </CardLayout>
     );
-};
-
-export default ImportPage;
+}

--- a/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
@@ -39,7 +39,7 @@ export function ImportPage({ mode = 'import' }: ImportPageProps) {
                 await dispatch(
                     createVault({
                         importedEntropy: entropyToSerialized(
-                            mnemonicToEntropy(mnemonic.join(' '))
+                            mnemonicToEntropy(mnemonic.join(' ').trim())
                         ),
                         password,
                     })

--- a/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.tsx
@@ -1,16 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ArrowLeft16, ArrowRight16 } from '@mysten/icons';
 import { Formik, Form } from 'formik';
 import { useNavigate } from 'react-router-dom';
 import * as Yup from 'yup';
 
-import Button from '_app/shared/button';
+import { Button } from '_app/shared/ButtonUI';
 import FieldLabel from '_app/shared/field-label';
 import Alert from '_components/alert';
-import Icon, { SuiIcons } from '_components/icon';
-import Loading from '_components/loading';
 import { mnemonicValidation } from '_pages/initialize/import/validation';
+import { PasswordInputField } from '_src/ui/app/shared/input/password';
+import { Text } from '_src/ui/app/shared/text';
 
 import type { StepProps } from '.';
 
@@ -24,11 +25,13 @@ export default function StepOne({ next, data, mode }: StepProps) {
         <Formik
             initialValues={data}
             validationSchema={validationSchema}
-            validateOnMount={true}
+            validateOnMount
             onSubmit={async (values) => {
                 await next(values, 1);
             }}
             enableReinitialize={true}
+            validateOnChange
+            validateOnBlur
         >
             {({
                 isSubmitting,
@@ -36,72 +39,103 @@ export default function StepOne({ next, data, mode }: StepProps) {
                 errors,
                 values: { mnemonic },
                 isValid,
-                handleChange,
                 setFieldValue,
-                handleBlur,
             }) => (
                 <Form className="flex flex-col flex-nowrap items-stretch flex-1 flex-grow justify-between">
-                    <FieldLabel txt="Enter Recovery Phrase">
-                        <textarea
-                            id="importMnemonicTxt"
-                            onChange={handleChange}
-                            value={mnemonic}
-                            onBlur={async (e) => {
-                                const adjMnemonic =
-                                    await validationSchema.fields.mnemonic.cast(
-                                        mnemonic
-                                    );
-                                await setFieldValue(
-                                    'mnemonic',
-                                    adjMnemonic,
-                                    false
+                    <FieldLabel txt="Enter your 12-word Recovery Phrase">
+                        <div className="grid grid-cols-2 gap-x-2 gap-y-2.5 mt-1.5">
+                            {mnemonic.map((_, index) => {
+                                return (
+                                    <div
+                                        key={index}
+                                        className="flex flex-col flex-nowrap gap-1.5 items-center"
+                                    >
+                                        <Text
+                                            variant="captionSmall"
+                                            weight="medium"
+                                            color="steel-darker"
+                                        >
+                                            {index + 1}
+                                        </Text>
+                                        <PasswordInputField
+                                            name={`mnemonic.${index}`}
+                                            disabled={isSubmitting}
+                                            onPaste={async (e) => {
+                                                const inputText =
+                                                    e.clipboardData.getData(
+                                                        'text'
+                                                    );
+                                                const words = inputText
+                                                    .trim()
+                                                    .split(' ')
+                                                    .map((aWord) =>
+                                                        aWord.trim()
+                                                    )
+                                                    .filter(String);
+                                                if (words.length > 1) {
+                                                    e.preventDefault();
+                                                    const pasteIndex =
+                                                        words.length ===
+                                                        mnemonic.length
+                                                            ? 0
+                                                            : index;
+                                                    const newMnemonic = [
+                                                        ...mnemonic,
+                                                    ];
+                                                    const wordsToPaste =
+                                                        words.slice(
+                                                            0,
+                                                            mnemonic.length -
+                                                                pasteIndex
+                                                        );
+                                                    newMnemonic.splice(
+                                                        pasteIndex,
+                                                        wordsToPaste.length,
+                                                        ...words.slice(
+                                                            0,
+                                                            mnemonic.length -
+                                                                pasteIndex
+                                                        )
+                                                    );
+                                                    setFieldValue(
+                                                        'mnemonic',
+                                                        newMnemonic
+                                                    );
+                                                }
+                                            }}
+                                        />
+                                    </div>
                                 );
-                                handleBlur(e);
-                            }}
-                            className="text-steel-dark flex flex-col flex-nowrap gap-2 self-stretch font-semibold text-heading5 p-3.5 rounded-15 bg-white border border-solid border-gray-45 shadow-button leading-snug resize-none min-h-[100px] placeholder:text-steel-dark"
-                            placeholder="Enter your 12-word recovery phrase"
-                            name="mnemonic"
-                            disabled={isSubmitting}
-                        />
-                        {touched.mnemonic && errors?.mnemonic && (
-                            <Alert>{errors?.mnemonic}</Alert>
-                        )}
+                            })}
+                        </div>
+                        {touched.mnemonic &&
+                            typeof errors.mnemonic === 'string' && (
+                                <Alert>{errors.mnemonic}</Alert>
+                            )}
                     </FieldLabel>
-
                     <div className="flex flex-nowrap items-center mt-5 gap-2.5">
                         {mode === 'forgot' ? (
                             <Button
                                 type="button"
                                 disabled={isSubmitting}
-                                mode="neutral"
-                                size="large"
-                                className="flex-1"
+                                variant="outline"
+                                size="tall"
                                 onClick={() => {
                                     navigate(-1);
                                 }}
-                            >
-                                <Icon
-                                    icon={SuiIcons.ArrowLeft}
-                                    className="text-subtitleSmallExtra font-light"
-                                />
-                                Back
-                            </Button>
+                                before={<ArrowLeft16 />}
+                                text="Back"
+                            />
                         ) : null}
                         <Button
                             type="submit"
                             disabled={isSubmitting || !isValid}
-                            mode="primary"
-                            className="flex-1"
-                            size="large"
-                        >
-                            <Loading loading={isSubmitting}>
-                                {mode === 'forgot' ? 'Next' : 'Continue'}
-                                <Icon
-                                    icon={SuiIcons.ArrowRight}
-                                    className="text-subtitleSmallExtra font-light"
-                                />
-                            </Loading>
-                        </Button>
+                            variant="primary"
+                            size="tall"
+                            loading={isSubmitting}
+                            text={mode === 'forgot' ? 'Next' : 'Continue'}
+                            after={<ArrowRight16 />}
+                        />
                     </div>
                 </Form>
             )}

--- a/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ArrowLeft16, ArrowRight16 } from '@mysten/icons';
+import { ArrowRight16 } from '@mysten/icons';
 import { Formik, Form } from 'formik';
-import { useNavigate } from 'react-router-dom';
 import * as Yup from 'yup';
 
 import { Button } from '_app/shared/ButtonUI';
@@ -20,7 +19,6 @@ const validationSchema = Yup.object({
 });
 
 export default function StepOne({ next, data, mode }: StepProps) {
-    const navigate = useNavigate();
     return (
         <Formik
             initialValues={data}
@@ -108,25 +106,12 @@ export default function StepOne({ next, data, mode }: StepProps) {
                                 );
                             })}
                         </div>
+                    </FieldLabel>
+                    <div className="bg-sui-lightest flex flex-col flex-nowrap items-stretch gap-2.5 sticky -bottom-7.5 px-7.5 pb-7.5 pt-4.5 -mx-7.5 -mb-7.5">
                         {touched.mnemonic &&
                             typeof errors.mnemonic === 'string' && (
                                 <Alert>{errors.mnemonic}</Alert>
                             )}
-                    </FieldLabel>
-                    <div className="flex flex-nowrap items-center mt-5 gap-2.5">
-                        {mode === 'forgot' ? (
-                            <Button
-                                type="button"
-                                disabled={isSubmitting}
-                                variant="outline"
-                                size="tall"
-                                onClick={() => {
-                                    navigate(-1);
-                                }}
-                                before={<ArrowLeft16 />}
-                                text="Back"
-                            />
-                        ) : null}
                         <Button
                             type="submit"
                             disabled={isSubmitting || !isValid}

--- a/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.tsx
@@ -18,6 +18,19 @@ const validationSchema = Yup.object({
     mnemonic: mnemonicValidation,
 });
 
+function findNextWordInput(element: HTMLElement) {
+    if (element.parentElement?.parentElement?.nextElementSibling) {
+        const nextElement =
+            element.parentElement?.parentElement?.nextElementSibling.children
+                .item(1)
+                ?.children.item(0);
+        if (nextElement instanceof HTMLInputElement) {
+            return nextElement;
+        }
+    }
+    return null;
+}
+
 export default function StepOne({ next, data, mode }: StepProps) {
     return (
         <Formik
@@ -58,6 +71,14 @@ export default function StepOne({ next, data, mode }: StepProps) {
                                         <PasswordInputField
                                             name={`mnemonic.${index}`}
                                             disabled={isSubmitting}
+                                            onKeyDown={(e) => {
+                                                if (e.key === ' ') {
+                                                    e.preventDefault();
+                                                    findNextWordInput(
+                                                        e.target as HTMLElement
+                                                    )?.focus();
+                                                }
+                                            }}
                                             onPaste={async (e) => {
                                                 const inputText =
                                                     e.clipboardData.getData(

--- a/apps/wallet/src/ui/app/pages/initialize/import/steps/StepTwo.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/steps/StepTwo.tsx
@@ -1,12 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ArrowLeft16 } from '@mysten/icons';
 import { Form, Formik } from 'formik';
 import { object } from 'yup';
 
-import Button from '_app/shared/button';
-import Icon, { SuiIcons } from '_components/icon';
-import Loading from '_components/loading';
+import { Button } from '_app/shared/ButtonUI';
 import PasswordFields from '_pages/initialize/shared/password-fields';
 import { passwordFieldsValidation } from '_pages/initialize/shared/password-fields/validation';
 
@@ -33,32 +32,20 @@ export default function StepTwo({ next, data, mode }: StepProps) {
                         <Button
                             type="button"
                             disabled={isSubmitting}
-                            className="flex-1 !text-steel-dark"
-                            mode="neutral"
-                            size="large"
+                            size="tall"
+                            variant="outline"
                             onClick={() => next(values, -1)}
-                        >
-                            <Icon
-                                icon={SuiIcons.ArrowLeft}
-                                className="text-subtitleSmallExtra font-normal"
-                            />
-                            Back
-                        </Button>
+                            before={<ArrowLeft16 />}
+                            text="Back"
+                        />
                         <Button
                             type="submit"
                             disabled={isSubmitting || !isValid}
-                            mode="primary"
-                            className="flex-1"
-                            size="large"
-                        >
-                            <Loading loading={isSubmitting}>
-                                {mode === 'import' ? 'Import' : 'Reset'}
-                                <Icon
-                                    icon={SuiIcons.ArrowRight}
-                                    className="text-subtitleSmallExtra font-light"
-                                />
-                            </Loading>
-                        </Button>
+                            size="tall"
+                            variant="primary"
+                            loading={isSubmitting}
+                            text={mode === 'import' ? 'Import' : 'Reset'}
+                        />
                     </div>
                 </Form>
             )}

--- a/apps/wallet/src/ui/app/pages/initialize/import/validation.ts
+++ b/apps/wallet/src/ui/app/pages/initialize/import/validation.ts
@@ -5,12 +5,13 @@ import * as Yup from 'yup';
 
 import { normalizeMnemonics, validateMnemonics } from '_src/shared/utils/bip39';
 
-export const mnemonicValidation = Yup.string()
-    .ensure()
-    .required()
-    .trim()
-    .transform((mnemonic) => normalizeMnemonics(mnemonic))
-    .test('mnemonic-valid', 'Recovery Passphrase is invalid', (mnemonic) =>
-        validateMnemonics(mnemonic)
-    )
+export const mnemonicValidation = Yup.array()
+    .of(Yup.string().ensure().trim())
+    .transform((mnemonic: string[]) => {
+        console.log(mnemonic.join(' '));
+        return normalizeMnemonics(mnemonic.join(' ')).split(' ');
+    })
+    .test('mnemonic-valid', 'Recovery Passphrase is invalid', (mnemonic) => {
+        return validateMnemonics(mnemonic?.join(' ') || '');
+    })
     .label('Recovery Passphrase');

--- a/apps/wallet/src/ui/app/pages/initialize/import/validation.ts
+++ b/apps/wallet/src/ui/app/pages/initialize/import/validation.ts
@@ -7,10 +7,9 @@ import { normalizeMnemonics, validateMnemonics } from '_src/shared/utils/bip39';
 
 export const mnemonicValidation = Yup.array()
     .of(Yup.string().ensure().trim())
-    .transform((mnemonic: string[]) => {
-        console.log(mnemonic.join(' '));
-        return normalizeMnemonics(mnemonic.join(' ')).split(' ');
-    })
+    .transform((mnemonic: string[]) =>
+        normalizeMnemonics(mnemonic.join(' ')).split(' ')
+    )
     .test('mnemonic-valid', 'Recovery Passphrase is invalid', (mnemonic) => {
         return validateMnemonics(mnemonic?.join(' ') || '');
     })

--- a/apps/wallet/src/ui/app/pages/initialize/select/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/select/index.tsx
@@ -34,7 +34,7 @@ const SelectPage = () => {
                 {selections.map((aSelection) => (
                     <div
                         className={
-                            'bg-alice-blue flex flex-col flex-nowrap items-center gap-3 text-center rounded-15 py-10 px-7.5 max-w-popup-width shadow-wallet-content'
+                            'bg-sui-lightest flex flex-col flex-nowrap items-center gap-3 text-center rounded-15 py-10 px-7.5 max-w-popup-width shadow-wallet-content'
                         }
                         key={aSelection.url}
                     >

--- a/apps/wallet/src/ui/app/pages/initialize/shared/password-fields/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/shared/password-fields/index.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFormikContext, Field } from 'formik';
+import { useFormikContext } from 'formik';
 
 import FieldLabel from '_app/shared/field-label';
-import PasswordInput from '_app/shared/input/password';
+import { PasswordInputField } from '_app/shared/input/password';
 import Alert from '_components/alert';
 
 export type PasswordFieldsValues = {
@@ -17,13 +17,13 @@ export default function PasswordFields() {
     return (
         <>
             <FieldLabel txt="Create Password">
-                <Field name="password" component={PasswordInput} />
+                <PasswordInputField name="password" />
                 {touched.password && errors.password ? (
                     <Alert>{errors.password}</Alert>
                 ) : null}
             </FieldLabel>
             <FieldLabel txt="Confirm Password">
-                <Field name="confirmPassword" component={PasswordInput} />
+                <PasswordInputField name="confirmPassword" />
                 {touched.confirmPassword && errors.confirmPassword ? (
                     <Alert>{errors.confirmPassword}</Alert>
                 ) : null}

--- a/apps/wallet/src/ui/app/pages/welcome/index.tsx
+++ b/apps/wallet/src/ui/app/pages/welcome/index.tsx
@@ -21,7 +21,7 @@ const WelcomePage = () => {
         <PageLayout forceFullscreen={true}>
             <Loading loading={checkingInitialized}>
                 <div className="flex flex-col flex-nowrap items-center justify-center">
-                    <div className="pt-6 rounded-20 bg-alice-blue shadow-wallet-content flex flex-col flex-nowrap items-center justify-center w-popup-width h-popup-height">
+                    <div className="pt-6 rounded-20 bg-sui-lightest shadow-wallet-content flex flex-col flex-nowrap items-center justify-center w-popup-width h-popup-height">
                         <BottomMenuLayout>
                             <Content className="flex flex-col flex-nowrap items-center p-7.5 pb-0">
                                 <div className="mt-7.5 text-hero">

--- a/apps/wallet/src/ui/app/shared/ButtonUI.tsx
+++ b/apps/wallet/src/ui/app/shared/ButtonUI.tsx
@@ -13,7 +13,7 @@ import type { ReactNode } from 'react';
 
 const styles = cva(
     [
-        'transition no-underline outline-none bg-transparent group',
+        'transition no-underline outline-none group',
         'flex flex-row flex-nowrap items-center justify-center gap-2',
         'cursor-pointer text-body font-semibold max-w-full min-w-0 w-full',
     ],

--- a/apps/wallet/src/ui/app/shared/card-layout/index.tsx
+++ b/apps/wallet/src/ui/app/shared/card-layout/index.tsx
@@ -1,49 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { cva, type VariantProps } from 'class-variance-authority';
-
 import { Heading } from '_app/shared/heading';
 import { Text } from '_app/shared/text';
 import Icon, { SuiIcons } from '_components/icon';
 
 import type { ReactNode } from 'react';
 
-const cardLayoutStyles = cva(
-    [
-        'flex flex-col flex-nowrap rounded-20 items-center justify-center bg-alice-blue shadow-wallet-content p-7.5 pt-10 flex-grow w-full',
-    ],
-    {
-        variants: {
-            mode: {
-                box: 'bg-alice-blue max-h-popup-height max-w-popup-width',
-                plain: 'bg-transparent',
-            },
-        },
-        defaultVariants: {
-            mode: 'box',
-        },
-    }
-);
-
-export interface CardLayoutProps extends VariantProps<typeof cardLayoutStyles> {
+export type CardLayoutProps = {
     title?: string;
     subtitle?: string;
     headerCaption?: string;
     icon?: 'success' | 'sui';
     children: ReactNode | ReactNode[];
-}
+};
 
-export default function CardLayout({
+export function CardLayout({
     children,
     title,
     subtitle,
     headerCaption,
     icon,
-    ...styleProps
 }: CardLayoutProps) {
     return (
-        <div className={cardLayoutStyles(styleProps)}>
+        <div className="flex flex-col flex-nowrap rounded-20 items-center bg-sui-lightest shadow-wallet-content p-7.5 pt-10 flex-grow w-full max-h-popup-height max-w-popup-width overflow-auto">
             {icon === 'success' ? (
                 <div className="rounded-full w-12 h-12 border-dotted border-success border-2 flex items-center justify-center mb-2.5 p-1">
                     <div className="bg-success rounded-full h-8 w-8 flex items-center justify-center">

--- a/apps/wallet/src/ui/app/shared/input/password/index.tsx
+++ b/apps/wallet/src/ui/app/shared/input/password/index.tsx
@@ -1,34 +1,34 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
+import { EyeClose16, EyeOpen16 } from '@mysten/icons';
+import { useField } from 'formik';
+import { type ComponentProps, useState } from 'react';
 
-import Icon, { SuiIcons } from '_components/icon';
+export interface PasswordInputProps
+    extends Omit<ComponentProps<'input'>, 'className' | 'type' | 'name'> {
+    name: string;
+}
 
-import type { FieldProps } from 'formik';
-
-export type PasswordInputProps = FieldProps;
-
-function PasswordInput({ field, meta, form, ...props }: PasswordInputProps) {
+export function PasswordInputField({ ...props }: PasswordInputProps) {
     const [passwordShown, setPasswordShown] = useState(false);
+    const [field] = useField(props.name);
+    const IconComponent = passwordShown ? EyeOpen16 : EyeClose16;
     return (
         <div className="flex w-full relative items-center">
             <input
                 type={passwordShown ? 'text' : 'password'}
-                {...field}
+                placeholder="Password"
                 {...props}
+                {...field}
                 className={
                     'peer h-11 w-full text-body text-steel-dark font-medium flex items-center gap-5 bg-white py-2.5 pr-0 pl-3 border border-solid  border-gray-45 rounded-2lg shadow-button focus:border-steel focus:shadow-none placeholder-gray-65'
                 }
-                placeholder="Password"
             />
-            <Icon
-                icon={SuiIcons[passwordShown ? 'ShowPassword' : 'HidePassword']}
+            <IconComponent
                 className="absolute text-heading6 font-normal text-gray-60 cursor-pointer right-3 peer-focus:text-steel"
                 onClick={() => setPasswordShown(!passwordShown)}
             />
         </div>
     );
 }
-
-export default PasswordInput;

--- a/apps/wallet/src/ui/app/wallet/forgot-password-page/index.tsx
+++ b/apps/wallet/src/ui/app/wallet/forgot-password-page/index.tsx
@@ -5,7 +5,7 @@ import PageMainLayout from '_app/shared/page-main-layout';
 import { useLockedGuard } from '_app/wallet/hooks';
 import Loading from '_components/loading';
 import { useInitializedGuard } from '_hooks';
-import ImportPage from '_pages/initialize/import';
+import { ImportPage } from '_pages/initialize/import';
 import PageLayout from '_pages/layout';
 
 import st from './ForgotPasswordPage.module.scss';

--- a/apps/wallet/src/ui/app/wallet/locked-page/index.tsx
+++ b/apps/wallet/src/ui/app/wallet/locked-page/index.tsx
@@ -1,15 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { LockUnlocked16 } from '@mysten/icons';
 import { Form, Formik } from 'formik';
 import { Link } from 'react-router-dom';
 import Browser from 'webextension-polyfill';
 import * as Yup from 'yup';
 
 import Alert from '_app/components/alert';
-import Icon, { SuiIcons } from '_app/components/icon';
-import Button from '_app/shared/button';
-import CardLayout from '_app/shared/card-layout';
+import { Button } from '_app/shared/ButtonUI';
+import { CardLayout } from '_app/shared/card-layout';
 import FieldLabel from '_app/shared/field-label';
 import { PasswordInputField } from '_app/shared/input/password';
 import PageMainLayout from '_app/shared/page-main-layout';
@@ -50,7 +50,6 @@ export default function LockedPage() {
                         icon="sui"
                         headerCaption="Hello There"
                         title="Welcome Back"
-                        mode="plain"
                     >
                         <Formik
                             initialValues={{ password: '' }}
@@ -92,15 +91,11 @@ export default function LockedPage() {
                                     <Button
                                         type="submit"
                                         disabled={isSubmitting || !isValid}
-                                        mode="primary"
-                                        size="large"
-                                    >
-                                        <Icon
-                                            icon={SuiIcons.Unlocked}
-                                            className={st.btnIcon}
-                                        />
-                                        Unlock Wallet
-                                    </Button>
+                                        variant="primary"
+                                        size="tall"
+                                        before={<LockUnlocked16 />}
+                                        text="Unlock Wallet"
+                                    />
                                     <Link
                                         to="/forgot-password"
                                         className={st.forgotLink}

--- a/apps/wallet/src/ui/app/wallet/locked-page/index.tsx
+++ b/apps/wallet/src/ui/app/wallet/locked-page/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Field, Form, Formik } from 'formik';
+import { Form, Formik } from 'formik';
 import { Link } from 'react-router-dom';
 import Browser from 'webextension-polyfill';
 import * as Yup from 'yup';
@@ -11,7 +11,7 @@ import Icon, { SuiIcons } from '_app/components/icon';
 import Button from '_app/shared/button';
 import CardLayout from '_app/shared/card-layout';
 import FieldLabel from '_app/shared/field-label';
-import PasswordInput from '_app/shared/input/password';
+import { PasswordInputField } from '_app/shared/input/password';
 import PageMainLayout from '_app/shared/page-main-layout';
 import { unlockWallet } from '_app/wallet/actions';
 import { devQuickUnlockEnabled } from '_app/wallet/constants';
@@ -80,9 +80,8 @@ export default function LockedPage() {
                             {({ touched, errors, isSubmitting, isValid }) => (
                                 <Form className={st.form}>
                                     <FieldLabel txt="Enter Password">
-                                        <Field
+                                        <PasswordInputField
                                             name="password"
-                                            component={PasswordInput}
                                             disabled={isSubmitting}
                                         />
                                         {touched.password && errors.password ? (

--- a/apps/wallet/tailwind.config.js
+++ b/apps/wallet/tailwind.config.js
@@ -17,7 +17,6 @@ module.exports = {
             colors: {
                 'gradient-blue-start': '#589AEA',
                 'gradient-blue-end': '#4C75A6',
-                'alice-blue': '#F1F8FD',
             },
             minHeight: {
                 8: '2rem',

--- a/apps/wallet/tests/onboarding.spec.ts
+++ b/apps/wallet/tests/onboarding.spec.ts
@@ -16,7 +16,7 @@ test('import wallet', async ({ page, extensionUrl }) => {
     await page.goto(extensionUrl);
     await page.getByRole('link', { name: /Get Started/ }).click();
     await page.getByRole('link', { name: /Import an Existing Wallet/ }).click();
-    await page.getByLabel('Enter Recovery Phrase').fill(mnemonic);
+    await page.getByLabel('Enter your 12-word Recovery Phrase').type(mnemonic);
     await page.getByRole('button', { name: /Continue/ }).click();
     await page.getByLabel('Create Password').fill('mystenlabs');
     await page.getByLabel('Confirm Password').fill('mystenlabs');


### PR DESCRIPTION
## Description 

Importing a mnemonic now is done using multiple input fields.

* users can paste the mnemonic to any of the fields and all others will populate automatically
* pressing Space inside an input of a mnemonic will focus the next input
* removed back button for forgot password page to match design
* updated some components to use the new Button element
* remove mode variant from CardLayout since now is not used anywhere

Import page



https://user-images.githubusercontent.com/10210143/224123153-bb678dd6-3d87-48d3-a7d6-763d81ad28a7.mov



Reset page


https://user-images.githubusercontent.com/10210143/224123019-d456ca5b-9428-4290-b794-27040ffcc424.mov



## Test Plan 

manually, import an account or reset it from forgot password page

there is also a e2e test that covers import page

closes [APPS-568
](https://mysten.atlassian.net/browse/APPS-568?atlOrigin=eyJpIjoiZjAxOGViY2FiM2E2NDIyM2IzOGE1NDhmMTA4MTVkMzQiLCJwIjoiaiJ9)