### PR TITLE
[Narwhal] fix cancellation issue, add validation for parents

### DIFF
--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -364,32 +364,6 @@ impl Synchronizer {
             .await
     }
 
-    /// Validates the certificate and accepts it into the DAG, if the certificate can be verified
-    /// and has all parents in the certificate store.
-    /// If the certificate has missing parents, wait until all parents are available to accept the
-    /// certificate.
-    /// Otherwise returns an error.
-    pub async fn wait_to_accept_certificate(
-        &self,
-        certificate: Certificate,
-        network: &Network,
-    ) -> DagResult<()> {
-        match self
-            .process_certificate_internal(certificate, network, true, true)
-            .await
-        {
-            Err(DagError::Suspended(notify)) => {
-                let notify = notify.lock().unwrap().take();
-                notify
-                    .unwrap()
-                    .recv()
-                    .await
-                    .map_err(|_| DagError::ShuttingDown)
-            }
-            result => result,
-        }
-    }
-
     /// Accepts a certificate produced by this primary. This is not expected to fail unless
     /// the primary is shutting down.
     pub async fn accept_own_certificate(


### PR DESCRIPTION
## Description 

It is possible that while processing certificates, the task is cancelled after the certificate is written to certificate store, but before the certificate is sent to consensus. In this case the consensus will not receive certificates in causal (parent dependency) order, which is a consistency violation. Instead, a new task is spawned to process certificates, to avoid cancellations.

I have considered using a separate task inside `Synchronizer` to process certificates and avoid the cancellation safety issue. But it may lead to more code duplications: reporting certificate suspended status needs to happen inline, but we want to accept certificates into storage and send certificate to consensus in a separate task.

Also, add a validation in `Synchronizer` to make sure when writing certificates to store, all of its parents exist in the store.

## Test Plan 

Existing unit tests
Deploy to private testnet

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
