### PR TITLE
reject txn when we have too many pending certs

### DIFF
--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -384,6 +384,12 @@ impl TransactionManager {
             .collect()
     }
 
+    // Returns the number of certificates pending execution or being executed by the execution driver right now.
+    pub(crate) fn execution_queue_len(&self) -> usize {
+        let inner = self.inner.read();
+        inner.pending_certificates.len() + inner.executing_certificates.len()
+    }
+
     // Reconfigures the TransactionManager for a new epoch. Existing transactions will be dropped
     // because they are no longer relevant and may be incorrect in the new epoch.
     pub(crate) fn reconfigure(&self, new_epoch: EpochId) {

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -512,8 +512,6 @@ async fn test_per_object_overload() {
     sleep(Duration::from_secs(1)).await;
 
     // Sign and try execute 1000 txns on the first three authorities. And enqueue them on the last authority.
-    let mut shared_txns = Vec::new();
-    let mut shared_certs = Vec::new();
     // First shared counter txn has input object available on authority 3. So to overload authority 3, 1 more
     // txn is needed.
     let num_txns = MAX_PER_OBJECT_EXECUTION_QUEUE_LENGTH + 1;
@@ -539,8 +537,6 @@ async fn test_per_object_overload() {
             send_consensus(authority, &shared_cert).await;
         }
         send_consensus(&authorities[3], &shared_cert).await;
-        shared_txns.push(shared_txn);
-        shared_certs.push(shared_cert);
     }
 
     // Trying to sign a new transaction would now fail.

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -192,6 +192,9 @@ pub enum SuiError {
     #[error("Expecting a single owner, shared ownership found")]
     UnexpectedOwnerType,
 
+    #[error("There are already {queue_len} transactions pending, above threshold of {threshold}")]
+    TooManyTransactionsPendingExecution { queue_len: usize, threshold: usize },
+
     #[error("Input {object_id} already has {queue_len} transactions pending, above threshold of {threshold}")]
     TooManyTransactionsPendingOnObject {
         object_id: ObjectID,
@@ -582,6 +585,10 @@ impl SuiError {
             SuiError::QuorumFailedToGetEffectsQuorumWhenProcessingTransaction { .. } => {
                 (false, true)
             }
+
+            // Overload errors
+            SuiError::TooManyTransactionsPendingExecution { .. } => (false, true),
+            SuiError::TooManyTransactionsPendingOnObject { .. } => (false, true),
             _ => (false, false),
         }
     }


### PR DESCRIPTION
## Description 

This PR adds generic load shedding in our handle_transaction code to reject signing a txn if we have too many certificates being executed or waiting to be executed.

## Test Plan 

Tested locally with small threshold numbers.

We will have to potentially refactor the code a bit to make it easier to test this feature. Right now we are using constants for the threshold and any test that triggers this threshold will have to run for a very long time. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
