### PR TITLE
[ts-sdk] Improve types for programmable tx, add from(bytes)

### DIFF
--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -103,17 +103,19 @@ export class Transaction {
    * - A byte array (or base64-encoded bytes) containing BCS transaction data.
    */
   static from(serialized: string | Uint8Array) {
+    const tx = new Transaction();
+
     // Check for bytes:
     if (typeof serialized !== 'string' || !serialized.startsWith('{')) {
-      const bytes = TransactionDataBuilder.fromBytes(
+      tx.#transactionData = TransactionDataBuilder.fromBytes(
         typeof serialized === 'string' ? fromB64(serialized) : serialized,
       );
-      return bytes;
+    } else {
+      tx.#transactionData = TransactionDataBuilder.restore(
+        JSON.parse(serialized),
+      );
     }
 
-    const parsed = JSON.parse(serialized);
-    const tx = new Transaction();
-    tx.#transactionData = TransactionDataBuilder.restore(parsed);
     return tx;
   }
 

--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { fromB64 } from '@mysten/bcs';
 import { is } from 'superstruct';
 import { Provider } from '../providers/provider';
 import {
@@ -104,8 +105,10 @@ export class Transaction {
   static from(serialized: string | Uint8Array) {
     // Check for bytes:
     if (typeof serialized !== 'string' || !serialized.startsWith('{')) {
-      // TODO: Support fromBytes.
-      throw new Error('from() does not yet support bytes');
+      const bytes = TransactionDataBuilder.fromBytes(
+        typeof serialized === 'string' ? fromB64(serialized) : serialized,
+      );
+      return bytes;
     }
 
     const parsed = JSON.parse(serialized);

--- a/sdk/typescript/src/builder/TransactionData.ts
+++ b/sdk/typescript/src/builder/TransactionData.ts
@@ -58,11 +58,16 @@ export type SerializedTransactionDataBuilder = Infer<
 >;
 
 export class TransactionDataBuilder {
+  static fromBytes(bytes: Uint8Array) {
+    const data = builder.de('TransactionData', bytes);
+    const transactionData = new TransactionDataBuilder();
+  }
+
   static restore(data: SerializedTransactionDataBuilder) {
     assert(data, SerializedTransactionDataBuilder);
-    const builder = new TransactionDataBuilder();
-    Object.assign(builder, data);
-    return builder;
+    const transactionData = new TransactionDataBuilder();
+    Object.assign(transactionData, data);
+    return transactionData;
   }
 
   version = 1 as const;

--- a/sdk/typescript/src/builder/TransactionData.ts
+++ b/sdk/typescript/src/builder/TransactionData.ts
@@ -12,25 +12,31 @@ import {
   object,
   optional,
   string,
+  union,
 } from 'superstruct';
-import { SuiObjectRef } from '../types';
+import { normalizeSuiAddress, SuiObjectRef } from '../types';
 import { builder } from './bcs';
 import { TransactionCommand, TransactionInput } from './Commands';
 import { BuilderCallArg } from './Inputs';
 import { create } from './utils';
 
 export const TransactionExpiration = optional(
-  nullable(object({ Epoch: integer() })),
+  nullable(
+    union([
+      object({ Epoch: integer() }),
+      object({ None: union([literal(true), literal(null)]) }),
+    ]),
+  ),
 );
 export type TransactionExpiration = Infer<typeof TransactionExpiration>;
 
 const SuiAddress = string();
 
 const StringEncodedBigint = define<string>('StringEncodedBigint', (val) => {
-  if (typeof val !== 'string') return false;
+  if (!['string', 'number', 'bigint'].includes(typeof val)) return false;
 
   try {
-    BigInt(val);
+    BigInt(val as string);
     return true;
   } catch {
     return false;
@@ -57,10 +63,35 @@ export type SerializedTransactionDataBuilder = Infer<
   typeof SerializedTransactionDataBuilder
 >;
 
+function prepareSuiAddress(address: string) {
+  return normalizeSuiAddress(address).replace('0x', '');
+}
+
 export class TransactionDataBuilder {
   static fromBytes(bytes: Uint8Array) {
     const data = builder.de('TransactionData', bytes);
+    const programmableTx = data?.V1?.kind?.Single?.ProgrammableTransaction;
+    if (!programmableTx) {
+      throw new Error('Unable to deserialize from bytes.');
+    }
+
+    const serialized = create(
+      {
+        version: 1,
+        sender: data.V1.sender,
+        expiration: data.V1.expiration,
+        gasConfig: data.V1.gasData,
+        inputs: programmableTx.inputs.map((value: unknown, index: number) =>
+          create({ kind: 'Input', value, index }, TransactionInput),
+        ),
+        commands: programmableTx.commands,
+      },
+      SerializedTransactionDataBuilder,
+    );
+
     const transactionData = new TransactionDataBuilder();
+    Object.assign(transactionData, serialized);
+    return transactionData;
   }
 
   static restore(data: SerializedTransactionDataBuilder) {
@@ -109,13 +140,13 @@ export class TransactionDataBuilder {
     });
 
     const transactionData = {
-      sender: this.sender,
+      sender: prepareSuiAddress(this.sender),
       expiration: this.expiration ? this.expiration : { None: true },
       gasData: {
         payment: this.gasConfig.payment,
-        owner: this.gasConfig.owner ?? this.sender,
-        price: this.gasConfig.price,
-        budget: this.gasConfig.budget,
+        owner: prepareSuiAddress(this.gasConfig.owner ?? this.sender),
+        price: BigInt(this.gasConfig.price),
+        budget: BigInt(this.gasConfig.budget),
       },
       kind: {
         Single: {

--- a/sdk/typescript/src/builder/__tests__/Transaction.test.ts
+++ b/sdk/typescript/src/builder/__tests__/Transaction.test.ts
@@ -88,7 +88,7 @@ describe('offline build', () => {
     await tx.build();
   });
 
-  it.only('builds a more complex interaction', async () => {
+  it('builds a more complex interaction', async () => {
     const tx = setup();
     const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(100)));
     tx.add(
@@ -105,8 +105,12 @@ describe('offline build', () => {
         ],
       }),
     );
+
     const bytes = await tx.build();
     const tx2 = Transaction.from(bytes);
+    const bytes2 = await tx2.build();
+
+    expect(bytes).toEqual(bytes2);
   });
 });
 
@@ -125,8 +129,8 @@ function ref(): { objectId: string; version: bigint; digest: string } {
 function setup() {
   const tx = new Transaction();
   tx.setSender('0x2');
-  tx.setGasPrice(1);
-  tx.setGasBudget(1);
+  tx.setGasPrice(5);
+  tx.setGasBudget(100);
   tx.setGasPayment([ref()]);
   return tx;
 }

--- a/sdk/typescript/src/builder/__tests__/Transaction.test.ts
+++ b/sdk/typescript/src/builder/__tests__/Transaction.test.ts
@@ -87,26 +87,28 @@ describe('offline build', () => {
     );
     await tx.build();
   });
-});
 
-// describe('online building (TODO: move to e2e)', () => {
-//   it('builds', async () => {
-//     const tx = setup();
-//     const provider = new JsonRpcProvider(localnetConnection);
-//     const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(100)));
-//     tx.add(
-//       Commands.MergeCoins(tx.gas, [coin, tx.input(Inputs.ObjectRef(ref()))]),
-//     );
-//     tx.add(
-//       Commands.MoveCall({
-//         target: '0x2::devnet_nft::mint',
-//         typeArguments: [],
-//         arguments: [tx.input('foo'), tx.input('bar'), tx.input('baz')],
-//       }),
-//     );
-//     await tx.build({ provider });
-//   });
-// });
+  it.only('builds a more complex interaction', async () => {
+    const tx = setup();
+    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(100)));
+    tx.add(
+      Commands.MergeCoins(tx.gas, [coin, tx.input(Inputs.ObjectRef(ref()))]),
+    );
+    tx.add(
+      Commands.MoveCall({
+        target: '0x2::devnet_nft::mint',
+        typeArguments: [],
+        arguments: [
+          tx.input(Inputs.Pure('string', 'foo')),
+          tx.input(Inputs.Pure('string', 'bar')),
+          tx.input(Inputs.Pure('string', 'baz')),
+        ],
+      }),
+    );
+    const bytes = await tx.build();
+    const tx2 = Transaction.from(bytes);
+  });
+});
 
 function ref(): { objectId: string; version: bigint; digest: string } {
   return {

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  define,
   Infer,
   literal,
   number,
@@ -48,13 +49,13 @@ export const ObjectOwner = union([
 ]);
 export type ObjectOwner = Infer<typeof ObjectOwner>;
 
-export const SuiJsonValue = unknown();
 export type SuiJsonValue =
   | boolean
   | number
   | string
   | CallArg
   | Array<SuiJsonValue>;
+export const SuiJsonValue = define<SuiJsonValue>('SuiJsonValue', () => true);
 
 // source of truth is
 // https://github.com/MystenLabs/sui/blob/acb2b97ae21f47600e05b0d28127d88d0725561d/crates/sui-types/src/base_types.rs#L171

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -9,7 +9,6 @@ import {
   object,
   string,
   union,
-  unknown,
 } from 'superstruct';
 import { CallArg, TransactionData, TransactionDataBCS } from './sui-bcs';
 import { sha256Hash } from '../cryptography/hash';

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -113,22 +113,11 @@ export type SharedObjectRef = {
 };
 
 /**
- * A reference to a shared object from 0.23.0.
- */
-export type SharedObjectRef_23 = {
-  /** Hex code as string representing the object id */
-  objectId: string;
-
-  /** The version the object was shared at */
-  initialSharedVersion: number;
-};
-
-/**
  * An object argument.
  */
 export type ObjectArg =
   | { ImmOrOwned: SuiObjectRef }
-  | { Shared: SharedObjectRef | SharedObjectRef_23 };
+  | { Shared: SharedObjectRef };
 
 /**
  * A pure argument.
@@ -430,38 +419,10 @@ const BCS_SPEC: TypeSchema = {
   },
 };
 
-// for version <= 0.27.0
-const BCS_0_27_SPEC: TypeSchema = {
-  structs: {
-    ...BCS_SPEC.structs,
-    TransactionData: {
-      kind: 'TransactionKind',
-      sender: BCS.ADDRESS,
-      gasData: 'GasData',
-    },
-    SenderSignedData: {
-      data: 'TransactionData',
-      txSignature: [VECTOR, BCS.U8],
-    },
-  },
-  enums: BCS_SPEC.enums,
-  aliases: {
-    ObjectDigest: BCS.BASE64,
-  },
-};
-
 const bcs = new BCS({ ...getSuiMoveConfig(), types: BCS_SPEC });
 registerUTF8String(bcs);
 
-// ========== Backward Compatibility ===========
-const bcs_0_27 = new BCS({ ...getSuiMoveConfig(), types: BCS_0_27_SPEC });
-registerUTF8String(bcs_0_27);
-
-export function bcsForVersion(v?: RpcApiVersion) {
-  if (v?.major === 0 && v?.minor <= 27) {
-    return bcs_0_27;
-  }
-
+export function bcsForVersion(_v?: RpcApiVersion) {
   return bcs;
 }
 

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -14,7 +14,7 @@ import {
   unknown,
   boolean,
   tuple,
-  any,
+  nullable,
 } from 'superstruct';
 import { SuiEvent } from './events';
 import { SuiGasData, SuiMovePackage, SuiObjectRef } from './objects';
@@ -94,6 +94,31 @@ export const Genesis = object({
 });
 export type Genesis = Infer<typeof Genesis>;
 
+export const SuiArgument = unknown();
+
+export const SuiCommand = union([
+  object({
+    MoveCall: object({
+      arguments: array(SuiArgument),
+      type_arguments: array(string()),
+      package: ObjectId,
+      module: string(),
+      function: string(),
+    }),
+  }),
+  object({ TransferObjects: tuple([array(SuiArgument), SuiArgument]) }),
+  object({ SplitCoin: tuple([SuiArgument, SuiAddress]) }),
+  object({ MergeCoins: tuple([SuiArgument, array(SuiArgument)]) }),
+  object({ Publish: SuiMovePackage }),
+  object({ MakeMoveVec: tuple([nullable(string()), array(SuiArgument)]) }),
+]);
+
+export const ProgrammableTransaction = object({
+  commands: array(),
+  inputs: array(SuiJsonValue),
+});
+export type ProgrammableTransaction = Infer<typeof ProgrammableTransaction>;
+
 export type ExecuteTransactionRequestType =
   | 'WaitForEffectsCert'
   | 'WaitForLocalExecution';
@@ -108,7 +133,8 @@ export type TransactionKindName =
   | 'Pay'
   | 'PaySui'
   | 'PayAllSui'
-  | 'Genesis';
+  | 'Genesis'
+  | 'ProgrammableTransaction';
 
 export const SuiTransactionKind = union([
   object({ TransferObject: TransferObject }),
@@ -121,8 +147,7 @@ export const SuiTransactionKind = union([
   object({ PaySui: PaySui }),
   object({ PayAllSui: PayAllSui }),
   object({ Genesis: Genesis }),
-  // TODO: Refine object type
-  object({ ProgrammableTransaction: any() }),
+  object({ ProgrammableTransaction: ProgrammableTransaction }),
 ]);
 export type SuiTransactionKind = Infer<typeof SuiTransactionKind>;
 
@@ -274,13 +299,6 @@ export type TransactionQuery =
 export type EmptySignInfo = object;
 export type AuthorityName = Infer<typeof AuthorityName>;
 export const AuthorityName = string();
-
-export const TransactionBytes = object({
-  txBytes: string(),
-  gas: array(SuiObjectRef),
-  // TODO: Type input_objects field
-  inputObjects: unknown(),
-});
 
 export const SuiTransaction = object({
   data: SuiTransactionData,


### PR DESCRIPTION
## Description 

Two key changes:
- Add return types for programmable transactions, so that they are now correctly typed in responses.
- Add support for `from(bytes)` in the transaction builder, and `fromBytes()` in the transaction data helper.
- Fixed some issues around deserialization of Sui addresses and bigints by changing how we serialize them.

## Test Plan 

Tests should continue to pass + added new tests.