### PR TITLE
[programmable transactions] Add scaffold for `Upgrade` command

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -271,6 +271,9 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
         Command::Publish(modules) => {
             execute_move_publish::<_, _, Mode>(context, &mut argument_updates, modules)?
         }
+        Command::Upgrade(upgrade_ticket, dep_ids, modules) => {
+            execute_move_upgrade::<_, _, Mode>(context, upgrade_ticket, dep_ids, modules)?
+        }
     };
 
     Mode::finish_command(context, mode_results, argument_updates, &results)?;
@@ -434,6 +437,22 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
         )?)]
     };
     Ok(values)
+}
+
+/// Upgrade a Move package.  Returns an `UpgradeReceipt` for the upgraded package on success.
+fn execute_move_upgrade<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<E, S>,
+    _upgrade_ticket_arg: Argument,
+    _dep_ids: Vec<ObjectID>,
+    _module_bytes: Vec<Vec<u8>>,
+) -> Result<Vec<Value>, ExecutionError> {
+    // Check that package upgrades are supported.
+    context
+        .protocol_config
+        .check_package_upgrades_supported()
+        .map_err(|_| ExecutionError::from_kind(ExecutionErrorKind::FeatureNotYetSupported))?;
+
+    invariant_violation!("Package upgrades are turned off. We should NEVER get here.")
 }
 
 /***************************************************************************************************

--- a/crates/sui-adapter/src/programmable_transactions/types.rs
+++ b/crates/sui-adapter/src/programmable_transactions/types.rs
@@ -116,6 +116,7 @@ pub enum CommandKind<'a> {
     SplitCoin,
     MergeCoins,
     Publish,
+    Upgrade,
 }
 
 impl InputValue {

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -23,7 +23,10 @@ use sui_types::{
     object::{Data, Owner},
     storage::DeleteKind,
 };
-use sui_types::{crypto::Signer, messages::CommandArgumentError};
+use sui_types::{
+    crypto::Signer,
+    messages::{CommandArgumentError, PackageUpgradeError},
+};
 use typed_store::rocks::TypedStoreError;
 
 fn get_registry() -> Result<Registry> {
@@ -91,6 +94,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<Argument>(&samples)?;
     tracer.trace_type::<Command>(&samples)?;
     tracer.trace_type::<CommandArgumentError>(&samples)?;
+    tracer.trace_type::<PackageUpgradeError>(&samples)?;
 
     tracer.registry()
 }

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -93,6 +93,14 @@ Command:
               TYPENAME: TypeTag
           - SEQ:
               TYPENAME: Argument
+    6:
+      Upgrade:
+        TUPLE:
+          - TYPENAME: Argument
+          - SEQ:
+              TYPENAME: ObjectID
+          - SEQ:
+              SEQ: U8
 CommandArgumentError:
   ENUM:
     0:
@@ -310,6 +318,12 @@ ExecutionFailureStatus:
           - idx: U16
     40:
       ArityMismatch: UNIT
+    41:
+      FeatureNotYetSupported: UNIT
+    42:
+      PackageUpgradeError:
+        NEWTYPE:
+          TYPENAME: PackageUpgradeError
 ExecutionStatus:
   ENUM:
     0:
@@ -481,6 +495,18 @@ Owner:
               TYPENAME: SequenceNumber
     3:
       Immutable: UNIT
+PackageUpgradeError:
+  ENUM:
+    0:
+      UnableToFetchPackage:
+        NEWTYPE:
+          TYPENAME: ObjectID
+    1:
+      NotAPackage:
+        NEWTYPE:
+          TYPENAME: ObjectID
+    2:
+      IncompatibleUpgrade: UNIT
 ProgrammableMoveCall:
   STRUCT:
     - package:

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -875,6 +875,8 @@ pub enum SuiCommand {
     MergeCoins(SuiArgument, Vec<SuiArgument>),
     /// Publishes a Move package
     Publish(SuiMovePackage),
+    /// Upgrades a Move package
+    Upgrade(SuiArgument, Vec<ObjectID>, SuiMovePackage),
     /// `forall T: Vec<T> -> vector<T>`
     /// Given n-values of the same type, it constructs a vector. For non objects or an empty vector,
     /// the type tag must be specified.
@@ -910,6 +912,12 @@ impl Display for SuiCommand {
                 write!(f, ")")
             }
             Self::Publish(_bytes) => write!(f, "Publish(_)"),
+            Self::Upgrade(ticket, deps, _bytes) => {
+                write!(f, "Upgrade({ticket},")?;
+                write_sep(f, deps, ",")?;
+                write!(f, ", _)")?;
+                write!(f, ")")
+            }
         }
     }
 }
@@ -933,6 +941,13 @@ impl From<Command> for SuiCommand {
             Command::MakeMoveVec(tag_opt, args) => SuiCommand::MakeMoveVec(
                 tag_opt.map(|tag| tag.to_string()),
                 args.into_iter().map(SuiArgument::from).collect(),
+            ),
+            Command::Upgrade(ticket, dep_ids, modules) => SuiCommand::Upgrade(
+                SuiArgument::from(ticket),
+                dep_ids,
+                SuiMovePackage {
+                    disassembled: disassemble_modules(modules.iter()).unwrap_or_default(),
+                },
             ),
         }
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5424,6 +5424,35 @@
             "additionalProperties": false
           },
           {
+            "description": "Upgrades a Move package",
+            "type": "object",
+            "required": [
+              "Upgrade"
+            ],
+            "properties": {
+              "Upgrade": {
+                "type": "array",
+                "items": [
+                  {
+                    "$ref": "#/components/schemas/SuiArgument"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ObjectID"
+                    }
+                  },
+                  {
+                    "$ref": "#/components/schemas/MovePackage"
+                  }
+                ],
+                "maxItems": 3,
+                "minItems": 3
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "`forall T: Vec<T> -> vector<T>` Given n-values of the same type, it constructs a vector. For non objects or an empty vector, the type tag must be specified.",
             "type": "object",
             "required": [

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -113,6 +113,7 @@ pub struct Error(pub String);
 struct FeatureFlags {
     // Add feature flags here, e.g.:
     // new_protocol_feature: bool,
+    package_upgrades: bool,
 }
 
 /// Constants that change the behavior of the protocol.
@@ -368,6 +369,17 @@ impl ProtocolConfig {
     //         )))
     //     }
     // }
+
+    pub fn check_package_upgrades_supported(&self) -> Result<(), Error> {
+        if self.feature_flags.package_upgrades {
+            Ok(())
+        } else {
+            Err(Error(format!(
+                "package upgrades are not supported at {:?}",
+                self.version
+            )))
+        }
+    }
 }
 
 // getters

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
@@ -3,7 +3,8 @@ source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur)"
 ---
 version: 1
-feature_flags: {}
+feature_flags:
+  package_upgrades: false
 max_tx_size: 65536
 max_tx_in_batch: 10
 max_gas_payment_objects: 32

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -533,6 +533,8 @@ pub enum Command {
     /// Given n-values of the same type, it constructs a vector. For non objects or an empty vector,
     /// the type tag must be specified.
     MakeMoveVec(Option<TypeTag>, Vec<Argument>),
+    /// Upgrades a Move package
+    Upgrade(Argument, Vec<ObjectID>, Vec<Vec<u8>>),
 }
 
 /// An argument to a programmable transaction command
@@ -623,7 +625,9 @@ impl Command {
 
     fn input_objects(&self) -> Vec<InputObjectKind> {
         match self {
-            Command::Publish(modules) => Self::publish_command_input_objects(modules),
+            Command::Upgrade(_, _, modules) | Command::Publish(modules) => {
+                Self::publish_command_input_objects(modules)
+            }
             Command::MoveCall(c) => c.input_objects(),
             Command::MakeMoveVec(Some(t), _) => {
                 let mut packages = BTreeSet::new();
@@ -717,6 +721,17 @@ impl Command {
                 );
             }
             Command::SplitCoin(_, _) => (),
+            Command::Upgrade(_, _, modules) => {
+                fp_ensure!(!modules.is_empty(), UserInputError::EmptyCommandInput);
+                fp_ensure!(
+                    modules.len() < config.max_modules_in_publish() as usize,
+                    UserInputError::SizeLimitExceeded {
+                        limit: "maximum modules in a programmable transaction upgrade command"
+                            .to_string(),
+                        value: config.max_modules_in_publish().to_string()
+                    }
+                );
+            }
         };
         Ok(())
     }
@@ -868,6 +883,12 @@ impl Display for Command {
                 write!(f, ")")
             }
             Command::Publish(_bytes) => write!(f, "Publish(_)"),
+            Command::Upgrade(ticket, deps, _bytes) => {
+                write!(f, "Upgrade({ticket},")?;
+                write_sep(f, deps, ",")?;
+                write!(f, ", _")?;
+                write!(f, ")")
+            }
         }
     }
 }
@@ -2339,8 +2360,20 @@ pub enum ExecutionFailureStatus {
         idx: u16,
     },
     ArityMismatch,
+
+    FeatureNotYetSupported,
+
+    // Package Upgrade Errors
+    PackageUpgradeError(PackageUpgradeError),
     // NOTE: if you want to add a new enum,
     // please add it at the end for Rust SDK backward compatibility.
+}
+
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Serialize, Deserialize, Hash)]
+pub enum PackageUpgradeError {
+    UnableToFetchPackage(ObjectID),
+    NotAPackage(ObjectID),
+    IncompatibleUpgrade,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Hash)]
@@ -2669,6 +2702,26 @@ impl Display for ExecutionFailureStatus {
                     "Arity mismatch for Move function. \
                     The number of arguments does not match the number of parameters"
                 )
+            }
+            ExecutionFailureStatus::FeatureNotYetSupported => {
+                write!(f, "Attempted to used feature that is not supported yet")
+            }
+            ExecutionFailureStatus::PackageUpgradeError(pkg_error) => {
+                write!(f, "Invalid package upgrade. {pkg_error}")
+            }
+        }
+    }
+}
+
+impl Display for PackageUpgradeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnableToFetchPackage(package_id) => {
+                write!(f, "Unable to fetch package at {package_id}")
+            }
+            Self::NotAPackage(object_id) => write!(f, "Object {object_id} is not a package"),
+            Self::IncompatibleUpgrade => {
+                write!(f, "New package is incompatible with previous version")
             }
         }
     }

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -32,6 +32,8 @@ use std::collections::BTreeMap;
 
 pub const PACKAGE_MODULE_NAME: &IdentStr = ident_str!("package");
 pub const UPGRADECAP_STRUCT_NAME: &IdentStr = ident_str!("UpgradeCap");
+pub const UPGRADETICKET_STRUCT_NAME: &IdentStr = ident_str!("UpgradeTicket");
+pub const UPGRADERECEIPT_STRUCT_NAME: &IdentStr = ident_str!("UpgradeReceipt");
 
 #[derive(Clone, Debug)]
 /// Additional information about a function
@@ -86,6 +88,22 @@ pub struct UpgradeCap {
     pub package: ID,
     pub version: u64,
     pub policy: u8,
+}
+
+/// Rust representation of `sui::package::UpgradeTicket`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpgradeTicket {
+    pub cap: ID,
+    pub package: ID,
+    pub policy: u8,
+    pub digest: Vec<u8>,
+}
+
+/// Rust representation of `sui::package::UpgradeReceipt`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpgradeReceipt {
+    pub cap: ID,
+    pub package: ID,
 }
 
 impl MovePackage {
@@ -214,6 +232,39 @@ impl UpgradeCap {
     }
 }
 
+impl UpgradeTicket {
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            module: PACKAGE_MODULE_NAME.to_owned(),
+            name: UPGRADETICKET_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+}
+
+impl UpgradeReceipt {
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            module: PACKAGE_MODULE_NAME.to_owned(),
+            name: UPGRADERECEIPT_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+
+    /// Create an `UpgradeReceipt` for the upgraded package at `package_id` using the
+    /// `UpgradeTicket` and newly published package id.
+    pub fn new(upgrade_ticket: UpgradeTicket, upgraded_package_id: ObjectID) -> Self {
+        UpgradeReceipt {
+            cap: upgrade_ticket.cap,
+            package: ID {
+                bytes: upgraded_package_id,
+            },
+        }
+    }
+}
+
 pub fn disassemble_modules<'a, I>(modules: I) -> SuiResult<BTreeMap<String, Value>>
 where
     I: Iterator<Item = &'a Vec<u8>>,
@@ -256,4 +307,16 @@ where
         normalized_modules.insert(normalized_module.name.to_string(), normalized_module);
     }
     Ok(normalized_modules)
+}
+
+pub fn normalize_deserialized_modules<'a, I>(modules: I) -> BTreeMap<String, normalized::Module>
+where
+    I: Iterator<Item = &'a CompiledModule>,
+{
+    let mut normalized_modules = BTreeMap::new();
+    for module in modules {
+        let normalized_module = normalized::Module::new(module);
+        normalized_modules.insert(normalized_module.name.to_string(), normalized_module);
+    }
+    normalized_modules
 }

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -202,8 +202,8 @@ impl UpgradeCap {
         }
     }
 
-    /// Create an UpgradeCap for the newly published package at `package_id`, and associate it with
-    /// the fresh `uid.
+    /// Create an `UpgradeCap` for the newly published package at `package_id`, and associate it with
+    /// the fresh `uid`.
     pub fn new(uid: ObjectID, package_id: ObjectID) -> Self {
         UpgradeCap {
             id: UID::new(uid),

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -118,6 +118,15 @@ impl ProgrammableTransactionBuilder {
             })));
     }
 
+    pub fn upgrade(
+        &mut self,
+        upgrade_ticket: Argument,
+        transitive_deps: Vec<ObjectID>,
+        modules: Vec<Vec<u8>>,
+    ) -> Argument {
+        self.command(Command::Upgrade(upgrade_ticket, transitive_deps, modules))
+    }
+
     pub fn transfer_arg(&mut self, recipient: SuiAddress, arg: Argument) {
         self.transfer_args(recipient, vec![arg])
     }

--- a/crates/sui/src/genesis_inspector.rs
+++ b/crates/sui/src/genesis_inspector.rs
@@ -318,7 +318,7 @@ fn display_validator(summary: &SuiValidatorSummary, metadata: &VerifiedValidator
     );
     println!("Rewards Pool: {}", summary.rewards_pool);
     println!("Pool Token Balance: {}", summary.pool_token_balance);
-    println!("Pending Delegation: {}", summary.pending_delegation);
+    println!("Pending Delegation: {}", summary.pending_stake);
     println!(
         "Pending Total Sui Withdraw: {}",
         summary.pending_total_sui_withdraw


### PR DESCRIPTION
This adds the basic plumbing for the `Upgrade` command. It takes an (owned) `UpgradeTicket` as an argument and will produce a `ReceiptTicket` with the new package's ID along with the `UpgradeTicket`'s `UpgradeCap` ID.  

There's probably some places where I did stupid stuff since I'm still paging things in, so please let me know if I went off-track somewhere :) 


