### PR TITLE
Version CheckpointContents

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -1119,7 +1119,9 @@ mod test {
         let genesis = network_config.genesis;
 
         let s = serde_yaml::to_string(&genesis).unwrap();
-        let from_s = serde_yaml::from_str(&s).unwrap();
+        let from_s: Genesis = serde_yaml::from_str(&s).unwrap();
+        // cache the digest so that the comparison succeeds.
+        from_s.checkpoint_contents.digest();
         assert_eq!(genesis, from_s);
     }
 

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -768,7 +768,7 @@ fn create_genesis_checkpoint(
         epoch: 0,
         sequence_number: 0,
         network_total_transactions: contents.size().try_into().unwrap(),
-        content_digest: contents.digest(),
+        content_digest: *contents.digest(),
         previous_digest: None,
         epoch_rolling_gas_cost_summary: Default::default(),
         end_of_epoch_data: None,

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -640,6 +640,7 @@ impl Builder {
             let validators = committee.clone().into_values().collect::<Vec<_>>();
 
             let built = build_unsigned_genesis_data(&parameters, &validators, &objects);
+            loaded_genesis.1.digest(); // cache digest before compare
             assert_eq!(
                 &built, loaded_genesis,
                 "loaded genesis does not match built genesis"

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -648,11 +648,21 @@ mod tests {
 
         let mut s = serde_yaml::to_string(&g).unwrap();
         let loaded_genesis: Genesis = serde_yaml::from_str(&s).unwrap();
+        loaded_genesis
+            .genesis()
+            .unwrap()
+            .checkpoint_contents()
+            .digest(); // cache digest before comparing.
         assert_eq!(g, loaded_genesis);
 
         // If both in-place and file location are provided, prefer the in-place variant
         s.push_str("\ngenesis-file-location: path/to/file");
         let loaded_genesis: Genesis = serde_yaml::from_str(&s).unwrap();
+        loaded_genesis
+            .genesis()
+            .unwrap()
+            .checkpoint_contents()
+            .digest(); // cache digest before comparing.
         assert_eq!(g, loaded_genesis);
     }
 
@@ -667,6 +677,7 @@ mod tests {
         genesis.save(file.path()).unwrap();
 
         let loaded_genesis = genesis_config.genesis().unwrap();
+        loaded_genesis.checkpoint_contents().digest(); // cache digest before comparing.
         assert_eq!(&genesis, loaded_genesis);
     }
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -328,8 +328,7 @@ impl CheckpointStore {
         &self,
         contents: CheckpointContents,
     ) -> Result<(), TypedStoreError> {
-        self.checkpoint_content
-            .insert(&contents.digest(), &contents)
+        self.checkpoint_content.insert(contents.digest(), &contents)
     }
 
     pub fn get_epoch_last_checkpoint(

--- a/crates/sui-network/src/state_sync/test_utils.rs
+++ b/crates/sui-network/src/state_sync/test_utils.rs
@@ -58,7 +58,7 @@ impl CommitteeFixture {
             epoch: 0,
             sequence_number: 0,
             network_total_transactions: 0,
-            content_digest: empty_contents()
+            content_digest: *empty_contents()
                 .into_inner()
                 .into_checkpoint_contents()
                 .digest(),
@@ -117,7 +117,7 @@ impl CommitteeFixture {
                 epoch: self.epoch,
                 sequence_number: prev.sequence_number + 1,
                 network_total_transactions: 0,
-                content_digest: empty_contents()
+                content_digest: *empty_contents()
                     .into_inner()
                     .into_checkpoint_contents()
                     .digest(),
@@ -162,7 +162,7 @@ impl CommitteeFixture {
             epoch: self.epoch,
             sequence_number: previous_checkpoint.sequence_number + 1,
             network_total_transactions: 0,
-            content_digest: empty_contents()
+            content_digest: *empty_contents()
                 .into_inner()
                 .into_checkpoint_contents()
                 .digest(),

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::hash::{Digest, MultisetHash};
+use once_cell::sync::OnceCell;
 use std::fmt::{Debug, Display, Formatter};
 use std::slice::Iter;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -162,7 +163,7 @@ impl CheckpointSummary {
         end_of_epoch_data: Option<EndOfEpochData>,
         timestamp_ms: CheckpointTimestamp,
     ) -> CheckpointSummary {
-        let content_digest = transactions.digest();
+        let content_digest = *transactions.digest();
 
         Self {
             epoch,
@@ -231,7 +232,7 @@ impl CertifiedCheckpointSummary {
         self.verify_signature(committee)?;
 
         if let Some(contents) = contents {
-            let content_digest = contents.digest();
+            let content_digest = *contents.digest();
             fp_ensure!(
                 content_digest == self.data().content_digest,
                 SuiError::GenericAuthorityError{error:format!("Checkpoint contents digest mismatch: summary={:?}, received content digest {:?}, received {} transactions", self.data(), content_digest, contents.size())}
@@ -261,12 +262,20 @@ impl CheckpointSignatureMessage {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum CheckpointContents {
+    V1(CheckpointContentsV1),
+}
+
 /// CheckpointContents are the transactions included in an upcoming checkpoint.
 /// They must have already been causally ordered. Since the causal order algorithm
 /// is the same among validators, we expect all honest validators to come up with
 /// the same order for each checkpoint content.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-pub struct CheckpointContents {
+pub struct CheckpointContentsV1 {
+    #[serde(skip)]
+    digest: OnceCell<CheckpointContentsDigest>,
+
     transactions: Vec<ExecutionDigests>,
     /// This field 'pins' user signatures for the checkpoint
     /// The length of this vector is same as length of transactions vector
@@ -281,10 +290,11 @@ impl CheckpointContents {
     {
         let transactions: Vec<_> = contents.into_iter().collect();
         let user_signatures = transactions.iter().map(|_| vec![]).collect();
-        Self {
+        Self::V1(CheckpointContentsV1 {
+            digest: Default::default(),
             transactions,
             user_signatures,
-        }
+        })
     }
 
     pub fn new_with_causally_ordered_transactions_and_signatures<T>(
@@ -296,22 +306,39 @@ impl CheckpointContents {
     {
         let transactions: Vec<_> = contents.into_iter().collect();
         assert_eq!(transactions.len(), user_signatures.len());
-        Self {
+        Self::V1(CheckpointContentsV1 {
+            digest: Default::default(),
             transactions,
             user_signatures,
+        })
+    }
+
+    fn as_v1(&self) -> &CheckpointContentsV1 {
+        match self {
+            Self::V1(v) => v,
+        }
+    }
+
+    fn into_v1(self) -> CheckpointContentsV1 {
+        match self {
+            Self::V1(v) => v,
         }
     }
 
     pub fn iter(&self) -> Iter<'_, ExecutionDigests> {
-        self.transactions.iter()
+        self.as_v1().transactions.iter()
     }
 
     pub fn into_iter_with_signatures(
         self,
     ) -> impl Iterator<Item = (ExecutionDigests, Vec<GenericSignature>)> {
-        self.transactions
-            .into_iter()
-            .zip(self.user_signatures.into_iter())
+        let CheckpointContentsV1 {
+            transactions,
+            user_signatures,
+            ..
+        } = self.into_v1();
+
+        transactions.into_iter().zip(user_signatures.into_iter())
     }
 
     /// Return an iterator that enumerates the transactions in the contents.
@@ -330,15 +357,17 @@ impl CheckpointContents {
     }
 
     pub fn into_inner(self) -> Vec<ExecutionDigests> {
-        self.transactions
+        self.into_v1().transactions
     }
 
     pub fn size(&self) -> usize {
-        self.transactions.len()
+        self.as_v1().transactions.len()
     }
 
-    pub fn digest(&self) -> CheckpointContentsDigest {
-        CheckpointContentsDigest::new(sha3_hash(self))
+    pub fn digest(&self) -> &CheckpointContentsDigest {
+        self.as_v1()
+            .digest
+            .get_or_init(|| CheckpointContentsDigest::new(sha3_hash(self)))
     }
 }
 
@@ -378,7 +407,7 @@ impl FullCheckpointContents {
         S: ReadStore,
     {
         let mut transactions = Vec::with_capacity(contents.size());
-        for tx in contents.transactions {
+        for tx in contents.iter() {
             if let (Some(t), Some(e)) = (
                 store.get_transaction(&tx.transaction)?,
                 store.get_transaction_effects(&tx.effects)?,
@@ -390,7 +419,7 @@ impl FullCheckpointContents {
         }
         Ok(Some(Self {
             transactions,
-            user_signatures: contents.user_signatures,
+            user_signatures: contents.into_v1().user_signatures,
         }))
     }
 
@@ -401,7 +430,7 @@ impl FullCheckpointContents {
     /// Verifies that this checkpoint's digest matches the given digest, and that all internal
     /// Transaction and TransactionEffects digests are consistent.
     pub fn verify_digests(&self, digest: CheckpointContentsDigest) -> Result<()> {
-        let self_digest = self.checkpoint_contents().digest();
+        let self_digest = *self.checkpoint_contents().digest();
         fp_ensure!(
             digest == self_digest,
             anyhow::anyhow!(
@@ -422,21 +451,23 @@ impl FullCheckpointContents {
     }
 
     pub fn checkpoint_contents(&self) -> CheckpointContents {
-        CheckpointContents {
+        CheckpointContents::V1(CheckpointContentsV1 {
+            digest: Default::default(),
             transactions: self.transactions.iter().map(|tx| tx.digests()).collect(),
             user_signatures: self.user_signatures.clone(),
-        }
+        })
     }
 
     pub fn into_checkpoint_contents(self) -> CheckpointContents {
-        CheckpointContents {
+        CheckpointContents::V1(CheckpointContentsV1 {
+            digest: Default::default(),
             transactions: self
                 .transactions
                 .into_iter()
                 .map(|tx| tx.digests())
                 .collect(),
             user_signatures: self.user_signatures,
-        }
+        })
     }
 
     pub fn size(&self) -> usize {

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -400,7 +400,8 @@ impl InMemoryStore {
                 .insert(tx.effects.digest(), tx.effects.to_owned());
         }
         let contents = contents.into_inner().into_checkpoint_contents();
-        self.checkpoint_contents.insert(contents.digest(), contents);
+        self.checkpoint_contents
+            .insert(*contents.digest(), contents);
     }
 
     pub fn insert_checkpoint(&mut self, checkpoint: VerifiedCheckpoint) {


### PR DESCRIPTION
## Description 

Stacked on #8972 

Version CheckpointContents.

Note that I didn't use the usual `#[enum_dispatch]` approach in this case because I think its unlikely we are going to extend this format any time soon. We can always add that in later if we need it.

## Test Plan 

```cargo simtest```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
