### PR TITLE
[Narwhal] Keep 10s of inflight certificate broadcasts

### DIFF
--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -1,13 +1,17 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use anemo::{Network, Request};
+use anemo::{rpc::Status, Network, Request, Response};
 use config::{Committee, Epoch, WorkerCache, WorkerId};
 use consensus::dag::Dag;
 use crypto::{NetworkPublicKey, PublicKey};
 use fastcrypto::hash::Hash as _;
+use futures::{stream::FuturesOrdered, StreamExt};
 use mysten_metrics::spawn_monitored_task;
-use network::{anemo_ext::NetworkExt, RetryConfig};
+use network::{
+    anemo_ext::{NetworkExt, WaitingPeer},
+    RetryConfig,
+};
 use parking_lot::Mutex;
 use std::{
     cmp::min,
@@ -24,7 +28,7 @@ use store::Store;
 use tokio::{
     sync::{broadcast, oneshot, watch, MutexGuard},
     task::JoinSet,
-    time::timeout,
+    time::sleep,
 };
 use tracing::{debug, error, trace, warn};
 use types::{
@@ -32,7 +36,8 @@ use types::{
     error::{new_accept_notification, AcceptNotification, DagError, DagResult},
     metered_channel::Sender,
     BatchDigest, Certificate, CertificateDigest, Header, PrimaryToPrimaryClient,
-    PrimaryToWorkerClient, Round, SendCertificateRequest, WorkerSynchronizeMessage,
+    PrimaryToWorkerClient, Round, SendCertificateRequest, SendCertificateResponse,
+    WorkerSynchronizeMessage,
 };
 
 use crate::{aggregators::CertificatesAggregator, metrics::PrimaryMetrics};
@@ -611,82 +616,78 @@ impl Synchronizer {
 
     /// Pushes new certificates received from the rx_own_certificate_broadcast channel
     /// to the target peer continuously. Only exits when the primary is shutting down.
-    // TODO: allow sending multiple (<=10) outgoing requests concurrently.
+    // TODO: move this to proposer, since this naturally follows after a certificate is created.
     async fn push_certificates(
         network: Network,
         name: PublicKey,
         network_key: NetworkPublicKey,
         mut rx_own_certificate_broadcast: broadcast::Receiver<Certificate>,
     ) {
-        const PUSH_TIMEOUT: Duration = Duration::from_secs(5);
-        const MIN_FAILURE_BACKOFF: Duration = Duration::from_millis(100);
-        const MAX_FAILURE_BACKOFF: Duration = Duration::from_secs(10);
+        const PUSH_TIMEOUT: Duration = Duration::from_secs(10);
         let peer_id = anemo::PeerId(network_key.0.to_bytes());
         let peer = network.waiting_peer(peer_id);
-        let mut client = PrimaryToPrimaryClient::new(peer);
-        let mut certificates = VecDeque::new();
-        let mut failure_backoff = MIN_FAILURE_BACKOFF;
+        let client = PrimaryToPrimaryClient::new(peer);
+        // Older broadcasts return early, so the last broadcast must be the latest certificate.
+        // This will contain at most certificates created within the last PUSH_TIMEOUT.
+        let mut requests = FuturesOrdered::new();
+        // Back off and retry only happen when there is only one certificate to be broadcasted.
+        // Otherwise no retry happens.
+        const BACKOFF_INTERVAL: Duration = Duration::from_millis(100);
+        const MAX_BACKOFF_MULTIPLIER: u32 = 100;
+        let mut backoff_multiplier: u32 = 0;
+
+        async fn send_certificate(
+            mut client: PrimaryToPrimaryClient<WaitingPeer>,
+            request: Request<SendCertificateRequest>,
+            cert: Certificate,
+        ) -> (
+            Certificate,
+            Result<Response<SendCertificateResponse>, Status>,
+        ) {
+            let resp = client.send_certificate(request).await;
+            (cert, resp)
+        }
+
         loop {
-            let wait_timeout = if certificates.is_empty() {
-                MAX_FAILURE_BACKOFF
-            } else {
-                failure_backoff
-            };
-            match timeout(wait_timeout, rx_own_certificate_broadcast.recv()).await {
-                Ok(Ok(cert)) => certificates.push_back(cert),
-                Ok(Err(broadcast::error::RecvError::Closed)) => {
-                    trace!("Certificate sender {name} shutting down!");
-                    return;
+            tokio::select! {
+                result = rx_own_certificate_broadcast.recv() => {
+                    let cert = match result {
+                        Ok(cert) => cert,
+                        Err(broadcast::error::RecvError::Closed) => {
+                            trace!("Certificate sender {name} is shutting down!");
+                            return;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(e)) => {
+                            warn!("Certificate broadcaster {name} lagging! {e}");
+                            // Re-run the loop to receive again.
+                            continue;
+                        }
+                    };
+                    let request = Request::new(SendCertificateRequest { certificate: cert.clone() }).with_timeout(PUSH_TIMEOUT);
+                    requests.push_back(send_certificate(client.clone(),request, cert));
                 }
-                Ok(Err(broadcast::error::RecvError::Lagged(e))) => {
-                    warn!("Certificate broadcaster {name} lagging! {e}");
-                    // Re-run the loop to receive again.
-                    continue;
-                }
-                Err(_) => {
-                    if certificates.is_empty() {
-                        // MAX_FAILURE_BACKOFF has elapsed without a certificate created.
-                        // This should rarely happen.
-                        continue;
+                Some((cert, resp)) = requests.next() => {
+                    backoff_multiplier = match resp {
+                        Ok(_) => {
+                            0
+                        },
+                        Err(_) => {
+                            if requests.is_empty() {
+                                // Retry broadcasting the latest certificate, to help the network stay alive.
+                                let request = Request::new(SendCertificateRequest { certificate: cert.clone() }).with_timeout(PUSH_TIMEOUT);
+                                requests.push_back(send_certificate(client.clone(), request, cert));
+                                min(backoff_multiplier * 2 + 1, MAX_BACKOFF_MULTIPLIER)
+                            } else {
+                                // TODO: add backoff and retries for transient & retriable errors.
+                                0
+                            }
+                        },
+                    };
+                    if backoff_multiplier > 0 {
+                        sleep(BACKOFF_INTERVAL * backoff_multiplier).await;
                     }
                 }
             };
-            // Get more certificates if available in the broadcast channel.
-            'recv: loop {
-                match rx_own_certificate_broadcast.try_recv() {
-                    Ok(cert) => {
-                        certificates.push_back(cert);
-                    }
-                    Err(broadcast::error::TryRecvError::Closed) => {
-                        trace!("Certificate sender {name} shutting down!");
-                        return;
-                    }
-                    Err(broadcast::error::TryRecvError::Lagged(e)) => {
-                        warn!("Certificate sender {name} lagging! {e}");
-                    }
-                    Err(broadcast::error::TryRecvError::Empty) => {
-                        break 'recv;
-                    }
-                };
-            }
-            // TODO: support sending multiple certificates concurrently.
-            // Only send the latest certificate.
-            while certificates.len() > 1 {
-                certificates.pop_front();
-            }
-            let cert = certificates.front().unwrap().clone();
-            let request = Request::new(SendCertificateRequest { certificate: cert })
-                .with_timeout(PUSH_TIMEOUT);
-            match client.send_certificate(request).await {
-                Ok(_) => {
-                    certificates.pop_front();
-                    failure_backoff = MIN_FAILURE_BACKOFF;
-                }
-                Err(status) => {
-                    debug!("Failed to send certificate to {name}! {status:?}");
-                    failure_backoff = min(failure_backoff * 2, MAX_FAILURE_BACKOFF);
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Description 

As the network grows in size with more remote peers, it is useful to tolerate temporary jitters in the latency to deliver certificates.

## Test Plan 

Deploy to private testnet and monitor.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
