### PR TITLE
[optimization] Do ok_or_else to save CPU

### DIFF
--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1302,7 +1302,7 @@ impl<const STRONG_THRESHOLD: bool> AuthoritySignInfoTrait
             let authority =
                 committee
                     .authority_by_index(authority_index)
-                    .ok_or(SuiError::UnknownSigner {
+                    .ok_or_else(|| SuiError::UnknownSigner {
                         signer: None,
                         index: Some(authority_index),
                         committee: Box::new(committee.clone()),


### PR DESCRIPTION
## Description 

Replave `ok_or` with `ok_or_else` to not execute the error construction unless there is actually an error.

## Test Plan 

Existing tests cover this part.