### PR TITLE
[refactor] consensus to drive gc_round

### DIFF
--- a/narwhal/consensus/benches/process_certificates.rs
+++ b/narwhal/consensus/benches/process_certificates.rs
@@ -55,7 +55,6 @@ pub fn process_certificates(c: &mut Criterion) {
         let mut ordering_engine = Bullshark {
             committee: committee.clone(),
             store,
-            gc_depth,
             metrics,
             last_successful_leader_election_timestamp: Instant::now(),
             last_leader_election: Default::default(),

--- a/narwhal/consensus/benches/process_certificates.rs
+++ b/narwhal/consensus/benches/process_certificates.rs
@@ -44,7 +44,7 @@ pub fn process_certificates(c: &mut Criterion) {
         let store = make_consensus_store(&store_path);
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-        let mut state = ConsensusState::new(metrics.clone(), &committee);
+        let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
 
         let data_size: usize = certificates
             .iter()

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -101,7 +101,7 @@ impl ConsensusProtocol for Bullshark {
         // Get the certificate's digest of the leader. If we already ordered this leader,
         // there is nothing to do.
         let leader_round = r;
-        if leader_round <= state.last_committed_round {
+        if leader_round <= state.last_round.committed_round {
             return Ok((Outcome::LeaderBelowCommitRound, Vec::new()));
         }
         let (leader_digest, leader) = match Self::leader(&self.committee, leader_round, &state.dag)

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -165,7 +165,7 @@ impl ConsensusProtocol for Bullshark {
             // Starting from the oldest leader, flatten the sub-dag referenced by the leader.
             for x in utils::order_dag(self.gc_depth, leader, state) {
                 // Update and clean up internal state.
-                state.update(&x, self.gc_depth);
+                state.update(&x);
 
                 // For logging.
                 min_round = min_round.min(x.round());

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -41,8 +41,6 @@ pub struct Bullshark {
     pub committee: Committee,
     /// Persistent storage to safe ensure crash-recovery.
     pub store: Arc<ConsensusStore>,
-    /// The depth of the garbage collector.
-    pub gc_depth: Round,
 
     pub metrics: Arc<ConsensusMetrics>,
     /// The last time we had a successful leader election
@@ -163,7 +161,7 @@ impl ConsensusProtocol for Bullshark {
             let mut sequence = Vec::new();
 
             // Starting from the oldest leader, flatten the sub-dag referenced by the leader.
-            for x in utils::order_dag(self.gc_depth, leader, state) {
+            for x in utils::order_dag(leader, state) {
                 // Update and clean up internal state.
                 state.update(&x);
 
@@ -243,14 +241,12 @@ impl Bullshark {
     pub fn new(
         committee: Committee,
         store: Arc<ConsensusStore>,
-        gc_depth: Round,
         metrics: Arc<ConsensusMetrics>,
         num_sub_dags_per_schedule: u64,
     ) -> Self {
         Self {
             committee,
             store,
-            gc_depth,
             last_successful_leader_election_timestamp: Instant::now(),
             last_leader_election: LastRound::default(),
             max_inserted_certificate_round: 0,

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::mutable_key_type)]
 
+use crate::utils::gc_round;
 use crate::{metrics::ConsensusMetrics, ConsensusError, Outcome, SequenceNumber};
 use config::Committee;
 use crypto::PublicKey;
@@ -35,6 +36,8 @@ pub struct ConsensusState {
     pub last_committed_round: Round,
     /// The current GC round.
     pub gc_round: Round,
+    /// The chosen gc_depth
+    pub gc_depth: Round,
     /// Keeps the last committed round for each authority. This map is used to clean up the dag and
     /// ensure we don't commit twice the same certificate.
     pub last_committed: HashMap<PublicKey, Round>,
@@ -53,10 +56,11 @@ pub struct ConsensusState {
 }
 
 impl ConsensusState {
-    pub fn new(metrics: Arc<ConsensusMetrics>, committee: &Committee) -> Self {
+    pub fn new(metrics: Arc<ConsensusMetrics>, committee: &Committee, gc_depth: Round) -> Self {
         Self {
             last_committed_round: 0,
             gc_round: 0,
+            gc_depth,
             last_committed: Default::default(),
             latest_sub_dag_index: 0,
             dag: Default::default(),
@@ -75,7 +79,7 @@ impl ConsensusState {
         cert_store: CertificateStore,
         committee: &Committee,
     ) -> Self {
-        let gc_round = last_committed_round.saturating_sub(gc_depth);
+        let gc_round = gc_round(last_committed_round, gc_depth);
         let dag =
             Self::construct_dag_from_cert_store(cert_store, &recovered_last_committed, gc_round)
                 .expect("error when recovering DAG from store");
@@ -89,6 +93,7 @@ impl ConsensusState {
         Self {
             last_committed_round,
             gc_round,
+            gc_depth,
             last_committed: recovered_last_committed,
             last_consensus_reputation_score,
             latest_sub_dag_index,
@@ -176,13 +181,13 @@ impl ConsensusState {
     }
 
     /// Update and clean up internal state after committing a certificate.
-    pub fn update(&mut self, certificate: &Certificate, gc_depth: Round) {
+    pub fn update(&mut self, certificate: &Certificate) {
         self.last_committed
             .entry(certificate.origin())
             .and_modify(|r| *r = max(*r, certificate.round()))
             .or_insert_with(|| certificate.round());
         self.last_committed_round = max(self.last_committed_round, certificate.round());
-        self.gc_round = self.last_committed_round.saturating_sub(gc_depth);
+        self.gc_round = gc_round(self.last_committed_round, self.gc_depth);
 
         self.metrics
             .last_committed_round
@@ -225,6 +230,10 @@ impl ConsensusState {
             panic!("Parent round not found in DAG for {certificate:?}!");
         }
     }
+
+    pub(crate) fn last_round_update(&self) -> RoundUpdate {
+        RoundUpdate::new(self.last_committed_round, self.gc_round)
+    }
 }
 
 /// Describe how to sequence input certificates.
@@ -238,6 +247,21 @@ pub trait ConsensusProtocol {
     ) -> Result<(Outcome, Vec<CommittedSubDag>), ConsensusError>;
 }
 
+#[derive(Debug, Default)]
+pub struct RoundUpdate {
+    pub committed_round: Round,
+    pub gc_round: Round,
+}
+
+impl RoundUpdate {
+    pub fn new(committed_round: Round, gc_round: Round) -> Self {
+        Self {
+            committed_round,
+            gc_round,
+        }
+    }
+}
+
 pub struct Consensus<ConsensusProtocol> {
     /// The committee information.
     committee: Committee,
@@ -249,8 +273,8 @@ pub struct Consensus<ConsensusProtocol> {
     rx_new_certificates: metered_channel::Receiver<Certificate>,
     /// Outputs the sequence of ordered certificates to the primary (for cleanup and feedback).
     tx_committed_certificates: metered_channel::Sender<(Round, Vec<Certificate>)>,
-    /// Outputs the highest committed round in the consensus. Controls GC round downstream.
-    tx_consensus_round_updates: watch::Sender<Round>,
+    /// Outputs the highest committed round & corresponding gc_round in the consensus.
+    tx_consensus_round_updates: watch::Sender<RoundUpdate>,
     /// Outputs the sequence of ordered certificates to the application layer.
     tx_sequence: metered_channel::Sender<CommittedSubDag>,
 
@@ -277,7 +301,7 @@ where
         rx_shutdown: ConditionalBroadcastReceiver,
         rx_new_certificates: metered_channel::Receiver<Certificate>,
         tx_committed_certificates: metered_channel::Sender<(Round, Vec<Certificate>)>,
-        tx_consensus_round_updates: watch::Sender<Round>,
+        tx_consensus_round_updates: watch::Sender<RoundUpdate>,
         tx_sequence: metered_channel::Sender<CommittedSubDag>,
         protocol: Protocol,
         metrics: Arc<ConsensusMetrics>,
@@ -309,7 +333,7 @@ where
         );
 
         tx_consensus_round_updates
-            .send(state.last_committed_round)
+            .send(state.last_round_update())
             .expect("Failed to send last_committed_round on initialization!");
 
         let s = Self {
@@ -402,7 +426,9 @@ where
                         .await
                         .map_err(|_|ConsensusError::ShuttingDown)?;
 
-                        self.tx_consensus_round_updates.send(leader_commit_round)
+                        assert_eq!(self.state.last_committed_round, leader_commit_round);
+
+                        self.tx_consensus_round_updates.send(self.state.last_round_update())
                         .map_err(|_|ConsensusError::ShuttingDown)?;
                     }
 

--- a/narwhal/consensus/src/lib.rs
+++ b/narwhal/consensus/src/lib.rs
@@ -15,7 +15,7 @@ pub mod consensus_utils;
 pub mod dag;
 pub mod metrics;
 pub mod tusk;
-mod utils;
+pub mod utils;
 
 pub use crate::consensus::Consensus;
 use store::StoreError;

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -60,7 +60,6 @@ async fn commit_one() {
     let bullshark = Bullshark::new(
         committee.clone(),
         store.clone(),
-        gc_depth,
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -143,7 +142,6 @@ async fn dead_node() {
     let bullshark = Bullshark::new(
         committee.clone(),
         store.clone(),
-        gc_depth,
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -300,7 +298,6 @@ async fn not_enough_support() {
     let bullshark = Bullshark::new(
         committee.clone(),
         store.clone(),
-        gc_depth,
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -421,7 +418,6 @@ async fn missing_leader() {
     let bullshark = Bullshark::new(
         committee.clone(),
         store.clone(),
-        gc_depth,
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -504,7 +500,6 @@ async fn committed_round_after_restart() {
         let bullshark = Bullshark::new(
             committee.clone(),
             store.clone(),
-            gc_depth,
             metrics.clone(),
             NUM_SUB_DAGS_PER_SCHEDULE,
         );
@@ -591,13 +586,7 @@ async fn delayed_certificates_are_rejected() {
 
     let store = make_consensus_store(&test_utils::temp_dir());
     let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
-    let mut bullshark = Bullshark::new(
-        committee,
-        store,
-        gc_depth,
-        metrics,
-        NUM_SUB_DAGS_PER_SCHEDULE,
-    );
+    let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
     // Populate DAG with the rounds up to round 5 so we trigger commits
     let mut all_subdags = Vec::new();
@@ -643,13 +632,8 @@ async fn submitting_equivocating_certificate_should_error() {
 
     let store = make_consensus_store(&test_utils::temp_dir());
     let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
-    let mut bullshark = Bullshark::new(
-        committee.clone(),
-        store,
-        gc_depth,
-        metrics,
-        NUM_SUB_DAGS_PER_SCHEDULE,
-    );
+    let mut bullshark =
+        Bullshark::new(committee.clone(), store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
     // Populate DAG with all the certificates
     for certificate in certificates.clone() {
@@ -706,13 +690,7 @@ async fn reset_consensus_scores_on_every_schedule_change() {
 
     let store = make_consensus_store(&test_utils::temp_dir());
     let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
-    let mut bullshark = Bullshark::new(
-        committee,
-        store,
-        gc_depth,
-        metrics,
-        NUM_SUB_DAGS_PER_SCHEDULE,
-    );
+    let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
     // Populate DAG with the rounds up to round 50 so we trigger commits
     let mut all_subdags = Vec::new();
@@ -782,7 +760,6 @@ async fn restart_with_new_committee() {
         let bullshark = Bullshark::new(
             committee.clone(),
             store.clone(),
-            gc_depth,
             metrics.clone(),
             NUM_SUB_DAGS_PER_SCHEDULE,
         );
@@ -897,13 +874,7 @@ async fn garbage_collection_basic() {
 
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let mut state = ConsensusState::new(metrics.clone(), &committee, GC_DEPTH);
-    let mut bullshark = Bullshark::new(
-        committee,
-        store,
-        GC_DEPTH,
-        metrics,
-        NUM_SUB_DAGS_PER_SCHEDULE,
-    );
+    let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
     // Now start feeding the certificates per round
     for c in certificates {
@@ -1004,13 +975,8 @@ async fn slow_node() {
     let store = make_consensus_store(&test_utils::temp_dir());
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let mut state = ConsensusState::new(metrics.clone(), &committee, GC_DEPTH);
-    let mut bullshark = Bullshark::new(
-        committee.clone(),
-        store,
-        GC_DEPTH,
-        metrics,
-        NUM_SUB_DAGS_PER_SCHEDULE,
-    );
+    let mut bullshark =
+        Bullshark::new(committee.clone(), store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
     // Now start feeding the certificates per round up to 8. We expect to have
     // triggered a commit up to round 6 and gc round 1 & 2.
@@ -1185,13 +1151,7 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
     let store = make_consensus_store(&test_utils::temp_dir());
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let mut state = ConsensusState::new(metrics.clone(), &committee, GC_DEPTH);
-    let mut bullshark = Bullshark::new(
-        committee,
-        store,
-        GC_DEPTH,
-        metrics,
-        NUM_SUB_DAGS_PER_SCHEDULE,
-    );
+    let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
     let mut committed = false;
     for c in &certificates {
@@ -1234,7 +1194,7 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
                     assert_eq!(sub_dags[1].leader.round(), 6);
 
                     assert_eq!(sub_dags[0].certificates.len(), 4);
-                    assert_eq!(sub_dags[1].certificates.len(), 9);
+                    assert_eq!(sub_dags[1].certificates.len(), 11);
 
                     // And GC has collected everything up to round 5.
                     assert_eq!(state.dag.len(), 5);

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 
-use crate::consensus::RoundUpdate;
+use crate::consensus::CommittedRound;
 use crate::consensus_utils::*;
 use crate::{metrics::ConsensusMetrics, Consensus, NUM_SHUTDOWN_RECEIVERS};
 use fastcrypto::hash::Hash;
@@ -49,7 +49,7 @@ async fn commit_one() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(0, 0));
+        watch::channel(CommittedRound::new(0, 0));
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -131,7 +131,7 @@ async fn dead_node() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(0, 0));
+        watch::channel(CommittedRound::new(0, 0));
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -287,7 +287,7 @@ async fn not_enough_support() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(0, 0));
+        watch::channel(CommittedRound::new(0, 0));
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -407,7 +407,7 @@ async fn missing_leader() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(0, 0));
+        watch::channel(CommittedRound::new(0, 0));
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -492,7 +492,7 @@ async fn committed_round_after_restart() {
         let (tx_primary, mut rx_primary) = test_utils::test_channel!(100);
         let (tx_output, mut rx_output) = test_utils::test_channel!(100);
         let (tx_consensus_round_updates, rx_consensus_round_updates) =
-            watch::channel(RoundUpdate::new(0, 0));
+            watch::channel(CommittedRound::new(0, 0));
 
         let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
         let gc_depth = 50;
@@ -750,7 +750,7 @@ async fn restart_with_new_committee() {
         let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
         let (tx_output, mut rx_output) = test_utils::test_channel!(1);
         let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-            watch::channel(RoundUpdate::new(0, 0));
+            watch::channel(CommittedRound::new(0, 0));
 
         let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
         let store = make_consensus_store(&test_utils::temp_dir());

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -1046,7 +1046,7 @@ async fn slow_node() {
                     .filter(|c| c.origin() == slow_node)
                     .count();
 
-                assert_eq!(slow_node_total, 4);
+                assert_eq!(slow_node_total, 6);
 
                 committed = true;
             }

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 
-use crate::consensus::CommittedRound;
+use crate::consensus::ConsensusRound;
 use crate::consensus_utils::*;
 use crate::{metrics::ConsensusMetrics, Consensus, NUM_SHUTDOWN_RECEIVERS};
 use fastcrypto::hash::Hash;
@@ -49,7 +49,7 @@ async fn commit_one() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(0, 0));
+        watch::channel(ConsensusRound::new(0, 0));
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -131,7 +131,7 @@ async fn dead_node() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(0, 0));
+        watch::channel(ConsensusRound::new(0, 0));
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -287,7 +287,7 @@ async fn not_enough_support() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(0, 0));
+        watch::channel(ConsensusRound::new(0, 0));
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -407,7 +407,7 @@ async fn missing_leader() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(0, 0));
+        watch::channel(ConsensusRound::new(0, 0));
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -492,7 +492,7 @@ async fn committed_round_after_restart() {
         let (tx_primary, mut rx_primary) = test_utils::test_channel!(100);
         let (tx_output, mut rx_output) = test_utils::test_channel!(100);
         let (tx_consensus_round_updates, rx_consensus_round_updates) =
-            watch::channel(CommittedRound::new(0, 0));
+            watch::channel(ConsensusRound::new(0, 0));
 
         let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
         let gc_depth = 50;
@@ -750,7 +750,7 @@ async fn restart_with_new_committee() {
         let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
         let (tx_output, mut rx_output) = test_utils::test_channel!(1);
         let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-            watch::channel(CommittedRound::new(0, 0));
+            watch::channel(ConsensusRound::new(0, 0));
 
         let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
         let store = make_consensus_store(&test_utils::temp_dir());

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -1046,7 +1046,7 @@ async fn slow_node() {
                     .filter(|c| c.origin() == slow_node)
                     .count();
 
-                assert_eq!(slow_node_total, 6);
+                assert_eq!(slow_node_total, 4);
 
                 committed = true;
             }
@@ -1194,7 +1194,7 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
                     assert_eq!(sub_dags[1].leader.round(), 6);
 
                     assert_eq!(sub_dags[0].certificates.len(), 4);
-                    assert_eq!(sub_dags[1].certificates.len(), 11);
+                    assert_eq!(sub_dags[1].certificates.len(), 9);
 
                     // And GC has collected everything up to round 5.
                     assert_eq!(state.dag.len(), 5);

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -67,7 +67,6 @@ async fn test_consensus_recovery_with_bullshark() {
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
-        gc_depth,
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -163,7 +162,6 @@ async fn test_consensus_recovery_with_bullshark() {
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
-        gc_depth,
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -233,7 +231,6 @@ async fn test_consensus_recovery_with_bullshark() {
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
-        gc_depth,
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -13,7 +13,7 @@ use test_utils::{temp_dir, CommitteeFixture};
 use tokio::sync::watch;
 
 use crate::bullshark::Bullshark;
-use crate::consensus::RoundUpdate;
+use crate::consensus::CommittedRound;
 use crate::metrics::ConsensusMetrics;
 use crate::Consensus;
 use crate::NUM_SHUTDOWN_RECEIVERS;
@@ -58,7 +58,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -152,7 +152,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let storage = NodeStorage::reopen(temp_dir());
 
@@ -226,7 +226,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let bullshark = Bullshark::new(
         committee.clone(),

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -13,6 +13,7 @@ use test_utils::{temp_dir, CommitteeFixture};
 use tokio::sync::watch;
 
 use crate::bullshark::Bullshark;
+use crate::consensus::RoundUpdate;
 use crate::metrics::ConsensusMetrics;
 use crate::Consensus;
 use crate::NUM_SHUTDOWN_RECEIVERS;
@@ -56,7 +57,8 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(100);
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
-    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -150,7 +152,8 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(100);
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
-    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let storage = NodeStorage::reopen(temp_dir());
 
@@ -224,7 +227,8 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(100);
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
-    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let bullshark = Bullshark::new(
         committee.clone(),

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -13,7 +13,7 @@ use test_utils::{temp_dir, CommitteeFixture};
 use tokio::sync::watch;
 
 use crate::bullshark::Bullshark;
-use crate::consensus::CommittedRound;
+use crate::consensus::ConsensusRound;
 use crate::metrics::ConsensusMetrics;
 use crate::Consensus;
 use crate::NUM_SHUTDOWN_RECEIVERS;
@@ -58,7 +58,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -152,7 +152,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let storage = NodeStorage::reopen(temp_dir());
 
@@ -226,7 +226,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let bullshark = Bullshark::new(
         committee.clone(),

--- a/narwhal/consensus/src/tests/tusk_tests.rs
+++ b/narwhal/consensus/src/tests/tusk_tests.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 
+use crate::consensus::RoundUpdate;
 use crate::consensus_utils::*;
 use crate::{metrics::ConsensusMetrics, Consensus, NUM_SHUTDOWN_RECEIVERS};
 #[allow(unused_imports)]
@@ -40,7 +41,8 @@ async fn commit_one() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
-    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let store = make_consensus_store(&test_utils::temp_dir());
     let cert_store = make_certificate_store(&test_utils::temp_dir());
@@ -104,7 +106,8 @@ async fn dead_node() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
-    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -224,7 +227,8 @@ async fn not_enough_support() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
-    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -313,7 +317,8 @@ async fn missing_leader() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
-    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -377,7 +382,8 @@ async fn restart_with_new_committee() {
         let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
         let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
         let (tx_output, mut rx_output) = test_utils::test_channel!(1);
-        let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
+        let (tx_consensus_round_updates, _rx_consensus_round_updates) =
+            watch::channel(RoundUpdate::default());
 
         let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
         let store = make_consensus_store(&test_utils::temp_dir());

--- a/narwhal/consensus/src/tests/tusk_tests.rs
+++ b/narwhal/consensus/src/tests/tusk_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 
-use crate::consensus::RoundUpdate;
+use crate::consensus::CommittedRound;
 use crate::consensus_utils::*;
 use crate::{metrics::ConsensusMetrics, Consensus, NUM_SHUTDOWN_RECEIVERS};
 #[allow(unused_imports)]
@@ -42,7 +42,7 @@ async fn commit_one() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let store = make_consensus_store(&test_utils::temp_dir());
     let cert_store = make_certificate_store(&test_utils::temp_dir());
@@ -107,7 +107,7 @@ async fn dead_node() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -228,7 +228,7 @@ async fn not_enough_support() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -318,7 +318,7 @@ async fn missing_leader() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -383,7 +383,7 @@ async fn restart_with_new_committee() {
         let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
         let (tx_output, mut rx_output) = test_utils::test_channel!(1);
         let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-            watch::channel(RoundUpdate::default());
+            watch::channel(CommittedRound::default());
 
         let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
         let store = make_consensus_store(&test_utils::temp_dir());

--- a/narwhal/consensus/src/tests/tusk_tests.rs
+++ b/narwhal/consensus/src/tests/tusk_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 
-use crate::consensus::CommittedRound;
+use crate::consensus::ConsensusRound;
 use crate::consensus_utils::*;
 use crate::{metrics::ConsensusMetrics, Consensus, NUM_SHUTDOWN_RECEIVERS};
 #[allow(unused_imports)]
@@ -42,7 +42,7 @@ async fn commit_one() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let store = make_consensus_store(&test_utils::temp_dir());
     let cert_store = make_certificate_store(&test_utils::temp_dir());
@@ -107,7 +107,7 @@ async fn dead_node() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -228,7 +228,7 @@ async fn not_enough_support() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -318,7 +318,7 @@ async fn missing_leader() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -383,7 +383,7 @@ async fn restart_with_new_committee() {
         let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
         let (tx_output, mut rx_output) = test_utils::test_channel!(1);
         let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-            watch::channel(CommittedRound::default());
+            watch::channel(ConsensusRound::default());
 
         let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
         let store = make_consensus_store(&test_utils::temp_dir());

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -97,7 +97,7 @@ impl ConsensusProtocol for Tusk {
             // Starting from the oldest leader, flatten the sub-dag referenced by the leader.
             for x in utils::order_dag(self.gc_depth, leader, state) {
                 // Update and clean up internal state.
-                state.update(&x, self.gc_depth);
+                state.update(&x);
 
                 // Add the certificate to the sequence.
                 sequence.push(x);
@@ -203,7 +203,7 @@ mod tests {
 
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-        let mut state = ConsensusState::new(metrics, &committee);
+        let mut state = ConsensusState::new(metrics, &committee, gc_depth);
         let mut tusk = Tusk::new(committee, store, gc_depth);
         for certificate in certificates {
             tusk.process_certificate(&mut state, certificate).unwrap();
@@ -248,7 +248,7 @@ mod tests {
 
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-        let mut state = ConsensusState::new(metrics, &committee);
+        let mut state = ConsensusState::new(metrics, &committee, gc_depth);
         let mut tusk = Tusk::new((**arc_committee.load()).clone(), store, gc_depth);
 
         for certificate in certificates {

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -95,7 +95,7 @@ impl ConsensusProtocol for Tusk {
             let mut sequence = Vec::new();
 
             // Starting from the oldest leader, flatten the sub-dag referenced by the leader.
-            for x in utils::order_dag(self.gc_depth, leader, state) {
+            for x in utils::order_dag(leader, state) {
                 // Update and clean up internal state.
                 state.update(&x);
 

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -54,7 +54,7 @@ impl ConsensusProtocol for Tusk {
         // Get the certificate's digest of the leader of round r-2. If we already ordered this leader,
         // there is nothing to do.
         let leader_round = r - 2;
-        if leader_round <= state.last_committed_round {
+        if leader_round <= state.last_round.committed_round {
             return Ok((Outcome::LeaderBelowCommitRound, Vec::new()));
         }
         let (leader_digest, leader) = match Self::leader(&self.committee, leader_round, &state.dag)

--- a/narwhal/consensus/src/utils.rs
+++ b/narwhal/consensus/src/utils.rs
@@ -20,7 +20,7 @@ where
     let mut to_commit = vec![leader.clone()];
     let mut leader = leader;
     assert_eq!(leader.round() % 2, 0);
-    for r in (state.last_committed_round + 2..=leader.round() - 2)
+    for r in (state.last_round.committed_round + 2..=leader.round() - 2)
         .rev()
         .step_by(2)
     {
@@ -67,7 +67,7 @@ pub fn order_dag(leader: &Certificate, state: &ConsensusState) -> Vec<Certificat
     while let Some(x) = buffer.pop() {
         debug!("Sequencing {:?}", x);
         ordered.push(x.clone());
-        if x.round() == state.gc_round + 1 {
+        if x.round() == state.last_round.gc_round + 1 {
             // Do not try to order parents of the certificate, since they have been GC'ed.
             continue;
         }

--- a/narwhal/consensus/src/utils.rs
+++ b/narwhal/consensus/src/utils.rs
@@ -55,15 +55,10 @@ fn linked(leader: &Certificate, prev_leader: &Certificate, dag: &Dag) -> bool {
 }
 
 /// Flatten the dag referenced by the input certificate. This is a classic depth-first search (pre-order):
-/// https://en.wikipedia.org/wiki/Tree_traversal#Pre-order
-pub fn order_dag(
-    gc_depth: Round,
-    leader: &Certificate,
-    state: &ConsensusState,
-) -> Vec<Certificate> {
+/// <https://en.wikipedia.org/wiki/Tree_traversal#Pre-order>
+pub fn order_dag(leader: &Certificate, state: &ConsensusState) -> Vec<Certificate> {
     debug!("Processing sub-dag of {:?}", leader);
     assert!(leader.round() > 0);
-    let gc_round = gc_round(leader.round(), gc_depth);
 
     let mut ordered = Vec::new();
     let mut already_ordered = HashSet::new();
@@ -72,7 +67,7 @@ pub fn order_dag(
     while let Some(x) = buffer.pop() {
         debug!("Sequencing {:?}", x);
         ordered.push(x.clone());
-        if x.round() == gc_round + 1 {
+        if x.round() == state.gc_round + 1 {
             // Do not try to order parents of the certificate, since they have been GC'ed.
             continue;
         }

--- a/narwhal/consensus/src/utils.rs
+++ b/narwhal/consensus/src/utils.rs
@@ -63,7 +63,7 @@ pub fn order_dag(
 ) -> Vec<Certificate> {
     debug!("Processing sub-dag of {:?}", leader);
     assert!(leader.round() > 0);
-    let gc_round = leader.round().saturating_sub(gc_depth);
+    let gc_round = gc_round(leader.round(), gc_depth);
 
     let mut ordered = Vec::new();
     let mut already_ordered = HashSet::new();
@@ -103,4 +103,9 @@ pub fn order_dag(
     // Ordering the output by round is not really necessary but it makes the commit sequence prettier.
     ordered.sort_by_key(|x| x.round());
     ordered
+}
+
+/// Calculates the GC round given a commit round and the gc_depth
+pub fn gc_round(commit_round: Round, gc_depth: Round) -> Round {
+    commit_round.saturating_sub(gc_depth)
 }

--- a/narwhal/consensus/src/utils.rs
+++ b/narwhal/consensus/src/utils.rs
@@ -59,6 +59,7 @@ fn linked(leader: &Certificate, prev_leader: &Certificate, dag: &Dag) -> bool {
 pub fn order_dag(leader: &Certificate, state: &ConsensusState) -> Vec<Certificate> {
     debug!("Processing sub-dag of {:?}", leader);
     assert!(leader.round() > 0);
+    let gc_round = leader.round().saturating_sub(state.gc_depth);
 
     let mut ordered = Vec::new();
     let mut already_ordered = HashSet::new();
@@ -67,7 +68,7 @@ pub fn order_dag(leader: &Certificate, state: &ConsensusState) -> Vec<Certificat
     while let Some(x) = buffer.pop() {
         debug!("Sequencing {:?}", x);
         ordered.push(x.clone());
-        if x.round() == state.last_round.gc_round + 1 {
+        if x.round() == gc_round + 1 {
             // Do not try to order parents of the certificate, since they have been GC'ed.
             continue;
         }

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -63,7 +63,6 @@ async fn test_recovery() {
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
-        GC_DEPTH,
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use bytes::Bytes;
 use consensus::bullshark::Bullshark;
+use consensus::consensus::RoundUpdate;
 use consensus::metrics::ConsensusMetrics;
 use consensus::Consensus;
 use fastcrypto::hash::Hash;
@@ -51,7 +52,8 @@ async fn test_recovery() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
-    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use bytes::Bytes;
 use consensus::bullshark::Bullshark;
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use consensus::metrics::ConsensusMetrics;
 use consensus::Consensus;
 use fastcrypto::hash::Hash;
@@ -53,7 +53,7 @@ async fn test_recovery() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use bytes::Bytes;
 use consensus::bullshark::Bullshark;
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use consensus::metrics::ConsensusMetrics;
 use consensus::Consensus;
 use fastcrypto::hash::Hash;
@@ -53,7 +53,7 @@ async fn test_recovery() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
     let (tx_consensus_round_updates, _rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -4,7 +4,7 @@ use crate::metrics::new_registry;
 use crate::{try_join_all, FuturesUnordered, NodeError};
 use config::{Committee, Parameters, WorkerCache};
 use consensus::bullshark::Bullshark;
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use consensus::dag::Dag;
 use consensus::metrics::{ChannelMetrics, ConsensusMetrics};
 use consensus::Consensus;
@@ -218,7 +218,7 @@ impl PrimaryNodeInner {
         let mut handles = Vec::new();
         let (tx_executor_network, rx_executor_network) = oneshot::channel();
         let (tx_consensus_round_updates, rx_consensus_round_updates) =
-            watch::channel(RoundUpdate::new(0, 0));
+            watch::channel(CommittedRound::new(0, 0));
         let (dag, network_model) = if !internal_consensus {
             debug!("Consensus is disabled: the primary will run w/o Bullshark");
             let consensus_metrics = Arc::new(ConsensusMetrics::new(registry));
@@ -294,7 +294,7 @@ impl PrimaryNodeInner {
         mut shutdown_receivers: Vec<ConditionalBroadcastReceiver>,
         rx_new_certificates: metered_channel::Receiver<Certificate>,
         tx_committed_certificates: metered_channel::Sender<(Round, Vec<Certificate>)>,
-        tx_consensus_round_updates: watch::Sender<RoundUpdate>,
+        tx_consensus_round_updates: watch::Sender<CommittedRound>,
         registry: &Registry,
     ) -> SubscriberResult<Vec<JoinHandle<()>>>
     where

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -4,6 +4,7 @@ use crate::metrics::new_registry;
 use crate::{try_join_all, FuturesUnordered, NodeError};
 use config::{Committee, Parameters, WorkerCache};
 use consensus::bullshark::Bullshark;
+use consensus::consensus::RoundUpdate;
 use consensus::dag::Dag;
 use consensus::metrics::{ChannelMetrics, ConsensusMetrics};
 use consensus::Consensus;
@@ -216,7 +217,8 @@ impl PrimaryNodeInner {
         let name = keypair.public().clone();
         let mut handles = Vec::new();
         let (tx_executor_network, rx_executor_network) = oneshot::channel();
-        let (tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+        let (tx_consensus_round_updates, rx_consensus_round_updates) =
+            watch::channel(RoundUpdate::new(0, 0));
         let (dag, network_model) = if !internal_consensus {
             debug!("Consensus is disabled: the primary will run w/o Bullshark");
             let consensus_metrics = Arc::new(ConsensusMetrics::new(registry));
@@ -292,7 +294,7 @@ impl PrimaryNodeInner {
         mut shutdown_receivers: Vec<ConditionalBroadcastReceiver>,
         rx_new_certificates: metered_channel::Receiver<Certificate>,
         tx_committed_certificates: metered_channel::Sender<(Round, Vec<Certificate>)>,
-        tx_consensus_round_updates: watch::Sender<Round>,
+        tx_consensus_round_updates: watch::Sender<RoundUpdate>,
         registry: &Registry,
     ) -> SubscriberResult<Vec<JoinHandle<()>>>
     where

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -329,7 +329,6 @@ impl PrimaryNodeInner {
         let ordering_engine = Bullshark::new(
             committee.clone(),
             store.consensus_store.clone(),
-            parameters.gc_depth,
             consensus_metrics.clone(),
             Self::CONSENSUS_SCHEDULE_CHANGE_SUB_DAGS,
         );

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -4,7 +4,7 @@ use crate::metrics::new_registry;
 use crate::{try_join_all, FuturesUnordered, NodeError};
 use config::{Committee, Parameters, WorkerCache};
 use consensus::bullshark::Bullshark;
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use consensus::dag::Dag;
 use consensus::metrics::{ChannelMetrics, ConsensusMetrics};
 use consensus::Consensus;
@@ -218,7 +218,7 @@ impl PrimaryNodeInner {
         let mut handles = Vec::new();
         let (tx_executor_network, rx_executor_network) = oneshot::channel();
         let (tx_consensus_round_updates, rx_consensus_round_updates) =
-            watch::channel(CommittedRound::new(0, 0));
+            watch::channel(ConsensusRound::new(0, 0));
         let (dag, network_model) = if !internal_consensus {
             debug!("Consensus is disabled: the primary will run w/o Bullshark");
             let consensus_metrics = Arc::new(ConsensusMetrics::new(registry));
@@ -294,7 +294,7 @@ impl PrimaryNodeInner {
         mut shutdown_receivers: Vec<ConditionalBroadcastReceiver>,
         rx_new_certificates: metered_channel::Receiver<Certificate>,
         tx_committed_certificates: metered_channel::Sender<(Round, Vec<Certificate>)>,
-        tx_consensus_round_updates: watch::Sender<CommittedRound>,
+        tx_consensus_round_updates: watch::Sender<ConsensusRound>,
         registry: &Registry,
     ) -> SubscriberResult<Vec<JoinHandle<()>>>
     where

--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -4,7 +4,7 @@
 use crate::{metrics::PrimaryMetrics, synchronizer::Synchronizer};
 use anemo::Network;
 use config::Committee;
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use crypto::{NetworkPublicKey, PublicKey};
 use futures::{stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
@@ -61,7 +61,7 @@ pub(crate) struct CertificateFetcher {
     /// Persistent storage for certificates. Read-only usage.
     certificate_store: CertificateStore,
     /// Receiver for signal of round changes.
-    rx_consensus_round_updates: watch::Receiver<RoundUpdate>,
+    rx_consensus_round_updates: watch::Receiver<CommittedRound>,
     /// Receiver for shutdown.
     rx_shutdown: ConditionalBroadcastReceiver,
     /// Receives certificates with missing parents from the `Synchronizer`.
@@ -96,7 +96,7 @@ impl CertificateFetcher {
         committee: Committee,
         network: anemo::Network,
         certificate_store: CertificateStore,
-        rx_consensus_round_updates: watch::Receiver<RoundUpdate>,
+        rx_consensus_round_updates: watch::Receiver<CommittedRound>,
         rx_shutdown: ConditionalBroadcastReceiver,
         rx_certificate_fetcher: Receiver<Certificate>,
         synchronizer: Arc<Synchronizer>,

--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -4,6 +4,7 @@
 use crate::{metrics::PrimaryMetrics, synchronizer::Synchronizer};
 use anemo::Network;
 use config::Committee;
+use consensus::consensus::RoundUpdate;
 use crypto::{NetworkPublicKey, PublicKey};
 use futures::{stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
@@ -59,10 +60,8 @@ pub(crate) struct CertificateFetcher {
     committee: Committee,
     /// Persistent storage for certificates. Read-only usage.
     certificate_store: CertificateStore,
-    /// Receiver for signal of round changes. Used for calculating gc_round.
-    rx_consensus_round_updates: watch::Receiver<u64>,
-    /// The depth of the garbage collector.
-    gc_depth: Round,
+    /// Receiver for signal of round changes.
+    rx_consensus_round_updates: watch::Receiver<RoundUpdate>,
     /// Receiver for shutdown.
     rx_shutdown: ConditionalBroadcastReceiver,
     /// Receives certificates with missing parents from the `Synchronizer`.
@@ -97,8 +96,7 @@ impl CertificateFetcher {
         committee: Committee,
         network: anemo::Network,
         certificate_store: CertificateStore,
-        rx_consensus_round_updates: watch::Receiver<u64>,
-        gc_depth: Round,
+        rx_consensus_round_updates: watch::Receiver<RoundUpdate>,
         rx_shutdown: ConditionalBroadcastReceiver,
         rx_certificate_fetcher: Receiver<Certificate>,
         synchronizer: Arc<Synchronizer>,
@@ -118,7 +116,6 @@ impl CertificateFetcher {
                     committee,
                     certificate_store,
                     rx_consensus_round_updates,
-                    gc_depth,
                     rx_shutdown,
                     rx_certificate_fetcher,
                     targets: BTreeMap::new(),
@@ -282,10 +279,7 @@ impl CertificateFetcher {
     }
 
     fn gc_round(&self) -> Round {
-        self.rx_consensus_round_updates
-            .borrow()
-            .to_owned()
-            .saturating_sub(self.gc_depth)
+        self.rx_consensus_round_updates.borrow().gc_round
     }
 }
 

--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -4,7 +4,7 @@
 use crate::{metrics::PrimaryMetrics, synchronizer::Synchronizer};
 use anemo::Network;
 use config::Committee;
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use crypto::{NetworkPublicKey, PublicKey};
 use futures::{stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
@@ -61,7 +61,7 @@ pub(crate) struct CertificateFetcher {
     /// Persistent storage for certificates. Read-only usage.
     certificate_store: CertificateStore,
     /// Receiver for signal of round changes.
-    rx_consensus_round_updates: watch::Receiver<CommittedRound>,
+    rx_consensus_round_updates: watch::Receiver<ConsensusRound>,
     /// Receiver for shutdown.
     rx_shutdown: ConditionalBroadcastReceiver,
     /// Receives certificates with missing parents from the `Synchronizer`.
@@ -96,7 +96,7 @@ impl CertificateFetcher {
         committee: Committee,
         network: anemo::Network,
         certificate_store: CertificateStore,
-        rx_consensus_round_updates: watch::Receiver<CommittedRound>,
+        rx_consensus_round_updates: watch::Receiver<ConsensusRound>,
         rx_shutdown: ConditionalBroadcastReceiver,
         rx_certificate_fetcher: Receiver<Certificate>,
         synchronizer: Arc<Synchronizer>,

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -283,8 +283,6 @@ pub struct PrimaryMetrics {
     pub certificates_currently_suspended: IntGauge,
     /// count number of duplicate certificates that the node processed (others + own)
     pub duplicate_certificates_processed: IntCounter,
-    /// Latency to perform a garbage collection in core module
-    pub gc_core_latency: Histogram,
     /// The current Narwhal round in proposer
     pub current_round: IntGauge,
     /// The highest Narwhal round of certificates that have been accepted.
@@ -384,12 +382,6 @@ impl PrimaryMetrics {
             duplicate_certificates_processed: register_int_counter_with_registry!(
                 "duplicate_certificates_processed",
                 "Number of certificates that node processed (others + own)",
-                registry
-            )
-            .unwrap(),
-            gc_core_latency: register_histogram_with_registry!(
-                "gc_core_latency",
-                "Latency of a the garbage collection process for core module",
                 registry
             )
             .unwrap(),

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -27,7 +27,7 @@ use anemo_tower::{
 };
 use async_trait::async_trait;
 use config::{Committee, Parameters, WorkerCache, WorkerId, WorkerInfo};
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use consensus::dag::Dag;
 use crypto::{KeyPair, NetworkKeyPair, NetworkPublicKey, PublicKey, Signature};
 use fastcrypto::{
@@ -111,7 +111,7 @@ impl Primary {
         vote_digest_store: Store<PublicKey, VoteInfo>,
         tx_new_certificates: Sender<Certificate>,
         rx_committed_certificates: Receiver<(Round, Vec<Certificate>)>,
-        rx_consensus_round_updates: watch::Receiver<RoundUpdate>,
+        rx_consensus_round_updates: watch::Receiver<CommittedRound>,
         dag: Option<Arc<Dag>>,
         network_model: NetworkModel,
         tx_shutdown: &mut PreSubscribedBroadcastSender,

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -27,6 +27,7 @@ use anemo_tower::{
 };
 use async_trait::async_trait;
 use config::{Committee, Parameters, WorkerCache, WorkerId, WorkerInfo};
+use consensus::consensus::RoundUpdate;
 use consensus::dag::Dag;
 use crypto::{KeyPair, NetworkKeyPair, NetworkPublicKey, PublicKey, Signature};
 use fastcrypto::{
@@ -110,7 +111,7 @@ impl Primary {
         vote_digest_store: Store<PublicKey, VoteInfo>,
         tx_new_certificates: Sender<Certificate>,
         rx_committed_certificates: Receiver<(Round, Vec<Certificate>)>,
-        rx_consensus_round_updates: watch::Receiver<Round>,
+        rx_consensus_round_updates: watch::Receiver<RoundUpdate>,
         dag: Option<Arc<Dag>>,
         network_model: NetworkModel,
         tx_shutdown: &mut PreSubscribedBroadcastSender,
@@ -467,8 +468,6 @@ impl Primary {
             certificate_store.clone(),
             synchronizer.clone(),
             signature_service,
-            rx_consensus_round_updates.clone(),
-            parameters.gc_depth,
             tx_shutdown.subscribe(),
             rx_headers,
             node_metrics.clone(),
@@ -483,7 +482,6 @@ impl Primary {
             network.clone(),
             certificate_store.clone(),
             rx_consensus_round_updates,
-            parameters.gc_depth,
             tx_shutdown.subscribe(),
             rx_certificate_fetcher,
             synchronizer.clone(),

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -27,7 +27,7 @@ use anemo_tower::{
 };
 use async_trait::async_trait;
 use config::{Committee, Parameters, WorkerCache, WorkerId, WorkerInfo};
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use consensus::dag::Dag;
 use crypto::{KeyPair, NetworkKeyPair, NetworkPublicKey, PublicKey, Signature};
 use fastcrypto::{
@@ -111,7 +111,7 @@ impl Primary {
         vote_digest_store: Store<PublicKey, VoteInfo>,
         tx_new_certificates: Sender<Certificate>,
         rx_committed_certificates: Receiver<(Round, Vec<Certificate>)>,
-        rx_consensus_round_updates: watch::Receiver<CommittedRound>,
+        rx_consensus_round_updates: watch::Receiver<ConsensusRound>,
         dag: Option<Arc<Dag>>,
         network_model: NetworkModel,
         tx_shutdown: &mut PreSubscribedBroadcastSender,

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use anemo::{rpc::Status, Network, Request, Response};
 use config::{Committee, Epoch, WorkerCache, WorkerId};
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use consensus::dag::Dag;
 use crypto::{NetworkPublicKey, PublicKey};
 use fastcrypto::hash::Hash as _;
@@ -79,7 +79,7 @@ struct Inner {
     /// Send own certificates to be broadcasted to all other peers.
     tx_own_certificate_broadcast: broadcast::Sender<Certificate>,
     /// Get a signal when the commit & gc round changes.
-    rx_consensus_round_updates: watch::Receiver<CommittedRound>,
+    rx_consensus_round_updates: watch::Receiver<ConsensusRound>,
     /// Genesis digests and contents.
     genesis: HashMap<CertificateDigest, Certificate>,
     /// The dag used for the external consensus
@@ -267,7 +267,7 @@ impl Synchronizer {
         tx_certificate_fetcher: Sender<Certificate>,
         tx_new_certificates: Sender<Certificate>,
         tx_parents: Sender<(Vec<Certificate>, Round, Epoch)>,
-        rx_consensus_round_updates: watch::Receiver<CommittedRound>,
+        rx_consensus_round_updates: watch::Receiver<ConsensusRound>,
         rx_synchronizer_network: oneshot::Receiver<Network>,
         dag: Option<Arc<Dag>>,
         metrics: Arc<PrimaryMetrics>,

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use anemo::{rpc::Status, Network, Request, Response};
 use config::{Committee, Epoch, WorkerCache, WorkerId};
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use consensus::dag::Dag;
 use crypto::{NetworkPublicKey, PublicKey};
 use fastcrypto::hash::Hash as _;
@@ -79,7 +79,7 @@ struct Inner {
     /// Send own certificates to be broadcasted to all other peers.
     tx_own_certificate_broadcast: broadcast::Sender<Certificate>,
     /// Get a signal when the commit & gc round changes.
-    rx_consensus_round_updates: watch::Receiver<RoundUpdate>,
+    rx_consensus_round_updates: watch::Receiver<CommittedRound>,
     /// Genesis digests and contents.
     genesis: HashMap<CertificateDigest, Certificate>,
     /// The dag used for the external consensus
@@ -267,7 +267,7 @@ impl Synchronizer {
         tx_certificate_fetcher: Sender<Certificate>,
         tx_new_certificates: Sender<Certificate>,
         tx_parents: Sender<(Vec<Certificate>, Round, Epoch)>,
-        rx_consensus_round_updates: watch::Receiver<RoundUpdate>,
+        rx_consensus_round_updates: watch::Receiver<CommittedRound>,
         rx_synchronizer_network: oneshot::Receiver<Network>,
         dag: Option<Arc<Dag>>,
         metrics: Arc<PrimaryMetrics>,

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use anemo::{rpc::Status, Network, Request, Response};
 use config::{Committee, Epoch, WorkerCache, WorkerId};
+use consensus::consensus::RoundUpdate;
 use consensus::dag::Dag;
 use crypto::{NetworkPublicKey, PublicKey};
 use fastcrypto::hash::Hash as _;
@@ -77,8 +78,8 @@ struct Inner {
     tx_parents: Sender<(Vec<Certificate>, Round, Epoch)>,
     /// Send own certificates to be broadcasted to all other peers.
     tx_own_certificate_broadcast: broadcast::Sender<Certificate>,
-    /// Get a signal when the commit round changes.
-    rx_consensus_round_updates: watch::Receiver<Round>,
+    /// Get a signal when the commit & gc round changes.
+    rx_consensus_round_updates: watch::Receiver<RoundUpdate>,
     /// Genesis digests and contents.
     genesis: HashMap<CertificateDigest, Certificate>,
     /// The dag used for the external consensus
@@ -266,7 +267,7 @@ impl Synchronizer {
         tx_certificate_fetcher: Sender<Certificate>,
         tx_new_certificates: Sender<Certificate>,
         tx_parents: Sender<(Vec<Certificate>, Round, Epoch)>,
-        rx_consensus_round_updates: watch::Receiver<Round>,
+        rx_consensus_round_updates: watch::Receiver<RoundUpdate>,
         rx_synchronizer_network: oneshot::Receiver<Network>,
         dag: Option<Arc<Dag>>,
         metrics: Arc<PrimaryMetrics>,
@@ -275,7 +276,7 @@ impl Synchronizer {
         let genesis = Self::make_genesis(committee);
         let highest_processed_round = certificate_store.highest_round_number();
         let highest_created_certificate = certificate_store.last_round(&name).unwrap();
-        let gc_round = (*rx_consensus_round_updates.borrow()).saturating_sub(gc_depth);
+        let gc_round = rx_consensus_round_updates.borrow().gc_round;
         let (tx_own_certificate_broadcast, _rx_own_certificate_broadcast) =
             broadcast::channel(CHANNEL_CAPACITY);
         let (tx_certificate_acceptor, mut rx_certificate_acceptor) =
@@ -333,7 +334,7 @@ impl Synchronizer {
                     debug!("Synchronizer is shutting down.");
                     return;
                 }
-                let gc_round = (*rx_consensus_round_updates.borrow()).saturating_sub(gc_depth);
+                let gc_round = rx_consensus_round_updates.borrow().gc_round;
                 let Some(inner) = weak_inner.upgrade() else {
                     debug!("Synchronizer is shutting down.");
                     return;
@@ -837,7 +838,7 @@ impl Synchronizer {
         // Clone the round updates channel so we can get update notifications specific to
         // this RPC handler.
         let mut rx_consensus_round_updates = inner.rx_consensus_round_updates.clone();
-        let mut consensus_round = *rx_consensus_round_updates.borrow();
+        let mut consensus_round = rx_consensus_round_updates.borrow().committed_round;
         ensure!(
             header.round >= consensus_round.saturating_sub(max_age),
             DagError::TooOld(
@@ -934,7 +935,7 @@ impl Synchronizer {
                 // problematic, this function could be augmented to also support cancellation based
                 // on narwhal round.
                 Ok(()) = rx_consensus_round_updates.changed() => {
-                    consensus_round = *rx_consensus_round_updates.borrow();
+                    consensus_round = rx_consensus_round_updates.borrow().committed_round;
                     ensure!(
                         header.round >= consensus_round.saturating_sub(max_age),
                         DagError::TooOld(

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -18,7 +18,7 @@ use storage::CertificateStore;
 use storage::NodeStorage;
 use tokio::sync::oneshot;
 
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use test_utils::{temp_dir, CommitteeFixture};
 use tokio::{
     sync::{
@@ -165,7 +165,7 @@ async fn fetch_certificates_basic() {
 
     // Signal rounds
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(0, 0));
+        watch::channel(CommittedRound::new(0, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Make a synchronizer for certificates.

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -18,6 +18,7 @@ use storage::CertificateStore;
 use storage::NodeStorage;
 use tokio::sync::oneshot;
 
+use consensus::consensus::RoundUpdate;
 use test_utils::{temp_dir, CommitteeFixture};
 use tokio::{
     sync::{
@@ -163,7 +164,8 @@ async fn fetch_certificates_basic() {
     let payload_store = store.payload_store.clone();
 
     // Signal rounds
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(0, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Make a synchronizer for certificates.
@@ -207,7 +209,6 @@ async fn fetch_certificates_basic() {
         client_network.clone(),
         certificate_store.clone(),
         rx_consensus_round_updates.clone(),
-        gc_depth,
         tx_shutdown.subscribe(),
         rx_certificate_fetcher,
         synchronizer.clone(),

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -18,7 +18,7 @@ use storage::CertificateStore;
 use storage::NodeStorage;
 use tokio::sync::oneshot;
 
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use test_utils::{temp_dir, CommitteeFixture};
 use tokio::{
     sync::{
@@ -165,7 +165,7 @@ async fn fetch_certificates_basic() {
 
     // Signal rounds
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(0, 0));
+        watch::channel(ConsensusRound::new(0, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Make a synchronizer for certificates.

--- a/narwhal/primary/src/tests/core_tests.rs
+++ b/narwhal/primary/src/tests/core_tests.rs
@@ -5,10 +5,12 @@ use super::*;
 use crate::common::create_db_stores;
 
 use crate::primary;
+use consensus::consensus::RoundUpdate;
 use fastcrypto::traits::KeyPair;
 use primary::NUM_SHUTDOWN_RECEIVERS;
 use prometheus::Registry;
 use test_utils::CommitteeFixture;
+use tokio::sync::watch;
 use tokio::time::Duration;
 use types::{
     MockPrimaryToPrimary, PreSubscribedBroadcastSender, PrimaryToPrimaryServer, RequestVoteResponse,
@@ -30,7 +32,8 @@ async fn propose_header() {
     let (tx_headers, rx_headers) = test_utils::test_channel!(1);
     let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(0, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let (header_store, certificate_store, payload_store) = create_db_stores();
 
@@ -109,8 +112,6 @@ async fn propose_header() {
         certificate_store.clone(),
         synchronizer,
         signature_service,
-        rx_consensus_round_updates,
-        /* gc_depth */ 50,
         tx_shutdown.subscribe(),
         rx_headers,
         metrics.clone(),
@@ -141,7 +142,8 @@ async fn propose_header_failure() {
     let (tx_headers, rx_headers) = test_utils::test_channel!(1);
     let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let (header_store, certificate_store, payload_store) = create_db_stores();
 
@@ -203,8 +205,6 @@ async fn propose_header_failure() {
         certificate_store.clone(),
         synchronizer,
         signature_service,
-        rx_consensus_round_updates,
-        /* gc_depth */ 50,
         tx_shutdown.subscribe(),
         rx_headers,
         metrics.clone(),
@@ -236,7 +236,8 @@ async fn shutdown_core() {
     let (_tx_headers, rx_headers) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(1);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(0, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.
@@ -276,8 +277,6 @@ async fn shutdown_core() {
         certificate_store.clone(),
         synchronizer.clone(),
         signature_service.clone(),
-        rx_consensus_round_updates.clone(),
-        /* gc_depth */ 50,
         tx_shutdown.subscribe(),
         rx_headers,
         metrics.clone(),

--- a/narwhal/primary/src/tests/core_tests.rs
+++ b/narwhal/primary/src/tests/core_tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::common::create_db_stores;
 
 use crate::primary;
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use fastcrypto::traits::KeyPair;
 use primary::NUM_SHUTDOWN_RECEIVERS;
 use prometheus::Registry;
@@ -33,7 +33,7 @@ async fn propose_header() {
     let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(0, 0));
+        watch::channel(CommittedRound::new(0, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let (header_store, certificate_store, payload_store) = create_db_stores();
 
@@ -143,7 +143,7 @@ async fn propose_header_failure() {
     let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let (header_store, certificate_store, payload_store) = create_db_stores();
 
@@ -237,7 +237,7 @@ async fn shutdown_core() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(1);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(0, 0));
+        watch::channel(CommittedRound::new(0, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.

--- a/narwhal/primary/src/tests/core_tests.rs
+++ b/narwhal/primary/src/tests/core_tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::common::create_db_stores;
 
 use crate::primary;
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use fastcrypto::traits::KeyPair;
 use primary::NUM_SHUTDOWN_RECEIVERS;
 use prometheus::Registry;
@@ -33,7 +33,7 @@ async fn propose_header() {
     let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(0, 0));
+        watch::channel(ConsensusRound::new(0, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let (header_store, certificate_store, payload_store) = create_db_stores();
 
@@ -143,7 +143,7 @@ async fn propose_header_failure() {
     let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let (header_store, certificate_store, payload_store) = create_db_stores();
 
@@ -237,7 +237,7 @@ async fn shutdown_core() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(1);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(0, 0));
+        watch::channel(ConsensusRound::new(0, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use bincode::Options;
 use config::{Committee, Parameters, WorkerId};
+use consensus::consensus::RoundUpdate;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::PublicKey;
 use fastcrypto::{
@@ -80,7 +81,8 @@ async fn get_network_peers_from_admin_server() {
         )
         .unwrap(),
     );
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -203,7 +205,8 @@ async fn get_network_peers_from_admin_server() {
         )
         .unwrap(),
     );
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
@@ -309,7 +312,8 @@ async fn test_request_vote_send_missing_parents() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(1, 0));
     let (tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -452,7 +456,8 @@ async fn test_request_vote_accept_missing_parents() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(1, 0));
     let (tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -587,7 +592,8 @@ async fn test_request_vote_missing_batches() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(1, 0));
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -711,7 +717,8 @@ async fn test_request_vote_already_voted() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(1, 0));
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -868,7 +875,8 @@ async fn test_fetch_certificates_handler() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -1035,7 +1043,8 @@ async fn test_process_payload_availability_success() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -1185,7 +1194,8 @@ async fn test_process_payload_availability_when_failures() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -1283,7 +1293,8 @@ async fn test_request_vote_created_at_in_future() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(1, 0));
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use bincode::Options;
 use config::{Committee, Parameters, WorkerId};
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::PublicKey;
 use fastcrypto::{
@@ -82,7 +82,7 @@ async fn get_network_peers_from_admin_server() {
         .unwrap(),
     );
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -206,7 +206,7 @@ async fn get_network_peers_from_admin_server() {
         .unwrap(),
     );
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
@@ -313,7 +313,7 @@ async fn test_request_vote_send_missing_parents() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(1, 0));
+        watch::channel(CommittedRound::new(1, 0));
     let (tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -457,7 +457,7 @@ async fn test_request_vote_accept_missing_parents() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(1, 0));
+        watch::channel(CommittedRound::new(1, 0));
     let (tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -593,7 +593,7 @@ async fn test_request_vote_missing_batches() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(1, 0));
+        watch::channel(CommittedRound::new(1, 0));
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -718,7 +718,7 @@ async fn test_request_vote_already_voted() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(1, 0));
+        watch::channel(CommittedRound::new(1, 0));
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -876,7 +876,7 @@ async fn test_fetch_certificates_handler() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -1044,7 +1044,7 @@ async fn test_process_payload_availability_success() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -1195,7 +1195,7 @@ async fn test_process_payload_availability_when_failures() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -1294,7 +1294,7 @@ async fn test_request_vote_created_at_in_future() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::new(1, 0));
+        watch::channel(CommittedRound::new(1, 0));
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use bincode::Options;
 use config::{Committee, Parameters, WorkerId};
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::PublicKey;
 use fastcrypto::{
@@ -82,7 +82,7 @@ async fn get_network_peers_from_admin_server() {
         .unwrap(),
     );
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -206,7 +206,7 @@ async fn get_network_peers_from_admin_server() {
         .unwrap(),
     );
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
@@ -313,7 +313,7 @@ async fn test_request_vote_send_missing_parents() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(1, 0));
+        watch::channel(ConsensusRound::new(1, 0));
     let (tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -457,7 +457,7 @@ async fn test_request_vote_accept_missing_parents() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(1, 0));
+        watch::channel(ConsensusRound::new(1, 0));
     let (tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -593,7 +593,7 @@ async fn test_request_vote_missing_batches() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(1, 0));
+        watch::channel(ConsensusRound::new(1, 0));
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -718,7 +718,7 @@ async fn test_request_vote_already_voted() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(1, 0));
+        watch::channel(ConsensusRound::new(1, 0));
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -876,7 +876,7 @@ async fn test_fetch_certificates_handler() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -1044,7 +1044,7 @@ async fn test_process_payload_availability_success() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -1195,7 +1195,7 @@ async fn test_process_payload_availability_when_failures() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
@@ -1294,7 +1294,7 @@ async fn test_request_vote_created_at_in_future() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(1, 0));
+        watch::channel(ConsensusRound::new(1, 0));
     let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -4,6 +4,8 @@ use crate::{
     common::create_db_stores, metrics::PrimaryMetrics, synchronizer::Synchronizer,
     NUM_SHUTDOWN_RECEIVERS,
 };
+use consensus::consensus::RoundUpdate;
+use consensus::utils::gc_round;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use fastcrypto::{hash::Hash, traits::KeyPair};
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -17,7 +19,7 @@ use std::{
 };
 use test_utils::{make_optimal_signed_certificates, CommitteeFixture};
 use tokio::sync::{oneshot, watch};
-use types::{error::DagError, Certificate, PreSubscribedBroadcastSender};
+use types::{error::DagError, Certificate, PreSubscribedBroadcastSender, Round};
 
 #[tokio::test]
 async fn accept_certificates() {
@@ -32,7 +34,8 @@ async fn accept_certificates() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, mut rx_parents) = test_utils::test_channel!(4);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.
@@ -130,7 +133,8 @@ async fn accept_suspended_certificates() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(100);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(1, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     let synchronizer = Arc::new(Synchronizer::new(
@@ -215,7 +219,8 @@ async fn synchronizer_recover_basic() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(4);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.
@@ -329,7 +334,8 @@ async fn synchronizer_recover_partial_certs() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(4);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.
@@ -437,7 +443,8 @@ async fn synchronizer_recover_previous_round() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(6);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(10);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.
@@ -546,7 +553,8 @@ async fn deliver_certificate_using_dag() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus, rx_consensus) = test_utils::test_channel!(1);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -621,7 +629,8 @@ async fn deliver_certificate_using_store() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     let synchronizer = Synchronizer::new(
@@ -684,7 +693,8 @@ async fn deliver_certificate_not_found_parents() {
     let (tx_certificate_fetcher, mut rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     let synchronizer = Synchronizer::new(
@@ -754,7 +764,8 @@ async fn sync_batches_drops_old() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(1, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     let synchronizer = Arc::new(Synchronizer::new(
@@ -800,7 +811,7 @@ async fn sync_batches_drops_old() {
 
     tokio::task::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let _ = tx_consensus_round_updates.send(30);
+        let _ = tx_consensus_round_updates.send(RoundUpdate::new(30, 0));
     });
     match synchronizer
         .sync_header_batches(&test_header, network.clone(), 10)
@@ -814,6 +825,8 @@ async fn sync_batches_drops_old() {
 #[tokio::test]
 async fn gc_suspended_certificates() {
     const NUM_AUTHORITIES: usize = 4;
+    const GC_DEPTH: Round = 5;
+
     telemetry_subscribers::init_for_testing();
     let fixture = CommitteeFixture::builder()
         .randomize_ports(true)
@@ -829,14 +842,15 @@ async fn gc_suspended_certificates() {
     let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(100);
     let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::new(1, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     let synchronizer = Arc::new(Synchronizer::new(
         name.clone(),
         fixture.committee(),
         worker_cache.clone(),
-        /* gc_depth */ 5,
+        /* gc_depth */ GC_DEPTH,
         certificate_store.clone(),
         payload_store.clone(),
         tx_certificate_fetcher,
@@ -890,7 +904,7 @@ async fn gc_suspended_certificates() {
     }
 
     // At commit round 8, round 3 becomes the GC round. Round 4 and 5 will be accepted.
-    let _ = tx_consensus_round_updates.send(8);
+    let _ = tx_consensus_round_updates.send(RoundUpdate::new(8, gc_round(8, GC_DEPTH)));
 
     // Wait for all notifications to arrive.
     accept.collect::<Vec<()>>().await;

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -4,7 +4,7 @@ use crate::{
     common::create_db_stores, metrics::PrimaryMetrics, synchronizer::Synchronizer,
     NUM_SHUTDOWN_RECEIVERS,
 };
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use consensus::utils::gc_round;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use fastcrypto::{hash::Hash, traits::KeyPair};
@@ -35,7 +35,7 @@ async fn accept_certificates() {
     let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, mut rx_parents) = test_utils::test_channel!(4);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.
@@ -134,7 +134,7 @@ async fn accept_suspended_certificates() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(1, 0));
+        watch::channel(ConsensusRound::new(1, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     let synchronizer = Arc::new(Synchronizer::new(
@@ -220,7 +220,7 @@ async fn synchronizer_recover_basic() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(4);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.
@@ -335,7 +335,7 @@ async fn synchronizer_recover_partial_certs() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(3);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(4);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.
@@ -444,7 +444,7 @@ async fn synchronizer_recover_previous_round() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(6);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(10);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.
@@ -554,7 +554,7 @@ async fn deliver_certificate_using_dag() {
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus, rx_consensus) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -630,7 +630,7 @@ async fn deliver_certificate_using_store() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     let synchronizer = Synchronizer::new(
@@ -694,7 +694,7 @@ async fn deliver_certificate_not_found_parents() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     let synchronizer = Synchronizer::new(
@@ -765,7 +765,7 @@ async fn sync_batches_drops_old() {
     let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(1, 0));
+        watch::channel(ConsensusRound::new(1, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     let synchronizer = Arc::new(Synchronizer::new(
@@ -811,7 +811,7 @@ async fn sync_batches_drops_old() {
 
     tokio::task::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let _ = tx_consensus_round_updates.send(CommittedRound::new(30, 0));
+        let _ = tx_consensus_round_updates.send(ConsensusRound::new(30, 0));
     });
     match synchronizer
         .sync_header_batches(&test_header, network.clone(), 10)
@@ -843,7 +843,7 @@ async fn gc_suspended_certificates() {
     let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(100);
     let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
     let (tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::new(1, 0));
+        watch::channel(ConsensusRound::new(1, 0));
     let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     let synchronizer = Arc::new(Synchronizer::new(
@@ -904,7 +904,7 @@ async fn gc_suspended_certificates() {
     }
 
     // At commit round 8, round 3 becomes the GC round. Round 4 and 5 will be accepted.
-    let _ = tx_consensus_round_updates.send(CommittedRound::new(8, gc_round(8, GC_DEPTH)));
+    let _ = tx_consensus_round_updates.send(ConsensusRound::new(8, gc_round(8, GC_DEPTH)));
 
     // Wait for all notifications to arrive.
     accept.collect::<Vec<()>>().await;

--- a/narwhal/primary/tests/integration_tests_proposer_api.rs
+++ b/narwhal/primary/tests/integration_tests_proposer_api.rs
@@ -3,6 +3,7 @@
 
 use bytes::Bytes;
 use config::{Epoch, Parameters};
+use consensus::consensus::RoundUpdate;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::{KeyPair, PublicKey};
 use fastcrypto::{
@@ -83,7 +84,8 @@ async fn test_rounds_errors() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -185,7 +187,8 @@ async fn test_rounds_return_successful_response() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -352,7 +355,8 @@ async fn test_node_read_causal_signed_certificates() {
 
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let primary_1_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -388,7 +392,8 @@ async fn test_node_read_causal_signed_certificates() {
     let (tx_new_certificates_2, rx_new_certificates_2) =
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) = test_utils::test_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates_2, rx_consensus_round_updates_2) = watch::channel(0);
+    let (_tx_consensus_round_updates_2, rx_consensus_round_updates_2) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 

--- a/narwhal/primary/tests/integration_tests_proposer_api.rs
+++ b/narwhal/primary/tests/integration_tests_proposer_api.rs
@@ -3,7 +3,7 @@
 
 use bytes::Bytes;
 use config::{Epoch, Parameters};
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::{KeyPair, PublicKey};
 use fastcrypto::{
@@ -85,7 +85,7 @@ async fn test_rounds_errors() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -188,7 +188,7 @@ async fn test_rounds_return_successful_response() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -356,7 +356,7 @@ async fn test_node_read_causal_signed_certificates() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let primary_1_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -393,7 +393,7 @@ async fn test_node_read_causal_signed_certificates() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) = test_utils::test_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates_2, rx_consensus_round_updates_2) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 

--- a/narwhal/primary/tests/integration_tests_proposer_api.rs
+++ b/narwhal/primary/tests/integration_tests_proposer_api.rs
@@ -3,7 +3,7 @@
 
 use bytes::Bytes;
 use config::{Epoch, Parameters};
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::{KeyPair, PublicKey};
 use fastcrypto::{
@@ -85,7 +85,7 @@ async fn test_rounds_errors() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -188,7 +188,7 @@ async fn test_rounds_return_successful_response() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -356,7 +356,7 @@ async fn test_node_read_causal_signed_certificates() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let primary_1_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -393,7 +393,7 @@ async fn test_node_read_causal_signed_certificates() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) = test_utils::test_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates_2, rx_consensus_round_updates_2) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config::{BlockSynchronizerParameters, Committee, Parameters, WorkerId};
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::PublicKey;
 use fastcrypto::{hash::Hash, traits::KeyPair as _};
@@ -106,7 +106,7 @@ async fn test_get_collections() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -322,7 +322,7 @@ async fn test_remove_collections() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     Primary::spawn(
         name.clone(),
@@ -564,7 +564,7 @@ async fn test_read_causal_signed_certificates() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let primary_1_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -602,7 +602,7 @@ async fn test_read_causal_signed_certificates() {
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates_2) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -800,7 +800,7 @@ async fn test_read_causal_unsigned_certificates() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     // Spawn Primary 1 that we will be interacting with.
     Primary::spawn(
@@ -831,7 +831,7 @@ async fn test_read_causal_unsigned_certificates() {
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates_2) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics_2 = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -1008,7 +1008,7 @@ async fn test_get_collections_with_missing_certificates() {
     let (tx_feedback_1, rx_feedback_1) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -1068,7 +1068,7 @@ async fn test_get_collections_with_missing_certificates() {
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config::{BlockSynchronizerParameters, Committee, Parameters, WorkerId};
+use consensus::consensus::RoundUpdate;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::PublicKey;
 use fastcrypto::{hash::Hash, traits::KeyPair as _};
@@ -104,7 +105,8 @@ async fn test_get_collections() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -319,7 +321,8 @@ async fn test_remove_collections() {
 
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     Primary::spawn(
         name.clone(),
@@ -560,7 +563,8 @@ async fn test_read_causal_signed_certificates() {
 
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let primary_1_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -597,7 +601,8 @@ async fn test_read_causal_signed_certificates() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates_2) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates_2) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -794,7 +799,8 @@ async fn test_read_causal_unsigned_certificates() {
 
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     // Spawn Primary 1 that we will be interacting with.
     Primary::spawn(
@@ -824,7 +830,8 @@ async fn test_read_causal_unsigned_certificates() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates_2) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates_2) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics_2 = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -1000,7 +1007,8 @@ async fn test_get_collections_with_missing_certificates() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_1, rx_feedback_1) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -1059,7 +1067,8 @@ async fn test_get_collections_with_missing_certificates() {
     let (tx_new_certificates_2, _) = test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config::{BlockSynchronizerParameters, Committee, Parameters, WorkerId};
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::PublicKey;
 use fastcrypto::{hash::Hash, traits::KeyPair as _};
@@ -106,7 +106,7 @@ async fn test_get_collections() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -322,7 +322,7 @@ async fn test_remove_collections() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     Primary::spawn(
         name.clone(),
@@ -564,7 +564,7 @@ async fn test_read_causal_signed_certificates() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let primary_1_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -602,7 +602,7 @@ async fn test_read_causal_signed_certificates() {
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates_2) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 
@@ -800,7 +800,7 @@ async fn test_read_causal_unsigned_certificates() {
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     // Spawn Primary 1 that we will be interacting with.
     Primary::spawn(
@@ -831,7 +831,7 @@ async fn test_read_causal_unsigned_certificates() {
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates_2) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics_2 = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -1008,7 +1008,7 @@ async fn test_get_collections_with_missing_certificates() {
     let (tx_feedback_1, rx_feedback_1) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -1068,7 +1068,7 @@ async fn test_get_collections_with_missing_certificates() {
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
 

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -4,6 +4,7 @@
 use super::*;
 use crate::{metrics::initialise_metrics, TrivialTransactionValidator};
 use bytes::Bytes;
+use consensus::consensus::RoundUpdate;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use fastcrypto::{
     encoding::{Encoding, Hex},
@@ -265,7 +266,8 @@ async fn get_network_peers_from_admin_server() {
     let (tx_new_certificates, rx_new_certificates) =
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback, rx_feedback) = test_utils::test_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
@@ -386,7 +388,8 @@ async fn get_network_peers_from_admin_server() {
     let (tx_new_certificates_2, rx_new_certificates_2) =
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) = test_utils::test_channel!(CHANNEL_CAPACITY);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(RoundUpdate::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::{metrics::initialise_metrics, TrivialTransactionValidator};
 use bytes::Bytes;
-use consensus::consensus::RoundUpdate;
+use consensus::consensus::CommittedRound;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use fastcrypto::{
     encoding::{Encoding, Hex},
@@ -267,7 +267,7 @@ async fn get_network_peers_from_admin_server() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback, rx_feedback) = test_utils::test_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
@@ -389,7 +389,7 @@ async fn get_network_peers_from_admin_server() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) = test_utils::test_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(RoundUpdate::default());
+        watch::channel(CommittedRound::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::{metrics::initialise_metrics, TrivialTransactionValidator};
 use bytes::Bytes;
-use consensus::consensus::CommittedRound;
+use consensus::consensus::ConsensusRound;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use fastcrypto::{
     encoding::{Encoding, Hex},
@@ -267,7 +267,7 @@ async fn get_network_peers_from_admin_server() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback, rx_feedback) = test_utils::test_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
@@ -389,7 +389,7 @@ async fn get_network_peers_from_admin_server() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) = test_utils::test_channel!(CHANNEL_CAPACITY);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(CommittedRound::default());
+        watch::channel(ConsensusRound::default());
 
     let mut tx_shutdown_2 = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));


### PR DESCRIPTION
## Description 

This PR cleans up the usage of the commit round updates. Right now all the components across our codebase calculate their own version of `gc_round`. On previous PR https://github.com/MystenLabs/sui/pull/8940/files we aligned the gc_round calculation across consensus and the other components, but there are still no strong guarantees that those will not become orthogonal.

This PR is:
* making consensus drive the `gc_round` calculation and propagate to the rest of codebase
* is refactoring the consensus logic to use `ConsensusState` now exclusively for any `gc_round` calculation and make Bullshark/Tusk agnostic of any gc logic
* refactored components to use the new propagated info instead of calculating their own version of gc_round
* on previous PR we changed how we calculate the gc_round cut off when ordering the DAG. That seems though to lead to excessive pruning and potentially skip rounds that could be committed. This PR is reverting the change to use the last known gc_round.

## Test Plan 

Unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
