### PR TITLE
Cache verification of certificate signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4220,6 +4220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "lz4-sys"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8651,6 +8660,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "itertools",
+ "lru",
  "more-asserts",
  "move-binary-format",
  "move-bytecode-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9309,6 +9309,7 @@ dependencies = [
  "anemo",
  "anemo-tower",
  "fastcrypto",
+ "lru",
  "move-package",
  "msim",
  "narwhal-network",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11472,6 +11472,7 @@ dependencies = [
  "linux-raw-sys",
  "lock_api",
  "log",
+ "lru",
  "lz4-sys",
  "mach",
  "match_opt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8652,6 +8652,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap 3.2.23",
+ "criterion",
  "dashmap",
  "either",
  "expect-test",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -47,6 +47,7 @@ sui-config = { path = "../sui-config" }
 sui-json = { path = "../sui-json" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 sui-protocol-config = { path = "../sui-protocol-config" }
+lru = "0.10"
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -78,6 +78,7 @@ sui-macros = { path = "../sui-macros" }
 
 [dev-dependencies]
 clap = { version = "3.2.17", features = ["derive"] }
+criterion = { version = "0.4.0" }
 fs_extra = "1.2.0"
 more-asserts="0.3.1"
 serde-reflection = "0.3.6"
@@ -98,3 +99,7 @@ test-utils = { path = "../test-utils" }
 name = "generate-format"
 path = "src/generate_format.rs"
 test = false
+
+[[bench]]
+name = "verified_cert_cache_bench"
+harness = false

--- a/crates/sui-core/benches/verified_cert_cache_bench.rs
+++ b/crates/sui-core/benches/verified_cert_cache_bench.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::*;
+
+use sui_core::authority::VerifiedCertificateCache;
+use sui_types::digests::CertificateDigest;
+
+use criterion::Criterion;
+
+fn verified_cert_cache_bench(c: &mut Criterion) {
+    let mut digests: Vec<_> = (0..(1 << 18))
+        .map(|_| CertificateDigest::random())
+        .collect();
+    digests.extend_from_slice(&digests.clone());
+    rand::seq::SliceRandom::shuffle(digests.as_mut_slice(), &mut rand::rngs::OsRng);
+
+    let cpus = num_cpus::get();
+    let chunk_size = digests.len() / cpus;
+    let chunks: Vec<Vec<CertificateDigest>> = digests
+        .chunks(chunk_size)
+        .take(cpus)
+        .map(|c| c.iter().cloned().collect())
+        .collect();
+    assert_eq!(chunks.len(), cpus);
+
+    let cache = VerifiedCertificateCache::new();
+
+    let mut group = c.benchmark_group("digest-caching");
+    group.throughput(Throughput::Elements(chunk_size as u64));
+
+    group.bench_function("digest cache", |b| {
+        b.iter(|| {
+            std::thread::scope(|s| {
+                let threads = chunks.iter().map(|chunk| {
+                    s.spawn(|| {
+                        for digest in &*chunk {
+                            if cache.is_cert_verified(digest) {
+                                continue;
+                            } else {
+                                cache.cache_cert_verified(*digest);
+                            }
+                        }
+                    })
+                });
+
+                for thread in threads {
+                    thread.join().unwrap();
+                }
+            });
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, verified_cert_cache_bench);
+criterion_main!(benches);

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -92,6 +92,7 @@ use sui_types::{
     SUI_FRAMEWORK_ADDRESS,
 };
 
+pub use crate::authority::authority_per_epoch_store::VerifiedCertificateCache;
 use crate::authority::authority_per_epoch_store::{
     AuthorityPerEpochStore, EpochStartConfiguration,
 };

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -92,9 +92,11 @@ use sui_types::{
     SUI_FRAMEWORK_ADDRESS,
 };
 
-pub use crate::authority::authority_per_epoch_store::VerifiedCertificateCache;
 use crate::authority::authority_per_epoch_store::{
     AuthorityPerEpochStore, EpochStartConfiguration,
+};
+pub use crate::authority::authority_per_epoch_store::{
+    VerifiedCertificateCache, VerifiedCertificateCacheMetrics,
 };
 use crate::authority::authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner;
 use crate::authority::authority_store::{ExecutionLockReadGuard, InputKey, ObjectLockStatus};
@@ -1649,6 +1651,7 @@ impl AuthorityState {
         );
         let registry = Registry::new();
         let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
+        let verified_cert_cache_metrics = VerifiedCertificateCacheMetrics::new(&registry);
         let epoch_store = AuthorityPerEpochStore::new(
             name,
             Arc::new(genesis_committee.clone()),
@@ -1658,6 +1661,7 @@ impl AuthorityState {
             EpochStartConfiguration::new_for_testing(),
             store.clone(),
             cache_metrics,
+            verified_cert_cache_metrics,
         );
 
         let epochs = Arc::new(CommitteeStore::new(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -55,7 +55,7 @@ use move_bytecode_utils::module_cache::SyncModuleCache;
 use move_vm_runtime::move_vm::MoveVM;
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use mysten_metrics::monitored_scope;
-use prometheus::IntCounter;
+use prometheus::{register_int_counter_with_registry, IntCounter, Registry};
 use std::cmp::Ordering as CmpOrdering;
 use sui_adapter::adapter;
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
@@ -392,6 +392,7 @@ impl AuthorityPerEpochStore {
         epoch_start_configuration: EpochStartConfiguration,
         store: Arc<AuthorityStore>,
         cache_metrics: Arc<ResolverMetrics>,
+        verified_cert_cache_metrics: Arc<VerifiedCertificateCacheMetrics>,
     ) -> Arc<Self> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
@@ -435,7 +436,7 @@ impl AuthorityPerEpochStore {
             epoch_alive_notify,
             epoch_alive: tokio::sync::RwLock::new(true),
             consensus_notify_read: NotifyRead::new(),
-            verified_cert_cache: VerifiedCertificateCache::new(),
+            verified_cert_cache: VerifiedCertificateCache::new(verified_cert_cache_metrics),
             checkpoint_state_notify_read: NotifyRead::new(),
             end_of_publish: Mutex::new(end_of_publish),
             pending_consensus_certificates: Mutex::new(pending_consensus_certificates),
@@ -481,6 +482,7 @@ impl AuthorityPerEpochStore {
             epoch_start_configuration,
             store,
             self.execution_component.metrics(),
+            self.verified_cert_cache.metrics.clone(),
         )
     }
 
@@ -2052,39 +2054,72 @@ impl ExecutionComponents {
 // on the assumption that we should see most certs twice within about 10-20 seconds at most: Once via RPC, once via consensus.
 const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 20000;
 
-pub struct VerifiedCertificateCache {
-    inner: RwLock<LruCache<CertificateDigest, ()>>,
+pub struct VerifiedCertificateCacheMetrics {
+    certificate_signatures_cache_hits: IntCounter,
+    certificate_signatures_cache_evictions: IntCounter,
 }
 
-impl Default for VerifiedCertificateCache {
-    fn default() -> Self {
-        Self::new()
+impl VerifiedCertificateCacheMetrics {
+    pub fn new(registry: &Registry) -> Arc<Self> {
+        Arc::new(Self {
+            certificate_signatures_cache_hits: register_int_counter_with_registry!(
+                "certificate_signatures_cache_hits",
+                "Number of certificates which were known to be verified because of signature cache.",
+                registry
+            )
+            .unwrap(),
+            certificate_signatures_cache_evictions: register_int_counter_with_registry!(
+                "certificate_signatures_cache_evictions",
+                "Number of times we evict a pre-existing key were known to be verified because of signature cache.",
+                registry
+            )
+            .unwrap(),
+        })
     }
 }
 
+pub struct VerifiedCertificateCache {
+    inner: RwLock<LruCache<CertificateDigest, ()>>,
+    metrics: Arc<VerifiedCertificateCacheMetrics>,
+}
+
 impl VerifiedCertificateCache {
-    pub fn new() -> Self {
+    pub fn new(metrics: Arc<VerifiedCertificateCacheMetrics>) -> Self {
         Self {
             inner: RwLock::new(LruCache::new(
                 NonZeroUsize::new(VERIFIED_CERTIFICATE_CACHE_SIZE).unwrap(),
             )),
+            metrics,
         }
     }
 
     pub fn is_cert_verified(&self, digest: &CertificateDigest) -> bool {
         let inner = self.inner.read();
-        inner.contains(digest)
+        if inner.contains(digest) {
+            self.metrics.certificate_signatures_cache_hits.inc();
+            true
+        } else {
+            false
+        }
     }
 
     pub fn cache_cert_verified(&self, digest: CertificateDigest) {
         let mut inner = self.inner.write();
-        inner.put(digest, ());
+        if let Some(old) = inner.push(digest, ()) {
+            if old.0 != digest {
+                self.metrics.certificate_signatures_cache_evictions.inc();
+            }
+        }
     }
 
     pub fn cache_certs_verified(&self, digests: Vec<CertificateDigest>) {
         let mut inner = self.inner.write();
         digests.into_iter().for_each(|d| {
-            inner.put(d, ());
+            if let Some(old) = inner.push(d, ()) {
+                if old.0 != d {
+                    self.metrics.certificate_signatures_cache_evictions.inc();
+                }
+            }
         });
     }
 }

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -376,6 +376,7 @@ impl ValidatorService {
                     VerifiedCertificate::new_unchecked(certificate)
                 } else {
                     let _timer = metrics.cert_verification_latency.start_timer();
+                    // Note: verify verifies user sigs as well before caching cert.
                     certificate.verify(epoch_store.committee()).tap_ok(|_| {
                         epoch_store
                             .verified_cert_cache()

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -368,8 +368,20 @@ impl ValidatorService {
             }
 
             let certificate = {
-                let _timer = metrics.cert_verification_latency.start_timer();
-                certificate.verify(epoch_store.committee())?
+                let cert_digest = certificate.certificate_digest();
+                if epoch_store
+                    .verified_cert_cache()
+                    .is_cert_verified(&cert_digest)
+                {
+                    VerifiedCertificate::new_unchecked(certificate)
+                } else {
+                    let _timer = metrics.cert_verification_latency.start_timer();
+                    certificate.verify(epoch_store.committee()).tap_ok(|_| {
+                        epoch_store
+                            .verified_cert_cache()
+                            .cache_cert_verified(cert_digest)
+                    })?
+                }
             };
 
             // 3) All certificates are sent to consensus (at least by some authorities)

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2729,6 +2729,7 @@ async fn test_authority_persist() {
         fs::create_dir(&epoch_store_path).unwrap();
         let registry = Registry::new();
         let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
+        let verified_cert_cache_metrics = VerifiedCertificateCacheMetrics::new(&registry);
         let epoch_store = AuthorityPerEpochStore::new(
             name,
             Arc::new(committee),
@@ -2738,6 +2739,7 @@ async fn test_authority_persist() {
             EpochStartConfiguration::new_for_testing(),
             store.clone(),
             cache_metrics,
+            verified_cert_cache_metrics,
         );
 
         let checkpoint_store_path = dir.join(format!("DB_{:?}", ObjectID::random()));
@@ -4802,6 +4804,7 @@ async fn test_tallying_rule_score_updates() {
     );
 
     let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
+    let verified_cert_cache_metrics = VerifiedCertificateCacheMetrics::new(&registry);
     let epoch_store = AuthorityPerEpochStore::new(
         auth_0_name,
         Arc::new(committee.clone()),
@@ -4811,6 +4814,7 @@ async fn test_tallying_rule_score_updates() {
         EpochStartConfiguration::new_for_testing(),
         store,
         cache_metrics,
+        verified_cert_cache_metrics,
     );
 
     let get_stored_seq_num_and_counter = |auth_name: &AuthorityName| {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -31,7 +31,7 @@ use sui_core::state_accumulator::StateAccumulator;
 use sui_core::storage::RocksDbStore;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_core::{
-    authority::{AuthorityState, AuthorityStore},
+    authority::{AuthorityState, AuthorityStore, VerifiedCertificateCacheMetrics},
     authority_client::NetworkAuthorityClient,
 };
 use sui_json_rpc::event_api::EventReadApi;
@@ -191,6 +191,8 @@ impl SuiNode {
             .get_epoch_start_configuration()?
             .expect("EpochStartConfiguration of the current epoch must exist");
         let cache_metrics = Arc::new(ResolverMetrics::new(&prometheus_registry));
+        let verified_cert_cache_metrics =
+            VerifiedCertificateCacheMetrics::new(&prometheus_registry);
         let epoch_store = AuthorityPerEpochStore::new(
             config.protocol_public_key(),
             committee,
@@ -200,6 +202,7 @@ impl SuiNode {
             epoch_start_configuration,
             store.clone(),
             cache_metrics,
+            verified_cert_cache_metrics,
         );
 
         let checkpoint_store = CheckpointStore::new(&config.db_path().join("checkpoints"));

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -32,6 +32,12 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
                 ::sui_simulator::sui_framework::get_sui_framework();
                 ::sui_simulator::sui_types::gas::SuiGasStatus::new_unmetered();
 
+                // For reasons I can't understand, LruCache causes divergent behavior the second
+                // time one is constructed and inserted into, so construct one before the first
+                // test run for determinism.
+                let mut cache = ::sui_simulator::lru::LruCache::new(1.try_into().unwrap());
+                cache.put(1, 1);
+
                 {
                     // Initialize the static initializers here:
                     // https://github.com/move-language/move/blob/652badf6fd67e1d4cc2aa6dc69d63ad14083b673/language/tools/move-package/src/package_lock.rs#L12

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -20,6 +20,7 @@ narwhal-network = { path = "../../narwhal/network" }
 fastcrypto = { workspace = true, features = ["copy_key"] }
 telemetry-subscribers.workspace = true
 tower = "0.4.13"
+lru = "0.10"
 
 [target.'cfg(msim)'.dependencies]
 msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "888a9dc4331b0ed944bd6e37bac982bbcf0625d5", package = "msim" }

--- a/crates/sui-simulator/src/lib.rs
+++ b/crates/sui-simulator/src/lib.rs
@@ -8,6 +8,7 @@ pub use msim::*;
 pub use anemo;
 pub use anemo_tower;
 pub use fastcrypto;
+pub use lru;
 pub use move_package;
 pub use narwhal_network;
 pub use sui_framework;

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -280,6 +280,16 @@ impl fmt::UpperHex for CheckpointContentsDigest {
     }
 }
 
+/// A digest of a cerificate, which commits to the signatures as well as the tx.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CertificateDigest(Sha3Digest);
+
+impl CertificateDigest {
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(Sha3Digest::new(digest))
+    }
+}
+
 /// A transaction will have a (unique) digest.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema)]
 pub struct TransactionDigest(Sha3Digest);

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -288,6 +288,16 @@ impl CertificateDigest {
     pub const fn new(digest: [u8; 32]) -> Self {
         Self(Sha3Digest::new(digest))
     }
+
+    pub fn random() -> Self {
+        Self(Sha3Digest::random())
+    }
+}
+
+impl fmt::Debug for CertificateDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CertificateDigest").field(&self.0).finish()
+    }
 }
 
 /// A transaction will have a (unique) digest.

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -78,6 +78,10 @@ impl<T: Message, S> Envelope<T, S> {
         &self.auth_signature
     }
 
+    pub fn auth_sig_mut_for_testing(&mut self) -> &mut S {
+        &mut self.auth_signature
+    }
+
     pub fn digest(&self) -> &T::DigestType {
         self.digest.get_or_init(|| self.data.digest())
     }

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -1319,7 +1319,7 @@ fn test_certificate_digest() {
     assert_ne!(digest, cert.certificate_digest());
 
     // mutating signature changes digest
-    cert = orig.clone();
+    cert = orig;
     *cert.auth_sig_mut_for_testing() = other_cert.auth_sig().clone();
     assert_ne!(digest, cert.certificate_digest());
 }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -311,6 +311,7 @@ libz-sys = { version = "1", default-features = false, features = ["static"] }
 linked-hash-map = { version = "0.5", default-features = false }
 lock_api = { version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
+lru = { version = "0.10" }
 lz4-sys = { version = "1", default-features = false }
 match_opt = { version = "0.1", default-features = false }
 matchers = { version = "0.1", default-features = false }
@@ -987,6 +988,7 @@ libz-sys = { version = "1", default-features = false, features = ["static"] }
 linked-hash-map = { version = "0.5", default-features = false }
 lock_api = { version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
+lru = { version = "0.10" }
 lz4-sys = { version = "1", default-features = false }
 match_opt = { version = "0.1", default-features = false }
 matchers = { version = "0.1", default-features = false }


### PR DESCRIPTION
consensus_validator and authority_server can avoid redundantly verifying the same cert twice.

Using simulated load tests (which provide a gross accounting of all the CPU time spent in a cluster) we see:

With optimization:

    ; SIM_STRESS_TEST_QPS=25 cargo simtest test_simulated_load_basic
        Starting 1 tests across 3 binaries (6 skipped)
            PASS [  20.395s] sui-benchmark::simtest test::test_simulated_load_basic
    ------------
         Summary [  20.395s] 1 tests run: 1 passed, 6 skipped

Without:

    ; SIM_STRESS_TEST_QPS=25 cargo simtest test_simulated_load_basic
        Starting 1 tests across 3 binaries (6 skipped)
            PASS [  29.491s] sui-benchmark::simtest test::test_simulated_load_basic
    ------------
         Summary [  29.491s] 1 tests run: 1 passed, 6 skipped
