### PR TITLE
Embed verified metadata in Validator

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -135,25 +135,22 @@ impl Genesis {
             .active_validators
             .iter()
             .map(|validator| {
-                let metadata = validator
-                    .metadata
-                    .verify()
-                    .expect("Genesis validator metadata must be valid");
+                let metadata = validator.verified_metadata();
                 ValidatorInfo {
-                    name: metadata.name,
+                    name: metadata.name.clone(),
                     account_key: AccountsPublicKey::Ed25519(metadata.network_pubkey.clone()), //TODO this is wrong and we shouldn't have this here
-                    protocol_key: (&metadata.protocol_pubkey).into(),
-                    worker_key: metadata.worker_pubkey,
-                    network_key: metadata.network_pubkey,
+                    protocol_key: metadata.sui_pubkey_bytes(),
+                    worker_key: metadata.worker_pubkey.clone(),
+                    network_key: metadata.network_pubkey.clone(),
                     gas_price: validator.gas_price,
                     commission_rate: validator.commission_rate,
-                    network_address: metadata.net_address,
-                    p2p_address: metadata.p2p_address,
-                    narwhal_primary_address: metadata.primary_address,
-                    narwhal_worker_address: metadata.worker_address,
-                    description: metadata.description,
-                    image_url: metadata.image_url,
-                    project_url: metadata.project_url,
+                    network_address: metadata.net_address.clone(),
+                    p2p_address: metadata.p2p_address.clone(),
+                    narwhal_primary_address: metadata.primary_address.clone(),
+                    narwhal_worker_address: metadata.worker_address.clone(),
+                    description: metadata.description.clone(),
+                    image_url: metadata.image_url.clone(),
+                    project_url: metadata.project_url.clone(),
                 }
             })
             .collect()
@@ -544,19 +541,11 @@ impl Builder {
             .map(|genesis_info| &genesis_info.info)
             .zip(system_object.validators.active_validators.iter())
         {
-            assert_eq!(
-                validator.sui_address().to_vec(),
-                onchain_validator.metadata.sui_address.to_vec(),
-            );
-            assert_eq!(
-                validator.protocol_key().as_ref().to_vec(),
-                onchain_validator.metadata.protocol_pubkey_bytes,
-            );
-            assert_eq!(validator.name(), onchain_validator.metadata.name);
-            assert_eq!(
-                validator.network_address().to_vec(),
-                onchain_validator.metadata.net_address
-            );
+            let metadata = onchain_validator.verified_metadata();
+            assert_eq!(validator.sui_address(), metadata.sui_address);
+            assert_eq!(validator.protocol_key(), metadata.sui_pubkey_bytes());
+            assert_eq!(validator.name(), &metadata.name);
+            assert_eq!(validator.network_address(), &metadata.net_address);
         }
 
         genesis

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -17,7 +17,7 @@ use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
-use self::sui_system_state_inner_v1::{SuiSystemStateInnerV1, ValidatorMetadataV1};
+use self::sui_system_state_inner_v1::SuiSystemStateInnerV1;
 use self::sui_system_state_summary::SuiSystemStateSummary;
 
 pub mod epoch_start_sui_system_state;
@@ -67,7 +67,6 @@ pub trait SuiSystemStateTrait {
     fn epoch_start_timestamp_ms(&self) -> u64;
     fn safe_mode(&self) -> bool;
     fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata;
-    fn get_validator_metadata_vec(&self) -> Vec<ValidatorMetadataV1>;
     fn into_epoch_start_state(self) -> EpochStartSystemState;
     fn into_sui_system_state_summary(self) -> SuiSystemStateSummary;
 }

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::balance::Balance;
-use crate::base_types::{AuthorityName, ObjectID, SuiAddress};
+use crate::base_types::{ObjectID, SuiAddress};
 use crate::collection_types::{Table, TableVec, VecMap, VecSet};
-use crate::committee::{
-    Committee, CommitteeWithNetworkMetadata, NetworkMetadata, ProtocolVersion, StakeUnit,
-};
+use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata, ProtocolVersion};
 use crate::crypto::AuthorityPublicKeyBytes;
 use crate::sui_system_state::epoch_start_sui_system_state::{
     EpochStartSystemState, EpochStartValidatorInfo,
@@ -14,6 +12,7 @@ use crate::sui_system_state::epoch_start_sui_system_state::{
 use anyhow::Result;
 use fastcrypto::traits::ToFromBytes;
 use multiaddr::Multiaddr;
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -65,7 +64,7 @@ pub struct ValidatorMetadataV1 {
     pub next_epoch_worker_address: Option<Vec<u8>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct VerifiedValidatorMetadataV1 {
     pub sui_address: SuiAddress,
     pub protocol_pubkey: narwhal_crypto::PublicKey,
@@ -88,6 +87,12 @@ pub struct VerifiedValidatorMetadataV1 {
     pub next_epoch_p2p_address: Option<Multiaddr>,
     pub next_epoch_primary_address: Option<Multiaddr>,
     pub next_epoch_worker_address: Option<Multiaddr>,
+}
+
+impl VerifiedValidatorMetadataV1 {
+    pub fn sui_pubkey_bytes(&self) -> AuthorityPublicKeyBytes {
+        (&self.protocol_pubkey).into()
+    }
 }
 
 impl ValidatorMetadataV1 {
@@ -196,22 +201,15 @@ impl ValidatorMetadataV1 {
     }
 }
 
-impl ValidatorMetadataV1 {
-    pub fn network_address(&self) -> Result<Multiaddr> {
-        Multiaddr::try_from(self.net_address.clone()).map_err(Into::into)
-    }
-
-    pub fn p2p_address(&self) -> Result<Multiaddr> {
-        Multiaddr::try_from(self.p2p_address.clone()).map_err(Into::into)
-    }
-}
-
 /// Rust version of the Move sui::validator::Validator type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 // TODO: Get rid of json schema once we deprecate getSuiSystemState RPC API.
 #[serde(rename = "Validator")]
 pub struct ValidatorV1 {
-    pub metadata: ValidatorMetadataV1,
+    metadata: ValidatorMetadataV1,
+    #[serde(skip)]
+    verified_metadata: OnceCell<VerifiedValidatorMetadataV1>,
+
     pub voting_power: u64,
     pub gas_price: u64,
     pub staking_pool: StakingPoolV1,
@@ -222,24 +220,12 @@ pub struct ValidatorV1 {
 }
 
 impl ValidatorV1 {
-    pub fn to_stake_and_network_metadata(&self) -> (AuthorityName, StakeUnit, NetworkMetadata) {
-        (
-            // TODO: Make sure we are actually verifying this on-chain.
-            AuthorityPublicKeyBytes::from_bytes(self.metadata.protocol_pubkey_bytes.as_ref())
-                .expect("Validity of public key bytes should be verified on-chain"),
-            self.voting_power,
-            NetworkMetadata {
-                network_address: self
-                    .metadata
-                    .network_address()
-                    .expect("Validity of network address should be verified on-chain"),
-            },
-        )
-    }
-
-    pub fn authority_name(&self) -> AuthorityName {
-        AuthorityPublicKeyBytes::from_bytes(self.metadata.protocol_pubkey_bytes.as_ref())
-            .expect("Validity of public key bytes should be verified on-chain")
+    pub fn verified_metadata(&self) -> &VerifiedValidatorMetadataV1 {
+        self.verified_metadata.get_or_init(|| {
+            self.metadata
+                .verify()
+                .expect("Validity of metadata should be verified on-chain")
+        })
     }
 
     pub fn into_sui_validator_summary(self) -> SuiValidatorSummary {
@@ -268,6 +254,7 @@ impl ValidatorV1 {
                     next_epoch_primary_address,
                     next_epoch_worker_address,
                 },
+            verified_metadata: _,
             voting_power,
             gas_price,
             staking_pool:
@@ -417,9 +404,15 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
         let mut voting_rights = BTreeMap::new();
         let mut network_metadata = BTreeMap::new();
         for validator in &self.validators.active_validators {
-            let (name, voting_stake, metadata) = validator.to_stake_and_network_metadata();
-            voting_rights.insert(name, voting_stake);
-            network_metadata.insert(name, metadata);
+            let verified_metadata = validator.verified_metadata();
+            let name = verified_metadata.sui_pubkey_bytes();
+            voting_rights.insert(name, validator.voting_power);
+            network_metadata.insert(
+                name,
+                NetworkMetadata {
+                    network_address: verified_metadata.net_address.clone(),
+                },
+            );
         }
         CommitteeWithNetworkMetadata {
             committee: Committee::new(self.epoch, voting_rights)
@@ -428,14 +421,6 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
                 .unwrap(),
             network_metadata,
         }
-    }
-
-    fn get_validator_metadata_vec(&self) -> Vec<ValidatorMetadataV1> {
-        self.validators
-            .active_validators
-            .iter()
-            .map(|v| v.metadata.clone())
-            .collect()
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
@@ -450,19 +435,16 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
                 .active_validators
                 .iter()
                 .map(|validator| {
-                    let metadata = validator
-                        .metadata
-                        .verify()
-                        .expect("Validator metadata must have been verified on-chain");
+                    let metadata = validator.verified_metadata();
                     EpochStartValidatorInfo {
                         sui_address: metadata.sui_address,
-                        protocol_pubkey: metadata.protocol_pubkey,
-                        narwhal_network_pubkey: metadata.network_pubkey,
-                        narwhal_worker_pubkey: metadata.worker_pubkey,
-                        sui_net_address: metadata.net_address,
-                        p2p_address: metadata.p2p_address,
-                        narwhal_primary_address: metadata.primary_address,
-                        narwhal_worker_address: metadata.worker_address,
+                        protocol_pubkey: metadata.protocol_pubkey.clone(),
+                        narwhal_network_pubkey: metadata.network_pubkey.clone(),
+                        narwhal_worker_pubkey: metadata.worker_pubkey.clone(),
+                        sui_net_address: metadata.net_address.clone(),
+                        p2p_address: metadata.p2p_address.clone(),
+                        narwhal_primary_address: metadata.primary_address.clone(),
+                        narwhal_worker_address: metadata.worker_address.clone(),
                         voting_power: validator.voting_power,
                     }
                 })


### PR DESCRIPTION
This PR embeds verified validator metadata in Validator data structure. This allows us to avoid re-verifying each time accessing it. It also consolidates all verifications in one place and we no longer have one-off checks in different places.