### PR TITLE
[ts-sdk][bcs] Support resizing bcs buffer

### DIFF
--- a/sdk/bcs/tests/bcs.test.ts
+++ b/sdk/bcs/tests/bcs.test.ts
@@ -126,6 +126,46 @@ describe("BCS: Primitives", () => {
     expect(data.kitties).toHaveLength(2);
     expect(data.owner).toEqual("00000000000000000000000000c0ffee");
   });
+
+  it("should support growing size", () => {
+    const bcs = new BCS(getSuiMoveConfig());
+
+    bcs.registerStructType("Coin", {
+      value: BCS.U64,
+      owner: BCS.STRING,
+      is_locked: BCS.BOOL,
+    });
+
+    const rustBcs = "gNGxBWAAAAAOQmlnIFdhbGxldCBHdXkA";
+    const expected = {
+      owner: "Big Wallet Guy",
+      value: 412412400000n,
+      is_locked: false,
+    };
+
+    const setBytes = bcs.ser("Coin", expected, { size: 1, maxSize: 1024 });
+
+    expect(bcs.de("Coin", fromB64(rustBcs))).toEqual(expected);
+    expect(setBytes.toString("base64")).toEqual(rustBcs);
+  });
+
+  it("should error when attempting to grow beyond the allowed size", () => {
+    const bcs = new BCS(getSuiMoveConfig());
+
+    bcs.registerStructType("Coin", {
+      value: BCS.U64,
+      owner: BCS.STRING,
+      is_locked: BCS.BOOL,
+    });
+
+    const expected = {
+      owner: "Big Wallet Guy",
+      value: 412412400000n,
+      is_locked: false,
+    };
+
+    expect(() => bcs.ser("Coin", expected, { size: 1 })).toThrowError();
+  });
 });
 
 // @ts-ignore

--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -233,11 +233,8 @@ export class Transaction {
   /** Build the transaction to BCS bytes. */
   async build({
     provider,
-    // TODO: derive the buffer size automatically
-    size = 8192,
   }: {
     provider?: Provider;
-    size?: number;
   } = {}): Promise<Uint8Array> {
     if (!this.#transactionData.sender) {
       throw new Error('Missing transaction sender');
@@ -465,6 +462,6 @@ export class Transaction {
       }
     }
 
-    return this.#transactionData.build({ size });
+    return this.#transactionData.build();
   }
 }

--- a/sdk/typescript/src/builder/TransactionData.ts
+++ b/sdk/typescript/src/builder/TransactionData.ts
@@ -67,6 +67,8 @@ function prepareSuiAddress(address: string) {
   return normalizeSuiAddress(address).replace('0x', '');
 }
 
+const TRANSACTION_DATA_MAX_SIZE = 64 * 1024;
+
 export class TransactionDataBuilder {
   static fromBytes(bytes: Uint8Array) {
     const data = builder.de('TransactionData', bytes);
@@ -116,7 +118,7 @@ export class TransactionDataBuilder {
     this.commands = clone?.commands ?? [];
   }
 
-  build({ size }: { size?: number } = {}) {
+  build() {
     if (!this.gasConfig.budget) {
       throw new Error('Missing gas budget');
     }
@@ -159,7 +161,11 @@ export class TransactionDataBuilder {
     };
 
     return builder
-      .ser('TransactionData', { V1: transactionData }, size)
+      .ser(
+        'TransactionData',
+        { V1: transactionData },
+        { maxSize: TRANSACTION_DATA_MAX_SIZE },
+      )
       .toBytes();
   }
 

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -378,7 +378,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
   ): Promise<Uint8Array> {
     const bcs = bcsForVersion(await this.provider.getRpcApiVersion());
     let txBcs = prepareTxDataForBcs(tx);
-    const dataBytes = bcs.ser('TransactionData', txBcs, size).toBytes();
+    const dataBytes = bcs.ser('TransactionData', txBcs, { size }).toBytes();
     return dataBytes;
   }
 
@@ -391,7 +391,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     size: number = 8192,
   ): Promise<Uint8Array> {
     const bcs = bcsForVersion(await this.provider.getRpcApiVersion());
-    const dataBytes = bcs.ser('TransactionKind', tx, size).toBytes();
+    const dataBytes = bcs.ser('TransactionKind', tx, { size }).toBytes();
     return dataBytes;
   }
 


### PR DESCRIPTION
## Description 

This adds some configuration to the BCS buffer creation that allows it to be dynamically resized when the size limit is reached. This should let us avoid over-allocating buffers upfront, and also allows the buffer size to grow up to the max transaction data size.

## Test Plan 

Added new test cases.