### PR TITLE
[RPC][cleanup] remove old executeTransaction endpoints

### DIFF
--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -30,31 +30,11 @@ impl WriteApiServer for WriteApi {
     async fn execute_transaction(
         &self,
         tx_bytes: Base64,
-        signature: Base64,
-        request_type: ExecuteTransactionRequestType,
-    ) -> RpcResult<SuiTransactionResponse> {
-        self.submit_transaction(tx_bytes, vec![signature], request_type)
-            .await
-    }
-
-    async fn execute_transaction_serialized_sig(
-        &self,
-        tx_bytes: Base64,
-        signature: Base64,
-        request_type: ExecuteTransactionRequestType,
-    ) -> RpcResult<SuiTransactionResponse> {
-        self.execute_transaction(tx_bytes, signature, request_type)
-            .await
-    }
-
-    async fn submit_transaction(
-        &self,
-        tx_bytes: Base64,
         signatures: Vec<Base64>,
         request_type: ExecuteTransactionRequestType,
     ) -> RpcResult<SuiTransactionResponse> {
         self.fullnode
-            .submit_transaction(tx_bytes, signatures, request_type)
+            .execute_transaction(tx_bytes, signatures, request_type)
             .await
     }
 

--- a/crates/sui-json-rpc/src/api/write.rs
+++ b/crates/sui-json-rpc/src/api/write.rs
@@ -22,32 +22,8 @@ pub trait WriteApi {
     ///     makes sure this node is aware of this transaction when client fires subsequent queries.
     ///     However if the node fails to execute the transaction locally in a timely manner,
     ///     a bool type in the response is set to false to indicated the case.
-    // TODO(joyqvq): remove this and rename executeTransactionSerializedSig to executeTransaction
     #[method(name = "executeTransaction", deprecated)]
     async fn execute_transaction(
-        &self,
-        /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
-        tx_bytes: Base64,
-        /// `flag || signature || pubkey` bytes, as base-64 encoded string, signature is committed to the intent message of the transaction data, as base-64 encoded string.
-        signature: Base64,
-        /// The request type
-        request_type: ExecuteTransactionRequestType,
-    ) -> RpcResult<SuiTransactionResponse>;
-
-    #[method(name = "executeTransactionSerializedSig", deprecated)]
-    async fn execute_transaction_serialized_sig(
-        &self,
-        /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
-        tx_bytes: Base64,
-        /// `flag || signature || pubkey` bytes, as base-64 encoded string, signature is committed to the intent message of the transaction data, as base-64 encoded string.
-        signature: Base64,
-        /// The request type
-        request_type: ExecuteTransactionRequestType,
-    ) -> RpcResult<SuiTransactionResponse>;
-
-    // TODO: migrate above two rpc calls to this one eventually.
-    #[method(name = "submitTransaction")]
-    async fn submit_transaction(
         &self,
         /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
         tx_bytes: Base64,

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -49,27 +49,6 @@ impl WriteApiServer for TransactionExecutionApi {
     async fn execute_transaction(
         &self,
         tx_bytes: Base64,
-        signature: Base64,
-        request_type: ExecuteTransactionRequestType,
-    ) -> RpcResult<SuiTransactionResponse> {
-        self.submit_transaction(tx_bytes, vec![signature], request_type)
-            .await
-    }
-
-    // TODO: remove this or execute_transaction
-    async fn execute_transaction_serialized_sig(
-        &self,
-        tx_bytes: Base64,
-        signature: Base64,
-        request_type: ExecuteTransactionRequestType,
-    ) -> RpcResult<SuiTransactionResponse> {
-        self.execute_transaction(tx_bytes, signature, request_type)
-            .await
-    }
-
-    async fn submit_transaction(
-        &self,
-        tx_bytes: Base64,
         signatures: Vec<Base64>,
         request_type: ExecuteTransactionRequestType,
     ) -> RpcResult<SuiTransactionResponse> {

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -83,7 +83,7 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let dryrun_response = http_client.dry_run_transaction(tx_bytes).await?;
 
     let tx_response: SuiTransactionResponse = http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes1,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -134,7 +134,7 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -184,7 +184,7 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -243,7 +243,7 @@ async fn test_tbls_sign_randomness_object() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForEffectsCert,
@@ -278,7 +278,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -329,7 +329,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -441,7 +441,7 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -498,7 +498,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -573,7 +573,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -613,7 +613,7 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
         let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
         let response = http_client
-            .submit_transaction(
+            .execute_transaction(
                 tx_bytes,
                 signatures,
                 ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -977,7 +977,7 @@ async fn test_locked_sui() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -1035,7 +1035,7 @@ async fn test_delegation() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -1097,7 +1097,7 @@ async fn test_delegation_multiple_coins() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -1164,7 +1164,7 @@ async fn test_delegation_with_locked_sui() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -1198,7 +1198,7 @@ async fn test_delegation_with_locked_sui() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .submit_transaction(
+        .execute_transaction(
             tx_bytes,
             signatures,
             ExecuteTransactionRequestType::WaitForLocalExecution,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -249,11 +249,14 @@
           }
         },
         {
-          "name": "signature",
-          "description": "`flag || signature || pubkey` bytes, as base-64 encoded string, signature is committed to the intent message of the transaction data, as base-64 encoded string.",
+          "name": "signatures",
+          "description": "A list of signatures (`flag || signature || pubkey` bytes, as base-64 encoded string). Signature is committed to the intent message of the transaction data, as base-64 encoded string.",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/Base64"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Base64"
+            }
           }
         },
         {
@@ -274,15 +277,17 @@
       },
       "examples": [
         {
-          "name": "Execute an transaction with serialized signature",
+          "name": "Execute an transaction with serialized signatures",
           "params": [
             {
               "name": "tx_bytes",
               "value": "AAAKAgAg4fwXyBRwidxDGP3UANtnNk7zUMlSZ22FfcN/rn2TKYoBABJFwxtCBojBaGy00TVtFxgN2C6TpIPFq18BopiHodleAgAAAAAAAAAgVX3EKq7+64wVTX3cRWuK6qMTLHQDUx3JjoP24ZjS19EBAQEBAQABAAC2xC++ge7BYDahHiEkB6jbUsPeeFhbABa7s2QFdd6jvgFbVIthbaY7DOB9gW6J73uaOCF3tEIruqJ/fmJeoxmqCgIAAAAAAAAAIBhIZm/+0ika4ko/gXc1OgUiDXZcqcQho2gIPxj+Ry85tsQvvoHuwWA2oR4hJAeo21LD3nhYWwAWu7NkBXXeo74BAAAAAAAAAOgDAAAAAAAAAA=="
             },
             {
-              "name": "signature",
-              "value": "ABJgjRjAVl+CNx9WAq5c3dBdHw925j16zeaVsEqcO0JyEAD0KdY/HaDioE5q0r37hUit96WBHnKw0Vv4A8HmKAslVGRdA7hw4S62EKbvrTzoAfsk9oO2PfKUXStkY7jELA=="
+              "name": "signatures",
+              "value": [
+                "ABJgjRjAVl+CNx9WAq5c3dBdHw925j16zeaVsEqcO0JyEAD0KdY/HaDioE5q0r37hUit96WBHnKw0Vv4A8HmKAslVGRdA7hw4S62EKbvrTzoAfsk9oO2PfKUXStkY7jELA=="
+              ]
             },
             {
               "name": "request_type",
@@ -403,48 +408,6 @@
           }
         }
       ],
-      "deprecated": true
-    },
-    {
-      "name": "sui_executeTransactionSerializedSig",
-      "tags": [
-        {
-          "name": "Write API"
-        }
-      ],
-      "params": [
-        {
-          "name": "tx_bytes",
-          "description": "BCS serialized transaction data bytes without its type tag, as base-64 encoded string.",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/Base64"
-          }
-        },
-        {
-          "name": "signature",
-          "description": "`flag || signature || pubkey` bytes, as base-64 encoded string, signature is committed to the intent message of the transaction data, as base-64 encoded string.",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/Base64"
-          }
-        },
-        {
-          "name": "request_type",
-          "description": "The request type",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/ExecuteTransactionRequestType"
-          }
-        }
-      ],
-      "result": {
-        "name": "SuiTransactionResponse",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/TransactionResponse"
-        }
-      },
       "deprecated": true
     },
     {
@@ -590,9 +553,9 @@
             "value": {
               "epoch": 5000,
               "sequenceNumber": 1000,
-              "digest": "88sbZ6JronTqbQUL25HUPouw9wJJRiSKtUjry81YgPDS",
+              "digest": "GfwJqw63FK6AVQnKKkQprvrk3cVLziMBqhMfNkDuCHj9",
               "networkTotalTransactions": 792385,
-              "previousDigest": "3yndxsmJNXFrRAUnuqKT6aekThhqmSDJ46opD7UjtL9N",
+              "previousDigest": "EnRQXe1hDGAJCFyF2ds2GmPHdvf9V6yxf24LisEsDkYt",
               "epochRollingGasCostSummary": {
                 "computation_cost": 0,
                 "storage_cost": 0,
@@ -601,7 +564,7 @@
               "timestampMs": 1676911928,
               "endOfEpochData": null,
               "transactions": [
-                "BhbWpBeESxuRWvmvLMyb2JNUuFa6j4aG1T4WUiPgKAHm"
+                "Cv7n2YaM7Am1ssZGu4khsFkcKHnpgVhwFCSs4kLjrtLW"
               ],
               "checkpointCommitments": []
             }
@@ -2418,183 +2381,6 @@
           "$ref": "#/components/schemas/TransactionBytes"
         }
       }
-    },
-    {
-      "name": "sui_submitTransaction",
-      "tags": [
-        {
-          "name": "Write API"
-        }
-      ],
-      "params": [
-        {
-          "name": "tx_bytes",
-          "description": "BCS serialized transaction data bytes without its type tag, as base-64 encoded string.",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/Base64"
-          }
-        },
-        {
-          "name": "signatures",
-          "description": "A list of signatures (`flag || signature || pubkey` bytes, as base-64 encoded string). Signature is committed to the intent message of the transaction data, as base-64 encoded string.",
-          "required": true,
-          "schema": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Base64"
-            }
-          }
-        },
-        {
-          "name": "request_type",
-          "description": "The request type",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/ExecuteTransactionRequestType"
-          }
-        }
-      ],
-      "result": {
-        "name": "SuiTransactionResponse",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/TransactionResponse"
-        }
-      },
-      "examples": [
-        {
-          "name": "Execute an transaction with serialized signature",
-          "params": [
-            {
-              "name": "tx_bytes",
-              "value": "AAAKAgAgo9vZKoPvJtEouI/ma/JuDg0Jza9yfR2EzMqpegLMOpgBAAQWcOFgnbcU6YWMlunkaYVfHPO/35foZbEMAEbik8CMAgAAAAAAAAAgMvS/bD6KxC7vE4XgFAPkmkspatyyLqJ9PJLkziJWrGQBAQEBAQABAACPLqvygft/cUSQXoDZoUEqKxN7oOKTKRGEbKUUTLt7wwHsD0B4PZrEv0q7TX+CBkf9hdGRg97nx/+VVpf+K3BMlQIAAAAAAAAAIECjhG6SmLddtyXB7jAnt4PqaJ4aOOtHbG78RO21zT3+jy6r8oH7f3FEkF6A2aFBKisTe6DikykRhGylFEy7e8MBAAAAAAAAAOgDAAAAAAAAAA=="
-            },
-            {
-              "name": "signatures",
-              "value": [
-                "ABUEpVIlKSxoeP9rAoSiIQPXAkxE1+qKl8pb5hIc2X+M7mduBamfU58wMyGHt6L4iwpH3uqL+00c39MYGdlroQ3tuQRDnGhz4Cc2ybUGiC/e91XHYD8RKnE9a3Rnk6fI0g=="
-              ]
-            },
-            {
-              "name": "request_type",
-              "value": "WaitForLocalExecution"
-            }
-          ],
-          "result": {
-            "name": "Result",
-            "value": {
-              "digest": "7DLsgW7cpwga58b8jHPFSR2j7eXx4y7eBdvSd36y3YoQ",
-              "transaction": {
-                "data": {
-                  "messageVersion": "v1",
-                  "transactions": [
-                    {
-                      "kind": "ProgrammableTransaction",
-                      "inputs": [
-                        "0xa3dbd92a83ef26d128b88fe66bf26e0e0d09cdaf727d1d84cccaa97a02cc3a98",
-                        "041670e1609db714e9858c96e9e469855f1cf3bfdf97e865b10c0046e293c08c"
-                      ],
-                      "commands": [
-                        {
-                          "TransferObjects": [
-                            [
-                              {
-                                "Input": 1
-                              }
-                            ],
-                            {
-                              "Input": 0
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "sender": "0x8f2eabf281fb7f7144905e80d9a1412a2b137ba0e2932911846ca5144cbb7bc3",
-                  "gasData": {
-                    "payment": [
-                      {
-                        "objectId": "0xec0f40783d9ac4bf4abb4d7f820647fd85d19183dee7c7ff955697fe2b704c95",
-                        "version": 2,
-                        "digest": "5MKi5NebY3q1VSz5G75bfLTbHRTVyVV64rBB7ufriYBf"
-                      }
-                    ],
-                    "owner": "0x8f2eabf281fb7f7144905e80d9a1412a2b137ba0e2932911846ca5144cbb7bc3",
-                    "price": 1,
-                    "budget": 1000
-                  }
-                },
-                "txSignatures": [
-                  "ABUEpVIlKSxoeP9rAoSiIQPXAkxE1+qKl8pb5hIc2X+M7mduBamfU58wMyGHt6L4iwpH3uqL+00c39MYGdlroQ3tuQRDnGhz4Cc2ybUGiC/e91XHYD8RKnE9a3Rnk6fI0g=="
-                ]
-              },
-              "effects": {
-                "messageVersion": "v1",
-                "status": {
-                  "status": "success"
-                },
-                "executedEpoch": 0,
-                "gasUsed": {
-                  "computationCost": 100,
-                  "storageCost": 100,
-                  "storageRebate": 10
-                },
-                "transactionDigest": "7EyfTiUYik55JWka5aGUkSFMCQeLzGnUM7wT8AYMh71b",
-                "mutated": [
-                  {
-                    "owner": {
-                      "AddressOwner": "0x8f2eabf281fb7f7144905e80d9a1412a2b137ba0e2932911846ca5144cbb7bc3"
-                    },
-                    "reference": {
-                      "objectId": "0xec0f40783d9ac4bf4abb4d7f820647fd85d19183dee7c7ff955697fe2b704c95",
-                      "version": 2,
-                      "digest": "5MKi5NebY3q1VSz5G75bfLTbHRTVyVV64rBB7ufriYBf"
-                    }
-                  },
-                  {
-                    "owner": {
-                      "AddressOwner": "0xa3dbd92a83ef26d128b88fe66bf26e0e0d09cdaf727d1d84cccaa97a02cc3a98"
-                    },
-                    "reference": {
-                      "objectId": "0x041670e1609db714e9858c96e9e469855f1cf3bfdf97e865b10c0046e293c08c",
-                      "version": 2,
-                      "digest": "4RuqnEzNdF4nKWjW1MhnKQ1E6sijZvSM5dUNgiPmjme3"
-                    }
-                  }
-                ],
-                "gasObject": {
-                  "owner": {
-                    "ObjectOwner": "0x8f2eabf281fb7f7144905e80d9a1412a2b137ba0e2932911846ca5144cbb7bc3"
-                  },
-                  "reference": {
-                    "objectId": "0xec0f40783d9ac4bf4abb4d7f820647fd85d19183dee7c7ff955697fe2b704c95",
-                    "version": 2,
-                    "digest": "5MKi5NebY3q1VSz5G75bfLTbHRTVyVV64rBB7ufriYBf"
-                  }
-                },
-                "eventsDigest": "7z6qPvSvB629YJdVvCxF4nG35Lm1CQeFeU9GSMMc6wFr"
-              },
-              "events": [
-                {
-                  "type": "transferObject",
-                  "content": {
-                    "packageId": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                    "transactionModule": "native",
-                    "sender": "0x8f2eabf281fb7f7144905e80d9a1412a2b137ba0e2932911846ca5144cbb7bc3",
-                    "recipient": {
-                      "AddressOwner": "0xa3dbd92a83ef26d128b88fe66bf26e0e0d09cdaf727d1d84cccaa97a02cc3a98"
-                    },
-                    "objectType": "0x2::example::Object",
-                    "objectId": "0x041670e1609db714e9858c96e9e469855f1cf3bfdf97e865b10c0046e293c08c",
-                    "version": 2
-                  }
-                }
-              ]
-            }
-          }
-        }
-      ]
     },
     {
       "name": "sui_subscribeEvent",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -78,7 +78,6 @@ impl RpcExampleProvider {
             self.get_transactions(),
             self.get_events(),
             self.execute_transaction_example(),
-            self.submit_transaction_example(),
             self.get_checkpoint_example(),
         ]
         .into_iter()
@@ -159,14 +158,14 @@ impl RpcExampleProvider {
         )
     }
 
-    fn submit_transaction_example(&mut self) -> Examples {
+    fn execute_transaction_example(&mut self) -> Examples {
         let (data, signatures, _, _, result, _) = self.get_transfer_data_response();
         let tx_bytes = TransactionBytes::from_data(data).unwrap();
 
         Examples::new(
-            "sui_submitTransaction",
+            "sui_executeTransaction",
             vec![ExamplePairing::new(
-                "Execute an transaction with serialized signature",
+                "Execute an transaction with serialized signatures",
                 vec![
                     ("tx_bytes", json!(tx_bytes.tx_bytes)),
                     (
@@ -176,27 +175,6 @@ impl RpcExampleProvider {
                             .map(|sig| sig.encode_base64())
                             .collect::<Vec<_>>()),
                     ),
-                    (
-                        "request_type",
-                        json!(ExecuteTransactionRequestType::WaitForLocalExecution),
-                    ),
-                ],
-                json!(result),
-            )],
-        )
-    }
-
-    fn execute_transaction_example(&mut self) -> Examples {
-        let (data, signatures, _, _, result, _) = self.get_transfer_data_response();
-        let tx_bytes = TransactionBytes::from_data(data).unwrap();
-
-        Examples::new(
-            "sui_executeTransaction",
-            vec![ExamplePairing::new(
-                "Execute an transaction with serialized signature",
-                vec![
-                    ("tx_bytes", json!(tx_bytes.tx_bytes)),
-                    ("signature", json!(signatures[0].encode_base64())),
                     (
                         "request_type",
                         json!(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -421,7 +421,7 @@ impl QuorumDriver {
         let mut response: SuiTransactionResponse = self
             .api
             .http
-            .submit_transaction(tx_bytes, signatures, request_type.clone())
+            .execute_transaction(tx_bytes, signatures, request_type.clone())
             .await?;
 
         Ok(match request_type {

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -1000,7 +1000,7 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
             ExecuteTransactionRequestType::WaitForLocalExecution
         ];
         let response: SuiTransactionResponse = jsonrpc_client
-            .request("sui_submitTransaction", params)
+            .request("sui_executeTransaction", params)
             .await
             .unwrap();
 
@@ -1040,7 +1040,7 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
         ExecuteTransactionRequestType::WaitForLocalExecution
     ];
     let response: SuiTransactionResponse = jsonrpc_client
-        .request("sui_submitTransaction", params)
+        .request("sui_executeTransaction", params)
         .await
         .unwrap();
 
@@ -1065,7 +1065,7 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
         ExecuteTransactionRequestType::WaitForEffectsCert
     ];
     let response: SuiTransactionResponse = jsonrpc_client
-        .request("sui_submitTransaction", params)
+        .request("sui_executeTransaction", params)
         .await
         .unwrap();
 

--- a/sdk/typescript/src/cryptography/signature.ts
+++ b/sdk/typescript/src/cryptography/signature.ts
@@ -22,6 +22,10 @@ export type SignaturePubkeyPair = {
   pubKey: PublicKey;
 };
 
+/**
+ * (`flag || signature || pubkey` bytes, as base-64 encoded string).
+ * Signature is committed to the intent message of the transaction data, as base-64 encoded string.
+ */
 export type SerializedSignature = string;
 
 export const SIGNATURE_SCHEME_TO_FLAG = {

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -672,15 +672,15 @@ export class JsonRpcProvider extends Provider {
 
   async executeTransaction(
     txnBytes: Uint8Array | string,
-    signature: SerializedSignature,
+    signature: SerializedSignature | SerializedSignature[],
     requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert',
   ): Promise<SuiTransactionResponse> {
     try {
       return await this.client.requestWithType(
-        'sui_executeTransactionSerializedSig',
+        'sui_executeTransaction',
         [
           typeof txnBytes === 'string' ? txnBytes : toB64(txnBytes),
-          signature,
+          Array.isArray(signature) ? signature : [signature],
           requestType,
         ],
         SuiTransactionResponse,

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -226,13 +226,14 @@ export abstract class Provider {
   abstract getTotalTransactionNumber(): Promise<number>;
 
   /**
-   * This is under development endpoint on Fullnode that will eventually
-   * replace the other `executeTransaction` that's only available on the
-   * Gateway
+   * Submit the transaction to fullnode for execution
+   * @param txnBytes BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
+   * @param signature A single signature or list of signatures(used for sponsored transactions)
+   * @param requestType WaitForEffectsCert or WaitForLocalExecution, see details in `ExecuteTransactionRequestType`
    */
   abstract executeTransaction(
     txnBytes: Uint8Array | string,
-    signature: SerializedSignature,
+    signature: SerializedSignature | SerializedSignature[],
     requestType: ExecuteTransactionRequestType,
   ): Promise<SuiTransactionResponse>;
 

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -157,7 +157,7 @@ export class VoidProvider extends Provider {
 
   async executeTransaction(
     _txnBytes: Uint8Array,
-    _signature: SerializedSignature,
+    _signature: SerializedSignature | SerializedSignature[],
     _requestType: ExecuteTransactionRequestType,
   ): Promise<SuiTransactionResponse> {
     throw this.newError('executeTransaction with request Type');

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -120,6 +120,15 @@ export const ProgrammableTransaction = object({
 });
 export type ProgrammableTransaction = Infer<typeof ProgrammableTransaction>;
 
+/**
+ * 1. WaitForEffectsCert: waits for TransactionEffectsCert and then returns to the client.
+ *    This mode is a proxy for transaction finality.
+ * 2. WaitForLocalExecution: waits for TransactionEffectsCert and makes sure the node
+ *    executed the transaction locally before returning to the client. The local execution
+ *    makes sure this node is aware of this transaction when the client fires subsequent queries.
+ *    However, if the node fails to execute the transaction locally in a timely manner,
+ *    a bool type in the response is set to false to indicate the case.
+ */
 export type ExecuteTransactionRequestType =
   | 'WaitForEffectsCert'
   | 'WaitForLocalExecution';


### PR DESCRIPTION
## Description 

I am doing this cleanup now because it would make the refactoring of adding `SuiTransactionResponseOptions` easier

- remove `sui_executeTransactionSerializedSig` and `sui_submitTransaction`
- `sui_executeTransaction` now takes in a vector of signatures

I decide to keep `sui_executeTransaction` instead of `sui_submitTransaction` because we use `executeTransaction` extensively on the client side and it's more intuitive.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- remove `sui_executeTransactionSerializedSig` and `sui_submitTransaction`
- `sui_executeTransaction` now takes in a vec of signatures
