### PR TITLE
record executing cert when enqueuing a ready cert

### DIFF
--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -214,6 +214,9 @@ impl TransactionManager {
                     .transaction_manager_num_enqueued_certificates
                     .with_label_values(&["ready"])
                     .inc();
+                // Record as an executing certificate.
+                assert!(inner.executing_certificates.insert(digest));
+                // Send to execution driver for execution.
                 self.certificate_ready(pending_cert.certificate);
                 continue;
             }


### PR DESCRIPTION
## Description 

We should record the certificate in the `executing_certificate` table whenever we send it to execution driver.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
