### PR TITLE
[rust-sdk] remove deprecated SuiClient::new

### DIFF
--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -164,6 +164,7 @@ impl SuiClientBuilder {
     }
 }
 
+/// Use [SuiClientBuilder] to build a SuiClient
 #[derive(Clone)]
 pub struct SuiClient {
     api: Arc<RpcClient>,
@@ -198,22 +199,6 @@ struct ServerInfo {
 }
 
 impl SuiClient {
-    #[deprecated(since = "0.23.0", note = "Please use `SuiClientBuilder` instead.")]
-    pub async fn new(
-        http_url: &str,
-        ws_url: Option<&str>,
-        request_timeout: Option<Duration>,
-    ) -> Result<Self, Error> {
-        let mut builder = SuiClientBuilder::default();
-        if let Some(ws_url) = ws_url {
-            builder = builder.ws_url(ws_url);
-        }
-        if let Some(request_timeout) = request_timeout {
-            builder = builder.request_timeout(request_timeout);
-        }
-        builder.build(http_url).await
-    }
-
     pub fn available_rpc_methods(&self) -> &Vec<String> {
         &self.api.info.rpc_methods
     }

--- a/doc/src/build/rust-sdk.md
+++ b/doc/src/build/rust-sdk.md
@@ -39,11 +39,13 @@ This will print a list of object summaries owned by the address `"0xec11cad080d0
 ```rust
 use std::str::FromStr;
 use sui_sdk::types::base_types::SuiAddress;
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SuiClientBuilder};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", None, None).await?;
+    let sui = SuiClientBuilder::default().build(
+      "https://fullnode.devnet.sui.io:443",
+    ).await.unwrap();
     let address = SuiAddress::from_str("0xec11cad080d0496a53bafcea629fcbcfff2a9866")?;
     let objects = sui.read_api().get_objects_owned_by_address(address).await?;
     println!("{:?}", objects);
@@ -67,11 +69,14 @@ use sui_sdk::{
         messages::Transaction,
     },
     SuiClient,
+    SuiClientBuilder,
 };
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", None, None).await?;
+    let sui = SuiClientBuilder::default().build(
+      "https://fullnode.devnet.sui.io:443",
+    ).await.unwrap();
     // Load keystore from ~/.sui/sui_config/sui.keystore
     let keystore_path = match dirs::home_dir() {
         Some(v) => v.join(".sui").join("sui_config").join("sui.keystore"),
@@ -110,11 +115,13 @@ Use the WebSocket client to [subscribe to events](event_api.md#subscribe-to-sui-
 ```rust
 use futures::StreamExt;
 use sui_sdk::rpc_types::SuiEventFilter;
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SuiClientBuilder};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", Some("ws://127.0.0.1:9001"), None).await?;
+    let sui = SuiClientBuilder::default().build(
+      "https://fullnode.devnet.sui.io:443",
+    ).await.unwrap();
     let mut subscribe_all = sui.event_api().subscribe_event(SuiEventFilter::All(vec![])).await?;
     loop {
         println!("{:?}", subscribe_all.next().await);

--- a/doc/src/learn/exchange-integration-guide.md
+++ b/doc/src/learn/exchange-integration-guide.md
@@ -137,12 +137,14 @@ The following example demonstrates using sui_getBalance in Rust:
 ```rust
 use std::str::FromStr;
 use sui_sdk::types::base_types::SuiAddress;
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SuiClientBuilder};
 
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-   let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", None, None).await?;
+   let sui = SuiClientBuilder::default().build(
+      "https://fullnode.devnet.sui.io:443",
+   ).await.unwrap();
    let address = SuiAddress::from_str("0xa38bc2aa63c34e37821f7abb34dbbe97b7ab2ea2")?;
    let objects = sui.read_api().get_balance(address).await?;
    println!("{:?}", objects);


### PR DESCRIPTION
## Description 

Remove this since it had been marked as deprecated for a while

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
