### PR TITLE
[programmable transactions][dev inspect] Fix DevInspect GasCoin and unused value checks

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -379,7 +379,7 @@ where
     }
 
     /// Determine the object changes and collect all user events
-    pub fn finish(self) -> Result<ExecutionResults, ExecutionError> {
+    pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
         use sui_types::error::convert_vm_error;
         let Self {
             protocol_config,
@@ -436,6 +436,8 @@ where
                 } = result_value;
                 match value {
                     None => (),
+                    // disable this check for dev inspect
+                    Some(_) if Mode::allow_arbitrary_values() => (),
                     Some(Value::Object(_)) => {
                         return Err(ExecutionErrorKind::UnusedValueWithoutDrop {
                             result_idx: i as u16,

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -428,43 +428,44 @@ where
             add_input_object_write(input)
         }
         // check for unused values
-        for (i, command_result) in results.iter().enumerate() {
-            for (j, result_value) in command_result.iter().enumerate() {
-                let ResultValue {
-                    last_usage_kind,
-                    value,
-                } = result_value;
-                match value {
-                    None => (),
-                    // disable this check for dev inspect
-                    Some(_) if Mode::allow_arbitrary_values() => (),
-                    Some(Value::Object(_)) => {
-                        return Err(ExecutionErrorKind::UnusedValueWithoutDrop {
-                            result_idx: i as u16,
-                            secondary_idx: j as u16,
+        // disable this check for dev inspect
+        if !Mode::allow_arbitrary_values() {
+            for (i, command_result) in results.iter().enumerate() {
+                for (j, result_value) in command_result.iter().enumerate() {
+                    let ResultValue {
+                        last_usage_kind,
+                        value,
+                    } = result_value;
+                    match value {
+                        None => (),
+                        Some(Value::Object(_)) => {
+                            return Err(ExecutionErrorKind::UnusedValueWithoutDrop {
+                                result_idx: i as u16,
+                                secondary_idx: j as u16,
+                            }
+                            .into())
                         }
-                        .into())
-                    }
-                    Some(Value::Raw(RawValueType::Any, _)) => (),
-                    Some(Value::Raw(RawValueType::Loaded { abilities, .. }, _)) => {
-                        // - nothing to check for drop
-                        // - if it does not have drop, but has copy,
-                        //   the last usage must be by value in order to "lie" and say that the
-                        //   last usage is actually a take instead of a clone
-                        // - Otherwise, an error
-                        if abilities.has_drop() {
-                        } else if abilities.has_copy()
-                            && !matches!(last_usage_kind, Some(UsageKind::ByValue))
-                        {
-                            let msg = "The value has copy, but not drop. \
+                        Some(Value::Raw(RawValueType::Any, _)) => (),
+                        Some(Value::Raw(RawValueType::Loaded { abilities, .. }, _)) => {
+                            // - nothing to check for drop
+                            // - if it does not have drop, but has copy,
+                            //   the last usage must be by value in order to "lie" and say that the
+                            //   last usage is actually a take instead of a clone
+                            // - Otherwise, an error
+                            if abilities.has_drop() {
+                            } else if abilities.has_copy()
+                                && !matches!(last_usage_kind, Some(UsageKind::ByValue))
+                            {
+                                let msg = "The value has copy, but not drop. \
                                 Its last usage must be by-value so it can be taken.";
-                            return Err(ExecutionError::new_with_source(
-                                ExecutionErrorKind::UnusedValueWithoutDrop {
-                                    result_idx: i as u16,
-                                    secondary_idx: j as u16,
-                                },
-                                msg,
-                            ));
+                                return Err(ExecutionError::new_with_source(
+                                    ExecutionErrorKind::UnusedValueWithoutDrop {
+                                        result_idx: i as u16,
+                                        secondary_idx: j as u16,
+                                    },
+                                    msg,
+                                ));
+                            }
                         }
                     }
                 }

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -79,7 +79,7 @@ pub fn execute<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     let ExecutionResults {
         object_changes,
         user_events,
-    } = context.finish()?;
+    } = context.finish::<Mode>()?;
     state_view.apply_object_changes(object_changes);
     for (module_id, tag, contents) in user_events {
         state_view.log_event(Event::move_event(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1095,8 +1095,9 @@ impl AuthorityState {
         let storage_gas_price = protocol_config.storage_gas_price();
 
         let gas_object_id = ObjectID::random();
+        // give the gas object 2x the max gas to have coin balance to play with during execution
         let gas_object = Object::new_move(
-            MoveObject::new_gas_coin(SequenceNumber::new(), gas_object_id, max_tx_gas),
+            MoveObject::new_gas_coin(SequenceNumber::new(), gas_object_id, max_tx_gas * 2),
             Owner::AddressOwner(sender),
             TransactionDigest::genesis(),
         );

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -833,7 +833,7 @@ async fn test_dev_inspect_gas_coin_argument() {
 fn check_coin_value(actual_value: &[u8], actual_type: &SuiTypeTag, expected_value: u64) {
     let actual_type: TypeTag = actual_type.clone().try_into().unwrap();
     assert_eq!(actual_type, TypeTag::Struct(Box::new(GasCoin::type_())));
-    let actual_coin: GasCoin = bcs::from_bytes(&actual_value).unwrap();
+    let actual_coin: GasCoin = bcs::from_bytes(actual_value).unwrap();
     assert_eq!(actual_coin.value(), expected_value);
 }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -33,9 +33,11 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use sui_json_rpc_types::{
-    SuiExecutionResult, SuiExecutionStatus, SuiGasCostSummary, SuiTransactionEffectsAPI,
+    SuiArgument, SuiExecutionResult, SuiExecutionStatus, SuiGasCostSummary,
+    SuiTransactionEffectsAPI, SuiTypeTag,
 };
 use sui_types::error::UserInputError;
+use sui_types::gas_coin::GasCoin;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::{
     make_committee_key, mock_certified_checkpoint, to_sender_signed_transaction,
@@ -722,13 +724,40 @@ async fn test_dev_inspect_return_values() {
     let type_tag: TypeTag = return_type.try_into().unwrap();
     assert!(matches!(type_tag, TypeTag::U64));
 
-    // read two values from it's bytes
+    // An unused value without drop is an error normally
+    let effects = call_move_(
+        &validator,
+        Some(&fullnode),
+        &gas_object_id,
+        &sender,
+        &sender_key,
+        &object_basics.0,
+        "object_basics",
+        "wrap_object",
+        vec![],
+        vec![TestCallArg::Object(created_object_id)],
+        false,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        effects.status(),
+        &ExecutionStatus::Failure {
+            error: ExecutionFailureStatus::UnusedValueWithoutDrop {
+                result_idx: 0,
+                secondary_idx: 0,
+            },
+            command: None,
+        }
+    );
+
+    // An unused value without drop is not an error in dev inspect
     let DevInspectResults { results, .. } = call_dev_inspect(
         &fullnode,
         &sender,
         &object_basics.0,
         "object_basics",
-        "get_contents",
+        "wrap_object",
         vec![],
         vec![TestCallArg::Pure(created_object_bytes)],
     )
@@ -742,12 +771,70 @@ async fn test_dev_inspect_return_values() {
         mut return_values,
     } = exec_results;
     assert!(mutable_reference_outputs.is_empty());
-    assert_eq!(return_values.len(), 2);
-    let (return_value_2, _return_type) = return_values.pop().unwrap();
-    let (returned_id_bytes, _return_type) = return_values.pop().unwrap();
-    let returned_id: ObjectID = bcs::from_bytes(&returned_id_bytes).unwrap();
-    assert_eq!(return_value_1, return_value_2);
-    assert_eq!(created_object_id, returned_id);
+    assert_eq!(return_values.len(), 1);
+    let (_return_value, return_type) = return_values.pop().unwrap();
+    let expected_type = TypeTag::Struct(Box::new(StructTag {
+        address: object_basics.0.into(),
+        module: Identifier::new("object_basics").unwrap(),
+        name: Identifier::new("Wrapper").unwrap(),
+        type_params: vec![],
+    }));
+    let return_type: TypeTag = return_type.try_into().unwrap();
+    assert_eq!(return_type, expected_type);
+}
+
+#[tokio::test]
+async fn test_dev_inspect_gas_coin_argument() {
+    let (validator, fullnode, _object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![]).await;
+    let epoch_store = validator.epoch_store_for_testing();
+    let protocol_config = epoch_store.protocol_config();
+
+    let sender = SuiAddress::random_for_testing_only();
+    let recipient = SuiAddress::random_for_testing_only();
+    let amount = 500;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.pay_sui(vec![recipient], vec![amount]).unwrap();
+        builder.finish()
+    };
+    let kind = TransactionKind::programmable(pt);
+    let results = fullnode
+        .dev_inspect_transaction(sender, kind, Some(1))
+        .await
+        .unwrap()
+        .results
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    // Split results
+    let SuiExecutionResult {
+        mutable_reference_outputs,
+        return_values,
+    } = &results[0];
+    // check argument is the gas coin updated
+    assert_eq!(mutable_reference_outputs.len(), 1);
+    let (arg, arg_value, arg_type) = &mutable_reference_outputs[0];
+    assert_eq!(arg, &SuiArgument::GasCoin);
+    check_coin_value(arg_value, arg_type, protocol_config.max_tx_gas() - amount);
+
+    assert_eq!(return_values.len(), 1);
+    let (ret_value, ret_type) = &return_values[0];
+    check_coin_value(ret_value, ret_type, amount);
+
+    // Transfer results
+    let SuiExecutionResult {
+        mutable_reference_outputs,
+        return_values,
+    } = &results[1];
+    assert!(mutable_reference_outputs.is_empty());
+    assert!(return_values.is_empty());
+}
+
+fn check_coin_value(actual_value: &[u8], actual_type: &SuiTypeTag, expected_value: u64) {
+    let actual_type: TypeTag = actual_type.clone().try_into().unwrap();
+    assert_eq!(actual_type, TypeTag::Struct(Box::new(GasCoin::type_())));
+    let actual_coin: GasCoin = bcs::from_bytes(&actual_value).unwrap();
+    assert_eq!(actual_coin.value(), expected_value);
 }
 
 #[tokio::test]

--- a/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
+++ b/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
@@ -60,13 +60,17 @@ module examples::object_basics {
     }
 
     public entry fun wrap(o: Object, ctx: &mut TxContext) {
-        transfer::transfer(Wrapper { id: object::new(ctx), o }, tx_context::sender(ctx))
+        transfer::transfer(wrap_object(o, ctx), tx_context::sender(ctx))
     }
 
     public entry fun unwrap(w: Wrapper, ctx: &mut TxContext) {
         let Wrapper { id, o } = w;
         object::delete(id);
         transfer::transfer(o, tx_context::sender(ctx))
+    }
+
+    public fun wrap_object(o: Object, ctx: &mut TxContext): Wrapper {
+        Wrapper { id: object::new(ctx), o }
     }
 
     public entry fun add_ofield(o: &mut Object, v: Object) {


### PR DESCRIPTION
## Description 

- Removed check in DevInspect for unused values without drop
- Doubled gas coin value for DevInspect to allow for it to be used in the transaction

## Test Plan 

- New tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
