### PR TITLE
Revert "[Narwhal] accept certificates in detached tasks to avoid canc…

### DIFF
--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -736,35 +736,15 @@ impl PrimaryReceiverHandler {
         self.metrics
             .certificates_in_votes
             .inc_by(request.body().parents.len() as u64);
+        let wait_network = network.clone();
         let mut wait_notifications: FuturesUnordered<_> = request
             .body()
             .parents
             .clone()
             .into_iter()
             .map(|cert| {
-                let synchronizer = self.synchronizer.clone();
-                let wait_network = network.clone();
-                async move {
-                    // Finish accepting certificate regardless of client cancellation by spawning
-                    // another task.
-                    // TODO: add simtest for cancellations.
-                    let result = spawn_monitored_task!(
-                        synchronizer.try_accept_certificate(cert, &wait_network)
-                    )
-                    .await
-                    .map_err(|_| DagError::Canceled)?;
-                    match result {
-                        Err(DagError::Suspended(notify)) => {
-                            let notify = notify.lock().unwrap().take();
-                            notify
-                                .unwrap()
-                                .recv()
-                                .await
-                                .map_err(|_| DagError::ShuttingDown)
-                        }
-                        r => r,
-                    }
-                }
+                self.synchronizer
+                    .wait_to_accept_certificate(cert, &wait_network)
             })
             .collect();
         loop {
@@ -944,18 +924,11 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
                     "Unable to access network to send child RPCs".to_owned(),
                 )
             })?;
-        let synchronizer = self.synchronizer.clone();
         let certificate = request.into_body().certificate;
-        // Finish accepting certificate regardless of client cancellation by spawning another task.
-        // TODO: add simtest for cancellations.
-        let _ = spawn_monitored_task!(async move {
-            synchronizer
-                .try_accept_certificate(certificate, &network)
-                .await
-        })
-        .await
-        .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?
-        .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
+        self.synchronizer
+            .try_accept_certificate(certificate, &network)
+            .await
+            .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
         Ok(anemo::Response::new(SendCertificateResponse {}))
     }
 

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -369,6 +369,32 @@ impl Synchronizer {
             .await
     }
 
+    /// Validates the certificate and accepts it into the DAG, if the certificate can be verified
+    /// and has all parents in the certificate store.
+    /// If the certificate has missing parents, wait until all parents are available to accept the
+    /// certificate.
+    /// Otherwise returns an error.
+    pub async fn wait_to_accept_certificate(
+        &self,
+        certificate: Certificate,
+        network: &Network,
+    ) -> DagResult<()> {
+        match self
+            .process_certificate_internal(certificate, network, true, true)
+            .await
+        {
+            Err(DagError::Suspended(notify)) => {
+                let notify = notify.lock().unwrap().take();
+                notify
+                    .unwrap()
+                    .recv()
+                    .await
+                    .map_err(|_| DagError::ShuttingDown)
+            }
+            result => result,
+        }
+    }
+
     /// Accepts a certificate produced by this primary. This is not expected to fail unless
     /// the primary is shutting down.
     pub async fn accept_own_certificate(


### PR DESCRIPTION
…ellations"

This reverts commit f7e732a0c711feeae997c5ac287a6468889a65ea.

## Description 

This needs to be better tested to avoid task leaks.

## Test Plan 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
