### PR TITLE
wallet-ext: backup view hide mnemonic by default

### DIFF
--- a/apps/wallet/src/ui/app/components/HideShowDisplayBox.tsx
+++ b/apps/wallet/src/ui/app/components/HideShowDisplayBox.tsx
@@ -2,49 +2,98 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Copy16, EyeClose16, EyeOpen16 } from '@mysten/icons';
-import { useState } from 'react';
+import { cx } from 'class-variance-authority';
+import { useEffect, useState } from 'react';
 
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import { Link } from '../shared/Link';
 import { Text } from '../shared/text';
 
+const AUTO_HIDE_INTERVAL = 3 * 60 * 1000;
+
 export type HideShowDisplayBoxProps = {
-    value: string;
+    value: string | string[];
+    hideCopy?: boolean;
     copiedMessage?: string;
 };
 
 export function HideShowDisplayBox({
     value,
+    hideCopy = false,
     copiedMessage,
 }: HideShowDisplayBoxProps) {
     const [valueHidden, setValueHidden] = useState(true);
-    const copyCallback = useCopyToClipboard(value, {
-        copySuccessMessage: copiedMessage,
-    });
+    const copyCallback = useCopyToClipboard(
+        hideCopy ? '' : typeof value === 'string' ? value : value.join(' '),
+        {
+            copySuccessMessage: copiedMessage,
+        }
+    );
+    useEffect(() => {
+        const updateOnVisibilityChange = () => {
+            if (document.visibilityState === 'hidden') {
+                setValueHidden(true);
+            }
+        };
+        document.addEventListener('visibilitychange', updateOnVisibilityChange);
+        return () => {
+            document.removeEventListener(
+                'visibilitychange',
+                updateOnVisibilityChange
+            );
+        };
+    }, []);
+    useEffect(() => {
+        let timeout: number;
+        if (!valueHidden) {
+            timeout = window.setTimeout(() => {
+                setValueHidden(true);
+            }, AUTO_HIDE_INTERVAL);
+        }
+        return () => {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+        };
+    }, [valueHidden]);
     return (
         <div className="flex flex-col flex-nowrap items-stretch gap-2 bg-white border border-solid border-gray-60 rounded-lg overflow-hidden py-4 px-5">
-            <div className="break-all">
-                {valueHidden ? (
-                    <div className="flex flex-col gap-1.5">
-                        <div className="h-3.5 bg-gray-40 rounded-md" />
-                        <div className="h-3.5 bg-gray-40 rounded-md" />
-                        <div className="h-3.5 bg-gray-40 rounded-md w-1/2" />
+            <div className="break-all relative">
+                {valueHidden ? null : (
+                    <div className="absolute top-0">
+                        <Text variant="p1" weight="medium" color="steel-darker">
+                            {typeof value === 'string'
+                                ? value
+                                : value.map((aValue, index) => (
+                                      <span key={index}>
+                                          {(index > 0 ? ' ' : '') + aValue}
+                                      </span>
+                                  ))}
+                        </Text>
                     </div>
-                ) : (
-                    <Text variant="p1" weight="medium" color="steel-darker">
-                        {value}
-                    </Text>
                 )}
+                <div
+                    className={cx(
+                        'flex flex-col gap-1.5',
+                        valueHidden ? 'visible' : 'invisible'
+                    )}
+                >
+                    <div className="h-3.5 bg-gray-40 rounded-md" />
+                    <div className="h-3.5 bg-gray-40 rounded-md" />
+                    <div className="h-3.5 bg-gray-40 rounded-md w-1/2" />
+                </div>
             </div>
             <div className="flex flex-row flex-nowrap items-center justify-between">
                 <div>
-                    <Link
-                        color="heroDark"
-                        weight="medium"
-                        text="Copy"
-                        before={<Copy16 />}
-                        onClick={copyCallback}
-                    />
+                    {!hideCopy ? (
+                        <Link
+                            color="heroDark"
+                            weight="medium"
+                            text="Copy"
+                            before={<Copy16 />}
+                            onClick={copyCallback}
+                        />
+                    ) : null}
                 </div>
                 <div>
                     <Link

--- a/apps/wallet/src/ui/app/components/HideShowDisplayBox.tsx
+++ b/apps/wallet/src/ui/app/components/HideShowDisplayBox.tsx
@@ -89,8 +89,11 @@ export function HideShowDisplayBox({
                         <Link
                             color="heroDark"
                             weight="medium"
+                            size="body"
                             text="Copy"
-                            before={<Copy16 />}
+                            before={
+                                <Copy16 className="text-base leading-none" />
+                            }
                             onClick={copyCallback}
                         />
                     ) : null}
@@ -98,6 +101,8 @@ export function HideShowDisplayBox({
                 <div>
                     <Link
                         color="steelDark"
+                        size="base"
+                        weight="medium"
                         text={
                             valueHidden ? (
                                 <EyeClose16 className="block" />

--- a/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
@@ -14,6 +14,7 @@ import Loading from '_components/loading';
 import { useAppDispatch } from '_hooks';
 import { loadEntropyFromKeyring } from '_redux/slices/account';
 import { entropyToMnemonic, toEntropy } from '_shared/utils/bip39';
+import { HideShowDisplayBox } from '_src/ui/app/components/HideShowDisplayBox';
 
 export type BackupPageProps = {
     mode?: 'created' | 'imported';
@@ -22,7 +23,7 @@ export type BackupPageProps = {
 const BackupPage = ({ mode = 'created' }: BackupPageProps) => {
     const guardsLoading = useLockedGuard(false);
     const [loading, setLoading] = useState(true);
-    const [mnemonic, setLocalMnemonic] = useState<string | null>(null);
+    const [mnemonic, setLocalMnemonic] = useState<string[] | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [passwordCopied, setPasswordCopied] = useState(false);
     const navigate = useNavigate();
@@ -39,7 +40,7 @@ const BackupPage = ({ mode = 'created' }: BackupPageProps) => {
                         toEntropy(
                             await dispatch(loadEntropyFromKeyring({})).unwrap()
                         )
-                    )
+                    ).split(' ')
                 );
             } catch (e) {
                 setError(
@@ -85,9 +86,10 @@ const BackupPage = ({ mode = 'created' }: BackupPageProps) => {
                             </div>
                             <Loading loading={loading}>
                                 {mnemonic ? (
-                                    <div className="text-steel-dark flex flex-col flex-nowrap gap-2 self-stretch font-semibold text-heading5 p-3.5 rounded-15 bg-white border border-solid border-gray-45 shadow-button leading-snug">
-                                        {mnemonic}
-                                    </div>
+                                    <HideShowDisplayBox
+                                        value={mnemonic}
+                                        hideCopy
+                                    />
                                 ) : (
                                     <Alert>{error}</Alert>
                                 )}

--- a/apps/wallet/src/ui/app/shared/Link.tsx
+++ b/apps/wallet/src/ui/app/shared/Link.tsx
@@ -10,7 +10,6 @@ const styles = cva(
     [
         'transition flex flex-nowrap items-center justify-center outline-none gap-1 w-full',
         'no-underline bg-transparent p-0 border-none',
-        'text-bodySmall',
         'active:opacity-70',
         'disabled:opacity-40',
         'cursor-pointer group',
@@ -29,6 +28,11 @@ const styles = cva(
             weight: {
                 semibold: 'font-semibold',
                 medium: 'font-medium',
+            },
+            size: {
+                bodySmall: 'text-bodySmall',
+                body: 'text-body',
+                base: 'text-base leading-none',
             },
         },
     }
@@ -61,11 +65,19 @@ interface LinkProps
 
 export const Link = forwardRef(
     (
-        { before, after, text, color, weight, ...otherProps }: LinkProps,
+        {
+            before,
+            after,
+            text,
+            color,
+            weight,
+            size = 'bodySmall',
+            ...otherProps
+        }: LinkProps,
         ref: Ref<HTMLAnchorElement | HTMLButtonElement>
     ) => (
         <ButtonOrLink
-            className={styles({ color, weight })}
+            className={styles({ color, weight, size })}
             {...otherProps}
             ref={ref}
         >
@@ -73,7 +85,7 @@ export const Link = forwardRef(
                 <div className={iconStyles({ color })}>{before}</div>
             ) : null}
             {text ? (
-                <div className={'truncate leading-tight'}>{text}</div>
+                <div className={'truncate leading-none'}>{text}</div>
             ) : null}
             {after ? (
                 <div className={iconStyles({ color })}>{after}</div>


### PR DESCRIPTION
* mnemonic is hidden by default in backup view and user will have to click to reveal it
* after 3 minutes hide-show box will hide it's contents automatically in case user forgot the tab open
* also after switching to another tab/app, moving the wallet to background it will auto hide again
* the above will be the same for exported private key as well
* store mnemonic in this view as an array hoping it's more difficult for an attacker to find it in memory while on this page
* also hide-show box renders arrays in spans separated by commas for the same reason


https://user-images.githubusercontent.com/10210143/224191344-44ba7881-0624-4a2e-8bd9-ab7c90b6f113.mov

Updated hide-show-box component to always keep the same height

<img width="494" alt="Screenshot 2023-03-10 at 00 22 24" src="https://user-images.githubusercontent.com/10210143/224191450-c2f90316-7adc-41c9-bcf3-bfac524de057.png">
<img width="494" alt="Screenshot 2023-03-10 at 00 22 27" src="https://user-images.githubusercontent.com/10210143/224191452-a0071d07-1047-494d-b223-8f59cbe849ba.png">


closes [APPS-601](https://mysten.atlassian.net/browse/APPS-601)