### PR TITLE
client publish: gather dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8416,6 +8416,7 @@ dependencies = [
  "clap 3.2.23",
  "colored",
  "const-str",
+ "expect-test",
  "fastcrypto",
  "futures",
  "git-version",

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -77,6 +77,7 @@ jsonrpsee = { version = "0.16.2", features = ["jsonrpsee-core"] }
 
 test-utils = { path = "../test-utils" }
 rand = "0.8.5"
+expect-test = "1.4.0"
 move-binary-format.workspace = true
 move-package.workspace = true
 sui-core = { path = "../sui-core" }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -31,7 +31,8 @@ use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 use sui_types::error::SuiError;
 
 use sui_framework_build::compiled_package::{
-    build_from_resolution_graph, ensure_published_dependencies, BuildConfig,
+    build_from_resolution_graph, check_invalid_dependencies, check_unpublished_dependencies,
+    gather_dependencies, BuildConfig,
 };
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
@@ -479,9 +480,12 @@ impl SuiClientCommands {
                 };
 
                 let resolution_graph = config.resolution_graph(&package_path)?;
+                let dependencies = gather_dependencies(&resolution_graph);
+
+                check_invalid_dependencies(dependencies.invalid)?;
 
                 if !with_unpublished_dependencies {
-                    ensure_published_dependencies(&resolution_graph)?;
+                    check_unpublished_dependencies(dependencies.unpublished)?;
                 };
 
                 let compiled_package = build_from_resolution_graph(

--- a/crates/sui/src/unit_tests/data/module_dependency_invalid/Move.toml
+++ b/crates/sui/src/unit_tests/data/module_dependency_invalid/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "Invalid"
+version = "0.0.1"
+published-at = "mystery"
+
+[addresses]
+invalid = "0x0"

--- a/crates/sui/src/unit_tests/data/module_dependency_invalid/sources/invalid.move
+++ b/crates/sui/src/unit_tests/data/module_dependency_invalid/sources/invalid.move
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module invalid::invalid {
+    public entry fun main() {}
+}

--- a/crates/sui/src/unit_tests/data/module_dependency_unpublished/Move.toml
+++ b/crates/sui/src/unit_tests/data/module_dependency_unpublished/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "Unpublished"
+version = "0.0.1"
+# No published-at address for this package.
+# published-at = "0x0"
+
+[addresses]
+invalid = "0x0"

--- a/crates/sui/src/unit_tests/data/module_dependency_unpublished/sources/invalid.move
+++ b/crates/sui/src/unit_tests/data/module_dependency_unpublished/sources/invalid.move
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module invalid::invalid {
+    public entry fun main() {}
+}

--- a/crates/sui/src/unit_tests/data/module_publish_failure_invalid/Move.toml
+++ b/crates/sui/src/unit_tests/data/module_publish_failure_invalid/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "Examples"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework" }
+Invalid = { local = "../module_dependency_invalid" }
+Unpublished = { local = "../module_dependency_unpublished" }
+
+[addresses]
+examples = "0x0"

--- a/crates/sui/src/unit_tests/data/module_publish_failure_invalid/sources/main.move
+++ b/crates/sui/src/unit_tests/data/module_publish_failure_invalid/sources/main.move
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module examples::main {
+  public entry fun main() {}
+}

--- a/crates/sui/src/unit_tests/data/module_publish_with_unpublished_dependency/Move.toml
+++ b/crates/sui/src/unit_tests/data/module_publish_with_unpublished_dependency/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "Examples"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework" }
+Unpublished = { local = "../module_dependency_unpublished" }
+
+[addresses]
+examples = "0x0"

--- a/crates/sui/src/unit_tests/data/module_publish_with_unpublished_dependency/sources/main.move
+++ b/crates/sui/src/unit_tests/data/module_publish_with_unpublished_dependency/sources/main.move
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module examples::main {
+  public entry fun main() {}
+}


### PR DESCRIPTION
## Description 

Changes the internal logic in `client publish` to actually collect package dependencies in a partitioned set of `published`/`unpublished` packages. We now separate error promotion for `unpublished` packages when `--with-unpublished-dependencies` is not set (no user-visible change).

Follow up of https://github.com/MystenLabs/sui/pull/8919#discussion_r1130923990

Next: 
- will add a check for self-addresses of modules where the value is `0x0`.
- update publish transaction to accept set of dependencies

Stacked on https://github.com/MystenLabs/sui/pull/9084

## Test Plan 

Updated existing tests.