### PR TITLE
[RFC][sui framework] Added transfer Recipient

### DIFF
--- a/crates/sui-framework/docs/address.md
+++ b/crates/sui-framework/docs/address.md
@@ -14,6 +14,8 @@
 -  [Function `to_string`](#0x2_address_to_string)
 -  [Function `length`](#0x2_address_length)
 -  [Function `max`](#0x2_address_max)
+-  [Function `recipient`](#0x2_address_recipient)
+-  [Function `from_recipient`](#0x2_address_from_recipient)
 -  [Module Specification](#@Module_Specification_1)
 
 
@@ -21,6 +23,7 @@
 <b>use</b> <a href="">0x1::bcs</a>;
 <b>use</b> <a href="">0x1::string</a>;
 <b>use</b> <a href="hex.md#0x2_hex">0x2::hex</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 </code></pre>
 
 
@@ -30,12 +33,32 @@
 ## Constants
 
 
+<a name="0x2_address_ADDRESS_RECIPIENT_KIND"></a>
+
+The recipient is an address
+
+
+<pre><code><b>const</b> <a href="address.md#0x2_address_ADDRESS_RECIPIENT_KIND">ADDRESS_RECIPIENT_KIND</a>: u8 = 0;
+</code></pre>
+
+
+
 <a name="0x2_address_EAddressParseError"></a>
 
 Error from <code>from_bytes</code> when it is supplied too many or too few bytes.
 
 
 <pre><code><b>const</b> <a href="address.md#0x2_address_EAddressParseError">EAddressParseError</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_address_ENotAnAddressRecipient"></a>
+
+The recipient is not an object
+
+
+<pre><code><b>const</b> <a href="address.md#0x2_address_ENotAnAddressRecipient">ENotAnAddressRecipient</a>: u64 = 100;
 </code></pre>
 
 
@@ -288,6 +311,59 @@ Largest possible address
 
 <pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_max">max</a>(): u256 {
     <a href="address.md#0x2_address_MAX">MAX</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_address_recipient"></a>
+
+## Function `recipient`
+
+Constructs an address Recipient
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="recipient.md#0x2_recipient">recipient</a>(<a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>): <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="recipient.md#0x2_recipient">recipient</a>(<a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>): Recipient {
+    <a href="recipient.md#0x2_recipient_new">recipient::new</a>(<a href="address.md#0x2_address_ADDRESS_RECIPIENT_KIND">ADDRESS_RECIPIENT_KIND</a>, <a href="recipient.md#0x2_recipient">recipient</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_address_from_recipient"></a>
+
+## Function `from_recipient`
+
+Converts the recipient to an address.
+Aborts if the kind is not an address kind
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_from_recipient">from_recipient</a>(<a href="recipient.md#0x2_recipient">recipient</a>: <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address.md#0x2_address_from_recipient">from_recipient</a>(<a href="recipient.md#0x2_recipient">recipient</a>: Recipient): <b>address</b> {
+    <b>let</b> (kind, value) = <a href="recipient.md#0x2_recipient_destroy">recipient::destroy</a>(<a href="recipient.md#0x2_recipient">recipient</a>);
+    <b>assert</b>!(kind == <a href="address.md#0x2_address_ADDRESS_RECIPIENT_KIND">ADDRESS_RECIPIENT_KIND</a>, <a href="address.md#0x2_address_ENotAnAddressRecipient">ENotAnAddressRecipient</a>);
+    value
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/coin.md
+++ b/crates/sui-framework/docs/coin.md
@@ -966,10 +966,10 @@ accordingly.
 
 ## Function `mint_and_transfer`
 
-Mint <code>amount</code> of <code><a href="coin.md#0x2_coin_Coin">Coin</a></code> and send it to <code>recipient</code>. Invokes <code><a href="coin.md#0x2_coin_mint">mint</a>()</code>.
+Mint <code>amount</code> of <code><a href="coin.md#0x2_coin_Coin">Coin</a></code> and send it to <code><a href="recipient.md#0x2_recipient">recipient</a></code>. Invokes <code><a href="coin.md#0x2_coin_mint">mint</a>()</code>.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, amount: u64, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -979,9 +979,9 @@ Mint <code>amount</code> of <code><a href="coin.md#0x2_coin_Coin">Coin</a></code
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(
-    c: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> TxContext
+    c: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, amount: u64, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>, ctx: &<b>mut</b> TxContext
 ) {
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_mint">mint</a>(c, amount, ctx), recipient)
+    <a href="transfer.md#0x2_transfer_transfer_to_address">transfer::transfer_to_address</a>(<a href="coin.md#0x2_coin_mint">mint</a>(c, amount, ctx), <a href="recipient.md#0x2_recipient">recipient</a>)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/devnet_nft.md
+++ b/crates/sui-framework/docs/devnet_nft.md
@@ -22,6 +22,7 @@ on Sui. The user should be able to use the wallet command line tool
 <pre><code><b>use</b> <a href="">0x1::string</a>;
 <b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="url.md#0x2_url">0x2::url</a>;
@@ -98,7 +99,7 @@ An example NFT that can be minted by anybody
 
 </dd>
 <dt>
-<code>creator: <b>address</b></code>
+<code>creator: <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a></code>
 </dt>
 <dd>
 
@@ -142,13 +143,13 @@ Create a new devnet_nft
         description: <a href="_utf8">string::utf8</a>(description),
         <a href="url.md#0x2_url">url</a>: <a href="url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(<a href="url.md#0x2_url">url</a>)
     };
-    <b>let</b> sender = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> <a href="recipient.md#0x2_recipient">recipient</a> = <a href="tx_context.md#0x2_tx_context_recipient">tx_context::recipient</a>(ctx);
     <a href="event.md#0x2_event_emit">event::emit</a>(<a href="devnet_nft.md#0x2_devnet_nft_MintNFTEvent">MintNFTEvent</a> {
         object_id: <a href="object.md#0x2_object_uid_to_inner">object::uid_to_inner</a>(&nft.id),
-        creator: sender,
+        creator: <a href="recipient.md#0x2_recipient">recipient</a>,
         name: nft.name,
     });
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(nft, sender);
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(nft, <a href="recipient.md#0x2_recipient">recipient</a>);
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/display.md
+++ b/crates/sui-framework/docs/display.md
@@ -38,6 +38,7 @@ More entry functions might be added in the future depending on the use cases.
 <b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="package.md#0x2_package">0x2::package</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="vec_map.md#0x2_vec_map">0x2::vec_map</a>;
@@ -313,7 +314,7 @@ Create a new empty Display<T> object and keep it.
 
 
 <pre><code>entry <b>public</b> <b>fun</b> <a href="display.md#0x2_display_create_and_keep">create_and_keep</a>&lt;T: key&gt;(pub: &Publisher, ctx: &<b>mut</b> TxContext) {
-    <a href="transfer.md#0x2_transfer">transfer</a>(<a href="display.md#0x2_display_new">new</a>&lt;T&gt;(pub, ctx), sender(ctx))
+    <a href="transfer.md#0x2_transfer">transfer</a>(<a href="display.md#0x2_display_new">new</a>&lt;T&gt;(pub, ctx), <a href="recipient.md#0x2_recipient">recipient</a>(ctx))
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -10,12 +10,15 @@
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="address.md#0x2_address">0x2::address</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="clock.md#0x2_clock">0x2::clock</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
 <b>use</b> <a href="sui_system.md#0x2_sui_system">0x2::sui_system</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="validator.md#0x2_validator">0x2::validator</a>;
 </code></pre>
@@ -187,7 +190,10 @@ all the information we need in the system.
     <a href="clock.md#0x2_clock_create">clock::create</a>();
 
     // Transfer the remaining <a href="balance.md#0x2_balance">balance</a> of <a href="sui.md#0x2_sui">sui</a>'s supply <b>to</b> the initial account
-    <a href="sui.md#0x2_sui_transfer">sui::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(sui_supply, ctx), initial_sui_custody_account_address);
+    sui::transfer::transfer(
+        <a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(sui_supply, ctx),
+        sui::address::recipient(initial_sui_custody_account_address),
+    );
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/locked_coin.md
+++ b/crates/sui-framework/docs/locked_coin.md
@@ -13,10 +13,12 @@
 -  [Function `unlock_coin`](#0x2_locked_coin_unlock_coin)
 
 
-<pre><code><b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<pre><code><b>use</b> <a href="address.md#0x2_address">0x2::address</a>;
+<b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
@@ -70,7 +72,7 @@ A coin of type <code>T</code> locked until <code>locked_until_epoch</code>.
 Create a LockedCoin from <code><a href="balance.md#0x2_balance">balance</a></code> and transfer it to <code>owner</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_new_from_balance">new_from_balance</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, locked_until_epoch: <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>, owner: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_new_from_balance">new_from_balance</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, locked_until_epoch: <a href="epoch_time_lock.md#0x2_epoch_time_lock_EpochTimeLock">epoch_time_lock::EpochTimeLock</a>, owner: <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -79,7 +81,7 @@ Create a LockedCoin from <code><a href="balance.md#0x2_balance">balance</a></cod
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_new_from_balance">new_from_balance</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: Balance&lt;T&gt;, locked_until_epoch: EpochTimeLock, owner: <b>address</b>, ctx: &<b>mut</b> TxContext) {
+<pre><code><b>public</b> <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_new_from_balance">new_from_balance</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>: Balance&lt;T&gt;, locked_until_epoch: EpochTimeLock, owner: Recipient, ctx: &<b>mut</b> TxContext) {
     <b>let</b> <a href="locked_coin.md#0x2_locked_coin">locked_coin</a> = <a href="locked_coin.md#0x2_locked_coin_LockedCoin">LockedCoin</a> {
         id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
         <a href="balance.md#0x2_balance">balance</a>,
@@ -150,11 +152,11 @@ Public getter for the locked coin's value
 ## Function `lock_coin`
 
 Lock a coin up until <code>locked_until_epoch</code>. The input Coin<T> is deleted and a LockedCoin<T>
-is transferred to the <code>recipient</code>. This function aborts if the <code>locked_until_epoch</code> is less than
+is transferred to the <code><a href="recipient.md#0x2_recipient">recipient</a></code>. This function aborts if the <code>locked_until_epoch</code> is less than
 or equal to the current epoch.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_lock_coin">lock_coin</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, recipient: <b>address</b>, locked_until_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_lock_coin">lock_coin</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>, locked_until_epoch: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -164,10 +166,11 @@ or equal to the current epoch.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="locked_coin.md#0x2_locked_coin_lock_coin">lock_coin</a>&lt;T&gt;(
-    <a href="coin.md#0x2_coin">coin</a>: Coin&lt;T&gt;, recipient: <b>address</b>, locked_until_epoch: u64, ctx: &<b>mut</b> TxContext
+    <a href="coin.md#0x2_coin">coin</a>: Coin&lt;T&gt;, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>, locked_until_epoch: u64, ctx: &<b>mut</b> TxContext
 ) {
     <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(<a href="coin.md#0x2_coin">coin</a>);
-    <a href="locked_coin.md#0x2_locked_coin_new_from_balance">new_from_balance</a>(<a href="balance.md#0x2_balance">balance</a>, <a href="epoch_time_lock.md#0x2_epoch_time_lock_new">epoch_time_lock::new</a>(locked_until_epoch, ctx), recipient, ctx);
+    <b>let</b> <a href="recipient.md#0x2_recipient">recipient</a> = sui::address::recipient(<a href="recipient.md#0x2_recipient">recipient</a>);
+    <a href="locked_coin.md#0x2_locked_coin_new_from_balance">new_from_balance</a>(<a href="balance.md#0x2_balance">balance</a>, <a href="epoch_time_lock.md#0x2_epoch_time_lock_new">epoch_time_lock::new</a>(locked_until_epoch, ctx), <a href="recipient.md#0x2_recipient">recipient</a>, ctx);
 }
 </code></pre>
 
@@ -198,7 +201,7 @@ to the sender.
     <a href="object.md#0x2_object_delete">object::delete</a>(id);
     <a href="epoch_time_lock.md#0x2_epoch_time_lock_destroy">epoch_time_lock::destroy</a>(locked_until_epoch, ctx);
     <b>let</b> <a href="coin.md#0x2_coin">coin</a> = <a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(<a href="balance.md#0x2_balance">balance</a>, ctx);
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin">coin</a>, <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin">coin</a>, <a href="tx_context.md#0x2_tx_context_recipient">tx_context::recipient</a>(ctx));
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/object.md
+++ b/crates/sui-framework/docs/object.md
@@ -15,6 +15,8 @@ Sui object identifiers
 -  [Function `id_to_address`](#0x2_object_id_to_address)
 -  [Function `id_from_bytes`](#0x2_object_id_from_bytes)
 -  [Function `id_from_address`](#0x2_object_id_from_address)
+-  [Function `recipient`](#0x2_object_recipient)
+-  [Function `from_recipient`](#0x2_object_from_recipient)
 -  [Function `sui_system_state`](#0x2_object_sui_system_state)
 -  [Function `clock`](#0x2_object_clock)
 -  [Function `uid_as_inner`](#0x2_object_uid_as_inner)
@@ -35,6 +37,7 @@ Sui object identifiers
 
 <pre><code><b>use</b> <a href="">0x1::bcs</a>;
 <b>use</b> <a href="address.md#0x2_address">0x2::address</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
 
@@ -174,6 +177,26 @@ containing object's address)
 ## Constants
 
 
+<a name="0x2_object_OBJECT_RECIPIENT_KIND"></a>
+
+Currently unused. The recipient is an object
+
+
+<pre><code><b>const</b> <a href="object.md#0x2_object_OBJECT_RECIPIENT_KIND">OBJECT_RECIPIENT_KIND</a>: u8 = 1;
+</code></pre>
+
+
+
+<a name="0x2_object_ENotAnObjectRecipient"></a>
+
+The recipient is not an object
+
+
+<pre><code><b>const</b> <a href="object.md#0x2_object_ENotAnObjectRecipient">ENotAnObjectRecipient</a>: u64 = 101;
+</code></pre>
+
+
+
 <a name="0x2_object_SUI_CLOCK_OBJECT_ID"></a>
 
 The hardcoded ID for the singleton Clock Object.
@@ -287,6 +310,58 @@ Make an <code><a href="object.md#0x2_object_ID">ID</a></code> from an address.
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id_from_address">id_from_address</a>(bytes: <b>address</b>): <a href="object.md#0x2_object_ID">ID</a> {
     <a href="object.md#0x2_object_ID">ID</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_recipient"></a>
+
+## Function `recipient`
+
+Not yet supported
+
+
+<pre><code><b>fun</b> <a href="recipient.md#0x2_recipient">recipient</a>(<a href="recipient.md#0x2_recipient">recipient</a>: <a href="object.md#0x2_object_ID">object::ID</a>): <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="recipient.md#0x2_recipient">recipient</a>(<a href="recipient.md#0x2_recipient">recipient</a>: <a href="object.md#0x2_object_ID">ID</a>): Recipient {
+    <a href="recipient.md#0x2_recipient_new">recipient::new</a>(<a href="object.md#0x2_object_OBJECT_RECIPIENT_KIND">OBJECT_RECIPIENT_KIND</a>, <a href="object.md#0x2_object_id_to_address">id_to_address</a>(&<a href="recipient.md#0x2_recipient">recipient</a>))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_from_recipient"></a>
+
+## Function `from_recipient`
+
+Not yet supported
+
+
+<pre><code><b>fun</b> <a href="object.md#0x2_object_from_recipient">from_recipient</a>(<a href="recipient.md#0x2_recipient">recipient</a>: <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a>): <a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="object.md#0x2_object_from_recipient">from_recipient</a>(<a href="recipient.md#0x2_recipient">recipient</a>: Recipient): <a href="object.md#0x2_object_ID">ID</a> {
+    <b>let</b> (kind, value) = <a href="recipient.md#0x2_recipient_destroy">recipient::destroy</a>(<a href="recipient.md#0x2_recipient">recipient</a>);
+    <b>assert</b>!(kind == <a href="object.md#0x2_object_OBJECT_RECIPIENT_KIND">OBJECT_RECIPIENT_KIND</a>, <a href="object.md#0x2_object_ENotAnObjectRecipient">ENotAnObjectRecipient</a>);
+    <a href="object.md#0x2_object_id_from_address">id_from_address</a>(value)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/package.md
+++ b/crates/sui-framework/docs/package.md
@@ -36,6 +36,7 @@ Functions for operating on Move packages from within Move:
 <pre><code><b>use</b> <a href="">0x1::ascii</a>;
 <b>use</b> <a href="">0x1::type_name</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="types.md#0x2_types">0x2::types</a>;
@@ -368,7 +369,7 @@ the sender is the publisher.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_claim_and_keep">claim_and_keep</a>&lt;OTW: drop&gt;(otw: OTW, ctx: &<b>mut</b> TxContext) {
-    sui::transfer::transfer(<a href="package.md#0x2_package_claim">claim</a>(otw, ctx), sender(ctx))
+    sui::transfer::transfer(<a href="package.md#0x2_package_claim">claim</a>(otw, ctx), <a href="recipient.md#0x2_recipient">recipient</a>(ctx))
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/pay.md
+++ b/crates/sui-framework/docs/pay.md
@@ -18,6 +18,7 @@ This module provides handy functionality for wallets and <code>sui::Coin</code> 
 
 
 <pre><code><b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
@@ -56,7 +57,7 @@ Transfer <code>c</code> to the sender of the current transaction
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_keep">keep</a>&lt;T&gt;(c: Coin&lt;T&gt;, ctx: &TxContext) {
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(c, <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx))
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(c, <a href="tx_context.md#0x2_tx_context_recipient">tx_context::recipient</a>(ctx))
 }
 </code></pre>
 
@@ -128,11 +129,11 @@ in <code>split_amounts</code>. Remaining balance is left in <code>self</code>.
 
 ## Function `split_and_transfer`
 
-Send <code>amount</code> units of <code>c</code> to <code>recipient</code>
+Send <code>amount</code> units of <code>c</code> to <code><a href="recipient.md#0x2_recipient">recipient</a></code>
 Aborts with <code>EVALUE</code> if <code>amount</code> is greater than or equal to <code>amount</code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_and_transfer">split_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_and_transfer">split_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, amount: u64, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -142,9 +143,9 @@ Aborts with <code>EVALUE</code> if <code>amount</code> is greater than or equal 
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_and_transfer">split_and_transfer</a>&lt;T&gt;(
-    c: &<b>mut</b> Coin&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> TxContext
+    c: &<b>mut</b> Coin&lt;T&gt;, amount: u64, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>, ctx: &<b>mut</b> TxContext
 ) {
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_split">coin::split</a>(c, amount, ctx), recipient)
+    <a href="transfer.md#0x2_transfer_transfer_to_address">transfer::transfer_to_address</a>(<a href="coin.md#0x2_coin_split">coin::split</a>(c, amount, ctx), <a href="recipient.md#0x2_recipient">recipient</a>)
 }
 </code></pre>
 
@@ -175,7 +176,7 @@ not evenly divisible by <code>n</code>, the remainder is left in <code>self</cod
     <b>let</b> vec: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt; = <a href="coin.md#0x2_coin_divide_into_n">coin::divide_into_n</a>(self, n, ctx);
     <b>let</b> (i, len) = (0, <a href="_length">vector::length</a>(&vec));
     <b>while</b> (i &lt; len) {
-        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="_pop_back">vector::pop_back</a>(&<b>mut</b> vec), <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="_pop_back">vector::pop_back</a>(&<b>mut</b> vec), <a href="tx_context.md#0x2_tx_context_recipient">tx_context::recipient</a>(ctx));
         i = i + 1;
     };
     <a href="_destroy_empty">vector::destroy_empty</a>(vec);
@@ -264,7 +265,7 @@ Join a vector of <code>Coin</code> into a single object and transfer it to <code
 
     <b>let</b> self = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> coins);
     <a href="pay.md#0x2_pay_join_vec">join_vec</a>(&<b>mut</b> self, coins);
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(self, receiver)
+    <a href="transfer.md#0x2_transfer_transfer_to_address">transfer::transfer_to_address</a>(self, receiver)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/prover_tests.md
+++ b/crates/sui-framework/docs/prover_tests.md
@@ -54,7 +54,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_transfer">simple_transfer</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">prover_tests::Obj</a>, recipient: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_transfer">simple_transfer</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">prover_tests::Obj</a>, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>)
 </code></pre>
 
 
@@ -63,8 +63,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_transfer">simple_transfer</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>, recipient: <b>address</b>) {
-    sui::transfer::transfer(o, recipient);
+<pre><code><b>public</b> <b>fun</b> <a href="prover_tests.md#0x2_prover_tests_simple_transfer">simple_transfer</a>(o: <a href="prover_tests.md#0x2_prover_tests_Obj">Obj</a>, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>) {
+    sui::transfer::transfer_to_address(o, <a href="recipient.md#0x2_recipient">recipient</a>);
 }
 </code></pre>
 
@@ -77,7 +77,7 @@
 
 
 
-<pre><code><b>ensures</b> sui::prover::owned_by(o, recipient);
+<pre><code><b>ensures</b> sui::prover::owned_by(o, <a href="recipient.md#0x2_recipient">recipient</a>);
 <b>aborts_if</b> <b>false</b>;
 </code></pre>
 

--- a/crates/sui-framework/docs/randomness.md
+++ b/crates/sui-framework/docs/randomness.md
@@ -51,6 +51,7 @@ This object can be used as a shared-/owned-object.
 <b>use</b> <a href="">0x1::vector</a>;
 <b>use</b> <a href="bcs.md#0x2_bcs">0x2::bcs</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
@@ -178,7 +179,7 @@ Supplied randomness is not of the right length.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>&lt;T&gt;(self: <a href="randomness.md#0x2_randomness_Randomness">randomness::Randomness</a>&lt;T&gt;, <b>to</b>: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>&lt;T&gt;(self: <a href="randomness.md#0x2_randomness_Randomness">randomness::Randomness</a>&lt;T&gt;, <b>to</b>: <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a>)
 </code></pre>
 
 
@@ -187,7 +188,7 @@ Supplied randomness is not of the right length.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>&lt;T&gt;(self: <a href="randomness.md#0x2_randomness_Randomness">Randomness</a>&lt;T&gt;, <b>to</b>: <b>address</b>) {
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>&lt;T&gt;(self: <a href="randomness.md#0x2_randomness_Randomness">Randomness</a>&lt;T&gt;, <b>to</b>: Recipient) {
     <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(self, <b>to</b>);
 }
 </code></pre>

--- a/crates/sui-framework/docs/recipient.md
+++ b/crates/sui-framework/docs/recipient.md
@@ -1,0 +1,147 @@
+
+<a name="0x2_recipient"></a>
+
+# Module `0x2::recipient`
+
+
+
+-  [Struct `Recipient`](#0x2_recipient_Recipient)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x2_recipient_new)
+-  [Function `destroy`](#0x2_recipient_destroy)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_recipient_Recipient"></a>
+
+## Struct `Recipient`
+
+The recipient of a transfer
+
+
+<pre><code><b>struct</b> <a href="recipient.md#0x2_recipient_Recipient">Recipient</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>kind: u8</code>
+</dt>
+<dd>
+ The kind of recipient, currently only an address recipient is supported,
+ but object recipients will be supported in the future
+</dd>
+<dt>
+<code>value: <b>address</b></code>
+</dt>
+<dd>
+ The underlying value for the recipient, ID or address
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_recipient_ADDRESS_RECIPIENT_KIND"></a>
+
+The recipient is an address
+
+
+<pre><code><b>const</b> <a href="recipient.md#0x2_recipient_ADDRESS_RECIPIENT_KIND">ADDRESS_RECIPIENT_KIND</a>: u8 = 0;
+</code></pre>
+
+
+
+<a name="0x2_recipient_ENotAnAddress"></a>
+
+The recipient is not an address
+
+
+<pre><code><b>const</b> <a href="recipient.md#0x2_recipient_ENotAnAddress">ENotAnAddress</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x2_recipient_ENotAnObject"></a>
+
+Currently unused. The recipient is not an object
+
+
+<pre><code><b>const</b> <a href="recipient.md#0x2_recipient_ENotAnObject">ENotAnObject</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_recipient_OBJECT_RECIPIENT_KIND"></a>
+
+Currently unused. The recipient is an object
+
+
+<pre><code><b>const</b> <a href="recipient.md#0x2_recipient_OBJECT_RECIPIENT_KIND">OBJECT_RECIPIENT_KIND</a>: u8 = 1;
+</code></pre>
+
+
+
+<a name="0x2_recipient_new"></a>
+
+## Function `new`
+
+internal construction of a Recipient
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="recipient.md#0x2_recipient_new">new</a>(kind: u8, value: <b>address</b>): <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="recipient.md#0x2_recipient_new">new</a>(kind: u8, value: <b>address</b>): <a href="recipient.md#0x2_recipient_Recipient">Recipient</a> {
+    <a href="recipient.md#0x2_recipient_Recipient">Recipient</a> { kind, value }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_recipient_destroy"></a>
+
+## Function `destroy`
+
+internal deconstruction of a Recipient
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="recipient.md#0x2_recipient_destroy">destroy</a>(<a href="recipient.md#0x2_recipient">recipient</a>: <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a>): (u8, <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="recipient.md#0x2_recipient_destroy">destroy</a>(<a href="recipient.md#0x2_recipient">recipient</a>: <a href="recipient.md#0x2_recipient_Recipient">Recipient</a>): (u8, <b>address</b>) {
+    <b>let</b> <a href="recipient.md#0x2_recipient_Recipient">Recipient</a> { kind, value } = <a href="recipient.md#0x2_recipient">recipient</a>;
+    (kind, value)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework/docs/safe.md
+++ b/crates/sui-framework/docs/safe.md
@@ -31,6 +31,7 @@ the capability to transfer coins away from their wallets, if they are provided w
 <pre><code><b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="vec_set.md#0x2_vec_set">0x2::vec_set</a>;
@@ -46,7 +47,6 @@ Allows any holder of a capability to transfer a fixed amount of assets from the 
 Useful in situations like an NFT marketplace where you wish to buy the NFTs at a specific price.
 
 @ownership: Shared
-
 
 
 <pre><code><b>struct</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt; <b>has</b> key
@@ -374,7 +374,7 @@ a trusted party (or smart contract) to transfer the object out.
 <pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_create">create</a>&lt;T&gt;(<a href="coin.md#0x2_coin">coin</a>: Coin&lt;T&gt;, ctx: &<b>mut</b> TxContext) {
     <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(<a href="coin.md#0x2_coin">coin</a>);
     <b>let</b> cap = <a href="safe.md#0x2_safe_create_">create_</a>&lt;T&gt;(<a href="balance.md#0x2_balance">balance</a>, ctx);
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(cap, sender(ctx));
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(cap, <a href="recipient.md#0x2_recipient">recipient</a>(ctx));
 }
 </code></pre>
 
@@ -400,7 +400,7 @@ a trusted party (or smart contract) to transfer the object out.
 <pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_create_empty">create_empty</a>&lt;T&gt;(ctx: &<b>mut</b> TxContext) {
     <b>let</b> empty_balance = <a href="balance.md#0x2_balance_zero">balance::zero</a>&lt;T&gt;();
     <b>let</b> cap = <a href="safe.md#0x2_safe_create_">create_</a>(empty_balance, ctx);
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(cap, sender(ctx));
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(cap, <a href="recipient.md#0x2_recipient">recipient</a>(ctx));
 }
 </code></pre>
 
@@ -505,7 +505,7 @@ Withdraw coins from the safe as a <code><a href="safe.md#0x2_safe_OwnerCapabilit
 <pre><code><b>public</b> entry <b>fun</b> <a href="safe.md#0x2_safe_withdraw">withdraw</a>&lt;T&gt;(<a href="safe.md#0x2_safe">safe</a>: &<b>mut</b> <a href="safe.md#0x2_safe_Safe">Safe</a>&lt;T&gt;, capability: &<a href="safe.md#0x2_safe_OwnerCapability">OwnerCapability</a>&lt;T&gt;, withdraw_amount: u64, ctx: &<b>mut</b> TxContext) {
     <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="safe.md#0x2_safe_withdraw_">withdraw_</a>(<a href="safe.md#0x2_safe">safe</a>, capability, withdraw_amount);
     <b>let</b> <a href="coin.md#0x2_coin">coin</a> = <a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(<a href="balance.md#0x2_balance">balance</a>, ctx);
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin">coin</a>, sender(ctx));
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin">coin</a>, <a href="recipient.md#0x2_recipient">recipient</a>(ctx));
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -43,12 +43,14 @@
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="address.md#0x2_address">0x2::address</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="epoch_time_lock.md#0x2_epoch_time_lock">0x2::epoch_time_lock</a>;
 <b>use</b> <a href="locked_coin.md#0x2_locked_coin">0x2::locked_coin</a>;
 <b>use</b> <a href="math.md#0x2_math">0x2::math</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
 <b>use</b> <a href="table.md#0x2_table">0x2::table</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
@@ -479,7 +481,7 @@ Request to delegate to a staking pool. The delegation starts counting at the beg
         sui_token_lock,
     };
     pool.pending_delegation = pool.pending_delegation + sui_amount;
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(staked_sui, delegator);
+    <a href="transfer.md#0x2_transfer_transfer_to_address">transfer::transfer_to_address</a>(staked_sui, delegator);
 }
 </code></pre>
 
@@ -512,7 +514,7 @@ A proportional amount of pool tokens is burnt.
 ) : u64 {
     <b>let</b> (pool_token_withdraw_amount, principal_withdraw, time_lock) =
         <a href="staking_pool.md#0x2_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(pool, staked_sui);
-    <b>let</b> delegator = <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> delegator = <a href="tx_context.md#0x2_tx_context_recipient">tx_context::recipient</a>(ctx);
     <b>let</b> principal_withdraw_amount = <a href="balance.md#0x2_balance_value">balance::value</a>(&principal_withdraw);
 
     <b>let</b> rewards_withdraw = <a href="staking_pool.md#0x2_staking_pool_withdraw_rewards_and_burn_pool_tokens">withdraw_rewards_and_burn_pool_tokens</a>(
@@ -857,9 +859,14 @@ portion because the principal portion was already taken out of the delegator's s
 
     // TODO: consider sharing code <b>with</b> `request_withdraw_delegation`
     <b>if</b> (<a href="_is_some">option::is_some</a>(&time_lock)) {
-        <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(principal, <a href="_destroy_some">option::destroy_some</a>(time_lock), delegator, ctx);
+        <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(
+            principal,
+            <a href="_destroy_some">option::destroy_some</a>(time_lock),
+            sui::address::recipient(delegator),
+            ctx,
+        );
     } <b>else</b> {
-        <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(principal, ctx), delegator);
+        <a href="transfer.md#0x2_transfer_transfer_to_address">transfer::transfer_to_address</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(principal, ctx), delegator);
         <a href="_destroy_none">option::destroy_none</a>(time_lock);
     };
     withdraw_amount
@@ -1091,7 +1098,7 @@ transfer the newly split part to the sender address.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x2_staking_pool_split_staked_sui">split_staked_sui</a>(c: &<b>mut</b> <a href="staking_pool.md#0x2_staking_pool_StakedSui">StakedSui</a>, split_amount: u64, ctx: &<b>mut</b> TxContext) {
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="staking_pool.md#0x2_staking_pool_split">split</a>(c, split_amount, ctx), <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="staking_pool.md#0x2_staking_pool_split">split</a>(c, split_amount, ctx), <a href="tx_context.md#0x2_tx_context_recipient">tx_context::recipient</a>(ctx));
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui.md
+++ b/crates/sui-framework/docs/sui.md
@@ -10,7 +10,6 @@ It has 9 decimals, and the smallest unit (10^-9) is called "mist".
 -  [Struct `SUI`](#0x2_sui_SUI)
 -  [Constants](#@Constants_0)
 -  [Function `new`](#0x2_sui_new)
--  [Function `transfer`](#0x2_sui_transfer)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -131,30 +130,6 @@ This should be called only once during genesis creation.
     <b>let</b> total_sui = <a href="balance.md#0x2_balance_increase_supply">balance::increase_supply</a>(&<b>mut</b> supply, <a href="sui.md#0x2_sui_TOTAL_SUPPLY_MIST">TOTAL_SUPPLY_MIST</a>);
     <a href="balance.md#0x2_balance_destroy_supply">balance::destroy_supply</a>(supply);
     total_sui
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_sui_transfer"></a>
-
-## Function `transfer`
-
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>(c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, recipient: <b>address</b>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>(c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">SUI</a>&gt;, recipient: <b>address</b>) {
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(c, recipient)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -69,6 +69,7 @@
 <b>use</b> <a href="locked_coin.md#0x2_locked_coin">0x2::locked_coin</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="pay.md#0x2_pay">0x2::pay</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
 <b>use</b> <a href="stake_subsidy.md#0x2_stake_subsidy">0x2::stake_subsidy</a>;
 <b>use</b> <a href="staking_pool.md#0x2_staking_pool">0x2::staking_pool</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
@@ -1922,7 +1923,10 @@ Extract required Balance from vector of Coin<SUI>, transfer the remainder back t
         <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> total_balance, amount);
         // <a href="transfer.md#0x2_transfer">transfer</a> back the remainder <b>if</b> non zero.
         <b>if</b> (<a href="balance.md#0x2_balance_value">balance::value</a>(&total_balance) &gt; 0) {
-            <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(total_balance, ctx), <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+            <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(
+                <a href="coin.md#0x2_coin_from_balance">coin::from_balance</a>(total_balance, ctx),
+                <a href="tx_context.md#0x2_tx_context_recipient">tx_context::recipient</a>(ctx),
+            );
         } <b>else</b> {
             <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(total_balance);
         };
@@ -1975,7 +1979,12 @@ Extract required Balance from vector of LockedCoin<SUI>, transfer the remainder 
         <b>let</b> amount = <a href="_destroy_some">option::destroy_some</a>(amount);
         <b>let</b> <a href="balance.md#0x2_balance">balance</a> = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> total_balance, amount);
         <b>if</b> (<a href="balance.md#0x2_balance_value">balance::value</a>(&total_balance) &gt; 0) {
-            <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(total_balance, first_lock, <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx), ctx);
+            <a href="locked_coin.md#0x2_locked_coin_new_from_balance">locked_coin::new_from_balance</a>(
+                total_balance,
+                first_lock,
+                <a href="tx_context.md#0x2_tx_context_recipient">tx_context::recipient</a>(ctx),
+                ctx,
+            );
         } <b>else</b> {
             <a href="balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(total_balance);
         };

--- a/crates/sui-framework/docs/transfer.md
+++ b/crates/sui-framework/docs/transfer.md
@@ -7,12 +7,15 @@
 
 -  [Constants](#@Constants_0)
 -  [Function `transfer`](#0x2_transfer_transfer)
+-  [Function `transfer_to_address`](#0x2_transfer_transfer_to_address)
 -  [Function `freeze_object`](#0x2_transfer_freeze_object)
 -  [Function `share_object`](#0x2_transfer_share_object)
 -  [Function `transfer_internal`](#0x2_transfer_transfer_internal)
 
 
-<pre><code></code></pre>
+<pre><code><b>use</b> <a href="address.md#0x2_address">0x2::address</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
+</code></pre>
 
 
 
@@ -36,12 +39,12 @@ be constructed in the transaction they are created.
 
 ## Function `transfer`
 
-Transfer ownership of <code>obj</code> to <code>recipient</code>. <code>obj</code> must have the
+Transfer ownership of <code>obj</code> to <code><a href="recipient.md#0x2_recipient">recipient</a></code>. <code>obj</code> must have the
 <code>key</code> attribute, which (in turn) ensures that <code>obj</code> has a globally
 unique ID.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>&lt;T: key&gt;(obj: T, <a href="recipient.md#0x2_recipient">recipient</a>: <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a>)
 </code></pre>
 
 
@@ -50,9 +53,36 @@ unique ID.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>) {
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>&lt;T: key&gt;(obj: T, <a href="recipient.md#0x2_recipient">recipient</a>: Recipient) {
+    <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>(obj, sui::address::from_recipient(<a href="recipient.md#0x2_recipient">recipient</a>))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_transfer_transfer_to_address"></a>
+
+## Function `transfer_to_address`
+
+Transfer ownership of <code>obj</code> to an address <code><a href="recipient.md#0x2_recipient">recipient</a></code>. <code>obj</code> must have the
+<code>key</code> attribute, which (in turn) ensures that <code>obj</code> has a globally
+unique ID.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer_transfer_to_address">transfer_to_address</a>&lt;T: key&gt;(obj: T, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer_transfer_to_address">transfer_to_address</a>&lt;T: key&gt;(obj: T, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>) {
     // TODO: emit <a href="event.md#0x2_event">event</a>
-    <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>(obj, recipient)
+    <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>(obj, <a href="recipient.md#0x2_recipient">recipient</a>)
 }
 </code></pre>
 
@@ -149,7 +179,7 @@ in this transaction. This restriction may be relaxed in the future.
 
 
 
-<pre><code><b>fun</b> <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>)
+<pre><code><b>fun</b> <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>&lt;T: key&gt;(obj: T, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>)
 </code></pre>
 
 
@@ -158,7 +188,7 @@ in this transaction. This restriction may be relaxed in the future.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>fun</b> <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>);
+<pre><code><b>native</b> <b>fun</b> <a href="transfer.md#0x2_transfer_transfer_internal">transfer_internal</a>&lt;T: key&gt;(obj: T, <a href="recipient.md#0x2_recipient">recipient</a>: <b>address</b>);
 </code></pre>
 
 
@@ -174,7 +204,7 @@ in this transaction. This restriction may be relaxed in the future.
 <b>aborts_if</b> [abstract] <b>false</b>;
 <b>modifies</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes);
 <b>ensures</b> [abstract] <b>exists</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes);
-<b>ensures</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes).owner == recipient;
+<b>ensures</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes).owner == <a href="recipient.md#0x2_recipient">recipient</a>;
 <b>ensures</b> [abstract] <b>global</b>&lt;<a href="object.md#0x2_object_Ownership">object::Ownership</a>&gt;(<a href="object.md#0x2_object_id">object::id</a>(obj).bytes).status == <a href="prover.md#0x2_prover_OWNED">prover::OWNED</a>;
 </code></pre>
 

--- a/crates/sui-framework/docs/tx_context.md
+++ b/crates/sui-framework/docs/tx_context.md
@@ -8,6 +8,7 @@
 -  [Struct `TxContext`](#0x2_tx_context_TxContext)
 -  [Constants](#@Constants_0)
 -  [Function `sender`](#0x2_tx_context_sender)
+-  [Function `recipient`](#0x2_tx_context_recipient)
 -  [Function `epoch`](#0x2_tx_context_epoch)
 -  [Function `epoch_timestamp_ms`](#0x2_tx_context_epoch_timestamp_ms)
 -  [Function `new_object`](#0x2_tx_context_new_object)
@@ -15,7 +16,9 @@
 -  [Function `derive_id`](#0x2_tx_context_derive_id)
 
 
-<pre><code></code></pre>
+<pre><code><b>use</b> <a href="address.md#0x2_address">0x2::address</a>;
+<b>use</b> <a href="recipient.md#0x2_recipient">0x2::recipient</a>;
+</code></pre>
 
 
 
@@ -118,6 +121,32 @@ transaction
 
 <pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_sender">sender</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <b>address</b> {
     self.sender
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_tx_context_recipient"></a>
+
+## Function `recipient`
+
+Return the recipient for the user that signed the current
+transaction
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="recipient.md#0x2_recipient">recipient</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="recipient.md#0x2_recipient_Recipient">recipient::Recipient</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="recipient.md#0x2_recipient">recipient</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): Recipient {
+    sui::address::recipient(self.sender)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator_cap.md
+++ b/crates/sui-framework/docs/validator_cap.md
@@ -174,7 +174,7 @@ or rotating an existing validaotr's <code>operation_cap_id</code>.
         authorizer_validator_address: validator_address,
     };
     <b>let</b> operation_cap_id = <a href="object.md#0x2_object_id">object::id</a>(&operation_cap);
-    <a href="transfer.md#0x2_transfer_transfer">transfer::transfer</a>(operation_cap, validator_address);
+    <a href="transfer.md#0x2_transfer_transfer_to_address">transfer::transfer_to_address</a>(operation_cap, validator_address);
     operation_cap_id
 }
 </code></pre>

--- a/crates/sui-framework/sources/address.move
+++ b/crates/sui-framework/sources/address.move
@@ -6,15 +6,23 @@ module sui::address {
     use std::ascii;
     use std::bcs;
     use std::string;
+    use sui::recipient::{Self, Recipient};
 
     /// The length of an address, in bytes
     const LENGTH: u64 = 32;
 
     // The largest integer that can be represented with 32 bytes: 2^(8*32) - 1
-    const MAX: u256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+    const MAX: u256 =
+        0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 
     /// Error from `from_bytes` when it is supplied too many or too few bytes.
     const EAddressParseError: u64 = 0;
+
+    /// The recipient is not an object
+    const ENotAnAddressRecipient: u64 = 100;
+
+    /// The recipient is an address
+    const ADDRESS_RECIPIENT_KIND: u8 = 0;
 
     /// Convert `a` into a u256 by interpreting `a` as the bytes of a big-endian integer
     /// (e.g., `to_u256(0x1) == 1`)
@@ -72,6 +80,19 @@ module sui::address {
     /// Largest possible address
     public fun max(): u256 {
         MAX
+    }
+
+    /// Constructs an address Recipient
+    public fun recipient(recipient: address): Recipient {
+        recipient::new(ADDRESS_RECIPIENT_KIND, recipient)
+    }
+
+    /// Converts the recipient to an address.
+    /// Aborts if the kind is not an address kind
+    public fun from_recipient(recipient: Recipient): address {
+        let (kind, value) = recipient::destroy(recipient);
+        assert!(kind == ADDRESS_RECIPIENT_KIND, ENotAnAddressRecipient);
+        value
     }
 
     spec module { pragma verify = false; }

--- a/crates/sui-framework/sources/coin.move
+++ b/crates/sui-framework/sources/coin.move
@@ -350,7 +350,7 @@ module sui::coin {
     public entry fun mint_and_transfer<T>(
         c: &mut TreasuryCap<T>, amount: u64, recipient: address, ctx: &mut TxContext
     ) {
-        transfer::transfer(mint(c, amount, ctx), recipient)
+        transfer::transfer_to_address(mint(c, amount, ctx), recipient)
     }
 
     /// Burn a Coin and reduce the total_supply. Invokes `burn()`.

--- a/crates/sui-framework/sources/crypto/randomness.move
+++ b/crates/sui-framework/sources/crypto/randomness.move
@@ -37,6 +37,7 @@ module sui::randomness {
     use sui::object::{Self, UID, ID};
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
+    use sui::recipient::Recipient;
 
     /// Set is called with an invalid signature.
     const EInvalidSignature: u64 = 0;
@@ -65,7 +66,7 @@ module sui::randomness {
         // TODO: Front load the fee.
     }
 
-    public fun transfer<T>(self: Randomness<T>, to: address) {
+    public fun transfer<T>(self: Randomness<T>, to: Recipient) {
         transfer::transfer(self, to);
     }
 

--- a/crates/sui-framework/sources/devnet_nft.move
+++ b/crates/sui-framework/sources/devnet_nft.move
@@ -12,6 +12,7 @@ module sui::devnet_nft {
     use sui::event;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
+    use sui::recipient::Recipient;
 
     /// An example NFT that can be minted by anybody
     struct DevNetNFT has key, store {
@@ -29,7 +30,7 @@ module sui::devnet_nft {
         // The Object ID of the NFT
         object_id: ID,
         // The creator of the NFT
-        creator: address,
+        creator: Recipient,
         // The name of the NFT
         name: string::String,
     }
@@ -47,13 +48,13 @@ module sui::devnet_nft {
             description: string::utf8(description),
             url: url::new_unsafe_from_bytes(url)
         };
-        let sender = tx_context::sender(ctx);
+        let recipient = tx_context::recipient(ctx);
         event::emit(MintNFTEvent {
             object_id: object::uid_to_inner(&nft.id),
-            creator: sender,
+            creator: recipient,
             name: nft.name,
         });
-        transfer::transfer(nft, sender);
+        transfer::transfer(nft, recipient);
     }
 
     /// Update the `description` of `nft` to `new_description`
@@ -106,7 +107,7 @@ module sui::devnet_nftTests {
         ts::next_tx(&mut scenario, addr1);
         {
             let nft = ts::take_from_sender<DevNetNFT>(&mut scenario);
-            transfer::transfer(nft, addr2);
+            transfer::transfer_to_address(nft, addr2);
         };
         // update its description
         ts::next_tx(&mut scenario, addr2);

--- a/crates/sui-framework/sources/display.move
+++ b/crates/sui-framework/sources/display.move
@@ -12,7 +12,7 @@
 /// More entry functions might be added in the future depending on the use cases.
 module sui::display {
     use sui::package::{from_package, Publisher};
-    use sui::tx_context::{sender, TxContext};
+    use sui::tx_context::{recipient, TxContext};
     use sui::vec_map::{Self, VecMap};
     use sui::object::{Self, ID, UID};
     use sui::transfer::transfer;
@@ -114,7 +114,7 @@ module sui::display {
 
     /// Create a new empty Display<T> object and keep it.
     entry public fun create_and_keep<T: key>(pub: &Publisher, ctx: &mut TxContext) {
-        transfer(new<T>(pub, ctx), sender(ctx))
+        transfer(new<T>(pub, ctx), recipient(ctx))
     }
 
     /// Manually bump the version and emit an event with the updated version's contents.
@@ -235,7 +235,7 @@ module sui::display_tests {
         display::add(&mut display, utf8(b"description"), utf8(b"A Lovely Capy"));
 
         package::burn_publisher(pub);
-        transfer(display, @0x2);
+        transfer(display, sui::address::recipient(@0x2));
         test::end(test);
     }
 }

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -130,6 +130,9 @@ module sui::genesis {
         clock::create();
 
         // Transfer the remaining balance of sui's supply to the initial account
-        sui::transfer(coin::from_balance(sui_supply, ctx), initial_sui_custody_account_address);
+        sui::transfer::transfer(
+            coin::from_balance(sui_supply, ctx),
+            sui::address::recipient(initial_sui_custody_account_address),
+        );
     }
 }

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -369,7 +369,7 @@ module sui::sui_system {
     /// Report a validator as a bad or non-performant actor in the system.
     /// Succeeds if all the following are satisfied:
     /// 1. both the reporter in `cap` and the input `reportee_addr` are active validators.
-    /// 2. reporter and reportee not the same address. 
+    /// 2. reporter and reportee not the same address.
     /// 3. the cap object is still valid.
     /// This function is idempotent.
     public entry fun report_validator(
@@ -806,7 +806,10 @@ module sui::sui_system {
             let balance = balance::split(&mut total_balance, amount);
             // transfer back the remainder if non zero.
             if (balance::value(&total_balance) > 0) {
-                transfer::transfer(coin::from_balance(total_balance, ctx), tx_context::sender(ctx));
+                transfer::transfer(
+                    coin::from_balance(total_balance, ctx),
+                    tx_context::recipient(ctx),
+                );
             } else {
                 balance::destroy_zero(total_balance);
             };
@@ -839,7 +842,12 @@ module sui::sui_system {
             let amount = option::destroy_some(amount);
             let balance = balance::split(&mut total_balance, amount);
             if (balance::value(&total_balance) > 0) {
-                locked_coin::new_from_balance(total_balance, first_lock, tx_context::sender(ctx), ctx);
+                locked_coin::new_from_balance(
+                    total_balance,
+                    first_lock,
+                    tx_context::recipient(ctx),
+                    ctx,
+                );
             } else {
                 balance::destroy_zero(total_balance);
             };

--- a/crates/sui-framework/sources/governance/validator_cap.move
+++ b/crates/sui-framework/sources/governance/validator_cap.move
@@ -63,7 +63,7 @@ module sui::validator_cap {
             authorizer_validator_address: validator_address,
         };
         let operation_cap_id = object::id(&operation_cap);
-        transfer::transfer(operation_cap, validator_address);
+        transfer::transfer_to_address(operation_cap, validator_address);
         operation_cap_id
     }
 

--- a/crates/sui-framework/sources/locked_coin.move
+++ b/crates/sui-framework/sources/locked_coin.move
@@ -8,6 +8,7 @@ module sui::locked_coin {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
     use sui::epoch_time_lock::{Self, EpochTimeLock};
+    use sui::recipient::Recipient;
 
     friend sui::sui_system;
 
@@ -19,7 +20,7 @@ module sui::locked_coin {
     }
 
     /// Create a LockedCoin from `balance` and transfer it to `owner`.
-    public fun new_from_balance<T>(balance: Balance<T>, locked_until_epoch: EpochTimeLock, owner: address, ctx: &mut TxContext) {
+    public fun new_from_balance<T>(balance: Balance<T>, locked_until_epoch: EpochTimeLock, owner: Recipient, ctx: &mut TxContext) {
         let locked_coin = LockedCoin {
             id: object::new(ctx),
             balance,
@@ -47,6 +48,7 @@ module sui::locked_coin {
         coin: Coin<T>, recipient: address, locked_until_epoch: u64, ctx: &mut TxContext
     ) {
         let balance = coin::into_balance(coin);
+        let recipient = sui::address::recipient(recipient);
         new_from_balance(balance, epoch_time_lock::new(locked_until_epoch, ctx), recipient, ctx);
     }
 
@@ -58,6 +60,6 @@ module sui::locked_coin {
         object::delete(id);
         epoch_time_lock::destroy(locked_until_epoch, ctx);
         let coin = coin::from_balance(balance, ctx);
-        transfer::transfer(coin, tx_context::sender(ctx));
+        transfer::transfer(coin, tx_context::recipient(ctx));
     }
 }

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -6,6 +6,7 @@ module sui::object {
     use std::bcs;
     use sui::address;
     use sui::tx_context::{Self, TxContext};
+    use sui::recipient::{Self, Recipient};
 
     friend sui::clock;
     friend sui::dynamic_field;
@@ -16,11 +17,17 @@ module sui::object {
     #[test_only]
     friend sui::test_scenario;
 
+    /// The recipient is not an object
+    const ENotAnObjectRecipient: u64 = 101;
+
     /// The hardcoded ID for the singleton Sui System State Object.
     const SUI_SYSTEM_STATE_OBJECT_ID: address = @0x5;
 
     /// The hardcoded ID for the singleton Clock Object.
     const SUI_CLOCK_OBJECT_ID: address = @0x6;
+
+    /// Currently unused. The recipient is an object
+    const OBJECT_RECIPIENT_KIND: u8 = 1;
 
     /// An object ID. This is used to reference Sui Objects.
     /// This is *not* guaranteed to be globally unique--anyone can create an `ID` from a `UID` or
@@ -66,6 +73,18 @@ module sui::object {
     /// Make an `ID` from an address.
     public fun id_from_address(bytes: address): ID {
         ID { bytes }
+    }
+
+    /// Not yet supported
+    fun recipient(recipient: ID): Recipient {
+        recipient::new(OBJECT_RECIPIENT_KIND, id_to_address(&recipient))
+    }
+
+    /// Not yet supported
+    fun from_recipient(recipient: Recipient): ID {
+        let (kind, value) = recipient::destroy(recipient);
+        assert!(kind == OBJECT_RECIPIENT_KIND, ENotAnObjectRecipient);
+        id_from_address(value)
     }
 
     // === uid ===

--- a/crates/sui-framework/sources/package.move
+++ b/crates/sui-framework/sources/package.move
@@ -6,7 +6,7 @@
 /// - Administering package upgrades through upgrade policies.
 module sui::package {
     use sui::object::{Self, ID, UID};
-    use sui::tx_context::{TxContext, sender};
+    use sui::tx_context::{TxContext, recipient};
     use std::ascii::String;
     use std::type_name;
     use sui::types;
@@ -106,7 +106,7 @@ module sui::package {
     /// Since this function can only be called in the module initializer,
     /// the sender is the publisher.
     public fun claim_and_keep<OTW: drop>(otw: OTW, ctx: &mut TxContext) {
-        sui::transfer::transfer(claim(otw, ctx), sender(ctx))
+        sui::transfer::transfer(claim(otw, ctx), recipient(ctx))
     }
 
     /// Destroy a Publisher object effectively removing all privileges

--- a/crates/sui-framework/sources/pay.move
+++ b/crates/sui-framework/sources/pay.move
@@ -13,7 +13,7 @@ module sui::pay {
 
     /// Transfer `c` to the sender of the current transaction
     public fun keep<T>(c: Coin<T>, ctx: &TxContext) {
-        transfer::transfer(c, tx_context::sender(ctx))
+        transfer::transfer(c, tx_context::recipient(ctx))
     }
 
     /// Split coin `self` to two coins, one with balance `split_amount`,
@@ -41,7 +41,7 @@ module sui::pay {
     public entry fun split_and_transfer<T>(
         c: &mut Coin<T>, amount: u64, recipient: address, ctx: &mut TxContext
     ) {
-        transfer::transfer(coin::split(c, amount, ctx), recipient)
+        transfer::transfer_to_address(coin::split(c, amount, ctx), recipient)
     }
 
 
@@ -53,7 +53,7 @@ module sui::pay {
         let vec: vector<Coin<T>> = coin::divide_into_n(self, n, ctx);
         let (i, len) = (0, vector::length(&vec));
         while (i < len) {
-            transfer::transfer(vector::pop_back(&mut vec), tx_context::sender(ctx));
+            transfer::transfer(vector::pop_back(&mut vec), tx_context::recipient(ctx));
             i = i + 1;
         };
         vector::destroy_empty(vec);
@@ -82,6 +82,6 @@ module sui::pay {
 
         let self = vector::pop_back(&mut coins);
         join_vec(&mut self, coins);
-        transfer::transfer(self, receiver)
+        transfer::transfer_to_address(self, receiver)
     }
 }

--- a/crates/sui-framework/sources/recipient.move
+++ b/crates/sui-framework/sources/recipient.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui::recipient {
+
+    friend sui::object;
+    friend sui::address;
+
+    /// The recipient is not an address
+    const ENotAnAddress: u64 = 0;
+    /// Currently unused. The recipient is not an object
+    const ENotAnObject: u64 = 1;
+
+    /// The recipient is an address
+    const ADDRESS_RECIPIENT_KIND: u8 = 0;
+    /// Currently unused. The recipient is an object
+    const OBJECT_RECIPIENT_KIND: u8 = 1;
+
+    /// The recipient of a transfer
+    struct Recipient has copy, drop, store {
+        /// The kind of recipient, currently only an address recipient is supported,
+        /// but object recipients will be supported in the future
+        kind: u8,
+        /// The underlying value for the recipient, ID or address
+        value: address,
+    }
+
+    /// internal construction of a Recipient
+    public(friend) fun new(kind: u8, value: address): Recipient {
+        Recipient { kind, value }
+    }
+
+    /// internal deconstruction of a Recipient
+    public(friend) fun destroy(recipient: Recipient): (u8, address) {
+        let Recipient { kind, value } = recipient;
+        (kind, value)
+    }
+
+}

--- a/crates/sui-framework/sources/safe.move
+++ b/crates/sui-framework/sources/safe.move
@@ -5,7 +5,7 @@
 /// the capability to transfer coins away from their wallets, if they are provided with the correct permission.
 module sui::safe {
     use sui::object::{Self, ID, UID};
-    use sui::tx_context::{TxContext, sender};
+    use sui::tx_context::{TxContext, recipient};
     use sui::transfer::Self;
     use sui::balance::{Self, Balance};
     use sui::coin::{Self, Coin};
@@ -22,9 +22,9 @@ module sui::safe {
     //
     /// Allows any holder of a capability to transfer a fixed amount of assets from the safe.
     /// Useful in situations like an NFT marketplace where you wish to buy the NFTs at a specific price.
-    /// 
+    ///
     /// @ownership: Shared
-    /// 
+    ///
     struct Safe<phantom T> has key {
         id: UID,
         balance: Balance<T>,
@@ -51,7 +51,7 @@ module sui::safe {
     //////////////////////////////////////////////////////
     /// HELPER FUNCTIONS
     //////////////////////////////////////////////////////
-    
+
     /// Check that the capability has not yet been revoked by the owner.
     fun check_capability_validity<T>(safe: &Safe<T>, capability: &TransferCapability<T>) {
         // Check that the ids match
@@ -81,7 +81,7 @@ module sui::safe {
     //////////////////////////////////////////////////////
     /// PUBLIC FUNCTIONS
     //////////////////////////////////////////////////////
-    
+
     public fun balance<T>(safe: &Safe<T>): &Balance<T> {
         &safe.balance
     }
@@ -105,13 +105,13 @@ module sui::safe {
     public entry fun create<T>(coin: Coin<T>, ctx: &mut TxContext) {
         let balance = coin::into_balance(coin);
         let cap = create_<T>(balance, ctx);
-        transfer::transfer(cap, sender(ctx));
+        transfer::transfer(cap, recipient(ctx));
     }
 
     public entry fun create_empty<T>(ctx: &mut TxContext) {
         let empty_balance = balance::zero<T>();
         let cap = create_(empty_balance, ctx);
-        transfer::transfer(cap, sender(ctx));
+        transfer::transfer(cap, recipient(ctx));
     }
 
     /// Deposit funds to the safe
@@ -136,7 +136,7 @@ module sui::safe {
     public entry fun withdraw<T>(safe: &mut Safe<T>, capability: &OwnerCapability<T>, withdraw_amount: u64, ctx: &mut TxContext) {
         let balance = withdraw_(safe, capability, withdraw_amount);
         let coin = coin::from_balance(balance, ctx);
-        transfer::transfer(coin, sender(ctx));
+        transfer::transfer(coin, recipient(ctx));
     }
 
     /// Withdraw coins from the safe as a `TransferCapability` holder.

--- a/crates/sui-framework/sources/sui.move
+++ b/crates/sui-framework/sources/sui.move
@@ -33,7 +33,7 @@ module sui::sui {
         assert!(tx_context::epoch(ctx) == 0, EAlreadyMinted);
 
         let (treasury, metadata) = coin::create_currency(
-            SUI {}, 
+            SUI {},
             9,
             b"SUI",
             b"Sui",
@@ -49,7 +49,4 @@ module sui::sui {
         total_sui
     }
 
-    public entry fun transfer(c: coin::Coin<SUI>, recipient: address) {
-        transfer::transfer(c, recipient)
-    }
 }

--- a/crates/sui-framework/sources/test/test_scenario.move
+++ b/crates/sui-framework/sources/test/test_scenario.move
@@ -7,6 +7,7 @@ module sui::test_scenario {
     use sui::object::{Self, ID, UID};
     use sui::tx_context::{Self, TxContext};
     use sui::vec_map::VecMap;
+    use sui::recipient::Recipient;
 
     /// the transaction failed when generating these effects. For example, a circular ownership
     /// of objects was created
@@ -162,6 +163,11 @@ module sui::test_scenario {
         tx_context::sender(&scenario.ctx)
     }
 
+    /// Return the recipient of the current tx in this `scenario`
+    public fun recipient(scenario: &Scenario): Recipient {
+        tx_context::recipient(&scenario.ctx)
+    }
+
     /// Return the number of concluded transactions in this scenario.
     /// This does not include the current transaction, e.g. this will return 0 if `next_tx` has
     /// not yet been called
@@ -248,7 +254,7 @@ module sui::test_scenario {
     public fun return_to_address<T: key>(account: address, t: T) {
         let id = object::id(&t);
         assert!(was_taken_from_address(account, id), ECantReturnObject);
-        sui::transfer::transfer(t, account)
+        sui::transfer::transfer_to_address(t, account)
     }
 
     /// Returns true if the object with `ID` id was in the inventory for `account`

--- a/crates/sui-framework/sources/transfer.move
+++ b/crates/sui-framework/sources/transfer.move
@@ -5,6 +5,7 @@ module sui::transfer {
 
     use sui::object;
     use sui::prover;
+    use sui::recipient::Recipient;
 
     /// Shared an object that was previously created. Shared objects must currently
     /// be constructed in the transaction they are created.
@@ -13,7 +14,14 @@ module sui::transfer {
     /// Transfer ownership of `obj` to `recipient`. `obj` must have the
     /// `key` attribute, which (in turn) ensures that `obj` has a globally
     /// unique ID.
-    public fun transfer<T: key>(obj: T, recipient: address) {
+    public fun transfer<T: key>(obj: T, recipient: Recipient) {
+        transfer_internal(obj, sui::address::from_recipient(recipient))
+    }
+
+    /// Transfer ownership of `obj` to an address `recipient`. `obj` must have the
+    /// `key` attribute, which (in turn) ensures that `obj` has a globally
+    /// unique ID.
+    public fun transfer_to_address<T: key>(obj: T, recipient: address) {
         // TODO: emit event
         transfer_internal(obj, recipient)
     }

--- a/crates/sui-framework/sources/tx_context.move
+++ b/crates/sui-framework/sources/tx_context.move
@@ -5,6 +5,8 @@ module sui::tx_context {
 
     friend sui::object;
 
+    use sui::recipient::Recipient;
+
     #[test_only]
     use std::vector;
 
@@ -40,6 +42,13 @@ module sui::tx_context {
     public fun sender(self: &TxContext): address {
         self.sender
     }
+
+    /// Return the recipient for the user that signed the current
+    /// transaction
+    public fun recipient(self: &TxContext): Recipient {
+        sui::address::recipient(self.sender)
+    }
+
 
     /// Return the current epoch
     public fun epoch(self: &TxContext): u64 {

--- a/crates/sui-framework/tests/coin_tests.move
+++ b/crates/sui-framework/tests/coin_tests.move
@@ -54,7 +54,7 @@ module sui::coin_tests {
         assert!(*icon_url == b"new_icon_url", 0);
 
         transfer::freeze_object(metadata);
-        transfer::transfer(treasury, tx_context::sender(ctx));
+        transfer::transfer(treasury, tx_context::recipient(ctx));
         test_scenario::end(scenario);
     }
 
@@ -79,7 +79,7 @@ module sui::coin_tests {
         pay::keep(coin, test_scenario::ctx(test));
 
         transfer::freeze_object(metadata);
-        transfer::transfer(treasury, tx_context::sender(test_scenario::ctx(test)));
+        transfer::transfer(treasury, tx_context::recipient(test_scenario::ctx(test)));
         test_scenario::end(scenario);
     }
 }

--- a/crates/sui-framework/tests/collectible_tests.move
+++ b/crates/sui-framework/tests/collectible_tests.move
@@ -5,7 +5,7 @@
 /// Initializes a simple collection.
 module sui::boars {
     use sui::tx_context::{TxContext, sender};
-    use sui::transfer::transfer;
+    use sui::transfer::transfer_to_address;
     use sui::collectible;
     use sui::display;
     use std::string::utf8;
@@ -42,9 +42,9 @@ module sui::boars {
         ]);
 
         display::update_version(&mut display);
-        transfer(creator_cap, sender(ctx));
-        transfer(display, sender(ctx));
-        transfer(pub, sender(ctx))
+        transfer_to_address(creator_cap, sender(ctx));
+        transfer_to_address(display, sender(ctx));
+        transfer_to_address(pub, sender(ctx))
     }
 
     #[test_only]
@@ -58,7 +58,7 @@ module sui::collectible_tests {
     use sui::test_scenario::{Self as ts};
     use sui::collectible::{Self, CollectionCreatorCap};
     use sui::boars::{Self, Boar};
-    use sui::transfer::transfer;
+    use sui::transfer::transfer_to_address;
     use std::option::{some, none};
     use std::string::utf8;
     use std::vector as vec;
@@ -86,8 +86,8 @@ module sui::collectible_tests {
                 ts::ctx(&mut test)
             );
 
-            transfer(creator_cap, creator);
-            transfer(boar, creator)
+            transfer_to_address(creator_cap, creator);
+            transfer_to_address(boar, creator)
         };
 
         ts::next_tx(&mut test, creator); {
@@ -103,10 +103,10 @@ module sui::collectible_tests {
             );
 
             while (vec::length(&boars) > 0) {
-                transfer(vec::pop_back(&mut boars), creator);
+                transfer_to_address(vec::pop_back(&mut boars), creator);
             };
 
-            transfer(creator_cap, creator);
+            transfer_to_address(creator_cap, creator);
             vec::destroy_empty(boars);
         };
 

--- a/crates/sui-framework/tests/prover_tests.move
+++ b/crates/sui-framework/tests/prover_tests.move
@@ -13,7 +13,7 @@ module sui::prover_tests {
     // ====================================================================
 
     public fun simple_transfer(o: Obj, recipient: address) {
-        sui::transfer::transfer(o, recipient);
+        sui::transfer::transfer_to_address(o, recipient);
     }
 
     spec simple_transfer {

--- a/crates/sui-framework/tests/safe_tests.move
+++ b/crates/sui-framework/tests/safe_tests.move
@@ -31,7 +31,7 @@ module sui::safe_tests {
         let cap = ts::take_from_sender<OwnerCapability<SUI>>(scenario);
         let capability = safe::create_transfer_capability(&mut safe, &cap, delegate_amount, ctx(scenario));
         id = object::id(&capability);
-        transfer::transfer(capability, delegate_to);
+        transfer::transfer_to_address(capability, delegate_to);
         ts::return_to_sender(scenario, cap);
         ts::return_shared(safe);
         id

--- a/crates/sui-framework/tests/sui_system_tests.move
+++ b/crates/sui-framework/tests/sui_system_tests.move
@@ -56,7 +56,7 @@ module sui::sui_system_tests {
 
         report_helper(@0x3, @0x2, false, scenario);
         assert!(get_reporters_of(@0x2, scenario) == vector[@0x1, @0x3], 0);
-        
+
         // After 0x3 leaves, its reports are gone
         remove_validator(@0x3, scenario);
         advance_epoch(scenario);
@@ -80,7 +80,7 @@ module sui::sui_system_tests {
         let delegatee_address = @0xbeef;
         test_scenario::next_tx(scenario, @0x1);
         let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
-        transfer::transfer(cap, delegatee_address);
+        transfer::transfer_to_address(cap, delegatee_address);
 
         // With the cap object in hand, delegatee could report validators on behalf of @0x1.
         report_helper(delegatee_address, @0x2, false, scenario);
@@ -93,7 +93,7 @@ module sui::sui_system_tests {
         test_scenario::next_tx(scenario, delegatee_address);
         let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
         let new_delegatee_address = @0xcafe;
-        transfer::transfer(cap, new_delegatee_address);
+        transfer::transfer_to_address(cap, new_delegatee_address);
 
         // New delegatee could report validators on behalf of @0x1.
         report_helper(new_delegatee_address, @0x2, false, scenario);
@@ -134,7 +134,7 @@ module sui::sui_system_tests {
         let delegatee_address = @0xbeef;
         test_scenario::next_tx(scenario, @0x1);
         let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
-        transfer::transfer(cap, delegatee_address);
+        transfer::transfer_to_address(cap, delegatee_address);
 
         report_helper(delegatee_address, @0x2, false, scenario);
         assert!(get_reporters_of(@0x2, scenario) == vector[@0x1], 0);
@@ -160,7 +160,7 @@ module sui::sui_system_tests {
         let delegatee_address = @0xbeef;
         test_scenario::next_tx(scenario, @0x1);
         let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
-        transfer::transfer(cap, delegatee_address);
+        transfer::transfer_to_address(cap, delegatee_address);
 
         // With the cap object in hand, delegatee could report validators on behalf of @0x1.
         set_gas_price_helper(delegatee_address, 888, scenario);

--- a/crates/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/tests/test_scenario_tests.move
@@ -40,7 +40,7 @@ module sui::test_scenarioTests {
         {
             let id = ts::new_object(&mut scenario);
             let obj = Object { id, value: 10 };
-            transfer::transfer(obj, copy sender);
+            transfer::transfer_to_address(obj, copy sender);
         };
         // now, object gets wrapped
         ts::next_tx(&mut scenario, sender);
@@ -48,7 +48,7 @@ module sui::test_scenarioTests {
             let id = ts::new_object(&mut scenario);
             let child = ts::take_from_sender<Object>(&mut scenario);
             let wrapper = Wrapper { id, child };
-            transfer::transfer(wrapper, copy sender);
+            transfer::transfer_to_address(wrapper, copy sender);
         };
         // wrapped object should no longer be removable, but wrapper should be
         ts::next_tx(&mut scenario, sender);
@@ -66,7 +66,7 @@ module sui::test_scenarioTests {
         {
             let id = ts::new_object(&mut scenario);
             let obj = Object { id, value: 10 };
-            transfer::transfer(obj, copy sender);
+            transfer::transfer_to_address(obj, copy sender);
         };
         // object gets removed, then returned
         ts::next_tx(&mut scenario, sender);
@@ -89,7 +89,7 @@ module sui::test_scenarioTests {
         {
             let id = ts::new_object(&mut scenario);
             let obj = Object { id, value: 10 };
-            transfer::transfer(obj, copy sender);
+            transfer::transfer_to_address(obj, copy sender);
         };
         ts::next_tx(&mut scenario, sender);
         {
@@ -114,7 +114,7 @@ module sui::test_scenarioTests {
         {
             let id = ts::new_object(&mut scenario);
             let obj = Object { id, value: 10 };
-            transfer::transfer(obj, copy sender);
+            transfer::transfer_to_address(obj, copy sender);
             // an object transferred during the tx shouldn't be available in that tx
             assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0)
         };
@@ -129,7 +129,7 @@ module sui::test_scenarioTests {
         {
             let id = ts::new_object(&mut scenario);
             let obj = Object { id, value: 10 };
-            transfer::transfer(obj, copy sender);
+            transfer::transfer_to_address(obj, copy sender);
         };
         ts::next_tx(&mut scenario, sender);
         {
@@ -153,13 +153,13 @@ module sui::test_scenarioTests {
             let id = ts::new_object(&mut scenario);
             let obj = Object { id, value: 10 };
             // self-transfer
-            transfer::transfer(obj, copy addr1);
+            transfer::transfer_to_address(obj, copy addr1);
         };
         // addr1 -> addr2
         ts::next_tx(&mut scenario, addr1);
         {
             let obj = ts::take_from_sender<Object>(&mut scenario);
-            transfer::transfer(obj, copy addr2)
+            transfer::transfer_to_address(obj, copy addr2)
         };
         // addr1 cannot access
         ts::next_tx(&mut scenario, addr1);
@@ -170,7 +170,7 @@ module sui::test_scenarioTests {
         ts::next_tx(&mut scenario, addr2);
         {
             let obj = ts::take_from_sender<Object>(&mut scenario);
-            transfer::transfer(obj, copy addr3)
+            transfer::transfer_to_address(obj, copy addr3)
         };
         // addr1 cannot access
         ts::next_tx(&mut scenario, addr1);
@@ -201,7 +201,7 @@ module sui::test_scenarioTests {
             let id = ts::new_object(&mut scenario);
             id_bytes = object::uid_to_inner(&id);
             let obj = Object { id, value: 100 };
-            transfer::transfer(obj, copy tx2_sender);
+            transfer::transfer_to_address(obj, copy tx2_sender);
             // sender cannot access the object
             assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
         };
@@ -237,9 +237,9 @@ module sui::test_scenarioTests {
             let obj1 = Object { id: uid1, value: 10 };
             let obj2 = Object { id: uid2, value: 20 };
             let obj3 = Object { id: uid3, value: 30 };
-            transfer::transfer(obj1, copy sender);
-            transfer::transfer(obj2, copy sender);
-            transfer::transfer(obj3, copy sender);
+            transfer::transfer_to_address(obj1, copy sender);
+            transfer::transfer_to_address(obj2, copy sender);
+            transfer::transfer_to_address(obj3, copy sender);
         };
         ts::next_tx(&mut scenario, sender);
         let ids = ts::ids_for_sender<Object>(&scenario);
@@ -261,9 +261,9 @@ module sui::test_scenarioTests {
             let obj1 = Object { id: uid1, value: 10 };
             let obj2 = Object { id: uid2, value: 20 };
             let obj3 = Object { id: uid3, value: 30 };
-            transfer::transfer(obj1, copy sender);
-            transfer::transfer(obj2, copy sender);
-            transfer::transfer(obj3, copy sender);
+            transfer::transfer_to_address(obj1, copy sender);
+            transfer::transfer_to_address(obj2, copy sender);
+            transfer::transfer_to_address(obj3, copy sender);
         };
         ts::next_tx(&mut scenario, sender);
         {
@@ -288,7 +288,7 @@ module sui::test_scenarioTests {
             let id = ts::new_object(&mut scenario);
             let id_addr = object::uid_to_address(&id);
             let obj = Object { id, value: 10 };
-            transfer::transfer(obj, copy sender);
+            transfer::transfer_to_address(obj, copy sender);
             let ctx = ts::ctx(&mut scenario);
             assert!(id_addr == tx_context::last_created_object_id(ctx), 0);
         };
@@ -409,7 +409,7 @@ module sui::test_scenarioTests {
         {
             transfer::share_object(Object { id: uid1, value: 10 });
             transfer::freeze_object(Object { id: uid2, value: 10 });
-            transfer::transfer(Object { id: uid3, value: 10 }, sender);
+            transfer::transfer_to_address(Object { id: uid3, value: 10 }, sender);
         };
         ts::next_tx(&mut scenario, sender);
         let shared = ts::take_shared<Object>(&scenario);
@@ -422,7 +422,7 @@ module sui::test_scenarioTests {
         ts::end(scenario);
         transfer::share_object(shared);
         transfer::freeze_object(imm);
-        transfer::transfer(owned, sender);
+        transfer::transfer_to_address(owned, sender);
     }
 
     #[test]
@@ -492,7 +492,7 @@ module sui::test_scenarioTests {
         ts::next_tx(&mut scenario, sender);
         {
             let obj1 = ts::take_immutable<Object>(&mut scenario);
-            transfer::transfer(obj1, @0x0);
+            transfer::transfer_to_address(obj1, @0x0);
         };
         ts::next_tx(&mut scenario, sender);
         abort 42
@@ -615,7 +615,7 @@ module sui::test_scenarioTests {
         let scenario = ts::begin(sender);
         let uid = ts::new_object(&mut scenario);
         let id = object::uid_to_inner(&uid);
-        transfer::transfer(Object { id: uid, value: 10 }, sender);
+        transfer::transfer_to_address(Object { id: uid, value: 10 }, sender);
         ts::return_to_sender(&scenario, ts::take_from_sender_by_id<Wrapper>(&scenario, id));
         abort 42
     }
@@ -677,7 +677,7 @@ module sui::test_scenarioTests {
         let uid = ts::new_object(&mut scenario);
         let obj = Object { id: uid, value: 10};
         let id = object::id(&obj);
-        transfer::transfer(obj, sender);
+        transfer::transfer_to_address(obj, sender);
         ts::next_tx(&mut scenario, sender);
         assert!(ts::has_most_recent_for_address<Object>(sender), 0);
         let obj = ts::take_from_sender<Object>(&mut scenario);
@@ -770,6 +770,6 @@ module sui::test_scenarioTests {
             id: ts::new_object(scenario),
             value,
         };
-        transfer::transfer(object, ts::sender(scenario));
+        transfer::transfer(object, ts::recipient(scenario));
     }
 }

--- a/crates/sui-verifier/src/private_generics.rs
+++ b/crates/sui-verifier/src/private_generics.rs
@@ -19,6 +19,7 @@ pub const TRANSFER_MODULE: &IdentStr = ident_str!("transfer");
 pub const EVENT_MODULE: &IdentStr = ident_str!("event");
 pub const TRANSFER_FUNCTIONS: &[&IdentStr] = &[
     ident_str!("transfer"),
+    ident_str!("transfer_to_address"),
     ident_str!("freeze_object"),
     ident_str!("share_object"),
 ];


### PR DESCRIPTION
As discussed, this would future proof us for send-to-object. It is a bit strange though since so many call sites would need to change. Many things are still broken and need to be cleaned up, but putting it up for initial feedback 


## Description 

- Added a new type to encapsulate sending to an object and to an address

## Test Plan 

WIP
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
