### PR TITLE
[sui-framework] change some system params to constants

### DIFF
--- a/apps/explorer/src/pages/epochs/EpochDetail.tsx
+++ b/apps/explorer/src/pages/epochs/EpochDetail.tsx
@@ -51,8 +51,7 @@ function EpochDetail() {
     const validatorsTable = validatorsTableData(
         data.activeValidators,
         data.epoch,
-        validatorEvents?.data,
-        data.minValidatorStake
+        validatorEvents?.data
     );
 
     return (

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -30,13 +30,15 @@ import { roundFloat } from '~/utils/roundFloat';
 
 const APY_DECIMALS = 3;
 
+// This constant needs to match the constant in the on-chain smart contract sui_system::MIN_VALIDATOR_STAKE。
+const MIN_VALIDATOR_STAKE = 25_000_000_000_000_000;
+
 const NodeMap = lazy(() => import('../../components/node-map'));
 
 export function validatorsTableData(
     validators: SuiValidatorSummary[],
     epoch: number,
-    validatorsEvents: SuiEventEnvelope[],
-    minimumStake: number
+    validatorsEvents: SuiEventEnvelope[]
 ) {
     return {
         data: validators.map((validator) => {
@@ -60,7 +62,7 @@ export function validatorsTableData(
                 img: img,
                 address: validator.suiAddress,
                 lastReward: event?.fields.stake_rewards || 0,
-                atRisk: totalStake < minimumStake,
+                atRisk: totalStake < MIN_VALIDATOR_STAKE,
             };
         }),
         columns: [
@@ -240,8 +242,7 @@ function ValidatorPageResult() {
         return validatorsTableData(
             validators,
             +data.epoch,
-            validatorEvents.data,
-            data.minValidatorStake
+            validatorEvents.data
         );
     }, [validatorEvents, data]);
 

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -275,8 +275,6 @@ validators:
 storage_fund:
   value: 0
 parameters:
-  min_validator_stake: 25000000000000000
-  max_validator_count: 100
   governance_start_epoch: 0
 reference_gas_price: 1
 validator_report_records:

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -27,26 +27,6 @@
 ## Constants
 
 
-<a name="0x2_genesis_INIT_MAX_VALIDATOR_COUNT"></a>
-
-Initial value of the upper-bound on the number of validators.
-
-
-<pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_MAX_VALIDATOR_COUNT">INIT_MAX_VALIDATOR_COUNT</a>: u64 = 100;
-</code></pre>
-
-
-
-<a name="0x2_genesis_INIT_MIN_VALIDATOR_STAKE"></a>
-
-Initial value of the lower-bound on the amount of stake required to become a validator.
-
-
-<pre><code><b>const</b> <a href="genesis.md#0x2_genesis_INIT_MIN_VALIDATOR_STAKE">INIT_MIN_VALIDATOR_STAKE</a>: u64 = 25000000000000000;
-</code></pre>
-
-
-
 <a name="0x2_genesis_INIT_STAKE_SUBSIDY_AMOUNT"></a>
 
 Stake subisidy to be given out in the very first epoch. Placeholder value.
@@ -174,8 +154,6 @@ all the information we need in the system.
         validators,
         subsidy_fund,
         storage_fund,
-        <a href="genesis.md#0x2_genesis_INIT_MAX_VALIDATOR_COUNT">INIT_MAX_VALIDATOR_COUNT</a>,
-        <a href="genesis.md#0x2_genesis_INIT_MIN_VALIDATOR_STAKE">INIT_MIN_VALIDATOR_STAKE</a>,
         governance_start_epoch,
         <a href="genesis.md#0x2_genesis_INIT_STAKE_SUBSIDY_AMOUNT">INIT_STAKE_SUBSIDY_AMOUNT</a>,
         protocol_version,

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -103,19 +103,6 @@ A list of system config parameters.
 
 <dl>
 <dt>
-<code>min_validator_stake: u64</code>
-</dt>
-<dd>
- Lower-bound on the amount of stake required to become a validator.
-</dd>
-<dt>
-<code>max_validator_count: u64</code>
-</dt>
-<dd>
- Maximum number of active validators at any moment.
- We do not allow the number of validators in any epoch to go above this.
-</dd>
-<dt>
 <code>governance_start_epoch: u64</code>
 </dt>
 <dd>
@@ -433,6 +420,27 @@ the epoch advancement transaction.
 
 
 
+<a name="0x2_sui_system_MAX_VALIDATOR_COUNT"></a>
+
+Maximum number of active validators at any moment.
+We do not allow the number of validators in any epoch to go above this.
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_MAX_VALIDATOR_COUNT">MAX_VALIDATOR_COUNT</a>: u64 = 150;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_MIN_VALIDATOR_STAKE"></a>
+
+Lower-bound on the amount of stake required to become a validator.
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_MIN_VALIDATOR_STAKE">MIN_VALIDATOR_STAKE</a>: u64 = 25000000000000000;
+</code></pre>
+
+
+
 <a name="0x2_sui_system_create"></a>
 
 ## Function `create`
@@ -441,7 +449,7 @@ Create a new SuiSystemState object and make it shared.
 This function will be called only once in genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, max_validator_count: u64, min_validator_stake: u64, governance_start_epoch: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, governance_start_epoch: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -454,8 +462,6 @@ This function will be called only once in genesis.
     validators: <a href="">vector</a>&lt;Validator&gt;,
     stake_subsidy_fund: Balance&lt;SUI&gt;,
     storage_fund: Balance&lt;SUI&gt;,
-    max_validator_count: u64,
-    min_validator_stake: u64,
     governance_start_epoch: u64,
     initial_stake_subsidy_amount: u64,
     protocol_version: u64,
@@ -471,8 +477,6 @@ This function will be called only once in genesis.
         validators,
         storage_fund,
         parameters: <a href="sui_system.md#0x2_sui_system_SystemParameters">SystemParameters</a> {
-            min_validator_stake,
-            max_validator_count,
             governance_start_epoch,
         },
         reference_gas_price,
@@ -500,7 +504,7 @@ This function will be called only once in genesis.
 ## Function `request_add_validator_candidate`
 
 Can be called by anyone who wishes to become a validator candidate and starts accuring delegated
-stakes in their staking pool. Once they have at least <code>min_validator_stake</code> amount of stake they
+stakes in their staking pool. Once they have at least <code><a href="sui_system.md#0x2_sui_system_MIN_VALIDATOR_STAKE">MIN_VALIDATOR_STAKE</a></code> amount of stake they
 can call <code>request_add_validator</code> to officially become an active validator at the next epoch.
 Aborts if the caller is already a pending or active validator, or a validator candidate.
 
@@ -618,11 +622,11 @@ epoch has already reached the maximum.
 ) {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
     <b>assert</b>!(
-        <a href="validator_set.md#0x2_validator_set_next_epoch_validator_count">validator_set::next_epoch_validator_count</a>(&self.validators) &lt; self.parameters.max_validator_count,
+        <a href="validator_set.md#0x2_validator_set_next_epoch_validator_count">validator_set::next_epoch_validator_count</a>(&self.validators) &lt; <a href="sui_system.md#0x2_sui_system_MAX_VALIDATOR_COUNT">MAX_VALIDATOR_COUNT</a>,
         <a href="sui_system.md#0x2_sui_system_ELimitExceeded">ELimitExceeded</a>,
     );
 
-    <a href="validator_set.md#0x2_validator_set_request_add_validator">validator_set::request_add_validator</a>(&<b>mut</b> self.validators, self.parameters.min_validator_stake, ctx);
+    <a href="validator_set.md#0x2_validator_set_request_add_validator">validator_set::request_add_validator</a>(&<b>mut</b> self.validators, <a href="sui_system.md#0x2_sui_system_MIN_VALIDATOR_STAKE">MIN_VALIDATOR_STAKE</a>, ctx);
 }
 </code></pre>
 

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -13,12 +13,6 @@ module sui::genesis {
     use sui::validator;
     use std::option;
 
-    /// Initial value of the lower-bound on the amount of stake required to become a validator.
-    const INIT_MIN_VALIDATOR_STAKE: u64 = 25_000_000_000_000_000;
-
-    /// Initial value of the upper-bound on the number of validators.
-    const INIT_MAX_VALIDATOR_COUNT: u64 = 100;
-
     /// Stake subisidy to be given out in the very first epoch. Placeholder value.
     const INIT_STAKE_SUBSIDY_AMOUNT: u64 = 1000000;
 
@@ -117,8 +111,6 @@ module sui::genesis {
             validators,
             subsidy_fund,
             storage_fund,
-            INIT_MAX_VALIDATOR_COUNT,
-            INIT_MIN_VALIDATOR_STAKE,
             governance_start_epoch,
             INIT_STAKE_SUBSIDY_AMOUNT,
             protocol_version,

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -64,8 +64,6 @@ module sui::governance_test_utils {
             validators,
             balance::create_for_testing<SUI>(sui_supply_amount), // sui_supply
             balance::create_for_testing<SUI>(storage_fund_amount), // storage_fund
-            1024, // max_validator_candidate_count
-            0, // min_validator_stake
             0, // governance_start_epoch
             0, // stake subsidy
             1, // protocol version
@@ -215,7 +213,7 @@ module sui::governance_test_utils {
             ctx
         );
         sui_system::request_add_delegation(&mut system_state, coin::mint_for_testing<SUI>(init_stake_amount, ctx), validator, ctx);
-        sui_system::request_add_validator(&mut system_state, ctx);
+        sui_system::request_add_validator_for_testing(&mut system_state, 0, ctx);
         test_scenario::return_shared(system_state);
     }
 
@@ -264,8 +262,9 @@ module sui::governance_test_utils {
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
         let ctx = test_scenario::ctx(scenario);
 
-        sui_system::request_add_validator(
+        sui_system::request_add_validator_for_testing(
             &mut system_state,
+            0,
             ctx
         );
         test_scenario::return_shared(system_state);

--- a/crates/sui-framework/tests/sui_system_tests.move
+++ b/crates/sui-framework/tests/sui_system_tests.move
@@ -56,7 +56,7 @@ module sui::sui_system_tests {
 
         report_helper(@0x3, @0x2, false, scenario);
         assert!(get_reporters_of(@0x2, scenario) == vector[@0x1, @0x3], 0);
-        
+
         // After 0x3 leaves, its reports are gone
         remove_validator(@0x3, scenario);
         advance_epoch(scenario);
@@ -516,7 +516,7 @@ module sui::sui_system_tests {
                 0,
                 ctx,
             );
-            sui_system::request_add_validator(&mut system_state, ctx);
+            sui_system::request_add_validator_for_testing(&mut system_state, 0, ctx);
         };
 
         test_scenario::next_tx(scenario, new_validator_addr);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5840,8 +5840,6 @@
           "governanceStartEpoch",
           "inactivePoolsId",
           "inactivePoolsSize",
-          "maxValidatorCount",
-          "minValidatorStake",
           "pendingActiveValidatorsId",
           "pendingActiveValidatorsSize",
           "pendingRemovals",
@@ -5895,18 +5893,6 @@
           },
           "inactivePoolsSize": {
             "description": "Number of inactive staking pools.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "maxValidatorCount": {
-            "description": "Maximum number of active validators at any moment. We do not allow the number of validators in any epoch to go above this.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "minValidatorStake": {
-            "description": "Lower-bound on the amount of stake required to become a validator.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -33,8 +33,6 @@ const E_METADATA_INVALID_WORKER_ADDR: u64 = 7;
 // TODO: Get rid of json schema once we deprecate getSuiSystemState RPC API.
 #[serde(rename = "SystemParameters")]
 pub struct SystemParametersV1 {
-    pub min_validator_stake: u64,
-    pub max_validator_count: u64,
     pub governance_start_epoch: u64,
 }
 
@@ -506,12 +504,9 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
                         },
                 },
             storage_fund,
-            parameters:
-                SystemParametersV1 {
-                    min_validator_stake,
-                    max_validator_count,
-                    governance_start_epoch,
-                },
+            parameters: SystemParametersV1 {
+                governance_start_epoch,
+            },
             reference_gas_price,
             validator_report_records:
                 VecMap {
@@ -533,8 +528,6 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
             reference_gas_price,
             safe_mode,
             epoch_start_timestamp_ms,
-            min_validator_stake,
-            max_validator_count,
             governance_start_epoch,
             stake_subsidy_epoch_counter,
             stake_subsidy_balance: stake_subsidy_balance.value(),
@@ -579,8 +572,6 @@ impl Default for SuiSystemStateInnerV1 {
             validators: validator_set,
             storage_fund: Balance::new(0),
             parameters: SystemParametersV1 {
-                min_validator_stake: 1,
-                max_validator_count: 100,
                 governance_start_epoch: 0,
             },
             reference_gas_price: 1,

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -36,11 +36,6 @@ pub struct SuiSystemStateSummary {
     pub epoch_start_timestamp_ms: u64,
 
     // System parameters
-    /// Lower-bound on the amount of stake required to become a validator.
-    pub min_validator_stake: u64,
-    /// Maximum number of active validators at any moment.
-    /// We do not allow the number of validators in any epoch to go above this.
-    pub max_validator_count: u64,
     /// The starting epoch in which various on-chain governance features take effect.
     pub governance_start_epoch: u64,
 

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -155,8 +155,6 @@ export const SuiSystemStateSummary = object({
   referenceGasPrice: number(),
   safeMode: boolean(),
   epochStartTimestampMs: number(),
-  minValidatorStake: number(),
-  maxValidatorCount: number(),
   governanceStartEpoch: number(),
   stakeSubsidyEpochCounter: number(),
   stakeSubsidyBalance: number(),


### PR DESCRIPTION
## Description 

This PR removes two parameters `min_validator_stake` and `max_validator_count` from the `SystemParameters` struct and make them constants in `sui_system` instead. This way we can more easily update their values by updating the framework code.

## Test Plan 

cargo test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
