### PR TITLE
[TypeScript SDK] clean up digest derivation

### DIFF
--- a/.changeset/hot-coats-mix.md
+++ b/.changeset/hot-coats-mix.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Remove `generateTransactionDigest`. Use one of the following instead: `signer.getTransactionDigest`, `Transaction.getDigest()` or `TransactionDataBuilder.getDigestFromBytes()` instead.

--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -242,6 +242,16 @@ export class Transaction {
     return this.#transactionData.build({ onlyTransactionKind });
   }
 
+  /** Derive transaction digest */
+  async getDigest({
+    provider,
+  }: {
+    provider?: Provider;
+  } = {}): Promise<string> {
+    await this.#prepare(provider);
+    return this.#transactionData.getDigest();
+  }
+
   /**
    * Prepare the transaction by valdiating the transaction data and resolving all inputs
    * so that it can be built into bytes.

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -10,9 +10,8 @@ import {
   string,
   union,
 } from 'superstruct';
-import { CallArg, TransactionData, TransactionDataBCS } from './sui-bcs';
-import { sha256Hash } from '../cryptography/hash';
-import { BCS, fromB58, toB58 } from '@mysten/bcs';
+import { CallArg } from './sui-bcs';
+import { fromB58 } from '@mysten/bcs';
 
 export const TransactionDigest = string();
 export type TransactionDigest = Infer<typeof TransactionDigest>;
@@ -114,36 +113,6 @@ export function normalizeSuiObjectId(
   forceAdd0x: boolean = false,
 ): ObjectId {
   return normalizeSuiAddress(value, forceAdd0x);
-}
-
-export function prepareTxDataForBcs(data: TransactionData): TransactionDataBCS {
-  switch (data.messageVersion) {
-    case 1: {
-      let { messageVersion: _, ...rest } = data;
-      return { V1: rest };
-    }
-    default:
-      throw new Error(`Unknown message version ${data.messageVersion}`);
-  }
-}
-
-/**
- * Generate transaction digest.
- *
- * @param data transaction data
- * @param signatureScheme signature scheme
- * @param signature signature as a base64 string
- * @param publicKey public key
- */
-export function generateTransactionDigest(
-  data: TransactionData,
-  bcs: BCS,
-): string {
-  let dataBcs = prepareTxDataForBcs(data);
-  const txBytes = bcs.ser('TransactionData', dataBcs).toBytes();
-  const hash = sha256Hash('TransactionData', txBytes);
-
-  return toB58(hash);
 }
 
 function isHex(value: string): boolean {

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -25,80 +25,6 @@ function registerUTF8String(bcs: BCS) {
 }
 
 /**
- * Transaction type used for transferring objects.
- * For this transaction to be executed, and `SuiObjectRef` should be queried
- * upfront and used as a parameter.
- */
-export type TransferObjectTx = {
-  TransferObject: {
-    recipient: string;
-    object_ref: SuiObjectRef;
-  };
-};
-
-/**
- * Transaction type used for transferring Sui.
- */
-export type TransferSuiTx = {
-  TransferSui: {
-    recipient: string;
-    amount: { Some: number } | { None: null };
-  };
-};
-
-/**
- * Transaction type used for Pay transaction.
- */
-export type PayTx = {
-  Pay: {
-    coins: SuiObjectRef[];
-    recipients: string[];
-    amounts: string[];
-  };
-};
-
-export type PaySuiTx = {
-  PaySui: {
-    coins: SuiObjectRef[];
-    recipients: string[];
-    amounts: string[];
-  };
-};
-
-export type PayAllSuiTx = {
-  PayAllSui: {
-    coins: SuiObjectRef[];
-    recipient: string;
-  };
-};
-
-/**
- * Transaction type used for publishing Move modules to the Sui.
- * Should be already compiled using `sui-move`, example:
- * ```
- * $ sui-move build
- * $ cat build/project_name/bytecode_modules/module.mv
- * ```
- * In JS:
- * ```
- * let file = fs.readFileSync('./move/build/project_name/bytecode_modules/module.mv');
- * let bytes = Array.from(bytes);
- * let modules = [ bytes ];
- *
- * // ... publish logic ...
- * ```
- *
- * Each module should be represented as a sequence of bytes.
- */
-export type PublishTx = {
-  Publish: {
-    modules: ArrayLike<ArrayLike<number>>;
-  };
-};
-
-// ========== Move Call Tx ===========
-
-/**
  * A reference to a shared object.
  */
 export type SharedObjectRef = {
@@ -150,10 +76,7 @@ export function isPureArg(arg: any): arg is PureArg {
  * For `Pure` arguments BCS is required. You must encode the values with BCS according
  * to the type required by the called function. Pure accepts only serialized values
  */
-export type CallArg =
-  | PureArg
-  | { Object: ObjectArg }
-  | { ObjVec: ArrayLike<ObjectArg> };
+export type CallArg = PureArg | { Object: ObjectArg };
 
 /**
  * Kind of a TypeTag which is represented by a Move type identifier.
@@ -181,41 +104,7 @@ export type TypeTag =
   | { u32: null }
   | { u256: null };
 
-/**
- * Transaction type used for calling Move modules' functions.
- * Should be crafted carefully, because the order of type parameters and
- * arguments matters.
- */
-export type MoveCallTx = {
-  Call: {
-    package: string;
-    module: string;
-    function: string;
-    typeArguments: TypeTag[];
-    arguments: CallArg[];
-  };
-};
-
 // ========== TransactionData ===========
-
-export type SingleTransactionKind =
-  | MoveCallTx
-  | PayTx
-  | PaySuiTx
-  | PayAllSuiTx
-  | PublishTx
-  | TransferObjectTx
-  | TransferSuiTx;
-
-/**
- * Transaction kind - either Batch or Single.
- *
- * Can be improved to change serialization automatically based on
- * the passed value (single Transaction or an array).
- */
-export type TransactionKind =
-  | { Single: SingleTransactionKind }
-  | { Batch: SingleTransactionKind[] };
 
 /**
  * The GasData to be used in the transaction.
@@ -233,50 +122,6 @@ export type GasData = {
  * Indications the expiration time for a transaction.
  */
 export type TransactionExpiration = { None: null } | { Epoch: number };
-
-/**
- * The TransactionData to be signed and sent to the RPC service.
- *
- * Field `sender` is made optional as it can be added during the signing
- * process and there's no need to define it sooner.
- *
- * Field `expiration` is made optional as it is defaulted to `None`.
- */
-export type TransactionData = {
-  messageVersion: 1; // Eventually: 1 | 2 | ...
-  sender?: string;
-  kind: TransactionKind;
-  gasData: GasData;
-  expiration?: TransactionExpiration;
-};
-
-export type TransactionDataBCS = {
-  V1: Omit<TransactionData, 'messageVersion'>;
-};
-
-export const TRANSACTION_DATA_TYPE_TAG = Array.from('TransactionData::').map(
-  (e) => e.charCodeAt(0),
-);
-
-export function deserializeTransactionBytesToTransactionData(
-  bcs: BCS,
-  bytes: Uint8Array,
-): TransactionData {
-  let deserialized = bcs.de('TransactionData', bytes);
-  let inner, messageVersion;
-
-  if (deserialized.V1 != null) {
-    inner = deserialized.V1;
-    messageVersion = 1;
-  } else {
-    throw new Error(`Unknown message: ${JSON.stringify(deserialized)}`);
-  }
-
-  return {
-    messageVersion,
-    ...inner,
-  };
-}
 
 // Move name of the Vector type.
 const VECTOR = 'vector';
@@ -346,31 +191,6 @@ const BCS_SPEC: TypeSchema = {
       version: BCS.U64,
       digest: 'ObjectDigest',
     },
-    TransferObjectTx: {
-      recipient: BCS.ADDRESS,
-      object_ref: 'SuiObjectRef',
-    },
-    PayTx: {
-      coins: [VECTOR, 'SuiObjectRef'],
-      recipients: [VECTOR, BCS.ADDRESS],
-      amounts: [VECTOR, BCS.U64],
-    },
-    PaySuiTx: {
-      coins: [VECTOR, 'SuiObjectRef'],
-      recipients: [VECTOR, BCS.ADDRESS],
-      amounts: [VECTOR, BCS.U64],
-    },
-    PayAllSuiTx: {
-      coins: [VECTOR, 'SuiObjectRef'],
-      recipient: BCS.ADDRESS,
-    },
-    TransferSuiTx: {
-      recipient: BCS.ADDRESS,
-      amount: ['Option', BCS.U64],
-    },
-    PublishTx: {
-      modules: [VECTOR, [VECTOR, BCS.U8]],
-    },
     SharedObjectRef: {
       objectId: BCS.ADDRESS,
       initialSharedVersion: BCS.U64,
@@ -381,13 +201,6 @@ const BCS_SPEC: TypeSchema = {
       module: BCS.STRING,
       name: BCS.STRING,
       typeParams: [VECTOR, 'TypeTag'],
-    },
-    MoveCallTx: {
-      package: BCS.ADDRESS,
-      module: BCS.STRING,
-      function: BCS.STRING,
-      typeArguments: [VECTOR, 'TypeTag'],
-      arguments: [VECTOR, 'CallArg'],
     },
     GasData: {
       payment: [VECTOR, 'SuiObjectRef'],


### PR DESCRIPTION
## Description 

- Refactor transaction digest derivation logic
- clean up after https://github.com/MystenLabs/sui/pull/9043/files#diff-609ece2db60e7ffb0ba427e3d9722bdc3aa70dbe7705d1228ff66445f47806ce

## Test Plan 

e2e test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Remove `generateTransactionDigest`. Use one of the following instead: `signer.getTransactionDigest`, `Transaction.getDigest()` or `TransactionDataBuilder.getDigestFromBytes()` instead.
