### PR TITLE
Genesis Checkpoint Inspection tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,6 +3735,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd079157ad94a32f7511b2e13037f3ae417ad80a6a9b0de29154d48b86f5d6c8"
+dependencies = [
+ "bitflags",
+ "crossterm 0.25.0",
+ "dyn-clone",
+ "lazy_static 1.4.0",
+ "newline-converter",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "insta"
 version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5784,6 +5800,15 @@ name = "nested"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
+
+[[package]]
+name = "newline-converter"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "nexlint"
@@ -8419,9 +8444,11 @@ dependencies = [
  "fastcrypto",
  "futures",
  "git-version",
+ "inquire",
  "jemalloc-ctl",
  "jsonrpsee",
  "move-binary-format",
+ "move-bytecode-utils",
  "move-cli",
  "move-core-types",
  "move-package",
@@ -9557,6 +9584,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "criterion",
+ "derivative",
  "derive_more",
  "enum_dispatch",
  "eyre",
@@ -11427,6 +11455,7 @@ dependencies = [
  "indicatif",
  "inferno",
  "inout",
+ "inquire",
  "insta",
  "instant",
  "internment",
@@ -11523,6 +11552,7 @@ dependencies = [
  "multimap",
  "named-lock",
  "nested",
+ "newline-converter",
  "nexlint",
  "nexlint-lints",
  "nibble_vec",

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -38,6 +38,8 @@ use sui_types::messages_checkpoint::{
 };
 use sui_types::object::Owner;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::sui_system_state::sui_system_state_inner_v1::VerifiedValidatorMetadataV1;
+use sui_types::sui_system_state::sui_system_state_summary::SuiValidatorSummary;
 use sui_types::sui_system_state::{
     get_sui_system_state, get_sui_system_state_version, get_sui_system_state_wrapper,
     SuiSystemStateInnerGenesis, SuiSystemStateTrait, SuiSystemStateWrapper,
@@ -152,6 +154,19 @@ impl Genesis {
                     image_url: metadata.image_url.clone(),
                     project_url: metadata.project_url.clone(),
                 }
+            })
+            .collect()
+    }
+
+    pub fn validator_summary_set(&self) -> Vec<(SuiValidatorSummary, VerifiedValidatorMetadataV1)> {
+        self.sui_system_object()
+            .validators
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let summary = validator.clone().into_sui_validator_summary();
+                let metadata = validator.verified_metadata().clone();
+                (summary, metadata)
             })
             .collect()
     }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -37,6 +37,7 @@ enum_dispatch = "^0.3"
 eyre = "0.6.8"
 multiaddr = "0.17.0"
 indexmap = "1.9.2"
+derivative = "2.2.0"
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -323,6 +323,13 @@ impl CoinMetadata {
 impl TryFrom<Object> for CoinMetadata {
     type Error = SuiError;
     fn try_from(object: Object) -> Result<Self, Self::Error> {
+        TryFrom::try_from(&object)
+    }
+}
+
+impl TryFrom<&Object> for CoinMetadata {
+    type Error = SuiError;
+    fn try_from(object: &Object) -> Result<Self, Self::Error> {
         match &object.data {
             Data::Move(o) => {
                 if CoinMetadata::is_coin_metadata(&o.type_) {

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -63,12 +63,14 @@ pub struct ValidatorMetadataV1 {
     pub next_epoch_worker_address: Option<Vec<u8>>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(derivative::Derivative, Clone, Eq, PartialEq)]
+#[derivative(Debug)]
 pub struct VerifiedValidatorMetadataV1 {
     pub sui_address: SuiAddress,
     pub protocol_pubkey: narwhal_crypto::PublicKey,
     pub network_pubkey: narwhal_crypto::NetworkPublicKey,
     pub worker_pubkey: narwhal_crypto::NetworkPublicKey,
+    #[derivative(Debug = "ignore")]
     pub proof_of_possession_bytes: Vec<u8>,
     pub name: String,
     pub description: String,

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -23,6 +23,8 @@ bip32 = "0.4.0"
 prettytable-rs = "0.10.0"
 git-version = "0.3.5"
 const-str = "0.5.3"
+rand = "0.8.5"
+inquire = "0.6.0"
 
 sui-core = { path = "../sui-core" }
 sui-framework = { path = "../sui-framework" }
@@ -39,6 +41,7 @@ sui-move = { path = "../sui-move", features = ["all"] }
 sui-protocol-config = { path = "../sui-protocol-config" }
 
 fastcrypto.workspace = true
+move-bytecode-utils.workspace = true
 
 rustyline = "9.1.2"
 rustyline-derive = "0.7.0"
@@ -91,3 +94,9 @@ assert_cmd = "2.0.6"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["jemalloc-ctl"]
+
+
+[[example]]
+name = "generate-genesis-checkpoint"
+path = "src/generate_genesis_checkpoint.rs"
+test = false

--- a/crates/sui/src/generate_genesis_checkpoint.rs
+++ b/crates/sui/src/generate_genesis_checkpoint.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use camino::Utf8PathBuf;
+use sui_config::genesis::Builder;
+use sui_config::utils;
+use sui_config::ValidatorInfo;
+use sui_types::crypto::{
+    generate_proof_of_possession, get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair,
+    KeypairTraits, NetworkKeyPair,
+};
+
+#[tokio::main]
+async fn main() {
+    let dir = std::env::current_dir().unwrap();
+    let dir = Utf8PathBuf::try_from(dir).unwrap();
+
+    let mut builder = Builder::new();
+    let mut keys = Vec::new();
+    for i in 0..2 {
+        let key: AuthorityKeyPair = get_key_pair_from_rng(&mut rand::rngs::OsRng).1;
+        let worker_key: NetworkKeyPair = get_key_pair_from_rng(&mut rand::rngs::OsRng).1;
+        let account_key: AccountKeyPair = get_key_pair_from_rng(&mut rand::rngs::OsRng).1;
+        let network_key: NetworkKeyPair = get_key_pair_from_rng(&mut rand::rngs::OsRng).1;
+        let validator = ValidatorInfo {
+            name: format!("Validator {}", i),
+            protocol_key: key.public().into(),
+            worker_key: worker_key.public().clone(),
+            account_key: account_key.public().clone().into(),
+            network_key: network_key.public().clone(),
+            gas_price: 1,
+            commission_rate: 0,
+            network_address: utils::new_tcp_network_address(),
+            p2p_address: utils::new_udp_network_address(),
+            narwhal_primary_address: utils::new_udp_network_address(),
+            narwhal_worker_address: utils::new_udp_network_address(),
+            description: String::new(),
+            image_url: String::new(),
+            project_url: String::new(),
+        };
+        let pop = generate_proof_of_possession(&key, account_key.public().into());
+        keys.push(key);
+        builder = builder.add_validator(validator, pop);
+    }
+
+    for key in keys {
+        builder = builder.add_validator_signature(&key);
+    }
+
+    builder.save(dir).unwrap();
+}

--- a/crates/sui/src/genesis_ceremony.rs
+++ b/crates/sui/src/genesis_ceremony.rs
@@ -24,6 +24,8 @@ use sui_keys::keypair_file::{
     read_authority_keypair_from_file, read_keypair_from_file, read_network_keypair_from_file,
 };
 
+use crate::genesis_inspector::examine_genesis_checkpoint;
+
 #[derive(Parser)]
 pub struct Ceremony {
     #[clap(long)]
@@ -83,6 +85,8 @@ pub enum CeremonyCommand {
     },
 
     BuildUnsignedCheckpoint,
+
+    ExamineGenesisCheckpoint,
 
     VerifyAndSign {
         #[clap(long)]
@@ -177,6 +181,12 @@ pub fn run(cmd: Ceremony) -> Result<()> {
             );
 
             builder.save(dir)?;
+        }
+
+        CeremonyCommand::ExamineGenesisCheckpoint => {
+            let builder = Builder::load(&dir)?;
+            let genesis = builder.build();
+            examine_genesis_checkpoint(genesis);
         }
 
         CeremonyCommand::VerifyAndSign { key_file } => {

--- a/crates/sui/src/genesis_inspector.rs
+++ b/crates/sui/src/genesis_inspector.rs
@@ -1,0 +1,369 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use inquire::Select;
+use std::collections::BTreeMap;
+use sui_config::genesis::Genesis;
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    coin::CoinMetadata,
+    gas_coin::{GasCoin, MIST_PER_SUI, TOTAL_SUPPLY_MIST},
+    governance::StakedSui,
+    move_package::MovePackage,
+    object::{MoveObject, Owner},
+    sui_system_state::{
+        sui_system_state_inner_v1::VerifiedValidatorMetadataV1,
+        sui_system_state_summary::SuiValidatorSummary,
+    },
+};
+
+const STR_ALL: &str = "All";
+const STR_EXIT: &str = "Exit";
+const STR_SUI: &str = "Sui";
+const STR_STAKED_SUI: &str = "StakedSui";
+const STR_PACKAGE: &str = "Package";
+const STR_COIN_METADATA: &str = "CoinMetadata";
+const STR_OTHER: &str = "Other";
+const STR_SUI_DISTRIBUTION: &str = "Sui Distribution";
+const STR_OBJECTS: &str = "Objects";
+const STR_VALIDATORS: &str = "Validators";
+
+#[allow(clippy::or_fun_call)]
+pub(crate) fn examine_genesis_checkpoint(genesis: Genesis) {
+    // Prepare Validator info
+    let summary_set = genesis.validator_summary_set();
+    let validator_map = summary_set
+        .iter()
+        .map(|(summary, metadata)| (summary.name.as_str(), (summary, metadata)))
+        .collect::<BTreeMap<_, _>>();
+    let validator_address_map = summary_set
+        .iter()
+        .map(|(summary, _metadata)| (summary.sui_address, summary))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut validator_options = validator_map
+        .iter()
+        .map(|(name, _)| *name)
+        .collect::<Vec<_>>();
+    validator_options.extend_from_slice(&[STR_ALL, STR_EXIT]);
+    println!(
+        "Total Number of Validators: {}",
+        genesis.validator_set().len()
+    );
+
+    // Prepare Sui distribution info
+    let system_object = genesis.sui_system_object();
+    let mut sui_distribution = BTreeMap::new();
+    let entry = sui_distribution
+        .entry("Sui System".to_string())
+        .or_insert(BTreeMap::new());
+    entry.insert(
+        "Storage Fund".to_string(),
+        (STR_SUI, system_object.storage_fund.value()),
+    );
+    entry.insert(
+        "Stake Subsidy".to_string(),
+        (STR_SUI, system_object.stake_subsidy.balance.value()),
+    );
+
+    // Prepare Object Info
+    let mut owner_map = BTreeMap::new();
+    let mut package_map = BTreeMap::new();
+    let mut sui_map = BTreeMap::new();
+    let mut staked_sui_map = BTreeMap::new();
+    let mut coin_metadata_map = BTreeMap::new();
+    let mut other_object_map = BTreeMap::new();
+
+    for object in genesis.objects() {
+        let object_id = object.id();
+        let object_id_str = object_id.to_string();
+        assert_eq!(object.storage_rebate, 0);
+        owner_map.insert(object.id(), object.owner);
+
+        match &object.data {
+            sui_types::object::Data::Move(move_object) => {
+                if let Ok(gas) = GasCoin::try_from(object) {
+                    let entry = sui_distribution
+                        .entry(object.owner.to_string())
+                        .or_default();
+                    entry.insert(object_id_str.clone(), (STR_SUI, gas.value()));
+                    sui_map.insert(object.id(), gas);
+                } else if let Ok(coin_metadata) = CoinMetadata::try_from(object) {
+                    coin_metadata_map.insert(object.id(), coin_metadata);
+                } else if let Ok(staked_sui) = StakedSui::try_from(object) {
+                    let entry = sui_distribution
+                        .entry(object.owner.to_string())
+                        .or_default();
+                    entry.insert(object_id_str, (STR_STAKED_SUI, staked_sui.principal()));
+                    // Assert pool id is associated with a knonw validator.
+                    let validator = validator_address_map
+                        .get(&staked_sui.validator_address())
+                        .unwrap();
+                    assert_eq!(validator.staking_pool_id, staked_sui.pool_id());
+
+                    staked_sui_map.insert(object.id(), staked_sui);
+                } else {
+                    other_object_map.insert(object.id(), move_object);
+                }
+            }
+            sui_types::object::Data::Package(p) => {
+                package_map.insert(object.id(), p);
+            }
+        }
+    }
+    println!(
+        "Total Number of Objects/Pacakges: {}",
+        genesis.objects().len()
+    );
+
+    // Always check the Total Supply
+    examine_total_supply(&sui_distribution, false);
+
+    // Main loop for inspection
+    let main_options: Vec<&str> = vec![STR_SUI_DISTRIBUTION, STR_VALIDATORS, STR_OBJECTS, STR_EXIT];
+    loop {
+        let ans = Select::new(
+            "Select one main category to examine ('Exit' to exit the program):",
+            main_options.clone(),
+        )
+        .prompt();
+        match ans {
+            Ok(name) if name == STR_SUI_DISTRIBUTION => {
+                examine_total_supply(&sui_distribution, true)
+            }
+            Ok(name) if name == STR_VALIDATORS => {
+                examine_validators(&validator_options, &validator_map);
+            }
+            Ok(name) if name == STR_OBJECTS => {
+                println!("Examine Objects (total: {})", genesis.objects().len());
+                examine_object(
+                    &owner_map,
+                    &validator_address_map,
+                    &package_map,
+                    &sui_map,
+                    &staked_sui_map,
+                    &coin_metadata_map,
+                    &other_object_map,
+                );
+            }
+            Ok(name) if name == STR_EXIT => break,
+            Ok(_) => (),
+            Err(err) => {
+                println!("Error: {err}");
+                break;
+            }
+        }
+    }
+}
+
+#[allow(clippy::ptr_arg)]
+fn examine_validators(
+    validator_options: &Vec<&str>,
+    validator_map: &BTreeMap<&str, (&SuiValidatorSummary, &VerifiedValidatorMetadataV1)>,
+) {
+    loop {
+        let ans = Select::new("Select one validator to examine ('All' to display all Validators, 'Exit' to return to Main):", validator_options.clone()).prompt();
+        match ans {
+            Ok(name) if name == STR_ALL => {
+                for (summary, metadata) in validator_map.values() {
+                    display_validator(summary, metadata);
+                }
+            }
+            Ok(name) if name == STR_EXIT => break,
+            Ok(name) => {
+                let (summary, metadata) = validator_map.get(name).unwrap();
+                display_validator(summary, metadata);
+            }
+            Err(err) => {
+                println!("Error: {err}");
+                break;
+            }
+        }
+    }
+    print_divider("Validator");
+}
+
+fn examine_object(
+    owner_map: &BTreeMap<ObjectID, Owner>,
+    validator_address_map: &BTreeMap<SuiAddress, &SuiValidatorSummary>,
+    package_map: &BTreeMap<ObjectID, &MovePackage>,
+    sui_map: &BTreeMap<ObjectID, GasCoin>,
+    staked_sui_map: &BTreeMap<ObjectID, StakedSui>,
+    coin_metadata_map: &BTreeMap<ObjectID, CoinMetadata>,
+    other_object_map: &BTreeMap<ObjectID, &MoveObject>,
+) {
+    let object_options: Vec<&str> = vec![
+        STR_SUI,
+        STR_STAKED_SUI,
+        STR_COIN_METADATA,
+        STR_PACKAGE,
+        STR_OTHER,
+        STR_EXIT,
+    ];
+    loop {
+        let ans = Select::new(
+            "Select one object category to examine ('Exit' to return to Main):",
+            object_options.clone(),
+        )
+        .prompt();
+        match ans {
+            Ok(name) if name == STR_EXIT => break,
+            Ok(name) if name == STR_SUI => {
+                for gas_coin in sui_map.values() {
+                    display_sui(gas_coin, owner_map);
+                }
+                print_divider("Sui");
+            }
+            Ok(name) if name == STR_STAKED_SUI => {
+                for staked_sui_coin in staked_sui_map.values() {
+                    display_staked_sui(staked_sui_coin, validator_address_map, owner_map);
+                }
+                print_divider(STR_STAKED_SUI);
+            }
+            Ok(name) if name == STR_PACKAGE => {
+                for package in package_map.values() {
+                    println!("Package ID: {}", package.id());
+                    println!("Version: {}", package.version());
+                    println!("Modules: {:?}\n", package.serialized_module_map().keys());
+                }
+                print_divider("Package");
+            }
+            Ok(name) if name == STR_OTHER => {
+                for other_obj in other_object_map.values() {
+                    println!("{:#?}", other_obj.type_);
+                    println!("{:?}", other_obj.version());
+                    println!("Has Public Transfer: {}\n", other_obj.has_public_transfer());
+                }
+                print_divider("Other");
+            }
+            Ok(name) if name == STR_COIN_METADATA => {
+                for coin_metadata in coin_metadata_map.values() {
+                    println!("{:#?}\n", coin_metadata);
+                }
+                print_divider("CoinMetadata");
+            }
+            Ok(_) => (),
+            Err(err) => {
+                println!("Error: {err}");
+                break;
+            }
+        }
+    }
+    print_divider("Object");
+}
+
+fn examine_total_supply(
+    sui_distribution: &BTreeMap<String, BTreeMap<String, (&str, u64)>>,
+    print: bool,
+) {
+    let mut total_sui = 0;
+    let mut total_staked_sui = 0;
+    for (owner, coins) in sui_distribution {
+        let mut amount_sum = 0;
+        for (owner, value) in coins.values() {
+            amount_sum += value;
+            if *owner == STR_STAKED_SUI {
+                total_staked_sui += value;
+            }
+        }
+        total_sui += amount_sum;
+        if print {
+            println!("Owner {:?}", owner);
+            println!(
+                "Total Amount of Sui/StakedSui Owned: {amount_sum} MIST or {} SUI:",
+                amount_sum / MIST_PER_SUI
+            );
+            println!("{:#?}\n", coins);
+        }
+    }
+    assert_eq!(total_sui, TOTAL_SUPPLY_MIST);
+    // Always print this.
+    println!(
+        "Total Supply of Sui: {total_sui} MIST or {} SUI",
+        total_sui / MIST_PER_SUI
+    );
+    println!(
+        "Total Amount of StakedSui: {total_staked_sui} MIST or {} SUI\n",
+        total_staked_sui / MIST_PER_SUI
+    );
+    if print {
+        print_divider("Sui Distribution");
+    }
+}
+
+fn display_validator(summary: &SuiValidatorSummary, metadata: &VerifiedValidatorMetadataV1) {
+    println!("Validator name: {}", metadata.name);
+    println!("{:#?}", metadata);
+    println!("Voting Power: {}", summary.voting_power);
+    println!("Gas Price: {}", summary.gas_price);
+    println!("Next Epoch Gas Price: {}", summary.next_epoch_gas_price);
+    println!("Commission Rate: {}", summary.commission_rate);
+    println!(
+        "Next Epoch Commission Rate: {}",
+        summary.next_epoch_commission_rate
+    );
+    println!("Next Epoch Stake: {}", summary.next_epoch_stake);
+    println!("Staking Pool ID: {}", summary.staking_pool_id);
+    println!(
+        "Staking Pool Activation Epoch: {:?}",
+        summary.staking_pool_activation_epoch
+    );
+    println!(
+        "Staking Pool Deactivation Epoch: {:?}",
+        summary.staking_pool_deactivation_epoch
+    );
+    println!(
+        "Staking Pool Sui Balance: {:?}",
+        summary.staking_pool_sui_balance
+    );
+    println!("Rewards Pool: {}", summary.rewards_pool);
+    println!("Pool Token Balance: {}", summary.pool_token_balance);
+    println!("Pending Delegation: {}", summary.pending_delegation);
+    println!(
+        "Pending Total Sui Withdraw: {}",
+        summary.pending_total_sui_withdraw
+    );
+    println!(
+        "Pendign Pool Token Withdraw: {}",
+        summary.pending_pool_token_withdraw
+    );
+    println!("Exchange Rates ID: {}", summary.exchange_rates_id);
+    println!("Exchange Rates Size: {}", summary.exchange_rates_size);
+    print_divider(&metadata.name);
+}
+
+fn display_sui(gas_coin: &GasCoin, owner_map: &BTreeMap<ObjectID, Owner>) {
+    println!("ID: {}", gas_coin.id());
+    println!("Balance: {}", gas_coin.value());
+    println!("Owner: {}\n", owner_map.get(gas_coin.id()).unwrap());
+}
+
+fn display_staked_sui(
+    staked_sui: &StakedSui,
+    validator_address_map: &BTreeMap<SuiAddress, &SuiValidatorSummary>,
+    owner_map: &BTreeMap<ObjectID, Owner>,
+) {
+    let validator = validator_address_map
+        .get(&staked_sui.validator_address())
+        .unwrap();
+    println!("{:#?}", staked_sui);
+    println!("Staked to Validator: {}", validator.name);
+    println!("Owner: {}\n", owner_map.get(&staked_sui.id()).unwrap());
+}
+
+fn print_divider(title: &str) {
+    let title = format!("End of {title}");
+    let divider_length = 80;
+    let left_divider_length = 10;
+    assert!(title.len() <= divider_length - left_divider_length * 2);
+    let divider_op = "-";
+    let divider = divider_op.repeat(divider_length);
+    let left_divider = divider_op.repeat(left_divider_length);
+    let margin_length = (divider_length - left_divider_length * 2 - title.len()) / 2;
+    let margin = " ".repeat(margin_length);
+    println!();
+    println!("{divider}");
+    println!("{left_divider}{margin}{title}{margin}{left_divider}");
+    println!("{divider}");
+    println!();
+}

--- a/crates/sui/src/lib.rs
+++ b/crates/sui/src/lib.rs
@@ -10,3 +10,4 @@ pub mod shell;
 pub mod sui_commands;
 
 pub mod genesis_ceremony;
+pub mod genesis_inspector;

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -277,6 +277,7 @@ indenter = { version = "0.3" }
 indexmap = { version = "1", default-features = false, features = ["serde", "std"] }
 indicatif = { version = "0.17" }
 inout = { version = "0.1", default-features = false, features = ["std"] }
+inquire = { version = "0.6" }
 insta = { version = "1", features = ["json", "redactions", "yaml"] }
 instant = { version = "0.1", default-features = false }
 internment = { version = "0.5", default-features = false, features = ["arc"] }
@@ -358,6 +359,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
+newline-converter = { version = "0.2", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da5c787636dad779c340affa65219134d127f5", default-features = false }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da5c787636dad779c340affa65219134d127f5", default-features = false }
 nibble_vec = { version = "0.1", default-features = false }
@@ -949,6 +951,7 @@ indenter = { version = "0.3" }
 indexmap = { version = "1", default-features = false, features = ["serde", "std"] }
 indicatif = { version = "0.17" }
 inout = { version = "0.1", default-features = false, features = ["std"] }
+inquire = { version = "0.6" }
 insta = { version = "1", features = ["json", "redactions", "yaml"] }
 instant = { version = "0.1", default-features = false }
 internment = { version = "0.5", default-features = false, features = ["arc"] }
@@ -1038,6 +1041,7 @@ multihash-derive = { version = "0.8", default-features = false, features = ["std
 multimap = { version = "0.8", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
+newline-converter = { version = "0.2", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da5c787636dad779c340affa65219134d127f5", default-features = false }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da5c787636dad779c340affa65219134d127f5", default-features = false }
 nibble_vec = { version = "0.1", default-features = false }


### PR DESCRIPTION
## Description 

The tool allows to inspect the genesis checkpoint in an interactive way.

It organizes:
1. Validators
2. Sui Distribution.
3. Objects & Packages

and asserts:

1. total sui supply
2. staked sui are in legit validators pools
3. genesis objects's storage fund is 0

Also added an example to generate genesis checkpoint for testing. See Test Plan.

## Test Plan 
```
cargo run --example generate-genesis-checkpoint  
cargo run --bin sui genesis-ceremony examine-genesis-checkpoint  
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Adding a tool to allow inspect the genesis checkpoint in an interactive way.
