### PR TITLE
Consistent case fields(camelCase v.s snake_case) in normalized.ts

### DIFF
--- a/.changeset/heavy-panthers-buy.md
+++ b/.changeset/heavy-panthers-buy.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Change all snake_case field in ts-sdk normalized.ts to camelCase.

--- a/apps/explorer/src/components/module/ModuleView.tsx
+++ b/apps/explorer/src/components/module/ModuleView.tsx
@@ -32,7 +32,7 @@ interface TypeReference {
     address: string;
     module: string;
     name: string;
-    type_arguments: SuiMoveNormalizedType[];
+    typeArguments: SuiMoveNormalizedType[];
 }
 
 /** Takes a normalized move type and returns the address information contained within it */
@@ -63,14 +63,14 @@ function ModuleView({ id, name, code }: Props) {
         if (!normalizedModule) {
             return typeReferences;
         }
-        Object.values(normalizedModule.exposed_functions).forEach(
+        Object.values(normalizedModule.exposedFunctions).forEach(
             (exposedFunction) => {
                 exposedFunction.parameters.forEach((param) => {
                     const unwrappedType = unwrapTypeReference(param);
                     if (!unwrappedType) return;
                     typeReferences[unwrappedType.name] = unwrappedType;
 
-                    unwrappedType.type_arguments.forEach((typeArg) => {
+                    unwrappedType.typeArguments.forEach((typeArg) => {
                         const unwrappedTypeArg = unwrapTypeReference(typeArg);
                         if (!unwrappedTypeArg) return;
                         typeReferences[unwrappedTypeArg.name] =

--- a/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
+++ b/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
@@ -54,7 +54,7 @@ export function ModuleFunction({
     const { isValidating, isValid, isSubmitting } = formState;
 
     const typeArguments = useFunctionTypeArguments(
-        functionDetails.type_parameters
+        functionDetails.typeParameters
     );
     const formTypeInputs = useWatch({ control, name: 'types' });
     const resolvedTypeArguments = useMemo(

--- a/apps/explorer/src/components/module/module-functions-interaction/index.tsx
+++ b/apps/explorer/src/components/module/module-functions-interaction/index.tsx
@@ -29,8 +29,8 @@ export function ModuleFunctionsInteraction({
         if (!normalizedModule) {
             return [];
         }
-        return Object.entries(normalizedModule.exposed_functions)
-            .filter(([_, anFn]) => anFn.is_entry)
+        return Object.entries(normalizedModule.exposedFunctions)
+            .filter(([_, anFn]) => anFn.isEntry)
             .map(([fnName, details]) => ({ name: fnName, details }));
     }, [normalizedModule]);
     const isEmpty = !isLoading && !executableFunctions.length && !error;

--- a/apps/explorer/src/components/module/utils.ts
+++ b/apps/explorer/src/components/module/utils.ts
@@ -48,7 +48,7 @@ export function normalizedFunctionParameterTypeToString(
     }
     if ('Struct' in param) {
         const theType = param.Struct;
-        const theTypeArgs = theType.type_arguments;
+        const theTypeArgs = theType.typeArguments;
         const theTypeArgsStr = theTypeArgs
             .map((aTypeArg) =>
                 normalizedFunctionParameterTypeToString(

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/utils/normalize.ts
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/utils/normalize.ts
@@ -7,7 +7,7 @@ export interface TypeReference {
     address: string;
     module: string;
     name: string;
-    type_arguments: SuiMoveNormalizedType[];
+    typeArguments: SuiMoveNormalizedType[];
 }
 
 export const TX_CONTEXT_TYPE = '0x2::tx_context::TxContext';

--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -52,9 +52,9 @@ pub struct SuiMoveStructTypeParameter {
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
-#[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedField {
     pub name: String,
+    #[serde(rename = "type")]
     pub type_: SuiMoveNormalizedType,
 }
 

--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -45,18 +45,21 @@ pub enum SuiMoveVisibility {
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SuiMoveStructTypeParameter {
     pub constraints: SuiMoveAbilitySet,
     pub is_phantom: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedField {
     pub name: String,
     pub type_: SuiMoveNormalizedType,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedStruct {
     pub abilities: SuiMoveAbilitySet,
     pub type_parameters: Vec<SuiMoveStructTypeParameter>,
@@ -74,6 +77,7 @@ pub enum SuiMoveNormalizedType {
     U256,
     Address,
     Signer,
+    #[serde(rename_all = "camelCase")]
     Struct {
         address: String,
         module: String,
@@ -87,6 +91,7 @@ pub enum SuiMoveNormalizedType {
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedFunction {
     pub visibility: SuiMoveVisibility,
     pub is_entry: bool,
@@ -102,6 +107,7 @@ pub struct SuiMoveModuleId {
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedModule {
     pub file_format_version: u32,
     pub address: String,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5549,13 +5549,13 @@
         "type": "object",
         "required": [
           "name",
-          "type_"
+          "type"
         ],
         "properties": {
           "name": {
             "type": "string"
           },
-          "type_": {
+          "type": {
             "$ref": "#/components/schemas/SuiMoveNormalizedType"
           }
         }
@@ -5563,14 +5563,14 @@
       "SuiMoveNormalizedFunction": {
         "type": "object",
         "required": [
-          "is_entry",
+          "isEntry",
           "parameters",
-          "return_",
-          "type_parameters",
+          "return",
+          "typeParameters",
           "visibility"
         ],
         "properties": {
-          "is_entry": {
+          "isEntry": {
             "type": "boolean"
           },
           "parameters": {
@@ -5579,13 +5579,13 @@
               "$ref": "#/components/schemas/SuiMoveNormalizedType"
             }
           },
-          "return_": {
+          "return": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SuiMoveNormalizedType"
             }
           },
-          "type_parameters": {
+          "typeParameters": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SuiMoveAbilitySet"
@@ -5600,8 +5600,8 @@
         "type": "object",
         "required": [
           "address",
-          "exposed_functions",
-          "file_format_version",
+          "exposedFunctions",
+          "fileFormatVersion",
           "friends",
           "name",
           "structs"
@@ -5610,13 +5610,13 @@
           "address": {
             "type": "string"
           },
-          "exposed_functions": {
+          "exposedFunctions": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/SuiMoveNormalizedFunction"
             }
           },
-          "file_format_version": {
+          "fileFormatVersion": {
             "type": "integer",
             "format": "uint32",
             "minimum": 0.0
@@ -5643,7 +5643,7 @@
         "required": [
           "abilities",
           "fields",
-          "type_parameters"
+          "typeParameters"
         ],
         "properties": {
           "abilities": {
@@ -5655,7 +5655,7 @@
               "$ref": "#/components/schemas/SuiMoveNormalizedField"
             }
           },
-          "type_parameters": {
+          "typeParameters": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SuiMoveStructTypeParameter"
@@ -5691,7 +5691,7 @@
                   "address",
                   "module",
                   "name",
-                  "type_arguments"
+                  "typeArguments"
                 ],
                 "properties": {
                   "address": {
@@ -5703,7 +5703,7 @@
                   "name": {
                     "type": "string"
                   },
-                  "type_arguments": {
+                  "typeArguments": {
                     "type": "array",
                     "items": {
                       "$ref": "#/components/schemas/SuiMoveNormalizedType"
@@ -5770,13 +5770,13 @@
         "type": "object",
         "required": [
           "constraints",
-          "is_phantom"
+          "isPhantom"
         ],
         "properties": {
           "constraints": {
             "$ref": "#/components/schemas/SuiMoveAbilitySet"
           },
-          "is_phantom": {
+          "isPhantom": {
             "type": "boolean"
           }
         }

--- a/sdk/typescript/src/builder/serializer.ts
+++ b/sdk/typescript/src/builder/serializer.ts
@@ -140,7 +140,7 @@ export function getPureSerializationType(
       return 'address';
     } else if (isSameStruct(normalizedType.Struct, RESOLVED_STD_OPTION)) {
       const optionToVec: SuiMoveNormalizedType = {
-        Vector: normalizedType.Struct.type_arguments[0],
+        Vector: normalizedType.Struct.typeArguments[0],
       };
       return getPureSerializationType(optionToVec, argVal);
     }

--- a/sdk/typescript/src/types/normalized.ts
+++ b/sdk/typescript/src/types/normalized.ts
@@ -47,7 +47,7 @@ export type SuiMoveAbilitySet = Infer<typeof SuiMoveAbilitySet>;
 
 export const SuiMoveStructTypeParameter = object({
   constraints: SuiMoveAbilitySet,
-  is_phantom: boolean(),
+  isPhantom: boolean(),
 });
 export type SuiMoveStructTypeParameter = Infer<
   typeof SuiMoveStructTypeParameter
@@ -94,7 +94,7 @@ export type SuiMoveNormalizedStructType = {
     address: string;
     module: string;
     name: string;
-    type_arguments: SuiMoveNormalizedType[];
+    typeArguments: SuiMoveNormalizedType[];
   };
 };
 
@@ -112,8 +112,8 @@ function isSuiMoveNormalizedStructType(
     typeof structProperties.address !== 'string' ||
     typeof structProperties.module !== 'string' ||
     typeof structProperties.name !== 'string' ||
-    !Array.isArray(structProperties.type_arguments) ||
-    !structProperties.type_arguments.every((value) =>
+    !Array.isArray(structProperties.typeArguments) ||
+    !structProperties.typeArguments.every((value) =>
       isSuiMoveNormalizedType(value),
     )
   ) {
@@ -131,33 +131,33 @@ export const SuiMoveNormalizedStructType = define<SuiMoveNormalizedStructType>(
 
 export const SuiMoveNormalizedFunction = object({
   visibility: SuiMoveVisibility,
-  is_entry: boolean(),
-  type_parameters: array(SuiMoveAbilitySet),
+  isEntry: boolean(),
+  typeParameters: array(SuiMoveAbilitySet),
   parameters: array(SuiMoveNormalizedType),
-  return_: array(SuiMoveNormalizedType),
+  return: array(SuiMoveNormalizedType),
 });
 export type SuiMoveNormalizedFunction = Infer<typeof SuiMoveNormalizedFunction>;
 
 export const SuiMoveNormalizedField = object({
   name: string(),
-  type_: SuiMoveNormalizedType,
+  type: SuiMoveNormalizedType,
 });
 export type SuiMoveNormalizedField = Infer<typeof SuiMoveNormalizedField>;
 
 export const SuiMoveNormalizedStruct = object({
   abilities: SuiMoveAbilitySet,
-  type_parameters: array(SuiMoveStructTypeParameter),
+  typeParameters: array(SuiMoveStructTypeParameter),
   fields: array(SuiMoveNormalizedField),
 });
 export type SuiMoveNormalizedStruct = Infer<typeof SuiMoveNormalizedStruct>;
 
 export const SuiMoveNormalizedModule = object({
-  file_format_version: number(),
+  fileFormatVersion: number(),
   address: string(),
   name: string(),
   friends: array(SuiMoveModuleId),
   structs: record(string(), SuiMoveNormalizedStruct),
-  exposed_functions: record(string(), SuiMoveNormalizedFunction),
+  exposedFunctions: record(string(), SuiMoveNormalizedFunction),
 });
 export type SuiMoveNormalizedModule = Infer<typeof SuiMoveNormalizedModule>;
 

--- a/sdk/typescript/test/e2e/normalized-modules.test.ts
+++ b/sdk/typescript/test/e2e/normalized-modules.test.ts
@@ -42,7 +42,7 @@ describe('Normalized modules API', () => {
       DEFAULT_PACKAGE,
       DEFAULT_MODULE,
     );
-    expect(Object.keys(normalized.exposed_functions)).toContain(
+    expect(Object.keys(normalized.exposedFunctions)).toContain(
       DEFAULT_FUNCTION,
     );
   });
@@ -53,7 +53,7 @@ describe('Normalized modules API', () => {
       DEFAULT_MODULE,
       DEFAULT_FUNCTION,
     );
-    expect(normalized.is_entry).toEqual(false);
+    expect(normalized.isEntry).toEqual(false);
   });
 
   it('Get Normalized Move Struct ', async () => {


### PR DESCRIPTION
Change all snake_case fields in ts-sdk normalized.ts to camelCase.
Add #[serde(rename_all = "camelCase")] to the respective rust structs in sui-move.rs
