### PR TITLE
Use blake2b for usages that are not user facing

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -24,7 +24,7 @@ created: object(113), object(114)
 written: object(111), object(112)
 
 task 6 'run'. lines 89-89:
-Error: Object 0x5e8b4686eb9ef82f1a4daecb1648bf43a5d232bcd119d1613a2c47acb575393c is owned by object 0x06b70f0fddd32895de05c5682c623e06dd60863d5a6688d0736907ac3cf1c59a. Objects owned by other objects cannot be used as input arguments.
+Error: Object 0xcbc830e8ea72f6683a00726dfdeb2aab857cab6219d557d9c8def5110fb6484f is owned by object 0x06b70f0fddd32895de05c5682c623e06dd60863d5a6688d0736907ac3cf1c59a. Objects owned by other objects cannot be used as input arguments.
 
 task 7 'run'. lines 91-91:
-Error: Object 0x5e8b4686eb9ef82f1a4daecb1648bf43a5d232bcd119d1613a2c47acb575393c is owned by object 0x06b70f0fddd32895de05c5682c623e06dd60863d5a6688d0736907ac3cf1c59a. Objects owned by other objects cannot be used as input arguments.
+Error: Object 0xcbc830e8ea72f6683a00726dfdeb2aab857cab6219d557d9c8def5110fb6484f is owned by object 0x06b70f0fddd32895de05c5682c623e06dd60863d5a6688d0736907ac3cf1c59a. Objects owned by other objects cannot be used as input arguments.

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -27,7 +27,7 @@ created: object(113), object(114)
 written: object(111), object(112)
 
 task 7 'run'. lines 132-136:
-Error: Object 0x01b2156087ad45d0d2fb96eb055cd6257a53618f4086e94ee301ec3388d82896 is owned by object 0xb221913a3af7acfea147609cf80ac9ff54e941c3fc918fc4972a9a2c95b9c5ba. Objects owned by other objects cannot be used as input arguments.
+Error: Object 0x01b2156087ad45d0d2fb96eb055cd6257a53618f4086e94ee301ec3388d82896 is owned by object 0xedf1619bc141398837261810dc56b3072eb6676658b95b9e480fe62cd358336a. Objects owned by other objects cannot be used as input arguments.
 
 task 8 'run'. lines 138-138:
 created: object(117)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
@@ -24,7 +24,7 @@ created: object(112), object(113)
 written: object(110), object(111)
 
 task 6 'run'. lines 129-133:
-Error: Object 0x032f88b6c64f0b334f8b020b385d08aa9df5c5625f1df486ace408ebf6096f6e is owned by object 0xf82d67caa424708f3f28fe5146d03bd9c1617bab2ba5142e8545541f41fe7d8d. Objects owned by other objects cannot be used as input arguments.
+Error: Object 0x032f88b6c64f0b334f8b020b385d08aa9df5c5625f1df486ace408ebf6096f6e is owned by object 0xf3f97aded2468cfa0b47d7c0a44b495a5e299d983aea6ebe250ef2aeb1d17638. Objects owned by other objects cannot be used as input arguments.
 
 task 7 'run'. lines 135-135:
 created: object(116)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
@@ -21,7 +21,7 @@ Version: 3
 Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(110)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(111)}}
 
 task 5 'transfer-object'. lines 35-35:
-Error: Object 0x6275cf6234e8410dffa1af64cf108d68e1912de97438e7a3c75d73e8ff5ca38f is owned by object 0x745ea5d547883aa753c1f9ad61290dafd7a462cc162ae5ddf2ede94917e3bf49. Objects owned by other objects cannot be used as input arguments.
+Error: Object 0xe59d4d64de85ab9e962e5ea8e0dda45c7544543a1714166c50644e49e2422b84 is owned by object 0x745ea5d547883aa753c1f9ad61290dafd7a462cc162ae5ddf2ede94917e3bf49. Objects owned by other objects cannot be used as input arguments.
 
 task 6 'view-object'. lines 37-37:
 Owner: Object ID: ( fake(108) )

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -59,7 +59,7 @@ use sui_storage::{
 };
 use sui_types::committee::{EpochId, ProtocolVersion};
 use sui_types::crypto::AuthoritySignInfo;
-use sui_types::crypto::{sha3_hash, AuthorityKeyPair, NetworkKeyPair, Signer};
+use sui_types::crypto::{user_hash, AuthorityKeyPair, NetworkKeyPair, Signer};
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType, Field};
 use sui_types::error::UserInputError;
@@ -1126,7 +1126,7 @@ impl AuthorityState {
             gas_price,
             gas_budget,
         );
-        let transaction_digest = TransactionDigest::new(sha3_hash(&data));
+        let transaction_digest = TransactionDigest::new(user_hash(&data));
         let transaction_kind = data.into_kind();
         let transaction_dependencies = input_objects.transaction_dependencies();
         let temporary_store = TemporaryStore::new(

--- a/crates/sui-core/src/authority/authority_store_types.rs
+++ b/crates/sui-core/src/authority/authority_store_types.rs
@@ -7,7 +7,7 @@ use serde_with::Bytes;
 use std::convert::TryFrom;
 use sui_types::base_types::MoveObjectType;
 use sui_types::base_types::{ObjectDigest, SequenceNumber, TransactionDigest};
-use sui_types::crypto::{sha3_hash, Signable};
+use sui_types::crypto::{internal_hash, Signable};
 use sui_types::error::SuiError;
 use sui_types::move_package::MovePackage;
 use sui_types::object::{Data, MoveObject, Object, Owner};
@@ -178,7 +178,7 @@ impl StoreMoveObject {
     pub fn digest(&self) -> ObjectContentDigest {
         // expected to be called on constructed object with default ref count 1
         assert_eq!(self.ref_count, 1);
-        ObjectContentDigest::new(sha3_hash(self))
+        ObjectContentDigest::new(internal_hash(self))
     }
 }
 

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -153,6 +153,8 @@ DeleteKind:
       UnwrapThenDelete: UNIT
     2:
       Wrap: UNIT
+Digest:
+  NEWTYPESTRUCT: BYTES
 ExecutionFailureStatus:
   ENUM:
     0:
@@ -385,7 +387,7 @@ ObjectArg:
           - mutable: BOOL
 ObjectDigest:
   NEWTYPESTRUCT:
-    TYPENAME: Sha3Digest
+    TYPENAME: Digest
 ObjectID:
   NEWTYPESTRUCT:
     TYPENAME: AccountAddress
@@ -440,8 +442,6 @@ ProtocolVersion:
   NEWTYPESTRUCT: U64
 SequenceNumber:
   NEWTYPESTRUCT: U64
-Sha3Digest:
-  NEWTYPESTRUCT: BYTES
 StructTag:
   STRUCT:
     - address:
@@ -460,10 +460,10 @@ SuiAddress:
       SIZE: 32
 TransactionDigest:
   NEWTYPESTRUCT:
-    TYPENAME: Sha3Digest
+    TYPENAME: Digest
 TransactionEffectsDigest:
   NEWTYPESTRUCT:
-    TYPENAME: Sha3Digest
+    TYPENAME: Digest
 TransactionKind:
   ENUM:
     0:

--- a/crates/sui-framework/sources/package.move
+++ b/crates/sui-framework/sources/package.move
@@ -256,7 +256,7 @@ module sui::package {
         // hashing the existing package and cap ID.
         let data = object::id_to_bytes(&cap);
         std::vector::append(&mut data, object::id_to_bytes(&package));
-        let package = object::id_from_bytes(std::hash::sha3_256(data));
+        let package = object::id_from_bytes(sui::hash::blake2b256(&data));
 
         UpgradeReceipt {
             cap, package

--- a/crates/sui-framework/tests/package_tests.move
+++ b/crates/sui-framework/tests/package_tests.move
@@ -4,7 +4,6 @@
 #[test_only]
 module sui::package_tests {
     use std::ascii;
-    use std::hash;
     use sui::address;
     use sui::object::id_from_address as id;
     use sui::package;
@@ -70,7 +69,7 @@ module sui::package_tests {
         let ticket = package::authorize_upgrade(
             &mut cap,
             package::dep_only_policy(),
-            hash::sha3_256(b"package contents"),
+            sui::hash::blake2b256(&b"package contents"),
         );
 
         let receipt = package::test_upgrade(ticket);
@@ -104,7 +103,7 @@ module sui::package_tests {
         let _ticket = package::authorize_upgrade(
             &mut cap,
             package::compatible_policy(),
-            hash::sha3_256(b"package contents"),
+            sui::hash::blake2b256(&b"package contents"),
         );
 
         abort 0
@@ -119,7 +118,7 @@ module sui::package_tests {
         let _ticket0 = package::authorize_upgrade(
             &mut cap,
             package::compatible_policy(),
-            hash::sha3_256(b"package contents 0"),
+            sui::hash::blake2b256(&b"package contents 0"),
         );
 
         // It's an error to try and issue more than one simultaneous
@@ -127,7 +126,7 @@ module sui::package_tests {
         let _ticket1 = package::authorize_upgrade(
             &mut cap,
             package::compatible_policy(),
-            hash::sha3_256(b"package contents 1"),
+            sui::hash::blake2b256(&b"package contents 1"),
         );
 
         abort 0
@@ -143,7 +142,7 @@ module sui::package_tests {
         let ticket1 = package::authorize_upgrade(
             &mut cap1,
             package::dep_only_policy(),
-            hash::sha3_256(b"package contents 1"),
+            sui::hash::blake2b256(&b"package contents 1"),
         );
 
         let receipt1 = package::test_upgrade(ticket1);

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -35,7 +35,7 @@ use sui_types::base_types::{
     ObjectID, SequenceNumber, SuiAddress, TransactionDigest, TxSequenceNumber,
 };
 use sui_types::collection_types::VecMap;
-use sui_types::crypto::sha3_hash;
+use sui_types::crypto::user_hash;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::display::{DisplayCreatedEvent, DisplayObject};
 use sui_types::dynamic_field::DynamicFieldName;
@@ -916,7 +916,7 @@ pub fn get_transaction_data_and_digest(
         },
         tx_data,
     );
-    let txn_digest = TransactionDigest::new(sha3_hash(&intent_msg.value));
+    let txn_digest = TransactionDigest::new(user_hash(&intent_msg.value));
     Ok((intent_msg.value, txn_digest))
 }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2919,7 +2919,7 @@
         "description": "Representation of a Checkpoint's digest",
         "allOf": [
           {
-            "$ref": "#/components/schemas/Sha3Digest"
+            "$ref": "#/components/schemas/Digest"
           }
         ]
       },
@@ -3164,6 +3164,14 @@
             ]
           }
         }
+      },
+      "Digest": {
+        "description": "A representation of a 32 byte digest",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Base58"
+          }
+        ]
       },
       "DryRunTransactionResponse": {
         "type": "object",
@@ -4943,7 +4951,7 @@
         }
       },
       "ObjectDigest": {
-        "$ref": "#/components/schemas/Sha3Digest"
+        "$ref": "#/components/schemas/Digest"
       },
       "ObjectID": {
         "$ref": "#/components/schemas/Hex"
@@ -5448,14 +5456,6 @@
         "type": "integer",
         "format": "uint64",
         "minimum": 0.0
-      },
-      "Sha3Digest": {
-        "description": "A representation of a SHA3-256 Digest",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Base58"
-          }
-        ]
       },
       "Signature": {
         "oneOf": [
@@ -6811,7 +6811,7 @@
         "description": "A transaction will have a (unique) digest.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/Sha3Digest"
+            "$ref": "#/components/schemas/Digest"
           }
         ]
       },
@@ -6940,7 +6940,7 @@
         ]
       },
       "TransactionEventsDigest": {
-        "$ref": "#/components/schemas/Sha3Digest"
+        "$ref": "#/components/schemas/Digest"
       },
       "TransactionFilter": {
         "oneOf": [

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -9,8 +9,8 @@ use crate::coin::COIN_MODULE_NAME;
 use crate::coin::COIN_STRUCT_NAME;
 pub use crate::committee::EpochId;
 use crate::crypto::{
-    AuthorityPublicKey, AuthorityPublicKeyBytes, InternalHash, KeypairTraits, PublicKey,
-    SignatureScheme, SuiPublicKey, SuiSignature, UserHash,
+    AuthorityPublicKey, AuthorityPublicKeyBytes, KeypairTraits, PublicKey, SignatureScheme,
+    SuiPublicKey, SuiSignature, UserHash,
 };
 pub use crate::digests::{ObjectDigest, TransactionDigest, TransactionEffectsDigest};
 use crate::dynamic_field::DynamicFieldInfo;

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -892,7 +892,7 @@ impl ObjectID {
     pub fn derive_id(digest: TransactionDigest, creation_num: u64) -> Self {
         // TODO(https://github.com/MystenLabs/sui/issues/58):audit ID derivation
 
-        let mut hasher = InternalHash::default();
+        let mut hasher = UserHash::default();
         hasher.update(digest);
         hasher.update(creation_num.to_le_bytes());
         let hash = hasher.finalize();

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -42,7 +42,7 @@ use crate::sui_serde::{Readable, SuiBitmap};
 pub use enum_dispatch::enum_dispatch;
 use fastcrypto::encoding::{Base64, Encoding, Hex};
 use fastcrypto::error::FastCryptoError;
-use fastcrypto::hash::{HashFunction, Sha3_256};
+use fastcrypto::hash::{Blake2b256, HashFunction, Sha3_256};
 pub use fastcrypto::traits::Signer;
 use std::fmt::Debug;
 
@@ -76,7 +76,12 @@ pub const DERIVATION_PATH_COIN_TYPE: u32 = 784;
 pub const DERVIATION_PATH_PURPOSE_ED25519: u32 = 44;
 pub const DERVIATION_PATH_PURPOSE_SECP256K1: u32 = 54;
 
-/// Default epoch used to sign PoP with.
+/// Default hash function for user-facing purposes, namely the ones that is also done by the wallet.
+pub type UserHash = Sha3_256;
+
+/// Default hash function for non-user-facing purposes, namely the ones not done by the wallet.
+pub type InternalHash = Blake2b256;
+
 pub const DEFAULT_EPOCH_ID: EpochId = 0;
 
 /// Creates a proof of that the authority account address is owned by the
@@ -1532,11 +1537,21 @@ where
     }
 }
 
-pub fn sha3_hash<S: Signable<Sha3_256>>(signable: &S) -> [u8; 32] {
-    let mut digest = Sha3_256::default();
+fn hash<S: Signable<H>, H: HashFunction<DIGEST_SIZE>, const DIGEST_SIZE: usize>(
+    signable: &S,
+) -> [u8; DIGEST_SIZE] {
+    let mut digest = H::default();
     signable.write(&mut digest);
     let hash = digest.finalize();
     hash.into()
+}
+
+pub fn user_hash<S: Signable<Sha3_256>>(signable: &S) -> [u8; 32] {
+    hash::<S, UserHash, 32>(signable)
+}
+
+pub fn internal_hash<S: Signable<Blake2b256>>(signable: &S) -> [u8; 32] {
+    hash::<S, InternalHash, 32>(signable)
 }
 
 #[derive(Default)]

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -9,19 +9,19 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Bytes};
 
-/// A representation of a SHA3-256 Digest
+/// A representation of a 32 byte digest
 #[serde_as]
 #[derive(
     Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
 )]
-pub struct Sha3Digest(
+pub struct Digest(
     #[schemars(with = "Base58")]
     #[serde_as(as = "Readable<Base58, Bytes>")]
     [u8; 32],
 );
 
-impl Sha3Digest {
-    pub const ZERO: Self = Sha3Digest([0; 32]);
+impl Digest {
+    pub const ZERO: Self = Digest([0; 32]);
 
     pub const fn new(digest: [u8; 32]) -> Self {
         Self(digest)
@@ -46,44 +46,44 @@ impl Sha3Digest {
     }
 }
 
-impl AsRef<[u8]> for Sha3Digest {
+impl AsRef<[u8]> for Digest {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl AsRef<[u8; 32]> for Sha3Digest {
+impl AsRef<[u8; 32]> for Digest {
     fn as_ref(&self) -> &[u8; 32] {
         &self.0
     }
 }
 
-impl From<Sha3Digest> for [u8; 32] {
-    fn from(digest: Sha3Digest) -> Self {
+impl From<Digest> for [u8; 32] {
+    fn from(digest: Digest) -> Self {
         digest.into_inner()
     }
 }
 
-impl From<[u8; 32]> for Sha3Digest {
+impl From<[u8; 32]> for Digest {
     fn from(digest: [u8; 32]) -> Self {
         Self::new(digest)
     }
 }
 
-impl fmt::Display for Sha3Digest {
+impl fmt::Display for Digest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO avoid the allocation
         f.write_str(&Base58::encode(self.0))
     }
 }
 
-impl fmt::Debug for Sha3Digest {
+impl fmt::Debug for Digest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }
 
-impl fmt::LowerHex for Sha3Digest {
+impl fmt::LowerHex for Digest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             write!(f, "0x")?;
@@ -97,7 +97,7 @@ impl fmt::LowerHex for Sha3Digest {
     }
 }
 
-impl fmt::UpperHex for Sha3Digest {
+impl fmt::UpperHex for Digest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             write!(f, "0x")?;
@@ -115,19 +115,19 @@ impl fmt::UpperHex for Sha3Digest {
 #[derive(
     Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
 )]
-pub struct CheckpointDigest(Sha3Digest);
+pub struct CheckpointDigest(Digest);
 
 impl CheckpointDigest {
     pub const fn new(digest: [u8; 32]) -> Self {
-        Self(Sha3Digest::new(digest))
+        Self(Digest::new(digest))
     }
 
     pub fn generate<R: rand::RngCore + rand::CryptoRng>(rng: R) -> Self {
-        Self(Sha3Digest::generate(rng))
+        Self(Digest::generate(rng))
     }
 
     pub fn random() -> Self {
-        Self(Sha3Digest::random())
+        Self(Digest::random())
     }
 
     pub const fn inner(&self) -> &[u8; 32] {
@@ -202,19 +202,19 @@ impl std::str::FromStr for CheckpointDigest {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema)]
-pub struct CheckpointContentsDigest(Sha3Digest);
+pub struct CheckpointContentsDigest(Digest);
 
 impl CheckpointContentsDigest {
     pub const fn new(digest: [u8; 32]) -> Self {
-        Self(Sha3Digest::new(digest))
+        Self(Digest::new(digest))
     }
 
     pub fn generate<R: rand::RngCore + rand::CryptoRng>(rng: R) -> Self {
-        Self(Sha3Digest::generate(rng))
+        Self(Digest::generate(rng))
     }
 
     pub fn random() -> Self {
-        Self(Sha3Digest::random())
+        Self(Digest::random())
     }
 
     pub const fn inner(&self) -> &[u8; 32] {
@@ -282,15 +282,15 @@ impl fmt::UpperHex for CheckpointContentsDigest {
 
 /// A digest of a cerificate, which commits to the signatures as well as the tx.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CertificateDigest(Sha3Digest);
+pub struct CertificateDigest(Digest);
 
 impl CertificateDigest {
     pub const fn new(digest: [u8; 32]) -> Self {
-        Self(Sha3Digest::new(digest))
+        Self(Digest::new(digest))
     }
 
     pub fn random() -> Self {
-        Self(Sha3Digest::random())
+        Self(Digest::random())
     }
 }
 
@@ -302,7 +302,7 @@ impl fmt::Debug for CertificateDigest {
 
 /// A transaction will have a (unique) digest.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema)]
-pub struct TransactionDigest(Sha3Digest);
+pub struct TransactionDigest(Digest);
 
 impl Default for TransactionDigest {
     fn default() -> Self {
@@ -311,10 +311,10 @@ impl Default for TransactionDigest {
 }
 
 impl TransactionDigest {
-    pub const ZERO: Self = Self(Sha3Digest::ZERO);
+    pub const ZERO: Self = Self(Digest::ZERO);
 
     pub const fn new(digest: [u8; 32]) -> Self {
-        Self(Sha3Digest::new(digest))
+        Self(Digest::new(digest))
     }
 
     /// A digest we use to signify the parent transaction was the genesis,
@@ -325,11 +325,11 @@ impl TransactionDigest {
     }
 
     pub fn generate<R: rand::RngCore + rand::CryptoRng>(rng: R) -> Self {
-        Self(Sha3Digest::generate(rng))
+        Self(Digest::generate(rng))
     }
 
     pub fn random() -> Self {
-        Self(Sha3Digest::random())
+        Self(Digest::random())
     }
 
     pub fn inner(&self) -> &[u8; 32] {
@@ -415,21 +415,21 @@ impl std::str::FromStr for TransactionDigest {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema)]
-pub struct TransactionEffectsDigest(Sha3Digest);
+pub struct TransactionEffectsDigest(Digest);
 
 impl TransactionEffectsDigest {
-    pub const ZERO: Self = Self(Sha3Digest::ZERO);
+    pub const ZERO: Self = Self(Digest::ZERO);
 
     pub const fn new(digest: [u8; 32]) -> Self {
-        Self(Sha3Digest::new(digest))
+        Self(Digest::new(digest))
     }
 
     pub fn generate<R: rand::RngCore + rand::CryptoRng>(rng: R) -> Self {
-        Self(Sha3Digest::generate(rng))
+        Self(Digest::generate(rng))
     }
 
     pub fn random() -> Self {
-        Self(Sha3Digest::random())
+        Self(Digest::random())
     }
 
     pub const fn inner(&self) -> &[u8; 32] {
@@ -497,17 +497,17 @@ impl fmt::UpperHex for TransactionEffectsDigest {
 
 #[serde_as]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, JsonSchema)]
-pub struct TransactionEventsDigest(Sha3Digest);
+pub struct TransactionEventsDigest(Digest);
 
 impl TransactionEventsDigest {
-    pub const ZERO: Self = Self(Sha3Digest::ZERO);
+    pub const ZERO: Self = Self(Digest::ZERO);
 
     pub const fn new(digest: [u8; 32]) -> Self {
-        Self(Sha3Digest::new(digest))
+        Self(Digest::new(digest))
     }
 
     pub fn random() -> Self {
-        Self(Sha3Digest::random())
+        Self(Digest::random())
     }
 }
 
@@ -521,7 +521,7 @@ impl fmt::Debug for TransactionEventsDigest {
 
 // Each object has a unique digest
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema)]
-pub struct ObjectDigest(Sha3Digest);
+pub struct ObjectDigest(Digest);
 
 impl ObjectDigest {
     pub const MIN: ObjectDigest = Self::new([u8::MIN; 32]);
@@ -538,15 +538,15 @@ impl ObjectDigest {
         Self::new([Self::OBJECT_DIGEST_WRAPPED_BYTE_VAL; 32]);
 
     pub const fn new(digest: [u8; 32]) -> Self {
-        Self(Sha3Digest::new(digest))
+        Self(Digest::new(digest))
     }
 
     pub fn generate<R: rand::RngCore + rand::CryptoRng>(rng: R) -> Self {
-        Self(Sha3Digest::generate(rng))
+        Self(Digest::generate(rng))
     }
 
     pub fn random() -> Self {
-        Self(Sha3Digest::random())
+        Self(Digest::random())
     }
 
     pub const fn inner(&self) -> &[u8; 32] {

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::base_types::{ObjectDigest, SuiAddress};
+use crate::crypto::InternalHash;
 use crate::error::{SuiError, SuiResult};
 use crate::id::UID;
 use crate::storage::ObjectStore;
 use crate::sui_serde::Readable;
 use crate::{MoveTypeTagTrait, ObjectID, SequenceNumber, SUI_FRAMEWORK_ADDRESS};
 use fastcrypto::encoding::Base58;
-use fastcrypto::hash::{HashFunction, Sha3_256};
+use fastcrypto::hash::HashFunction;
 use move_core_types::language_storage::{StructTag, TypeTag};
 use move_core_types::value::{MoveStruct, MoveValue};
 use schemars::JsonSchema;
@@ -216,7 +217,7 @@ where
     let k_tag_bytes = bcs::to_bytes(key_type_tag)?;
 
     // hash(parent || key || key_type_tag)
-    let mut hasher = Sha3_256::default();
+    let mut hasher = InternalHash::default();
     hasher.update(parent.into());
     hasher.update(key_bytes.len().to_le_bytes());
     hasher.update(key_bytes);

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -7,7 +7,8 @@ use crate::certificate_proof::CertificateProof;
 use crate::committee::{EpochId, ProtocolVersion};
 use crate::crypto::{
     internal_hash, user_hash, AuthoritySignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo,
-    Ed25519SuiSignature, EmptySignInfo, Signature, Signer, SuiSignatureInner, ToFromBytes,
+    Ed25519SuiSignature, EmptySignInfo, InternalHash, Signature, Signer, SuiSignatureInner,
+    ToFromBytes,
 };
 use crate::digests::{CertificateDigest, TransactionEventsDigest};
 use crate::gas::GasCostSummary;
@@ -25,10 +26,7 @@ use crate::{
 };
 use byteorder::{BigEndian, ReadBytesExt};
 use enum_dispatch::enum_dispatch;
-use fastcrypto::{
-    encoding::Base64,
-    hash::{HashFunction, Sha3_256},
-};
+use fastcrypto::{encoding::Base64, hash::HashFunction};
 use itertools::Either;
 use move_binary_format::access::ModuleAccess;
 use move_binary_format::file_format::{CodeOffset, TypeParameterIndex};
@@ -2038,7 +2036,7 @@ pub type CertifiedTransaction = Envelope<SenderSignedData, AuthorityStrongQuorum
 
 impl CertifiedTransaction {
     pub fn certificate_digest(&self) -> CertificateDigest {
-        let mut digest = Sha3_256::default();
+        let mut digest = InternalHash::default();
         bcs::serialize_into(&mut digest, self).expect("serialization should not fail");
         let hash = digest.finalize();
         CertificateDigest::new(hash.into())

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -6,7 +6,7 @@ use super::{base_types::*, committee::Committee, error::*, event::Event};
 use crate::certificate_proof::CertificateProof;
 use crate::committee::{EpochId, ProtocolVersion};
 use crate::crypto::{
-    sha3_hash, AuthoritySignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo,
+    internal_hash, user_hash, AuthoritySignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo,
     Ed25519SuiSignature, EmptySignInfo, Signature, Signer, SuiSignatureInner, ToFromBytes,
 };
 use crate::digests::{CertificateDigest, TransactionEventsDigest};
@@ -1811,7 +1811,7 @@ impl Message for SenderSignedData {
     const SCOPE: IntentScope = IntentScope::SenderSignedTransaction;
 
     fn digest(&self) -> Self::DigestType {
-        TransactionDigest::new(sha3_hash(&self.intent_message.value))
+        TransactionDigest::new(user_hash(&self.intent_message.value))
     }
 
     fn verify(&self, _sig_epoch: Option<EpochId>) -> SuiResult {
@@ -2905,7 +2905,7 @@ pub struct TransactionEvents {
 
 impl TransactionEvents {
     pub fn digest(&self) -> TransactionEventsDigest {
-        TransactionEventsDigest::new(sha3_hash(self))
+        TransactionEventsDigest::new(internal_hash(self))
     }
 }
 
@@ -2914,7 +2914,7 @@ impl Message for TransactionEffects {
     const SCOPE: IntentScope = IntentScope::TransactionEffects;
 
     fn digest(&self) -> Self::DigestType {
-        TransactionEffectsDigest::new(sha3_hash(self))
+        TransactionEffectsDigest::new(internal_hash(self))
     }
 
     fn verify(&self, _sig_epoch: Option<EpochId>) -> SuiResult {

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -10,14 +10,14 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::accumulator::Accumulator;
 use crate::base_types::{ExecutionData, ExecutionDigests, VerifiedExecutionData};
 use crate::committee::{EpochId, ProtocolVersion, StakeUnit};
-use crate::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
+use crate::crypto::{internal_hash, AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
 use crate::error::SuiResult;
 use crate::gas::GasCostSummary;
 use crate::message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope};
 use crate::messages::TransactionEffectsAPI;
 use crate::signature::GenericSignature;
 use crate::storage::ReadStore;
-use crate::{base_types::AuthorityName, committee::Committee, crypto::sha3_hash, error::SuiError};
+use crate::{base_types::AuthorityName, committee::Committee, error::SuiError};
 use anyhow::Result;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -137,7 +137,7 @@ impl Message for CheckpointSummary {
     const SCOPE: IntentScope = IntentScope::CheckpointSummary;
 
     fn digest(&self) -> Self::DigestType {
-        CheckpointDigest::new(sha3_hash(self))
+        CheckpointDigest::new(internal_hash(self))
     }
 
     fn verify(&self, sig_epoch: Option<EpochId>) -> SuiResult {
@@ -367,7 +367,7 @@ impl CheckpointContents {
     pub fn digest(&self) -> &CheckpointContentsDigest {
         self.as_v1()
             .digest
-            .get_or_init(|| CheckpointContentsDigest::new(sha3_hash(self)))
+            .get_or_init(|| CheckpointContentsDigest::new(internal_hash(self)))
     }
 }
 

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -17,7 +17,7 @@ use serde_with::serde_as;
 use serde_with::Bytes;
 
 use crate::base_types::{MoveObjectType, ObjectIDParseError};
-use crate::crypto::{deterministic_random_account_key, sha3_hash};
+use crate::crypto::{deterministic_random_account_key, internal_hash};
 use crate::error::{ExecutionError, ExecutionErrorKind, UserInputError, UserInputResult};
 use crate::error::{SuiError, SuiResult};
 use crate::gas_coin::TOTAL_SUPPLY_MIST;
@@ -643,7 +643,7 @@ impl Object {
     }
 
     pub fn digest(&self) -> ObjectDigest {
-        ObjectDigest::new(sha3_hash(self))
+        ObjectDigest::new(internal_hash(self))
     }
 
     /// Approximate size of the object in bytes. This is used for gas metering.


### PR DESCRIPTION
## Description 

Use Blake2b for hashing for usages that are not user facing. Since Blaks2b is 2-3x faster than Sha3, this should improve performance for validators.

Closing #9075
Closing #1490

## Test Plan 

Test suite.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
