### PR TITLE
Ensure the initial TrustedPeerChangeEvents are handled

### DIFF
--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -92,6 +92,10 @@ impl DiscoveryEventLoop {
             subscriber
         };
 
+        // Ensure the initial TrustedPeerChangeEvents are handled.
+        let event: TrustedPeerChangeEvent = self.trusted_peer_change_rx.borrow_and_update().clone();
+        self.handle_trusted_peer_change_event(event);
+
         loop {
             tokio::select! {
                 now = interval.tick() => {

--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -92,10 +92,6 @@ impl DiscoveryEventLoop {
             subscriber
         };
 
-        // Ensure the initial TrustedPeerChangeEvents are handled.
-        let event: TrustedPeerChangeEvent = self.trusted_peer_change_rx.borrow_and_update().clone();
-        self.handle_trusted_peer_change_event(event);
-
         loop {
             tokio::select! {
                 now = interval.tick() => {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -242,11 +242,16 @@ impl SuiNode {
         // TODO only configure validators as seed/preferred peers for validators and not for
         // fullnodes once we've had a chance to re-work fullnode configuration generation.
         let (trusted_peer_change_tx, trusted_peer_change_rx) =
-            watch::channel(TrustedPeerChangeEvent {
+            watch::channel(TrustedPeerChangeEvent { new_peers: vec![] });
+        // Sending the inital TrustedPeerChangeEvents separately, to ensure receivers get notified.
+        trusted_peer_change_tx
+            .send(TrustedPeerChangeEvent {
                 new_peers: epoch_store
                     .epoch_start_state()
                     .get_validator_as_p2p_peers(config.protocol_public_key()),
-            });
+            })
+            .unwrap();
+
         let (p2p_network, discovery_handle, state_sync_handle) = Self::create_p2p_network(
             &config,
             state_sync_store,


### PR DESCRIPTION
## Description 

Sending initial events explicitly to make sure receivers become aware of the content and process them.

## Test Plan 

`cargo simtest --test simtest test_simulated_load_basic`
deploy to private testnet

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
