### PR TITLE
[ts sdk/ indexer] Added multiget call for batch object fetches 

### DIFF
--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use sui_json_rpc::api::{cap_page_limit, ReadApiClient, ReadApiServer};
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
-    Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, Page,
+    Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, Page, SuiGetPastObjectRequest,
     SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct,
     SuiObjectDataOptions, SuiObjectInfo, SuiObjectResponse, SuiPastObjectResponse,
     SuiTransactionResponse, SuiTransactionResponseOptions, TransactionsPage,
@@ -372,6 +372,16 @@ where
     ) -> RpcResult<SuiPastObjectResponse> {
         self.fullnode
             .try_get_past_object(object_id, version, options)
+            .await
+    }
+
+    async fn try_multi_get_past_objects(
+        &self,
+        past_objects: Vec<SuiGetPastObjectRequest>,
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<Vec<SuiPastObjectResponse>> {
+        self.fullnode
+            .try_multi_get_past_objects(past_objects, options)
             .await
     }
 

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -20,9 +20,9 @@ use mysten_metrics::spawn_monitored_task;
 use prometheus::Registry;
 use std::collections::BTreeMap;
 use sui_json_rpc_types::{
-    OwnedObjectRef, SuiCommand, SuiObjectData, SuiObjectDataOptions, SuiRawData,
-    SuiTransactionDataAPI, SuiTransactionEffectsAPI, SuiTransactionKind, SuiTransactionResponse,
-    SuiTransactionResponseOptions,
+    OwnedObjectRef, SuiCommand, SuiGetPastObjectRequest, SuiObjectData, SuiObjectDataOptions,
+    SuiRawData, SuiTransactionDataAPI, SuiTransactionEffectsAPI, SuiTransactionKind,
+    SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_sdk::error::Error;
 use sui_sdk::SuiClient;
@@ -170,19 +170,40 @@ where
                 },
             );
 
-        // TODO: Use multi get objects
         let rpc = self.rpc_client.clone();
-        let all_mutated_objects = join_all(all_mutated.into_iter().map(|(id, version, status)| {
-            rpc.read_api()
-                .try_get_parsed_past_object(id, version, SuiObjectDataOptions::bcs_lossless())
-                .map(move |resp| (resp, status))
-        }))
-        .await
-        .into_iter()
-        .try_fold(vec![], |mut acc, (response, status)| {
-            acc.push((status, response?.into_object()?));
-            Ok::<_, Error>(acc)
-        })?;
+        let all_mutated_objects =
+            join_all(all_mutated.chunks(MULTI_GET_CHUNK_SIZE).map(|objects| {
+                let wanted_past_object_statuses: Vec<ObjectStatus> =
+                    objects.iter().map(|(_, _, status)| *status).collect();
+
+                let wanted_past_object_request = objects
+                    .iter()
+                    .map(|(id, seq_num, _)| SuiGetPastObjectRequest {
+                        object_id: *id,
+                        version: *seq_num,
+                    })
+                    .collect();
+
+                rpc.read_api()
+                    .try_multi_get_parsed_past_object(
+                        wanted_past_object_request,
+                        SuiObjectDataOptions::bcs_lossless(),
+                    )
+                    .map(move |resp| (resp, wanted_past_object_statuses))
+            }))
+            .await
+            .into_iter()
+            .try_fold(vec![], |mut acc, chunk| {
+                let object_datas: Vec<SuiObjectData> = chunk
+                    .0?
+                    .into_iter()
+                    // Unwrap should be ok here as the batched response will fail if any objects are invalid.
+                    .map(|resp| resp.into_object().unwrap())
+                    .collect();
+                let mutated_object_chunk = chunk.1.into_iter().zip(object_datas);
+                acc.extend(mutated_object_chunk);
+                Ok::<_, Error>(acc)
+            })?;
 
         Ok(CheckpointData {
             checkpoint,

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -882,6 +882,6 @@ impl From<ObjectInfo> for SuiObjectInfo {
 pub struct SuiGetPastObjectRequest {
     /// the ID of the queried object
     pub object_id: ObjectID,
-    /// the version of the queried object. If None, default to the latest known version
+    /// the version of the queried object.
     pub version: SequenceNumber,
 }

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -876,3 +876,12 @@ impl From<ObjectInfo> for SuiObjectInfo {
         }
     }
 }
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Eq, PartialEq)]
+#[serde(rename = "GetPastObjectRequest", rename_all = "camelCase")]
+pub struct SuiGetPastObjectRequest {
+    /// the ID of the queried object
+    pub object_id: ObjectID,
+    /// the version of the queried object. If None, default to the latest known version
+    pub version: SequenceNumber,
+}

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -5,10 +5,10 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 use std::collections::BTreeMap;
 use sui_json_rpc_types::{
-    Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, SuiMoveNormalizedFunction,
-    SuiMoveNormalizedModule, SuiMoveNormalizedStruct, SuiObjectDataOptions, SuiObjectInfo,
-    SuiObjectResponse, SuiPastObjectResponse, SuiTransactionResponse,
-    SuiTransactionResponseOptions, TransactionsPage,
+    Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, SuiGetPastObjectRequest,
+    SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct,
+    SuiObjectDataOptions, SuiObjectInfo, SuiObjectResponse, SuiPastObjectResponse,
+    SuiTransactionResponse, SuiTransactionResponseOptions, TransactionsPage,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{
@@ -178,6 +178,19 @@ pub trait ReadApi {
         /// options for specifying the content to be returned
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<SuiPastObjectResponse>;
+
+    /// Note there is no software-level guarantee/SLA that objects with past versions
+    /// can be retrieved by this API, even if the object and version exists/existed.
+    /// The result may vary across nodes depending on their pruning policies.
+    /// Return the object information for a specified version
+    #[method(name = "tryMultiGetPastObjects")]
+    async fn try_multi_get_past_objects(
+        &self,
+        /// a vector of object and versions to be queried
+        past_objects: Vec<SuiGetPastObjectRequest>,
+        /// options for specifying the content to be returned
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<Vec<SuiPastObjectResponse>>;
 
     /// Return the sequence number of the latest checkpoint that has been executed
     #[method(name = "getLatestCheckpointSequenceNumber")]

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2625,6 +2625,45 @@
           }
         }
       ]
+    },
+    {
+      "name": "sui_tryMultiGetPastObjects",
+      "tags": [
+        {
+          "name": "Read API"
+        }
+      ],
+      "description": "Note there is no software-level guarantee/SLA that objects with past versions can be retrieved by this API, even if the object and version exists/existed. The result may vary across nodes depending on their pruning policies. Return the object information for a specified version",
+      "params": [
+        {
+          "name": "past_objects",
+          "description": "a vector of object and versions to be queried",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GetPastObjectRequest"
+            }
+          }
+        },
+        {
+          "name": "options",
+          "description": "options for specifying the content to be returned",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectDataOptions"
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec<SuiPastObjectResponse>",
+        "required": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/ObjectRead"
+          }
+        }
+      }
     }
   ],
   "components": {
@@ -4149,6 +4188,31 @@
             "additionalProperties": false
           }
         ]
+      },
+      "GetPastObjectRequest": {
+        "type": "object",
+        "required": [
+          "objectId",
+          "version"
+        ],
+        "properties": {
+          "objectId": {
+            "description": "the ID of the queried object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            ]
+          },
+          "version": {
+            "description": "the version of the queried object. If None, default to the latest known version",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SequenceNumber"
+              }
+            ]
+          }
+        }
       },
       "Hex": {
         "description": "Hex string encoding.",

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4205,7 +4205,7 @@
             ]
           },
           "version": {
-            "description": "the version of the queried object. If None, default to the latest known version",
+            "description": "the version of the queried object.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/SequenceNumber"

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -15,8 +15,8 @@ use sui_json_rpc::api::GovernanceReadApiClient;
 use sui_json_rpc_types::{
     Balance, Checkpoint, CheckpointId, Coin, CoinPage, DelegatedStake, DryRunTransactionResponse,
     DynamicFieldPage, EventPage, SuiCoinMetadata, SuiCommittee, SuiEventEnvelope, SuiEventFilter,
-    SuiMoveNormalizedModule, SuiObjectDataOptions, SuiObjectInfo, SuiObjectResponse,
-    SuiPastObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
+    SuiGetPastObjectRequest, SuiMoveNormalizedModule, SuiObjectDataOptions, SuiObjectInfo,
+    SuiObjectResponse, SuiPastObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
     SuiTransactionResponseOptions, TransactionsPage,
 };
 use sui_types::balance::Supply;
@@ -77,6 +77,18 @@ impl ReadApi {
             .await?)
     }
 
+    pub async fn try_multi_get_parsed_past_object(
+        &self,
+        past_objects: Vec<SuiGetPastObjectRequest>,
+        options: SuiObjectDataOptions,
+    ) -> SuiRpcResult<Vec<SuiPastObjectResponse>> {
+        Ok(self
+            .api
+            .http
+            .try_multi_get_past_objects(past_objects, Some(options))
+            .await?)
+    }
+
     pub async fn get_object_with_options(
         &self,
         object_id: ObjectID,
@@ -86,6 +98,18 @@ impl ReadApi {
             .api
             .http
             .get_object_with_options(object_id, Some(options))
+            .await?)
+    }
+
+    pub async fn multi_get_object_with_options(
+        &self,
+        object_ids: Vec<ObjectID>,
+        options: SuiObjectDataOptions,
+    ) -> SuiRpcResult<Vec<SuiObjectResponse>> {
+        Ok(self
+            .api
+            .http
+            .multi_get_object_with_options(object_ids, Some(options))
             .await?)
     }
 

--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -434,7 +434,6 @@ export class Transaction {
 
     if (objectsToResolve.length) {
       const dedupedIds = [...new Set(objectsToResolve.map(({ id }) => id))];
-      // TODO: Use multi-get objects when that API exists instead of batch:
       const objects = await expectProvider(provider).getObjectBatch(
         dedupedIds,
         { showOwner: true },

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -515,7 +515,7 @@ export class JsonRpcProvider extends Provider {
     options?: SuiObjectDataOptions,
   ): Promise<SuiObjectResponse[]> {
     try {
-      objectIds.map((id) => {
+      objectIds.forEach((id) => {
         if (!id || !isValidSuiObjectId(normalizeSuiObjectId(id))) {
           throw new Error(`Invalid Sui Object id ${id}`);
         }
@@ -645,7 +645,7 @@ export class JsonRpcProvider extends Provider {
     options?: SuiTransactionResponseOptions,
   ): Promise<SuiTransactionResponse[]> {
     try {
-      digests.map((d) => {
+      digests.forEach((d) => {
         if (!isValidTransactionDigest(d)) {
           throw new Error(`Invalid Transaction digest ${d}`);
         }

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -515,18 +515,16 @@ export class JsonRpcProvider extends Provider {
     options?: SuiObjectDataOptions,
   ): Promise<SuiObjectResponse[]> {
     try {
-      const requests = objectIds.map((id) => {
+      objectIds.map((id) => {
         if (!id || !isValidSuiObjectId(normalizeSuiObjectId(id))) {
           throw new Error(`Invalid Sui Object id ${id}`);
         }
-        return {
-          method: 'sui_getObject',
-          args: [id, options],
-        };
       });
-      return await this.client.batchRequestWithType(
-        requests,
-        SuiObjectResponse,
+
+      return await this.client.requestWithType(
+        'sui_multiGetObjects',
+        [objectIds, options],
+        array(SuiObjectResponse),
         this.options.skipDataValidation,
       );
     } catch (err) {
@@ -647,18 +645,16 @@ export class JsonRpcProvider extends Provider {
     options?: SuiTransactionResponseOptions,
   ): Promise<SuiTransactionResponse[]> {
     try {
-      const requests = digests.map((d) => {
+      digests.map((d) => {
         if (!isValidTransactionDigest(d)) {
           throw new Error(`Invalid Transaction digest ${d}`);
         }
-        return {
-          method: 'sui_getTransaction',
-          args: [d, options],
-        };
       });
-      return await this.client.batchRequestWithType(
-        requests,
-        SuiTransactionResponse,
+
+      return await this.client.requestWithType(
+        'sui_multiGetTransactions',
+        [digests, options],
+        array(SuiTransactionResponse),
         this.options.skipDataValidation,
       );
     } catch (err) {

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -520,6 +520,10 @@ export class JsonRpcProvider extends Provider {
           throw new Error(`Invalid Sui Object id ${id}`);
         }
       });
+      const hasDuplicates = objectIds.length !== new Set(objectIds).size;
+      if (hasDuplicates) {
+        throw new Error(`Duplicate object ids in batch call ${objectIds}`);
+      }
 
       return await this.client.requestWithType(
         'sui_multiGetObjects',
@@ -650,6 +654,11 @@ export class JsonRpcProvider extends Provider {
           throw new Error(`Invalid Transaction digest ${d}`);
         }
       });
+
+      const hasDuplicates = digests.length !== new Set(digests).size;
+      if (hasDuplicates) {
+        throw new Error(`Duplicate digests in batch call ${digests}`);
+      }
 
       return await this.client.requestWithType(
         'sui_multiGetTransactions',

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -192,6 +192,11 @@ export abstract class Provider {
    */
   abstract getObjectRef(objectId: string): Promise<SuiObjectRef | undefined>;
 
+  /**
+   * Batch get details about a list of objects. If any of the object ids are duplicates the call will fail
+   * @param objectIds
+   * @param options
+   */
   abstract getObjectBatch(
     objectIds: ObjectId[],
     options?: SuiObjectDataOptions,

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -33,4 +33,21 @@ describe('Object Reading API', () => {
       ),
     );
   });
+
+  it('Get Objects', async () => {
+    const gasObjects = await toolbox.getGasObjectsOwnedByAddress();
+    expect(gasObjects.length).to.greaterThan(0);
+    const gasObjectIds = gasObjects.map((gasObject) => gasObject['objectId']);
+    const objectInfos = await toolbox.provider.getObjectBatch(gasObjectIds, {
+      showType: true,
+    });
+
+    expect(gasObjects.length).to.equal(objectInfos.length);
+
+    objectInfos.forEach((objectInfo) =>
+      expect(getObjectType(objectInfo)).to.equal(
+        '0x2::coin::Coin<0x2::sui::SUI>',
+      ),
+    );
+  });
 });


### PR DESCRIPTION
## Description 

Indexer batch object fetch replaced with a multi get call.

TS sdk implementation also replaced with multiget api.

## Test Plan 

How did you test the new or updated feature?

CI/ local testing

Indexer run locally 
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
