### PR TITLE
[kiosk] Adds a PurchaseCap to the Kiosk

### DIFF
--- a/crates/sui-framework/sources/balance.move
+++ b/crates/sui-framework/sources/balance.move
@@ -129,6 +129,13 @@ module sui::balance {
     public fun create_for_testing<T>(value: u64): Balance<T> {
         Balance { value }
     }
+
+    #[test_only]
+    /// Destry a `Balance` of any coin for testing purposes.
+    public fun destroy_for_testing<T>(self: Balance<T>): u64 {
+        let Balance { value } = self;
+        value
+    }
 }
 
 #[test_only]

--- a/crates/sui-framework/sources/coin.move
+++ b/crates/sui-framework/sources/coin.move
@@ -431,4 +431,12 @@ module sui::coin {
     public fun mint_for_testing<T>(value: u64, ctx: &mut TxContext): Coin<T> {
         Coin { id: object::new(ctx), balance: balance::create_for_testing(value) }
     }
+
+    #[test_only]
+    /// Burn coins of any type for testing purposes only
+    public fun burn_for_testing<T>(coin: Coin<T>): u64 {
+        let Coin { id, balance } = coin;
+        object::delete(id);
+        balance::destroy_for_testing(balance)
+    }
 }


### PR DESCRIPTION
## Description 

Fixed price listing is not always the case (for example - auction). Allows one exclusive PurchaseCap for an item with the min price setting.