### PR TITLE
[sui-framework] implement low stake departure

### DIFF
--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -30,8 +30,8 @@ import { roundFloat } from '~/utils/roundFloat';
 
 const APY_DECIMALS = 3;
 
-// This constant needs to match the constant in the on-chain smart contract sui_system::MIN_VALIDATOR_STAKE。
-const MIN_VALIDATOR_STAKE = 25_000_000_000_000_000;
+// This constant needs to match the constant in the on-chain smart contract sui_system::VALIDATOR_LOW_STAKE_THRESHOLD.
+const VALIDATOR_LOW_STAKE_THRESHOLD = 25_000_000_000_000_000;
 
 const NodeMap = lazy(() => import('../../components/node-map'));
 
@@ -62,7 +62,7 @@ export function validatorsTableData(
                 img: img,
                 address: validator.suiAddress,
                 lastReward: event?.fields.stake_rewards || 0,
-                atRisk: totalStake < MIN_VALIDATOR_STAKE,
+                atRisk: totalStake < VALIDATOR_LOW_STAKE_THRESHOLD,
             };
         }),
         columns: [

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -273,6 +273,8 @@ validators:
   validator_candidates:
     id: "0x6d3ffc5213ed4df6802cd4535d3c18f66d85bab5e9f004a7087a005e2f8dc455"
     size: 0
+  at_risk_validators:
+    contents: []
 storage_fund:
   value: 0
 parameters:

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -434,12 +434,44 @@ We do not allow the number of validators in any epoch to go above this.
 
 
 
-<a name="0x2_sui_system_MIN_VALIDATOR_STAKE"></a>
+<a name="0x2_sui_system_MIN_VALIDATOR_JOINING_STAKE"></a>
 
 Lower-bound on the amount of stake required to become a validator.
 
 
-<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_MIN_VALIDATOR_STAKE">MIN_VALIDATOR_STAKE</a>: u64 = 25000000000000000;
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_MIN_VALIDATOR_JOINING_STAKE">MIN_VALIDATOR_JOINING_STAKE</a>: u64 = 30000000000000000;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_VALIDATOR_LOW_STAKE_GRACE_PERIOD"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_VALIDATOR_LOW_STAKE_GRACE_PERIOD">VALIDATOR_LOW_STAKE_GRACE_PERIOD</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_VALIDATOR_LOW_STAKE_THRESHOLD"></a>
+
+Validators with stake amount below <code><a href="sui_system.md#0x2_sui_system_VALIDATOR_LOW_STAKE_THRESHOLD">VALIDATOR_LOW_STAKE_THRESHOLD</a></code> are considered to
+have low stake and will be escorted out of the validator set after being below this
+threshold for more than <code><a href="sui_system.md#0x2_sui_system_VALIDATOR_LOW_STAKE_GRACE_PERIOD">VALIDATOR_LOW_STAKE_GRACE_PERIOD</a></code> number of epochs.
+And validators with stake below <code><a href="sui_system.md#0x2_sui_system_VALIDATOR_VERY_LOW_STAKE_THRESHOLD">VALIDATOR_VERY_LOW_STAKE_THRESHOLD</a></code> will be removed
+immediately at epoch change, no grace period.
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_VALIDATOR_LOW_STAKE_THRESHOLD">VALIDATOR_LOW_STAKE_THRESHOLD</a>: u64 = 25000000000000000;
+</code></pre>
+
+
+
+<a name="0x2_sui_system_VALIDATOR_VERY_LOW_STAKE_THRESHOLD"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system.md#0x2_sui_system_VALIDATOR_VERY_LOW_STAKE_THRESHOLD">VALIDATOR_VERY_LOW_STAKE_THRESHOLD</a>: u64 = 20000000000000000;
 </code></pre>
 
 
@@ -507,8 +539,8 @@ This function will be called only once in genesis.
 
 ## Function `request_add_validator_candidate`
 
-Can be called by anyone who wishes to become a validator candidate and starts accuring
-stakes in their staking pool. Once they have at least <code><a href="sui_system.md#0x2_sui_system_MIN_VALIDATOR_STAKE">MIN_VALIDATOR_STAKE</a></code> amount of stake they
+Can be called by anyone who wishes to become a validator candidate and starts accuring delegated
+stakes in their staking pool. Once they have at least <code><a href="sui_system.md#0x2_sui_system_MIN_VALIDATOR_JOINING_STAKE">MIN_VALIDATOR_JOINING_STAKE</a></code> amount of stake they
 can call <code>request_add_validator</code> to officially become an active validator at the next epoch.
 Aborts if the caller is already a pending or active validator, or a validator candidate.
 Note: <code>proof_of_possession</code> MUST be a valid signature using sui_address and protocol_pubkey_bytes.
@@ -631,7 +663,7 @@ epoch has already reached the maximum.
         <a href="sui_system.md#0x2_sui_system_ELimitExceeded">ELimitExceeded</a>,
     );
 
-    <a href="validator_set.md#0x2_validator_set_request_add_validator">validator_set::request_add_validator</a>(&<b>mut</b> self.validators, <a href="sui_system.md#0x2_sui_system_MIN_VALIDATOR_STAKE">MIN_VALIDATOR_STAKE</a>, ctx);
+    <a href="validator_set.md#0x2_validator_set_request_add_validator">validator_set::request_add_validator</a>(&<b>mut</b> self.validators, <a href="sui_system.md#0x2_sui_system_MIN_VALIDATOR_JOINING_STAKE">MIN_VALIDATOR_JOINING_STAKE</a>, ctx);
 }
 </code></pre>
 
@@ -1471,6 +1503,10 @@ gas coins.
         &<b>mut</b> storage_fund_reward,
         &<b>mut</b> self.validator_report_records,
         reward_slashing_rate,
+        self.parameters.governance_start_epoch,
+        <a href="sui_system.md#0x2_sui_system_VALIDATOR_LOW_STAKE_THRESHOLD">VALIDATOR_LOW_STAKE_THRESHOLD</a>,
+        <a href="sui_system.md#0x2_sui_system_VALIDATOR_VERY_LOW_STAKE_THRESHOLD">VALIDATOR_VERY_LOW_STAKE_THRESHOLD</a>,
+        <a href="sui_system.md#0x2_sui_system_VALIDATOR_LOW_STAKE_GRACE_PERIOD">VALIDATOR_LOW_STAKE_GRACE_PERIOD</a>,
         ctx,
     );
 

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -123,8 +123,16 @@ module sui::sui_system {
     const MAX_VALIDATOR_COUNT: u64 = 150;
 
     /// Lower-bound on the amount of stake required to become a validator.
-    const MIN_VALIDATOR_STAKE: u64 = 25_000_000_000_000_000; // 25 million SUI
+    const MIN_VALIDATOR_JOINING_STAKE: u64 = 30_000_000_000_000_000; // 30 million SUI
 
+    /// Validators with stake amount below `VALIDATOR_LOW_STAKE_THRESHOLD` are considered to
+    /// have low stake and will be escorted out of the validator set after being below this
+    /// threshold for more than `VALIDATOR_LOW_STAKE_GRACE_PERIOD` number of epochs.
+    /// And validators with stake below `VALIDATOR_VERY_LOW_STAKE_THRESHOLD` will be removed
+    /// immediately at epoch change, no grace period.
+    const VALIDATOR_LOW_STAKE_THRESHOLD: u64 = 25_000_000_000_000_000; // 25 million SUI
+    const VALIDATOR_VERY_LOW_STAKE_THRESHOLD: u64 = 20_000_000_000_000_000; // 20 million SUI
+    const VALIDATOR_LOW_STAKE_GRACE_PERIOD: u64 = 7; // A validator can have stake below VALIDATOR_LOW_STAKE_THRESHOLD for 7 epochs before being kicked out.
 
     // ==== functions that can only be called by genesis ====
 
@@ -169,8 +177,8 @@ module sui::sui_system {
 
     // ==== entry functions ====
 
-    /// Can be called by anyone who wishes to become a validator candidate and starts accuring
-    /// stakes in their staking pool. Once they have at least `MIN_VALIDATOR_STAKE` amount of stake they
+    /// Can be called by anyone who wishes to become a validator candidate and starts accuring delegated
+    /// stakes in their staking pool. Once they have at least `MIN_VALIDATOR_JOINING_STAKE` amount of stake they
     /// can call `request_add_validator` to officially become an active validator at the next epoch.
     /// Aborts if the caller is already a pending or active validator, or a validator candidate.
     /// Note: `proof_of_possession` MUST be a valid signature using sui_address and protocol_pubkey_bytes.
@@ -242,7 +250,7 @@ module sui::sui_system {
             ELimitExceeded,
         );
 
-        validator_set::request_add_validator(&mut self.validators, MIN_VALIDATOR_STAKE, ctx);
+        validator_set::request_add_validator(&mut self.validators, MIN_VALIDATOR_JOINING_STAKE, ctx);
     }
 
     /// A validator can call this function to request a removal in the next epoch.
@@ -625,6 +633,10 @@ module sui::sui_system {
             &mut storage_fund_reward,
             &mut self.validator_report_records,
             reward_slashing_rate,
+            self.parameters.governance_start_epoch,
+            VALIDATOR_LOW_STAKE_THRESHOLD,
+            VALIDATOR_VERY_LOW_STAKE_THRESHOLD,
+            VALIDATOR_LOW_STAKE_GRACE_PERIOD,
             ctx,
         );
 

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -62,7 +62,8 @@ module sui::governance_test_utils {
             validators,
             balance::create_for_testing<SUI>(sui_supply_amount), // sui_supply
             balance::create_for_testing<SUI>(storage_fund_amount), // storage_fund
-            0, // governance_start_epoch
+            100, // governance_start_epoch, we set this to a big-ish number so that
+                 // low stake departure won't start kicking in for testing
             0, // stake subsidy
             1, // protocol version
             1, // system state version

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5856,6 +5856,7 @@
         "type": "object",
         "required": [
           "activeValidators",
+          "atRiskValidators",
           "epoch",
           "epochStartTimestampMs",
           "governanceStartEpoch",
@@ -5885,6 +5886,25 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SuiValidatorSummary"
+            }
+          },
+          "atRiskValidators": {
+            "description": "Map storing the number of epochs for which each validator has been below the low stake threshold.",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/components/schemas/SuiAddress"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           },
           "epoch": {
@@ -6009,7 +6029,7 @@
             "minimum": 0.0
           },
           "validatorCandidatesId": {
-            "description": "ID of the object that stores preactive validators, mapping their addresses to their `Validator ` structs.",
+            "description": "ID of the object that stores preactive validators, mapping their addresses to their `Validator` structs.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ObjectID"

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -398,6 +398,7 @@ pub struct ValidatorSetV1 {
     pub staking_pool_mappings: Table,
     pub inactive_pools: Table,
     pub validator_candidates: Table,
+    pub at_risk_validators: VecMap<SuiAddress, u64>,
 }
 
 /// Rust version of the Move sui::sui_system::SuiSystemStateInner type
@@ -539,6 +540,10 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
                             id: validator_candidates_id,
                             size: validator_candidates_size,
                         },
+                    at_risk_validators:
+                        VecMap {
+                            contents: at_risk_validators,
+                        },
                 },
             storage_fund,
             parameters: SystemParametersV1 {
@@ -584,6 +589,10 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
             inactive_pools_size,
             validator_candidates_id,
             validator_candidates_size,
+            at_risk_validators: at_risk_validators
+                .into_iter()
+                .map(|e| (e.key, e.value))
+                .collect(),
             validator_report_records: validator_report_records
                 .into_iter()
                 .map(|e| (e.key, e.value.contents))
@@ -603,6 +612,7 @@ impl Default for SuiSystemStateInnerV1 {
             staking_pool_mappings: Table::default(),
             inactive_pools: Table::default(),
             validator_candidates: Table::default(),
+            at_risk_validators: VecMap { contents: vec![] },
         };
         Self {
             epoch: 0,

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -71,10 +71,12 @@ pub struct SuiSystemStateSummary {
     pub inactive_pools_id: ObjectID,
     /// Number of inactive staking pools.
     pub inactive_pools_size: u64,
-    /// ID of the object that stores preactive validators, mapping their addresses to their `Validator ` structs.
+    /// ID of the object that stores preactive validators, mapping their addresses to their `Validator` structs.
     pub validator_candidates_id: ObjectID,
     /// Number of preactive validators.
     pub validator_candidates_size: u64,
+    /// Map storing the number of epochs for which each validator has been below the low stake threshold.
+    pub at_risk_validators: Vec<(SuiAddress, u64)>,
     /// A map storing the records of validator reporting each other.
     pub validator_report_records: Vec<(SuiAddress, Vec<SuiAddress>)>,
 }

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -356,7 +356,7 @@ async fn test_reconfig_with_committee_change_basic() {
     let new_validator_address = new_node_config.sui_address();
     let gas_objects = generate_test_gas_objects_with_owner(4, new_validator_address);
     let stake = Object::new_gas_with_balance_and_owner_for_testing(
-        25_000_000_000_000_000,
+        30_000_000_000_000_000,
         new_validator_address,
     );
     let mut genesis_objects = gas_objects.clone();

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -170,6 +170,7 @@ export const SuiSystemStateSummary = object({
   inactivePoolsSize: number(),
   validatorCandidatesId: string(),
   validatorCandidatesSize: number(),
+  atRiskValidators: array(tuple([SuiAddress, number()])),
   validatorReportRecords: array(tuple([SuiAddress, array(SuiAddress)])),
 });
 


### PR DESCRIPTION
## Description 

This PR adds low stake validator departure to our framework code. A validator is kicked out of the validator set if she has low stake for more than 7 consecutive epochs or if she has very low stake for just one epoch.

## Test Plan 

Added a new test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
