### PR TITLE
TODOs and placeholders for handling protocol upgrades with committee changes

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -238,6 +238,7 @@ validators:
         next_epoch_p2p_address: ~
         next_epoch_primary_address: ~
         next_epoch_worker_address: ~
+        initial_supported_protocol_versions: ~
       voting_power: 10000
       operation_cap_id: "0x16bb51edad1714f14cae3a3b1265f619900cee6126bafed1e743e68f2928a536"
       gas_price: 1

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3123,6 +3123,10 @@ impl AuthorityState {
                 epoch_store.protocol_version(),
                 epoch_store.committee(),
                 epoch_store.protocol_config(),
+                // TODO: capabilities reflects the capabilities of the current committee. It
+                // does not reflect the capabilities of the next epoch committee. We should
+                // consider discounting the vote of any validator who will be leaving the
+                // committee after this epoch.
                 epoch_store.get_capabilities(),
             );
 

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -5,6 +5,7 @@
 
 
 
+-  [Struct `SupportedProtocolVersions`](#0x2_validator_SupportedProtocolVersions)
 -  [Struct `ValidatorMetadata`](#0x2_validator_ValidatorMetadata)
 -  [Struct `Validator`](#0x2_validator_Validator)
 -  [Struct `StakingRequestEvent`](#0x2_validator_StakingRequestEvent)
@@ -100,6 +101,39 @@
 </code></pre>
 
 
+
+<a name="0x2_validator_SupportedProtocolVersions"></a>
+
+## Struct `SupportedProtocolVersions`
+
+
+
+<pre><code><b>struct</b> <a href="validator.md#0x2_validator_SupportedProtocolVersions">SupportedProtocolVersions</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><b>min</b>: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>max: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
 
 <a name="0x2_validator_ValidatorMetadata"></a>
 
@@ -246,6 +280,18 @@
 </dt>
 <dd>
 
+</dd>
+<dt>
+<code>initial_supported_protocol_versions: <a href="_Option">option::Option</a>&lt;<a href="validator.md#0x2_validator_SupportedProtocolVersions">validator::SupportedProtocolVersions</a>&gt;</code>
+</dt>
+<dd>
+ Currently unused - may be used in the future to allow validators to pledge to support
+ some range of protocol versions when they join the committee, which would allow the
+ reconfiguration process to omit would-be validators who haven't pledged to support the
+ version that will become active in the new epoch. Without this, it is possible for the
+ current committee to vote to upgrade to a protocol version that may not have 2f+1
+ support in the new epoch, due to newly-joined validators that did not participate in
+ the vote.
 </dd>
 </dl>
 
@@ -630,6 +676,7 @@ Intended validator is not a candidate one.
         next_epoch_p2p_address: <a href="_none">option::none</a>(),
         next_epoch_primary_address: <a href="_none">option::none</a>(),
         next_epoch_worker_address: <a href="_none">option::none</a>(),
+        initial_supported_protocol_versions: <a href="_none">option::none</a>(),
     };
     metadata
 }

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -70,6 +70,11 @@ module sui::validator {
 
     const MAX_COMMISSION_RATE: u64 = 10_000; // Max rate is 100%, which is 10K base points
 
+    struct SupportedProtocolVersions has store, drop, copy {
+      min: u64,
+      max: u64,
+    }
+
     struct ValidatorMetadata has store, drop, copy {
         /// The Sui Address of the validator. This is the sender that created the Validator object,
         /// and also the address to send validator/coins to during withdraws.
@@ -108,6 +113,15 @@ module sui::validator {
         next_epoch_p2p_address: Option<vector<u8>>,
         next_epoch_primary_address: Option<vector<u8>>,
         next_epoch_worker_address: Option<vector<u8>>,
+
+        /// Currently unused - may be used in the future to allow validators to pledge to support
+        /// some range of protocol versions when they join the committee, which would allow the
+        /// reconfiguration process to omit would-be validators who haven't pledged to support the
+        /// version that will become active in the new epoch. Without this, it is possible for the
+        /// current committee to vote to upgrade to a protocol version that may not have 2f+1
+        /// support in the new epoch, due to newly-joined validators that did not participate in
+        /// the vote.
+        initial_supported_protocol_versions: Option<SupportedProtocolVersions>,
     }
 
     struct Validator has store {
@@ -189,6 +203,7 @@ module sui::validator {
             next_epoch_p2p_address: option::none(),
             next_epoch_primary_address: option::none(),
             next_epoch_worker_address: option::none(),
+            initial_supported_protocol_versions: option::none(),
         };
         metadata
     }

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -37,6 +37,12 @@ pub struct SystemParametersV1 {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct SupportedProtocolVersions {
+    pub min: u64,
+    pub max: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct ValidatorMetadataV1 {
     pub sui_address: SuiAddress,
     pub protocol_pubkey_bytes: Vec<u8>,
@@ -59,6 +65,7 @@ pub struct ValidatorMetadataV1 {
     pub next_epoch_p2p_address: Option<Vec<u8>>,
     pub next_epoch_primary_address: Option<Vec<u8>>,
     pub next_epoch_worker_address: Option<Vec<u8>>,
+    pub initial_supported_protocol_versions: Option<SupportedProtocolVersions>,
 }
 
 #[derive(derivative::Derivative, Clone, Eq, PartialEq)]
@@ -280,6 +287,7 @@ impl ValidatorV1 {
                     next_epoch_p2p_address,
                     next_epoch_primary_address,
                     next_epoch_worker_address,
+                    initial_supported_protocol_versions: _,
                 },
             verified_metadata: _,
             voting_power,


### PR DESCRIPTION
## Description 

This adds a placeholder field to SuiValidator to record the protocol versions that the incoming validator pledges to support. No functionality associated with it is implemented yet, but i'd like to check this in so that we can add the functionality later without changing the layout of the type.

Also, a TODO for the related problem of dealing with validators who vote for an upgrade and then leave.

## Test Plan 

```cargo simtest```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
