### PR TITLE
[programmable transactions] Add support for package upgrade command

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -8,6 +8,7 @@ use std::{
 
 use move_binary_format::{
     access::ModuleAccess,
+    compatibility::Compatibility,
     errors::{Location, PartialVMResult, VMResult},
     file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
     CompiledModule,
@@ -36,9 +37,13 @@ use sui_types::{
     gas::SuiGasStatus,
     id::UID,
     messages::{
-        Argument, Command, CommandArgumentError, ProgrammableMoveCall, ProgrammableTransaction,
+        Argument, Command, CommandArgumentError, PackageUpgradeError, ProgrammableMoveCall,
+        ProgrammableTransaction,
     },
-    move_package::{MovePackage, UpgradeCap},
+    move_package::{
+        is_valid_package_upgrade_policy, normalize_deserialized_modules, MovePackage, UpgradeCap,
+        UpgradeReceipt, UpgradeTicket, UPGRADE_POLICY_COMPATIBLE,
+    },
     SUI_FRAMEWORK_ADDRESS,
 };
 use sui_verifier::{
@@ -49,7 +54,10 @@ use sui_verifier::{
     INIT_FN_NAME,
 };
 
-use crate::{adapter::generate_package_id, execution_mode::ExecutionMode};
+use crate::{
+    adapter::{generate_package_id, substitute_package_id},
+    execution_mode::ExecutionMode,
+};
 
 use super::{context::*, types::*};
 
@@ -396,7 +404,7 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     context
         .gas_status
         .charge_publish_package(module_bytes.iter().map(|v| v.len()).sum())?;
-    let modules = publish_and_verify_modules::<_, _, Mode>(context, module_bytes)?;
+    let modules = publish_and_verify_new_modules::<_, _, Mode>(context, &module_bytes)?;
     let modules_to_init = modules
         .iter()
         .filter_map(|module| {
@@ -414,9 +422,7 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     let dependencies = fetch_packages(context, &dep_ids)?;
 
     // new_package also initializes type origin table in the package object
-    let package_object = context.new_package(modules, &dependencies, None)?;
-    let package_id = package_object.id();
-    context.add_package(package_object);
+    let package_id = context.new_package(modules, &dependencies, None)?;
     for module_id in &modules_to_init {
         let return_values = execute_move_call::<_, _, Mode>(
             context,
@@ -450,10 +456,10 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
 /// Upgrade a Move package.  Returns an `UpgradeReceipt` for the upgraded package on success.
 fn execute_move_upgrade<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     context: &mut ExecutionContext<E, S>,
-    _module_bytes: Vec<Vec<u8>>,
-    _dep_ids: Vec<ObjectID>,
-    _current_package_id: ObjectID,
-    _upgrade_ticket_arg: Argument,
+    module_bytes: Vec<Vec<u8>>,
+    dep_ids: Vec<ObjectID>,
+    current_package_id: ObjectID,
+    upgrade_ticket_arg: Argument,
 ) -> Result<Vec<Value>, ExecutionError> {
     // Check that package upgrades are supported.
     context
@@ -461,10 +467,157 @@ fn execute_move_upgrade<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
         .check_package_upgrades_supported()
         .map_err(|_| ExecutionError::from_kind(ExecutionErrorKind::FeatureNotYetSupported))?;
 
-    invariant_violation!("Package upgrades are turned off. We should NEVER get here.")
+    assert_invariant!(
+        !module_bytes.is_empty(),
+        "empty package is checked in transaction input checker"
+    );
+
+    let upgrade_ticket: UpgradeTicket = {
+        let mut ticket_bytes = Vec::new();
+        let ticket_val: Value =
+            context.by_value_arg(CommandKind::Upgrade, 0, upgrade_ticket_arg)?;
+        let ticket_type = context
+            .session
+            .load_type(&TypeTag::Struct(Box::new(UpgradeTicket::type_())))
+            .map_err(|e| context.convert_vm_error(e))?;
+        check_param_type::<_, _, Mode>(context, 0, &ticket_val, &ticket_type)?;
+        ticket_val.write_bcs_bytes(&mut ticket_bytes);
+        bcs::from_bytes(&ticket_bytes).map_err(|_| {
+            ExecutionError::from_kind(ExecutionErrorKind::CommandArgumentError {
+                arg_idx: 0,
+                kind: CommandArgumentError::InvalidBCSBytes,
+            })
+        })?
+    };
+
+    // Make sure the passed-in package ID matches the package ID in the `upgrade_ticket`.
+    if current_package_id != upgrade_ticket.package.bytes {
+        return Err(ExecutionError::from_kind(
+            ExecutionErrorKind::PackageUpgradeError {
+                upgrade_error: PackageUpgradeError::PackageIDDoesNotMatch {
+                    package_id: current_package_id,
+                    ticket_id: upgrade_ticket.package.bytes,
+                },
+            },
+        ));
+    }
+
+    // Check digest.
+    let computed_digest =
+        MovePackage::compute_digest_for_modules_and_deps(&module_bytes, &dep_ids).to_vec();
+    if computed_digest != upgrade_ticket.digest {
+        return Err(ExecutionError::from_kind(
+            ExecutionErrorKind::PackageUpgradeError {
+                upgrade_error: PackageUpgradeError::DigestDoesNotMatch {
+                    digest: computed_digest,
+                },
+            },
+        ));
+    }
+
+    // Check that this package ID points to a package and get the package we're upgrading.
+    let current_package = fetch_package(context, &upgrade_ticket.package.bytes)?;
+
+    // Run the move + sui verifier on the modules and publish them into the cache.
+    // NB: this will substitute in the original package id for the `self` address in all of these modules.
+    let upgraded_package_modules = publish_and_verify_upgraded_modules::<_, _, Mode>(
+        context,
+        &module_bytes,
+        current_package.original_package_id(),
+    )?;
+
+    // Full backwards compatibility except that we allow friend function signatures to change.
+    check_compatibility(
+        &current_package,
+        &upgraded_package_modules,
+        upgrade_ticket.policy,
+    )?;
+
+    // Read the package dependencies.
+    let dependency_packages = fetch_packages(context, &dep_ids)?;
+
+    let upgraded_object_id = context.upgrade_package(
+        &current_package,
+        upgraded_package_modules,
+        &dependency_packages,
+    )?;
+
+    let upgrade_receipt_type = context
+        .session
+        .load_type(&TypeTag::Struct(Box::new(UpgradeReceipt::type_())))
+        .map_err(|e| context.convert_vm_error(e))?;
+
+    Ok(vec![Value::Raw(
+        RawValueType::Loaded {
+            ty: upgrade_receipt_type,
+            abilities: AbilitySet::EMPTY,
+            used_in_non_entry_move_call: false,
+        },
+        bcs::to_bytes(&UpgradeReceipt::new(upgrade_ticket, upgraded_object_id)).unwrap(),
+    )])
 }
 
-#[allow(dead_code)]
+fn check_compatibility<'a>(
+    existing_package: &MovePackage,
+    upgrading_modules: impl IntoIterator<Item = &'a CompiledModule>,
+    policy: u8,
+) -> Result<(), ExecutionError> {
+    let check_struct_and_pub_function_linking = true;
+    let check_struct_layout = true;
+    let check_friend_linking = false;
+    let compatiblity_checker = Compatibility::new(
+        check_struct_and_pub_function_linking,
+        check_struct_layout,
+        check_friend_linking,
+    );
+    // Make sure this is a known upgrade policy.
+    if !is_valid_package_upgrade_policy(&policy) {
+        return Err(ExecutionError::from_kind(
+            ExecutionErrorKind::PackageUpgradeError {
+                upgrade_error: PackageUpgradeError::UnknownUpgradePolicy { policy },
+            },
+        ));
+    }
+
+    // TODO(tzakian): We currently only support compatible upgrades. Need to add in support for
+    // additive and dep-only upgrades as well.
+    if policy != UPGRADE_POLICY_COMPATIBLE {
+        return Err(ExecutionError::new_with_source(
+            ExecutionErrorKind::FeatureNotYetSupported,
+            format!("Upgrade policy {policy} not yet supported"),
+        ));
+    }
+
+    let Ok(current_normalized) = existing_package.normalize() else {
+        invariant_violation!("Tried to normalize modules in existing package but failed")
+    };
+
+    let mut new_normalized = normalize_deserialized_modules(upgrading_modules.into_iter());
+
+    for (name, cur_module) in current_normalized {
+        let msg = format!("Existing module {name} not found in next version of package");
+        let Some(new_module) = new_normalized.remove(&name) else {
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::PackageUpgradeError {
+                    upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
+                },
+                msg,
+            ));
+        };
+
+        if let Err(e) = compatiblity_checker.check(&cur_module, &new_module) {
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::PackageUpgradeError {
+                    upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
+                },
+                e,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 fn fetch_package<'a, E: fmt::Debug, S: StorageView<E>>(
     context: &'a ExecutionContext<E, S>,
     package_id: &ObjectID,
@@ -555,14 +708,11 @@ fn vm_move_call<E: fmt::Debug, S: StorageView<E>>(
     Ok(result)
 }
 
-/// - Deserializes the modules
-/// - Publishes them into the VM, which invokes the Move verifier
-/// - Run the Sui Verifier
-fn publish_and_verify_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
+fn deserialize_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     context: &mut ExecutionContext<E, S>,
-    module_bytes: Vec<Vec<u8>>,
+    module_bytes: &[Vec<u8>],
 ) -> Result<Vec<CompiledModule>, ExecutionError> {
-    let mut modules = module_bytes
+    let modules = module_bytes
         .iter()
         .map(|b| {
             CompiledModule::deserialize(b)
@@ -575,6 +725,17 @@ fn publish_and_verify_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionM
         !modules.is_empty(),
         "input checker ensures package is not empty"
     );
+    Ok(modules)
+}
+
+/// - Deserializes the modules
+/// - Publishes them into the VM, which invokes the Move verifier
+/// - Run the Sui Verifier
+fn publish_and_verify_new_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<E, S>,
+    module_bytes: &[Vec<u8>],
+) -> Result<Vec<CompiledModule>, ExecutionError> {
+    let mut modules = deserialize_modules::<_, _, Mode>(context, module_bytes)?;
 
     // It should be fine that this does not go through ExecutionContext::fresh_id since the Move
     // runtime does not to know about new packages created, since Move objects and Move packages
@@ -585,6 +746,24 @@ fn publish_and_verify_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionM
     } else {
         generate_package_id(&mut modules, context.tx_context)?
     };
+    publish_and_verify_modules(context, package_id, modules)
+}
+
+fn publish_and_verify_upgraded_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<E, S>,
+    module_bytes: &[Vec<u8>],
+    package_id: ObjectID,
+) -> Result<Vec<CompiledModule>, ExecutionError> {
+    let mut modules = deserialize_modules::<_, _, Mode>(context, module_bytes)?;
+    substitute_package_id(&mut modules, package_id)?;
+    publish_and_verify_modules(context, package_id, modules)
+}
+
+fn publish_and_verify_modules<E: fmt::Debug, S: StorageView<E>>(
+    context: &mut ExecutionContext<E, S>,
+    package_id: ObjectID,
+    modules: Vec<CompiledModule>,
+) -> Result<Vec<CompiledModule>, ExecutionError> {
     // TODO(https://github.com/MystenLabs/sui/issues/69): avoid this redundant serialization by exposing VM API that allows us to run the linker directly on `Vec<CompiledModule>`
     let new_module_bytes: Vec<_> = modules
         .iter()
@@ -611,6 +790,7 @@ fn publish_and_verify_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionM
         // bytecode verifier has passed.
         sui_verifier::verifier::verify_module(module, &BTreeMap::new())?;
     }
+
     Ok(modules)
 }
 

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -21,7 +21,7 @@ use sui_types::{
     },
     messages::{
         Argument, CallArg, Command, CommandArgumentError, ExecutionFailureStatus, ExecutionStatus,
-        ObjectArg, ObjectInfoRequestKind, TransactionKind, TypeArgumentError,
+        ObjectArg, ObjectInfoRequestKind, PackageUpgradeError, TransactionKind, TypeArgumentError,
     },
     object::{Data, Owner},
     storage::DeleteKind,
@@ -93,6 +93,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<Command>(&samples)?;
     tracer.trace_type::<CommandArgumentError>(&samples)?;
     tracer.trace_type::<TypeArgumentError>(&samples)?;
+    tracer.trace_type::<PackageUpgradeError>(&samples)?;
 
     tracer.registry()
 }

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -34,6 +34,9 @@ pub mod transaction_orchestrator;
 #[path = "unit_tests/move_package_tests.rs"]
 mod move_package_tests;
 #[cfg(test)]
+#[path = "unit_tests/move_package_upgrade_tests.rs"]
+mod move_package_upgrade_tests;
+#[cfg(test)]
 #[path = "unit_tests/pay_sui_tests.rs"]
 mod pay_sui_tests;
 pub mod test_authority_clients;

--- a/crates/sui-core/src/unit_tests/data/move_package/Bv2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Bv2/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "B"
+version = "0.0.1"
+
+[addresses]
+b = "0xb1"
+
+[dependencies]
+C = { local = "../Cv2" }

--- a/crates/sui-core/src/unit_tests/data/move_package/Bv2/sources/b.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/Bv2/sources/b.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module b::b {
+    public fun b(): u64 {
+        c::c::c()
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv1/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv1/Move.toml
@@ -1,6 +1,7 @@
 [package]
 name = "C"
 version = "0.0.1"
+published-at = "0xc1"
 
 [addresses]
 c = "0xc1"

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv2/Move.toml
@@ -1,6 +1,7 @@
 [package]
 name = "C"
 version = "0.0.2"
+published-at = "0xc2"
 
 [addresses]
 c = "0xc1"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "package_upgrade_base"
+version = "0.0.1"
+
+[addresses]
+base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base/sources/base.move
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+
+    struct A<T> {
+        f1: bool,
+        f2: T
+    }
+
+    friend base_addr::friend_module;
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    public(friend) fun friend_fun(x: u64): u64 { x }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base/sources/friend_module.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct A<T> {
+        field1: u64,
+        field2: T
+    }
+
+    public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "package_upgrade_base"
+version = "0.0.1"
+
+[addresses]
+base_addr =  "_"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/sources/base.move
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+
+    struct A<T> {
+        f1: bool,
+        f2: T
+    }
+
+    friend base_addr::friend_module;
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    public(friend) fun friend_fun(x: u64): u64 { x }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/sources/friend_module.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct A<T> {
+        field1: u64,
+        field2: T
+    }
+
+    public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "compatibility_invalid"
+version = "0.0.2"
+
+[addresses]
+base_addr = "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/sources/base.move
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+
+    struct A<T> {
+        f1: bool,
+        f2: T
+    }
+
+    friend base_addr::friend_module;
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64, y: u64): u64 { x + y }
+
+    public(friend) fun friend_fun(x: u64): u64 { x }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/sources/friend_module.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct A<T> {
+        field1: u64,
+        field2: T
+    }
+
+    public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_dep/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_dep/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "dep_on_dep"
+version = "0.0.1"
+
+[dependencies]
+dep_on_upgrading_package = { local = "../dep_on_upgrading_package_upgradeable" }
+
+[addresses]
+a =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_dep/sources/my_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_dep/sources/my_module.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module a::my_module {
+    use dep_on_upgrading_package::my_module;
+
+    public fun call_return_0(): u64 { my_module::call_return_0() }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "dep_on_upgrading_package"
+version = "0.0.1"
+
+[dependencies]
+package_upgrade_base = { local = "../base_as_dep" }
+
+[addresses]
+dep_on_upgrading_package =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package/sources/my_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package/sources/my_module.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module dep_on_upgrading_package::my_module {
+    use base_addr::base;
+
+    public fun call_return_0(): u64 { base::return_0() }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_upgradeable/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_upgradeable/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "dep_on_upgrading_package"
+version = "0.0.1"
+
+[dependencies]
+package_upgrade_base = { local = "../base_as_dep" }
+
+[addresses]
+dep_on_upgrading_package =  "_"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_upgradeable/sources/my_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_upgradeable/sources/my_module.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module dep_on_upgrading_package::my_module {
+    use base_addr::base;
+
+    public fun call_return_0(): u64 { base::return_0() }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "stage1_basic_compatibility_valid"
+version = "0.0.2"
+
+[addresses]
+base_addr = "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/sources/base.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+
+    struct A<T> {
+        f1: bool,
+        f2: T
+    }
+
+    // Add a struct
+    struct B<T> {
+        f1: bool,
+        f2: T
+    }
+
+    friend base_addr::friend_module;
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    // We currently cannot change a friend function as the loader will yell at us.
+    public(friend) fun friend_fun(x: u64): u64 { x }
+
+    // Change this private function
+    fun non_public_fun(y: bool, g: u64): u64 { if (y) 0 else g }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/sources/friend_module.move
@@ -1,0 +1,19 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct A<T> {
+        field1: u64,
+        field2: T
+    }
+
+    public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
+
+    public fun return_0(): u64 { 0 }
+
+    fun non_public_fun(y: u64): u64 { y }
+
+    // Reorder the functions
+    public fun plus_1(x: u64): u64 { x + 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/sources/new_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/sources/new_module.move
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::new_module {
+    public fun this_is_a_new_module() { }
+
+    public fun i_can_call_funs_in_other_modules_that_already_existed(): u64 {
+        base_addr::friend_module::friend_call()
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "stage2_basic_compatibility_valid"
+version = "0.0.3"
+
+[dependencies]
+Sui = { local = "../../../../../../sui-framework" }
+
+[addresses]
+base_addr = "0x0"
+sui = "0x2"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/sources/base.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+
+    struct A<T> {
+        f1: bool,
+        f2: T
+    }
+
+    // Add a struct
+    struct B<T> {
+        f1: bool,
+        f2: T
+    }
+
+    friend base_addr::friend_module;
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    // We currently cannot change a friend function as the loader will yell at us.
+    public(friend) fun friend_fun(x: u64): u64 { x }
+
+    // Change this private function
+    fun non_public_fun(y: bool, g: u64): u64 { if (y) 0 else g }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/sources/friend_module.move
@@ -1,0 +1,19 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct A<T> {
+        field1: u64,
+        field2: T
+    }
+
+    public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
+
+    public fun return_0(): u64 { 0 }
+
+    fun non_public_fun(y: u64): u64 { y }
+
+    // Reorder the functions
+    public fun plus_1(x: u64): u64 { x + 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/sources/new_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/sources/new_module.move
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::new_module {
+
+    struct MyObject has key, store {
+        id: sui::object::UID,
+        data: u64
+    }
+
+    public fun this_is_a_new_module() { }
+
+    public fun i_can_call_funs_in_other_modules_that_already_existed(): u64 {
+        base_addr::friend_module::friend_call()
+    }
+}

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -1,0 +1,699 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::{account_address::AccountAddress, ident_str};
+use sui_framework_build::compiled_package::BuildConfig;
+use sui_protocol_config::ProtocolConfig;
+use sui_types::{
+    base_types::{ObjectID, ObjectRef, SuiAddress},
+    crypto::{get_key_pair, AccountKeyPair},
+    messages::{
+        Argument, CommandArgumentError, ExecutionFailureStatus, ObjectArg, PackageUpgradeError,
+        ProgrammableTransaction, TransactionEffects,
+    },
+    move_package::{UPGRADE_POLICY_COMPATIBLE, UPGRADE_POLICY_DEP_ONLY},
+    object::{Object, Owner},
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    storage::BackingPackageStore,
+    MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID,
+};
+
+use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
+
+use crate::authority::{
+    authority_tests::{execute_programmable_transaction, init_state},
+    move_integration_tests::build_and_publish_test_package_with_upgrade_cap,
+    AuthorityState,
+};
+
+macro_rules! move_call {
+    {$builder:expr, ($addr:expr)::$module_name:ident::$func:ident($($args:expr),* $(,)?)} => {
+        $builder.programmable_move_call(
+            $addr,
+            ident_str!(stringify!($module_name)).to_owned(),
+            ident_str!(stringify!($func)).to_owned(),
+            vec![],
+            vec![$($args),*],
+        )
+    }
+}
+
+pub fn build_upgrade_test_modules(test_dir: &str) -> (Vec<u8>, Vec<Vec<u8>>) {
+    let build_config = BuildConfig::new_for_testing();
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["src", "unit_tests", "data", "move_upgrade", test_dir]);
+    let with_unpublished_deps = false;
+    let package = sui_framework::build_move_package(&path, build_config).unwrap();
+    (
+        package.get_package_digest(with_unpublished_deps).to_vec(),
+        package.get_package_bytes(with_unpublished_deps),
+    )
+}
+
+pub fn build_upgrade_test_modules_with_dep_addr(
+    test_dir: &str,
+    dep_ids: impl IntoIterator<Item = (&'static str, ObjectID)>,
+) -> (Vec<u8>, Vec<Vec<u8>>, Vec<ObjectID>) {
+    let mut build_config = BuildConfig::new_for_testing();
+    for (addr_name, obj_id) in dep_ids.into_iter() {
+        build_config
+            .config
+            .additional_named_addresses
+            .insert(addr_name.to_string(), AccountAddress::from(obj_id));
+    }
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["src", "unit_tests", "data", "move_upgrade", test_dir]);
+    let with_unpublished_deps = false;
+    let package = sui_framework::build_move_package(&path, build_config).unwrap();
+    (
+        package.get_package_digest(with_unpublished_deps).to_vec(),
+        package.get_package_bytes(with_unpublished_deps),
+        package.get_dependency_original_package_ids(),
+    )
+}
+
+pub struct UpgradeStateRunner {
+    pub sender: SuiAddress,
+    pub sender_key: AccountKeyPair,
+    pub gas_object_id: ObjectID,
+    pub authority_state: Arc<AuthorityState>,
+    pub package: ObjectRef,
+    pub upgrade_cap: ObjectRef,
+}
+
+impl UpgradeStateRunner {
+    pub async fn new(base_package_name: &str) -> Self {
+        let _dont_remove = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_package_upgrades_for_testing(true);
+            config
+        });
+        let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+        let gas_object_id = ObjectID::random();
+        let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, 100000);
+        let authority_state = init_state().await;
+        authority_state.insert_genesis_object(gas_object).await;
+
+        let (package, upgrade_cap) = build_and_publish_test_package_with_upgrade_cap(
+            &authority_state,
+            &sender,
+            &sender_key,
+            &gas_object_id,
+            base_package_name,
+            /* with_unpublished_deps */ false,
+        )
+        .await;
+
+        Self {
+            sender,
+            sender_key,
+            gas_object_id,
+            authority_state,
+            package,
+            upgrade_cap,
+        }
+    }
+
+    pub async fn publish(
+        &self,
+        modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+    ) -> (ObjectRef, ObjectRef) {
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            let cap = builder.publish_upgradeable(modules, dep_ids);
+            builder.transfer_arg(self.sender, cap);
+            builder.finish()
+        };
+        let TransactionEffects::V1(effects) = self.run(pt).await;
+        assert!(effects.status.is_ok());
+
+        let package = effects
+            .created
+            .iter()
+            .find(|(_, owner)| matches!(owner, Owner::Immutable))
+            .unwrap();
+
+        let cap = effects
+            .created
+            .iter()
+            .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
+            .unwrap();
+
+        (package.0, cap.0)
+    }
+
+    pub async fn run(&self, pt: ProgrammableTransaction) -> TransactionEffects {
+        execute_programmable_transaction(
+            &self.authority_state,
+            &self.gas_object_id,
+            &self.sender,
+            &self.sender_key,
+            pt,
+        )
+        .await
+        .unwrap()
+    }
+}
+
+#[tokio::test]
+async fn test_upgrade_package_happy_path() {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = runner.package.0;
+        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+
+        // We take as input the upgrade cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+
+        // Create the upgrade ticket
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_COMPATIBLE).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
+        move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+        };
+
+        builder.finish()
+    };
+    let TransactionEffects::V1(effects) = runner.run(pt).await;
+
+    assert!(effects.status.is_ok());
+    let new_package = effects
+        .created
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::Immutable))
+        .unwrap();
+    let package = runner
+        .authority_state
+        .database
+        .get_package(&new_package.0 .0)
+        .unwrap()
+        .unwrap();
+    let normalized_modules = package.normalize().unwrap();
+    assert!(normalized_modules.contains_key("new_module"));
+    assert!(normalized_modules["new_module"]
+        .exposed_functions
+        .contains_key(ident_str!("this_is_a_new_module")));
+    assert!(normalized_modules["new_module"]
+        .exposed_functions
+        .contains_key(ident_str!(
+            "i_can_call_funs_in_other_modules_that_already_existed"
+        )));
+}
+
+// TODO(tzakian): turn this test on once the Move loader changes.
+#[tokio::test]
+#[ignore]
+async fn test_upgrade_incompatible() {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = runner.package.0;
+        let (digest, modules) = build_upgrade_test_modules("compatibility_invalid");
+
+        // We take as input the upgrade cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+
+        // Create the upgrade ticket
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_COMPATIBLE).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
+        move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+        };
+
+        builder.finish()
+    };
+    let TransactionEffects::V1(effects) = runner.run(pt).await;
+
+    assert!(effects.status.is_ok());
+}
+
+#[tokio::test]
+async fn test_upgrade_package_incorrect_digest() {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let (pt, actual_digest) = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = runner.package.0;
+        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+        let bad_digest: Vec<u8> = digest.iter().map(|_| 0).collect();
+
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_COMPATIBLE).unwrap();
+        let digest_arg = builder.pure(bad_digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
+        (builder.finish(), digest)
+    };
+
+    let TransactionEffects::V1(effects) = runner.run(pt).await;
+
+    assert_eq!(
+        effects.status.unwrap_err().0,
+        ExecutionFailureStatus::PackageUpgradeError {
+            upgrade_error: PackageUpgradeError::DigestDoesNotMatch {
+                digest: actual_digest
+            }
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_upgrade_package_compatibility_too_permissive() {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = runner.package.0;
+        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+
+        // We take as input the upgrade runner.upgrade_cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+
+        // Create the upgrade ticket
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_COMPATIBLE).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::only_dep_upgrades(Argument::Input(0))
+        };
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
+        builder.finish()
+    };
+
+    let TransactionEffects::V1(effects) = runner.run(pt).await;
+
+    // ETooPermissive abort when we try to authorize the upgrade.
+    assert!(matches!(
+        effects.status.unwrap_err().0,
+        ExecutionFailureStatus::MoveAbort(_, 1)
+    ));
+}
+
+#[tokio::test]
+async fn test_upgrade_package_unsupported_compatibility() {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = runner.package.0;
+        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+
+        // We take as input the upgrade runner.upgrade_cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+
+        // Create the upgrade ticket
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_DEP_ONLY).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
+        builder.finish()
+    };
+
+    let TransactionEffects::V1(effects) = runner.run(pt).await;
+
+    // An error currently because we only support compatible upgrades
+    assert_eq!(
+        effects.status.unwrap_err().0,
+        ExecutionFailureStatus::FeatureNotYetSupported
+    );
+}
+
+#[tokio::test]
+async fn test_upgrade_package_invalid_compatibility() {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = runner.package.0;
+        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+
+        // We take as input the upgrade runner.upgrade_cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+
+        // Create the upgrade ticket -- but it has an invalid compatibility policy.
+        let upgrade_arg = builder.pure(255u8).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
+        builder.finish()
+    };
+
+    let TransactionEffects::V1(effects) = runner.run(pt).await;
+
+    assert!(matches!(
+        effects.status.unwrap_err().0,
+        ExecutionFailureStatus::PackageUpgradeError {
+            upgrade_error: PackageUpgradeError::UnknownUpgradePolicy { policy: 255 }
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_upgrade_package_not_a_ticket() {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = runner.package.0;
+        let (_, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+
+        // We take as input the upgrade runner.upgrade_cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+        builder.upgrade(current_package_id, Argument::Input(0), vec![], modules);
+        builder.finish()
+    };
+    let TransactionEffects::V1(effects) = runner.run(pt).await;
+
+    assert_eq!(
+        effects.status.unwrap_err().0,
+        ExecutionFailureStatus::CommandArgumentError {
+            arg_idx: 0,
+            kind: CommandArgumentError::TypeMismatch
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_upgrade_ticket_doesnt_match() {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+        // We take as input the upgrade runner.upgrade_cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+        // Create the upgrade ticket
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_COMPATIBLE).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        builder.upgrade(MOVE_STDLIB_OBJECT_ID, upgrade_ticket, vec![], modules);
+        builder.finish()
+    };
+    let TransactionEffects::V1(effects) = runner.run(pt).await;
+
+    assert!(matches!(
+        effects.status.unwrap_err().0,
+        ExecutionFailureStatus::PackageUpgradeError {
+            upgrade_error: PackageUpgradeError::PackageIDDoesNotMatch {
+                package_id: _,
+                ticket_id: _
+            }
+        }
+    ));
+}
+
+#[tokio::test]
+async fn upgrade_missing_deps() {
+    let TransactionEffects::V1(effects) = test_multiple_upgrades(true).await;
+    assert!(matches!(
+        effects.status.unwrap_err().0,
+        ExecutionFailureStatus::PackageUpgradeError {
+            upgrade_error: PackageUpgradeError::DigestDoesNotMatch { digest: _ }
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_multiple_upgrades_valid() {
+    let TransactionEffects::V1(effects) = test_multiple_upgrades(false).await;
+    assert!(effects.status.is_ok());
+}
+
+async fn test_multiple_upgrades(use_empty_deps: bool) -> TransactionEffects {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let pt1 = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = runner.package.0;
+        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+
+        // We take as input the upgrade cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+
+        // Create the upgrade ticket
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_COMPATIBLE).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
+        move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+        };
+
+        builder.finish()
+    };
+    let TransactionEffects::V1(effects) = runner.run(pt1).await;
+    assert!(effects.status.is_ok());
+
+    let new_package = effects
+        .created
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::Immutable))
+        .unwrap();
+
+    let new_upgrade_cap = effects
+        .mutated
+        .iter()
+        .find(|(obj, _)| obj.0 == runner.upgrade_cap.0)
+        .unwrap();
+
+    // Second upgrade: Also adds a dep on the sui framework and stdlib.
+    let pt2 = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = new_package.0 .0;
+        let (digest, modules) = build_upgrade_test_modules("stage2_basic_compatibility_valid");
+
+        // We take as input the upgrade cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(new_upgrade_cap.0))
+            .unwrap();
+
+        // Create the upgrade ticket
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_COMPATIBLE).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        let deps = if use_empty_deps {
+            vec![]
+        } else {
+            vec![MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID]
+        };
+        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, deps, modules);
+        move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+        };
+
+        builder.finish()
+    };
+    runner.run(pt2).await
+}
+
+// TODO(tzakian): turn this test on once the Move loader changes.
+#[tokio::test]
+#[ignore]
+async fn test_interleaved_upgrades() {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+
+    // Base has been published. Publish a package now that depends on the base package.
+    let (_, module_bytes, dep_ids) = build_upgrade_test_modules_with_dep_addr(
+        "dep_on_upgrading_package",
+        [("base_addr", runner.package.0)],
+    );
+    let (depender_package, depender_cap) = runner.publish(module_bytes, dep_ids).await;
+
+    // publish dependency at version 2
+    let pt1 = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = runner.package.0;
+        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+
+        // We take as input the upgrade cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+
+        // Create the upgrade ticket
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_COMPATIBLE).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
+        move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+        };
+
+        builder.finish()
+    };
+    let TransactionEffects::V1(effects) = runner.run(pt1).await;
+    assert!(effects.status.is_ok());
+
+    let dep_v2_package = effects
+        .created
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::Immutable))
+        .unwrap()
+        .0;
+
+    let pt2 = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = depender_package.0;
+        // Now recompile the depending package with the upgraded dependency
+        // Currently doesn't work -- need to wait for linkage table to be added to the loader.
+        let (digest, modules, dep_ids) = build_upgrade_test_modules_with_dep_addr(
+            "dep_on_upgrading_package",
+            [("base_addr", dep_v2_package.0)],
+        );
+
+        // We take as input the upgrade cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(depender_cap))
+            .unwrap();
+
+        // Create the upgrade ticket
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_COMPATIBLE).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, dep_ids, modules);
+        move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+        };
+
+        builder.finish()
+    };
+    let TransactionEffects::V1(effects) = runner.run(pt2).await;
+    assert!(effects.status.is_ok());
+}
+
+#[tokio::test]
+async fn test_publish_override_happy_path() {
+    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+
+    // Base has been published already. Publish a package now that depends on the base package.
+    let (_, module_bytes, dep_ids) = build_upgrade_test_modules_with_dep_addr(
+        "dep_on_upgrading_package",
+        [("base_addr", runner.package.0)],
+    );
+    // Dependency graph: base <-- dep_on_upgrading_package
+    let (depender_package, _) = runner.publish(module_bytes, dep_ids).await;
+
+    // publish base package at version 2
+    // Dependency graph: base(v1) <-- dep_on_upgrading_package
+    //                   base(v2)
+    let pt1 = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let current_package_id = runner.package.0;
+        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+
+        // We take as input the upgrade cap
+        builder
+            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+            .unwrap();
+
+        // Create the upgrade ticket
+        let upgrade_arg = builder.pure(UPGRADE_POLICY_COMPATIBLE).unwrap();
+        let digest_arg = builder.pure(digest).unwrap();
+        let upgrade_ticket = move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+        };
+        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
+        move_call! {
+            builder,
+            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+        };
+
+        builder.finish()
+    };
+    let TransactionEffects::V1(effects) = runner.run(pt1).await;
+    assert!(effects.status.is_ok());
+
+    let dep_v2_package = effects
+        .created
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::Immutable))
+        .unwrap()
+        .0;
+
+    // Publish P that depends on both `dep_on_upgrading_package` and `stage1_basic_compatibility_valid`
+    // Dependency graph for dep_on_dep:
+    //    base(v1)
+    //    base(v2) <-- dep_on_upgrading_package <-- dep_on_dep
+    let (_, modules, dep_ids) = build_upgrade_test_modules_with_dep_addr(
+        "dep_on_dep",
+        [
+            ("base_addr", dep_v2_package.0),
+            ("dep_on_upgrading_package", depender_package.0),
+        ],
+    );
+
+    let (new_package, _) = runner.publish(modules, dep_ids).await;
+
+    let package = runner
+        .authority_state
+        .database
+        .get_package(&new_package.0)
+        .unwrap()
+        .unwrap();
+
+    // Make sure the linkage table points to the correct versions!
+    let dep_ids_in_linkage_table: BTreeSet<_> = package
+        .linkage_table()
+        .values()
+        .map(|up| up.upgraded_id)
+        .collect();
+    assert!(dep_ids_in_linkage_table.contains(&dep_v2_package.0));
+    assert!(dep_ids_in_linkage_table.contains(&depender_package.0));
+}

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -244,6 +244,11 @@ ExecutionFailureStatus:
       PublishUpgradeMissingDependency: UNIT
     26:
       PublishUpgradeDependencyDowngrade: UNIT
+    27:
+      PackageUpgradeError:
+        STRUCT:
+          - upgrade_error:
+              TYPENAME: PackageUpgradeError
 ExecutionStatus:
   ENUM:
     0:
@@ -432,6 +437,36 @@ Owner:
               TYPENAME: SequenceNumber
     3:
       Immutable: UNIT
+PackageUpgradeError:
+  ENUM:
+    0:
+      UnableToFetchPackage:
+        STRUCT:
+          - package_id:
+              TYPENAME: ObjectID
+    1:
+      NotAPackage:
+        STRUCT:
+          - object_id:
+              TYPENAME: ObjectID
+    2:
+      IncompatibleUpgrade: UNIT
+    3:
+      DigestDoesNotMatch:
+        STRUCT:
+          - digest:
+              SEQ: U8
+    4:
+      UnknownUpgradePolicy:
+        STRUCT:
+          - policy: U8
+    5:
+      PackageIDDoesNotMatch:
+        STRUCT:
+          - package_id:
+              TYPENAME: ObjectID
+          - ticket_id:
+              TYPENAME: ObjectID
 ProgrammableMoveCall:
   STRUCT:
     - package:

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -41,7 +41,7 @@ use serde_reflection::Registry;
 use sui_types::{
     base_types::ObjectID,
     error::{SuiError, SuiResult},
-    move_package::{FnInfo, FnInfoKey, FnInfoMap},
+    move_package::{FnInfo, FnInfoKey, FnInfoMap, MovePackage},
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
 use sui_verifier::verifier as sui_bytecode_verifier;
@@ -304,6 +304,13 @@ impl CompiledPackage {
         // dependencies.
         ids.remove(&ObjectID::ZERO);
         ids.into_iter().collect()
+    }
+
+    pub fn get_package_digest(&self, with_unpublished_deps: bool) -> [u8; 32] {
+        MovePackage::compute_digest_for_modules_and_deps(
+            &self.get_package_bytes(with_unpublished_deps),
+            self.dependency_ids.published.values(),
+        )
     }
 
     /// Return a serialized representation of the bytecode modules in this package, topologically sorted in dependency order

--- a/crates/sui-framework/docs/package.md
+++ b/crates/sui-framework/docs/package.md
@@ -918,7 +918,7 @@ for the upgrade to succeed.
     <a href="package.md#0x2_package_UpgradeTicket">UpgradeTicket</a> {
         cap: <a href="object.md#0x2_object_id">object::id</a>(cap),
         <a href="package.md#0x2_package">package</a>,
-        policy: cap.policy,
+        policy,
         <a href="digest.md#0x2_digest">digest</a>,
     }
 }

--- a/crates/sui-framework/sources/package.move
+++ b/crates/sui-framework/sources/package.move
@@ -188,7 +188,7 @@ module sui::package {
     /// package.  This ticket only authorizes an upgrade to a package
     /// that matches this digest.  A package's contents are identified
     /// by two things:
-    ///   
+    ///
     ///  - modules: [[u8]]       a list of the package's module contents
     ///  - deps:    [[u8; 32]]   a list of 32 byte ObjectIDs of the
     ///                          package's transitive dependencies
@@ -248,7 +248,7 @@ module sui::package {
         UpgradeTicket {
             cap: object::id(cap),
             package,
-            policy: cap.policy,
+            policy,
             digest,
         }
     }

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
+use fastcrypto::encoding::{Encoding, Hex};
 use move_cli::base::{self, build};
 use move_package::BuildConfig as MoveBuildConfig;
 use serde_json::json;
@@ -34,6 +35,9 @@ pub struct Build {
     /// and events.
     #[clap(long, global = true)]
     pub generate_struct_layouts: bool,
+    /// Compute and display the package digest in hex.
+    #[clap(long, global = true)]
+    pub dump_package_digest: bool,
 }
 
 impl Build {
@@ -50,6 +54,7 @@ impl Build {
             self.with_unpublished_dependencies,
             self.dump_bytecode_as_base64,
             self.generate_struct_layouts,
+            self.dump_package_digest,
         )
     }
 
@@ -59,6 +64,7 @@ impl Build {
         with_unpublished_deps: bool,
         dump_bytecode_as_base64: bool,
         generate_struct_layouts: bool,
+        dump_package_digest: bool,
     ) -> anyhow::Result<()> {
         let pkg = sui_framework::build_move_package(
             rerooted_path,
@@ -82,6 +88,13 @@ impl Build {
                     "dependencies": json!(package_dependencies),
                 })
             )
+        }
+
+        if dump_package_digest {
+            println!(
+                "{}",
+                Hex::encode(pkg.get_package_digest(with_unpublished_deps))
+            );
         }
 
         if generate_struct_layouts {

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -46,6 +46,7 @@ impl Test {
         let with_unpublished_deps = false;
         let dump_bytecode_as_base64 = false;
         let generate_struct_layouts: bool = false;
+        let dump_package_digest = false;
         build::Build::execute_internal(
             &rerooted_path,
             BuildConfig {
@@ -55,6 +56,7 @@ impl Test {
             with_unpublished_deps,
             dump_bytecode_as_base64,
             generate_struct_layouts,
+            dump_package_digest,
         )?;
         run_move_unit_tests(
             &rerooted_path,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -852,6 +852,9 @@ impl ProtocolConfig {
     pub fn set_buffer_stake_for_protocol_upgrade_bps_for_testing(&mut self, b: u64) {
         self.buffer_stake_for_protocol_upgrade_bps = Some(b)
     }
+    pub fn set_package_upgrades_for_testing(&mut self, val: bool) {
+        self.feature_flags.package_upgrades = val
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send;

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2260,6 +2260,9 @@ pub enum ExecutionFailureStatus {
          transitive dependencies."
     )]
     PublishUpgradeDependencyDowngrade,
+
+    #[error("Invalid package upgrade. {upgrade_error}")]
+    PackageUpgradeError { upgrade_error: PackageUpgradeError },
     // NOTE: if you want to add a new enum,
     // please add it at the end for Rust SDK backward compatibility.
 }
@@ -2320,6 +2323,25 @@ pub enum CommandArgumentError {
     InvalidObjectByValue,
     #[error("Immutable objects cannot be passed by mutable reference, &mut.")]
     InvalidObjectByMutRef,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Error)]
+pub enum PackageUpgradeError {
+    #[error("Unable to fetch package at {package_id}")]
+    UnableToFetchPackage { package_id: ObjectID },
+    #[error("Object {object_id} is not a package")]
+    NotAPackage { object_id: ObjectID },
+    #[error("New package is incompatible with previous version")]
+    IncompatibleUpgrade,
+    #[error("Digest in upgrade ticket and computed digest disagree")]
+    DigestDoesNotMatch { digest: Vec<u8> },
+    #[error("Upgrade policy {policy} is not a valid upgrade policy")]
+    UnknownUpgradePolicy { policy: u8 },
+    #[error("Package ID {package_id} does not match package ID in upgrade ticket {ticket_id}")]
+    PackageIDDoesNotMatch {
+        package_id: ObjectID,
+        ticket_id: ObjectID,
+    },
 }
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Serialize, Deserialize, Hash, Error)]

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -588,6 +588,25 @@ impl Object {
         ))
     }
 
+    pub fn new_upgraded_package<'a>(
+        previous_package: &MovePackage,
+        new_package_id: ObjectID,
+        modules: Vec<CompiledModule>,
+        previous_transaction: TransactionDigest,
+        max_move_package_size: u64,
+        dependencies: impl IntoIterator<Item = &'a MovePackage>,
+    ) -> Result<Self, ExecutionError> {
+        Ok(Self::new_package_from_data(
+            Data::Package(previous_package.new_upgraded(
+                new_package_id,
+                modules,
+                max_move_package_size,
+                dependencies,
+            )?),
+            previous_transaction,
+        ))
+    }
+
     pub fn new_package_for_testing<'p>(
         modules: Vec<CompiledModule>,
         previous_transaction: TransactionDigest,

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -659,15 +659,15 @@ impl From<&ObjectRef> for ObjectKey {
 /// Fetch the `ObjectKey`s (IDs and versions) for non-shared input objects.  Includes owned,
 /// and immutable objects as well as the gas objects, but not move packages or shared objects.
 pub fn transaction_input_object_keys(tx: &SenderSignedData) -> SuiResult<Vec<ObjectKey>> {
-    use crate::messages::InputObjectKind::{ImmOrOwnedMoveObject, MovePackage, SharedMoveObject};
+    use crate::messages::InputObjectKind as I;
     Ok(tx
         .intent_message()
         .value
         .input_objects()?
         .into_iter()
         .filter_map(|object| match object {
-            MovePackage(_) | SharedMoveObject { .. } => None,
-            ImmOrOwnedMoveObject(obj) => Some(obj.into()),
+            I::MovePackage(_) | I::SharedMoveObject { .. } => None,
+            I::ImmOrOwnedMoveObject(obj) => Some(obj.into()),
         })
         .collect())
 }


### PR DESCRIPTION
## Description 

This adds initial support for the package upgrade command, and adds a number of tests to make sure that package upgrades behave as expected.

## Test Plan 

Added a number of tests to make sure package upgrades behave as expected. 
