### PR TITLE
[sui-proxy] introduce a sui-proxy for metrics and telemetry items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -1025,7 +1026,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tower-layer",
  "tower-service",
 ]
@@ -1061,7 +1062,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tower-layer",
  "tower-service",
 ]
@@ -3619,6 +3620,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5515,7 +5541,7 @@ dependencies = [
  "tonic",
  "tonic-health",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tracing",
  "workspace-hack",
 ]
@@ -7058,9 +7084,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -7068,9 +7094,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5320c680de74ba083512704acb90fe00f28f79207286a848e730c45dd73ed6"
+checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
  "bytes",
  "heck 0.4.0",
@@ -7090,9 +7116,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -7103,11 +7129,10 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
+checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
- "bytes",
  "prost",
 ]
 
@@ -7116,6 +7141,9 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "protobuf-src"
@@ -7804,11 +7832,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -8125,9 +8153,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "indexmap",
  "itoa 1.0.5",
@@ -9030,7 +9058,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tracing",
  "typed-store",
  "typed-store-derive",
@@ -9215,7 +9243,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tracing",
  "workspace-hack",
 ]
@@ -9460,6 +9488,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-proxy"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "axum",
+ "axum-server",
+ "bytes",
+ "clap 3.2.23",
+ "const-str",
+ "fastcrypto",
+ "futures",
+ "git-version",
+ "hyper",
+ "itertools",
+ "mime",
+ "multiaddr",
+ "prometheus",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "protobuf",
+ "rand 0.8.5",
+ "reqwest",
+ "rustls",
+ "rustls-pemfile",
+ "serde 1.0.152",
+ "serde_json",
+ "serde_with",
+ "serde_yaml",
+ "snap",
+ "sui-tls",
+ "sui-types",
+ "telemetry-subscribers",
+ "tokio",
+ "tower",
+ "tower-http 0.4.0",
+ "tower-layer",
+ "tracing",
+ "workspace-hack",
+]
+
+[[package]]
 name = "sui-rosetta"
 version = "0.1.0"
 dependencies = [
@@ -9504,7 +9574,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tracing",
  "typed-store",
  "typed-store-derive",
@@ -9692,7 +9762,7 @@ dependencies = [
  "telemetry-subscribers",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "workspace-hack",
 ]
 
@@ -10594,6 +10664,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11431,6 +11520,7 @@ dependencies = [
  "base-x",
  "base16ct",
  "base64 0.13.1",
+ "base64 0.21.0",
  "base64ct",
  "bcs",
  "beef",
@@ -11645,6 +11735,8 @@ dependencies = [
  "hashbrown 0.12.3",
  "hashbrown 0.13.2",
  "hdrhistogram",
+ "headers",
+ "headers-core",
  "heck 0.3.3",
  "heck 0.4.0",
  "hex",
@@ -11974,6 +12066,7 @@ dependencies = [
  "serde_yaml",
  "sha-1 0.10.1",
  "sha-1 0.9.8",
+ "sha1",
  "sha2 0.10.6",
  "sha2 0.9.9",
  "sha3 0.10.6",
@@ -12064,7 +12157,8 @@ dependencies = [
  "tonic-health",
  "toolchain_find",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
+ "tower-http 0.4.0",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/sui-open-rpc-macros",
     "crates/sui-proc-macros",
     "crates/sui-protocol-config",
+    "crates/sui-proxy",
     "crates/sui-rosetta",
     "crates/sui-sdk",
     "crates/sui-simulator",

--- a/crates/sui-proxy/Cargo.toml
+++ b/crates/sui-proxy/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "sui-proxy"
+version = "0.0.1"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+axum = {version = "0.6.2", features = ["headers"]}
+axum-server = { version = "0.4.4", default-features = false, features = ["tls-rustls"] }
+anyhow = { version = "1.0.64", features = ["backtrace"] }
+bytes = "1.4"
+clap = { version = "3.2.17", features = ["derive"] }
+protobuf = {version="2.28", features=["with-bytes"]}
+tokio = { workspace = true, features = ["full"] }
+tracing = "0.1.36"
+futures = "0.3.23"
+const-str = "0.5.3"
+tower-http = { version="0.4", features = ["trace"] }
+tower = "0.4"
+tower-layer = "0.3.2"
+serde = { version = "1.0.144", features = ["derive", "rc"] }
+serde_with = "2.1.0"
+serde_json = "1.0.93"
+serde_yaml = "0.8.26"
+git-version = "0.3.5"
+itertools = "0.10.5"
+rand = "0.8.5"
+reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
+hyper = { version = "0.14", features = ["full"] }
+sui-tls = { path = "../sui-tls" }
+sui-types = { path = "../sui-types" }
+multiaddr = "0.17.0"
+prometheus = "0.13.3"
+snap = "1.1.0"
+rustls = { version = "0.20.4", features = ["dangerous_configuration"] }
+rustls-pemfile = "1.0.2"
+prost = "0.11.8"
+prost-types = "0.11.8"
+
+
+telemetry-subscribers.workspace = true
+fastcrypto.workspace = true
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+mime = "0.3"
+serde_json = "1.0"
+tower = { version = "0.4", features = ["util"] }
+axum-server = { version = "0.4.4", default-features = false, features = ["tls-rustls"] }
+
+[build-dependencies]
+prost-build = "0.11.8"

--- a/crates/sui-proxy/build.rs
+++ b/crates/sui-proxy/build.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use std::io::Result;
+fn main() -> Result<()> {
+    // add this env var to build. you'll need protoc installed locally and a copy of the proto files
+    if option_env!("BUILD_REMOTE_WRITE").is_some() {
+        prost_build::compile_protos(
+            &["protobufs/remote.proto", "protobufs/types.proto"],
+            &["protobufs/"],
+        )?;
+    }
+    Ok(())
+}

--- a/crates/sui-proxy/src/admin.rs
+++ b/crates/sui-proxy/src/admin.rs
@@ -1,0 +1,205 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::config::{PeerValidationConfig, RemoteWriteConfig};
+use crate::handlers::publish_metrics;
+use crate::middleware::{expect_mysten_proxy_header, expect_valid_public_key};
+use crate::peers::SuiNodeProvider;
+use anyhow::Result;
+
+use axum::routing::post as axum_post;
+use axum::Extension;
+use axum::{middleware, Router};
+use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PublicKey};
+use fastcrypto::traits::KeyPair;
+use std::fs;
+use std::io::BufReader;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use sui_tls::{rustls::ServerConfig, AllowAll, CertVerifier, SelfSignedCertificate, TlsAcceptor};
+use tokio::signal;
+
+use tower::ServiceBuilder;
+use tower_http::{
+    trace::{DefaultOnResponse, TraceLayer},
+    LatencyUnit,
+};
+use tracing::{info, Level};
+
+/// user agent we use when posting to mimir
+static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+
+/// Configure our graceful shutdown scenarios
+pub async fn shutdown_signal(h: axum_server::Handle) {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    let grace = 30;
+    info!(
+        "signal received, starting graceful shutdown, grace period {} seconds, if needed",
+        &grace
+    );
+    h.graceful_shutdown(Some(Duration::from_secs(grace)))
+}
+
+/// Reqwest client holds the global client for remote_push api calls
+/// it also holds the username and password.  The client has an underlying
+/// connection pool.  See reqwest documentation for details
+#[derive(Clone)]
+pub struct ReqwestClient {
+    pub client: reqwest::Client,
+    pub settings: RemoteWriteConfig,
+}
+
+pub fn make_reqwest_client(settings: RemoteWriteConfig) -> ReqwestClient {
+    ReqwestClient {
+        client: reqwest::Client::builder()
+            .user_agent(APP_USER_AGENT)
+            .pool_max_idle_per_host(32)
+            .timeout(Duration::from_secs(15))
+            .build()
+            .expect("cannot create reqwest client"),
+        settings,
+    }
+}
+
+/// App will configure our routes. This fn is also used to instrument our tests
+pub fn app(network: String, client: ReqwestClient, allower: Option<SuiNodeProvider>) -> Router {
+    // build our application with a route and our sender mpsc
+    let mut router = Router::new()
+        .route("/publish/metrics", axum_post(publish_metrics))
+        .route_layer(middleware::from_fn(expect_mysten_proxy_header));
+
+    if let Some(allower) = allower {
+        router = router
+            .route_layer(middleware::from_fn(expect_valid_public_key))
+            .layer(Extension(Arc::new(allower)));
+    }
+    router
+        .layer(Extension(network))
+        .layer(Extension(client))
+        .layer(
+            ServiceBuilder::new().layer(
+                TraceLayer::new_for_http().on_response(
+                    DefaultOnResponse::new()
+                        .level(Level::INFO)
+                        .latency_unit(LatencyUnit::Seconds),
+                ),
+            ),
+        )
+}
+
+/// Server creates our http/https server
+pub async fn server(
+    listener: std::net::TcpListener,
+    app: Router,
+    acceptor: Option<TlsAcceptor>,
+) -> std::io::Result<()> {
+    // setup our graceful shutdown
+    let handle = axum_server::Handle::new();
+    // Spawn a task to gracefully shutdown server.
+    tokio::spawn(shutdown_signal(handle.clone()));
+
+    if let Some(verify_peers) = acceptor {
+        axum_server::Server::from_tcp(listener)
+            .acceptor(verify_peers)
+            .handle(handle)
+            .serve(app.into_make_service_with_connect_info::<SocketAddr>())
+            .await
+    } else {
+        axum_server::Server::from_tcp(listener)
+            .handle(handle)
+            .serve(app.into_make_service_with_connect_info::<SocketAddr>())
+            .await
+    }
+}
+
+/// Generate server certs for use with peer verification
+pub fn generate_self_cert(hostname: String) -> (SelfSignedCertificate, Ed25519PublicKey) {
+    let mut rng = rand::thread_rng();
+    let keypair = Ed25519KeyPair::generate(&mut rng);
+    (
+        SelfSignedCertificate::new(keypair.copy().private(), &hostname),
+        keypair.public().to_owned(),
+    )
+}
+
+/// Load a certificate for use by the listening service
+fn load_certs(filename: &str) -> Vec<rustls::Certificate> {
+    let certfile = fs::File::open(filename).expect("cannot open certificate file");
+    let mut reader = BufReader::new(certfile);
+    rustls_pemfile::certs(&mut reader)
+        .unwrap()
+        .iter()
+        .map(|v| rustls::Certificate(v.clone()))
+        .collect()
+}
+
+fn load_private_key(filename: &str) -> rustls::PrivateKey {
+    let keyfile = fs::File::open(filename).expect("cannot open private key file");
+    let mut reader = BufReader::new(keyfile);
+
+    loop {
+        match rustls_pemfile::read_one(&mut reader).expect("cannot parse private key .pem file") {
+            Some(rustls_pemfile::Item::RSAKey(key)) => return rustls::PrivateKey(key),
+            Some(rustls_pemfile::Item::PKCS8Key(key)) => return rustls::PrivateKey(key),
+            Some(rustls_pemfile::Item::ECKey(key)) => return rustls::PrivateKey(key),
+            None => break,
+            _ => {}
+        }
+    }
+
+    panic!(
+        "no keys found in {:?} (encrypted keys not supported)",
+        filename
+    );
+}
+
+/// Default allow mode for server, we don't verify clients, everything is accepted
+pub fn create_server_cert_default_allow(
+    hostname: String,
+) -> Result<ServerConfig, sui_tls::rustls::Error> {
+    let (server_certificate, _) = generate_self_cert(hostname);
+
+    CertVerifier::new(AllowAll).rustls_server_config(
+        vec![server_certificate.rustls_certificate()],
+        server_certificate.rustls_private_key(),
+    )
+}
+
+/// Verify clients against sui blockchain, clients that are not found in sui_getValidators
+/// will be rejected
+pub fn create_server_cert_enforce_peer(
+    peer_config: PeerValidationConfig,
+) -> Result<(ServerConfig, Option<SuiNodeProvider>), sui_tls::rustls::Error> {
+    let (Some(certificate_path), Some(private_key_path)) = (peer_config.certificate_file, peer_config.private_key) else {
+        return Err(sui_tls::rustls::Error::General("missing certs to initialize server".into()));
+    };
+    let allower = SuiNodeProvider::new(peer_config.url, peer_config.interval);
+    allower.poll_peer_list();
+    let c = CertVerifier::new(allower.clone()).rustls_server_config(
+        load_certs(&certificate_path),
+        load_private_key(&private_key_path),
+    )?;
+    Ok((c, Some(allower)))
+}

--- a/crates/sui-proxy/src/config.rs
+++ b/crates/sui-proxy/src/config.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use anyhow::{Context, Result};
+use core::time::Duration;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_with::{serde_as, DurationSeconds};
+use std::net::SocketAddr;
+use tracing::debug;
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ProxyConfig {
+    pub network: String,
+    pub listen_address: SocketAddr,
+    pub remote_write: RemoteWriteConfig,
+    pub json_rpc: PeerValidationConfig,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RemoteWriteConfig {
+    // TODO upgrade to https
+    /// the remote_write url to post data to
+    #[serde(default = "remote_write_url")]
+    pub url: String,
+    /// username is used for posting data to the remote_write api
+    pub username: String,
+    pub password: String,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct PeerValidationConfig {
+    /// url is the json-rpc url we use to obtain valid peers on the blockchain
+    pub url: String,
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub interval: Duration,
+    /// if certificate_file and private_key are not provided, we'll create a self-signed
+    /// cert using this hostname
+    #[serde(default = "hostname_default")]
+    pub hostname: Option<String>,
+
+    /// incoming client connections to this proxy will be presented with this pub key
+    /// please use an aboslute path
+    pub certificate_file: Option<String>,
+    /// private key for tls
+    /// please use an absolute path
+    pub private_key: Option<String>,
+}
+
+fn hostname_default() -> Option<String> {
+    Some("localhost".to_string())
+}
+
+fn remote_write_url() -> String {
+    "http://metrics-gw.testnet.sui.io/api/v1/push".to_string()
+}
+
+pub fn load<P: AsRef<std::path::Path>, T: DeserializeOwned + Serialize>(path: P) -> Result<T> {
+    let path = path.as_ref();
+    debug!("Reading config from {:?}", path);
+    Ok(serde_yaml::from_reader(
+        std::fs::File::open(path).context(format!("cannot open {:?}", path))?,
+    )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn config_load() {
+        const TEMPLATE: &str = include_str!("./data/config.yaml");
+
+        let _template: ProxyConfig = serde_yaml::from_str(TEMPLATE).unwrap();
+    }
+}

--- a/crates/sui-proxy/src/consumer.rs
+++ b/crates/sui-proxy/src/consumer.rs
@@ -1,0 +1,176 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::admin::ReqwestClient;
+use crate::prom_to_mimir::Mimir;
+use anyhow::Result;
+use axum::body::Bytes;
+use axum::http::StatusCode;
+use bytes::{buf::Reader, Buf};
+use fastcrypto::ed25519::Ed25519PublicKey;
+use multiaddr::Multiaddr;
+use prometheus::proto;
+use prost::Message;
+use protobuf::CodedInputStream;
+use std::io::Read;
+use tracing::{debug, error};
+
+/// NodeMetric holds metadata and a metric payload from the calling node
+#[derive(Debug)]
+pub struct NodeMetric {
+    pub name: String,                 // the sui node name from the blockchain
+    pub network: String,              // the sui blockchain name, mainnet
+    pub peer_addr: Multiaddr,         // the sockaddr source address from the incoming request
+    pub public_key: Ed25519PublicKey, // the public key from the sui blockchain
+    pub data: Bytes,                  // raw post data from node
+}
+
+/// The ProtobufDecoder will decode message delimited protobuf messages from prom_model.proto types
+/// They are delimited by size, eg a format is such:
+/// []byte{size, data, size, data, size, data}, etc etc
+pub struct ProtobufDecoder {
+    buf: Reader<Bytes>,
+}
+
+impl ProtobufDecoder {
+    pub fn new(buf: Reader<Bytes>) -> Self {
+        Self { buf }
+    }
+    /// parse a delimited buffer of protobufs. this is used to consume data sent from a sui-node
+    pub fn parse<T: protobuf::Message>(&mut self) -> Result<Vec<T>> {
+        let mut result: Vec<T> = vec![];
+        while !self.buf.get_ref().is_empty() {
+            let len = {
+                let mut is = CodedInputStream::from_buffered_reader(&mut self.buf);
+                is.read_raw_varint32()
+            }?;
+            let mut buf = vec![0; len as usize];
+            self.buf.read_exact(&mut buf)?;
+            result.push(T::parse_from_bytes(&buf)?);
+        }
+        Ok(result)
+    }
+}
+
+pub async fn convert_to_remote_write(
+    rc: ReqwestClient,
+    nm: NodeMetric,
+) -> (StatusCode, &'static str) {
+    let mut decoder = ProtobufDecoder::new(nm.data.reader());
+    let mut decoded = match decoder.parse::<proto::MetricFamily>() {
+        Ok(metrics) => metrics,
+        Err(error) => {
+            error!("unable to decode Vec<MetricFamily> from bytes provided by node; {error}");
+            return (
+                StatusCode::BAD_REQUEST,
+                "unable to decode Vec<MetricFamily> from bytes provided by node",
+            );
+        }
+    };
+
+    // proto::LabelPair doesn't have pub fields so we can't use
+    // struct literals to construct
+    let mut network = proto::LabelPair::default();
+    network.set_name("network".into());
+    network.set_value(nm.network);
+
+    let mut host = proto::LabelPair::default();
+    host.set_name("host".into());
+    host.set_value(nm.name);
+
+    let labels = vec![network, host];
+
+    // add our extra labels to our incoming metric data
+    for mf in decoded.iter_mut() {
+        for m in mf.mut_metric() {
+            m.mut_label().extend(labels.clone());
+        }
+    }
+
+    for timeseries in Mimir::from(decoded) {
+        let mut buf = Vec::new();
+        buf.reserve(timeseries.encoded_len());
+        let Ok(()) = timeseries.encode(&mut buf) else {
+            error!("unable to encode prompb to mimirpb");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "unable to encode prompb to remote_write pb",
+            );
+        };
+
+        let mut s = snap::raw::Encoder::new();
+        let compressed = match s.compress_vec(&buf) {
+            Ok(compressed) => compressed,
+            Err(error) => {
+                error!("unable to compress to snappy block format; {error}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "unable to compress to snappy block format",
+                );
+            }
+        };
+
+        let response = match rc
+            .client
+            .post(rc.settings.url.to_owned())
+            .header(reqwest::header::CONTENT_ENCODING, "snappy")
+            .header(reqwest::header::CONTENT_TYPE, "application/x-protobuf")
+            .header("X-Prometheus-Remote-Write-Version", "0.1.0")
+            .basic_auth(
+                rc.settings.username.to_owned(),
+                Some(rc.settings.password.to_owned()),
+            )
+            .body(compressed)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                error!("DROPPING METRICS due to post error: {error}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "DROPPING METRICS due to post error",
+                );
+            }
+        };
+
+        match response.status() {
+            reqwest::StatusCode::OK => {
+                debug!("({}) SUCCESS: {:?}", reqwest::StatusCode::OK, timeseries);
+            }
+            reqwest::StatusCode::BAD_REQUEST => {
+                error!("TRIED: {:?}", timeseries);
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "response body cannot be decoded".into());
+
+                if body.contains("err-mimir-sample-out-of-order") {
+                    error!("({}) ERROR: {:?}", reqwest::StatusCode::BAD_REQUEST, body);
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "IGNORNING METRICS due to err-mimir-sample-out-of-order",
+                    );
+                }
+                error!("({}) ERROR: {:?}", reqwest::StatusCode::BAD_REQUEST, body);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "unknown bad request error encountered in remote_push",
+                );
+            }
+            code => {
+                error!("TRIED: {:?}", timeseries);
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "response body cannot be decoded".into());
+                error!("({}) ERROR: {:?}", code, body);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "unknown error encountered in remote_push",
+                );
+            }
+        }
+    }
+    (StatusCode::CREATED, "created")
+}

--- a/crates/sui-proxy/src/data/config.yaml
+++ b/crates/sui-proxy/src/data/config.yaml
@@ -1,0 +1,11 @@
+network: joenet
+listen-address: 192.168.0.2:8080
+remote-write:
+  url: http://unittest.abcd.io/api/v1/push
+  username: foo
+  password: fooman
+json-rpc:
+  url: http://127.0.0.1:9000
+  interval: 30
+  certificate-file: /opt/joeman/fullchain.pem
+  private-key: /opt/joeman/privkey.pem

--- a/crates/sui-proxy/src/handlers.rs
+++ b/crates/sui-proxy/src/handlers.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::admin::ReqwestClient;
+use crate::consumer::{convert_to_remote_write, NodeMetric};
+use crate::peers::SuiPeer;
+use axum::{
+    body::Body,
+    extract::{ConnectInfo, Extension},
+    http::{Request, StatusCode},
+};
+use multiaddr::Multiaddr;
+use std::net::SocketAddr;
+
+/// Publish handler which receives metrics from nodes.  Nodes will call us at this endpoint
+/// and we relay them to the upstream tsdb
+///
+/// An mpsc is used within this handler so that we can immediately return an accept to calling nodes.
+/// Downstream processing failures may still result in metrics being dropped.
+pub async fn publish_metrics(
+    Extension(network): Extension<String>,
+    Extension(client): Extension<ReqwestClient>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    Extension(peer): Extension<SuiPeer>,
+    request: Request<Body>,
+) -> (StatusCode, &'static str) {
+    let data = match hyper::body::to_bytes(request.into_body()).await {
+        Ok(data) => data,
+        Err(_e) => {
+            return (StatusCode::BAD_REQUEST, "unable to extract post body");
+        }
+    };
+
+    convert_to_remote_write(
+        client.clone(),
+        NodeMetric {
+            name: peer.name,
+            network,
+            data,
+            peer_addr: Multiaddr::from(addr.ip()),
+            public_key: peer.public_key,
+        },
+    )
+    .await
+}

--- a/crates/sui-proxy/src/lib.rs
+++ b/crates/sui-proxy/src/lib.rs
@@ -1,0 +1,147 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+pub mod admin;
+pub mod config;
+pub mod consumer;
+pub mod handlers;
+pub mod middleware;
+pub mod peers;
+pub mod prom_to_mimir;
+pub mod remote_write;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prom_to_mimir::tests::*;
+
+    use crate::{config::RemoteWriteConfig, peers::SuiNodeProvider};
+    use axum::http::{header, StatusCode};
+    use axum::routing::post;
+    use axum::Router;
+    use multiaddr::Multiaddr;
+    use prometheus::Encoder;
+    use prometheus::PROTOBUF_FORMAT;
+    use protobuf::RepeatedField;
+    use std::net::TcpListener;
+    use std::time::Duration;
+    use sui_tls::{CertVerifier, TlsAcceptor, TlsConnectionInfo};
+
+    async fn run_dummy_remote_write(listener: TcpListener) {
+        /// i accept everything, send me the trash
+        async fn handler() -> StatusCode {
+            StatusCode::OK
+        }
+
+        // build our application with a route
+        let app = Router::new().route("/v1/push", post(handler));
+
+        // run it
+        axum::Server::from_tcp(listener)
+            .unwrap()
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    }
+
+    /// axum_acceptor is a basic e2e test that creates a mock remote_write post endpoint and has a simple
+    /// sui-node client that posts data to the proxy using the protobuf format.  The server processes this
+    /// data and sends it to the mock remote_write which accepts everything.  Future work is to make this more
+    /// robust and expand the scope of coverage, probabaly moving this test elsewhere and renaming it.
+    #[tokio::test]
+    async fn axum_acceptor() {
+        // generate self-signed certificates
+        let (client_priv_cert, client_pub_key) = admin::generate_self_cert("sui".into());
+        let (server_priv_cert, _) = admin::generate_self_cert("localhost".into());
+
+        // create a fake rpc server
+        let dummy_remote_write_listener = std::net::TcpListener::bind("localhost:0").unwrap();
+        let dummy_remote_write_address = dummy_remote_write_listener.local_addr().unwrap();
+        let dummy_remote_write_url = format!(
+            "http://localhost:{}/v1/push",
+            dummy_remote_write_address.port()
+        );
+
+        let _dummy_remote_write =
+            tokio::spawn(async move { run_dummy_remote_write(dummy_remote_write_listener).await });
+
+        // init the tls config and allower
+        let mut allower = SuiNodeProvider::new("".into(), Duration::from_secs(30));
+        let tls_config = CertVerifier::new(allower.clone())
+            .rustls_server_config(
+                vec![server_priv_cert.rustls_certificate()],
+                server_priv_cert.rustls_private_key(),
+            )
+            .unwrap();
+
+        let client = admin::make_reqwest_client(RemoteWriteConfig {
+            url: dummy_remote_write_url.to_owned(),
+            username: "bar".into(),
+            password: "foo".into(),
+        });
+
+        // add handler to server
+        async fn handler(tls_info: axum::Extension<TlsConnectionInfo>) -> String {
+            tls_info.public_key().unwrap().to_string()
+        }
+        let app = admin::app("unittest-network".into(), client, Some(allower.clone()));
+
+        let listener = std::net::TcpListener::bind("localhost:0").unwrap();
+        let server_address = listener.local_addr().unwrap();
+        let server_url = format!(
+            "https://localhost:{}/publish/metrics",
+            server_address.port()
+        );
+
+        let acceptor = TlsAcceptor::new(tls_config);
+        let _server = tokio::spawn(async move {
+            admin::server(listener, app, Some(acceptor)).await.unwrap();
+        });
+
+        // build a client
+        let client = reqwest::Client::builder()
+            .add_root_certificate(server_priv_cert.reqwest_certificate())
+            .identity(client_priv_cert.reqwest_identity())
+            .https_only(true)
+            .build()
+            .unwrap();
+
+        // Client request is rejected because it isn't in the allowlist
+        client.get(&server_url).send().await.unwrap_err();
+
+        // Insert the client's public key into the allowlist and verify the request is successful
+        allower.get_mut().write().unwrap().insert(
+            client_pub_key.to_owned(),
+            peers::SuiPeer {
+                name: "some-node".into(),
+                p2p_address: Multiaddr::empty(),
+                public_key: client_pub_key.to_owned(),
+            },
+        );
+
+        let mf = create_metric_family(
+            "foo_metric",
+            "some help this is",
+            None,
+            RepeatedField::from_vec(vec![create_metric_counter(
+                RepeatedField::from_vec(create_labels(vec![("some", "label")])),
+                create_counter(2046.0),
+            )]),
+        );
+
+        let mut buf = vec![];
+        let encoder = prometheus::ProtobufEncoder::new();
+        encoder.encode(&[mf], &mut buf).unwrap();
+
+        let res = client
+            .post(&server_url)
+            .header(header::CONTENT_TYPE, PROTOBUF_FORMAT)
+            .body(buf)
+            .send()
+            .await
+            .expect("expected a successful post with a self-signed certificate");
+        let status = res.status();
+        let body = res.text().await.unwrap();
+        assert_eq!("created", body);
+        assert_eq!(status, StatusCode::CREATED);
+    }
+}

--- a/crates/sui-proxy/src/main.rs
+++ b/crates/sui-proxy/src/main.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use sui_proxy::config::ProxyConfig;
+use sui_proxy::{
+    admin::{
+        app, create_server_cert_default_allow, create_server_cert_enforce_peer,
+        make_reqwest_client, server,
+    },
+    config::load,
+};
+use sui_tls::TlsAcceptor;
+use telemetry_subscribers::TelemetryConfig;
+use tracing::info;
+
+#[derive(Parser, Debug)]
+#[clap(rename_all = "kebab-case")]
+#[clap(name = env!("CARGO_BIN_NAME"))]
+#[clap(version = VERSION)]
+struct Args {
+    #[clap(
+        long,
+        short,
+        default_value = "./sui-proxy.yaml",
+        help = "Specify the config file path to use"
+    )]
+    config: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let (_guard, _handle) = TelemetryConfig::new().init();
+
+    let args = Args::parse();
+
+    let config: ProxyConfig = load(args.config)?;
+
+    info!(
+        "listen on {:?} send to {:?}",
+        config.listen_address, config.remote_write.url
+    );
+
+    let listener = std::net::TcpListener::bind(config.listen_address).unwrap();
+
+    let (tls_config, allower) =
+        if config.json_rpc.certificate_file.is_none() || config.json_rpc.private_key.is_none() {
+            (
+                create_server_cert_default_allow(config.json_rpc.hostname.unwrap())
+                    .expect("unable to create self-signed server cert"),
+                None,
+            )
+        } else {
+            create_server_cert_enforce_peer(config.json_rpc)
+                .expect("unable to create tls server config")
+        };
+    let acceptor = TlsAcceptor::new(tls_config);
+    let client = make_reqwest_client(config.remote_write);
+    let app = app(config.network, client, allower);
+    server(listener, app, Some(acceptor)).await.unwrap();
+
+    Ok(())
+}
+
+const GIT_REVISION: &str = {
+    if let Some(revision) = option_env!("GIT_REVISION") {
+        revision
+    } else {
+        let version = git_version::git_version!(
+            args = ["--always", "--dirty", "--exclude", "*"],
+            fallback = ""
+        );
+
+        if version.is_empty() {
+            panic!("unable to query git revision");
+        }
+        version
+    }
+};
+const VERSION: &str = const_str::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
+
+/// var extracts environment variables at runtime with a default fallback value
+/// if a default is not provided, the value is simply an empty string if not found
+/// This function will return the provided default if env::var cannot find the key
+/// or if the key is somehow malformed.
+#[macro_export]
+macro_rules! var {
+    ($key:expr) => {
+        match std::env::var($key) {
+            Ok(val) => val,
+            Err(_) => "".into(),
+        }
+    };
+    ($key:expr, $default:expr) => {
+        match std::env::var($key) {
+            Ok(val) => val,
+            Err(_) => $default,
+        }
+    };
+}

--- a/crates/sui-proxy/src/middleware.rs
+++ b/crates/sui-proxy/src/middleware.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::peers::SuiNodeProvider;
+use axum::{
+    extract::Extension,
+    headers::ContentType,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::Response,
+    TypedHeader,
+};
+use std::sync::Arc;
+use sui_tls::TlsConnectionInfo;
+use tracing::error;
+
+/// we expect sui-node to send us an http header content-type encoding.
+pub async fn expect_mysten_proxy_header<B>(
+    TypedHeader(content_type): TypedHeader<ContentType>,
+    request: Request<B>,
+    next: Next<B>,
+) -> Result<Response, (StatusCode, &'static str)> {
+    match format!("{content_type}").as_str() {
+        prometheus::PROTOBUF_FORMAT => Ok(next.run(request).await),
+        ct => {
+            error!("invalid content-type; {ct}");
+            Err((StatusCode::BAD_REQUEST, "invalid content-type header"))
+        }
+    }
+}
+
+/// we expect that calling sui-nodes are known on the blockchain and we enforce
+/// their pub key tls creds here
+pub async fn expect_valid_public_key<B>(
+    Extension(allower): Extension<Arc<SuiNodeProvider>>,
+    Extension(tls_connect_info): Extension<TlsConnectionInfo>,
+    mut request: Request<B>,
+    next: Next<B>,
+) -> Result<Response, (StatusCode, &'static str)> {
+    let Some(peer) = allower.get(tls_connect_info.public_key().unwrap()) else {
+        error!("node with unknown pub key tried to connect");
+        return Err((StatusCode::FORBIDDEN, "unknown clients are not allowed"));
+    };
+
+    request.extensions_mut().insert(peer);
+    Ok(next.run(request).await)
+}

--- a/crates/sui-proxy/src/peers.rs
+++ b/crates/sui-proxy/src/peers.rs
@@ -1,0 +1,157 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use anyhow::{bail, Context, Result};
+use fastcrypto::ed25519::Ed25519PublicKey;
+use fastcrypto::traits::ToFromBytes;
+use multiaddr::Multiaddr;
+use serde::Deserialize;
+use std::time::Duration;
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+use sui_tls::Allower;
+use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
+use tracing::{debug, error, info};
+
+/// SuiNods a mapping of public key to SuiPeer data
+pub type SuiPeers = Arc<RwLock<HashMap<Ed25519PublicKey, SuiPeer>>>;
+
+/// A SuiPeer is the collated sui chain data we have about validators
+#[derive(Hash, PartialEq, Eq, Debug, Clone)]
+pub struct SuiPeer {
+    pub name: String,
+    pub p2p_address: Multiaddr,
+    pub public_key: Ed25519PublicKey,
+}
+
+/// SuiNodeProvider queries the sui blockchain and keeps a record of known validators based on the response from
+/// sui_getValidators.  The node name, public key and other info is extracted from the chain and stored in this
+/// data structure.  We pass this struct to the tls verifier and it depends on the state contained within.
+/// Handlers also use this data in an Extractor extension to check incoming clients on the http api against known keys.
+#[derive(Debug, Clone)]
+pub struct SuiNodeProvider {
+    nodes: SuiPeers,
+    rpc_url: String,
+    rpc_poll_interval: Duration,
+}
+
+impl Allower for SuiNodeProvider {
+    fn allowed(&self, key: &Ed25519PublicKey) -> bool {
+        self.nodes.read().unwrap().contains_key(key)
+    }
+}
+
+impl SuiNodeProvider {
+    pub fn new(rpc_url: String, rpc_poll_interval: Duration) -> Self {
+        let nodes = Arc::new(RwLock::new(HashMap::new()));
+        Self {
+            nodes,
+            rpc_url,
+            rpc_poll_interval,
+        }
+    }
+
+    /// get is used to retrieve peer info in our handlers
+    pub fn get(&self, key: &Ed25519PublicKey) -> Option<SuiPeer> {
+        debug!("look for {:?}", key);
+        if let Some(v) = self.nodes.read().unwrap().get(key) {
+            return Some(SuiPeer {
+                name: v.name.to_owned(),
+                p2p_address: v.p2p_address.to_owned(),
+                public_key: v.public_key.to_owned(),
+            });
+        }
+        None
+    }
+    /// Get a reference to the inner service
+    pub fn get_ref(&self) -> &SuiPeers {
+        &self.nodes
+    }
+
+    /// Get a mutable reference to the inner service
+    pub fn get_mut(&mut self) -> &mut SuiPeers {
+        &mut self.nodes
+    }
+
+    /// get_validators will retrieve known validators
+    async fn get_validators(url: String) -> Result<SuiSystemStateSummary> {
+        let client = reqwest::Client::builder().build().unwrap();
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method":"sui_getLatestSuiSystemState",
+            "id":1,
+        });
+        let response = client
+            .post(url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(request.to_string())
+            .send()
+            .await
+            .context("unable to perform rpc")?;
+
+        #[derive(Debug, Deserialize)]
+        struct ResponseBody {
+            result: SuiSystemStateSummary,
+        }
+
+        let body = match response.json::<ResponseBody>().await {
+            Ok(b) => b,
+            Err(error) => {
+                bail!("unable to decode json: {error}")
+            }
+        };
+
+        Ok(body.result)
+    }
+
+    /// poll_peer_list will act as a refresh interval for our cache
+    pub fn poll_peer_list(&self) {
+        info!("Started polling for peers using rpc: {}", self.rpc_url);
+
+        let rpc_poll_interval = self.rpc_poll_interval;
+        let rpc_url = self.rpc_url.to_owned();
+        let nodes = self.nodes.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(rpc_poll_interval);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                interval.tick().await;
+
+                match Self::get_validators(rpc_url.to_owned()).await {
+                    Ok(summary) => {
+                        let peers = extract(summary);
+                        // maintain the tls acceptor set
+                        let mut allow = nodes.write().unwrap();
+                        allow.clear();
+                        allow.extend(peers);
+                        info!("{} peers managed to make it on the allow list", allow.len());
+                    }
+                    Err(error) => error!("unable to refresh peer list: {error}"),
+                }
+            }
+        });
+    }
+}
+
+fn extract(summary: SuiSystemStateSummary) -> impl Iterator<Item = (Ed25519PublicKey, SuiPeer)> {
+    summary.active_validators.into_iter().filter_map(|vm| {
+        match Ed25519PublicKey::from_bytes(&vm.network_pubkey_bytes) {
+            Ok(public_key) => {
+                let Ok(p2p_address) = Multiaddr::try_from(vm.p2p_address) else {
+                    error!("refusing to add peer to allow list; unable to decode multiaddr for {}", vm.name);
+                    return None // scoped to filter_map
+                };
+                debug!("adding public key {:?} for address {:?}", public_key, p2p_address);
+                Some((public_key.clone(), SuiPeer { name: vm.name, p2p_address, public_key })) // scoped to filter_map
+            },
+            Err(error) => {
+                error!(
+                "unable to decode public key for name: {:?} sui_address: {:?} error: {error}",
+                vm.name, vm.sui_address);
+                 None  // scoped to filter_map
+            }
+        }
+    })
+}

--- a/crates/sui-proxy/src/prom_to_mimir.rs
+++ b/crates/sui-proxy/src/prom_to_mimir.rs
@@ -1,0 +1,375 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::remote_write;
+use itertools::Itertools;
+use prometheus::proto::{Counter, Gauge, Histogram, Metric, MetricFamily, MetricType};
+use protobuf::RepeatedField;
+use tracing::{debug, error};
+
+#[derive(Debug)]
+pub struct Mimir<S> {
+    state: S,
+}
+
+impl From<&Metric> for Mimir<RepeatedField<remote_write::Label>> {
+    fn from(m: &Metric) -> Self {
+        // we consume metric labels from an owned version so we can sort them
+        let mut m = m.to_owned();
+        let mut sorted = m.take_label();
+        sorted.sort_by(|a, b| {
+            (a.get_name(), a.get_value())
+                .partial_cmp(&(b.get_name(), b.get_value()))
+                .unwrap()
+        });
+        let mut r = RepeatedField::<remote_write::Label>::default();
+        for label in sorted {
+            let lp = remote_write::Label {
+                name: label.get_name().into(),
+                value: label.get_value().into(),
+            };
+            r.push(lp);
+        }
+        Self { state: r }
+    }
+}
+
+impl IntoIterator for Mimir<RepeatedField<remote_write::Label>> {
+    type Item = remote_write::Label;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.state.into_iter()
+    }
+}
+
+impl From<&Counter> for Mimir<remote_write::Sample> {
+    fn from(c: &Counter) -> Self {
+        Self {
+            state: remote_write::Sample {
+                value: c.get_value(),
+                ..Default::default()
+            },
+        }
+    }
+}
+impl From<&Gauge> for Mimir<remote_write::Sample> {
+    fn from(c: &Gauge) -> Self {
+        Self {
+            state: remote_write::Sample {
+                value: c.get_value(),
+                ..Default::default()
+            },
+        }
+    }
+}
+impl Mimir<remote_write::Sample> {
+    fn sample(self) -> remote_write::Sample {
+        self.state
+    }
+}
+
+/// TODO implement histogram
+impl From<&Histogram> for Mimir<remote_write::Histogram> {
+    fn from(_h: &Histogram) -> Self {
+        Self {
+            state: remote_write::Histogram::default(),
+        }
+    }
+}
+/// TODO implement histogram
+impl Mimir<remote_write::Histogram> {
+    #[allow(dead_code)]
+    fn histogram(self) -> remote_write::Histogram {
+        self.state
+    }
+}
+impl From<Vec<MetricFamily>> for Mimir<Vec<remote_write::WriteRequest>> {
+    fn from(metric_families: Vec<MetricFamily>) -> Self {
+        let mut timeseries: Vec<remote_write::TimeSeries> = Vec::new();
+        // we may have more but we'll have at least this many timeseries
+        timeseries.reserve(metric_families.len());
+
+        for mf in metric_families {
+            // TOOD add From impl
+            let mt = match mf.get_field_type() {
+                MetricType::COUNTER => remote_write::metric_metadata::MetricType::Counter,
+                MetricType::GAUGE => remote_write::metric_metadata::MetricType::Gauge,
+                MetricType::HISTOGRAM => remote_write::metric_metadata::MetricType::Histogram,
+                MetricType::SUMMARY => remote_write::metric_metadata::MetricType::Summary,
+                MetricType::UNTYPED => remote_write::metric_metadata::MetricType::Unknown,
+            };
+
+            // filter out the types we don't support
+            match mt {
+                remote_write::metric_metadata::MetricType::Counter
+                | remote_write::metric_metadata::MetricType::Gauge => (),
+                other => {
+                    debug!("{:?} is not yet implemented, skipping metric", other);
+                    continue;
+                }
+            }
+
+            // TODO stop using state directly
+            timeseries.extend(Mimir::from(mf.clone()).state);
+        }
+
+        Self {
+            state: timeseries
+                .into_iter()
+                .chunks(500) // the upstream remote_write should have a max sample size per request set to this number
+                .into_iter()
+                .map(|ts| remote_write::WriteRequest {
+                    timeseries: ts.collect(),
+                    ..Default::default()
+                })
+                .collect_vec(),
+        }
+    }
+}
+
+impl IntoIterator for Mimir<Vec<remote_write::WriteRequest>> {
+    type Item = remote_write::WriteRequest;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.state.into_iter()
+    }
+}
+
+impl Mimir<RepeatedField<remote_write::TimeSeries>> {
+    pub fn repeated(self) -> RepeatedField<remote_write::TimeSeries> {
+        self.state
+    }
+}
+
+impl From<MetricFamily> for Mimir<Vec<remote_write::TimeSeries>> {
+    fn from(mf: MetricFamily) -> Self {
+        let mut timeseries = vec![];
+        for metric in mf.get_metric() {
+            let mut ts = remote_write::TimeSeries::default();
+            ts.labels.extend(vec![
+                // mimir requires that we use __name__ as a key that points to a value
+                // of the metric name
+                remote_write::Label {
+                    name: "__name__".into(),
+                    value: mf.get_name().into(),
+                },
+            ]);
+            ts.labels
+                .extend(Mimir::<RepeatedField<remote_write::Label>>::from(metric));
+
+            // assumption here is that since a MetricFamily will have one MetricType, we'll only need
+            // to look for one of these types.  Setting two different types on Metric at the same time
+            // in a way that is conflicting with the MetricFamily type will result in undefined mimir
+            // behavior, probably an error.
+            if metric.has_counter() {
+                let mut s = Mimir::<remote_write::Sample>::from(metric.get_counter()).sample();
+                s.timestamp = metric.get_timestamp_ms();
+                ts.samples.push(s);
+            } else if metric.has_gauge() {
+                let mut s = Mimir::<remote_write::Sample>::from(metric.get_gauge()).sample();
+                s.timestamp = metric.get_timestamp_ms();
+                ts.samples.push(s);
+            } else if metric.has_histogram() {
+                // TODO implement
+                // ts.mut_histograms()
+                //     .push(Mimir::<remote_write::Histogram>::from(metric.get_histogram()).histogram());
+            } else if metric.has_summary() {
+                // TODO implement
+                error!("summary is not implemented for a metric type");
+            }
+            timeseries.push(ts);
+        }
+        Self { state: timeseries }
+    }
+}
+
+impl Mimir<remote_write::TimeSeries> {
+    pub fn timeseries(self) -> remote_write::TimeSeries {
+        self.state
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::prom_to_mimir::Mimir;
+    use crate::remote_write;
+    use prometheus::proto;
+    use protobuf::RepeatedField;
+
+    // protobuf stuff
+    pub fn create_metric_family(
+        name: &str,
+        help: &str,
+        field_type: Option<proto::MetricType>,
+        metric: RepeatedField<proto::Metric>,
+    ) -> proto::MetricFamily {
+        // no public fields, cannot use literals
+        let mut mf = proto::MetricFamily::default();
+        mf.set_name(name.into());
+        mf.set_help(help.into());
+        // TODO remove the metric type serialization if we still don't use it
+        // after implementing histogram and summary
+        if let Some(ft) = field_type {
+            mf.set_field_type(ft);
+        }
+        mf.set_metric(metric);
+        mf
+    }
+    #[allow(dead_code)]
+    fn create_metric_gauge(
+        labels: RepeatedField<proto::LabelPair>,
+        gauge: proto::Gauge,
+    ) -> proto::Metric {
+        let mut m = proto::Metric::default();
+        m.set_label(labels);
+        m.set_gauge(gauge);
+        m.set_timestamp_ms(12345);
+        m
+    }
+
+    pub fn create_metric_counter(
+        labels: RepeatedField<proto::LabelPair>,
+        counter: proto::Counter,
+    ) -> proto::Metric {
+        let mut m = proto::Metric::default();
+        m.set_label(labels);
+        m.set_counter(counter);
+        m.set_timestamp_ms(12345);
+        m
+    }
+
+    pub fn create_labels(labels: Vec<(&str, &str)>) -> Vec<proto::LabelPair> {
+        labels
+            .into_iter()
+            .map(|(key, value)| {
+                let mut lp = proto::LabelPair::default();
+                lp.set_name(key.into());
+                lp.set_value(value.into());
+                lp
+            })
+            .collect()
+    }
+    #[allow(dead_code)]
+    fn create_gauge(value: f64) -> proto::Gauge {
+        let mut g = proto::Gauge::default();
+        g.set_value(value);
+        g
+    }
+
+    pub fn create_counter(value: f64) -> proto::Counter {
+        let mut c = proto::Counter::default();
+        c.set_value(value);
+        c
+    }
+
+    // end protobuf stuff
+
+    // mimir stuff
+    fn create_timeseries_with_samples(
+        labels: Vec<remote_write::Label>,
+        samples: Vec<remote_write::Sample>,
+    ) -> remote_write::TimeSeries {
+        remote_write::TimeSeries {
+            labels,
+            samples,
+            ..Default::default()
+        }
+    }
+    // end mimir stuff
+
+    #[test]
+    fn metricfamily_to_timeseries() {
+        let tests: Vec<(proto::MetricFamily, Vec<remote_write::TimeSeries>)> = vec![
+            (
+                create_metric_family(
+                    "test_gauge",
+                    "i'm a help message",
+                    Some(proto::MetricType::GAUGE),
+                    RepeatedField::from(vec![create_metric_gauge(
+                        RepeatedField::from_vec(create_labels(vec![
+                            ("host", "local-test-validator"),
+                            ("network", "unittest-network"),
+                        ])),
+                        create_gauge(2046.0),
+                    )]),
+                ),
+                vec![create_timeseries_with_samples(
+                    vec![
+                        remote_write::Label {
+                            name: "__name__".into(),
+                            value: "test_gauge".into(),
+                        },
+                        remote_write::Label {
+                            name: "host".into(),
+                            value: "local-test-validator".into(),
+                        },
+                        remote_write::Label {
+                            name: "network".into(),
+                            value: "unittest-network".into(),
+                        },
+                    ],
+                    vec![remote_write::Sample {
+                        value: 2046.0,
+                        timestamp: 12345,
+                    }],
+                )],
+            ),
+            (
+                create_metric_family(
+                    "test_counter",
+                    "i'm a help message",
+                    Some(proto::MetricType::GAUGE),
+                    RepeatedField::from(vec![create_metric_counter(
+                        RepeatedField::from_vec(create_labels(vec![
+                            ("host", "local-test-validator"),
+                            ("network", "unittest-network"),
+                        ])),
+                        create_counter(2046.0),
+                    )]),
+                ),
+                vec![create_timeseries_with_samples(
+                    vec![
+                        remote_write::Label {
+                            name: "__name__".into(),
+                            value: "test_counter".into(),
+                        },
+                        remote_write::Label {
+                            name: "host".into(),
+                            value: "local-test-validator".into(),
+                        },
+                        remote_write::Label {
+                            name: "network".into(),
+                            value: "unittest-network".into(),
+                        },
+                    ],
+                    vec![remote_write::Sample {
+                        value: 2046.0,
+                        timestamp: 12345,
+                    }],
+                )],
+            ),
+        ];
+        for (mf, expected_ts) in tests {
+            // TODO stop using state directly
+            for (actual, expected) in Mimir::from(mf).state.into_iter().zip(expected_ts) {
+                assert_eq!(actual.labels, expected.labels);
+                for (actual_sample, expected_sample) in
+                    actual.samples.into_iter().zip(expected.samples)
+                {
+                    assert_eq!(
+                        actual_sample.value, expected_sample.value,
+                        "sample values do not match"
+                    );
+
+                    // timestamps are injected on the sui-node and we copy it to our sample
+                    // make sure that works
+                    assert_eq!(
+                        actual_sample.timestamp, expected_sample.timestamp,
+                        "timestamp should be non-zero"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/sui-proxy/src/remote_write.rs
+++ b/crates/sui-proxy/src/remote_write.rs
@@ -1,0 +1,484 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MetricMetadata {
+    /// Represents the metric type, these match the set from Prometheus.
+    /// Refer to model/textparse/interface.go for details.
+    #[prost(enumeration = "metric_metadata::MetricType", tag = "1")]
+    pub r#type: i32,
+    #[prost(string, tag = "2")]
+    pub metric_family_name: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub help: ::prost::alloc::string::String,
+    #[prost(string, tag = "5")]
+    pub unit: ::prost::alloc::string::String,
+}
+/// Nested message and enum types in `MetricMetadata`.
+pub mod metric_metadata {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum MetricType {
+        Unknown = 0,
+        Counter = 1,
+        Gauge = 2,
+        Histogram = 3,
+        Gaugehistogram = 4,
+        Summary = 5,
+        Info = 6,
+        Stateset = 7,
+    }
+    impl MetricType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                MetricType::Unknown => "UNKNOWN",
+                MetricType::Counter => "COUNTER",
+                MetricType::Gauge => "GAUGE",
+                MetricType::Histogram => "HISTOGRAM",
+                MetricType::Gaugehistogram => "GAUGEHISTOGRAM",
+                MetricType::Summary => "SUMMARY",
+                MetricType::Info => "INFO",
+                MetricType::Stateset => "STATESET",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "UNKNOWN" => Some(Self::Unknown),
+                "COUNTER" => Some(Self::Counter),
+                "GAUGE" => Some(Self::Gauge),
+                "HISTOGRAM" => Some(Self::Histogram),
+                "GAUGEHISTOGRAM" => Some(Self::Gaugehistogram),
+                "SUMMARY" => Some(Self::Summary),
+                "INFO" => Some(Self::Info),
+                "STATESET" => Some(Self::Stateset),
+                _ => None,
+            }
+        }
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Sample {
+    #[prost(double, tag = "1")]
+    pub value: f64,
+    /// timestamp is in ms format, see model/timestamp/timestamp.go for
+    /// conversion from time.Time to Prometheus timestamp.
+    #[prost(int64, tag = "2")]
+    pub timestamp: i64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Exemplar {
+    /// Optional, can be empty.
+    #[prost(message, repeated, tag = "1")]
+    pub labels: ::prost::alloc::vec::Vec<Label>,
+    #[prost(double, tag = "2")]
+    pub value: f64,
+    /// timestamp is in ms format, see model/timestamp/timestamp.go for
+    /// conversion from time.Time to Prometheus timestamp.
+    #[prost(int64, tag = "3")]
+    pub timestamp: i64,
+}
+/// A native histogram, also known as a sparse histogram.
+/// Original design doc:
+/// <https://docs.google.com/document/d/1cLNv3aufPZb3fNfaJgdaRBZsInZKKIHo9E6HinJVbpM/edit>
+/// The appendix of this design doc also explains the concept of float
+/// histograms. This Histogram message can represent both, the usual
+/// integer histogram as well as a float histogram.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Histogram {
+    /// Sum of observations in the histogram.
+    #[prost(double, tag = "3")]
+    pub sum: f64,
+    /// The schema defines the bucket schema. Currently, valid numbers
+    /// are -4 <= n <= 8. They are all for base-2 bucket schemas, where 1
+    /// is a bucket boundary in each case, and then each power of two is
+    /// divided into 2^n logarithmic buckets. Or in other words, each
+    /// bucket boundary is the previous boundary times 2^(2^-n). In the
+    /// future, more bucket schemas may be added using numbers < -4 or >
+    /// 8.
+    #[prost(sint32, tag = "4")]
+    pub schema: i32,
+    /// Breadth of the zero bucket.
+    #[prost(double, tag = "5")]
+    pub zero_threshold: f64,
+    /// Negative Buckets.
+    #[prost(message, repeated, tag = "8")]
+    pub negative_spans: ::prost::alloc::vec::Vec<BucketSpan>,
+    /// Use either "negative_deltas" or "negative_counts", the former for
+    /// regular histograms with integer counts, the latter for float
+    /// histograms.
+    ///
+    /// Count delta of each bucket compared to previous one (or to zero for 1st bucket).
+    #[prost(sint64, repeated, tag = "9")]
+    pub negative_deltas: ::prost::alloc::vec::Vec<i64>,
+    /// Absolute count of each bucket.
+    #[prost(double, repeated, tag = "10")]
+    pub negative_counts: ::prost::alloc::vec::Vec<f64>,
+    /// Positive Buckets.
+    #[prost(message, repeated, tag = "11")]
+    pub positive_spans: ::prost::alloc::vec::Vec<BucketSpan>,
+    /// Use either "positive_deltas" or "positive_counts", the former for
+    /// regular histograms with integer counts, the latter for float
+    /// histograms.
+    ///
+    /// Count delta of each bucket compared to previous one (or to zero for 1st bucket).
+    #[prost(sint64, repeated, tag = "12")]
+    pub positive_deltas: ::prost::alloc::vec::Vec<i64>,
+    /// Absolute count of each bucket.
+    #[prost(double, repeated, tag = "13")]
+    pub positive_counts: ::prost::alloc::vec::Vec<f64>,
+    #[prost(enumeration = "histogram::ResetHint", tag = "14")]
+    pub reset_hint: i32,
+    /// timestamp is in ms format, see model/timestamp/timestamp.go for
+    /// conversion from time.Time to Prometheus timestamp.
+    #[prost(int64, tag = "15")]
+    pub timestamp: i64,
+    /// Count of observations in the histogram.
+    #[prost(oneof = "histogram::Count", tags = "1, 2")]
+    pub count: ::core::option::Option<histogram::Count>,
+    /// Count in zero bucket.
+    #[prost(oneof = "histogram::ZeroCount", tags = "6, 7")]
+    pub zero_count: ::core::option::Option<histogram::ZeroCount>,
+}
+/// Nested message and enum types in `Histogram`.
+pub mod histogram {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum ResetHint {
+        /// Need to test for a counter reset explicitly.
+        Unknown = 0,
+        /// This is the 1st histogram after a counter reset.
+        Yes = 1,
+        /// There was no counter reset between this and the previous Histogram.
+        No = 2,
+        /// This is a gauge histogram where counter resets don't happen.
+        Gauge = 3,
+    }
+    impl ResetHint {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                ResetHint::Unknown => "UNKNOWN",
+                ResetHint::Yes => "YES",
+                ResetHint::No => "NO",
+                ResetHint::Gauge => "GAUGE",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "UNKNOWN" => Some(Self::Unknown),
+                "YES" => Some(Self::Yes),
+                "NO" => Some(Self::No),
+                "GAUGE" => Some(Self::Gauge),
+                _ => None,
+            }
+        }
+    }
+    /// Count of observations in the histogram.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Count {
+        #[prost(uint64, tag = "1")]
+        CountInt(u64),
+        #[prost(double, tag = "2")]
+        CountFloat(f64),
+    }
+    /// Count in zero bucket.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum ZeroCount {
+        #[prost(uint64, tag = "6")]
+        ZeroCountInt(u64),
+        #[prost(double, tag = "7")]
+        ZeroCountFloat(f64),
+    }
+}
+/// A BucketSpan defines a number of consecutive buckets with their
+/// offset. Logically, it would be more straightforward to include the
+/// bucket counts in the Span. However, the protobuf representation is
+/// more compact in the way the data is structured here (with all the
+/// buckets in a single array separate from the Spans).
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BucketSpan {
+    /// Gap to previous span, or starting point for 1st span (which can be negative).
+    #[prost(sint32, tag = "1")]
+    pub offset: i32,
+    /// Length of consecutive buckets.
+    #[prost(uint32, tag = "2")]
+    pub length: u32,
+}
+/// TimeSeries represents samples and labels for a single time series.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TimeSeries {
+    /// For a timeseries to be valid, and for the samples and exemplars
+    /// to be ingested by the remote system properly, the labels field is required.
+    #[prost(message, repeated, tag = "1")]
+    pub labels: ::prost::alloc::vec::Vec<Label>,
+    #[prost(message, repeated, tag = "2")]
+    pub samples: ::prost::alloc::vec::Vec<Sample>,
+    #[prost(message, repeated, tag = "3")]
+    pub exemplars: ::prost::alloc::vec::Vec<Exemplar>,
+    #[prost(message, repeated, tag = "4")]
+    pub histograms: ::prost::alloc::vec::Vec<Histogram>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Label {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub value: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Labels {
+    #[prost(message, repeated, tag = "1")]
+    pub labels: ::prost::alloc::vec::Vec<Label>,
+}
+/// Matcher specifies a rule, which can match or set of labels or not.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LabelMatcher {
+    #[prost(enumeration = "label_matcher::Type", tag = "1")]
+    pub r#type: i32,
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub value: ::prost::alloc::string::String,
+}
+/// Nested message and enum types in `LabelMatcher`.
+pub mod label_matcher {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Type {
+        Eq = 0,
+        Neq = 1,
+        Re = 2,
+        Nre = 3,
+    }
+    impl Type {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Type::Eq => "EQ",
+                Type::Neq => "NEQ",
+                Type::Re => "RE",
+                Type::Nre => "NRE",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "EQ" => Some(Self::Eq),
+                "NEQ" => Some(Self::Neq),
+                "RE" => Some(Self::Re),
+                "NRE" => Some(Self::Nre),
+                _ => None,
+            }
+        }
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadHints {
+    /// Query step size in milliseconds.
+    #[prost(int64, tag = "1")]
+    pub step_ms: i64,
+    /// String representation of surrounding function or aggregation.
+    #[prost(string, tag = "2")]
+    pub func: ::prost::alloc::string::String,
+    /// Start time in milliseconds.
+    #[prost(int64, tag = "3")]
+    pub start_ms: i64,
+    /// End time in milliseconds.
+    #[prost(int64, tag = "4")]
+    pub end_ms: i64,
+    /// List of label names used in aggregation.
+    #[prost(string, repeated, tag = "5")]
+    pub grouping: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Indicate whether it is without or by.
+    #[prost(bool, tag = "6")]
+    pub by: bool,
+    /// Range vector selector range in milliseconds.
+    #[prost(int64, tag = "7")]
+    pub range_ms: i64,
+}
+/// Chunk represents a TSDB chunk.
+/// Time range [min, max] is inclusive.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Chunk {
+    #[prost(int64, tag = "1")]
+    pub min_time_ms: i64,
+    #[prost(int64, tag = "2")]
+    pub max_time_ms: i64,
+    #[prost(enumeration = "chunk::Encoding", tag = "3")]
+    pub r#type: i32,
+    #[prost(bytes = "vec", tag = "4")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}
+/// Nested message and enum types in `Chunk`.
+pub mod chunk {
+    /// We require this to match chunkenc.Encoding.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Encoding {
+        Unknown = 0,
+        Xor = 1,
+        Histogram = 2,
+    }
+    impl Encoding {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Encoding::Unknown => "UNKNOWN",
+                Encoding::Xor => "XOR",
+                Encoding::Histogram => "HISTOGRAM",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "UNKNOWN" => Some(Self::Unknown),
+                "XOR" => Some(Self::Xor),
+                "HISTOGRAM" => Some(Self::Histogram),
+                _ => None,
+            }
+        }
+    }
+}
+/// ChunkedSeries represents single, encoded time series.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChunkedSeries {
+    /// Labels should be sorted.
+    #[prost(message, repeated, tag = "1")]
+    pub labels: ::prost::alloc::vec::Vec<Label>,
+    /// Chunks will be in start time order and may overlap.
+    #[prost(message, repeated, tag = "2")]
+    pub chunks: ::prost::alloc::vec::Vec<Chunk>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WriteRequest {
+    #[prost(message, repeated, tag = "1")]
+    pub timeseries: ::prost::alloc::vec::Vec<TimeSeries>,
+    #[prost(message, repeated, tag = "3")]
+    pub metadata: ::prost::alloc::vec::Vec<MetricMetadata>,
+}
+/// ReadRequest represents a remote read request.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadRequest {
+    #[prost(message, repeated, tag = "1")]
+    pub queries: ::prost::alloc::vec::Vec<Query>,
+    /// accepted_response_types allows negotiating the content type of the response.
+    ///
+    /// Response types are taken from the list in the FIFO order. If no response type in `accepted_response_types` is
+    /// implemented by server, error is returned.
+    /// For request that do not contain `accepted_response_types` field the SAMPLES response type will be used.
+    #[prost(enumeration = "read_request::ResponseType", repeated, tag = "2")]
+    pub accepted_response_types: ::prost::alloc::vec::Vec<i32>,
+}
+/// Nested message and enum types in `ReadRequest`.
+pub mod read_request {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum ResponseType {
+        /// Server will return a single ReadResponse message with matched series that includes list of raw samples.
+        /// It's recommended to use streamed response types instead.
+        ///
+        /// Response headers:
+        /// Content-Type: "application/x-protobuf"
+        /// Content-Encoding: "snappy"
+        Samples = 0,
+        /// Server will stream a delimited ChunkedReadResponse message that
+        /// contains XOR or HISTOGRAM(!) encoded chunks for a single series.
+        /// Each message is following varint size and fixed size bigendian
+        /// uint32 for CRC32 Castagnoli checksum.
+        ///
+        /// Response headers:
+        /// Content-Type: "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse"
+        /// Content-Encoding: ""
+        StreamedXorChunks = 1,
+    }
+    impl ResponseType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                ResponseType::Samples => "SAMPLES",
+                ResponseType::StreamedXorChunks => "STREAMED_XOR_CHUNKS",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "SAMPLES" => Some(Self::Samples),
+                "STREAMED_XOR_CHUNKS" => Some(Self::StreamedXorChunks),
+                _ => None,
+            }
+        }
+    }
+}
+/// ReadResponse is a response when response_type equals SAMPLES.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadResponse {
+    /// In same order as the request's queries.
+    #[prost(message, repeated, tag = "1")]
+    pub results: ::prost::alloc::vec::Vec<QueryResult>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Query {
+    #[prost(int64, tag = "1")]
+    pub start_timestamp_ms: i64,
+    #[prost(int64, tag = "2")]
+    pub end_timestamp_ms: i64,
+    #[prost(message, repeated, tag = "3")]
+    pub matchers: ::prost::alloc::vec::Vec<LabelMatcher>,
+    #[prost(message, optional, tag = "4")]
+    pub hints: ::core::option::Option<ReadHints>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryResult {
+    /// Samples within a time series must be ordered by time.
+    #[prost(message, repeated, tag = "1")]
+    pub timeseries: ::prost::alloc::vec::Vec<TimeSeries>,
+}
+/// ChunkedReadResponse is a response when response_type equals STREAMED_XOR_CHUNKS.
+/// We strictly stream full series after series, optionally split by time. This means that a single frame can contain
+/// partition of the single series, but once a new series is started to be streamed it means that no more chunks will
+/// be sent for previous one. Series are returned sorted in the same way TSDB block are internally.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChunkedReadResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub chunked_series: ::prost::alloc::vec::Vec<ChunkedSeries>,
+    /// query_index represents an index of the query from ReadRequest.queries these chunks relates to.
+    #[prost(int64, tag = "2")]
+    pub query_index: i64,
+}

--- a/crates/sui-tls/src/verifier.rs
+++ b/crates/sui-tls/src/verifier.rs
@@ -21,6 +21,7 @@ pub trait Allower: Send + Sync {
 }
 
 /// AllowAll will allow all public certificates to be validated, it fails open
+#[derive(Clone, Default)]
 pub struct AllowAll;
 
 impl Allower for AllowAll {

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -61,7 +61,7 @@ async-stream = { version = "0.3", default-features = false }
 atomicwrites = { version = "0.3", default-features = false }
 atty = { version = "0.2", default-features = false }
 auto_ops = { version = "0.3", default-features = false }
-axum = { version = "0.6" }
+axum = { version = "0.6", features = ["headers"] }
 axum-core = { version = "0.3", default-features = false }
 axum-extra = { version = "0.4" }
 axum-server = { version = "0.4", features = ["tls-rustls"] }
@@ -69,7 +69,8 @@ backoff = { version = "0.4", features = ["tokio"] }
 backtrace = { version = "0.3" }
 base-x = { version = "0.2", default-features = false }
 base16ct = { version = "0.1", default-features = false, features = ["alloc"] }
-base64 = { version = "0.13", features = ["alloc"] }
+base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["alloc"] }
+base64-647d43efb71741da = { package = "base64", version = "0.21" }
 base64ct = { version = "1", default-features = false, features = ["alloc"] }
 bcs = { version = "0.1", default-features = false }
 beef = { version = "0.5", features = ["impl_serde"] }
@@ -244,6 +245,8 @@ half = { version = "1", default-features = false }
 hashbrown-594e8ee84c453af0 = { package = "hashbrown", version = "0.13" }
 hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", features = ["raw"] }
 hdrhistogram = { version = "7" }
+headers = { version = "0.3", default-features = false }
+headers-core = { version = "0.2", default-features = false }
 heck-468e82937335b1c9 = { package = "heck", version = "0.3", default-features = false }
 hex = { version = "0.4" }
 hkdf = { version = "0.12", default-features = false, features = ["std"] }
@@ -422,7 +425,7 @@ prometheus = { version = "0.13" }
 proptest = { version = "1" }
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
-protobuf = { version = "2", default-features = false }
+protobuf = { version = "2", default-features = false, features = ["with-bytes"] }
 ptree = { version = "0.4" }
 quanta = { version = "0.9" }
 quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
@@ -496,6 +499,7 @@ serde_with = { version = "2", features = ["hex"] }
 serde_yaml = { version = "0.8", default-features = false }
 sha-1-274715c4dabd11b0 = { package = "sha-1", version = "0.9", default-features = false }
 sha-1-93f6ce9d446188ac = { package = "sha-1", version = "0.10" }
+sha1 = { version = "0.10" }
 sha2-274715c4dabd11b0 = { package = "sha2", version = "0.9" }
 sha2-93f6ce9d446188ac = { package = "sha2", version = "0.10" }
 sha3-274715c4dabd11b0 = { package = "sha3", version = "0.9" }
@@ -566,7 +570,8 @@ toml_edit = { version = "0.15" }
 tonic = { version = "0.8", features = ["tls"] }
 tonic-health = { version = "0.8" }
 tower = { version = "0.4", features = ["full"] }
-tower-http = { version = "0.3", features = ["full"] }
+tower-http-468e82937335b1c9 = { package = "tower-http", version = "0.3", features = ["full"] }
+tower-http-9fbad63c4bcf4a8f = { package = "tower-http", version = "0.4", features = ["trace"] }
 tower-layer = { version = "0.3", default-features = false }
 tower-service = { version = "0.3", default-features = false }
 tracing = { version = "0.1", features = ["log"] }
@@ -685,7 +690,7 @@ atomicwrites = { version = "0.3", default-features = false }
 atty = { version = "0.2", default-features = false }
 auto_ops = { version = "0.3", default-features = false }
 autocfg = { version = "1", default-features = false }
-axum = { version = "0.6" }
+axum = { version = "0.6", features = ["headers"] }
 axum-core = { version = "0.3", default-features = false }
 axum-extra = { version = "0.4" }
 axum-server = { version = "0.4", features = ["tls-rustls"] }
@@ -693,7 +698,8 @@ backoff = { version = "0.4", features = ["tokio"] }
 backtrace = { version = "0.3" }
 base-x = { version = "0.2", default-features = false }
 base16ct = { version = "0.1", default-features = false, features = ["alloc"] }
-base64 = { version = "0.13", features = ["alloc"] }
+base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["alloc"] }
+base64-647d43efb71741da = { package = "base64", version = "0.21" }
 base64ct = { version = "1", default-features = false, features = ["alloc"] }
 bcs = { version = "0.1", default-features = false }
 beef = { version = "0.5", features = ["impl_serde"] }
@@ -895,6 +901,8 @@ half = { version = "1", default-features = false }
 hashbrown-594e8ee84c453af0 = { package = "hashbrown", version = "0.13" }
 hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", features = ["raw"] }
 hdrhistogram = { version = "7" }
+headers = { version = "0.3", default-features = false }
+headers-core = { version = "0.2", default-features = false }
 heck-468e82937335b1c9 = { package = "heck", version = "0.3", default-features = false }
 heck-9fbad63c4bcf4a8f = { package = "heck", version = "0.4" }
 hex = { version = "0.4" }
@@ -1110,7 +1118,7 @@ prost = { version = "0.11" }
 prost-build = { version = "0.11" }
 prost-derive = { version = "0.11", default-features = false }
 prost-types = { version = "0.11" }
-protobuf = { version = "2", default-features = false }
+protobuf = { version = "2", default-features = false, features = ["with-bytes"] }
 ptree = { version = "0.4" }
 quanta = { version = "0.9" }
 quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
@@ -1199,6 +1207,7 @@ serde_with_macros = { version = "2", default-features = false }
 serde_yaml = { version = "0.8", default-features = false }
 sha-1-274715c4dabd11b0 = { package = "sha-1", version = "0.9", default-features = false }
 sha-1-93f6ce9d446188ac = { package = "sha-1", version = "0.10" }
+sha1 = { version = "0.10" }
 sha2-274715c4dabd11b0 = { package = "sha2", version = "0.9" }
 sha2-93f6ce9d446188ac = { package = "sha2", version = "0.10" }
 sha3-274715c4dabd11b0 = { package = "sha3", version = "0.9" }
@@ -1281,7 +1290,8 @@ tonic-build = { version = "0.8" }
 tonic-health = { version = "0.8" }
 toolchain_find = { version = "0.2", default-features = false }
 tower = { version = "0.4", features = ["full"] }
-tower-http = { version = "0.3", features = ["full"] }
+tower-http-468e82937335b1c9 = { package = "tower-http", version = "0.3", features = ["full"] }
+tower-http-9fbad63c4bcf4a8f = { package = "tower-http", version = "0.4", features = ["trace"] }
 tower-layer = { version = "0.3", default-features = false }
 tower-service = { version = "0.3", default-features = false }
 tracing = { version = "0.1", features = ["log"] }


### PR DESCRIPTION
## Summary:

    * add a sui proxy for metrics
    * the proxy ingests prom protobuf format, adds labels, and sends it upstream
    * the proxy consults sui's blockchain for valid validators, obtains the pub key and uses that to validate clients.
    * the client validation comes in the form of extracting the pub key from the incoming tls request and checking that it's a known key per on chain data.
    * the decode from sui-node uses the deliminated format such as read a u32, allocate a temp buffer with the size reported from the u32, fill buffer with data from input stream; repeat.
    * gauge and counter are implemented, other types remain as future work.

## Test Plan:

    * it builds
    * metrics load into a remote_write endpoint (counter and gauge)
    * unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
