### PR TITLE
Add system state version to system state

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -4,6 +4,7 @@ expression: genesis.sui_system_object()
 ---
 epoch: 0
 protocol_version: 1
+system_state_version: 1
 validators:
   total_stake: 25000000000000000
   active_validators:

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3126,7 +3126,8 @@ async fn test_sui_system_state_nop_upgrade() {
         inner.get_sui_system_state_wrapper_object().unwrap().version,
         new_system_state_version
     );
-    inner.get_sui_system_state_object().unwrap();
+    let inner_state = inner.get_sui_system_state_object().unwrap();
+    assert_eq!(inner_state.version(), new_system_state_version);
 }
 
 #[tokio::test]

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -146,6 +146,14 @@ The top-level object containing all information of the Sui system.
  The current protocol version, starting from 1.
 </dd>
 <dt>
+<code>system_state_version: u64</code>
+</dt>
+<dd>
+ The current version of the system state data structure type.
+ This is always the same as SuiSystemState.version. Keeping a copy here so that
+ we know what version it is by inspecting SuiSystemStateInner as well.
+</dd>
+<dt>
 <code>validators: <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a></code>
 </dt>
 <dd>
@@ -474,6 +482,7 @@ This function will be called only once in genesis.
     <b>let</b> system_state = <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a> {
         epoch: 0,
         protocol_version,
+        system_state_version,
         validators,
         storage_fund,
         parameters: <a href="sui_system.md#0x2_sui_system_SystemParameters">SystemParameters</a> {
@@ -574,7 +583,7 @@ To produce a valid PoP, run [fn test_proof_of_possession].
 ## Function `request_remove_validator_candidate`
 
 Called by a validator candidate to remove themselves from the candidacy. After this call
-their staking pool becomes deactive.
+their staking pool becomes deactivate.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_request_remove_validator_candidate">request_remove_validator_candidate</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -1581,6 +1590,7 @@ gas coins.
         <b>assert</b>!(old_protocol_version != next_protocol_version, 0);
         <b>let</b> cur_state: <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a> = <a href="dynamic_field.md#0x2_dynamic_field_remove">dynamic_field::remove</a>(&<b>mut</b> wrapper.id, wrapper.version);
         <b>let</b> new_state = <a href="sui_system.md#0x2_sui_system_upgrade_system_state">upgrade_system_state</a>(cur_state);
+        new_state.system_state_version = new_system_state_version;
         wrapper.version = new_system_state_version;
         <a href="dynamic_field.md#0x2_dynamic_field_add">dynamic_field::add</a>(&<b>mut</b> wrapper.id, wrapper.version, new_state);
     };
@@ -1842,7 +1852,10 @@ Returns all the validators who are currently reporting <code>addr</code>
 
 
 <pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_load_system_state">load_system_state</a>(self: &<a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>): &<a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a> {
-    <a href="dynamic_field.md#0x2_dynamic_field_borrow">dynamic_field::borrow</a>(&self.id, self.version)
+    <b>let</b> version = self.version;
+    <b>let</b> inner: &<a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a> = <a href="dynamic_field.md#0x2_dynamic_field_borrow">dynamic_field::borrow</a>(&self.id, version);
+    <b>assert</b>!(inner.system_state_version == version, 0);
+    inner
 }
 </code></pre>
 
@@ -1866,7 +1879,10 @@ Returns all the validators who are currently reporting <code>addr</code>
 
 
 <pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(self: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>): &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a> {
-    <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut">dynamic_field::borrow_mut</a>(&<b>mut</b> self.id, self.version)
+    <b>let</b> version = self.version;
+    <b>let</b> inner: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a> = <a href="dynamic_field.md#0x2_dynamic_field_borrow_mut">dynamic_field::borrow_mut</a>(&<b>mut</b> self.id, version);
+    <b>assert</b>!(inner.system_state_version == version, 0);
+    inner
 }
 </code></pre>
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5881,6 +5881,7 @@
           "stakingPoolMappingsId",
           "stakingPoolMappingsSize",
           "storageFund",
+          "systemStateVersion",
           "totalStake",
           "validatorCandidatesId",
           "validatorCandidatesSize",
@@ -5999,6 +6000,12 @@
           },
           "storageFund": {
             "description": "The storage fund balance.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "systemStateVersion": {
+            "description": "The current version of the system state data structure type.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -64,6 +64,7 @@ pub trait SuiSystemStateTrait {
     fn epoch(&self) -> u64;
     fn reference_gas_price(&self) -> u64;
     fn protocol_version(&self) -> u64;
+    fn system_state_version(&self) -> u64;
     fn epoch_start_timestamp_ms(&self) -> u64;
     fn safe_mode(&self) -> bool;
     fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata;
@@ -115,6 +116,10 @@ impl SuiSystemState {
             epoch,
             ..Default::default()
         })
+    }
+
+    pub fn version(&self) -> u64 {
+        self.system_state_version()
     }
 }
 

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use super::sui_system_state_summary::{SuiSystemStateSummary, SuiValidatorSummary};
-use super::SuiSystemStateTrait;
+use super::{SuiSystemStateTrait, INIT_SYSTEM_STATE_VERSION};
 
 const E_METADATA_INVALID_POP: u64 = 0;
 const E_METADATA_INVALID_PUBKEY: u64 = 1;
@@ -407,6 +407,7 @@ pub struct ValidatorSetV1 {
 pub struct SuiSystemStateInnerV1 {
     pub epoch: u64,
     pub protocol_version: u64,
+    pub system_state_version: u64,
     pub validators: ValidatorSetV1,
     pub storage_fund: Balance,
     pub parameters: SystemParametersV1,
@@ -438,6 +439,10 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
 
     fn protocol_version(&self) -> u64 {
         self.protocol_version
+    }
+
+    fn system_state_version(&self) -> u64 {
+        self.system_state_version
     }
 
     fn epoch_start_timestamp_ms(&self) -> u64 {
@@ -507,6 +512,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
         let Self {
             epoch,
             protocol_version,
+            system_state_version,
             validators:
                 ValidatorSetV1 {
                     total_stake,
@@ -557,6 +563,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
         SuiSystemStateSummary {
             epoch,
             protocol_version,
+            system_state_version,
             storage_fund: storage_fund.value(),
             reference_gas_price,
             safe_mode,
@@ -602,6 +609,7 @@ impl Default for SuiSystemStateInnerV1 {
         Self {
             epoch: 0,
             protocol_version: ProtocolVersion::MIN.as_u64(),
+            system_state_version: INIT_SYSTEM_STATE_VERSION,
             validators: validator_set,
             storage_fund: Balance::new(0),
             parameters: SystemParametersV1 {

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -24,6 +24,8 @@ pub struct SuiSystemStateSummary {
     pub epoch: u64,
     /// The current protocol version, starting from 1.
     pub protocol_version: u64,
+    /// The current version of the system state data structure type.
+    pub system_state_version: u64,
     /// The storage fund balance.
     pub storage_fund: u64,
     /// The reference gas price for the current epoch.

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -151,6 +151,7 @@ export type SuiValidatorSummary = Infer<typeof SuiValidatorSummary>;
 export const SuiSystemStateSummary = object({
   epoch: number(),
   protocolVersion: number(),
+  systemStateVersion: number(),
   storageFund: number(),
   referenceGasPrice: number(),
   safeMode: boolean(),


### PR DESCRIPTION
## Description 

Adds system state version to the state itself. This is useful as now we could tell which version it is only by looking at the state itself, without re-lookup the wrapper object.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [x ] breaking change for a client SDKs
- [x ] breaking change for FNs (FN binary must upgrade)
- [x ] breaking change for validators or node operators (must upgrade binaries)
- [x ] breaking change for on-chain data layout
- [x ] necessitate either a data wipe or data migration

### Release notes
