### PR TITLE
[programmable transactions] Fixed Object Argument de-duping

### DIFF
--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -31,14 +31,16 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
     .await;
     let mut builder = ProgrammableTransactionBuilder::new();
     for obj_id in all_ids.iter().take(N) {
-        builder.transfer_object(
-            recipient,
-            authority_state
-                .get_object(obj_id)
-                .await?
-                .unwrap()
-                .compute_object_reference(),
-        )
+        builder
+            .transfer_object(
+                recipient,
+                authority_state
+                    .get_object(obj_id)
+                    .await?
+                    .unwrap()
+                    .compute_object_reference(),
+            )
+            .unwrap()
     }
     for _ in 0..N {
         builder
@@ -105,14 +107,16 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
     .await;
     let mut builder = ProgrammableTransactionBuilder::new();
     for obj_id in all_ids.iter().take(N) {
-        builder.transfer_object(
-            recipient,
-            authority_state
-                .get_object(obj_id)
-                .await?
-                .unwrap()
-                .compute_object_reference(),
-        )
+        builder
+            .transfer_object(
+                recipient,
+                authority_state
+                    .get_object(obj_id)
+                    .await?
+                    .unwrap()
+                    .compute_object_reference(),
+            )
+            .unwrap()
     }
     builder
         .move_call(

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -609,7 +609,9 @@ async fn execute_transfer_with_price(
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.transfer_object(recipient, object.compute_object_reference());
+        builder
+            .transfer_object(recipient, object.compute_object_reference())
+            .unwrap();
         builder.finish()
     };
     let kind = TransactionKind::ProgrammableTransaction(pt);

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -124,14 +124,16 @@ impl RpcExampleProvider {
                     ],
                 )
                 .unwrap();
-            builder.transfer_object(
-                recipient,
-                (
-                    object_id,
-                    SequenceNumber::from_u64(1),
-                    ObjectDigest::new(self.rng.gen()),
-                ),
-            );
+            builder
+                .transfer_object(
+                    recipient,
+                    (
+                        object_id,
+                        SequenceNumber::from_u64(1),
+                        ObjectDigest::new(self.rng.gen()),
+                    ),
+                )
+                .unwrap();
             builder.finish()
         };
         let data = TransactionData::new_with_dummy_gas_price(

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -906,14 +906,16 @@ impl InternalOperation {
                             initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
                             mutable: true,
                         }))
-                        .unwrap(),
-                    builder.make_obj_vec(coins.into_iter().map(ObjectArg::ImmOrOwnedObject)),
+                        .map_err(Error::InternalError)?,
+                    builder
+                        .make_obj_vec(coins.into_iter().map(ObjectArg::ImmOrOwnedObject))
+                        .map_err(Error::InternalError)?,
                     builder
                         .input(CallArg::Pure(bcs::to_bytes(&Some(amount as u64))?))
-                        .unwrap(),
+                        .map_err(Error::InternalError)?,
                     builder
                         .input(CallArg::Pure(bcs::to_bytes(&validator)?))
-                        .unwrap(),
+                        .map_err(Error::InternalError)?,
                 ];
                 builder.command(Command::move_call(
                     SUI_FRAMEWORK_OBJECT_ID,

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -98,7 +98,7 @@ async fn test_transfer_object() {
     let object_ref = get_random_sui(&client, sender, vec![]).await;
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.transfer_object(recipient, object_ref);
+        builder.transfer_object(recipient, object_ref).unwrap();
         builder.finish()
     };
     test_transaction(

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -142,7 +142,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         object_id: ObjectID,
         recipient: SuiAddress,
     ) -> anyhow::Result<()> {
-        builder.transfer_object(recipient, self.get_object_ref(object_id).await?);
+        builder.transfer_object(recipient, self.get_object_ref(object_id).await?)?;
         Ok(())
     }
 
@@ -434,11 +434,11 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let args = check_args
             .into_iter()
             .map(|check_arg| match check_arg {
-                CheckCallArg::Pure(bytes) => builder.input(CallArg::Pure(bytes)).unwrap(),
-                CheckCallArg::Object(obj) => builder.input(CallArg::Object(obj)).unwrap(),
+                CheckCallArg::Pure(bytes) => builder.input(CallArg::Pure(bytes)),
+                CheckCallArg::Object(obj) => builder.input(CallArg::Object(obj)),
                 CheckCallArg::ObjVec(objs) => builder.make_obj_vec(objs),
             })
-            .collect();
+            .collect::<Result<_, _>>()?;
         Ok(args)
     }
 
@@ -695,7 +695,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                         mutable: true,
                     }))
                     .unwrap(),
-                builder.make_obj_vec(obj_vec),
+                builder.make_obj_vec(obj_vec)?,
                 builder
                     .input(CallArg::Pure(bcs::to_bytes(&amount)?))
                     .unwrap(),

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -145,14 +145,12 @@ impl SuiValue {
         test_adapter: &SuiTestAdapter,
     ) -> anyhow::Result<Argument> {
         Ok(match self {
-            SuiValue::Object(fake_id) => {
-                builder.input(CallArg::Object(Self::object_arg(fake_id, test_adapter)?))?
-            }
+            SuiValue::Object(fake_id) => builder.obj(Self::object_arg(fake_id, test_adapter)?)?,
             SuiValue::ObjVec(vec) => builder.make_obj_vec(
                 vec.iter()
                     .map(|fake_id| Self::object_arg(*fake_id, test_adapter))
                     .collect::<Result<Vec<ObjectArg>, _>>()?,
-            ),
+            )?,
             SuiValue::MoveValue(v) => {
                 builder.input(CallArg::Pure(v.simple_serialize().unwrap()))?
             }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -456,6 +456,14 @@ impl CallArg {
     }
 }
 
+impl ObjectArg {
+    pub fn id(&self) -> ObjectID {
+        match self {
+            ObjectArg::ImmOrOwnedObject((id, _, _)) | ObjectArg::SharedObject { id, .. } => *id,
+        }
+    }
+}
+
 impl MoveCall {
     pub fn input_objects(&self) -> Vec<InputObjectKind> {
         let MoveCall {
@@ -1313,7 +1321,7 @@ impl TransactionData {
     ) -> Self {
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder.transfer_object(recipient, object_ref);
+            builder.transfer_object(recipient, object_ref).unwrap();
             builder.finish()
         };
         Self::new_programmable(sender, vec![gas_payment], pt, gas_budget, gas_price)

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -668,7 +668,9 @@ fn test_sponsored_transaction_message() {
     let sponsor = (&sponsor_kp.public()).into();
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.transfer_object(get_new_address::<AccountKeyPair>(), random_object_ref());
+        builder
+            .transfer_object(get_new_address::<AccountKeyPair>(), random_object_ref())
+            .unwrap();
         builder.finish()
     };
     let kind = TransactionKind::programmable(pt);
@@ -782,7 +784,9 @@ fn test_sponsored_transaction_validity_check() {
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.transfer_object(get_new_address::<AccountKeyPair>(), random_object_ref());
+        builder
+            .transfer_object(get_new_address::<AccountKeyPair>(), random_object_ref())
+            .unwrap();
         builder.finish()
     };
     let kind = TransactionKind::programmable(pt);
@@ -1080,10 +1084,12 @@ fn test_move_input_objects() {
         builder
             .input(CallArg::Object(ObjectArg::ImmOrOwnedObject(o1)))
             .unwrap(),
-        builder.make_obj_vec(vec![
-            ObjectArg::ImmOrOwnedObject(o2),
-            ObjectArg::ImmOrOwnedObject(o3),
-        ]),
+        builder
+            .make_obj_vec(vec![
+                ObjectArg::ImmOrOwnedObject(o2),
+                ObjectArg::ImmOrOwnedObject(o3),
+            ])
+            .unwrap(),
         builder
             .input(CallArg::Object(ObjectArg::SharedObject {
                 id: shared.0,
@@ -1166,10 +1172,12 @@ fn test_unique_input_objects() {
         builder
             .input(CallArg::Object(ObjectArg::ImmOrOwnedObject(o1)))
             .unwrap(),
-        builder.make_obj_vec(vec![
-            ObjectArg::ImmOrOwnedObject(o2),
-            ObjectArg::ImmOrOwnedObject(o3),
-        ]),
+        builder
+            .make_obj_vec(vec![
+                ObjectArg::ImmOrOwnedObject(o2),
+                ObjectArg::ImmOrOwnedObject(o3),
+            ])
+            .unwrap(),
     ];
     let args_2 = vec![builder
         .input(CallArg::Object(ObjectArg::SharedObject {

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -127,7 +127,7 @@ async fn test_sponsored_transaction() -> Result<(), anyhow::Error> {
     // Construct the sponsored transction
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.transfer_object(another_addr, object_ref);
+        builder.transfer_object(another_addr, object_ref).unwrap();
         builder.finish()
     };
     let kind = TransactionKind::programmable(pt);


### PR DESCRIPTION
## Description 

- Fixed case where object de-duping did not handle mismatched call args
- Added the option to not de-dupe pure values, as it might not always be valid

## Test Plan 

- Updated tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
