### PR TITLE
Batch verification with fallback + tests and benchmark

### DIFF
--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -105,3 +105,7 @@ test = false
 [[bench]]
 name = "verified_cert_cache_bench"
 harness = false
+
+[[bench]]
+name = "batch_verification_bench"
+harness = false

--- a/crates/sui-core/benches/batch_verification_bench.rs
+++ b/crates/sui-core/benches/batch_verification_bench.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::*;
+
+use rand::prelude::*;
+use rand::seq::SliceRandom;
+
+use sui_core::test_utils::{make_cert_with_large_committee, make_dummy_tx};
+use sui_types::committee::Committee;
+use sui_types::crypto::{get_key_pair, AccountKeyPair};
+
+use sui_core::batch_bls_verifier::*;
+
+use criterion::Criterion;
+
+fn batch_verification_bench(c: &mut Criterion) {
+    let (committee, key_pairs) = Committee::new_simple_test_committee_of_size(100);
+
+    let mut group = c.benchmark_group("batch_verify");
+    // throughput improvements mostly level off at a batch size of 32, and latency starts getting
+    // pretty significant at that point.
+    for batch_size in [1, 4, 16, 32, 64] {
+        for num_errors in [0, 1] {
+            let (receiver, _): (_, AccountKeyPair) = get_key_pair();
+
+            let senders: Vec<_> = (0..batch_size)
+                .into_iter()
+                .map(|_| get_key_pair::<AccountKeyPair>())
+                .collect();
+
+            let txns: Vec<_> = senders
+                .iter()
+                .map(|(sender, sender_sec)| make_dummy_tx(receiver, *sender, sender_sec))
+                .collect();
+
+            let mut certs: Vec<_> = txns
+                .iter()
+                .map(|t| make_cert_with_large_committee(&committee, &key_pairs, t))
+                .collect();
+
+            let (other_sender, other_sender_sec): (_, AccountKeyPair) = get_key_pair();
+            let other_tx = make_dummy_tx(receiver, other_sender, &other_sender_sec);
+            let other_cert = make_cert_with_large_committee(&committee, &key_pairs, &other_tx);
+
+            for cert in certs.iter_mut().take(num_errors as usize) {
+                *cert.auth_sig_mut_for_testing() = other_cert.auth_sig().clone();
+            }
+
+            group.throughput(Throughput::Elements(batch_size));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("size={} errors={}", batch_size, num_errors)),
+                &batch_size,
+                |b, batch_size| {
+                    assert_eq!(certs.len() as u64, *batch_size);
+                    b.iter(|| {
+                        certs.shuffle(&mut thread_rng());
+                        batch_verify_certificates(&committee, &certs);
+                    })
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, batch_verification_bench);
+criterion_main!(benches);

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -128,6 +128,10 @@ pub mod move_integration_tests;
 #[path = "unit_tests/gas_tests.rs"]
 mod gas_tests;
 
+#[cfg(test)]
+#[path = "unit_tests/batch_verification_tests.rs"]
+mod batch_verification_tests;
+
 pub mod authority_per_epoch_store;
 pub mod authority_per_epoch_store_pruner;
 

--- a/crates/sui-core/src/batch_bls_verifier.rs
+++ b/crates/sui-core/src/batch_bls_verifier.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use shared_crypto::intent::{Intent, IntentScope};
+use sui_types::{
+    committee::Committee,
+    crypto::{AuthoritySignInfoTrait, VerificationObligation},
+    error::SuiResult,
+    message_envelope::Message,
+    messages::CertifiedTransaction,
+};
+
+use tap::TapFallible;
+use tracing::error;
+
+/// Verifies all certificates - if any fail return error.
+pub fn batch_verify_all_certificates(
+    committee: &Committee,
+    certs: &[CertifiedTransaction],
+) -> SuiResult {
+    // Verify user signatures
+    for cert in certs {
+        cert.data().verify(None)?;
+    }
+
+    batch_verify_certificates_impl(committee, certs)
+}
+
+/// Verifies certificates in batch mode, but returns a separate result for each cert.
+pub fn batch_verify_certificates(
+    committee: &Committee,
+    certs: &[CertifiedTransaction],
+) -> Vec<SuiResult> {
+    match batch_verify_certificates_impl(committee, certs) {
+        Ok(_) => certs
+            .iter()
+            .map(|c| {
+                c.data().verify(None).tap_err(|e| {
+                    error!(
+                        "Cert was signed by quorum, but contained bad user signatures! {}",
+                        e
+                    )
+                })?;
+                Ok(())
+            })
+            .collect(),
+
+        // Verify one by one to find which certs were invalid.
+        Err(_) if certs.len() > 1 => certs
+            .iter()
+            .map(|c| c.verify_signature(committee))
+            .collect(),
+
+        Err(e) => vec![Err(e)],
+    }
+}
+
+fn batch_verify_certificates_impl(
+    committee: &Committee,
+    certs: &[CertifiedTransaction],
+) -> SuiResult {
+    let mut obligation = VerificationObligation::default();
+
+    for cert in certs {
+        let idx = obligation.add_message(
+            cert.data(),
+            cert.epoch(),
+            Intent::default().with_scope(IntentScope::SenderSignedTransaction),
+        );
+        cert.auth_sig()
+            .add_to_verification_obligation(committee, &mut obligation, idx)?;
+    }
+
+    obligation.verify_all()
+}

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -35,4 +35,6 @@ mod pay_sui_tests;
 pub mod signature_verifier;
 pub mod test_authority_clients;
 
+pub mod batch_bls_verifier;
+
 pub const SUI_CORE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_types::committee::Committee;
+
+use crate::batch_bls_verifier::*;
+use crate::test_utils::{make_cert_with_large_committee, make_dummy_tx};
+use sui_macros::sim_test;
+use sui_types::crypto::{get_key_pair, AccountKeyPair};
+
+#[sim_test]
+async fn test_batch_verify() {
+    let (committee, key_pairs) = Committee::new_simple_test_committee();
+
+    let (receiver, _): (_, AccountKeyPair) = get_key_pair();
+
+    let senders: Vec<_> = (0..16)
+        .into_iter()
+        .map(|_| get_key_pair::<AccountKeyPair>())
+        .collect();
+
+    let txns: Vec<_> = senders
+        .iter()
+        .map(|(sender, sender_sec)| make_dummy_tx(receiver, *sender, sender_sec))
+        .collect();
+
+    let certs: Vec<_> = txns
+        .iter()
+        .map(|t| make_cert_with_large_committee(&committee, &key_pairs, t))
+        .collect();
+
+    batch_verify_all_certificates(&committee, &certs).unwrap();
+
+    let (other_sender, other_sender_sec): (_, AccountKeyPair) = get_key_pair();
+    // this test is a bit much for the current implementation - it was originally written to verify
+    // a bisecting fall back approach.
+    for i in 0..16 {
+        let mut certs = certs.clone();
+        let other_tx = make_dummy_tx(receiver, other_sender, &other_sender_sec);
+        let other_cert = make_cert_with_large_committee(&committee, &key_pairs, &other_tx);
+        *certs[i].auth_sig_mut_for_testing() = other_cert.auth_sig().clone();
+        batch_verify_all_certificates(&committee, &certs).unwrap_err();
+
+        let results = batch_verify_certificates(&committee, &certs);
+        results[i].as_ref().unwrap_err();
+        for (_, r) in results.iter().enumerate().filter(|(j, _)| *j != i) {
+            r.as_ref().unwrap();
+        }
+    }
+}

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::base_types::*;
-use crate::crypto::{random_committee_key_pairs, AuthorityKeyPair, AuthorityPublicKey};
+use crate::crypto::{random_committee_key_pairs_of_size, AuthorityKeyPair, AuthorityPublicKey};
 use crate::error::{SuiError, SuiResult};
 use fastcrypto::traits::KeyPair;
 use itertools::Itertools;
@@ -293,10 +293,11 @@ impl Committee {
     }
 
     // ===== Testing-only methods =====
-
-    /// Generate a simple committee with 4 validators each with equal voting stake of 1.
-    pub fn new_simple_test_committee() -> (Self, Vec<AuthorityKeyPair>) {
-        let key_pairs: Vec<_> = random_committee_key_pairs().into_iter().collect();
+    //
+    pub fn new_simple_test_committee_of_size(size: usize) -> (Self, Vec<AuthorityKeyPair>) {
+        let key_pairs: Vec<_> = random_committee_key_pairs_of_size(size)
+            .into_iter()
+            .collect();
         let committee = Self::new(
             0,
             key_pairs
@@ -308,6 +309,11 @@ impl Committee {
         )
         .unwrap();
         (committee, key_pairs)
+    }
+
+    /// Generate a simple committee with 4 validators each with equal voting stake of 1.
+    pub fn new_simple_test_committee() -> (Self, Vec<AuthorityKeyPair>) {
+        Self::new_simple_test_committee_of_size(4)
     }
 }
 

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -546,10 +546,15 @@ where
 }
 
 pub const TEST_COMMITTEE_SIZE: usize = 4;
-/// Generate a random committee key pairs with size of TEST_COMMITTEE_SIZE.
+
 pub fn random_committee_key_pairs() -> Vec<AuthorityKeyPair> {
+    random_committee_key_pairs_of_size(TEST_COMMITTEE_SIZE)
+}
+
+/// Generate a random committee key pairs with size of TEST_COMMITTEE_SIZE.
+pub fn random_committee_key_pairs_of_size(size: usize) -> Vec<AuthorityKeyPair> {
     let mut rng = StdRng::from_seed([0; 32]);
-    (0..TEST_COMMITTEE_SIZE)
+    (0..size)
         .map(|_| {
             // TODO: We are generating the keys 4 times to match exactly as how we generate
             // keys in ConfigBuilder::build (sui-config/src/builder.rs). This is because


### PR DESCRIPTION
First part of batch verification for sui. (Second part will be aggregating certs across requests in authority_server).

Overall looks like a 2x throughput increase for the happy path, and then 0.6x decrease (from the baseline) for the unhappy path.

Bench results:

```
batch_verify/size=1 errors=0
                        time:   [1.0262 ms 1.0277 ms 1.0294 ms]
                        thrpt:  [971.45  elem/s 973.00  elem/s 974.49  elem/s]
                 change:
                        time:   [-0.6662% -0.3750% -0.0595%] (p = 0.02 < 0.05)
                        thrpt:  [+0.0595% +0.3765% +0.6707%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
batch_verify/size=1 errors=1
                        time:   [986.73 µs 988.15 µs 989.59 µs]
                        thrpt:  [1.0105 Kelem/s 1.0120 Kelem/s 1.0134 Kelem/s]
                 change:
                        time:   [-51.159% -51.074% -50.993%] (p = 0.00 < 0.05)
                        thrpt:  [+104.05% +104.39% +104.75%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
batch_verify/size=4 errors=0
                        time:   [2.3744 ms 2.3783 ms 2.3826 ms]
                        thrpt:  [1.6788 Kelem/s 1.6819 Kelem/s 1.6846 Kelem/s]
                 change:
                        time:   [-0.3667% -0.1114% +0.1534%] (p = 0.42 > 0.05)
                        thrpt:  [-0.1532% +0.1115% +0.3680%]
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
batch_verify/size=4 errors=1
                        time:   [6.3136 ms 6.3205 ms 6.3274 ms]
                        thrpt:  [632.17  elem/s 632.86  elem/s 633.56  elem/s]
                 change:
                        time:   [-0.5964% -0.4193% -0.2447%] (p = 0.00 < 0.05)
                        thrpt:  [+0.2453% +0.4211% +0.6000%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) low mild
batch_verify/size=16 errors=0
                        time:   [7.7978 ms 7.8092 ms 7.8225 ms]
                        thrpt:  [2.0454 Kelem/s 2.0489 Kelem/s 2.0519 Kelem/s]
                 change:
                        time:   [+0.0378% +0.2138% +0.4253%] (p = 0.03 < 0.05)
                        thrpt:  [-0.4235% -0.2133% -0.0378%]
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
batch_verify/size=16 errors=1
                        time:   [23.500 ms 23.539 ms 23.579 ms]
                        thrpt:  [678.58  elem/s 679.72  elem/s 680.85  elem/s]
                 change:
                        time:   [-1.1010% -0.8016% -0.5308%] (p = 0.00 < 0.05)
                        thrpt:  [+0.5336% +0.8080% +1.1132%]
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  7 (7.00%) high mild
  1 (1.00%) high severe
batch_verify/size=32 errors=0
                        time:   [15.105 ms 15.124 ms 15.141 ms]
                        thrpt:  [2.1134 Kelem/s 2.1159 Kelem/s 2.1184 Kelem/s]
                 change:
                        time:   [-0.2129% +0.0024% +0.2042%] (p = 0.98 > 0.05)
                        thrpt:  [-0.2038% -0.0024% +0.2133%]
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
batch_verify/size=32 errors=1
                        time:   [46.550 ms 46.592 ms 46.633 ms]
                        thrpt:  [686.22  elem/s 686.81  elem/s 687.44  elem/s]
                 change:
                        time:   [+0.0790% +0.1989% +0.3261%] (p = 0.00 < 0.05)
                        thrpt:  [-0.3250% -0.1985% -0.0789%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
batch_verify/size=64 errors=0
                        time:   [29.663 ms 29.721 ms 29.779 ms]
                        thrpt:  [2.1491 Kelem/s 2.1534 Kelem/s 2.1576 Kelem/s]
Benchmarking batch_verify/size=64 errors=1: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.3s, or reduce sample count to 50.
batch_verify/size=64 errors=1
                        time:   [92.444 ms 92.570 ms 92.690 ms]
                        thrpt:  [690.47  elem/s 691.37  elem/s 692.31  elem/s]
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) low severe
  9 (9.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
```