### PR TITLE
[Sui move Math] Support sqrt_u256

### DIFF
--- a/crates/sui-framework/sources/math.move
+++ b/crates/sui-framework/sources/math.move
@@ -133,7 +133,7 @@ module sui::math {
         (res as u128)
     }
 
-    // calculate square root of usigned integger by using Babylonian method
+    // calculate square root of usigned integer by using Babylonian method
     public fun sqrt_u256(y: u256): u256 {
         let z = 0u256;
         if (y > 3) {

--- a/crates/sui-framework/sources/math.move
+++ b/crates/sui-framework/sources/math.move
@@ -133,6 +133,7 @@ module sui::math {
         (res as u128)
     }
 
+    // calculate square root of usigned integger by using Babylonian method
     public fun sqrt_u256(y: u256): u256 {
         let z = 0u256;
         if (y > 3) {

--- a/crates/sui-framework/sources/math.move
+++ b/crates/sui-framework/sources/math.move
@@ -133,7 +133,7 @@ module sui::math {
         (res as u128)
     }
 
-    // calculate square root of usigned integer by using Babylonian method
+    // Calculate the square root of an usigned integer using Babylonian method.
     public fun sqrt_u256(y: u256): u256 {
         let z = 0u256;
         if (y > 3) {

--- a/crates/sui-framework/sources/math.move
+++ b/crates/sui-framework/sources/math.move
@@ -133,6 +133,22 @@ module sui::math {
         (res as u128)
     }
 
+    public fun sqrt_u256(y: u256): u256 {
+        let z = 0u256;
+        if (y > 3) {
+            z = y;
+            let x = y / 2 + 1;
+            while (x < z) {
+                z = x;
+                x = (y / x + x) / 2;
+            };
+        } else if (y != 0) {
+            z = 1;
+        };
+
+        z
+    }
+
     /// Calculate x / y, but round up the result.
     public fun divide_and_round_up(x: u64, y: u64): u64 {
         if (x % y == 0) {

--- a/crates/sui-framework/tests/math_tests.move
+++ b/crates/sui-framework/tests/math_tests.move
@@ -4,6 +4,7 @@
 #[test_only]
 module sui::math_tests {
     use sui::math;
+    use sui::math::sqrt_u256;
 
     #[test]
     fun test_max() {
@@ -18,7 +19,7 @@ module sui::math_tests {
         assert!(math::min(100, 10) == 10, 2);
         assert!(math::min(0, 0) == 0, 3);
     }
-    
+
     #[test]
     fun test_pow() {
         assert!(math::pow(1, 0) == 1, 0);
@@ -68,5 +69,22 @@ module sui::math_tests {
     fun test_sqrt_big_numbers() {
         let u64_max = 18446744073709551615;
         assert!(4294967295 == math::sqrt(u64_max), 0)
+    }
+
+    #[test]
+    fun test_sqrt_u256() {
+        let i = 0;
+        while (i <= 5) {
+            assert!(i == sqrt_u256(i * i), 0);
+            i = i + 1;
+        };
+
+        // python3
+        // import math
+        // int(math.sqrt(115792089237316195423570985008687907853269984665640564039457584007913129639935))
+        // result: 340282366920938463463374607431768211456
+        // different here is 1 which is acceptable
+        let u256_max = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+        assert!(340282366920938463463374607431768211455 == math::sqrt_u256(u256_max), 0);
     }
 }


### PR DESCRIPTION
## Description 

Support square root for u256 by using Babylonian method.
Port from https://etherscan.io/address/0x6d9893fa101cd2b1f8d1a12de3189ff7b80fdc10#code#F1#L28

## Test Plan 

How did you test the new or updated feature?
By using unit tests and compare to Python result

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
