### PR TITLE
client publish: add scaffolding for package dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9013,6 +9013,7 @@ dependencies = [
  "sui-config",
  "sui-core",
  "sui-faucet",
+ "sui-framework-build",
  "sui-json",
  "sui-json-rpc-types",
  "sui-keys",

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -263,8 +263,8 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
                 /* is_init */ false,
             )?
         }
-        Command::Publish(modules) => {
-            execute_move_publish::<_, _, Mode>(context, &mut argument_updates, modules)?
+        Command::Publish(modules, dep_ids) => {
+            execute_move_publish::<_, _, Mode>(context, &mut argument_updates, modules, dep_ids)?
         }
         Command::Upgrade(modules, dep_ids, upgrade_ticket) => {
             execute_move_upgrade::<_, _, Mode>(context, modules, dep_ids, upgrade_ticket)?
@@ -380,6 +380,7 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     context: &mut ExecutionContext<E, S>,
     argument_updates: &mut Mode::ArgumentUpdates,
     module_bytes: Vec<Vec<u8>>,
+    _dep_ids: Vec<ObjectID>,
 ) -> Result<Vec<Value>, ExecutionError> {
     assert_invariant!(
         !module_bytes.is_empty(),

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -28,6 +28,7 @@ sui-faucet = { path = "../sui-faucet" }
 sui-swarm = { path = "../sui-swarm" }
 sui = { path = "../sui" }
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }
+sui-framework-build = { path = "../sui-framework-build" }
 sui-sdk = { path = "../sui-sdk" }
 sui-keys = { path = "../sui-keys" }
 sui-types = { path = "../sui-types" }

--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -5,7 +5,6 @@ use crate::{TestCaseImpl, TestContext};
 use async_trait::async_trait;
 use jsonrpsee::rpc_params;
 use sui_core::test_utils::compile_basics_package;
-use sui_framework_build::compiled_package::package_dependencies;
 use sui_json_rpc_types::SuiTransactionEffectsAPI;
 use sui_types::{base_types::ObjectID, object::Owner};
 
@@ -24,10 +23,8 @@ impl TestCaseImpl for FullNodeBuildPublishTransactionTest {
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
         let compiled_package = compile_basics_package();
         let all_module_bytes =
-            compile_basics_package().get_package_base64(/* with_unpublished_deps */ false);
-
-        let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
-        let dependencies = package_dependencies(compiled_modules);
+            compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+        let dependencies = compiled_package.get_dependency_original_package_ids();
 
         let params = rpc_params![
             ctx.get_wallet_address(),

--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -5,6 +5,7 @@ use crate::{TestCaseImpl, TestContext};
 use async_trait::async_trait;
 use jsonrpsee::rpc_params;
 use sui_core::test_utils::compile_basics_package;
+use sui_framework_build::compiled_package::package_dependencies;
 use sui_json_rpc_types::SuiTransactionEffectsAPI;
 use sui_types::{base_types::ObjectID, object::Owner};
 
@@ -21,12 +22,17 @@ impl TestCaseImpl for FullNodeBuildPublishTransactionTest {
     }
 
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
+        let compiled_package = compile_basics_package();
         let all_module_bytes =
             compile_basics_package().get_package_base64(/* with_unpublished_deps */ false);
+
+        let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
+        let dependencies = package_dependencies(compiled_modules);
 
         let params = rpc_params![
             ctx.get_wallet_address(),
             all_module_bytes,
+            dependencies,
             None::<ObjectID>,
             10000
         ];

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -963,7 +963,7 @@ fn process_package(
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         // executing in Genesis mode does not create a package upgrade
-        builder.command(Command::Publish(module_bytes));
+        builder.command(Command::Publish(module_bytes, ids));
         builder.finish()
     };
     programmable_transactions::execution::execute::<_, _, execution_mode::Genesis>(

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -33,6 +33,7 @@ use std::fs;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use sui_framework_build::compiled_package::package_dependencies;
 use sui_json_rpc_types::{
     SuiArgument, SuiExecutionResult, SuiExecutionStatus, SuiGasCostSummary,
     SuiTransactionEffectsAPI, SuiTypeTag,
@@ -1557,12 +1558,14 @@ async fn test_publish_dependent_module_ok() {
         dependent_module.serialize(&mut bytes).unwrap();
         bytes
     };
+
     let authority = init_state_with_objects(vec![gas_payment_object]).await;
 
     let data = TransactionData::new_module_with_dummy_gas_price(
         sender,
         gas_payment_object_ref,
         vec![dependent_module_bytes],
+        package_dependencies(vec![&dependent_module]),
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
@@ -1605,6 +1608,7 @@ async fn test_publish_module_no_dependencies_ok() {
         sender,
         gas_payment_object_ref,
         module_bytes,
+        package_dependencies(vec![&module]),
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
@@ -1653,6 +1657,7 @@ async fn test_publish_non_existing_dependent_module() {
         sender,
         gas_payment_object_ref,
         vec![dependent_module_bytes],
+        package_dependencies(vec![&dependent_module]),
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
@@ -1703,6 +1708,7 @@ async fn test_package_size_limit() {
         sender,
         gas_payment_object_ref,
         package,
+        vec![],
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -302,7 +302,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
     // We need the original package bytes in order to reproduce the publish computation cost.
     let publish_bytes = match response.0.data().intent_message.value.kind() {
         TransactionKind::ProgrammableTransaction(pt) => match pt.commands.first().unwrap() {
-            Command::Publish(modules) => modules,
+            Command::Publish(modules, _dep_ids) => modules,
             _ => unreachable!(),
         },
         _ => unreachable!(),

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -19,7 +19,7 @@ use move_core_types::{
 };
 use move_package::source_package::manifest_parser;
 use sui_framework_build::compiled_package::{
-    check_unpublished_dependencies, gather_dependencies, BuildConfig,
+    check_unpublished_dependencies, gather_dependencies, package_dependencies, BuildConfig,
 };
 use sui_types::{
     crypto::{get_key_pair, AccountKeyPair},
@@ -2247,7 +2247,15 @@ pub async fn build_and_try_publish_test_package(
     gas_budget: u64,
     with_unpublished_deps: bool,
 ) -> (Transaction, SignedTransactionEffects) {
-    let all_module_bytes = build_test_package(test_dir, with_unpublished_deps);
+    let build_config = BuildConfig::new_for_testing();
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/unit_tests/data/");
+    path.push(test_dir);
+    let compiled_package = sui_framework::build_move_package(&path, build_config).unwrap();
+    let all_module_bytes = compiled_package.get_package_bytes(with_unpublished_deps);
+
+    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
+    let dependencies = package_dependencies(compiled_modules);
 
     let gas_object = authority.get_object(gas_object_id).await.unwrap();
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
@@ -2256,6 +2264,7 @@ pub async fn build_and_try_publish_test_package(
         *sender,
         gas_object_ref,
         all_module_bytes,
+        dependencies,
         gas_budget,
     );
     let transaction = to_sender_signed_transaction(data, sender_key);

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -19,7 +19,7 @@ use move_core_types::{
 };
 use move_package::source_package::manifest_parser;
 use sui_framework_build::compiled_package::{
-    check_unpublished_dependencies, gather_dependencies, package_dependencies, BuildConfig,
+    check_unpublished_dependencies, gather_dependencies, BuildConfig,
 };
 use sui_types::{
     crypto::{get_key_pair, AccountKeyPair},
@@ -2253,9 +2253,7 @@ pub async fn build_and_try_publish_test_package(
     path.push(test_dir);
     let compiled_package = sui_framework::build_move_package(&path, build_config).unwrap();
     let all_module_bytes = compiled_package.get_package_bytes(with_unpublished_deps);
-
-    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
-    let dependencies = package_dependencies(compiled_modules);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
 
     let gas_object = authority.get_object(gas_object_id).await.unwrap();
     let gas_object_ref = gas_object.unwrap().compute_object_reference();

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -79,9 +79,11 @@ Command:
               TYPENAME: Argument
     4:
       Publish:
-        NEWTYPE:
-          SEQ:
-            SEQ: U8
+        TUPLE:
+          - SEQ:
+              SEQ: U8
+          - SEQ:
+              TYPENAME: ObjectID
     5:
       MakeMoveVec:
         TUPLE:

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -586,3 +586,19 @@ pub fn check_invalid_dependencies(invalid: BTreeMap<Symbol, String>) -> Result<(
         error: error_messages.join("\n"),
     })
 }
+
+/// Resolve external package dependency addresses for a collection of modules
+/// (i.e., package) from module handle addresses.
+pub fn package_dependencies(modules: Vec<&CompiledModule>) -> Vec<ObjectID> {
+    let module_self_addresses: BTreeSet<_> = modules.iter().map(|m| m.self_id()).collect();
+    let mut dependent_packages = BTreeSet::new();
+    for module in modules {
+        for handle in &module.module_handles {
+            if !module_self_addresses.contains(&module.module_id_for_handle(handle)) {
+                let address = ObjectID::from(*module.address_identifier_at(handle.address));
+                dependent_packages.insert(address);
+            }
+        }
+    }
+    Vec::from_iter(dependent_packages)
+}

--- a/crates/sui-indexer/src/apis/transaction_builder_api.rs
+++ b/crates/sui-indexer/src/apis/transaction_builder_api.rs
@@ -98,11 +98,12 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         &self,
         sender: SuiAddress,
         compiled_modules: Vec<Base64>,
+        dep_ids: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes> {
         self.fullnode
-            .publish(sender, compiled_modules, gas, gas_budget)
+            .publish(sender, compiled_modules, dep_ids, gas, gas_budget)
             .await
     }
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -893,8 +893,9 @@ pub enum SuiCommand {
     /// `(&mut Coin<T>, Vec<Coin<T>>)`
     /// It merges n-coins into the first coin
     MergeCoins(SuiArgument, Vec<SuiArgument>),
-    /// Publishes a Move package
-    Publish(SuiMovePackage),
+    /// Publishes a Move package. It takes the package bytes and a list of the package's transitive
+    /// dependencies to link against on-chain.
+    Publish(SuiMovePackage, Vec<ObjectID>),
     /// Upgrades a Move package
     Upgrade(SuiMovePackage, Vec<ObjectID>, SuiArgument),
     /// `forall T: Vec<T> -> vector<T>`
@@ -931,7 +932,7 @@ impl Display for SuiCommand {
                 write_sep(f, coins, ",")?;
                 write!(f, ")")
             }
-            Self::Publish(_bytes) => write!(f, "Publish(_)"),
+            Self::Publish(_bytes, _deps) => write!(f, "Publish(_)"),
             Self::Upgrade(_bytes, deps, ticket) => {
                 write!(f, "Upgrade({ticket},")?;
                 write_sep(f, deps, ",")?;
@@ -955,9 +956,12 @@ impl From<Command> for SuiCommand {
                 arg.into(),
                 args.into_iter().map(SuiArgument::from).collect(),
             ),
-            Command::Publish(modules) => SuiCommand::Publish(SuiMovePackage {
-                disassembled: disassemble_modules(modules.iter()).unwrap_or_default(),
-            }),
+            Command::Publish(modules, dep_ids) => SuiCommand::Publish(
+                SuiMovePackage {
+                    disassembled: disassemble_modules(modules.iter()).unwrap_or_default(),
+                },
+                dep_ids,
+            ),
             Command::MakeMoveVec(tag_opt, args) => SuiCommand::MakeMoveVec(
                 tag_opt.map(|tag| tag.to_string()),
                 args.into_iter().map(SuiArgument::from).collect(),

--- a/crates/sui-json-rpc/src/api/transaction_builder.rs
+++ b/crates/sui-json-rpc/src/api/transaction_builder.rs
@@ -146,6 +146,8 @@ pub trait TransactionBuilder {
         sender: SuiAddress,
         /// the compiled bytes of a move module, the
         compiled_modules: Vec<Base64>,
+        /// a list of transitive dependency addresses that this set of modules depends on.
+        dependencies: Vec<ObjectID>,
         /// gas object to be used in this transaction, node will pick one from the signer's possession if not provided
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -172,6 +172,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         &self,
         sender: SuiAddress,
         compiled_modules: Vec<Base64>,
+        dependencies: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes> {
@@ -181,7 +182,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
             .collect::<Result<Vec<_>, _>>()?;
         let data = self
             .builder
-            .publish(sender, compiled_modules, gas, gas_budget)
+            .publish(sender, compiled_modules, dependencies, gas, gas_budget)
             .await?;
         Ok(TransactionBytes::from_data(data)?)
     }

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 #[cfg(not(msim))]
 use std::str::FromStr;
 use sui_config::SUI_KEYSTORE_FILENAME;
-use sui_framework_build::compiled_package::{package_dependencies, BuildConfig};
+use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
 
 use sui_json_rpc_types::SuiObjectInfo;
@@ -111,9 +111,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
         .build(Path::new("../../sui_programmability/examples/fungible_tokens").to_path_buf())?;
     let compiled_modules_bytes =
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
-
-    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
-    let dependencies = package_dependencies(compiled_modules);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
 
     let transaction_bytes: TransactionBytes = http_client
         .publish(
@@ -286,9 +284,7 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
         .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?;
     let compiled_modules_bytes =
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
-
-    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
-    let dependencies = package_dependencies(compiled_modules);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
 
     let transaction_bytes: TransactionBytes = http_client
         .publish(
@@ -354,9 +350,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?;
     let compiled_modules_bytes =
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
-
-    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
-    let dependencies = package_dependencies(compiled_modules);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
 
     let transaction_bytes: TransactionBytes = http_client
         .publish(

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 #[cfg(not(msim))]
 use std::str::FromStr;
 use sui_config::SUI_KEYSTORE_FILENAME;
-use sui_framework_build::compiled_package::BuildConfig;
+use sui_framework_build::compiled_package::{package_dependencies, BuildConfig};
 use sui_json::SuiJsonValue;
 
 use sui_json_rpc_types::SuiObjectInfo;
@@ -107,12 +107,22 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let objects = http_client.get_objects_owned_by_address(*address).await?;
     let gas = objects.first().unwrap();
 
-    let compiled_modules = BuildConfig::new_for_testing()
-        .build(Path::new("../../sui_programmability/examples/fungible_tokens").to_path_buf())?
-        .get_package_base64(/* with_unpublished_deps */ false);
+    let compiled_package = BuildConfig::new_for_testing()
+        .build(Path::new("../../sui_programmability/examples/fungible_tokens").to_path_buf())?;
+    let compiled_modules_bytes =
+        compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+
+    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
+    let dependencies = package_dependencies(compiled_modules);
 
     let transaction_bytes: TransactionBytes = http_client
-        .publish(*address, compiled_modules, Some(gas.object_id), 10000)
+        .publish(
+            *address,
+            compiled_modules_bytes,
+            dependencies,
+            Some(gas.object_id),
+            10000,
+        )
         .await?;
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
@@ -272,12 +282,22 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
     let gas = objects.first().unwrap();
 
     // Publish test coin package
-    let compiled_modules = BuildConfig::default()
-        .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?
-        .get_package_base64(/* with_unpublished_deps */ false);
+    let compiled_package = BuildConfig::default()
+        .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?;
+    let compiled_modules_bytes =
+        compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+
+    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
+    let dependencies = package_dependencies(compiled_modules);
 
     let transaction_bytes: TransactionBytes = http_client
-        .publish(*address, compiled_modules, Some(gas.object_id), 10000)
+        .publish(
+            *address,
+            compiled_modules_bytes,
+            dependencies,
+            Some(gas.object_id),
+            10000,
+        )
         .await?;
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
@@ -330,12 +350,22 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let gas = objects.first().unwrap();
 
     // Publish test coin package
-    let compiled_modules = BuildConfig::new_for_testing()
-        .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?
-        .get_package_base64(/* with_unpublished_deps */ false);
+    let compiled_package = BuildConfig::new_for_testing()
+        .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?;
+    let compiled_modules_bytes =
+        compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+
+    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
+    let dependencies = package_dependencies(compiled_modules);
 
     let transaction_bytes: TransactionBytes = http_client
-        .publish(*address, compiled_modules, Some(gas.object_id), 10000)
+        .publish(
+            *address,
+            compiled_modules_bytes,
+            dependencies,
+            Some(gas.object_id),
+            10000,
+        )
         .await?;
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2113,6 +2113,17 @@
           }
         },
         {
+          "name": "dependencies",
+          "description": "a list of transitive dependency addresses that this set of modules depends on.",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectID"
+            }
+          }
+        },
+        {
           "name": "gas",
           "description": "gas object to be used in this transaction, node will pick one from the signer's possession if not provided",
           "schema": {
@@ -5482,14 +5493,27 @@
             "additionalProperties": false
           },
           {
-            "description": "Publishes a Move package",
+            "description": "Publishes a Move package. It takes the package bytes and a list of the package's transitive dependencies to link against on-chain.",
             "type": "object",
             "required": [
               "Publish"
             ],
             "properties": {
               "Publish": {
-                "$ref": "#/components/schemas/MovePackage"
+                "type": "array",
+                "items": [
+                  {
+                    "$ref": "#/components/schemas/MovePackage"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ObjectID"
+                    }
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
               }
             },
             "additionalProperties": false

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -14,7 +14,7 @@ use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 
 use crate::operations::Operations;
 use shared_crypto::intent::Intent;
-use sui_framework_build::compiled_package::{package_dependencies, BuildConfig};
+use sui_framework_build::compiled_package::BuildConfig;
 use sui_keys::keystore::AccountKeystore;
 use sui_keys::keystore::Keystore;
 use sui_sdk::rpc_types::{
@@ -127,17 +127,9 @@ async fn test_publish_and_move_call() {
         .join("../../sui_programmability/examples/fungible_tokens");
     let compiled_package =
         sui_framework::build_move_package(&path, BuildConfig::new_for_testing()).unwrap();
-    let compiled_modules_bytes = compiled_package
-        .get_modules()
-        .map(|m| {
-            let mut module_bytes = Vec::new();
-            m.serialize(&mut module_bytes).unwrap();
-            module_bytes
-        })
-        .collect::<Vec<_>>();
-
-    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
-    let dependencies = package_dependencies(compiled_modules);
+    let compiled_modules_bytes =
+        compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -14,7 +14,7 @@ use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 
 use crate::operations::Operations;
 use shared_crypto::intent::Intent;
-use sui_framework_build::compiled_package::BuildConfig;
+use sui_framework_build::compiled_package::{package_dependencies, BuildConfig};
 use sui_keys::keystore::AccountKeystore;
 use sui_keys::keystore::Keystore;
 use sui_sdk::rpc_types::{
@@ -125,8 +125,9 @@ async fn test_publish_and_move_call() {
     let sender = get_random_address(&network.accounts, vec![]);
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../sui_programmability/examples/fungible_tokens");
-    let package = sui_framework::build_move_package(&path, BuildConfig::new_for_testing()).unwrap();
-    let compiled_module = package
+    let compiled_package =
+        sui_framework::build_move_package(&path, BuildConfig::new_for_testing()).unwrap();
+    let compiled_modules_bytes = compiled_package
         .get_modules()
         .map(|m| {
             let mut module_bytes = Vec::new();
@@ -135,9 +136,12 @@ async fn test_publish_and_move_call() {
         })
         .collect::<Vec<_>>();
 
+    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
+    let dependencies = package_dependencies(compiled_modules);
+
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.publish(compiled_module);
+        builder.publish(compiled_modules_bytes, dependencies);
         builder.finish()
     };
     let response =

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -441,6 +441,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         &self,
         sender: SuiAddress,
         compiled_modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> anyhow::Result<TransactionData> {
@@ -452,6 +453,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             sender,
             gas,
             compiled_modules,
+            dep_ids,
             gas_budget,
             gas_price,
         ))

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -30,6 +30,8 @@ pub struct SuiPublishArgs {
     pub sender: Option<String>,
     #[clap(long = "upgradeable", action = clap::ArgAction::SetTrue)]
     pub upgradeable: bool,
+    #[clap(long = "dependencies")]
+    pub dependencies: Vec<String>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -303,6 +303,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let SuiPublishArgs {
             sender,
             upgradeable,
+            dependencies: _,
         } = extra;
         let module_name = module.self_id().name().to_string();
         let module_bytes = {
@@ -314,10 +315,10 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let data = |sender, gas| {
             let mut builder = ProgrammableTransactionBuilder::new();
             if upgradeable {
-                let cap = builder.publish_upgradeable(vec![module_bytes]);
+                let cap = builder.publish_upgradeable(vec![module_bytes], vec![]);
                 builder.transfer_arg(sender, cap);
             } else {
-                builder.publish(vec![module_bytes]);
+                builder.publish(vec![module_bytes], vec![]);
             };
             let pt = builder.finish();
             TransactionData::new_programmable_with_dummy_gas_price(

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -907,7 +907,11 @@ impl Display for Command {
                 write_sep(f, coins, ",")?;
                 write!(f, ")")
             }
-            Command::Publish(_bytes, _dep_ids) => write!(f, "Publish(_)"),
+            Command::Publish(_bytes, _dep_ids) => {
+                write!(f, "Publish(_,")?;
+                write_sep(f, _dep_ids, ",")?;
+                write!(f, ")")
+            }
             Command::Upgrade(_bytes, deps, ticket) => {
                 write!(f, "Upgrade({ticket},")?;
                 write_sep(f, deps, ",")?;

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -196,6 +196,18 @@ impl MoveModulePublish {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct SuiMovePackageDependencies {
+    pub modules: Vec<ObjectRef>,
+}
+
+impl SuiMovePackageDependencies {
+    pub fn validity_check(&self, _config: &ProtocolConfig) -> UserInputResult {
+        // TODO fp_ensure!(...)
+        Ok(())
+    }
+}
+
 // TODO: we can deprecate TransferSui when its callsites on RPC & SDK are
 // fully replaced by PaySui and PayAllSui.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
@@ -535,8 +547,9 @@ pub enum Command {
     /// `(&mut Coin<T>, Vec<Coin<T>>)`
     /// It merges n-coins into the first coin
     MergeCoins(Argument, Vec<Argument>),
-    /// Publishes a Move package
-    Publish(Vec<Vec<u8>>),
+    /// Publishes a Move package. It takes the package bytes and a list of the package's transitive
+    /// dependencies to link against on-chain.
+    Publish(Vec<Vec<u8>>, Vec<ObjectID>),
     /// `forall T: Vec<T> -> vector<T>`
     /// Given n-values of the same type, it constructs a vector. For non objects or an empty vector,
     /// the type tag must be specified.
@@ -612,7 +625,10 @@ impl Command {
         }))
     }
 
-    fn publish_command_input_objects(modules: &[Vec<u8>]) -> Vec<InputObjectKind> {
+    fn publish_command_input_objects(
+        modules: &[Vec<u8>],
+        _dep_ids: &[ObjectID],
+    ) -> Vec<InputObjectKind> {
         // For module publishing, all the dependent packages are implicit input objects
         // because they must all be on-chain in order for the package to publish.
         // All authorities must have the same view of those dependencies in order
@@ -633,9 +649,10 @@ impl Command {
 
     fn input_objects(&self) -> Vec<InputObjectKind> {
         match self {
-            Command::Upgrade(modules, _, _) | Command::Publish(modules) => {
-                Self::publish_command_input_objects(modules)
+            Command::Publish(modules, dep_ids) => {
+                Self::publish_command_input_objects(modules, dep_ids)
             }
+            Command::Upgrade(modules, _, _) => Self::publish_command_input_objects(modules, &[]),
             Command::MoveCall(c) => c.input_objects(),
             Command::MakeMoveVec(Some(t), _) => {
                 let mut packages = BTreeSet::new();
@@ -717,7 +734,7 @@ impl Command {
                     }
                 );
             }
-            Command::Publish(modules) => {
+            Command::Publish(modules, _dep_ids) => {
                 fp_ensure!(!modules.is_empty(), UserInputError::EmptyCommandInput);
                 fp_ensure!(
                     modules.len() < config.max_modules_in_publish() as usize,
@@ -890,7 +907,7 @@ impl Display for Command {
                 write_sep(f, coins, ",")?;
                 write!(f, ")")
             }
-            Command::Publish(_bytes) => write!(f, "Publish(_)"),
+            Command::Publish(_bytes, _dep_ids) => write!(f, "Publish(_)"),
             Command::Upgrade(_bytes, deps, ticket) => {
                 write!(f, "Upgrade({ticket},")?;
                 write_sep(f, deps, ",")?;
@@ -1462,21 +1479,30 @@ impl TransactionData {
         sender: SuiAddress,
         gas_payment: ObjectRef,
         modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
         gas_budget: u64,
     ) -> Self {
-        Self::new_module(sender, gas_payment, modules, gas_budget, DUMMY_GAS_PRICE)
+        Self::new_module(
+            sender,
+            gas_payment,
+            modules,
+            dep_ids,
+            gas_budget,
+            DUMMY_GAS_PRICE,
+        )
     }
 
     pub fn new_module(
         sender: SuiAddress,
         gas_payment: ObjectRef,
         modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
         gas_budget: u64,
         gas_price: u64,
     ) -> Self {
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder.publish(modules);
+            builder.publish(modules, dep_ids);
             builder.finish()
         };
         Self::new_programmable(sender, vec![gas_payment], pt, gas_budget, gas_price)

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -179,12 +179,16 @@ impl ProgrammableTransactionBuilder {
         })))
     }
 
-    pub fn publish_upgradeable(&mut self, modules: Vec<Vec<u8>>) -> Argument {
-        self.command(Command::Publish(modules))
+    pub fn publish_upgradeable(
+        &mut self,
+        modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+    ) -> Argument {
+        self.command(Command::Publish(modules, dep_ids))
     }
 
-    pub fn publish(&mut self, modules: Vec<Vec<u8>>) {
-        let cap = self.publish_upgradeable(modules);
+    pub fn publish(&mut self, modules: Vec<Vec<u8>>, dep_ids: Vec<ObjectID>) {
+        let cap = self.publish_upgradeable(modules, dep_ids);
         self.commands
             .push(Command::MoveCall(Box::new(ProgrammableMoveCall {
                 package: SUI_FRAMEWORK_OBJECT_ID,

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -816,7 +816,7 @@ fn test_sponsored_transaction_validity_check() {
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.publish(vec![vec![]]);
+        builder.publish(vec![vec![]], vec![]);
         builder.finish()
     };
     let kind = TransactionKind::programmable(pt);

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -528,7 +528,13 @@ impl SuiClientCommands {
 
                 let data = client
                     .transaction_builder()
-                    .publish(sender, compiled_modules, gas, gas_budget)
+                    .publish(
+                        sender,
+                        compiled_modules,
+                        dependencies.published.into_values().collect(),
+                        gas,
+                        gas_budget,
+                    )
                     .await?;
                 let signature =
                     context

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_core::test_utils::dummy_transaction_effects;
-use sui_framework_build::compiled_package::{package_dependencies, BuildConfig};
+use sui_framework_build::compiled_package::BuildConfig;
 use sui_json_rpc_types::SuiObjectInfo;
 use sui_keys::keystore::AccountKeystore;
 use sui_keys::keystore::Keystore;
@@ -291,9 +291,7 @@ pub fn create_publish_move_package_transaction(
     let compiled_package = sui_framework::build_move_package(&path, build_config).unwrap();
     let all_module_bytes =
         compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
-
-    let compiled_modules = compiled_package.get_modules().collect::<Vec<_>>();
-    let dependencies = package_dependencies(compiled_modules);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
 
     let data = TransactionData::new_module(
         sender,

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -96,7 +96,7 @@ pub async fn publish_package_with_wallet(
     let transaction = {
         let data = client
             .transaction_builder()
-            .publish(sender, all_module_bytes, None, GAS_BUDGET)
+            .publish(sender, all_module_bytes, vec![], None, GAS_BUDGET)
             .await
             .unwrap();
 


### PR DESCRIPTION
Adds `ObjectID` address list to `Publish` command and `publish` functions and propagates the change.

Status: Rust tests are updated with helper to derive dependencies and pass. Still working on getting existing e2e SDK tests to pass, then should be good to go. I tried updating [`Command.ts`](https://github.com/MystenLabs/sui/blob/b1d8ccb558ce1011ee6a1dcd32ed4617731ded31/sdk/typescript/src/builder/Commands.ts#L103-L106) but still get this error:

>  test/e2e/coin-metadata.test.ts > Test Coin Metadata > Test accessing coin metadata
[1]      → Error executing transaction with request type: Error: RPC Error: malformed utf8

Will try reproduce these locally and fix next, but maybe there's an easy idea why this is going wrong.

---

Separate question (for future PR probably): (How) will we make use of the `Publish::Command` to create txn (`programmable_transaction_builder::publish` [uses `MoveCall`](https://github.com/MystenLabs/sui/blob/b47d759a73bff64b7593a3c892a5640353d9ff78/crates/sui-types/src/programmable_transaction_builder.rs#L186-L196) right now).

## Test Plan 

Updated existing tests, dedicated tests to follow actual use of dependencies.
