### PR TITLE
[TypeScript SDK] Dedupe object ids in transaction builder

### DIFF
--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -30,9 +30,9 @@ export async function mint(address: string) {
         Transaction.Commands.MoveCall({
             target: '0x2::devnet_nft::mint',
             arguments: [
-                tx.input('Example NFT'),
-                tx.input('An example NFT.'),
-                tx.input(
+                tx.pure('Example NFT'),
+                tx.pure('An example NFT.'),
+                tx.pure(
                     'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty'
                 ),
             ],

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -49,8 +49,8 @@ export function TransferNFTForm({ objectId }: { objectId: string }) {
             tx.setGasBudget(DEFAULT_NFT_TRANSFER_GAS_FEE);
             tx.add(
                 Transaction.Commands.TransferObjects(
-                    [tx.input(objectId)],
-                    tx.input(to)
+                    [tx.object(objectId)],
+                    tx.pure(to)
                 )
             );
             return signer.signAndExecuteTransaction(tx);

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -62,7 +62,7 @@ function TransferCoinPage() {
                     tx.add(
                         Transaction.Commands.TransferObjects(
                             [tx.gas],
-                            tx.input(formData.to)
+                            tx.pure(formData.to)
                         )
                     );
                     tx.setGasPayment(
@@ -87,36 +87,40 @@ function TransferCoinPage() {
                     const coin = tx.add(
                         Transaction.Commands.SplitCoin(
                             tx.gas,
-                            tx.input(bigIntAmount)
+                            tx.pure(bigIntAmount)
                         )
                     );
                     tx.add(
                         Transaction.Commands.TransferObjects(
                             [coin],
-                            tx.input(formData.to)
+                            tx.pure(formData.to)
                         )
                     );
                 } else {
-                    const primaryCoinInput = tx.input(primaryCoin);
+                    const primaryCoinInput = tx.object(
+                        primaryCoin.coinObjectId
+                    );
                     if (coins.length) {
                         // TODO: This could just merge a subset of coins that meet the balance requirements instead of all of them.
                         tx.add(
                             Transaction.Commands.MergeCoins(
                                 primaryCoinInput,
-                                coins.map((coin) => tx.input(coin.coinObjectId))
+                                coins.map((coin) =>
+                                    tx.object(coin.coinObjectId)
+                                )
                             )
                         );
                     }
                     const coin = tx.add(
                         Transaction.Commands.SplitCoin(
                             primaryCoinInput,
-                            tx.input(bigIntAmount)
+                            tx.pure(bigIntAmount)
                         )
                     );
                     tx.add(
                         Transaction.Commands.TransferObjects(
                             [coin],
-                            tx.input(formData.to)
+                            tx.pure(formData.to)
                         )
                     );
                 }

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -77,6 +77,7 @@ export class Coin {
         );
     }
 
+    // TODO: we should replace this function with the SDK implementation
     /**
      * Stake `amount` of Coin<T> to `validator`. Technically it means user stakes `amount` of Coin<T> to `validator`,
      * such that `validator` will stake the `amount` of Coin<T> for the user.
@@ -102,15 +103,15 @@ export class Coin {
             const tx = new Transaction();
             tx.setGasBudget(DEFAULT_GAS_BUDGET_FOR_STAKE);
             const stakeCoin = tx.add(
-                Transaction.Commands.SplitCoin(tx.gas, tx.input(amount))
+                Transaction.Commands.SplitCoin(tx.gas, tx.pure(amount))
             );
             tx.add(
                 Transaction.Commands.MoveCall({
                     target: '0x2::sui_system::request_add_stake',
                     arguments: [
-                        tx.input(SUI_SYSTEM_STATE_OBJECT_ID),
+                        tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
                         stakeCoin,
-                        tx.input(validator),
+                        tx.pure(validator),
                     ],
                 })
             );
@@ -134,9 +135,9 @@ export class Coin {
                 Transaction.Commands.MoveCall({
                     target: '0x2::sui_system::request_withdraw_stake',
                     arguments: [
-                        tx.input(SUI_SYSTEM_STATE_OBJECT_ID),
-                        tx.input(stake),
-                        tx.input(stakedSuiId),
+                        tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+                        tx.object(stake),
+                        tx.object(stakedSuiId),
                     ],
                 })
             );

--- a/sdk/typescript/src/builder/Commands.ts
+++ b/sdk/typescript/src/builder/Commands.ts
@@ -27,6 +27,7 @@ export const TransactionInput = object({
   index: integer(),
   name: optional(string()),
   value: optional(any()),
+  type: optional(union([literal('pure'), literal('object')])),
 });
 export type TransactionInput = Infer<typeof TransactionInput>;
 

--- a/sdk/typescript/src/builder/TransactionData.ts
+++ b/sdk/typescript/src/builder/TransactionData.ts
@@ -8,6 +8,7 @@ import {
   define,
   Infer,
   integer,
+  is,
   literal,
   nullable,
   object,
@@ -19,7 +20,7 @@ import { sha256Hash } from '../cryptography/hash';
 import { normalizeSuiAddress, SuiObjectRef } from '../types';
 import { builder } from './bcs';
 import { TransactionCommand, TransactionInput } from './Commands';
-import { BuilderCallArg } from './Inputs';
+import { BuilderCallArg, PureCallArg } from './Inputs';
 import { create } from './utils';
 
 export const TransactionExpiration = optional(
@@ -86,7 +87,15 @@ export class TransactionDataBuilder {
         expiration: data.V1.expiration,
         gasConfig: data.V1.gasData,
         inputs: programmableTx.inputs.map((value: unknown, index: number) =>
-          create({ kind: 'Input', value, index }, TransactionInput),
+          create(
+            {
+              kind: 'Input',
+              value,
+              index,
+              type: is(value, PureCallArg) ? 'pure' : 'object',
+            },
+            TransactionInput,
+          ),
         ),
         commands: programmableTx.commands,
       },

--- a/sdk/typescript/src/builder/__tests__/Transaction.test.ts
+++ b/sdk/typescript/src/builder/__tests__/Transaction.test.ts
@@ -13,7 +13,7 @@ it('can construct and serialize an empty tranaction', () => {
 
 it('can be serialized and deserialized to the same values', () => {
   const tx = new Transaction();
-  tx.add(Commands.SplitCoin(tx.gas, tx.input(100)));
+  tx.add(Commands.SplitCoin(tx.gas, tx.pure(100)));
   const serialized = tx.serialize();
   const tx2 = Transaction.from(serialized);
   expect(serialized).toEqual(tx2.serialize());
@@ -21,8 +21,8 @@ it('can be serialized and deserialized to the same values', () => {
 
 it('allows transfer with the result of split commands', () => {
   const tx = new Transaction();
-  const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(100)));
-  tx.add(Commands.TransferObjects([coin], tx.input('0x2')));
+  const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(100)));
+  tx.add(Commands.TransferObjects([coin], tx.object('0x2')));
 });
 
 it('supports nested results through either array index or destructuring', () => {
@@ -54,30 +54,30 @@ describe('offline build', () => {
 
   it('builds a split command', async () => {
     const tx = setup();
-    tx.add(Commands.SplitCoin(tx.gas, tx.input(Inputs.Pure('u64', 100))));
+    tx.add(Commands.SplitCoin(tx.gas, tx.pure(Inputs.Pure('u64', 100))));
     await tx.build();
   });
 
   it('infers the type of inputs', async () => {
     const tx = setup();
-    tx.add(Commands.SplitCoin(tx.gas, tx.input(100)));
+    tx.add(Commands.SplitCoin(tx.gas, tx.pure(100)));
     await tx.build();
   });
 
   it('builds a more complex interaction', async () => {
     const tx = setup();
-    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(100)));
+    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(100)));
     tx.add(
-      Commands.MergeCoins(tx.gas, [coin, tx.input(Inputs.ObjectRef(ref()))]),
+      Commands.MergeCoins(tx.gas, [coin, tx.object(Inputs.ObjectRef(ref()))]),
     );
     tx.add(
       Commands.MoveCall({
         target: '0x2::devnet_nft::mint',
         typeArguments: [],
         arguments: [
-          tx.input(Inputs.Pure('string', 'foo')),
-          tx.input(Inputs.Pure('string', 'bar')),
-          tx.input(Inputs.Pure('string', 'baz')),
+          tx.pure(Inputs.Pure('string', 'foo')),
+          tx.pure(Inputs.Pure('string', 'bar')),
+          tx.pure(Inputs.Pure('string', 'baz')),
         ],
       }),
     );
@@ -86,18 +86,18 @@ describe('offline build', () => {
 
   it('builds a more complex interaction', async () => {
     const tx = setup();
-    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(100)));
+    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(100)));
     tx.add(
-      Commands.MergeCoins(tx.gas, [coin, tx.input(Inputs.ObjectRef(ref()))]),
+      Commands.MergeCoins(tx.gas, [coin, tx.object(Inputs.ObjectRef(ref()))]),
     );
     tx.add(
       Commands.MoveCall({
         target: '0x2::devnet_nft::mint',
         typeArguments: [],
         arguments: [
-          tx.input(Inputs.Pure('string', 'foo')),
-          tx.input(Inputs.Pure('string', 'bar')),
-          tx.input(Inputs.Pure('string', 'baz')),
+          tx.pure(Inputs.Pure('string', 'foo')),
+          tx.pure(Inputs.Pure('string', 'bar')),
+          tx.pure(Inputs.Pure('string', 'baz')),
         ],
       }),
     );

--- a/sdk/typescript/src/builder/index.ts
+++ b/sdk/typescript/src/builder/index.ts
@@ -5,3 +5,4 @@ export * from './Transaction';
 export * from './Commands';
 export * from './Inputs';
 export * from './bcs';
+export * from './serializer';

--- a/sdk/typescript/src/framework/sui-system-state.ts
+++ b/sdk/typescript/src/framework/sui-system-state.ts
@@ -42,14 +42,14 @@ export class SuiSystemStateUtil {
   ): Promise<Transaction> {
     // TODO: validate coin types and handle locked coins
     const tx = new Transaction();
-    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(amount)));
+    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(amount)));
     tx.add(
       Commands.MoveCall({
         target: `${SUI_FRAMEWORK_ADDRESS}::${SUI_SYSTEM_MODULE_NAME}::${ADD_STAKE_FUN_NAME}`,
         arguments: [
-          tx.input(SUI_SYSTEM_STATE_OBJECT_ID),
+          tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
           coin,
-          tx.input(validatorAddress),
+          tx.pure(validatorAddress),
         ],
       }),
     );
@@ -77,9 +77,9 @@ export class SuiSystemStateUtil {
       Commands.MoveCall({
         target: `${SUI_FRAMEWORK_ADDRESS}::${SUI_SYSTEM_MODULE_NAME}::${WITHDRAW_STAKE_FUN_NAME}`,
         arguments: [
-          tx.input(SUI_SYSTEM_STATE_OBJECT_ID),
-          tx.input(stake),
-          tx.input(stakedCoinId),
+          tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+          tx.object(stake),
+          tx.object(stakedCoinId),
         ],
       }),
     );

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -27,9 +27,9 @@ describe('Coin related API', () => {
     coinToSplit = coins[0].objectId;
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    const recieverInput = tx.input(toolbox.address());
+    const recieverInput = tx.pure(toolbox.address());
     SPLIT_AMOUNTS.forEach((amount) => {
-      const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(amount)));
+      const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(amount)));
       tx.add(Commands.TransferObjects([coin], recieverInput));
     });
 

--- a/sdk/typescript/test/e2e/data/serializer/sources/serializer.move
+++ b/sdk/typescript/test/e2e/data/serializer/sources/serializer.move
@@ -14,7 +14,7 @@ module serializer::serializer_tests {
      fun init(ctx: &mut TxContext) {
         transfer::share_object(MutableShared {
             id: object::new(ctx),
-            value: 0,
+            value: 1,
         })
     }
 

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -24,8 +24,8 @@ describe('Test dev inspect', () => {
   it.skip('Dev inspect split + transfer', async () => {
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(10)));
-    tx.add(Commands.TransferObjects([coin], tx.input(toolbox.address())));
+    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(10)));
+    tx.add(Commands.TransferObjects([coin], tx.pure(toolbox.address())));
     await validateDevInspectTransaction(toolbox.signer, tx, 'success');
   });
 
@@ -38,12 +38,12 @@ describe('Test dev inspect', () => {
       Commands.MoveCall({
         target: `${packageId}::serializer_tests::return_struct`,
         typeArguments: ['0x2::coin::Coin<0x2::sui::SUI>'],
-        arguments: [tx.input(coins[0].objectId)],
+        arguments: [tx.pure(coins[0].objectId)],
       }),
     );
 
     // TODO: Ideally dev inspect transactions wouldn't need this, but they do for now
-    tx.add(Commands.TransferObjects([obj], tx.input(toolbox.address())));
+    tx.add(Commands.TransferObjects([obj], tx.pure(toolbox.address())));
 
     await validateDevInspectTransaction(toolbox.signer, tx, 'success');
   });

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -25,7 +25,7 @@ describe('Test Move call with strings', () => {
     tx.add(
       Commands.MoveCall({
         target: `${packageId}::entry_point_string::${funcName}`,
-        arguments: [tx.input(str)],
+        arguments: [tx.pure(str)],
       }),
     );
     const result = await toolbox.signer.signAndExecuteTransaction(tx);

--- a/sdk/typescript/test/e2e/event-subscription.test.ts
+++ b/sdk/typescript/test/e2e/event-subscription.test.ts
@@ -29,7 +29,7 @@ describe('Event Subscription API', () => {
 
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    tx.add(Commands.TransferObjects([tx.gas], tx.input(DEFAULT_RECIPIENT)));
+    tx.add(Commands.TransferObjects([tx.gas], tx.pure(DEFAULT_RECIPIENT)));
     await toolbox.signer.signAndExecuteTransaction(tx);
 
     const subFoundAndRemoved = await toolbox.provider.unsubscribeEvent(

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -27,7 +27,7 @@ describe('Test ID as args to entry functions', () => {
       Commands.MoveCall({
         target: `${packageId}::test::test_id`,
         arguments: [
-          tx.input(
+          tx.pure(
             '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
           ),
         ],

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -28,7 +28,7 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
     tx.add(
       Commands.MoveCall({
         target: `${packageId}::entry_point_vector::mint`,
-        arguments: [tx.input(String(val))],
+        arguments: [tx.pure(String(val))],
       }),
     );
     const result = await toolbox.signer.signAndExecuteTransaction(tx);
@@ -40,7 +40,7 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
     const vec = tx.add(
-      Commands.MakeMoveVec({ objects: objects.map((id) => tx.input(id)) }),
+      Commands.MakeMoveVec({ objects: objects.map((id) => tx.object(id)) }),
     );
     tx.add(
       Commands.MoveCall({
@@ -71,14 +71,14 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
     const vec = tx.add(
       Commands.MakeMoveVec({
-        objects: [tx.input(coinIDs[1]), tx.input(coinIDs[2])],
+        objects: [tx.object(coinIDs[1]), tx.object(coinIDs[2])],
       }),
     );
     tx.add(
       Commands.MoveCall({
         target: `${SUI_FRAMEWORK_ADDRESS}::pay::join_vec`,
         typeArguments: ['0x2::sui::SUI'],
-        arguments: [tx.input(coinIDs[0]), vec],
+        arguments: [tx.object(coinIDs[0]), vec],
       }),
     );
     tx.setGasPayment([coins[3]]);

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -1,24 +1,42 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import {
   Commands,
   getExecutionStatusType,
+  getObjectId,
+  getSharedObjectInitialVersion,
   getTransactionDigest,
+  ObjectId,
   RawSigner,
+  SuiTransactionResponse,
   SUI_SYSTEM_STATE_OBJECT_ID,
   Transaction,
+  getCreatedObjects,
 } from '../../src';
 import {
   DEFAULT_RECIPIENT,
   DEFAULT_GAS_BUDGET,
   setup,
   TestToolbox,
+  publishPackage,
 } from './utils/setup';
 
 describe('Transaction Builders', () => {
   let toolbox: TestToolbox;
+  let packageId: ObjectId;
+  let publishTxn: SuiTransactionResponse;
+  let sharedObjectId: ObjectId;
+
+  beforeAll(async () => {
+    const packagePath = __dirname + '/./data/serializer';
+    ({ packageId, publishTxn } = await publishPackage(packagePath));
+    const sharedObject = getCreatedObjects(publishTxn)!.filter(
+      (o) => getSharedObjectInitialVersion(o.owner) !== undefined,
+    )[0];
+    sharedObjectId = getObjectId(sharedObject);
+  });
 
   beforeEach(async () => {
     toolbox = await setup();
@@ -29,11 +47,11 @@ describe('Transaction Builders', () => {
     const tx = new Transaction();
     const coin = tx.add(
       Commands.SplitCoin(
-        tx.input(coins[0].objectId),
-        tx.input(DEFAULT_GAS_BUDGET * 2),
+        tx.object(coins[0].objectId),
+        tx.pure(DEFAULT_GAS_BUDGET * 2),
       ),
     );
-    tx.add(Commands.TransferObjects([coin], tx.input(toolbox.address())));
+    tx.add(Commands.TransferObjects([coin], tx.pure(toolbox.address())));
     await validateTransaction(toolbox.signer, tx);
   });
 
@@ -41,8 +59,8 @@ describe('Transaction Builders', () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
     const tx = new Transaction();
     tx.add(
-      Commands.MergeCoins(tx.input(coins[0].objectId), [
-        tx.input(coins[1].objectId),
+      Commands.MergeCoins(tx.object(coins[0].objectId), [
+        tx.object(coins[1].objectId),
       ]),
     );
     await validateTransaction(toolbox.signer, tx);
@@ -54,9 +72,9 @@ describe('Transaction Builders', () => {
       Commands.MoveCall({
         target: '0x2::devnet_nft::mint',
         arguments: [
-          tx.input('Example NFT'),
-          tx.input('An NFT created by the wallet Command Line Tool'),
-          tx.input(
+          tx.pure('Example NFT'),
+          tx.pure('An NFT created by the wallet Command Line Tool'),
+          tx.pure(
             'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
           ),
         ],
@@ -76,9 +94,9 @@ describe('Transaction Builders', () => {
       Commands.MoveCall({
         target: '0x2::sui_system::request_add_stake',
         arguments: [
-          tx.input(SUI_SYSTEM_STATE_OBJECT_ID),
-          tx.input(coins[2].objectId),
-          tx.input(validatorAddress),
+          tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+          tx.object(coins[2].objectId),
+          tx.pure(validatorAddress),
         ],
       }),
     );
@@ -88,14 +106,14 @@ describe('Transaction Builders', () => {
 
   it('SplitCoin from gas object + TransferObjects', async () => {
     const tx = new Transaction();
-    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.input(1)));
-    tx.add(Commands.TransferObjects([coin], tx.input(DEFAULT_RECIPIENT)));
+    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(1)));
+    tx.add(Commands.TransferObjects([coin], tx.pure(DEFAULT_RECIPIENT)));
     await validateTransaction(toolbox.signer, tx);
   });
 
   it('TransferObjects gas object', async () => {
     const tx = new Transaction();
-    tx.add(Commands.TransferObjects([tx.gas], tx.input(DEFAULT_RECIPIENT)));
+    tx.add(Commands.TransferObjects([tx.gas], tx.pure(DEFAULT_RECIPIENT)));
     await validateTransaction(toolbox.signer, tx);
   });
 
@@ -104,9 +122,26 @@ describe('Transaction Builders', () => {
     const tx = new Transaction();
     tx.add(
       Commands.TransferObjects(
-        [tx.input(coins[0].objectId)],
-        tx.input(DEFAULT_RECIPIENT),
+        [tx.object(coins[0].objectId)],
+        tx.pure(DEFAULT_RECIPIENT),
       ),
+    );
+    await validateTransaction(toolbox.signer, tx);
+  });
+
+  it('Move Shared Object Call with mixed usage of mutable and immutable references', async () => {
+    const tx = new Transaction();
+    tx.add(
+      Commands.MoveCall({
+        target: `${packageId}::serializer_tests::value`,
+        arguments: [tx.object(sharedObjectId)],
+      }),
+    );
+    tx.add(
+      Commands.MoveCall({
+        target: `${packageId}::serializer_tests::set_value`,
+        arguments: [tx.object(sharedObjectId)],
+      }),
     );
     await validateTransaction(toolbox.signer, tx);
   });

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -64,9 +64,9 @@ describe('Transaction Serialization and deserialization', () => {
       Commands.MoveCall({
         target: '0x2::sui_system::request_add_stake',
         arguments: [
-          tx.input(SUI_SYSTEM_STATE_OBJECT_ID),
-          tx.input(coins[2].objectId),
-          tx.input(validatorAddress),
+          tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+          tx.object(coins[2].objectId),
+          tx.pure(validatorAddress),
         ],
       }),
     );
@@ -78,7 +78,7 @@ describe('Transaction Serialization and deserialization', () => {
     tx.add(
       Commands.MoveCall({
         target: `${packageId}::serializer_tests::value`,
-        arguments: [tx.input(sharedObjectId)],
+        arguments: [tx.object(sharedObjectId)],
       }),
     );
     await serializeAndDeserialize(tx, [false]);
@@ -89,15 +89,15 @@ describe('Transaction Serialization and deserialization', () => {
     tx.add(
       Commands.MoveCall({
         target: `${packageId}::serializer_tests::value`,
-        arguments: [tx.input(sharedObjectId)],
+        arguments: [tx.object(sharedObjectId)],
       }),
     );
     tx.add(
       Commands.MoveCall({
         target: `${packageId}::serializer_tests::set_value`,
-        arguments: [tx.input(sharedObjectId)],
+        arguments: [tx.object(sharedObjectId)],
       }),
     );
-    await serializeAndDeserialize(tx, [false, true]);
+    await serializeAndDeserialize(tx, [true]);
   });
 });


### PR DESCRIPTION
## Description 

We need to dedup object ids, otherwise it will fail on the rust side. This PR

- implemented dedup
- change the interface so that people need to provide hints about `pure` vs `object`

## Test Plan 

1. added e2e tests
2. manually tested wallet(send + staking) and explorer(module function execution)
![CleanShot 2023-03-11 at 04 17 40](https://user-images.githubusercontent.com/76067158/224476957-5c8a3bf0-5107-4789-a195-8ce4989e8578.png)
![CleanShot 2023-03-11 at 04 16 25](https://user-images.githubusercontent.com/76067158/224476960-236ce3ef-e4df-4457-9dba-f089edce6735.png)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
