### PR TITLE
[sui-node/ encode push metrics in pb]

### DIFF
--- a/crates/sui-node/src/metrics.rs
+++ b/crates/sui-node/src/metrics.rs
@@ -1,12 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use axum::{
+    extract::Extension,
+    http::{header, StatusCode},
+    routing::get,
+    Router,
+};
 
-use axum::{extract::Extension, http::StatusCode, routing::get, Router};
 use mysten_network::metrics::MetricsCallbackProvider;
 use prometheus::{
-    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, IntCounterVec,
-    IntGaugeVec, Registry, TextEncoder,
+    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, Encoder,
+    IntCounterVec, IntGaugeVec, Registry, TextEncoder, PROTOBUF_FORMAT,
 };
+
 use std::net::SocketAddr;
 use std::time::Duration;
 use sui_network::tonic::Code;
@@ -92,7 +98,6 @@ impl MetricsPushClient {
 /// Starts a task to periodically push metrics to a configured endpoint if a metrics push endpoint
 /// is configured.
 pub fn start_metrics_push_task(config: &sui_config::NodeConfig, registry: RegistryService) {
-    use anyhow::Context;
     use fastcrypto::traits::KeyPair;
     use sui_config::node::MetricsConfig;
 
@@ -119,21 +124,28 @@ pub fn start_metrics_push_task(config: &sui_config::NodeConfig, registry: Regist
         url: &reqwest::Url,
         registry: &RegistryService,
     ) -> Result<(), anyhow::Error> {
-        let metrics = TextEncoder
-            .encode_to_string(&registry.gather_all())
-            .context("encoding metrics")?;
+        let mut buf: Vec<u8> = vec![];
+        let encoder = prometheus::ProtobufEncoder::new();
+        encoder.encode(&registry.gather_all(), &mut buf)?;
 
         let response = client
             .client()
             .post(url.to_owned())
-            .body(metrics)
+            .header(header::CONTENT_TYPE, PROTOBUF_FORMAT)
+            .body(buf)
             .send()
             .await?;
 
         if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(body) => body,
+                Err(error) => format!("couldn't decode response body; {error}"),
+            };
             return Err(anyhow::anyhow!(
-                "metrics push failed with status: {}",
-                response.status()
+                "metrics push failed: [{}]:{}",
+                status,
+                body
             ));
         }
 


### PR DESCRIPTION
Summary:

we need to encode our pushed metrics in protobuf format. this diff changes to that encoding scheme from the text exposition format.

Test Plan:

tested against proxy code.


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
