### PR TITLE
[RPC][1 of 2] Add options to executeTransaction

### DIFF
--- a/.changeset/little-pears-shave.md
+++ b/.changeset/little-pears-shave.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Update `executeTransaction` and `signAndExecuteTransaction` to take in an additional parameter `SuiTransactionResponseOptions` which is used to specify which fields to include in `SuiTransactionResponse` (e.g., transaction, effects, events, etc). By default, only the transaction digest will be included.

--- a/.changeset/witty-peaches-agree.md
+++ b/.changeset/witty-peaches-agree.md
@@ -1,0 +1,6 @@
+---
+"@mysten/wallet-adapter-unsafe-burner": minor
+"@mysten/wallet-standard": minor
+---
+
+Add an optional `contentOptions` field to `SuiSignAndExecuteTransactionOptions` to specify which fields to include in `SuiTransactionResponse` (e.g., transaction, effects, events, etc). By default, only the transaction digest will be included.

--- a/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
+++ b/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
@@ -89,7 +89,16 @@ export function ModuleFunction({
                         ) ?? [],
                 })
             );
-            const result = await signAndExecuteTransaction({ transaction: tx });
+            const result = await signAndExecuteTransaction({
+                transaction: tx,
+                options: {
+                    contentOptions: {
+                        showEffect: true,
+                        showEvents: true,
+                        showInputs: true,
+                    },
+                },
+            });
             if (getExecutionStatusType(result) === 'failure') {
                 throw new Error(
                     getExecutionStatusError(result) || 'Transaction failed'

--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -40,7 +40,11 @@ export async function mint(address: string) {
     );
     tx.setGasBudget(30000);
 
-    const result = await signer.signAndExecuteTransaction(tx);
+    const result = await signer.signAndExecuteTransaction(tx, {
+        showInput: true,
+        showEffects: true,
+        showEvents: true,
+    });
 
     return result;
 }

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -53,7 +53,11 @@ export function TransferNFTForm({ objectId }: { objectId: string }) {
                     tx.pure(to)
                 )
             );
-            return signer.signAndExecuteTransaction(tx);
+            return signer.signAndExecuteTransaction(tx, {
+                showInput: true,
+                showEffects: true,
+                showEvents: true,
+            });
         },
         onSuccess: (response) => {
             queryClient.invalidateQueries(['object', objectId]);

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -75,7 +75,11 @@ function TransferCoinPage() {
                             }))
                     );
 
-                    return signer.signAndExecuteTransaction(tx);
+                    return signer.signAndExecuteTransaction(tx, {
+                        showInput: true,
+                        showEffects: true,
+                        showEvents: true,
+                    });
                 }
 
                 const bigIntAmount = parseAmount(formData.amount, coinDecimals);
@@ -125,7 +129,11 @@ function TransferCoinPage() {
                     );
                 }
 
-                return signer.signAndExecuteTransaction(tx);
+                return signer.signAndExecuteTransaction(tx, {
+                    showInput: true,
+                    showEffects: true,
+                    showEvents: true,
+                });
             } catch (error) {
                 transaction.setTag('failure', true);
                 throw error;

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -115,7 +115,11 @@ export class Coin {
                     ],
                 })
             );
-            return await signer.signAndExecuteTransaction(tx);
+            return await signer.signAndExecuteTransaction(tx, {
+                showInput: true,
+                showEffects: true,
+                showEvents: true,
+            });
         } finally {
             span.finish();
             transaction.finish();
@@ -141,7 +145,11 @@ export class Coin {
                     ],
                 })
             );
-            return await signer.signAndExecuteTransaction(tx);
+            return await signer.signAndExecuteTransaction(tx, {
+                showInput: true,
+                showEffects: true,
+                showEvents: true,
+            });
         } finally {
             transaction.finish();
         }

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -73,6 +73,7 @@ export const respondToTransactionRequest = createAsyncThunk<
                     } else {
                         txResult = await signer.signAndExecuteTransaction(
                             tx,
+                            txRequest.tx.options?.contentOptions,
                             txRequest.tx.options?.requestType
                         );
                     }

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -24,6 +24,7 @@ use sui_core::{
 };
 use sui_json_rpc_types::{
     SuiObjectDataOptions, SuiObjectResponse, SuiTransactionEffects, SuiTransactionEffectsAPI,
+    SuiTransactionResponseOptions,
 };
 use sui_network::{DEFAULT_CONNECT_TIMEOUT_SEC, DEFAULT_REQUEST_TIMEOUT_SEC};
 use sui_sdk::{SuiClient, SuiClientBuilder};
@@ -44,10 +45,7 @@ use sui_types::{
     },
     object::Object,
 };
-use sui_types::{
-    base_types::ObjectRef, crypto::AuthorityStrongQuorumSignInfo,
-    messages::ExecuteTransactionRequestType, object::Owner,
-};
+use sui_types::{base_types::ObjectRef, crypto::AuthorityStrongQuorumSignInfo, object::Owner};
 use sui_types::{
     base_types::{AuthorityName, SuiAddress},
     sui_system_state::SuiSystemStateTrait,
@@ -551,8 +549,8 @@ impl ValidatorProxy for FullNodeProxy {
                 .quorum_driver()
                 .execute_transaction(
                     tx.clone(),
-                    // We need to use WaitForLocalExecution to make sure objects are updated on FN
-                    Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+                    SuiTransactionResponseOptions::new().with_effects(),
+                    None,
                 )
                 .await
             {

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -138,6 +138,7 @@ impl TestContext {
                 Transaction::from_data(txn_data, Intent::default(), vec![signature])
                     .verify()
                     .unwrap(),
+                SuiTransactionResponseOptions::new().with_effects(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await

--- a/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -57,7 +57,11 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
 
         let response = fullnode
             .quorum_driver()
-            .execute_transaction(txn, Some(ExecuteTransactionRequestType::WaitForEffectsCert))
+            .execute_transaction(
+                txn,
+                SuiTransactionResponseOptions::new().with_effects(),
+                Some(ExecuteTransactionRequestType::WaitForEffectsCert),
+            )
             .await?;
 
         assert!(!response.confirmed_local_execution.unwrap());
@@ -82,6 +86,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
             .quorum_driver()
             .execute_transaction(
                 txn,
+                SuiTransactionResponseOptions::new().with_effects(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -16,6 +16,7 @@ use shared_crypto::intent::Intent;
 use sui::client_commands::WalletContext;
 use sui_json_rpc_types::{
     SuiObjectDataOptions, SuiObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
+    SuiTransactionResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_types::object::Owner;
@@ -414,6 +415,7 @@ impl SimpleFaucet {
             .quorum_driver()
             .execute_transaction(
                 tx.clone(),
+                SuiTransactionResponseOptions::new().with_effects(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await

--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -8,7 +8,10 @@ use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::RpcModule;
 use sui_json_rpc::api::{WriteApiClient, WriteApiServer};
 use sui_json_rpc::SuiRpcModule;
-use sui_json_rpc_types::{DevInspectResults, DryRunTransactionResponse, SuiTransactionResponse};
+use sui_json_rpc_types::{
+    DevInspectResults, DryRunTransactionResponse, SuiTransactionResponse,
+    SuiTransactionResponseOptions,
+};
 use sui_open_rpc::Module;
 use sui_types::base_types::{EpochId, SuiAddress};
 use sui_types::messages::ExecuteTransactionRequestType;
@@ -31,10 +34,11 @@ impl WriteApiServer for WriteApi {
         &self,
         tx_bytes: Base64,
         signatures: Vec<Base64>,
-        request_type: ExecuteTransactionRequestType,
+        options: Option<SuiTransactionResponseOptions>,
+        request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<SuiTransactionResponse> {
         self.fullnode
-            .execute_transaction(tx_bytes, signatures, request_type)
+            .execute_transaction(tx_bytes, signatures, options, request_type)
             .await
     }
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -19,10 +19,10 @@ use sui_types::digests::TransactionEventsDigest;
 use sui_types::error::ExecutionError;
 use sui_types::gas::GasCostSummary;
 use sui_types::messages::{
-    Argument, Command, ExecutionStatus, GenesisObject, InputObjectKind, ProgrammableMoveCall,
-    ProgrammableTransaction, SenderSignedData, TransactionData, TransactionDataAPI,
-    TransactionEffects, TransactionEffectsAPI, TransactionEvents, TransactionKind,
-    VersionedProtocolMessage,
+    Argument, Command, ExecuteTransactionRequestType, ExecutionStatus, GenesisObject,
+    InputObjectKind, ProgrammableMoveCall, ProgrammableTransaction, SenderSignedData,
+    TransactionData, TransactionDataAPI, TransactionEffects, TransactionEffectsAPI,
+    TransactionEvents, TransactionKind, VersionedProtocolMessage,
 };
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::move_package::disassemble_modules;
@@ -102,6 +102,26 @@ impl SuiTransactionResponseOptions {
     pub fn with_events(mut self) -> Self {
         self.show_events = true;
         self
+    }
+
+    /// default to return `WaitForEffectsCert` unless some options require
+    /// local execution
+    pub fn default_execution_request_type(&self) -> ExecuteTransactionRequestType {
+        // if people want effects or events, they typically want to wait for local execution
+        if self.require_effects() {
+            ExecuteTransactionRequestType::WaitForLocalExecution
+        } else {
+            ExecuteTransactionRequestType::WaitForEffectsCert
+        }
+    }
+
+    pub fn require_local_execution(&self) -> bool {
+        // TODO: change this if we add new options that require local execution
+        false
+    }
+
+    pub fn require_effects(&self) -> bool {
+        self.show_effects || self.show_events
     }
 }
 

--- a/crates/sui-json-rpc/src/api/write.rs
+++ b/crates/sui-json-rpc/src/api/write.rs
@@ -4,7 +4,10 @@
 use fastcrypto::encoding::Base64;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
-use sui_json_rpc_types::{DevInspectResults, DryRunTransactionResponse, SuiTransactionResponse};
+use sui_json_rpc_types::{
+    DevInspectResults, DryRunTransactionResponse, SuiTransactionResponse,
+    SuiTransactionResponseOptions,
+};
 
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{EpochId, SuiAddress};
@@ -22,6 +25,7 @@ pub trait WriteApi {
     ///     makes sure this node is aware of this transaction when client fires subsequent queries.
     ///     However if the node fails to execute the transaction locally in a timely manner,
     ///     a bool type in the response is set to false to indicated the case.
+    /// request_type is default to be `WaitForEffectsCert` unless options.show_events or options.show_effects is true
     #[method(name = "executeTransaction", deprecated)]
     async fn execute_transaction(
         &self,
@@ -29,8 +33,10 @@ pub trait WriteApi {
         tx_bytes: Base64,
         /// A list of signatures (`flag || signature || pubkey` bytes, as base-64 encoded string). Signature is committed to the intent message of the transaction data, as base-64 encoded string.
         signatures: Vec<Base64>,
-        /// The request type
-        request_type: ExecuteTransactionRequestType,
+        /// options for specifying the content to be returned
+        options: Option<SuiTransactionResponseOptions>,
+        /// The request type, derived from `SuiTransactionResponseOptions` if None
+        request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<SuiTransactionResponse>;
 
     /// Runs the transaction in dev-inspect mode. Which allows for nearly any

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -332,7 +332,7 @@ impl ReadApiServer for ReadApi {
         }
 
         // Fetch effects when `show_events` is true because events relies on effects
-        if opts.show_effects || opts.show_events {
+        if opts.require_effects() {
             temp_response.effects =
                 Some(self.state.get_executed_effects(digest).await.tap_err(
                     |err| debug!(tx_digest=?digest, "Failed to get effects: {:?}", err),

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -85,7 +85,8 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
         .execute_transaction(
             tx_bytes1,
             signatures,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(SuiTransactionResponseOptions::new().with_effects()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
 
@@ -123,7 +124,8 @@ async fn test_publish() -> Result<(), anyhow::Error> {
         .execute_transaction(
             tx_bytes,
             signatures,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(SuiTransactionResponseOptions::new().with_effects()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
     matches!(tx_response, SuiTransactionResponse {effects, ..} if effects.as_ref().unwrap().created().len() == 6);
@@ -174,7 +176,8 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
         .execute_transaction(
             tx_bytes,
             signatures,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(SuiTransactionResponseOptions::new().with_effects()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
     matches!(tx_response, SuiTransactionResponse {effects, ..} if effects.as_ref().unwrap().created().len() == 1);
@@ -286,7 +289,8 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
         .execute_transaction(
             tx_bytes,
             signatures,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(SuiTransactionResponseOptions::new().with_events()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
 
@@ -343,7 +347,8 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         .execute_transaction(
             tx_bytes,
             signatures,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(SuiTransactionResponseOptions::new().with_events()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
 
@@ -418,7 +423,8 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         .execute_transaction(
             tx_bytes,
             signatures,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(SuiTransactionResponseOptions::new().with_effects()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
 
@@ -458,7 +464,8 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
             .execute_transaction(
                 tx_bytes,
                 signatures,
-                ExecuteTransactionRequestType::WaitForLocalExecution,
+                Some(SuiTransactionResponseOptions::new()),
+                Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;
 
@@ -530,6 +537,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
                 .quorum_driver()
                 .execute_transaction(
                     tx,
+                    SuiTransactionResponseOptions::new(),
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )
                 .await
@@ -666,6 +674,7 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
                 .quorum_driver()
                 .execute_transaction(
                     tx,
+                    SuiTransactionResponseOptions::new(),
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )
                 .await
@@ -822,7 +831,8 @@ async fn test_locked_sui() -> Result<(), anyhow::Error> {
         .execute_transaction(
             tx_bytes,
             signatures,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(SuiTransactionResponseOptions::new()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
 
@@ -880,7 +890,8 @@ async fn test_staking() -> Result<(), anyhow::Error> {
         .execute_transaction(
             tx_bytes,
             signatures,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(SuiTransactionResponseOptions::new()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
 
@@ -941,7 +952,8 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
         .execute_transaction(
             tx_bytes,
             signatures,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(SuiTransactionResponseOptions::new()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -238,7 +238,7 @@
           "name": "Write API"
         }
       ],
-      "description": "Execute the transaction and wait for results if desired. Request types: 1. WaitForEffectsCert: waits for TransactionEffectsCert and then return to client.     This mode is a proxy for transaction finality. 2. WaitForLocalExecution: waits for TransactionEffectsCert and make sure the node     executed the transaction locally before returning the client. The local execution     makes sure this node is aware of this transaction when client fires subsequent queries.     However if the node fails to execute the transaction locally in a timely manner,     a bool type in the response is set to false to indicated the case.",
+      "description": "Execute the transaction and wait for results if desired. Request types: 1. WaitForEffectsCert: waits for TransactionEffectsCert and then return to client.     This mode is a proxy for transaction finality. 2. WaitForLocalExecution: waits for TransactionEffectsCert and make sure the node     executed the transaction locally before returning the client. The local execution     makes sure this node is aware of this transaction when client fires subsequent queries.     However if the node fails to execute the transaction locally in a timely manner,     a bool type in the response is set to false to indicated the case. request_type is default to be `WaitForEffectsCert` unless options.show_events or options.show_effects is true",
       "params": [
         {
           "name": "tx_bytes",
@@ -260,9 +260,15 @@
           }
         },
         {
+          "name": "options",
+          "description": "options for specifying the content to be returned",
+          "schema": {
+            "$ref": "#/components/schemas/TransactionResponseOptions"
+          }
+        },
+        {
           "name": "request_type",
-          "description": "The request type",
-          "required": true,
+          "description": "The request type, derived from `SuiTransactionResponseOptions` if None",
           "schema": {
             "$ref": "#/components/schemas/ExecuteTransactionRequestType"
           }
@@ -288,6 +294,14 @@
               "value": [
                 "AA9tNqi8gJ0UsWVhKjjrUWyCHKZaF/8fPInGM6vIsoTn7dcg58y4Ix7v3UjxtUilrT1SHuMysjm4Bc5oj8XPyQ0lVGRdA7hw4S62EKbvrTzoAfsk9oO2PfKUXStkY7jELA=="
               ]
+            },
+            {
+              "name": "options",
+              "value": {
+                "showInput": true,
+                "showEffects": true,
+                "showEvents": true
+              }
             },
             {
               "name": "request_type",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -184,6 +184,10 @@ impl RpcExampleProvider {
                             .collect::<Vec<_>>()),
                     ),
                     (
+                        "options",
+                        json!(SuiTransactionResponseOptions::full_content()),
+                    ),
+                    (
                         "request_type",
                         json!(ExecuteTransactionRequestType::WaitForLocalExecution),
                     ),

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -3,7 +3,7 @@
 
 use axum::{Extension, Json};
 use fastcrypto::encoding::{Encoding, Hex};
-use sui_json_rpc_types::SuiTransactionEffectsAPI;
+use sui_json_rpc_types::{SuiTransactionEffectsAPI, SuiTransactionResponseOptions};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{SignatureScheme, ToFromBytes};
 use sui_types::messages::{
@@ -128,6 +128,7 @@ pub async fn submit(
         .quorum_driver()
         .execute_transaction(
             signed_tx,
+            SuiTransactionResponseOptions::new().with_effects(),
             Some(ExecuteTransactionRequestType::WaitForEffectsCert),
         )
         .await?;

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -9,6 +9,7 @@ use anyhow::anyhow;
 use move_core_types::identifier::Identifier;
 use rand::seq::{IteratorRandom, SliceRandom};
 use signature::rand_core::OsRng;
+use sui_json_rpc_types::SuiTransactionResponseOptions;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 
 use crate::operations::Operations;
@@ -622,6 +623,7 @@ async fn test_transaction(
             Transaction::from_data(data.clone(), Intent::default(), vec![signature])
                 .verify()
                 .unwrap(),
+            SuiTransactionResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -85,7 +85,7 @@ async fn test_locked_sui() {
     let tx = to_sender_signed_transaction(tx, keystore.get_key(&address).unwrap());
     client
         .quorum_driver()
-        .execute_transaction(tx, None)
+        .execute_transaction(tx, SuiTransactionResponseOptions::new(), None)
         .await
         .unwrap();
 
@@ -192,7 +192,7 @@ async fn test_get_staked_sui() {
     let tx = to_sender_signed_transaction(delegation_tx, keystore.get_key(&address).unwrap());
     client
         .quorum_driver()
-        .execute_transaction(tx, None)
+        .execute_transaction(tx, SuiTransactionResponseOptions::new(), None)
         .await
         .unwrap();
 

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -14,7 +14,7 @@ use clap::Subcommand;
 use serde::Deserialize;
 
 use shared_crypto::intent::Intent;
-use sui_json_rpc_types::SuiObjectDataOptions;
+use sui_json_rpc_types::{SuiObjectDataOptions, SuiTransactionResponseOptions};
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_sdk::{
     json::SuiJsonValue,
@@ -105,6 +105,7 @@ impl TicTacToe {
             .execute_transaction(
                 Transaction::from_data(create_game_call, Intent::default(), vec![signature])
                     .verify()?,
+                SuiTransactionResponseOptions::full_content(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;
@@ -203,6 +204,7 @@ impl TicTacToe {
                 .execute_transaction(
                     Transaction::from_data(place_mark_call, Intent::default(), vec![signature])
                         .verify()?,
+                    SuiTransactionResponseOptions::new().with_effects(),
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )
                 .await?;

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use shared_crypto::intent::Intent;
+use sui_json_rpc_types::SuiTransactionResponseOptions;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_sdk::{
     types::{
@@ -42,6 +43,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .quorum_driver()
         .execute_transaction(
             Transaction::from_data(transfer_tx, Intent::default(), vec![signature]).verify()?,
+            SuiTransactionResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -436,15 +436,20 @@ impl QuorumDriver {
     pub async fn execute_transaction(
         &self,
         tx: VerifiedTransaction,
+        options: SuiTransactionResponseOptions,
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> SuiRpcResult<SuiTransactionResponse> {
         let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
-        let request_type =
-            request_type.unwrap_or(ExecuteTransactionRequestType::WaitForLocalExecution);
+        let request_type = request_type.unwrap_or_else(|| options.default_execution_request_type());
         let mut response: SuiTransactionResponse = self
             .api
             .http
-            .execute_transaction(tx_bytes, signatures, request_type.clone())
+            .execute_transaction(
+                tx_bytes,
+                signatures,
+                Some(options),
+                Some(request_type.clone()),
+            )
             .await?;
 
         Ok(match request_type {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -38,7 +38,7 @@ use sui_framework_build::compiled_package::{
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     DynamicFieldPage, SuiObjectData, SuiObjectInfo, SuiObjectResponse, SuiRawData,
-    SuiTransactionEffectsAPI, SuiTransactionResponse,
+    SuiTransactionEffectsAPI, SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_json_rpc_types::{SuiExecutionStatus, SuiObjectDataOptions};
 use sui_keys::keystore::AccountKeystore;
@@ -1252,6 +1252,8 @@ impl WalletContext {
             .quorum_driver()
             .execute_transaction(
                 tx,
+                // TODO(chris): we probably don't need full content here
+                SuiTransactionResponseOptions::full_content(),
                 Some(sui_types::messages::ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?)

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -15,7 +15,7 @@ use sui::client_commands::{SuiClientCommandResult, SuiClientCommands, WalletCont
 use sui_json_rpc_types::{
     type_and_fields_from_move_struct, EventPage, SuiEvent, SuiEventEnvelope, SuiEventFilter,
     SuiExecutionStatus, SuiMoveStruct, SuiMoveValue, SuiTransactionEffectsAPI,
-    SuiTransactionResponse,
+    SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_macros::*;
@@ -1000,6 +1000,7 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
         let params = rpc_params![
             tx_bytes,
             signatures,
+            SuiTransactionResponseOptions::new(),
             ExecuteTransactionRequestType::WaitForLocalExecution
         ];
         let response: SuiTransactionResponse = jsonrpc_client
@@ -1040,6 +1041,7 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
     let params = rpc_params![
         tx_bytes,
         signatures,
+        SuiTransactionResponseOptions::new(),
         ExecuteTransactionRequestType::WaitForLocalExecution
     ];
     let response: SuiTransactionResponse = jsonrpc_client
@@ -1065,6 +1067,7 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
     let params = rpc_params![
         tx_bytes,
         signatures,
+        SuiTransactionResponseOptions::new().with_effects(),
         ExecuteTransactionRequestType::WaitForEffectsCert
     ];
     let response: SuiTransactionResponse = jsonrpc_client

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -14,6 +14,7 @@ use sui_core::authority_client::AuthorityAPI;
 pub use sui_core::test_utils::{compile_basics_package, wait_for_all_txes, wait_for_tx};
 use sui_json_rpc_types::{
     SuiObjectResponse, SuiTransactionDataAPI, SuiTransactionEffectsAPI, SuiTransactionResponse,
+    SuiTransactionResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::json::SuiJsonValue;
@@ -113,6 +114,7 @@ pub async fn publish_package_with_wallet(
         .quorum_driver()
         .execute_transaction(
             transaction,
+            SuiTransactionResponseOptions::new().with_effects(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await
@@ -172,6 +174,7 @@ pub async fn submit_move_transaction(
         .quorum_driver()
         .execute_transaction(
             tx,
+            SuiTransactionResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await
@@ -409,6 +412,7 @@ pub async fn delete_devnet_nft(
         .quorum_driver()
         .execute_transaction(
             tx,
+            SuiTransactionResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -676,7 +676,8 @@ export class JsonRpcProvider extends Provider {
   async executeTransaction(
     txnBytes: Uint8Array | string,
     signature: SerializedSignature | SerializedSignature[],
-    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert',
+    options?: SuiTransactionResponseOptions,
+    requestType?: ExecuteTransactionRequestType,
   ): Promise<SuiTransactionResponse> {
     try {
       return await this.client.requestWithType(
@@ -684,6 +685,7 @@ export class JsonRpcProvider extends Provider {
         [
           typeof txnBytes === 'string' ? txnBytes : toB64(txnBytes),
           Array.isArray(signature) ? signature : [signature],
+          options,
           requestType,
         ],
         SuiTransactionResponse,

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -44,6 +44,7 @@ import {
   SuiObjectDataOptions,
   SuiSystemStateSummary,
   CoinStruct,
+  SuiTransactionResponseOptions,
 } from '../types';
 
 import { DynamicFieldName, DynamicFieldPage } from '../types/dynamic_fields';
@@ -233,12 +234,15 @@ export abstract class Provider {
    * Submit the transaction to fullnode for execution
    * @param txnBytes BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
    * @param signature A single signature or list of signatures(used for sponsored transactions)
+   * @param options specify which fields to return (e.g., transaction, effects, events, etc).
+   * By default, only the transaction digest will be returned.
    * @param requestType WaitForEffectsCert or WaitForLocalExecution, see details in `ExecuteTransactionRequestType`
    */
   abstract executeTransaction(
     txnBytes: Uint8Array | string,
     signature: SerializedSignature | SerializedSignature[],
-    requestType: ExecuteTransactionRequestType,
+    options?: SuiTransactionResponseOptions,
+    requestType?: ExecuteTransactionRequestType,
   ): Promise<SuiTransactionResponse>;
 
   // Move info

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -42,6 +42,7 @@ import {
   SuiObjectDataOptions,
   SuiSystemStateSummary,
   CoinStruct,
+  SuiTransactionResponseOptions,
 } from '../types';
 import { Provider } from './provider';
 
@@ -157,7 +158,8 @@ export class VoidProvider extends Provider {
   async executeTransaction(
     _txnBytes: Uint8Array,
     _signature: SerializedSignature | SerializedSignature[],
-    _requestType: ExecuteTransactionRequestType,
+    _options?: SuiTransactionResponseOptions,
+    _requestType?: ExecuteTransactionRequestType,
   ): Promise<SuiTransactionResponse> {
     throw this.newError('executeTransaction with request Type');
   }

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -16,6 +16,7 @@ import {
   DevInspectResults,
   DryRunTransactionResponse,
   SuiTransactionResponse,
+  SuiTransactionResponseOptions,
 } from '../types';
 import { IntentScope, messageWithIntent } from '../utils/intent';
 import { Signer } from './signer';
@@ -107,10 +108,16 @@ export abstract class SignerWithProvider implements Signer {
 
   /**
    * Sign a transaction and submit to the Fullnode for execution.
+   *
+   * @param options specify which fields to return (e.g., transaction, effects, events, etc).
+   * By default, only the transaction digest will be returned.
+   * @param requestType WaitForEffectsCert or WaitForLocalExecution, see details in `ExecuteTransactionRequestType`.
+   * Defaults to `WaitForLocalExecution` if options.show_effects or options.show_events is true
    */
   async signAndExecuteTransaction(
     transaction: Uint8Array | Transaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution',
+    options?: SuiTransactionResponseOptions,
+    requestType?: ExecuteTransactionRequestType,
   ): Promise<SuiTransactionResponse> {
     const { transactionBytes, signature } = await this.signTransaction(
       transaction,
@@ -119,6 +126,7 @@ export abstract class SignerWithProvider implements Signer {
     return await this.provider.executeTransaction(
       transactionBytes,
       signature,
+      options,
       requestType,
     );
   }

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -34,7 +34,11 @@ describe('Coin related API', () => {
     });
 
     // split coins into desired amount
-    await toolbox.signer.signAndExecuteTransaction(tx);
+    await toolbox.signer.signAndExecuteTransaction(
+      tx,
+      {},
+      'WaitForLocalExecution',
+    );
     coinsAfterSplit = await toolbox.getGasObjectsOwnedByAddress();
   });
 

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -28,7 +28,9 @@ describe('Test Move call with strings', () => {
         arguments: [tx.pure(str)],
       }),
     );
-    const result = await toolbox.signer.signAndExecuteTransaction(tx);
+    const result = await toolbox.signer.signAndExecuteTransaction(tx, {
+      showEffects: true,
+    });
     expect(getExecutionStatusType(result)).toEqual('success');
   }
 

--- a/sdk/typescript/test/e2e/event-subscription.test.ts
+++ b/sdk/typescript/test/e2e/event-subscription.test.ts
@@ -30,7 +30,11 @@ describe('Event Subscription API', () => {
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
     tx.add(Commands.TransferObjects([tx.gas], tx.pure(DEFAULT_RECIPIENT)));
-    await toolbox.signer.signAndExecuteTransaction(tx);
+    await toolbox.signer.signAndExecuteTransaction(
+      tx,
+      {},
+      'WaitForLocalExecution',
+    );
 
     const subFoundAndRemoved = await toolbox.provider.unsubscribeEvent(
       subscriptionId,

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -63,5 +63,7 @@ async function addStake(signer: RawSigner) {
 
   tx.setGasBudget(DEFAULT_GAS_BUDGET);
 
-  return await signer.signAndExecuteTransaction(tx);
+  return await signer.signAndExecuteTransaction(tx, {
+    showEffects: true,
+  });
 }

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -33,7 +33,9 @@ describe('Test ID as args to entry functions', () => {
         ],
       }),
     );
-    const result = await toolbox.signer.signAndExecuteTransaction(tx);
+    const result = await toolbox.signer.signAndExecuteTransaction(tx, {
+      showEffects: true,
+    });
     expect(getExecutionStatusType(result)).toEqual('success');
   });
 });

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -31,7 +31,9 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
         arguments: [tx.pure(String(val))],
       }),
     );
-    const result = await toolbox.signer.signAndExecuteTransaction(tx);
+    const result = await toolbox.signer.signAndExecuteTransaction(tx, {
+      showEffects: true,
+    });
     expect(getExecutionStatusType(result)).toEqual('success');
     return getCreatedObjects(result)![0].reference.objectId;
   }
@@ -48,7 +50,9 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
         arguments: [vec],
       }),
     );
-    const result = await toolbox.signer.signAndExecuteTransaction(tx);
+    const result = await toolbox.signer.signAndExecuteTransaction(tx, {
+      showEffects: true,
+    });
     expect(getExecutionStatusType(result)).toEqual('success');
   }
 
@@ -82,7 +86,9 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
       }),
     );
     tx.setGasPayment([coins[3]]);
-    const result = await toolbox.signer.signAndExecuteTransaction(tx);
+    const result = await toolbox.signer.signAndExecuteTransaction(tx, {
+      showEffects: true,
+    });
     expect(getExecutionStatusType(result)).toEqual('success');
   });
 });

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -150,7 +150,9 @@ describe('Transaction Builders', () => {
 async function validateTransaction(signer: RawSigner, tx: Transaction) {
   tx.setGasBudget(DEFAULT_GAS_BUDGET);
   const localDigest = await signer.getTransactionDigest(tx);
-  const result = await signer.signAndExecuteTransaction(tx);
+  const result = await signer.signAndExecuteTransaction(tx, {
+    showEffects: true,
+  });
   expect(localDigest).toEqual(getTransactionDigest(result));
   expect(getExecutionStatusType(result)).toEqual('success');
 }

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -124,7 +124,9 @@ export async function publishPackage(
     }),
   );
 
-  const publishTxn = await toolbox.signer.signAndExecuteTransaction(tx);
+  const publishTxn = await toolbox.signer.signAndExecuteTransaction(tx, {
+    showEffects: true,
+  });
   expect(getExecutionStatusType(publishTxn)).toEqual('success');
 
   const publishEvent = getEvents(publishTxn)?.find((e) => e.type === 'publish');

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -63,6 +63,7 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
     async (transactionInput) => {
       return await this.#signer.signAndExecuteTransaction(
         transactionInput.transaction,
+        transactionInput.options?.contentOptions,
         transactionInput.options?.requestType
       );
     };

--- a/sdk/wallet-adapter/example/src/App.tsx
+++ b/sdk/wallet-adapter/example/src/App.tsx
@@ -46,7 +46,12 @@ function App() {
       <div>
         <button
           onClick={async () => {
-            console.log(await signAndExecuteTransaction({ transaction }));
+            console.log(
+              await signAndExecuteTransaction({
+                transaction,
+                options: { contentOptions: { showEffect: true } },
+              })
+            );
           }}
         >
           Sign + Execute Transaction

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiSignAndExecuteTransaction.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiSignAndExecuteTransaction.ts
@@ -4,6 +4,7 @@
 import type {
   ExecuteTransactionRequestType,
   SuiTransactionResponse,
+  SuiTransactionResponseOptions,
 } from "@mysten/sui.js";
 import type { SuiSignTransactionInput } from "./suiSignTransaction";
 
@@ -41,4 +42,5 @@ export interface SuiSignAndExecuteTransactionOutput
 /** Options for signing and sending transactions. */
 export interface SuiSignAndExecuteTransactionOptions {
   requestType?: ExecuteTransactionRequestType;
+  contentOptions?: SuiTransactionResponseOptions;
 }


### PR DESCRIPTION
## Description 

As a follow-up to https://github.com/MystenLabs/sui/pull/8888, this PR changes the interface of `sui_executeTransaction` without changing the behavior(i.e., the `options` is ignored). To keep PRs small, I will implement the logic to use `options` in the next PR, which will also trigger more TS changes.

## Test Plan 

E2E tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Update `executeTransaction` and `signAndExecuteTransaction` to take in an additional parameter `SuiTransactionResponse` which is used to specify which fields to fetch (e.g., transaction, effects, events, etc). By default, only the transaction digest will be returned.