### PR TITLE
client publish: propagate package dependency ids

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -270,8 +270,8 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
                 /* is_init */ false,
             )?
         }
-        Command::Publish(modules) => {
-            execute_move_publish::<_, _, Mode>(context, &mut argument_updates, modules)?
+        Command::Publish(modules, dep_ids) => {
+            execute_move_publish::<_, _, Mode>(context, &mut argument_updates, modules, dep_ids)?
         }
         Command::Upgrade(upgrade_ticket, dep_ids, modules) => {
             execute_move_upgrade::<_, _, Mode>(context, upgrade_ticket, dep_ids, modules)?
@@ -387,6 +387,7 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     context: &mut ExecutionContext<E, S>,
     argument_updates: &mut Mode::ArgumentUpdates,
     module_bytes: Vec<Vec<u8>>,
+    _dependencies: Vec<ObjectID>,
 ) -> Result<Vec<Value>, ExecutionError> {
     assert_invariant!(
         !module_bytes.is_empty(),

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -963,7 +963,7 @@ fn process_package(
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         // executing in Genesis mode does not create a package upgrade
-        builder.command(Command::Publish(module_bytes));
+        builder.command(Command::Publish(module_bytes, ids));
         builder.finish()
     };
     programmable_transactions::execution::execute::<_, _, execution_mode::Genesis>(

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1563,6 +1563,7 @@ async fn test_publish_dependent_module_ok() {
         sender,
         gas_payment_object_ref,
         vec![dependent_module_bytes],
+        vec![],
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
@@ -1605,6 +1606,7 @@ async fn test_publish_module_no_dependencies_ok() {
         sender,
         gas_payment_object_ref,
         module_bytes,
+        vec![],
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
@@ -1653,6 +1655,7 @@ async fn test_publish_non_existing_dependent_module() {
         sender,
         gas_payment_object_ref,
         vec![dependent_module_bytes],
+        vec![],
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
@@ -1703,6 +1706,7 @@ async fn test_package_size_limit() {
         sender,
         gas_payment_object_ref,
         package,
+        vec![],
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -299,7 +299,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
     // We need the original package bytes in order to reproduce the publish computation cost.
     let publish_bytes = match response.0.data().intent_message.value.kind() {
         TransactionKind::ProgrammableTransaction(pt) => match pt.commands.first().unwrap() {
-            Command::Publish(modules) => modules,
+            Command::Publish(modules, _dep_ids) => modules,
             _ => unreachable!(),
         },
         _ => unreachable!(),

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -2177,6 +2177,7 @@ pub async fn build_and_try_publish_test_package(
         *sender,
         gas_object_ref,
         all_module_bytes,
+        vec![],
         gas_budget,
     );
     let transaction = to_sender_signed_transaction(data, sender_key);

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -83,9 +83,11 @@ Command:
               TYPENAME: Argument
     4:
       Publish:
-        NEWTYPE:
-          SEQ:
-            SEQ: U8
+        TUPLE:
+          - SEQ:
+              SEQ: U8
+          - SEQ:
+              TYPENAME: ObjectID
     5:
       MakeMoveVec:
         TUPLE:

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -586,3 +586,19 @@ pub fn check_invalid_dependencies(invalid: BTreeMap<Symbol, String>) -> Result<(
         error: error_messages.join("\n"),
     })
 }
+
+/// Resolve external package dependency addresses for a collection of modules
+/// (i.e., package) from module handle addresses.
+pub fn package_dependencies(modules: Vec<CompiledModule>) -> Vec<ObjectID> {
+    let module_self_addresses: BTreeSet<_> = modules.iter().map(|m| m.self_id()).collect();
+    let mut dependent_packages = BTreeSet::new();
+    for module in modules {
+        for handle in &module.module_handles {
+            if !module_self_addresses.contains(&module.module_id_for_handle(handle)) {
+                let address = ObjectID::from(*module.address_identifier_at(handle.address));
+                dependent_packages.insert(address);
+            }
+        }
+    }
+    Vec::from_iter(dependent_packages)
+}

--- a/crates/sui-indexer/src/apis/transaction_builder_api.rs
+++ b/crates/sui-indexer/src/apis/transaction_builder_api.rs
@@ -98,11 +98,12 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         &self,
         sender: SuiAddress,
         compiled_modules: Vec<Base64>,
+        dependencies: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes> {
         self.fullnode
-            .publish(sender, compiled_modules, gas, gas_budget)
+            .publish(sender, compiled_modules, dependencies, gas, gas_budget)
             .await
     }
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -873,8 +873,9 @@ pub enum SuiCommand {
     /// `(&mut Coin<T>, Vec<Coin<T>>)`
     /// It merges n-coins into the first coin
     MergeCoins(SuiArgument, Vec<SuiArgument>),
-    /// Publishes a Move package
-    Publish(SuiMovePackage),
+    /// Publishes a Move package. It takes the package bytes and a list of the package's transitive
+    /// dependencies to link against on-chain.
+    Publish(SuiMovePackage, Vec<ObjectID>),
     /// Upgrades a Move package
     Upgrade(SuiArgument, Vec<ObjectID>, SuiMovePackage),
     /// `forall T: Vec<T> -> vector<T>`
@@ -911,7 +912,7 @@ impl Display for SuiCommand {
                 write_sep(f, coins, ",")?;
                 write!(f, ")")
             }
-            Self::Publish(_bytes) => write!(f, "Publish(_)"),
+            Self::Publish(_bytes, _deps) => write!(f, "Publish(_)"),
             Self::Upgrade(ticket, deps, _bytes) => {
                 write!(f, "Upgrade({ticket},")?;
                 write_sep(f, deps, ",")?;
@@ -935,9 +936,12 @@ impl From<Command> for SuiCommand {
                 arg.into(),
                 args.into_iter().map(SuiArgument::from).collect(),
             ),
-            Command::Publish(modules) => SuiCommand::Publish(SuiMovePackage {
-                disassembled: disassemble_modules(modules.iter()).unwrap_or_default(),
-            }),
+            Command::Publish(modules, dep_ids) => SuiCommand::Publish(
+                SuiMovePackage {
+                    disassembled: disassemble_modules(modules.iter()).unwrap_or_default(),
+                },
+                dep_ids,
+            ),
             Command::MakeMoveVec(tag_opt, args) => SuiCommand::MakeMoveVec(
                 tag_opt.map(|tag| tag.to_string()),
                 args.into_iter().map(SuiArgument::from).collect(),

--- a/crates/sui-json-rpc/src/api/transaction_builder.rs
+++ b/crates/sui-json-rpc/src/api/transaction_builder.rs
@@ -146,6 +146,8 @@ pub trait TransactionBuilder {
         sender: SuiAddress,
         /// the compiled bytes of a move module, the
         compiled_modules: Vec<Base64>,
+        /// a list of transitive dependencies that this set of modules depend on.
+        dep_ids: Vec<ObjectID>,
         /// gas object to be used in this transaction, node will pick one from the signer's possession if not provided
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -172,6 +172,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         &self,
         sender: SuiAddress,
         compiled_modules: Vec<Base64>,
+        dependencies: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes> {
@@ -181,7 +182,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
             .collect::<Result<Vec<_>, _>>()?;
         let data = self
             .builder
-            .publish(sender, compiled_modules, gas, gas_budget)
+            .publish(sender, compiled_modules, dependencies, gas, gas_budget)
             .await?;
         Ok(TransactionBytes::from_data(data)?)
     }

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -111,7 +111,13 @@ async fn test_publish() -> Result<(), anyhow::Error> {
         .get_package_base64(/* with_unpublished_deps */ false);
 
     let transaction_bytes: TransactionBytes = http_client
-        .publish(*address, compiled_modules, Some(gas.object_id), 10000)
+        .publish(
+            *address,
+            compiled_modules,
+            vec![],
+            Some(gas.object_id),
+            10000,
+        )
         .await?;
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
@@ -274,7 +280,13 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
         .get_package_base64(/* with_unpublished_deps */ false);
 
     let transaction_bytes: TransactionBytes = http_client
-        .publish(*address, compiled_modules, Some(gas.object_id), 10000)
+        .publish(
+            *address,
+            compiled_modules,
+            vec![],
+            Some(gas.object_id),
+            10000,
+        )
         .await?;
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
@@ -331,7 +343,13 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         .get_package_base64(/* with_unpublished_deps */ false);
 
     let transaction_bytes: TransactionBytes = http_client
-        .publish(*address, compiled_modules, Some(gas.object_id), 10000)
+        .publish(
+            *address,
+            compiled_modules,
+            vec![],
+            Some(gas.object_id),
+            10000,
+        )
         .await?;
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2098,6 +2098,17 @@
           }
         },
         {
+          "name": "dep_ids",
+          "description": "a list of transitive dependencies that this set of modules depend on.",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectID"
+            }
+          }
+        },
+        {
           "name": "gas",
           "description": "gas object to be used in this transaction, node will pick one from the signer's possession if not provided",
           "schema": {
@@ -5411,14 +5422,27 @@
             "additionalProperties": false
           },
           {
-            "description": "Publishes a Move package",
+            "description": "Publishes a Move package. It takes the package bytes and a list of the package's transitive dependencies to link against on-chain.",
             "type": "object",
             "required": [
               "Publish"
             ],
             "properties": {
               "Publish": {
-                "$ref": "#/components/schemas/MovePackage"
+                "type": "array",
+                "items": [
+                  {
+                    "$ref": "#/components/schemas/MovePackage"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ObjectID"
+                    }
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
               }
             },
             "additionalProperties": false

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -136,7 +136,10 @@ async fn test_publish_and_move_call() {
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.publish(compiled_module);
+        builder.publish(
+            compiled_module,
+            vec![], /* TODO: update this test to collect deps */
+        );
         builder.finish()
     };
     let response =

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -445,6 +445,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         &self,
         sender: SuiAddress,
         compiled_modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> anyhow::Result<TransactionData> {
@@ -456,6 +457,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             sender,
             gas,
             compiled_modules,
+            dep_ids,
             gas_budget,
             gas_price,
         ))

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -30,6 +30,8 @@ pub struct SuiPublishArgs {
     pub sender: Option<String>,
     #[clap(long = "upgradeable", action = clap::ArgAction::SetTrue)]
     pub upgradeable: bool,
+    #[clap(long = "dependencies")]
+    pub dependencies: Vec<String>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -303,6 +303,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let SuiPublishArgs {
             sender,
             upgradeable,
+            dependencies: _,
         } = extra;
         let module_name = module.self_id().name().to_string();
         let module_bytes = {
@@ -314,10 +315,10 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let data = |sender, gas| {
             let mut builder = ProgrammableTransactionBuilder::new();
             if upgradeable {
-                let cap = builder.publish_upgradeable(vec![module_bytes]);
+                let cap = builder.publish_upgradeable(vec![module_bytes], vec![]);
                 builder.transfer_arg(sender, cap);
             } else {
-                builder.publish(vec![module_bytes]);
+                builder.publish(vec![module_bytes], vec![]);
             };
             let pt = builder.finish();
             TransactionData::new_programmable_with_dummy_gas_price(

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -179,12 +179,16 @@ impl ProgrammableTransactionBuilder {
         })))
     }
 
-    pub fn publish_upgradeable(&mut self, modules: Vec<Vec<u8>>) -> Argument {
-        self.command(Command::Publish(modules))
+    pub fn publish_upgradeable(
+        &mut self,
+        modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+    ) -> Argument {
+        self.command(Command::Publish(modules, dep_ids))
     }
 
-    pub fn publish(&mut self, modules: Vec<Vec<u8>>) {
-        let cap = self.publish_upgradeable(modules);
+    pub fn publish(&mut self, modules: Vec<Vec<u8>>, dep_ids: Vec<ObjectID>) {
+        let cap = self.publish_upgradeable(modules, dep_ids);
         self.commands
             .push(Command::MoveCall(Box::new(ProgrammableMoveCall {
                 package: SUI_FRAMEWORK_OBJECT_ID,

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -816,7 +816,7 @@ fn test_sponsored_transaction_validity_check() {
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.publish(vec![vec![]]);
+        builder.publish(vec![vec![]], vec![]);
         builder.finish()
     };
     let kind = TransactionKind::programmable(pt);

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -528,7 +528,13 @@ impl SuiClientCommands {
 
                 let data = client
                     .transaction_builder()
-                    .publish(sender, compiled_modules, gas, gas_budget)
+                    .publish(
+                        sender,
+                        compiled_modules,
+                        dependencies.published.into_values().collect(),
+                        gas,
+                        gas_budget,
+                    )
                     .await?;
                 let signature =
                     context

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -295,6 +295,7 @@ pub fn create_publish_move_package_transaction(
         sender,
         gas_object_ref,
         all_module_bytes,
+        vec![],
         MAX_GAS,
         gas_price.unwrap_or(DUMMY_GAS_PRICE),
     );
@@ -326,6 +327,7 @@ pub fn make_publish_basics_transaction(gas_object: ObjectRef) -> VerifiedTransac
         sender,
         gas_object,
         all_module_bytes,
+        vec![],
         MAX_GAS,
     );
     to_sender_signed_transaction(data, &keypair)

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -95,7 +95,7 @@ pub async fn publish_package_with_wallet(
     let transaction = {
         let data = client
             .transaction_builder()
-            .publish(sender, all_module_bytes, None, GAS_BUDGET)
+            .publish(sender, all_module_bytes, vec![], None, GAS_BUDGET)
             .await
             .unwrap();
 

--- a/sdk/typescript/src/builder/Commands.ts
+++ b/sdk/typescript/src/builder/Commands.ts
@@ -102,6 +102,7 @@ export type MakeMoveVecCommand = Infer<typeof MakeMoveVecCommand>;
 export const PublishCommand = object({
   kind: literal('Publish'),
   modules: array(array(integer())),
+  dependencies: array(integer()),
 });
 export type PublishCommand = Infer<typeof PublishCommand>;
 
@@ -156,7 +157,11 @@ export const Commands = {
     return { kind: 'MergeCoins', destination, sources };
   },
   Publish(modules: number[][]): PublishCommand {
-    return { kind: 'Publish', modules };
+    return {
+      kind: 'Publish',
+      modules,
+      dependencies: [] /* TODO: SDK changes for dependencies */,
+    };
   },
   MakeMoveVec({
     type,


### PR DESCRIPTION
WIP. Right now added address list to `Publish` and propagated the change so things compile. 

Questions / feedback requested: 

- (How) will we make use of the `Publish::Command` to create txn (`programmable_transaction_builder::publish` [uses `MoveCall`](https://github.com/MystenLabs/sui/blob/b47d759a73bff64b7593a3c892a5640353d9ff78/crates/sui-types/src/programmable_transaction_builder.rs#L186-L196) right now).
- How deep to go with SDK updates (since we're changing RPC, we have to at least minimally update those references, but I haven't dug into whether we strictly need to pass dependencies here)

Known / planned updates:

- Minimal TS SDK updates
- Tests

## Test Plan 

TBD.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
