### PR TITLE
[ts-sdk] Add transaction command shorthand

### DIFF
--- a/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
+++ b/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
@@ -6,7 +6,6 @@ import {
     getExecutionStatusType,
     getExecutionStatusError,
     Transaction,
-    Commands,
 } from '@mysten/sui.js';
 import { useWalletKit, ConnectButton } from '@mysten/wallet-kit';
 import { useMutation } from '@tanstack/react-query';
@@ -74,21 +73,19 @@ export function ModuleFunction({
         mutationFn: async ({ params, types }: TypeOf<typeof argsSchema>) => {
             const tx = new Transaction();
             tx.setGasBudget(2000);
-            tx.add(
-                Commands.MoveCall({
-                    target: `${packageId}::${moduleName}::${functionName}`,
-                    typeArguments: types ?? [],
-                    arguments:
-                        params?.map((param, i) =>
-                            getPureSerializationType(
-                                functionDetails.parameters[i],
-                                param
-                            )
-                                ? tx.pure(param)
-                                : tx.object(param)
-                        ) ?? [],
-                })
-            );
+            tx.moveCall({
+                target: `${packageId}::${moduleName}::${functionName}`,
+                typeArguments: types ?? [],
+                arguments:
+                    params?.map((param, i) =>
+                        getPureSerializationType(
+                            functionDetails.parameters[i],
+                            param
+                        )
+                            ? tx.pure(param)
+                            : tx.object(param)
+                    ) ?? [],
+            });
             const result = await signAndExecuteTransaction({
                 transaction: tx,
                 options: {

--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -26,18 +26,16 @@ export async function mint(address: string) {
     const signer = new RawSigner(keypair, provider);
 
     const tx = new Transaction();
-    tx.add(
-        Transaction.Commands.MoveCall({
-            target: '0x2::devnet_nft::mint',
-            arguments: [
-                tx.pure('Example NFT'),
-                tx.pure('An example NFT.'),
-                tx.pure(
-                    'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty'
-                ),
-            ],
-        })
-    );
+    tx.moveCall({
+        target: '0x2::devnet_nft::mint',
+        arguments: [
+            tx.pure('Example NFT'),
+            tx.pure('An example NFT.'),
+            tx.pure(
+                'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty'
+            ),
+        ],
+    });
     tx.setGasBudget(30000);
 
     const result = await signer.signAndExecuteTransaction(tx, {

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -47,12 +47,7 @@ export function TransferNFTForm({ objectId }: { objectId: string }) {
             }
             const tx = new Transaction();
             tx.setGasBudget(DEFAULT_NFT_TRANSFER_GAS_FEE);
-            tx.add(
-                Transaction.Commands.TransferObjects(
-                    [tx.object(objectId)],
-                    tx.pure(to)
-                )
-            );
+            tx.transferObjects([tx.object(objectId)], tx.pure(to));
             return signer.signAndExecuteTransaction(tx, {
                 showInput: true,
                 showEffects: true,

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -102,19 +102,15 @@ export class Coin {
         try {
             const tx = new Transaction();
             tx.setGasBudget(DEFAULT_GAS_BUDGET_FOR_STAKE);
-            const stakeCoin = tx.add(
-                Transaction.Commands.SplitCoin(tx.gas, tx.pure(amount))
-            );
-            tx.add(
-                Transaction.Commands.MoveCall({
-                    target: '0x2::sui_system::request_add_stake',
-                    arguments: [
-                        tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
-                        stakeCoin,
-                        tx.pure(validator),
-                    ],
-                })
-            );
+            const stakeCoin = tx.splitCoin(tx.gas, tx.pure(amount));
+            tx.moveCall({
+                target: '0x2::sui_system::request_add_stake',
+                arguments: [
+                    tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+                    stakeCoin,
+                    tx.pure(validator),
+                ],
+            });
             return await signer.signAndExecuteTransaction(tx, {
                 showInput: true,
                 showEffects: true,
@@ -135,16 +131,14 @@ export class Coin {
         try {
             const tx = new Transaction();
             tx.setGasBudget(DEFAULT_GAS_BUDGET_FOR_STAKE);
-            tx.add(
-                Transaction.Commands.MoveCall({
-                    target: '0x2::sui_system::request_withdraw_stake',
-                    arguments: [
-                        tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
-                        tx.object(stake),
-                        tx.object(stakedSuiId),
-                    ],
-                })
-            );
+            tx.moveCall({
+                target: '0x2::sui_system::request_withdraw_stake',
+                arguments: [
+                    tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+                    tx.object(stake),
+                    tx.object(stakedSuiId),
+                ],
+            });
             return await signer.signAndExecuteTransaction(tx, {
                 showInput: true,
                 showEffects: true,

--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -237,6 +237,27 @@ export class Transaction {
     return createTransactionResult(index - 1);
   }
 
+  // Method shorthands:
+
+  splitCoin(...args: Parameters<(typeof Commands)['SplitCoin']>) {
+    return this.add(Commands.SplitCoin(...args));
+  }
+  mergeCoins(...args: Parameters<(typeof Commands)['MergeCoins']>) {
+    return this.add(Commands.MergeCoins(...args));
+  }
+  publish(...args: Parameters<(typeof Commands)['Publish']>) {
+    return this.add(Commands.Publish(...args));
+  }
+  moveCall(...args: Parameters<(typeof Commands)['MoveCall']>) {
+    return this.add(Commands.MoveCall(...args));
+  }
+  transferObjects(...args: Parameters<(typeof Commands)['TransferObjects']>) {
+    return this.add(Commands.TransferObjects(...args));
+  }
+  makeMoveVec(...args: Parameters<(typeof Commands)['MakeMoveVec']>) {
+    return this.add(Commands.MakeMoveVec(...args));
+  }
+
   /**
    * Serialize the transaction to a string so that it can be sent to a separate context.
    * This is different from `build` in that it does not serialize to BCS bytes, and instead

--- a/sdk/typescript/src/framework/sui-system-state.ts
+++ b/sdk/typescript/src/framework/sui-system-state.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Commands, Transaction } from '../builder';
+import { Transaction } from '../builder';
 import { Provider } from '../providers/provider';
 import {
   getObjectReference,
@@ -42,17 +42,16 @@ export class SuiSystemStateUtil {
   ): Promise<Transaction> {
     // TODO: validate coin types and handle locked coins
     const tx = new Transaction();
-    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(amount)));
-    tx.add(
-      Commands.MoveCall({
-        target: `${SUI_FRAMEWORK_ADDRESS}::${SUI_SYSTEM_MODULE_NAME}::${ADD_STAKE_FUN_NAME}`,
-        arguments: [
-          tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
-          coin,
-          tx.pure(validatorAddress),
-        ],
-      }),
-    );
+
+    const coin = tx.splitCoin(tx.gas, tx.pure(amount));
+    tx.moveCall({
+      target: `${SUI_FRAMEWORK_ADDRESS}::${SUI_SYSTEM_MODULE_NAME}::${ADD_STAKE_FUN_NAME}`,
+      arguments: [
+        tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+        coin,
+        tx.pure(validatorAddress),
+      ],
+    });
     const coinObjects = await provider.getObjectBatch(coins, {
       showOwner: true,
     });
@@ -73,16 +72,15 @@ export class SuiSystemStateUtil {
     stakedCoinId: ObjectId,
   ): Promise<Transaction> {
     const tx = new Transaction();
-    tx.add(
-      Commands.MoveCall({
-        target: `${SUI_FRAMEWORK_ADDRESS}::${SUI_SYSTEM_MODULE_NAME}::${WITHDRAW_STAKE_FUN_NAME}`,
-        arguments: [
-          tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
-          tx.object(stake),
-          tx.object(stakedCoinId),
-        ],
-      }),
-    );
+    tx.moveCall({
+      target: `${SUI_FRAMEWORK_ADDRESS}::${SUI_SYSTEM_MODULE_NAME}::${WITHDRAW_STAKE_FUN_NAME}`,
+      arguments: [
+        tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+        tx.object(stake),
+        tx.object(stakedCoinId),
+      ],
+    });
+
     return tx;
   }
 }

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -4,7 +4,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
   Coin,
-  Commands,
   normalizeSuiObjectId,
   ObjectId,
   SuiObjectInfo,
@@ -29,8 +28,8 @@ describe('Coin related API', () => {
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
     const recieverInput = tx.pure(toolbox.address());
     SPLIT_AMOUNTS.forEach((amount) => {
-      const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(amount)));
-      tx.add(Commands.TransferObjects([coin], recieverInput));
+      const coin = tx.splitCoin(tx.gas, tx.pure(amount));
+      tx.transferObjects([coin], recieverInput);
     });
 
     // split coins into desired amount

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { RawSigner, Transaction, Commands } from '../../src';
+import { RawSigner, Transaction } from '../../src';
 import {
   DEFAULT_GAS_BUDGET,
   publishPackage,
@@ -24,8 +24,8 @@ describe('Test dev inspect', () => {
   it.skip('Dev inspect split + transfer', async () => {
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(10)));
-    tx.add(Commands.TransferObjects([coin], tx.pure(toolbox.address())));
+    const coin = tx.splitCoin(tx.gas, tx.pure(10));
+    tx.transferObjects([coin], tx.pure(toolbox.address()));
     await validateDevInspectTransaction(toolbox.signer, tx, 'success');
   });
 
@@ -34,16 +34,14 @@ describe('Test dev inspect', () => {
 
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    const obj = tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::serializer_tests::return_struct`,
-        typeArguments: ['0x2::coin::Coin<0x2::sui::SUI>'],
-        arguments: [tx.pure(coins[0].objectId)],
-      }),
-    );
+    const obj = tx.moveCall({
+      target: `${packageId}::serializer_tests::return_struct`,
+      typeArguments: ['0x2::coin::Coin<0x2::sui::SUI>'],
+      arguments: [tx.pure(coins[0].objectId)],
+    });
 
     // TODO: Ideally dev inspect transactions wouldn't need this, but they do for now
-    tx.add(Commands.TransferObjects([obj], tx.pure(toolbox.address())));
+    tx.transferObjects([obj], tx.pure(toolbox.address()));
 
     await validateDevInspectTransaction(toolbox.signer, tx, 'success');
   });
@@ -51,13 +49,11 @@ describe('Test dev inspect', () => {
   it('Move Call that aborts', async () => {
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::serializer_tests::test_abort`,
-        typeArguments: [],
-        arguments: [],
-      }),
-    );
+    tx.moveCall({
+      target: `${packageId}::serializer_tests::test_abort`,
+      typeArguments: [],
+      arguments: [],
+    });
 
     await validateDevInspectTransaction(toolbox.signer, tx, 'failure');
   });

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import {
-  Commands,
-  getExecutionStatusType,
-  ObjectId,
-  Transaction,
-} from '../../src';
+import { getExecutionStatusType, ObjectId, Transaction } from '../../src';
 import {
   DEFAULT_GAS_BUDGET,
   publishPackage,
@@ -22,12 +17,10 @@ describe('Test Move call with strings', () => {
   async function callWithString(str: string | string[], funcName: string) {
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::entry_point_string::${funcName}`,
-        arguments: [tx.pure(str)],
-      }),
-    );
+    tx.moveCall({
+      target: `${packageId}::entry_point_string::${funcName}`,
+      arguments: [tx.pure(str)],
+    });
     const result = await toolbox.signer.signAndExecuteTransaction(tx, {
       showEffects: true,
     });

--- a/sdk/typescript/test/e2e/event-subscription.test.ts
+++ b/sdk/typescript/test/e2e/event-subscription.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll, vi } from 'vitest';
-import { Commands, SuiEventEnvelope, Transaction } from '../../src';
+import { SuiEventEnvelope, Transaction } from '../../src';
 import {
   DEFAULT_GAS_BUDGET,
   DEFAULT_RECIPIENT,
@@ -29,7 +29,7 @@ describe('Event Subscription API', () => {
 
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    tx.add(Commands.TransferObjects([tx.gas], tx.pure(DEFAULT_RECIPIENT)));
+    tx.transferObjects([tx.gas], tx.pure(DEFAULT_RECIPIENT));
     await toolbox.signer.signAndExecuteTransaction(
       tx,
       {},

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import {
-  Commands,
-  getExecutionStatusType,
-  ObjectId,
-  Transaction,
-} from '../../src';
+import { getExecutionStatusType, ObjectId, Transaction } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test ID as args to entry functions', () => {
@@ -23,16 +18,14 @@ describe('Test ID as args to entry functions', () => {
   it('Test ID as arg to entry functions', async () => {
     const tx = new Transaction();
     tx.setGasBudget(2000);
-    tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::test::test_id`,
-        arguments: [
-          tx.pure(
-            '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
-          ),
-        ],
-      }),
-    );
+    tx.moveCall({
+      target: `${packageId}::test::test_id`,
+      arguments: [
+        tx.pure(
+          '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
+        ),
+      ],
+    });
     const result = await toolbox.signer.signAndExecuteTransaction(tx, {
       showEffects: true,
     });

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -4,7 +4,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   Coin,
-  Commands,
   getCreatedObjects,
   getExecutionStatusType,
   ObjectId,
@@ -25,12 +24,10 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
   async function mintObject(val: number) {
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::entry_point_vector::mint`,
-        arguments: [tx.pure(String(val))],
-      }),
-    );
+    tx.moveCall({
+      target: `${packageId}::entry_point_vector::mint`,
+      arguments: [tx.pure(String(val))],
+    });
     const result = await toolbox.signer.signAndExecuteTransaction(tx, {
       showEffects: true,
     });
@@ -41,15 +38,11 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
   async function destroyObjects(objects: ObjectId[]) {
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    const vec = tx.add(
-      Commands.MakeMoveVec({ objects: objects.map((id) => tx.object(id)) }),
-    );
-    tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::entry_point_vector::two_obj_vec_destroy`,
-        arguments: [vec],
-      }),
-    );
+    const vec = tx.makeMoveVec({ objects: objects.map((id) => tx.object(id)) });
+    tx.moveCall({
+      target: `${packageId}::entry_point_vector::two_obj_vec_destroy`,
+      arguments: [vec],
+    });
     const result = await toolbox.signer.signAndExecuteTransaction(tx, {
       showEffects: true,
     });
@@ -73,18 +66,14 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
     const coinIDs = coins.map((coin) => Coin.getID(coin));
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
-    const vec = tx.add(
-      Commands.MakeMoveVec({
-        objects: [tx.object(coinIDs[1]), tx.object(coinIDs[2])],
-      }),
-    );
-    tx.add(
-      Commands.MoveCall({
-        target: `${SUI_FRAMEWORK_ADDRESS}::pay::join_vec`,
-        typeArguments: ['0x2::sui::SUI'],
-        arguments: [tx.object(coinIDs[0]), vec],
-      }),
-    );
+    const vec = tx.makeMoveVec({
+      objects: [tx.object(coinIDs[1]), tx.object(coinIDs[2])],
+    });
+    tx.moveCall({
+      target: `${SUI_FRAMEWORK_ADDRESS}::pay::join_vec`,
+      typeArguments: ['0x2::sui::SUI'],
+      arguments: [tx.object(coinIDs[0]), vec],
+    });
     tx.setGasPayment([coins[3]]);
     const result = await toolbox.signer.signAndExecuteTransaction(tx, {
       showEffects: true,

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -3,7 +3,6 @@
 
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import {
-  Commands,
   getExecutionStatusType,
   getObjectId,
   getSharedObjectInitialVersion,
@@ -45,41 +44,33 @@ describe('Transaction Builders', () => {
   it('SplitCoin + TransferObjects', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
     const tx = new Transaction();
-    const coin = tx.add(
-      Commands.SplitCoin(
-        tx.object(coins[0].objectId),
-        tx.pure(DEFAULT_GAS_BUDGET * 2),
-      ),
+    const coin = tx.splitCoin(
+      tx.object(coins[0].objectId),
+      tx.pure(DEFAULT_GAS_BUDGET * 2),
     );
-    tx.add(Commands.TransferObjects([coin], tx.pure(toolbox.address())));
+    tx.transferObjects([coin], tx.pure(toolbox.address()));
     await validateTransaction(toolbox.signer, tx);
   });
 
   it('MergeCoins', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
     const tx = new Transaction();
-    tx.add(
-      Commands.MergeCoins(tx.object(coins[0].objectId), [
-        tx.object(coins[1].objectId),
-      ]),
-    );
+    tx.mergeCoins(tx.object(coins[0].objectId), [tx.object(coins[1].objectId)]);
     await validateTransaction(toolbox.signer, tx);
   });
 
   it('MoveCall', async () => {
     const tx = new Transaction();
-    tx.add(
-      Commands.MoveCall({
-        target: '0x2::devnet_nft::mint',
-        arguments: [
-          tx.pure('Example NFT'),
-          tx.pure('An NFT created by the wallet Command Line Tool'),
-          tx.pure(
-            'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
-          ),
-        ],
-      }),
-    );
+    tx.moveCall({
+      target: '0x2::devnet_nft::mint',
+      arguments: [
+        tx.pure('Example NFT'),
+        tx.pure('An NFT created by the wallet Command Line Tool'),
+        tx.pure(
+          'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+        ),
+      ],
+    });
     await validateTransaction(toolbox.signer, tx);
   });
 
@@ -90,59 +81,51 @@ describe('Transaction Builders', () => {
       await toolbox.getActiveValidators();
 
     const tx = new Transaction();
-    tx.add(
-      Commands.MoveCall({
-        target: '0x2::sui_system::request_add_stake',
-        arguments: [
-          tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
-          tx.object(coins[2].objectId),
-          tx.pure(validatorAddress),
-        ],
-      }),
-    );
+    tx.moveCall({
+      target: '0x2::sui_system::request_add_stake',
+      arguments: [
+        tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+        tx.object(coins[2].objectId),
+        tx.pure(validatorAddress),
+      ],
+    });
 
     await validateTransaction(toolbox.signer, tx);
   });
 
   it('SplitCoin from gas object + TransferObjects', async () => {
     const tx = new Transaction();
-    const coin = tx.add(Commands.SplitCoin(tx.gas, tx.pure(1)));
-    tx.add(Commands.TransferObjects([coin], tx.pure(DEFAULT_RECIPIENT)));
+    const coin = tx.splitCoin(tx.gas, tx.pure(1));
+    tx.transferObjects([coin], tx.pure(DEFAULT_RECIPIENT));
     await validateTransaction(toolbox.signer, tx);
   });
 
   it('TransferObjects gas object', async () => {
     const tx = new Transaction();
-    tx.add(Commands.TransferObjects([tx.gas], tx.pure(DEFAULT_RECIPIENT)));
+    tx.transferObjects([tx.gas], tx.pure(DEFAULT_RECIPIENT));
     await validateTransaction(toolbox.signer, tx);
   });
 
   it('TransferObject', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
     const tx = new Transaction();
-    tx.add(
-      Commands.TransferObjects(
-        [tx.object(coins[0].objectId)],
-        tx.pure(DEFAULT_RECIPIENT),
-      ),
+    tx.transferObjects(
+      [tx.object(coins[0].objectId)],
+      tx.pure(DEFAULT_RECIPIENT),
     );
     await validateTransaction(toolbox.signer, tx);
   });
 
   it('Move Shared Object Call with mixed usage of mutable and immutable references', async () => {
     const tx = new Transaction();
-    tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::serializer_tests::value`,
-        arguments: [tx.object(sharedObjectId)],
-      }),
-    );
-    tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::serializer_tests::set_value`,
-        arguments: [tx.object(sharedObjectId)],
-      }),
-    );
+    tx.moveCall({
+      target: `${packageId}::serializer_tests::value`,
+      arguments: [tx.object(sharedObjectId)],
+    });
+    tx.moveCall({
+      target: `${packageId}::serializer_tests::set_value`,
+      arguments: [tx.object(sharedObjectId)],
+    });
     await validateTransaction(toolbox.signer, tx);
   });
 });

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -3,7 +3,6 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
-  Commands,
   getCreatedObjects,
   getObjectId,
   getSharedObjectInitialVersion,
@@ -60,44 +59,36 @@ describe('Transaction Serialization and deserialization', () => {
       await toolbox.getActiveValidators();
 
     const tx = new Transaction();
-    tx.add(
-      Commands.MoveCall({
-        target: '0x2::sui_system::request_add_stake',
-        arguments: [
-          tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
-          tx.object(coins[2].objectId),
-          tx.pure(validatorAddress),
-        ],
-      }),
-    );
+    tx.moveCall({
+      target: '0x2::sui_system::request_add_stake',
+      arguments: [
+        tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+        tx.object(coins[2].objectId),
+        tx.pure(validatorAddress),
+      ],
+    });
     await serializeAndDeserialize(tx, [true]);
   });
 
   it('Move Shared Object Call with immutable reference', async () => {
     const tx = new Transaction();
-    tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::serializer_tests::value`,
-        arguments: [tx.object(sharedObjectId)],
-      }),
-    );
+    tx.moveCall({
+      target: `${packageId}::serializer_tests::value`,
+      arguments: [tx.object(sharedObjectId)],
+    });
     await serializeAndDeserialize(tx, [false]);
   });
 
   it('Move Shared Object Call with mixed usage of mutable and immutable references', async () => {
     const tx = new Transaction();
-    tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::serializer_tests::value`,
-        arguments: [tx.object(sharedObjectId)],
-      }),
-    );
-    tx.add(
-      Commands.MoveCall({
-        target: `${packageId}::serializer_tests::set_value`,
-        arguments: [tx.object(sharedObjectId)],
-      }),
-    );
+    tx.moveCall({
+      target: `${packageId}::serializer_tests::value`,
+      arguments: [tx.object(sharedObjectId)],
+    });
+    tx.moveCall({
+      target: `${packageId}::serializer_tests::set_value`,
+      arguments: [tx.object(sharedObjectId)],
+    });
     await serializeAndDeserialize(tx, [true]);
   });
 });

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -15,7 +15,6 @@ import {
   Connection,
   Coin,
   Transaction,
-  Commands,
   RawSigner,
   FaucetResponse,
   assert,
@@ -114,15 +113,13 @@ export async function publishPackage(
   );
   const tx = new Transaction();
   tx.setGasBudget(DEFAULT_GAS_BUDGET);
-  const cap = tx.add(
-    Commands.Publish(compiledModules.map((m: any) => Array.from(fromB64(m)))),
+  const cap = tx.publish(
+    compiledModules.map((m: any) => Array.from(fromB64(m))),
   );
-  tx.add(
-    Commands.MoveCall({
-      target: '0x2::package::make_immutable',
-      arguments: [cap],
-    }),
-  );
+  tx.moveCall({
+    target: '0x2::package::make_immutable',
+    arguments: [cap],
+  });
 
   const publishTxn = await toolbox.signer.signAndExecuteTransaction(tx, {
     showEffects: true,

--- a/sdk/wallet-adapter/example/src/App.tsx
+++ b/sdk/wallet-adapter/example/src/App.tsx
@@ -3,21 +3,19 @@
 
 import "./App.css";
 import { ConnectButton, useWalletKit } from "@mysten/wallet-kit";
-import { Commands, Transaction } from "@mysten/sui.js";
+import { Transaction } from "@mysten/sui.js";
 import { useEffect } from "react";
 
 const transaction = new Transaction();
 transaction.setGasBudget(2000);
-transaction.add(
-  Commands.MoveCall({
-    target: `0x2::devnet_nft::mint`,
-    arguments: [
-      transaction.pure("foo"),
-      transaction.pure("bar"),
-      transaction.pure("baz"),
-    ],
-  })
-);
+transaction.moveCall({
+  target: `0x2::devnet_nft::mint`,
+  arguments: [
+    transaction.pure("foo"),
+    transaction.pure("bar"),
+    transaction.pure("baz"),
+  ],
+});
 
 function App() {
   const {


### PR DESCRIPTION
## Description 

This adds shorthand methods for all of the transaction builder commands. This allows transactions to be written in a more intuitive way, but still gives us the benefit of having a generic `add` method (which is useful for external SDKs that want to construct commands, and also for internal data modeling). 

## Test Plan 

Rewrote to use it, and tests should pass.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
