### PR TITLE
Allow payload to have mutable internal state

### DIFF
--- a/crates/sui-benchmark/src/workloads/payload.rs
+++ b/crates/sui-benchmark/src/workloads/payload.rs
@@ -10,8 +10,8 @@ use rand_distr::WeightedAliasIndex;
 use crate::workloads::workload::WorkloadType;
 
 pub trait Payload: Send + Sync + std::fmt::Debug {
-    fn make_new_payload(self: Box<Self>, effects: &ExecutionEffects) -> Box<dyn Payload>;
-    fn make_transaction(&self) -> VerifiedTransaction;
+    fn make_new_payload(&mut self, effects: &ExecutionEffects);
+    fn make_transaction(&mut self) -> VerifiedTransaction;
     fn get_workload_type(&self) -> WorkloadType;
 }
 
@@ -24,27 +24,18 @@ pub struct CombinationPayload {
 }
 
 impl Payload for CombinationPayload {
-    fn make_new_payload(self: Box<Self>, effects: &ExecutionEffects) -> Box<dyn Payload> {
-        let mut new_payloads = vec![];
-        for (pos, e) in self.payloads.into_iter().enumerate() {
+    fn make_new_payload(&mut self, effects: &ExecutionEffects) {
+        for (pos, e) in self.payloads.iter_mut().enumerate() {
             if pos == self.curr_index {
-                let updated = e.make_new_payload(effects);
-                new_payloads.push(updated);
-            } else {
-                new_payloads.push(e);
+                e.make_new_payload(effects);
             }
         }
         let mut rng = self.rng;
         let next_index = self.dist.sample(&mut rng);
-        Box::new(CombinationPayload {
-            payloads: new_payloads,
-            dist: self.dist,
-            curr_index: next_index,
-            rng: self.rng,
-        })
+        self.curr_index = next_index;
     }
-    fn make_transaction(&self) -> VerifiedTransaction {
-        let curr = self.payloads.get(self.curr_index).unwrap();
+    fn make_transaction(&mut self) -> VerifiedTransaction {
+        let curr = self.payloads.get_mut(self.curr_index).unwrap();
         curr.make_transaction()
     }
     fn get_workload_type(&self) -> WorkloadType {

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -35,16 +35,10 @@ pub struct SharedCounterTestPayload {
 }
 
 impl Payload for SharedCounterTestPayload {
-    fn make_new_payload(self: Box<Self>, effects: &ExecutionEffects) -> Box<dyn Payload> {
-        Box::new(SharedCounterTestPayload {
-            package_id: self.package_id,
-            counter_id: self.counter_id,
-            counter_initial_shared_version: self.counter_initial_shared_version,
-            gas: (effects.gas_object().0, self.gas.1, self.gas.2),
-            system_state_observer: self.system_state_observer,
-        })
+    fn make_new_payload(&mut self, effects: &ExecutionEffects) {
+        self.gas.0 = effects.gas_object().0;
     }
-    fn make_transaction(&self) -> VerifiedTransaction {
+    fn make_transaction(&mut self) -> VerifiedTransaction {
         make_counter_increment_transaction(
             self.gas.0,
             self.package_id,
@@ -222,9 +216,5 @@ impl Workload<dyn Payload> for SharedCounterWorkload {
     }
     fn get_workload_type(&self) -> WorkloadType {
         WorkloadType::SharedCounter
-    }
-
-    fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self as &SharedCounterWorkload)
     }
 }

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -37,7 +37,7 @@ impl fmt::Display for WorkloadType {
 }
 
 #[async_trait]
-pub trait Workload<T: Payload + ?Sized>: Send + Sync {
+pub trait Workload<T: Payload + ?Sized>: Send + Sync + std::fmt::Debug {
     async fn init(
         &mut self,
         init_config: WorkloadInitGas,
@@ -52,14 +52,6 @@ pub trait Workload<T: Payload + ?Sized>: Send + Sync {
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Vec<Box<T>>;
     fn get_workload_type(&self) -> WorkloadType;
-
-    fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
-}
-
-impl std::fmt::Debug for dyn Workload<dyn Payload> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.debug(f)
-    }
 }
 
 type WeightAndPayload = (u32, Box<dyn Workload<dyn Payload>>);
@@ -130,10 +122,6 @@ impl Workload<dyn Payload> for CombinationWorkload {
     }
     fn get_workload_type(&self) -> WorkloadType {
         WorkloadType::Combination
-    }
-
-    fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self as &CombinationWorkload)
     }
 }
 


### PR DESCRIPTION
## Description 

Allow `Payload` type to mutate its internal state when calling `make_transaction()`. This allows for adding more workloads which want to keep RNGs inside to generate random transactions, etc

## Test Plan 

Existing tests