### PR TITLE
[RPC][2 of 2] use option to filter executeTransaction result

### DIFF
--- a/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
+++ b/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
@@ -93,9 +93,9 @@ export function ModuleFunction({
                 transaction: tx,
                 options: {
                     contentOptions: {
-                        showEffect: true,
+                        showEffects: true,
                         showEvents: true,
-                        showInputs: true,
+                        showInput: true,
                     },
                 },
             });

--- a/apps/wallet/src/background/Transactions.ts
+++ b/apps/wallet/src/background/Transactions.ts
@@ -65,8 +65,8 @@ class Transactions {
             throw new Error('Transaction signature is empty');
         }
         if (tx) {
-            if (!txResult || !('transaction' in txResult)) {
-                throw new Error(`Transaction result is empty`);
+            if (!txResult || !('digest' in txResult)) {
+                throw new Error(`Transaction result is empty ${txResult}`);
             }
             return txResult;
         }

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -138,7 +138,9 @@ impl TestContext {
                 Transaction::from_data(txn_data, Intent::default(), vec![signature])
                     .verify()
                     .unwrap(),
-                SuiTransactionResponseOptions::new().with_effects(),
+                SuiTransactionResponseOptions::new()
+                    .with_effects()
+                    .with_events(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -128,7 +128,7 @@ pub async fn submit(
         .quorum_driver()
         .execute_transaction(
             signed_tx,
-            SuiTransactionResponseOptions::new().with_effects(),
+            SuiTransactionResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForEffectsCert),
         )
         .await?;

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -15,6 +15,7 @@ use sui_rosetta::types::{
 };
 use sui_sdk::json::SuiJsonValue;
 use sui_sdk::rpc_types::{SuiExecutionStatus, SuiTransactionEffectsAPI};
+use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{parse_sui_type_tag, SUI_FRAMEWORK_OBJECT_ID};
 use test_utils::network::TestClusterBuilder;
@@ -85,7 +86,11 @@ async fn test_locked_sui() {
     let tx = to_sender_signed_transaction(tx, keystore.get_key(&address).unwrap());
     client
         .quorum_driver()
-        .execute_transaction(tx, SuiTransactionResponseOptions::new(), None)
+        .execute_transaction(
+            tx,
+            SuiTransactionResponseOptions::new(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
         .await
         .unwrap();
 
@@ -192,7 +197,11 @@ async fn test_get_staked_sui() {
     let tx = to_sender_signed_transaction(delegation_tx, keystore.get_key(&address).unwrap());
     client
         .quorum_driver()
-        .execute_transaction(tx, SuiTransactionResponseOptions::new(), None)
+        .execute_transaction(
+            tx,
+            SuiTransactionResponseOptions::new(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
         .await
         .unwrap();
 

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -126,6 +126,7 @@ export async function publishPackage(
 
   const publishTxn = await toolbox.signer.signAndExecuteTransaction(tx, {
     showEffects: true,
+    showEvents: true,
   });
   expect(getExecutionStatusType(publishTxn)).toEqual('success');
 

--- a/sdk/wallet-adapter/example/src/App.tsx
+++ b/sdk/wallet-adapter/example/src/App.tsx
@@ -12,9 +12,9 @@ transaction.add(
   Commands.MoveCall({
     target: `0x2::devnet_nft::mint`,
     arguments: [
-      transaction.input("foo"),
-      transaction.input("bar"),
-      transaction.input("baz"),
+      transaction.pure("foo"),
+      transaction.pure("bar"),
+      transaction.pure("baz"),
     ],
   })
 );
@@ -49,7 +49,7 @@ function App() {
             console.log(
               await signAndExecuteTransaction({
                 transaction,
-                options: { contentOptions: { showEffect: true } },
+                options: { contentOptions: { showEffects: true } },
               })
             );
           }}

--- a/sdk/wallet-adapter/wallet-kit-core/src/index.ts
+++ b/sdk/wallet-adapter/wallet-kit-core/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from "@mysten/wallet-adapter-base";
 import { localStorageAdapter, StorageAdapter } from "./storage";
 import {
+  SuiSignAndExecuteTransactionInput,
   SuiSignMessageInput,
   SuiSignTransactionInput,
   WalletAccount,
@@ -68,7 +69,7 @@ export interface WalletKitCore {
   ) => ReturnType<WalletAdapter["signTransaction"]>;
   signAndExecuteTransaction: (
     transactionInput: OptionalProperties<
-      SuiSignTransactionInput,
+      SuiSignAndExecuteTransactionInput,
       "chain" | "account"
     >
   ) => ReturnType<WalletAdapter["signAndExecuteTransaction"]>;


### PR DESCRIPTION
## Description 

- Follow up to https://github.com/MystenLabs/sui/pull/9141 to use options to config which fields to return
- more testing + bug fixing

## Test Plan 

Test wallet adapter + Explorer
![CleanShot 2023-03-11 at 22 33 44](https://user-images.githubusercontent.com/76067158/224522817-b22f120c-f957-4988-8095-3f3d444d8ef4.png)

Test Example App
![CleanShot 2023-03-11 at 22 30 38](https://user-images.githubusercontent.com/76067158/224522823-6cf5ddac-14f5-470e-aa41-7eee8dc671ad.png)

Test in wallet flow(send + stake)
![CleanShot 2023-03-11 at 22 13 16](https://user-images.githubusercontent.com/76067158/224522833-46edb9d2-e622-42bb-ab0d-06ae9c95106f.png)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
