### PR TITLE
[rpc] Mark get_transactions_in_range deprecated

### DIFF
--- a/.changeset/odd-eyes-wave.md
+++ b/.changeset/odd-eyes-wave.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Deprecate getTransactionDigestsInRange. This method will be removed before April 2023, please use `getTransactions` instead

--- a/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
+++ b/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
@@ -63,8 +63,8 @@ async function getRecentTransactions(
 ): Promise<TxnData[]> {
     // Get the latest transactions
     // Instead of getRecentTransactions, use getTransactionCount
-    // then use getTransactionDigestsInRange using the totalTx as the start totalTx sequence number - txNum as the end sequence number
-    // Get the total number of transactions, then use as the start and end values for the getTransactionDigestsInRange
+    // then use getTransactionDigestsInRangeDeprecated using the totalTx as the start totalTx sequence number - txNum as the end sequence number
+    // Get the total number of transactions, then use as the start and end values for the getTransactionDigestsInRangeDeprecated
     const { endGatewayTxSeqNumber, startGatewayTxSeqNumber } =
         generateStartEndRange(totalTx, txNum, pageNum);
 
@@ -73,12 +73,13 @@ async function getRecentTransactions(
     if (endGatewayTxSeqNumber < 0) {
         throw new Error('Invalid transaction number');
     }
-    const transactionDigests = await rpc.getTransactionDigestsInRange(
+    // TODO: migrate this to `getTransactions`
+    const transactionDigests = await rpc.getTransactionDigestsInRangeDeprecated(
         startGatewayTxSeqNumber,
         endGatewayTxSeqNumber
     );
 
-    // result returned by getTransactionDigestsInRange is in ascending order
+    // result returned by getTransactionDigestsInRangeDeprecated is in ascending order
     const transactionData = await getDataOnTxDigests(
         rpc,
         [...transactionDigests].reverse()

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2242,12 +2242,13 @@ impl AuthorityState {
         Ok(self.get_indexes()?.next_sequence_number())
     }
 
-    pub fn get_transactions_in_range(
+    pub fn get_transactions_in_range_deprecated(
         &self,
         start: TxSequenceNumber,
         end: TxSequenceNumber,
     ) -> Result<Vec<(TxSequenceNumber, TransactionDigest)>, anyhow::Error> {
-        self.get_indexes()?.get_transactions_in_range(start, end)
+        self.get_indexes()?
+            .get_transactions_in_range_deprecated(start, end)
     }
 
     pub fn get_recent_transactions(

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -269,12 +269,14 @@ where
         Ok(self.get_transactions(query, cursor, limit, descending_order)?)
     }
 
-    async fn get_transactions_in_range(
+    async fn get_transactions_in_range_deprecated(
         &self,
         start: TxSequenceNumber,
         end: TxSequenceNumber,
     ) -> RpcResult<Vec<TransactionDigest>> {
-        self.fullnode.get_transactions_in_range(start, end).await
+        self.fullnode
+            .get_transactions_in_range_deprecated(start, end)
+            .await
     }
 
     async fn get_transaction_with_options(

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -46,8 +46,9 @@ pub trait ReadApi {
     async fn get_total_transaction_number(&self) -> RpcResult<u64>;
 
     /// Return list of transaction digests within the queried range.
-    #[method(name = "getTransactionsInRange")]
-    async fn get_transactions_in_range(
+    /// This method will be removed before April 2023, please use `getTransactions` instead
+    #[method(name = "getTransactionsInRangeDeprecated", deprecated)]
+    async fn get_transactions_in_range_deprecated(
         &self,
         /// the matching transactions' sequence number will be greater than or equals to the starting sequence number
         start: TxSequenceNumber,

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -303,14 +303,14 @@ impl ReadApiServer for ReadApi {
         Ok(self.state.get_total_transaction_number()?)
     }
 
-    async fn get_transactions_in_range(
+    async fn get_transactions_in_range_deprecated(
         &self,
         start: TxSequenceNumber,
         end: TxSequenceNumber,
     ) -> RpcResult<Vec<TransactionDigest>> {
         Ok(self
             .state
-            .get_transactions_in_range(start, end)?
+            .get_transactions_in_range_deprecated(start, end)?
             .into_iter()
             .map(|(_, digest)| digest)
             .collect())

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -471,8 +471,10 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
 
         tx_responses.push(response);
     }
-    // test get_transactions_in_range
-    let tx: Vec<TransactionDigest> = http_client.get_transactions_in_range(0, 10).await?;
+    // test get_transactions_in_range_deprecated
+    let tx: Vec<TransactionDigest> = http_client
+        .get_transactions_in_range_deprecated(0, 10)
+        .await?;
     assert_eq!(5, tx.len());
 
     // test get_transaction_batch
@@ -488,8 +490,10 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
             .any(|resp| matches!(resp, SuiTransactionResponse {digest, ..} if *digest == r.digest)))
     }
 
-    // test get_transactions_in_range with smaller range
-    let tx: Vec<TransactionDigest> = http_client.get_transactions_in_range(1, 3).await?;
+    // test get_transactions_in_range_deprecated with smaller range
+    let tx: Vec<TransactionDigest> = http_client
+        .get_transactions_in_range_deprecated(1, 3)
+        .await?;
     assert_eq!(2, tx.len());
 
     // test get_transaction

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1610,13 +1610,13 @@
       ]
     },
     {
-      "name": "sui_getTransactionsInRange",
+      "name": "sui_getTransactionsInRangeDeprecated",
       "tags": [
         {
           "name": "Read API"
         }
       ],
-      "description": "Return list of transaction digests within the queried range.",
+      "description": "Return list of transaction digests within the queried range. This method will be removed before April 2023, please use `getTransactions` instead",
       "params": [
         {
           "name": "start",
@@ -1648,7 +1648,8 @@
             "$ref": "#/components/schemas/TransactionDigest"
           }
         }
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "sui_mergeCoins",

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -117,12 +117,16 @@ impl ReadApi {
         Ok(self.api.http.get_total_transaction_number().await?)
     }
 
-    pub async fn get_transactions_in_range(
+    pub async fn get_transactions_in_range_deprecated(
         &self,
         start: TxSequenceNumber,
         end: TxSequenceNumber,
     ) -> SuiRpcResult<Vec<TransactionDigest>> {
-        Ok(self.api.http.get_transactions_in_range(start, end).await?)
+        Ok(self
+            .api
+            .http
+            .get_transactions_in_range_deprecated(start, end)
+            .await?)
     }
 
     pub async fn get_transaction_with_options(

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -308,7 +308,7 @@ impl IndexStore {
         })
     }
 
-    pub fn get_transactions_in_range(
+    pub fn get_transactions_in_range_deprecated(
         &self,
         start: TxSequenceNumber,
         end: TxSequenceNumber,
@@ -369,7 +369,7 @@ impl IndexStore {
         );
         let end = self.next_sequence_number();
         let start = if end >= count { end - count } else { 0 };
-        self.get_transactions_in_range(start, end)
+        self.get_transactions_in_range_deprecated(start, end)
     }
 
     /// Returns unix timestamp for a transaction if it exists

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -710,13 +710,13 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async getTransactionDigestsInRange(
+  async getTransactionDigestsInRangeDeprecated(
     start: GatewayTxSeqNumber,
     end: GatewayTxSeqNumber,
   ): Promise<GetTxnDigestsResponse> {
     try {
       return await this.client.requestWithType(
-        'sui_getTransactionsInRange',
+        'sui_getTransactionsInRangeDeprecated',
         [start, end],
         GetTxnDigestsResponse,
         this.options.skipDataValidation,

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -206,10 +206,9 @@ export abstract class Provider {
   // Transactions
   /**
    * Get transaction digests for a given range
-   *
-   * NOTE: this method may get deprecated after DevNet
+   * @deprecated this method will be removed before April 2023, please use `getTransactions` instead
    */
-  abstract getTransactionDigestsInRange(
+  abstract getTransactionDigestsInRangeDeprecated(
     start: GatewayTxSeqNumber,
     end: GatewayTxSeqNumber,
   ): Promise<GetTxnDigestsResponse>;
@@ -226,7 +225,6 @@ export abstract class Provider {
 
   /**
    * Get total number of transactions
-   * NOTE: this method may get deprecated after DevNet
    */
   abstract getTotalTransactionNumber(): Promise<number>;
 

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -196,11 +196,11 @@ export class VoidProvider extends Provider {
     throw this.newError('getTotalTransactionNumber');
   }
 
-  async getTransactionDigestsInRange(
+  async getTransactionDigestsInRangeDeprecated(
     _start: GatewayTxSeqNumber,
     _end: GatewayTxSeqNumber,
   ): Promise<GetTxnDigestsResponse> {
-    throw this.newError('getTransactionDigestsInRange');
+    throw this.newError('getTransactionDigestsInRangeDeprecated');
   }
 
   async getMoveFunctionArgTypes(


### PR DESCRIPTION
## Description 

We will remove this endpoint soon, but it's currently used by the Explorer. This PR adds `deprecated` to the function name to discourage people from using the method.

## Test Plan 

E2E

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
