### PR TITLE
[rpc][1 of 2] refactor getTransactions -> queryTransactions

### DIFF
--- a/.changeset/sour-dolls-search.md
+++ b/.changeset/sour-dolls-search.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Refactor `getTransactions` to `queryTransactions`

--- a/apps/explorer/src/components/transaction-card/TxForID.tsx
+++ b/apps/explorer/src/components/transaction-card/TxForID.tsx
@@ -31,8 +31,8 @@ const getTx = async (
     category: categoryType
 ): Promise<GetTxnDigestsResponse> =>
     category === 'address'
-        ? rpc(network).getTransactionsForAddress(id, true)
-        : rpc(network).getTransactionsForObject(id, true);
+        ? rpc(network).queryTransactionsForAddress(id, true)
+        : rpc(network).queryTransactionsForObject(id, true);
 
 const viewFn = (results: any) => <TxForIDView showData={results} />;
 

--- a/apps/explorer/src/components/transaction-card/TxForID.tsx
+++ b/apps/explorer/src/components/transaction-card/TxForID.tsx
@@ -31,8 +31,8 @@ const getTx = async (
     category: categoryType
 ): Promise<GetTxnDigestsResponse> =>
     category === 'address'
-        ? rpc(network).queryTransactionsForAddress(id, true)
-        : rpc(network).queryTransactionsForObject(id, true);
+        ? rpc(network).queryTransactionsForAddressDeprecated(id, true)
+        : rpc(network).queryTransactionsForObjectDeprecated(id, true);
 
 const viewFn = (results: any) => <TxForIDView showData={results} />;
 

--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -87,8 +87,8 @@ const getResultsForAddress = async (rpc: JsonRpcProvider, query: string) => {
         return null;
 
     const [from, to] = await Promise.all([
-        rpc.queryTransactions({ FromAddress: normalized }, null, 1),
-        rpc.queryTransactions({ ToAddress: normalized }, null, 1),
+        rpc.queryTransactions({ filter: { FromAddress: normalized } }, null, 1),
+        rpc.queryTransactions({ filter: { ToAddress: normalized } }, null, 1),
     ]);
 
     if (from.data?.length || to.data?.length) {

--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -87,8 +87,8 @@ const getResultsForAddress = async (rpc: JsonRpcProvider, query: string) => {
         return null;
 
     const [from, to] = await Promise.all([
-        rpc.getTransactions({ FromAddress: normalized }, null, 1),
-        rpc.getTransactions({ ToAddress: normalized }, null, 1),
+        rpc.queryTransactions({ FromAddress: normalized }, null, 1),
+        rpc.queryTransactions({ ToAddress: normalized }, null, 1),
     ]);
 
     if (from.data?.length || to.data?.length) {

--- a/apps/explorer/src/pages/checkpoints/Transactions.tsx
+++ b/apps/explorer/src/pages/checkpoints/Transactions.tsx
@@ -22,7 +22,7 @@ export function CheckpointTransactions({
     const { data: txData, isLoading } = useQuery(
         ['checkpoint-transactions', digest],
         async () => {
-            // todo: replace this with `sui_getTransactions` call when we are
+            // todo: replace this with `sui_queryTransactions` call when we are
             // able to query by checkpoint digest
             const txData = await getDataOnTxDigests(rpc, transactions!);
             return genTableDataFromTxData(txData as TxnData[]);

--- a/apps/wallet/src/ui/app/hooks/index.ts
+++ b/apps/wallet/src/ui/app/hooks/index.ts
@@ -16,7 +16,7 @@ export { useGetNFTMeta } from './useGetNFTMeta';
 export { useTransactionDryRun } from './useTransactionDryRun';
 export { useGetObject } from './useGetObject';
 export { useGetTxnRecipientAddress } from './useGetTxnRecipientAddress';
-export { useGetTransactionsByAddress } from './useGetTransactionsByAddress';
+export { useQueryTransactionsByAddress } from './useQueryTransactionsByAddress';
 export { useGetTransferAmount } from './useGetTransferAmount';
 export { useGetCoinBalance } from './useGetCoinBalance';
 export { useGetAllBalances } from './useGetAllBalances';

--- a/apps/wallet/src/ui/app/hooks/useQueryTransactionsByAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useQueryTransactionsByAddress.ts
@@ -7,7 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 
 const dedupe = (arr: string[]) => Array.from(new Set(arr));
 
-export function useGetTransactionsByAddress(address: SuiAddress | null) {
+export function useQueryTransactionsByAddress(address: SuiAddress | null) {
     const rpc = useRpcClient();
 
     return useQuery(
@@ -15,10 +15,10 @@ export function useGetTransactionsByAddress(address: SuiAddress | null) {
         async () => {
             // combine from and to transactions
             const [txnIds, fromTxnIds] = await Promise.all([
-                rpc.getTransactions({
+                rpc.queryTransactions({
                     ToAddress: address!,
                 }),
-                rpc.getTransactions({
+                rpc.queryTransactions({
                     FromAddress: address!,
                 }),
             ]);

--- a/apps/wallet/src/ui/app/hooks/useQueryTransactionsByAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useQueryTransactionsByAddress.ts
@@ -16,14 +16,22 @@ export function useQueryTransactionsByAddress(address: SuiAddress | null) {
             // combine from and to transactions
             const [txnIds, fromTxnIds] = await Promise.all([
                 rpc.queryTransactions({
-                    ToAddress: address!,
+                    filter: {
+                        ToAddress: address!,
+                    },
                 }),
                 rpc.queryTransactions({
-                    FromAddress: address!,
+                    filter: {
+                        FromAddress: address!,
+                    },
                 }),
             ]);
+            // TODO: replace this with queryTransactions
+            // It seems to be expensive to fetch all transaction data at once though
             const resp = await rpc.getTransactionResponseBatch(
-                dedupe([...txnIds.data, ...fromTxnIds.data]),
+                dedupe(
+                    [...txnIds.data, ...fromTxnIds.data].map((x) => x.digest)
+                ),
                 {
                     showInput: true,
                     showEffects: true,

--- a/apps/wallet/src/ui/app/pages/home/tokens/CoinActivityCard.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/CoinActivityCard.tsx
@@ -8,7 +8,7 @@ import { ErrorBoundary } from '_components/error-boundary';
 import Loading from '_components/loading';
 import { TransactionCard } from '_components/transactions-card';
 import { getEventsSummary } from '_helpers';
-import { useAppSelector, useGetTransactionsByAddress } from '_hooks';
+import { useAppSelector, useQueryTransactionsByAddress } from '_hooks';
 import Alert from '_src/ui/app/components/alert';
 
 export function CoinActivitiesCard({ coinType }: { coinType: string }) {
@@ -18,7 +18,7 @@ export function CoinActivitiesCard({ coinType }: { coinType: string }) {
         isLoading,
         error,
         isError,
-    } = useGetTransactionsByAddress(activeAddress);
+    } = useQueryTransactionsByAddress(activeAddress);
 
     // filter txns by coinType
     const txnByCoinType = useMemo(() => {

--- a/apps/wallet/src/ui/app/pages/home/transactions/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transactions/index.tsx
@@ -8,7 +8,7 @@ import { ErrorBoundary } from '_components/error-boundary';
 import Loading from '_components/loading';
 import { TransactionCard } from '_components/transactions-card';
 import { NoActivityCard } from '_components/transactions-card/NoActivityCard';
-import { useAppSelector, useGetTransactionsByAddress } from '_hooks';
+import { useAppSelector, useQueryTransactionsByAddress } from '_hooks';
 import Alert from '_src/ui/app/components/alert';
 import PageTitle from '_src/ui/app/shared/PageTitle';
 
@@ -19,7 +19,7 @@ function TransactionsPage() {
         isLoading,
         error,
         isError,
-    } = useGetTransactionsByAddress(activeAddress);
+    } = useQueryTransactionsByAddress(activeAddress);
 
     if (isError) {
         return (

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -76,7 +76,7 @@ use sui_types::messages_checkpoint::{
 };
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::{MoveObject, Owner, PastObjectRead, OBJECT_START_VERSION};
-use sui_types::query::{EventQuery, TransactionQuery};
+use sui_types::query::{EventQuery, TransactionFilter};
 use sui_types::storage::{ObjectKey, WriteKind};
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::temporary_store::InnerTemporaryStore;
@@ -2341,7 +2341,7 @@ impl AuthorityState {
 
     pub fn get_transactions(
         &self,
-        query: TransactionQuery,
+        query: TransactionFilter,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2341,14 +2341,14 @@ impl AuthorityState {
 
     pub fn get_transactions(
         &self,
-        query: TransactionFilter,
+        filter: Option<TransactionFilter>,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         reverse: bool,
     ) -> Result<Vec<TransactionDigest>, anyhow::Error> {
         self.get_indexes()?
-            .get_transactions(query, cursor, limit, reverse)
+            .get_transactions(filter, cursor, limit, reverse)
     }
 
     fn get_checkpoint_store(&self) -> Arc<CheckpointStore> {

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -56,7 +56,7 @@ impl<S: IndexerStore> ReadApi<S> {
         Ok(txn_resp)
     }
 
-    fn get_transactions(
+    fn query_transactions(
         &self,
         query: TransactionQuery,
         cursor: Option<TransactionDigest>,
@@ -250,7 +250,7 @@ where
         Ok(self.get_total_transaction_number()?)
     }
 
-    async fn get_transactions(
+    async fn query_transactions(
         &self,
         query: TransactionQuery,
         cursor: Option<TransactionDigest>,
@@ -259,14 +259,14 @@ where
     ) -> RpcResult<TransactionsPage> {
         if self
             .method_to_be_forwarded
-            .contains(&"get_transactions".to_string())
+            .contains(&"query_transactions".to_string())
         {
             return self
                 .fullnode
-                .get_transactions(query, cursor, limit, descending_order)
+                .query_transactions(query, cursor, limit, descending_order)
                 .await;
         }
-        Ok(self.get_transactions(query, cursor, limit, descending_order)?)
+        Ok(self.query_transactions(query, cursor, limit, descending_order)?)
     }
 
     async fn get_transactions_in_range_deprecated(

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -30,8 +30,8 @@ mod sui_transaction;
 
 pub type DynamicFieldPage = Page<DynamicFieldInfo, ObjectID>;
 /// `next_cursor` points to the last item in the page;
-/// Reading with `next_cursor` will start from the next item after `next_cursor`,
-/// if `next_cursor` is `Some`, otherwise it will start from the first item.
+/// Reading with `next_cursor` will start from the next item after `next_cursor` if
+/// `next_cursor` is `Some`, otherwise it will start from the first item.
 #[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Page<T, C> {

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -62,7 +62,9 @@ impl Display for BigInt {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
 #[serde(rename_all = "camelCase", rename = "TransactionResponseQuery", default)]
 pub struct SuiTransactionResponseQuery {
+    /// If None, no filter will be applied
     pub filter: Option<TransactionFilter>,
+    /// config which fields to include in the response, by default only digest is included
     pub options: Option<SuiTransactionResponseOptions>,
 }
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -28,6 +28,7 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::move_package::disassemble_modules;
 use sui_types::object::Owner;
 use sui_types::parse_sui_type_tag;
+use sui_types::query::TransactionFilter;
 use sui_types::signature::GenericSignature;
 
 use crate::{Page, SuiEvent, SuiMovePackage, SuiObjectRef};
@@ -58,8 +59,30 @@ impl Display for BigInt {
         write!(f, "{}", self.0)
     }
 }
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase", rename = "TransactionResponseQuery", default)]
+pub struct SuiTransactionResponseQuery {
+    pub filter: Option<TransactionFilter>,
+    pub options: Option<SuiTransactionResponseOptions>,
+}
 
-pub type TransactionsPage = Page<TransactionDigest, TransactionDigest>;
+impl SuiTransactionResponseQuery {
+    pub fn new(
+        filter: Option<TransactionFilter>,
+        options: Option<SuiTransactionResponseOptions>,
+    ) -> Self {
+        Self { filter, options }
+    }
+
+    pub fn new_with_filter(filter: TransactionFilter) -> Self {
+        Self {
+            filter: Some(filter),
+            options: None,
+        }
+    }
+}
+
+pub type TransactionsPage = Page<SuiTransactionResponse, TransactionDigest>;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Eq, PartialEq, Default)]
 #[serde(

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -140,8 +140,8 @@ pub trait ReadApi {
     ) -> RpcResult<SuiMoveNormalizedFunction>;
 
     /// Return list of transactions for a specified query criteria.
-    #[method(name = "getTransactions")]
-    async fn get_transactions(
+    #[method(name = "queryTransactions")]
+    async fn query_transactions(
         &self,
         /// the transaction query criteria.
         query: TransactionQuery,

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -8,7 +8,8 @@ use sui_json_rpc_types::{
     Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, SuiGetPastObjectRequest,
     SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct,
     SuiObjectDataOptions, SuiObjectInfo, SuiObjectResponse, SuiPastObjectResponse,
-    SuiTransactionResponse, SuiTransactionResponseOptions, TransactionsPage,
+    SuiTransactionResponse, SuiTransactionResponseOptions, SuiTransactionResponseQuery,
+    TransactionsPage,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{
@@ -16,7 +17,6 @@ use sui_types::base_types::{
 };
 use sui_types::dynamic_field::DynamicFieldName;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use sui_types::query::TransactionQuery;
 
 #[open_rpc(namespace = "sui", tag = "Read API")]
 #[rpc(server, client, namespace = "sui")]
@@ -46,7 +46,7 @@ pub trait ReadApi {
     async fn get_total_transaction_number(&self) -> RpcResult<u64>;
 
     /// Return list of transaction digests within the queried range.
-    /// This method will be removed before April 2023, please use `getTransactions` instead
+    /// This method will be removed before April 2023, please use `queryTransactions` instead
     #[method(name = "getTransactionsInRangeDeprecated", deprecated)]
     async fn get_transactions_in_range_deprecated(
         &self,
@@ -144,7 +144,7 @@ pub trait ReadApi {
     async fn query_transactions(
         &self,
         /// the transaction query criteria.
-        query: TransactionQuery,
+        query: SuiTransactionResponseQuery,
         /// Optional paging cursor
         cursor: Option<TransactionDigest>,
         /// Maximum item returned per page, default to QUERY_MAX_RESULT_LIMIT if not specified.

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -647,7 +647,7 @@ impl ReadApiServer for ReadApi {
         }?)
     }
 
-    async fn get_transactions(
+    async fn query_transactions(
         &self,
         query: TransactionQuery,
         // exclusive cursor if `Some`, otherwise start from the beginning

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -44,7 +44,7 @@ use sui_types::messages::{
 use sui_types::messages_checkpoint::{CheckpointSequenceNumber, CheckpointTimestamp};
 use sui_types::move_package::normalize_modules;
 use sui_types::object::{Data, Object, ObjectRead, PastObjectRead};
-use sui_types::query::{EventQuery, TransactionFilter};
+use sui_types::query::EventQuery;
 
 use crate::api::cap_page_limit;
 use crate::api::ReadApiServer;
@@ -657,13 +657,11 @@ impl ReadApiServer for ReadApi {
     ) -> RpcResult<TransactionsPage> {
         let limit = cap_page_limit(limit);
         let descending = descending_order.unwrap_or_default();
-        // TODO(chris): should we just remove `TransactionFilter::All`?
-        let filter = query.filter.unwrap_or(TransactionFilter::All);
 
         // Retrieve 1 extra item for next cursor
-        let mut data = self
-            .state
-            .get_transactions(filter, cursor, Some(limit + 1), descending)?;
+        let mut data =
+            self.state
+                .get_transactions(query.filter, cursor, Some(limit + 1), descending)?;
 
         // extract next cursor
         let has_next_page = data.len() > limit;

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -554,7 +554,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get_recent_transactions with smaller range
     let tx = client
         .read_api()
-        .get_transactions(TransactionQuery::All, None, Some(3), true)
+        .query_transactions(TransactionQuery::All, None, Some(3), true)
         .await
         .unwrap();
     assert_eq!(3, tx.data.len());
@@ -563,7 +563,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get all transactions paged
     let first_page = client
         .read_api()
-        .get_transactions(TransactionQuery::All, None, Some(5), false)
+        .query_transactions(TransactionQuery::All, None, Some(5), false)
         .await
         .unwrap();
     assert_eq!(5, first_page.data.len());
@@ -571,7 +571,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     let second_page = client
         .read_api()
-        .get_transactions(TransactionQuery::All, first_page.next_cursor, None, false)
+        .query_transactions(TransactionQuery::All, first_page.next_cursor, None, false)
         .await
         .unwrap();
     assert_eq!(16, second_page.data.len());
@@ -584,7 +584,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get 10 latest transactions paged
     let latest = client
         .read_api()
-        .get_transactions(TransactionQuery::All, None, Some(10), true)
+        .query_transactions(TransactionQuery::All, None, Some(10), true)
         .await
         .unwrap();
     assert_eq!(10, latest.data.len());
@@ -595,7 +595,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get from address txs in ascending order
     let address_txs_asc = client
         .read_api()
-        .get_transactions(
+        .query_transactions(
             TransactionQuery::FromAddress(cluster.accounts[0]),
             None,
             None,
@@ -608,7 +608,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get from address txs in descending order
     let address_txs_desc = client
         .read_api()
-        .get_transactions(
+        .query_transactions(
             TransactionQuery::FromAddress(cluster.accounts[0]),
             None,
             None,
@@ -626,7 +626,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get_recent_transactions
     let tx = client
         .read_api()
-        .get_transactions(TransactionQuery::All, None, Some(20), true)
+        .query_transactions(TransactionQuery::All, None, Some(20), true)
         .await
         .unwrap();
     assert_eq!(20, tx.data.len());

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -13,12 +13,12 @@ use sui_config::SUI_KEYSTORE_FILENAME;
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
 
-use sui_json_rpc_types::SuiObjectInfo;
 use sui_json_rpc_types::{
     Balance, CoinPage, DelegatedStake, StakeStatus, SuiCoinMetadata, SuiEvent, SuiExecutionStatus,
     SuiObjectDataOptions, SuiObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
     SuiTransactionResponseOptions, TransactionBytes,
 };
+use sui_json_rpc_types::{SuiObjectInfo, SuiTransactionResponseQuery};
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_types::balance::Supply;
 use sui_types::base_types::ObjectID;
@@ -27,7 +27,7 @@ use sui_types::coin::{TreasuryCap, COIN_MODULE_NAME, LOCKED_COIN_MODULE_NAME};
 use sui_types::gas_coin::GAS;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::object::Owner;
-use sui_types::query::{EventQuery, TransactionQuery};
+use sui_types::query::{EventQuery, TransactionFilter};
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{parse_sui_struct_tag, parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS};
 use test_utils::network::TestClusterBuilder;
@@ -554,7 +554,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get_recent_transactions with smaller range
     let tx = client
         .read_api()
-        .query_transactions(TransactionQuery::All, None, Some(3), true)
+        .query_transactions(SuiTransactionResponseQuery::default(), None, Some(3), true)
         .await
         .unwrap();
     assert_eq!(3, tx.data.len());
@@ -563,7 +563,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get all transactions paged
     let first_page = client
         .read_api()
-        .query_transactions(TransactionQuery::All, None, Some(5), false)
+        .query_transactions(SuiTransactionResponseQuery::default(), None, Some(5), false)
         .await
         .unwrap();
     assert_eq!(5, first_page.data.len());
@@ -571,7 +571,12 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     let second_page = client
         .read_api()
-        .query_transactions(TransactionQuery::All, first_page.next_cursor, None, false)
+        .query_transactions(
+            SuiTransactionResponseQuery::default(),
+            first_page.next_cursor,
+            None,
+            false,
+        )
         .await
         .unwrap();
     assert_eq!(16, second_page.data.len());
@@ -584,11 +589,11 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get 10 latest transactions paged
     let latest = client
         .read_api()
-        .query_transactions(TransactionQuery::All, None, Some(10), true)
+        .query_transactions(SuiTransactionResponseQuery::default(), None, Some(10), true)
         .await
         .unwrap();
     assert_eq!(10, latest.data.len());
-    assert_eq!(Some(all_txs_rev[9]), latest.next_cursor);
+    assert_eq!(Some(all_txs_rev[9].digest), latest.next_cursor);
     assert_eq!(all_txs_rev[0..10], latest.data);
     assert!(latest.has_next_page);
 
@@ -596,7 +601,9 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     let address_txs_asc = client
         .read_api()
         .query_transactions(
-            TransactionQuery::FromAddress(cluster.accounts[0]),
+            SuiTransactionResponseQuery::new_with_filter(TransactionFilter::FromAddress(
+                cluster.accounts[0],
+            )),
             None,
             None,
             false,
@@ -609,7 +616,9 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     let address_txs_desc = client
         .read_api()
         .query_transactions(
-            TransactionQuery::FromAddress(cluster.accounts[0]),
+            SuiTransactionResponseQuery::new_with_filter(TransactionFilter::FromAddress(
+                cluster.accounts[0],
+            )),
             None,
             None,
             true,
@@ -626,16 +635,16 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get_recent_transactions
     let tx = client
         .read_api()
-        .query_transactions(TransactionQuery::All, None, Some(20), true)
+        .query_transactions(SuiTransactionResponseQuery::default(), None, Some(20), true)
         .await
         .unwrap();
     assert_eq!(20, tx.data.len());
 
     // test get_transaction
-    for tx_digest in tx.data {
+    for tx_resp in tx.data {
         let response: SuiTransactionResponse = client
             .read_api()
-            .get_transaction_with_options(tx_digest, SuiTransactionResponseOptions::new())
+            .get_transaction_with_options(tx_resp.digest, SuiTransactionResponseOptions::new())
             .await
             .unwrap();
         assert!(tx_responses

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6657,13 +6657,6 @@
       "TransactionFilter": {
         "oneOf": [
           {
-            "description": "All transaction hashes.",
-            "type": "string",
-            "enum": [
-              "All"
-            ]
-          },
-          {
             "description": "Query by move function.",
             "type": "object",
             "required": [
@@ -6979,6 +6972,7 @@
         "type": "object",
         "properties": {
           "filter": {
+            "description": "If None, no filter will be applied",
             "default": null,
             "anyOf": [
               {
@@ -6990,6 +6984,7 @@
             ]
           },
           "options": {
+            "description": "config which fields to include in the response, by default only digest is included",
             "default": null,
             "anyOf": [
               {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1529,7 +1529,7 @@
           "name": "Read API"
         }
       ],
-      "description": "Return list of transaction digests within the queried range. This method will be removed before April 2023, please use `getTransactions` instead",
+      "description": "Return list of transaction digests within the queried range. This method will be removed before April 2023, please use `queryTransactions` instead",
       "params": [
         {
           "name": "start",
@@ -2065,7 +2065,7 @@
           "description": "the transaction query criteria.",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/TransactionQuery"
+            "$ref": "#/components/schemas/TransactionResponseQuery"
           }
         },
         {
@@ -2096,7 +2096,7 @@
         "name": "TransactionsPage",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/Page_for_TransactionDigest_and_TransactionDigest"
+          "$ref": "#/components/schemas/Page_for_TransactionResponse_and_TransactionDigest"
         }
       },
       "examples": [
@@ -2126,10 +2126,18 @@
             "name": "Result",
             "value": {
               "data": [
-                "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi",
-                "9BQobwxQvJ1JxSXNn8v8htZPTu8FEzJJGgcD4kgLUuMd",
-                "GUPcK4cmRmgsTFr52ab9f6fnzNVg3Lz6hF2aXFcsRzaD",
-                "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2"
+                {
+                  "digest": "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi"
+                },
+                {
+                  "digest": "9BQobwxQvJ1JxSXNn8v8htZPTu8FEzJJGgcD4kgLUuMd"
+                },
+                {
+                  "digest": "GUPcK4cmRmgsTFr52ab9f6fnzNVg3Lz6hF2aXFcsRzaD"
+                },
+                {
+                  "digest": "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2"
+                }
               ],
               "nextCursor": "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2",
               "hasNextPage": false
@@ -4862,7 +4870,7 @@
         ]
       },
       "Page_for_Coin_and_ObjectID": {
-        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor`, if `next_cursor` is `Some`, otherwise it will start from the first item.",
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
           "data",
@@ -4891,7 +4899,7 @@
         }
       },
       "Page_for_DynamicFieldInfo_and_ObjectID": {
-        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor`, if `next_cursor` is `Some`, otherwise it will start from the first item.",
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
           "data",
@@ -4920,7 +4928,7 @@
         }
       },
       "Page_for_EventEnvelope_and_EventID": {
-        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor`, if `next_cursor` is `Some`, otherwise it will start from the first item.",
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
           "data",
@@ -4948,8 +4956,8 @@
           }
         }
       },
-      "Page_for_TransactionDigest_and_TransactionDigest": {
-        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor`, if `next_cursor` is `Some`, otherwise it will start from the first item.",
+      "Page_for_TransactionResponse_and_TransactionDigest": {
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
           "data",
@@ -4959,7 +4967,7 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TransactionDigest"
+              "$ref": "#/components/schemas/TransactionResponse"
             }
           },
           "hasNextPage": {
@@ -6646,6 +6654,102 @@
       "TransactionEventsDigest": {
         "$ref": "#/components/schemas/Sha3Digest"
       },
+      "TransactionFilter": {
+        "oneOf": [
+          {
+            "description": "All transaction hashes.",
+            "type": "string",
+            "enum": [
+              "All"
+            ]
+          },
+          {
+            "description": "Query by move function.",
+            "type": "object",
+            "required": [
+              "MoveFunction"
+            ],
+            "properties": {
+              "MoveFunction": {
+                "type": "object",
+                "required": [
+                  "package"
+                ],
+                "properties": {
+                  "function": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "module": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "package": {
+                    "$ref": "#/components/schemas/ObjectID"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Query by input object.",
+            "type": "object",
+            "required": [
+              "InputObject"
+            ],
+            "properties": {
+              "InputObject": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Query by mutated object.",
+            "type": "object",
+            "required": [
+              "MutatedObject"
+            ],
+            "properties": {
+              "MutatedObject": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Query by sender address.",
+            "type": "object",
+            "required": [
+              "FromAddress"
+            ],
+            "properties": {
+              "FromAddress": {
+                "$ref": "#/components/schemas/SuiAddress"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Query by recipient address.",
+            "type": "object",
+            "required": [
+              "ToAddress"
+            ],
+            "properties": {
+              "ToAddress": {
+                "$ref": "#/components/schemas/SuiAddress"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
       "TransactionKind": {
         "oneOf": [
           {
@@ -6781,102 +6885,6 @@
           }
         ]
       },
-      "TransactionQuery": {
-        "oneOf": [
-          {
-            "description": "All transaction hashes.",
-            "type": "string",
-            "enum": [
-              "All"
-            ]
-          },
-          {
-            "description": "Query by move function.",
-            "type": "object",
-            "required": [
-              "MoveFunction"
-            ],
-            "properties": {
-              "MoveFunction": {
-                "type": "object",
-                "required": [
-                  "package"
-                ],
-                "properties": {
-                  "function": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "module": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "package": {
-                    "$ref": "#/components/schemas/ObjectID"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Query by input object.",
-            "type": "object",
-            "required": [
-              "InputObject"
-            ],
-            "properties": {
-              "InputObject": {
-                "$ref": "#/components/schemas/ObjectID"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Query by mutated object.",
-            "type": "object",
-            "required": [
-              "MutatedObject"
-            ],
-            "properties": {
-              "MutatedObject": {
-                "$ref": "#/components/schemas/ObjectID"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Query by sender address.",
-            "type": "object",
-            "required": [
-              "FromAddress"
-            ],
-            "properties": {
-              "FromAddress": {
-                "$ref": "#/components/schemas/SuiAddress"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Query by recipient address.",
-            "type": "object",
-            "required": [
-              "ToAddress"
-            ],
-            "properties": {
-              "ToAddress": {
-                "$ref": "#/components/schemas/SuiAddress"
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      },
       "TransactionResponse": {
         "type": "object",
         "required": [
@@ -6964,6 +6972,33 @@
             "description": "Whether to show transaction input data. Default to be False",
             "default": false,
             "type": "boolean"
+          }
+        }
+      },
+      "TransactionResponseQuery": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TransactionFilter"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "options": {
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TransactionResponseOptions"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         }
       },

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1523,93 +1523,6 @@
       ]
     },
     {
-      "name": "sui_getTransactions",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "description": "Return list of transactions for a specified query criteria.",
-      "params": [
-        {
-          "name": "query",
-          "description": "the transaction query criteria.",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/TransactionQuery"
-          }
-        },
-        {
-          "name": "cursor",
-          "description": "Optional paging cursor",
-          "schema": {
-            "$ref": "#/components/schemas/TransactionDigest"
-          }
-        },
-        {
-          "name": "limit",
-          "description": "Maximum item returned per page, default to QUERY_MAX_RESULT_LIMIT if not specified.",
-          "schema": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0.0
-          }
-        },
-        {
-          "name": "descending_order",
-          "description": "query result ordering, default to false (ascending order), oldest record first.",
-          "schema": {
-            "type": "boolean"
-          }
-        }
-      ],
-      "result": {
-        "name": "TransactionsPage",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/Page_for_TransactionDigest_and_TransactionDigest"
-        }
-      },
-      "examples": [
-        {
-          "name": "Return the transaction digest for specified query criteria",
-          "params": [
-            {
-              "name": "query",
-              "value": {
-                "InputObject": "0x6e1e02f6658d21bce9b88bdceee1294144eec47cf39388bb680f69b7426bc529"
-              }
-            },
-            {
-              "name": "cursor",
-              "value": "3nek86HEjXZ7K3EtrAcBG4wMrCS21gqr8BqwwC6M6P7F"
-            },
-            {
-              "name": "limit",
-              "value": 100
-            },
-            {
-              "name": "descending_order",
-              "value": false
-            }
-          ],
-          "result": {
-            "name": "Result",
-            "value": {
-              "data": [
-                "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi",
-                "9BQobwxQvJ1JxSXNn8v8htZPTu8FEzJJGgcD4kgLUuMd",
-                "GUPcK4cmRmgsTFr52ab9f6fnzNVg3Lz6hF2aXFcsRzaD",
-                "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2"
-              ],
-              "nextCursor": "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2",
-              "hasNextPage": false
-            }
-          }
-        }
-      ]
-    },
-    {
       "name": "sui_getTransactionsInRangeDeprecated",
       "tags": [
         {
@@ -2137,6 +2050,93 @@
           "$ref": "#/components/schemas/TransactionBytes"
         }
       }
+    },
+    {
+      "name": "sui_queryTransactions",
+      "tags": [
+        {
+          "name": "Read API"
+        }
+      ],
+      "description": "Return list of transactions for a specified query criteria.",
+      "params": [
+        {
+          "name": "query",
+          "description": "the transaction query criteria.",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/TransactionQuery"
+          }
+        },
+        {
+          "name": "cursor",
+          "description": "Optional paging cursor",
+          "schema": {
+            "$ref": "#/components/schemas/TransactionDigest"
+          }
+        },
+        {
+          "name": "limit",
+          "description": "Maximum item returned per page, default to QUERY_MAX_RESULT_LIMIT if not specified.",
+          "schema": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "descending_order",
+          "description": "query result ordering, default to false (ascending order), oldest record first.",
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "result": {
+        "name": "TransactionsPage",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/Page_for_TransactionDigest_and_TransactionDigest"
+        }
+      },
+      "examples": [
+        {
+          "name": "Return the transaction digest for specified query criteria",
+          "params": [
+            {
+              "name": "query",
+              "value": {
+                "InputObject": "0x6e1e02f6658d21bce9b88bdceee1294144eec47cf39388bb680f69b7426bc529"
+              }
+            },
+            {
+              "name": "cursor",
+              "value": "3nek86HEjXZ7K3EtrAcBG4wMrCS21gqr8BqwwC6M6P7F"
+            },
+            {
+              "name": "limit",
+              "value": 100
+            },
+            {
+              "name": "descending_order",
+              "value": false
+            }
+          ],
+          "result": {
+            "name": "Result",
+            "value": {
+              "data": [
+                "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi",
+                "9BQobwxQvJ1JxSXNn8v8htZPTu8FEzJJGgcD4kgLUuMd",
+                "GUPcK4cmRmgsTFr52ab9f6fnzNVg3Lz6hF2aXFcsRzaD",
+                "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2"
+              ],
+              "nextCursor": "B2iV1SVbBjgTKfbJKPQrvTT6F3kNdekFuBwY9tQcAxV2",
+              "hasNextPage": false
+            }
+          }
+        }
+      ]
     },
     {
       "name": "sui_requestAddStake",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -76,7 +76,7 @@ impl RpcExampleProvider {
             self.get_objects_owned_by_address(),
             self.get_total_transaction_number(),
             self.get_transaction(),
-            self.get_transactions(),
+            self.query_transactions(),
             self.get_events(),
             self.execute_transaction_example(),
             self.get_checkpoint_example(),
@@ -355,7 +355,7 @@ impl RpcExampleProvider {
         )
     }
 
-    fn get_transactions(&mut self) -> Examples {
+    fn query_transactions(&mut self) -> Examples {
         let mut data = self.get_transaction_digests(5..9);
         let has_next_page = data.len() > (9 - 5);
         data.truncate(9 - 5);
@@ -367,7 +367,7 @@ impl RpcExampleProvider {
             has_next_page,
         };
         Examples::new(
-            "sui_getTransactions",
+            "sui_queryTransactions",
             vec![ExamplePairing::new(
                 "Return the transaction digest for specified query criteria",
                 vec![

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -38,7 +38,7 @@ use sui_types::messages_checkpoint::CheckpointDigest;
 use sui_types::object::Owner;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::query::EventQuery;
-use sui_types::query::TransactionQuery;
+use sui_types::query::TransactionFilter;
 use sui_types::signature::GenericSignature;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::SUI_FRAMEWORK_OBJECT_ID;
@@ -360,6 +360,7 @@ impl RpcExampleProvider {
         let has_next_page = data.len() > (9 - 5);
         data.truncate(9 - 5);
         let next_cursor = data.last().cloned();
+        let data = data.into_iter().map(SuiTransactionResponse::new).collect();
 
         let result = TransactionsPage {
             data,
@@ -373,7 +374,9 @@ impl RpcExampleProvider {
                 vec![
                     (
                         "query",
-                        json!(TransactionQuery::InputObject(ObjectID::new(self.rng.gen()))),
+                        json!(TransactionFilter::InputObject(ObjectID::new(
+                            self.rng.gen()
+                        ))),
                     ),
                     ("cursor", json!(TransactionDigest::new(self.rng.gen()))),
                     ("limit", json!(100)),

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -17,7 +17,7 @@ use sui_json_rpc_types::{
     DynamicFieldPage, EventPage, SuiCoinMetadata, SuiCommittee, SuiEventEnvelope, SuiEventFilter,
     SuiGetPastObjectRequest, SuiMoveNormalizedModule, SuiObjectDataOptions, SuiObjectInfo,
     SuiObjectResponse, SuiPastObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
-    SuiTransactionResponseOptions, TransactionsPage,
+    SuiTransactionResponseOptions, SuiTransactionResponseQuery, TransactionsPage,
 };
 use sui_types::balance::Supply;
 use sui_types::base_types::{
@@ -28,7 +28,7 @@ use sui_types::error::TRANSACTION_NOT_FOUND_MSG_PREFIX;
 use sui_types::event::EventID;
 use sui_types::messages::{ExecuteTransactionRequestType, TransactionData, VerifiedTransaction};
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use sui_types::query::{EventQuery, TransactionQuery};
+use sui_types::query::EventQuery;
 
 use futures::StreamExt;
 use sui_json_rpc::api::{CoinReadApiClient, EventReadApiClient, ReadApiClient, WriteApiClient};
@@ -159,7 +159,7 @@ impl ReadApi {
 
     pub async fn query_transactions(
         &self,
-        query: TransactionQuery,
+        query: SuiTransactionResponseQuery,
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         descending_order: bool,
@@ -189,10 +189,10 @@ impl ReadApi {
 
     pub fn get_transactions_stream(
         &self,
-        query: TransactionQuery,
+        query: SuiTransactionResponseQuery,
         cursor: Option<TransactionDigest>,
         descending_order: bool,
-    ) -> impl Stream<Item = TransactionDigest> + '_ {
+    ) -> impl Stream<Item = SuiTransactionResponse> + '_ {
         stream::unfold(
             (vec![], cursor, true, query),
             move |(mut data, cursor, first, query)| async move {

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -157,7 +157,7 @@ impl ReadApi {
         Ok(self.api.http.get_committee_info(epoch).await?)
     }
 
-    pub async fn get_transactions(
+    pub async fn query_transactions(
         &self,
         query: TransactionQuery,
         cursor: Option<TransactionDigest>,
@@ -167,7 +167,7 @@ impl ReadApi {
         Ok(self
             .api
             .http
-            .get_transactions(query, cursor, limit, Some(descending_order))
+            .query_transactions(query, cursor, limit, Some(descending_order))
             .await?)
     }
 
@@ -200,7 +200,7 @@ impl ReadApi {
                     Some((item, (data, cursor, false, query)))
                 } else if (cursor.is_none() && first) || cursor.is_some() {
                     let page = self
-                        .get_transactions(query.clone(), cursor, Some(100), descending_order)
+                        .query_transactions(query.clone(), cursor, Some(100), descending_order)
                         .await
                         .ok()?;
                     let mut data = page.data;

--- a/crates/sui-sdk/tests/stream_tests.rs
+++ b/crates/sui-sdk/tests/stream_tests.rs
@@ -4,9 +4,10 @@
 use futures::StreamExt;
 use std::future;
 use sui::client_commands::SuiClientCommands;
+use sui_json_rpc_types::SuiTransactionResponseQuery;
 use sui_sdk::{SuiClientBuilder, SUI_COIN_TYPE};
 use sui_types::event::EventType;
-use sui_types::query::{EventQuery, TransactionQuery};
+use sui_types::query::EventQuery;
 use test_utils::network::TestClusterBuilder;
 
 #[tokio::test]
@@ -17,7 +18,7 @@ async fn test_transactions_stream() -> Result<(), anyhow::Error> {
     let client = SuiClientBuilder::default().build(rpc_url).await?;
     let txs = client
         .read_api()
-        .get_transactions_stream(TransactionQuery::All, None, true)
+        .get_transactions_stream(SuiTransactionResponseQuery::default(), None, true)
         .collect::<Vec<_>>()
         .await;
 
@@ -36,7 +37,7 @@ async fn test_transactions_stream() -> Result<(), anyhow::Error> {
 
     let txs = client
         .read_api()
-        .get_transactions_stream(TransactionQuery::All, None, true)
+        .get_transactions_stream(SuiTransactionResponseQuery::default(), None, true)
         .collect::<Vec<_>>()
         .await;
 

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -23,7 +23,7 @@ use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::fp_ensure;
 use sui_types::object::Owner;
-use sui_types::query::TransactionQuery;
+use sui_types::query::TransactionFilter;
 
 use crate::default_db_options;
 
@@ -245,7 +245,7 @@ impl IndexStore {
 
     pub fn get_transactions(
         &self,
-        query: TransactionQuery,
+        query: TransactionFilter,
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         reverse: bool,
@@ -260,26 +260,26 @@ impl IndexStore {
             None
         };
         Ok(match query {
-            TransactionQuery::MoveFunction {
+            TransactionFilter::MoveFunction {
                 package,
                 module,
                 function,
             } => self.get_transactions_by_move_function(
                 package, module, function, cursor, limit, reverse,
             )?,
-            TransactionQuery::InputObject(object_id) => {
+            TransactionFilter::InputObject(object_id) => {
                 self.get_transactions_by_input_object(object_id, cursor, limit, reverse)?
             }
-            TransactionQuery::MutatedObject(object_id) => {
+            TransactionFilter::MutatedObject(object_id) => {
                 self.get_transactions_by_mutated_object(object_id, cursor, limit, reverse)?
             }
-            TransactionQuery::FromAddress(address) => {
+            TransactionFilter::FromAddress(address) => {
                 self.get_transactions_from_addr(address, cursor, limit, reverse)?
             }
-            TransactionQuery::ToAddress(address) => {
+            TransactionFilter::ToAddress(address) => {
                 self.get_transactions_to_addr(address, cursor, limit, reverse)?
             }
-            TransactionQuery::All => {
+            TransactionFilter::All => {
                 let iter = self.tables.transaction_order.iter();
 
                 if reverse {

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -245,7 +245,7 @@ impl IndexStore {
 
     pub fn get_transactions(
         &self,
-        query: TransactionFilter,
+        filter: Option<TransactionFilter>,
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         reverse: bool,
@@ -259,27 +259,27 @@ impl IndexStore {
         } else {
             None
         };
-        Ok(match query {
-            TransactionFilter::MoveFunction {
+        Ok(match filter {
+            Some(TransactionFilter::MoveFunction {
                 package,
                 module,
                 function,
-            } => self.get_transactions_by_move_function(
+            }) => self.get_transactions_by_move_function(
                 package, module, function, cursor, limit, reverse,
             )?,
-            TransactionFilter::InputObject(object_id) => {
+            Some(TransactionFilter::InputObject(object_id)) => {
                 self.get_transactions_by_input_object(object_id, cursor, limit, reverse)?
             }
-            TransactionFilter::MutatedObject(object_id) => {
+            Some(TransactionFilter::MutatedObject(object_id)) => {
                 self.get_transactions_by_mutated_object(object_id, cursor, limit, reverse)?
             }
-            TransactionFilter::FromAddress(address) => {
+            Some(TransactionFilter::FromAddress(address)) => {
                 self.get_transactions_from_addr(address, cursor, limit, reverse)?
             }
-            TransactionFilter::ToAddress(address) => {
+            Some(TransactionFilter::ToAddress(address)) => {
                 self.get_transactions_to_addr(address, cursor, limit, reverse)?
             }
-            TransactionFilter::All => {
+            None => {
                 let iter = self.tables.transaction_order.iter();
 
                 if reverse {

--- a/crates/sui-types/src/query.rs
+++ b/crates/sui-types/src/query.rs
@@ -12,8 +12,6 @@ use crate::ObjectID;
 
 #[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
 pub enum TransactionFilter {
-    /// All transaction hashes.
-    All,
     /// Query by move function.
     MoveFunction {
         package: ObjectID,

--- a/crates/sui-types/src/query.rs
+++ b/crates/sui-types/src/query.rs
@@ -11,7 +11,7 @@ use crate::object::Owner;
 use crate::ObjectID;
 
 #[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
-pub enum TransactionQuery {
+pub enum TransactionFilter {
     /// All transaction hashes.
     All,
     /// Query by move function.

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -32,7 +32,7 @@ use sui_types::messages::{
 };
 use sui_types::object::{Object, ObjectRead, Owner, PastObjectRead};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::query::{EventQuery, TransactionQuery};
+use sui_types::query::{EventQuery, TransactionFilter};
 use sui_types::utils::to_sender_signed_transaction_with_multi_signers;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
@@ -172,7 +172,7 @@ async fn test_full_node_move_function_index() -> Result<(), anyhow::Error> {
 
     wait_for_tx(digest, node.state().clone()).await;
     let txes = node.state().get_transactions(
-        TransactionQuery::MoveFunction {
+        TransactionFilter::MoveFunction {
             package: package_ref.0,
             module: Some("counter".to_string()),
             function: Some("increment".to_string()),
@@ -186,7 +186,7 @@ async fn test_full_node_move_function_index() -> Result<(), anyhow::Error> {
     assert_eq!(txes[0], digest);
 
     let txes = node.state().get_transactions(
-        TransactionQuery::MoveFunction {
+        TransactionFilter::MoveFunction {
             package: package_ref.0,
             module: None,
             function: None,
@@ -202,7 +202,7 @@ async fn test_full_node_move_function_index() -> Result<(), anyhow::Error> {
 
     eprint!("start...");
     let txes = node.state().get_transactions(
-        TransactionQuery::MoveFunction {
+        TransactionFilter::MoveFunction {
             package: package_ref.0,
             module: Some("counter".to_string()),
             function: None,
@@ -235,7 +235,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     wait_for_tx(digest, node.state().clone()).await;
 
     let txes = node.state().get_transactions(
-        TransactionQuery::InputObject(transferred_object),
+        TransactionFilter::InputObject(transferred_object),
         None,
         None,
         false,
@@ -245,7 +245,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     assert_eq!(txes[0], digest);
 
     let txes = node.state().get_transactions(
-        TransactionQuery::MutatedObject(transferred_object),
+        TransactionFilter::MutatedObject(transferred_object),
         None,
         None,
         false,
@@ -255,13 +255,13 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
 
     let txes =
         node.state()
-            .get_transactions(TransactionQuery::FromAddress(sender), None, None, false)?;
+            .get_transactions(TransactionFilter::FromAddress(sender), None, None, false)?;
     assert_eq!(txes.len(), 1);
     assert_eq!(txes[0], digest);
 
     let txes =
         node.state()
-            .get_transactions(TransactionQuery::ToAddress(receiver), None, None, false)?;
+            .get_transactions(TransactionFilter::ToAddress(receiver), None, None, false)?;
     assert_eq!(txes.len(), 2);
     assert_eq!(txes[1], digest);
 
@@ -269,13 +269,13 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     // one or more of the sender's objects.
     let txes =
         node.state()
-            .get_transactions(TransactionQuery::ToAddress(sender), None, None, false)?;
+            .get_transactions(TransactionFilter::ToAddress(sender), None, None, false)?;
     assert_eq!(txes.len(), 2);
     assert_eq!(txes[1], digest);
 
     // No transactions have originated from the receiver
     let txes = node.state().get_transactions(
-        TransactionQuery::FromAddress(receiver),
+        TransactionFilter::FromAddress(receiver),
         None,
         None,
         false,
@@ -683,7 +683,7 @@ async fn test_full_node_event_read_api_ok() {
     let txes = node
         .state()
         .get_transactions(
-            TransactionQuery::InputObject(transferred_object),
+            TransactionFilter::InputObject(transferred_object),
             None,
             None,
             false,

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -172,11 +172,11 @@ async fn test_full_node_move_function_index() -> Result<(), anyhow::Error> {
 
     wait_for_tx(digest, node.state().clone()).await;
     let txes = node.state().get_transactions(
-        TransactionFilter::MoveFunction {
+        Some(TransactionFilter::MoveFunction {
             package: package_ref.0,
             module: Some("counter".to_string()),
             function: Some("increment".to_string()),
-        },
+        }),
         None,
         None,
         false,
@@ -186,11 +186,11 @@ async fn test_full_node_move_function_index() -> Result<(), anyhow::Error> {
     assert_eq!(txes[0], digest);
 
     let txes = node.state().get_transactions(
-        TransactionFilter::MoveFunction {
+        Some(TransactionFilter::MoveFunction {
             package: package_ref.0,
             module: None,
             function: None,
-        },
+        }),
         None,
         None,
         false,
@@ -202,11 +202,11 @@ async fn test_full_node_move_function_index() -> Result<(), anyhow::Error> {
 
     eprint!("start...");
     let txes = node.state().get_transactions(
-        TransactionFilter::MoveFunction {
+        Some(TransactionFilter::MoveFunction {
             package: package_ref.0,
             module: Some("counter".to_string()),
             function: None,
-        },
+        }),
         None,
         None,
         false,
@@ -235,7 +235,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     wait_for_tx(digest, node.state().clone()).await;
 
     let txes = node.state().get_transactions(
-        TransactionFilter::InputObject(transferred_object),
+        Some(TransactionFilter::InputObject(transferred_object)),
         None,
         None,
         false,
@@ -245,7 +245,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     assert_eq!(txes[0], digest);
 
     let txes = node.state().get_transactions(
-        TransactionFilter::MutatedObject(transferred_object),
+        Some(TransactionFilter::MutatedObject(transferred_object)),
         None,
         None,
         false,
@@ -253,29 +253,38 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     assert_eq!(txes.len(), 2);
     assert_eq!(txes[1], digest);
 
-    let txes =
-        node.state()
-            .get_transactions(TransactionFilter::FromAddress(sender), None, None, false)?;
+    let txes = node.state().get_transactions(
+        Some(TransactionFilter::FromAddress(sender)),
+        None,
+        None,
+        false,
+    )?;
     assert_eq!(txes.len(), 1);
     assert_eq!(txes[0], digest);
 
-    let txes =
-        node.state()
-            .get_transactions(TransactionFilter::ToAddress(receiver), None, None, false)?;
+    let txes = node.state().get_transactions(
+        Some(TransactionFilter::ToAddress(receiver)),
+        None,
+        None,
+        false,
+    )?;
     assert_eq!(txes.len(), 2);
     assert_eq!(txes[1], digest);
 
     // Note that this is also considered a tx to the sender, because it mutated
     // one or more of the sender's objects.
-    let txes =
-        node.state()
-            .get_transactions(TransactionFilter::ToAddress(sender), None, None, false)?;
+    let txes = node.state().get_transactions(
+        Some(TransactionFilter::ToAddress(sender)),
+        None,
+        None,
+        false,
+    )?;
     assert_eq!(txes.len(), 2);
     assert_eq!(txes[1], digest);
 
     // No transactions have originated from the receiver
     let txes = node.state().get_transactions(
-        TransactionFilter::FromAddress(receiver),
+        Some(TransactionFilter::FromAddress(receiver)),
         None,
         None,
         false,
@@ -683,7 +692,7 @@ async fn test_full_node_event_read_api_ok() {
     let txes = node
         .state()
         .get_transactions(
-            TransactionFilter::InputObject(transferred_object),
+            Some(TransactionFilter::InputObject(transferred_object)),
             None,
             None,
             false,

--- a/dapps/frenemies/src/network/queries/scorecard-history.ts
+++ b/dapps/frenemies/src/network/queries/scorecard-history.ts
@@ -24,7 +24,7 @@ export function useScorecardHistory(scorecardId?: string | null) {
 
       // It's very likely to have duplicates in the `txIds`; so we need to
       // filter them out and pass a unique set.
-      const txIds = await provider.getTransactionsForObject(scorecardId);
+      const txIds = await provider.queryTransactionsForObject(scorecardId);
       const txs = await provider.getTransactionResponseBatch(
         Array.from(new Set(txIds))
       );

--- a/dapps/frenemies/src/network/queries/scorecard-history.ts
+++ b/dapps/frenemies/src/network/queries/scorecard-history.ts
@@ -24,7 +24,9 @@ export function useScorecardHistory(scorecardId?: string | null) {
 
       // It's very likely to have duplicates in the `txIds`; so we need to
       // filter them out and pass a unique set.
-      const txIds = await provider.queryTransactionsForObject(scorecardId);
+      const txIds = await provider.queryTransactionsForObjectDeprecated(
+        scorecardId
+      );
       const txs = await provider.getTransactionResponseBatch(
         Array.from(new Set(txIds))
       );

--- a/doc/src/learn/exchange-integration-guide.md
+++ b/doc/src/learn/exchange-integration-guide.md
@@ -466,7 +466,7 @@ Sui is [DAG](https://cointelegraph.com/explained/what-is-a-directed-acyclic-grap
     {
       "jsonrpc": "2.0",
       "id": 1,
-      "method": "sui_getTransactions",
+      "method": "sui_queryTransactions",
       "params": [
         "All",
         <last known transaction digest>,

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -539,7 +539,7 @@ export class JsonRpcProvider extends Provider {
   }
 
   // Transactions
-  async getTransactions(
+  async queryTransactions(
     query: TransactionQuery,
     cursor: TransactionDigest | null = null,
     limit: number | null = null,
@@ -547,7 +547,7 @@ export class JsonRpcProvider extends Provider {
   ): Promise<PaginatedTransactionDigests> {
     try {
       return await this.client.requestWithType(
-        'sui_getTransactions',
+        'sui_queryTransactions',
         [query, cursor, limit, order === 'descending'],
         PaginatedTransactionDigests,
         this.options.skipDataValidation,
@@ -559,17 +559,17 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async getTransactionsForObject(
+  async queryTransactionsForObject(
     objectID: ObjectId,
     descendingOrder: boolean = true,
   ): Promise<GetTxnDigestsResponse> {
     const requests = [
       {
-        method: 'sui_getTransactions',
+        method: 'sui_queryTransactions',
         args: [{ InputObject: objectID }, null, null, descendingOrder],
       },
       {
-        method: 'sui_getTransactions',
+        method: 'sui_queryTransactions',
         args: [{ MutatedObject: objectID }, null, null, descendingOrder],
       },
     ];
@@ -591,17 +591,17 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async getTransactionsForAddress(
+  async queryTransactionsForAddress(
     addressID: SuiAddress,
     descendingOrder: boolean = true,
   ): Promise<GetTxnDigestsResponse> {
     const requests = [
       {
-        method: 'sui_getTransactions',
+        method: 'sui_queryTransactions',
         args: [{ ToAddress: addressID }, null, null, descendingOrder],
       },
       {
-        method: 'sui_getTransactions',
+        method: 'sui_queryTransactions',
         args: [{ FromAddress: addressID }, null, null, descendingOrder],
       },
     ];

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -10,7 +10,7 @@ import {
   getObjectReference,
   GetTxnDigestsResponse,
   ObjectId,
-  PaginatedTransactionDigests,
+  PaginatedTransactionResponse,
   SubscriptionId,
   SuiAddress,
   SuiEventEnvelope,
@@ -24,7 +24,7 @@ import {
   SuiObjectRef,
   SuiTransactionResponse,
   TransactionDigest,
-  TransactionQuery,
+  SuiTransactionResponseQuery,
   SUI_TYPE_ARG,
   RpcApiVersion,
   parseVersionFromString,
@@ -540,16 +540,16 @@ export class JsonRpcProvider extends Provider {
 
   // Transactions
   async queryTransactions(
-    query: TransactionQuery,
+    query: SuiTransactionResponseQuery,
     cursor: TransactionDigest | null = null,
     limit: number | null = null,
     order: Order = 'descending',
-  ): Promise<PaginatedTransactionDigests> {
+  ): Promise<PaginatedTransactionResponse> {
     try {
       return await this.client.requestWithType(
         'sui_queryTransactions',
         [query, cursor, limit, order === 'descending'],
-        PaginatedTransactionDigests,
+        PaginatedTransactionResponse,
         this.options.skipDataValidation,
       );
     } catch (err) {
@@ -559,18 +559,32 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async queryTransactionsForObject(
+  /**
+   * @deprecated this method will be removed by April 2023.
+   * Use `queryTransactions` instead
+   */
+  async queryTransactionsForObjectDeprecated(
     objectID: ObjectId,
     descendingOrder: boolean = true,
   ): Promise<GetTxnDigestsResponse> {
     const requests = [
       {
         method: 'sui_queryTransactions',
-        args: [{ InputObject: objectID }, null, null, descendingOrder],
+        args: [
+          { filter: { InputObject: objectID } },
+          null,
+          null,
+          descendingOrder,
+        ],
       },
       {
         method: 'sui_queryTransactions',
-        args: [{ MutatedObject: objectID }, null, null, descendingOrder],
+        args: [
+          { filter: { MutatedObject: objectID } },
+          null,
+          null,
+          descendingOrder,
+        ],
       },
     ];
 
@@ -580,10 +594,13 @@ export class JsonRpcProvider extends Provider {
       }
       const results = await this.client.batchRequestWithType(
         requests,
-        PaginatedTransactionDigests,
+        PaginatedTransactionResponse,
         this.options.skipDataValidation,
       );
-      return [...results[0].data, ...results[1].data];
+      return [
+        ...results[0].data.map((r) => r.digest),
+        ...results[1].data.map((r) => r.digest),
+      ];
     } catch (err) {
       throw new Error(
         `Error getting transactions for object: ${err} for id ${objectID}`,
@@ -591,18 +608,32 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async queryTransactionsForAddress(
+  /**
+   * @deprecated this method will be removed by April 2023.
+   * Use `queryTransactions` instead
+   */
+  async queryTransactionsForAddressDeprecated(
     addressID: SuiAddress,
     descendingOrder: boolean = true,
   ): Promise<GetTxnDigestsResponse> {
     const requests = [
       {
         method: 'sui_queryTransactions',
-        args: [{ ToAddress: addressID }, null, null, descendingOrder],
+        args: [
+          { filter: { ToAddress: addressID } },
+          null,
+          null,
+          descendingOrder,
+        ],
       },
       {
         method: 'sui_queryTransactions',
-        args: [{ FromAddress: addressID }, null, null, descendingOrder],
+        args: [
+          { filter: { FromAddress: addressID } },
+          null,
+          null,
+          descendingOrder,
+        ],
       },
     ];
     try {
@@ -611,10 +642,13 @@ export class JsonRpcProvider extends Provider {
       }
       const results = await this.client.batchRequestWithType(
         requests,
-        PaginatedTransactionDigests,
+        PaginatedTransactionResponse,
         this.options.skipDataValidation,
       );
-      return [...results[0].data, ...results[1].data];
+      return [
+        ...results[0].data.map((r) => r.digest),
+        ...results[1].data.map((r) => r.digest),
+      ];
     } catch (err) {
       throw new Error(
         `Error getting transactions for address: ${err} for id ${addressID}`,

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -24,8 +24,8 @@ import {
   SuiAddress,
   EventQuery,
   EventId,
-  PaginatedTransactionDigests,
-  TransactionQuery,
+  PaginatedTransactionResponse,
+  SuiTransactionResponseQuery,
   PaginatedEvents,
   RpcApiVersion,
   FaucetResponse,
@@ -206,7 +206,7 @@ export abstract class Provider {
   // Transactions
   /**
    * Get transaction digests for a given range
-   * @deprecated this method will be removed before April 2023, please use `getTransactions` instead
+   * @deprecated this method will be removed before April 2023, please use `queryTransactions` instead
    */
   abstract getTransactionDigestsInRangeDeprecated(
     start: GatewayTxSeqNumber,
@@ -217,11 +217,11 @@ export abstract class Provider {
    * Get transactions for a given query criteria
    */
   abstract queryTransactions(
-    query: TransactionQuery,
+    query: SuiTransactionResponseQuery,
     cursor: TransactionDigest | null,
     limit: number | null,
     order: Order,
-  ): Promise<PaginatedTransactionDigests>;
+  ): Promise<PaginatedTransactionResponse>;
 
   /**
    * Get total number of transactions

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -216,7 +216,7 @@ export abstract class Provider {
   /**
    * Get transactions for a given query criteria
    */
-  abstract getTransactions(
+  abstract queryTransactions(
     query: TransactionQuery,
     cursor: TransactionDigest | null,
     limit: number | null,

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -235,16 +235,12 @@ export type GatewayTxSeqNumber = number;
 export const GetTxnDigestsResponse = array(TransactionDigest);
 export type GetTxnDigestsResponse = Infer<typeof GetTxnDigestsResponse>;
 
-export const PaginatedTransactionDigests = object({
-  data: array(TransactionDigest),
-  nextCursor: union([TransactionDigest, literal(null)]),
-  hasNextPage: boolean(),
-});
-export type PaginatedTransactionDigests = Infer<
-  typeof PaginatedTransactionDigests
->;
+export type SuiTransactionResponseQuery = {
+  filter?: TransactionFilter;
+  options?: SuiTransactionResponseOptions;
+};
 
-export type TransactionQuery =
+export type TransactionFilter =
   | 'All'
   | {
       MoveFunction: {
@@ -292,6 +288,15 @@ export const SuiTransactionResponseOptions = object({
 
 export type SuiTransactionResponseOptions = Infer<
   typeof SuiTransactionResponseOptions
+>;
+
+export const PaginatedTransactionResponse = object({
+  data: array(SuiTransactionResponse),
+  nextCursor: union([TransactionDigest, literal(null)]),
+  hasNextPage: boolean(),
+});
+export type PaginatedTransactionResponse = Infer<
+  typeof PaginatedTransactionResponse
 >;
 
 /* -------------------------------------------------------------------------- */

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -241,7 +241,6 @@ export type SuiTransactionResponseQuery = {
 };
 
 export type TransactionFilter =
-  | 'All'
   | {
       MoveFunction: {
         package: ObjectId;

--- a/sdk/typescript/test/e2e/invalid-ids.test.ts
+++ b/sdk/typescript/test/e2e/invalid-ids.test.ts
@@ -20,7 +20,7 @@ describe('Object id/Address/Transaction digest validation', () => {
 
     //wrong id
     expect(
-      toolbox.provider.queryTransactionsForAddress('Wrong'),
+      toolbox.provider.queryTransactionsForAddressDeprecated('Wrong'),
     ).rejects.toThrowError(/Invalid Sui address/);
   });
 
@@ -37,7 +37,7 @@ describe('Object id/Address/Transaction digest validation', () => {
       ),
     ).rejects.toThrowError(/Invalid Sui Object id/);
     expect(
-      toolbox.provider.queryTransactionsForObject(
+      toolbox.provider.queryTransactionsForObjectDeprecated(
         '0000000000000000000000004ce52ee7b659b610d59a1ced129291b3d0d421632',
       ),
     ).rejects.toThrowError(/Invalid Sui Object id/);

--- a/sdk/typescript/test/e2e/invalid-ids.test.ts
+++ b/sdk/typescript/test/e2e/invalid-ids.test.ts
@@ -20,7 +20,7 @@ describe('Object id/Address/Transaction digest validation', () => {
 
     //wrong id
     expect(
-      toolbox.provider.getTransactionsForAddress('Wrong'),
+      toolbox.provider.queryTransactionsForAddress('Wrong'),
     ).rejects.toThrowError(/Invalid Sui address/);
   });
 
@@ -37,7 +37,7 @@ describe('Object id/Address/Transaction digest validation', () => {
       ),
     ).rejects.toThrowError(/Invalid Sui Object id/);
     expect(
-      toolbox.provider.getTransactionsForObject(
+      toolbox.provider.queryTransactionsForObject(
         '0000000000000000000000004ce52ee7b659b610d59a1ced129291b3d0d421632',
       ),
     ).rejects.toThrowError(/Invalid Sui Object id/);

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -18,48 +18,48 @@ describe('Transaction Reading API', () => {
   });
 
   it('Get Transaction', async () => {
-    const resp = await toolbox.provider.queryTransactions('All', null, 1);
-    const digest = resp.data[0];
+    const resp = await toolbox.provider.queryTransactions({}, null, 1);
+    const digest = resp.data[0].digest;
     const txn = await toolbox.provider.getTransactionResponse(digest);
     expect(getTransactionDigest(txn)).toEqual(digest);
   });
 
   it('Get Transactions', async () => {
-    const resp = await toolbox.provider.queryTransactionsForAddress(
+    const resp = await toolbox.provider.queryTransactionsForAddressDeprecated(
       toolbox.address(),
       false,
     );
     expect(resp.length).to.greaterThan(0);
 
     const allTransactions = await toolbox.provider.queryTransactions(
-      'All',
+      {},
       null,
       10,
     );
     expect(allTransactions.data.length).to.greaterThan(0);
 
     const resp2 = await toolbox.provider.queryTransactions(
-      { ToAddress: toolbox.address() },
+      { filter: { ToAddress: toolbox.address() } },
       null,
       null,
     );
     const resp3 = await toolbox.provider.queryTransactions(
-      { FromAddress: toolbox.address() },
+      { filter: { FromAddress: toolbox.address() } },
       null,
       null,
     );
-    expect([...resp2.data, ...resp3.data]).toEqual(resp);
+    expect([...resp2.data, ...resp3.data].map((r) => r.digest)).toEqual(resp);
   });
 
   it('Genesis exists', async () => {
     const allTransactions = await toolbox.provider.queryTransactions(
-      'All',
+      {},
       null,
       1,
       'ascending',
     );
     const resp = await toolbox.provider.getTransactionResponse(
-      allTransactions.data[0],
+      allTransactions.data[0].digest,
       { showInput: true },
     );
     const txKind = getTransactionKind(resp)!;

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -18,32 +18,32 @@ describe('Transaction Reading API', () => {
   });
 
   it('Get Transaction', async () => {
-    const resp = await toolbox.provider.getTransactions('All', null, 1);
+    const resp = await toolbox.provider.queryTransactions('All', null, 1);
     const digest = resp.data[0];
     const txn = await toolbox.provider.getTransactionResponse(digest);
     expect(getTransactionDigest(txn)).toEqual(digest);
   });
 
   it('Get Transactions', async () => {
-    const resp = await toolbox.provider.getTransactionsForAddress(
+    const resp = await toolbox.provider.queryTransactionsForAddress(
       toolbox.address(),
       false,
     );
     expect(resp.length).to.greaterThan(0);
 
-    const allTransactions = await toolbox.provider.getTransactions(
+    const allTransactions = await toolbox.provider.queryTransactions(
       'All',
       null,
       10,
     );
     expect(allTransactions.data.length).to.greaterThan(0);
 
-    const resp2 = await toolbox.provider.getTransactions(
+    const resp2 = await toolbox.provider.queryTransactions(
       { ToAddress: toolbox.address() },
       null,
       null,
     );
-    const resp3 = await toolbox.provider.getTransactions(
+    const resp3 = await toolbox.provider.queryTransactions(
       { FromAddress: toolbox.address() },
       null,
       null,
@@ -52,7 +52,7 @@ describe('Transaction Reading API', () => {
   });
 
   it('Genesis exists', async () => {
-    const allTransactions = await toolbox.provider.getTransactions(
+    const allTransactions = await toolbox.provider.queryTransactions(
       'All',
       null,
       1,


### PR DESCRIPTION
## Description 

- rename `get_transactions` to `query_transactions`
- rename `TransactionQuery` to `TransactionFilter`
- remove `All` from `TransactionFilter` since it can be replaced by `None`(no filters means return all results)
- change the `query` parameter in `query_transactions` from `TransactionFilter` to `SuiTransactionResponseQuery`, which contains both the `TransactionFilter` and `SuiTransactionResponseOptions`
- change the return type in `query_transactions` from `Page<TransactionDigest, TransactionDigest>` to `Page<SuiTransactionResponse, TransactionDigest>`

```
    #[method(name = "queryTransactions")]
    async fn query_transactions(
        &self,
        /// the transaction query criteria.
        query: SuiTransactionResponseQuery,
        /// Optional paging cursor
        cursor: Option<TransactionDigest>,
        /// Maximum item returned per page, default to QUERY_MAX_RESULT_LIMIT if not specified.
        limit: Option<usize>,
        /// query result ordering, default to false (ascending order), oldest record first.
        descending_order: Option<bool>,
    ) -> RpcResult<TransactionsPage>;

#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
#[serde(rename_all = "camelCase", rename = "TransactionResponseQuery", default)]
pub struct SuiTransactionResponseQuery {
    /// If None, no filter will be applied
    pub filter: Option<TransactionFilter>,
    /// config which fields to include in the response, by default only digest is included
    pub options: Option<SuiTransactionResponseOptions>,
}

impl SuiTransactionResponseQuery {
    pub fn new(
        filter: Option<TransactionFilter>,
        options: Option<SuiTransactionResponseOptions>,
    ) -> Self {
        Self { filter, options }
    }

    pub fn new_with_filter(filter: TransactionFilter) -> Self {
        Self {
            filter: Some(filter),
            options: None,
        }
    }
}

pub type TransactionsPage = Page<SuiTransactionResponse, TransactionDigest>;
```

## Next PR
- implement the logic in `query_transactions` to fetch other fields for `SuiTransactionResponse`

## Test Plan 
wallet
![CleanShot 2023-03-12 at 15 31 21](https://user-images.githubusercontent.com/76067158/224568500-f1f12b03-17ca-4e65-83d8-627e3c765a83.png)

explorer
![CleanShot 2023-03-12 at 15 30 06](https://user-images.githubusercontent.com/76067158/224568503-e63772f6-3168-4e48-8e14-52d9df15d29b.png)
![CleanShot 2023-03-12 at 15 30 02](https://user-images.githubusercontent.com/76067158/224568505-799ee0aa-19aa-4649-bb20-f373b87b2d59.png)
![CleanShot 2023-03-12 at 15 29 51](https://user-images.githubusercontent.com/76067158/224568512-1a77ddca-98b5-48ff-aa07-98eb67f7052d.png)
![CleanShot 2023-03-12 at 15 29 42](https://user-images.githubusercontent.com/76067158/224568515-f3a80768-51b1-4eae-9783-06933fe1b142.png)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Refactor get_transactions
- rename `get_transactions` to `query_transactions`
- rename `TransactionQuery` to `TransactionFilter`
- remove `All` from `TransactionFilter` since it can be replaced by `None`(no filters means return all results)
- change the `query` parameter in `query_transactions` from `TransactionFilter` to `SuiTransactionResponseQuery`, which contains both the `TransactionFilter` and `SuiTransactionResponseOptions`
- change the return type in `query_transactions` from `Page<TransactionDigest, TransactionDigest>` to `Page<SuiTransactionResponse, TransactionDigest>`
