### PR TITLE
[rpc] Inactive validator and exchange rate API

### DIFF
--- a/crates/sui-cluster-test/src/test_case/call_contract_test.rs
+++ b/crates/sui-cluster-test/src/test_case/call_contract_test.rs
@@ -116,7 +116,7 @@ impl TestCaseImpl for CallContractTest {
             package_id == &SUI_FRAMEWORK_OBJECT_ID
             && sender == &signer
             && type_ == &String::from("0x2::devnet_nft::MintNFTEvent")
-            && bcs::from_bytes::<MintNFTEvent>(bcs).unwrap() == MintNFTEvent {object_id: ID {bytes: nft_id}, creator: signer, name: EXAMPLE_NFT_NAME.into()}
+            && bcs::from_bytes::<MintNFTEvent>(bcs).unwrap() == MintNFTEvent {object_id: ID::new(nft_id), creator: signer, name: EXAMPLE_NFT_NAME.into()}
         )).unwrap_or_else(|| panic!("Expect such a MoveEvent in events {:?}", events));
 
         // Verify fullnode observes the txn

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -74,7 +74,7 @@ use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::{MoveObject, Owner, PastObjectRead, OBJECT_START_VERSION};
 use sui_types::parse_sui_struct_tag;
 use sui_types::query::{EventQuery, TransactionFilter};
-use sui_types::storage::{ObjectKey, WriteKind};
+use sui_types::storage::{ObjectKey, ObjectStore, WriteKind};
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::sui_system_state::SuiSystemStateTrait;
@@ -1961,7 +1961,6 @@ impl AuthorityState {
     }
 
     // This function is only used for testing.
-    #[cfg(test)]
     pub fn get_sui_system_state_object_for_testing(&self) -> SuiResult<SuiSystemState> {
         self.database.get_sui_system_state_object()
     }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -368,11 +368,6 @@ impl AuthorityStore {
             .transpose()
     }
 
-    /// Read an object and return it, or Ok(None) if the object was not found.
-    pub fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
-        self.perpetual_tables.as_ref().get_object(object_id)
-    }
-
     /// Get many objects
     pub fn get_objects(&self, objects: &[ObjectID]) -> Result<Vec<Option<Object>>, SuiError> {
         let mut result = Vec::new();
@@ -1392,6 +1387,13 @@ impl BackingPackageStore for AuthorityStore {
     }
 }
 
+impl ObjectStore for AuthorityStore {
+    /// Read an object and return it, or Ok(None) if the object was not found.
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+        self.perpetual_tables.as_ref().get_object(object_id)
+    }
+}
+
 impl ChildObjectResolver for AuthorityStore {
     fn read_child_object(&self, parent: &ObjectID, child: &ObjectID) -> SuiResult<Option<Object>> {
         let child_object = match self.get_object(child)? {
@@ -1449,12 +1451,6 @@ impl GetModule for AuthorityStore {
         Ok(self
             .get_module(id)?
             .map(|bytes| CompiledModule::deserialize(&bytes).unwrap()))
-    }
-}
-
-impl ObjectStore for AuthorityStore {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
-        self.get_object(object_id)
     }
 }
 

--- a/crates/sui-framework/src/natives/dynamic_field.rs
+++ b/crates/sui-framework/src/natives/dynamic_field.rs
@@ -75,7 +75,13 @@ pub fn hash_type_and_key(
             ))
         }
     };
-    let Some(id) = derive_dynamic_field_id(parent, &k_tag, &k_layout, &k) else {
+    let Some(k_bytes) = k.simple_serialize(&k_layout) else {
+        return Ok(NativeResult::err(
+            legacy_emit_cost(),
+            E_BCS_SERIALIZATION_FAILURE,
+        ))
+    };
+    let Ok(id) = derive_dynamic_field_id(parent, &k_tag, &k_bytes) else {
         return Ok(NativeResult::err(
             legacy_emit_cost(),
             E_BCS_SERIALIZATION_FAILURE,

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -126,7 +126,7 @@ impl GovernanceReadApi {
                 system_state.system_state_version,
                 self.state.db().as_ref(),
                 system_state.inactive_pools_id,
-                &ID { bytes: *pool_id },
+                &ID::new(*pool_id),
             )?;
 
             Ok(validator.exchange_rates_id)

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -17,10 +17,12 @@ use sui_json_rpc_types::{DelegatedStake, Stake, StakeStatus};
 use sui_open_rpc::Module;
 use sui_types::base_types::{MoveObjectType, ObjectID, SuiAddress};
 use sui_types::committee::EpochId;
+use sui_types::dynamic_field::get_dynamic_field_from_store;
 use sui_types::governance::StakedSui;
-use sui_types::sui_system_state::sui_system_state_inner_v1::{PoolTokenExchangeRate, ValidatorV1};
-use sui_types::sui_system_state::SuiSystemState;
+use sui_types::id::ID;
+use sui_types::sui_system_state::PoolTokenExchangeRate;
 use sui_types::sui_system_state::SuiSystemStateTrait;
+use sui_types::sui_system_state::{get_validator_from_table, SuiSystemState};
 
 pub struct GovernanceReadApi {
     state: Arc<AuthorityState>,
@@ -117,21 +119,18 @@ impl GovernanceReadApi {
         });
 
         if let Some(active_rate) = active_rate {
-            return Ok(active_rate);
+            Ok(active_rate)
         } else {
             // try find from inactive pool
-            let inactive_validators = system_state.inactive_pools_id;
-            let inactive_validators = self
-                .state
-                .read_table_value::<ObjectID, ValidatorV1>(inactive_validators, pool_id)
-                .await;
-            if let Some(inactive_validators) = inactive_validators {
-                return Ok(inactive_validators.staking_pool.exchange_rates.id);
-            }
+            let validator = get_validator_from_table(
+                system_state.system_state_version,
+                self.state.db().as_ref(),
+                system_state.inactive_pools_id,
+                &ID { bytes: *pool_id },
+            )?;
+
+            Ok(validator.exchange_rates_id)
         }
-        Err(Error::UnexpectedError(format!(
-            "Cannot find exchange rate table for pool [{pool_id}]."
-        )))
     }
 
     async fn get_exchange_rate(
@@ -139,14 +138,9 @@ impl GovernanceReadApi {
         table: ObjectID,
         epoch: EpochId,
     ) -> Result<PoolTokenExchangeRate, Error> {
-        self.state
-            .read_table_value(table, &epoch)
-            .await
-            .ok_or_else(|| {
-                Error::UnexpectedError(format!(
-                    "Cannot find exchange rate for epoch [{epoch}], from rate table object [{table}]."
-                ))
-            })
+        let exchange_rate: PoolTokenExchangeRate =
+            get_dynamic_field_from_store(self.state.db().as_ref(), table, &epoch)?;
+        Ok(exchange_rate)
     }
 }
 

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -9,7 +9,7 @@ use crate::{ObjectID, SequenceNumber, SUI_FRAMEWORK_ADDRESS};
 use fastcrypto::encoding::Base58;
 use fastcrypto::hash::{HashFunction, Sha3_256};
 use move_core_types::language_storage::{StructTag, TypeTag};
-use move_core_types::value::{MoveStruct, MoveTypeLayout, MoveValue};
+use move_core_types::value::{MoveStruct, MoveValue};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -206,28 +206,22 @@ pub fn is_dynamic_object(move_struct: &MoveStruct) -> bool {
 pub fn derive_dynamic_field_id<T>(
     parent: T,
     key_type_tag: &TypeTag,
-    key_type_layout: &MoveTypeLayout,
-    key: &move_vm_types::values::Value,
-) -> Option<ObjectID>
+    key_bytes: &[u8],
+) -> Result<ObjectID, bcs::Error>
 where
     T: Into<SuiAddress>,
 {
-    let Ok(k_tag_bytes) = bcs::to_bytes(key_type_tag) else {
-        return None;
-    };
-    let Some(k_bytes) = key.simple_serialize(key_type_layout) else {
-        return None;
-    };
+    let k_tag_bytes = bcs::to_bytes(key_type_tag)?;
 
     // hash(parent || key || key_type_tag)
     let mut hasher = Sha3_256::default();
     hasher.update(parent.into());
-    hasher.update(k_bytes.len().to_le_bytes());
-    hasher.update(k_bytes);
+    hasher.update(key_bytes.len().to_le_bytes());
+    hasher.update(key_bytes);
     hasher.update(k_tag_bytes);
     let hash = hasher.finalize();
 
     // truncate into an ObjectID and return
     // OK to access slice because Sha3_256 should never be shorter than ObjectID::LENGTH.
-    Some(ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap())
+    Ok(ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap())
 }

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -6,7 +6,7 @@ use crate::error::{SuiError, SuiResult};
 use crate::id::UID;
 use crate::storage::ObjectStore;
 use crate::sui_serde::Readable;
-use crate::{ObjectID, SequenceNumber, SUI_FRAMEWORK_ADDRESS};
+use crate::{MoveTypeTagTrait, ObjectID, SequenceNumber, SUI_FRAMEWORK_ADDRESS};
 use fastcrypto::encoding::Base58;
 use fastcrypto::hash::{HashFunction, Sha3_256};
 use move_core_types::language_storage::{StructTag, TypeTag};
@@ -228,16 +228,6 @@ where
     Ok(ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap())
 }
 
-pub trait MoveTypeTagTrait {
-    fn get_type_tag() -> TypeTag;
-}
-
-impl MoveTypeTagTrait for u64 {
-    fn get_type_tag() -> TypeTag {
-        TypeTag::U64
-    }
-}
-
 /// Given a parent object ID (e.g. a table), and a `key`, retrieve the corresponding dynamic field
 /// from the `object_store`. The key type `K` must implement `MoveTypeTagTrait` which has an associated
 /// function that returns the Move type tag. This is needed to properly derive the field object ID.
@@ -254,7 +244,7 @@ where
     let id = derive_dynamic_field_id(parent_id, &K::get_type_tag(), &bcs::to_bytes(key).unwrap())
         .map_err(|err| SuiError::DynamicFieldReadError(err.to_string()))?;
     let object = object_store.get_object(&id)?.ok_or_else(|| {
-        SuiError::DynamicFieldReadError("Dynamic field not found in the table".to_owned())
+        SuiError::DynamicFieldReadError("Dynamic field not found on parent".to_owned())
     })?;
     let move_object = object.data.try_as_move().ok_or_else(|| {
         SuiError::DynamicFieldReadError("Dynamic field is not a Move object".to_owned())

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -4,6 +4,7 @@
 use crate::base_types::{ObjectDigest, SuiAddress};
 use crate::error::{SuiError, SuiResult};
 use crate::id::UID;
+use crate::storage::ObjectStore;
 use crate::sui_serde::Readable;
 use crate::{ObjectID, SequenceNumber, SUI_FRAMEWORK_ADDRESS};
 use fastcrypto::encoding::Base58;
@@ -11,6 +12,7 @@ use fastcrypto::hash::{HashFunction, Sha3_256};
 use move_core_types::language_storage::{StructTag, TypeTag};
 use move_core_types::value::{MoveStruct, MoveValue};
 use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
@@ -224,4 +226,40 @@ where
     // truncate into an ObjectID and return
     // OK to access slice because Sha3_256 should never be shorter than ObjectID::LENGTH.
     Ok(ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap())
+}
+
+pub trait MoveTypeTagTrait {
+    fn get_type_tag() -> TypeTag;
+}
+
+impl MoveTypeTagTrait for u64 {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::U64
+    }
+}
+
+/// Given a parent object ID (e.g. a table), and a `key`, retrieve the corresponding dynamic field
+/// from the `object_store`. The key type `K` must implement `MoveTypeTagTrait` which has an associated
+/// function that returns the Move type tag. This is needed to properly derive the field object ID.
+pub fn get_dynamic_field_from_store<S, K, V>(
+    object_store: &S,
+    parent_id: ObjectID,
+    key: &K,
+) -> Result<V, SuiError>
+where
+    S: ObjectStore,
+    K: MoveTypeTagTrait + Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    let id = derive_dynamic_field_id(parent_id, &K::get_type_tag(), &bcs::to_bytes(key).unwrap())
+        .map_err(|err| SuiError::DynamicFieldReadError(err.to_string()))?;
+    let object = object_store.get_object(&id)?.ok_or_else(|| {
+        SuiError::DynamicFieldReadError("Dynamic field not found in the table".to_owned())
+    })?;
+    let move_object = object.data.try_as_move().ok_or_else(|| {
+        SuiError::DynamicFieldReadError("Dynamic field is not a Move object".to_owned())
+    })?;
+    Ok(bcs::from_bytes::<Field<K, V>>(move_object.contents())
+        .map_err(|err| SuiError::DynamicFieldReadError(err.to_string()))?
+        .value)
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -423,11 +423,11 @@ pub enum SuiError {
     #[error("Index store not available on this Fullnode.")]
     IndexStoreNotAvailable,
 
-    #[error("Failed to get the system state object content")]
-    SuiSystemStateNotFound,
+    #[error("Failed to read dynamic field from table in the object store: {0}")]
+    DynamicFieldReadError(String),
 
-    #[error("Found the sui system state object but it has an unexpected version")]
-    SuiSystemStateUnexpectedVersion,
+    #[error("Failed to read or deserialize system state related data structures on-chain: {0}")]
+    SuiSystemStateReadError(String),
 
     #[error("Message version is not supported at the current protocol version: {error}")]
     WrongMessageVersion { error: String },

--- a/crates/sui-types/src/id.rs
+++ b/crates/sui-types/src/id.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::dynamic_field::MoveTypeTagTrait;
+use crate::MoveTypeTagTrait;
 use crate::{base_types::ObjectID, SUI_FRAMEWORK_ADDRESS};
 use move_core_types::language_storage::TypeTag;
 use move_core_types::{
@@ -34,7 +34,7 @@ pub struct ID {
 impl UID {
     pub fn new(bytes: ObjectID) -> Self {
         Self {
-            id: { ID { bytes } },
+            id: { ID::new(bytes) },
         }
     }
 
@@ -67,6 +67,10 @@ impl UID {
 }
 
 impl ID {
+    pub fn new(object_id: ObjectID) -> Self {
+        Self { bytes: object_id }
+    }
+
     pub fn type_() -> StructTag {
         StructTag {
             address: SUI_FRAMEWORK_ADDRESS,

--- a/crates/sui-types/src/id.rs
+++ b/crates/sui-types/src/id.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::dynamic_field::MoveTypeTagTrait;
 use crate::{base_types::ObjectID, SUI_FRAMEWORK_ADDRESS};
+use move_core_types::language_storage::TypeTag;
 use move_core_types::{
     ident_str,
     identifier::IdentStr,
@@ -82,5 +84,11 @@ impl ID {
                 MoveTypeLayout::Address,
             )],
         }
+    }
+}
+
+impl MoveTypeTagTrait for ID {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::Struct(Box::new(Self::type_()))
     }
 }

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -106,3 +106,13 @@ fn resolve_address(addr: &str) -> Option<AccountAddress> {
         _ => None,
     }
 }
+
+pub trait MoveTypeTagTrait {
+    fn get_type_tag() -> TypeTag;
+}
+
+impl MoveTypeTagTrait for u64 {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::U64
+    }
+}

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -225,7 +225,7 @@ impl UpgradeCap {
     pub fn new(uid: ObjectID, package_id: ObjectID) -> Self {
         UpgradeCap {
             id: UID::new(uid),
-            package: ID { bytes: package_id },
+            package: ID::new(package_id),
             version: 1,
             policy: UPGRADE_POLICY_COMPATIBLE,
         }
@@ -258,9 +258,7 @@ impl UpgradeReceipt {
     pub fn new(upgrade_ticket: UpgradeTicket, upgraded_package_id: ObjectID) -> Self {
         UpgradeReceipt {
             cap: upgrade_ticket.cap,
-            package: ID {
-                bytes: upgraded_package_id,
-            },
+            package: ID::new(upgraded_package_id),
         }
     }
 }

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -3,11 +3,11 @@
 
 use crate::base_types::ObjectID;
 use crate::committee::{CommitteeWithNetworkMetadata, EpochId, ProtocolVersion};
-use crate::dynamic_field::{get_dynamic_field_from_store, MoveTypeTagTrait};
+use crate::dynamic_field::get_dynamic_field_from_store;
 use crate::error::SuiError;
 use crate::storage::ObjectStore;
 use crate::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
-use crate::{id::UID, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID};
+use crate::{id::UID, MoveTypeTagTrait, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID};
 use anyhow::Result;
 use enum_dispatch::enum_dispatch;
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -10,9 +10,7 @@ use crate::{id::UID, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID};
 use anyhow::Result;
 use enum_dispatch::enum_dispatch;
 use move_core_types::language_storage::TypeTag;
-use move_core_types::value::MoveTypeLayout;
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
-use move_vm_types::values::Value;
 use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -156,8 +154,7 @@ where
     let inner_id = derive_dynamic_field_id(
         wrapper.id.id.bytes,
         &TypeTag::U64,
-        &MoveTypeLayout::U64,
-        &Value::u64(wrapper.version),
+        &bcs::to_bytes(&wrapper.version).unwrap(),
     )
     .expect("Sui System State object must exist");
     let inner = object_store

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::balance::Balance;
-use crate::base_types::{ObjectID, SuiAddress};
+use crate::base_types::{EpochId, ObjectID, SuiAddress};
 use crate::collection_types::{Table, TableVec, VecMap, VecSet};
 use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata, ProtocolVersion};
 use crate::crypto::verify_proof_of_possession;
@@ -373,19 +373,6 @@ pub struct StakingPoolV1 {
     pub pending_pool_token_withdraw: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub struct PoolTokenExchangeRate {
-    sui_amount: u64,
-    pool_token_amount: u64,
-}
-
-impl PoolTokenExchangeRate {
-    /// Rate of the staking pool, pool token amount : Sui amount
-    pub fn rate(&self) -> f64 {
-        self.pool_token_amount as f64 / self.sui_amount as f64
-    }
-}
-
 /// Rust version of the Move sui::validator_set::ValidatorSet type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 // TODO: Get rid of json schema once we deprecate getSuiSystemState RPC API.
@@ -417,6 +404,15 @@ pub struct SuiSystemStateInnerV1 {
     pub safe_mode: bool,
     pub epoch_start_timestamp_ms: u64,
     // TODO: Use getters instead of all pub.
+}
+
+impl SuiSystemStateInnerV1 {
+    pub fn new_for_testing(epoch: EpochId) -> Self {
+        Self {
+            epoch,
+            ..Default::default()
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -381,9 +381,7 @@ async fn test_inactive_validator_pool_read() {
             version,
             node.state().db().as_ref(),
             inactive_pool_id,
-            &ID {
-                bytes: staking_pool_id,
-            },
+            &ID::new(staking_pool_id),
         )
         .unwrap();
         assert_eq!(validator.sui_address, address);


### PR DESCRIPTION
Introduce indirection APIs to read inactive validators and their exchange rates, without depending on the inner types. This allows us to upgrade system state type while keeping the RPC layer independent.
Added a few APIs in dynamic_field.rs