### PR TITLE
async batch verification

### DIFF
--- a/crates/sui-core/benches/batch_verification_bench.rs
+++ b/crates/sui-core/benches/batch_verification_bench.rs
@@ -6,13 +6,101 @@ use criterion::*;
 use rand::prelude::*;
 use rand::seq::SliceRandom;
 
+use futures::future::join_all;
+use prometheus::Registry;
+use std::sync::Arc;
 use sui_core::test_utils::{make_cert_with_large_committee, make_dummy_tx};
 use sui_types::committee::Committee;
-use sui_types::crypto::{get_key_pair, AccountKeyPair};
+use sui_types::crypto::{get_key_pair, AccountKeyPair, AuthorityKeyPair};
+use sui_types::messages::CertifiedTransaction;
 
 use sui_core::batch_bls_verifier::*;
 
-use criterion::Criterion;
+fn gen_certs(
+    committee: &Committee,
+    key_pairs: &[AuthorityKeyPair],
+    count: u64,
+) -> Vec<CertifiedTransaction> {
+    let (receiver, _): (_, AccountKeyPair) = get_key_pair();
+
+    let senders: Vec<_> = (0..count)
+        .into_iter()
+        .map(|_| get_key_pair::<AccountKeyPair>())
+        .collect();
+
+    let txns: Vec<_> = senders
+        .iter()
+        .map(|(sender, sender_sec)| make_dummy_tx(receiver, *sender, sender_sec))
+        .collect();
+
+    txns.iter()
+        .map(|t| make_cert_with_large_committee(committee, key_pairs, t))
+        .collect()
+}
+
+fn async_verifier_bench(c: &mut Criterion) {
+    let (committee, key_pairs) = Committee::new_simple_test_committee_of_size(100);
+    let committee = Arc::new(committee);
+    let count = 200;
+    let certs = gen_certs(&committee, &key_pairs, count);
+
+    let mut group = c.benchmark_group("async_verify");
+
+    // 8 times as many tasks as CPUs.
+    let over_subscription = 32;
+
+    // Get throughput per core
+    group.throughput(Throughput::Elements(count * over_subscription));
+
+    group.sample_size(10);
+
+    let registry = Registry::new();
+    let metrics = BatchCertificateVerifierMetrics::new(&registry);
+
+    let num_cpus = num_cpus::get() as u64;
+    for num_threads in [1, num_cpus / 2, num_cpus] {
+        for batch_size in [8, 16, 32] {
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!("num_threads={num_threads} batch_size={batch_size}"),
+                    count,
+                ),
+                &count,
+                |b, _| {
+                    let runtime = tokio::runtime::Builder::new_multi_thread()
+                        .worker_threads(num_threads as usize)
+                        .enable_time()
+                        .build()
+                        .unwrap();
+                    let batch_verifier = Arc::new(BatchCertificateVerifier::new(
+                        committee.clone(),
+                        batch_size,
+                        metrics.clone(),
+                    ));
+
+                    b.iter(|| {
+                        let handles: Vec<_> = (0..(num_threads * over_subscription))
+                            .into_iter()
+                            .map(|_| {
+                                let batch_verifier = batch_verifier.clone();
+                                let certs = certs.clone();
+                                runtime.spawn(async move {
+                                    for c in certs.into_iter() {
+                                        batch_verifier.verify_cert_skip_cache(c).await.unwrap();
+                                    }
+                                })
+                            })
+                            .collect();
+
+                        runtime.block_on(async move {
+                            join_all(handles).await;
+                        });
+                    })
+                },
+            );
+        }
+    }
+}
 
 fn batch_verification_bench(c: &mut Criterion) {
     let (committee, key_pairs) = Committee::new_simple_test_committee_of_size(100);
@@ -22,23 +110,9 @@ fn batch_verification_bench(c: &mut Criterion) {
     // pretty significant at that point.
     for batch_size in [1, 4, 16, 32, 64] {
         for num_errors in [0, 1] {
+            let mut certs = gen_certs(&committee, &key_pairs, batch_size);
+
             let (receiver, _): (_, AccountKeyPair) = get_key_pair();
-
-            let senders: Vec<_> = (0..batch_size)
-                .into_iter()
-                .map(|_| get_key_pair::<AccountKeyPair>())
-                .collect();
-
-            let txns: Vec<_> = senders
-                .iter()
-                .map(|(sender, sender_sec)| make_dummy_tx(receiver, *sender, sender_sec))
-                .collect();
-
-            let mut certs: Vec<_> = txns
-                .iter()
-                .map(|t| make_cert_with_large_committee(&committee, &key_pairs, t))
-                .collect();
-
             let (other_sender, other_sender_sec): (_, AccountKeyPair) = get_key_pair();
             let other_tx = make_dummy_tx(receiver, other_sender, &other_sender_sec);
             let other_cert = make_cert_with_large_committee(&committee, &key_pairs, &other_tx);
@@ -64,5 +138,5 @@ fn batch_verification_bench(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, batch_verification_bench);
+criterion_group!(benches, batch_verification_bench, async_verifier_bench);
 criterion_main!(benches);

--- a/crates/sui-core/benches/batch_verification_bench.rs
+++ b/crates/sui-core/benches/batch_verification_bench.rs
@@ -72,7 +72,7 @@ fn async_verifier_bench(c: &mut Criterion) {
                         .enable_time()
                         .build()
                         .unwrap();
-                    let batch_verifier = Arc::new(BatchCertificateVerifier::new(
+                    let batch_verifier = Arc::new(BatchCertificateVerifier::new_with_batch_size(
                         committee.clone(),
                         batch_size,
                         metrics.clone(),

--- a/crates/sui-core/benches/verified_cert_cache_bench.rs
+++ b/crates/sui-core/benches/verified_cert_cache_bench.rs
@@ -3,7 +3,7 @@
 
 use criterion::*;
 
-use sui_core::authority::{VerifiedCertificateCache, VerifiedCertificateCacheMetrics};
+use sui_core::batch_bls_verifier::{BatchCertificateVerifierMetrics, VerifiedCertificateCache};
 use sui_types::digests::CertificateDigest;
 
 use criterion::Criterion;
@@ -25,7 +25,7 @@ fn verified_cert_cache_bench(c: &mut Criterion) {
     assert_eq!(chunks.len(), cpus);
 
     let registry = prometheus::Registry::new();
-    let metrics = VerifiedCertificateCacheMetrics::new(&registry);
+    let metrics = BatchCertificateVerifierMetrics::new(&registry);
     let cache = VerifiedCertificateCache::new(metrics);
 
     let mut group = c.benchmark_group("digest-caching");

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -95,14 +95,12 @@ use sui_types::{
 use typed_store::Map;
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
-pub use crate::authority::authority_per_epoch_store::{
-    VerifiedCertificateCache, VerifiedCertificateCacheMetrics,
-};
 use crate::authority::authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner;
 use crate::authority::authority_store::{ExecutionLockReadGuard, InputKey, ObjectLockStatus};
 use crate::authority::authority_store_pruner::AuthorityStorePruner;
 use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
+use crate::batch_bls_verifier::BatchCertificateVerifierMetrics;
 use crate::checkpoints::CheckpointStore;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::epoch::epoch_metrics::EpochMetrics;
@@ -1678,7 +1676,7 @@ impl AuthorityState {
         );
         let registry = Registry::new();
         let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
-        let verified_cert_cache_metrics = VerifiedCertificateCacheMetrics::new(&registry);
+        let batch_verifier_metrics = BatchCertificateVerifierMetrics::new(&registry);
         let epoch_store = AuthorityPerEpochStore::new(
             name,
             Arc::new(genesis_committee.clone()),
@@ -1688,7 +1686,7 @@ impl AuthorityState {
             EpochStartConfiguration::new_for_testing(),
             store.clone(),
             cache_metrics,
-            verified_cert_cache_metrics,
+            batch_verifier_metrics,
         );
 
         let epochs = Arc::new(CommitteeStore::new(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -3,7 +3,6 @@
 
 use futures::future::{join_all, select, Either};
 use futures::FutureExt;
-use lru::LruCache;
 use narwhal_executor::ExecutionIndices;
 use narwhal_types::Round;
 use parking_lot::RwLock;
@@ -13,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::iter;
-use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use sui_storage::default_db_options;
@@ -22,7 +20,6 @@ use sui_types::accumulator::Accumulator;
 use sui_types::base_types::{AuthorityName, EpochId, ObjectID, SequenceNumber, TransactionDigest};
 use sui_types::committee::Committee;
 use sui_types::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
-use sui_types::digests::CertificateDigest;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     AuthorityCapabilities, CertifiedTransaction, ConsensusTransaction, ConsensusTransactionKey,
@@ -38,6 +35,7 @@ use typed_store::traits::{TableSummary, TypedStoreDebug};
 use crate::authority::authority_notify_read::NotifyRead;
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 use crate::authority::{AuthorityStore, CertTxGuard, ResolverWrapper, MAX_TX_RECOVERY_RETRY};
+use crate::batch_bls_verifier::*;
 use crate::checkpoints::{
     CheckpointCommitHeight, CheckpointServiceNotify, EpochStats, PendingCheckpoint,
     PendingCheckpointInfo,
@@ -56,7 +54,7 @@ use move_vm_runtime::move_vm::MoveVM;
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use mysten_common::notify_once::NotifyOnce;
 use mysten_metrics::monitored_scope;
-use prometheus::{register_int_counter_with_registry, IntCounter, Registry};
+use prometheus::IntCounter;
 use std::cmp::Ordering as CmpOrdering;
 use sui_adapter::adapter;
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
@@ -117,9 +115,10 @@ pub struct AuthorityPerEpochStore {
     reconfig_state_mem: RwLock<ReconfigState>,
     consensus_notify_read: NotifyRead<SequencedConsensusTransactionKey, ()>,
 
-    // Cache of certificates that are known to have valid signatures.
-    // Lives in per-epoch store because the caching is only valid within an epoch.
-    verified_cert_cache: VerifiedCertificateCache,
+    /// Batch verifier for certificates - also caches certificates that are known to have
+    /// valid signatures. Lives in per-epoch store because the caching/batching is only valid
+    /// within for certs within the current epoch.
+    pub(crate) batch_verifier: BatchCertificateVerifier,
 
     pub(crate) checkpoint_state_notify_read: NotifyRead<CheckpointSequenceNumber, Accumulator>,
 
@@ -334,7 +333,7 @@ impl AuthorityPerEpochStore {
         epoch_start_configuration: EpochStartConfiguration,
         store: Arc<AuthorityStore>,
         cache_metrics: Arc<ResolverMetrics>,
-        verified_cert_cache_metrics: Arc<VerifiedCertificateCacheMetrics>,
+        batch_verifier_metrics: Arc<BatchCertificateVerifierMetrics>,
     ) -> Arc<Self> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
@@ -373,6 +372,8 @@ impl AuthorityPerEpochStore {
             .protocol_version();
         let protocol_config = ProtocolConfig::get_for_version(protocol_version);
         let execution_component = ExecutionComponents::new(&protocol_config, store, cache_metrics);
+        let batch_verifier =
+            BatchCertificateVerifier::new(committee.clone(), 8, batch_verifier_metrics);
         Arc::new(Self {
             committee,
             protocol_config,
@@ -383,7 +384,7 @@ impl AuthorityPerEpochStore {
             epoch_alive_notify,
             epoch_alive: tokio::sync::RwLock::new(true),
             consensus_notify_read: NotifyRead::new(),
-            verified_cert_cache: VerifiedCertificateCache::new(verified_cert_cache_metrics),
+            batch_verifier,
             checkpoint_state_notify_read: NotifyRead::new(),
             end_of_publish: Mutex::new(end_of_publish),
             pending_consensus_certificates: Mutex::new(pending_consensus_certificates),
@@ -429,7 +430,7 @@ impl AuthorityPerEpochStore {
             epoch_start_configuration,
             store,
             self.execution_component.metrics(),
-            self.verified_cert_cache.metrics.clone(),
+            self.batch_verifier.metrics.clone(),
         )
     }
 
@@ -451,10 +452,6 @@ impl AuthorityPerEpochStore {
 
     pub fn epoch(&self) -> EpochId {
         self.committee.epoch
-    }
-
-    pub fn verified_cert_cache(&self) -> &VerifiedCertificateCache {
-        &self.verified_cert_cache
     }
 
     pub fn get_state_hash_for_checkpoint(
@@ -1993,80 +1990,5 @@ impl ExecutionComponents {
 
     pub(crate) fn metrics(&self) -> Arc<ResolverMetrics> {
         self.metrics.clone()
-    }
-}
-
-// Cache up to 20000 verified certs. We will need to tune this number in the future - a decent
-// guess to start with is that it should be 10-20 times larger than peak transactions per second,
-// on the assumption that we should see most certs twice within about 10-20 seconds at most: Once via RPC, once via consensus.
-const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 20000;
-
-pub struct VerifiedCertificateCacheMetrics {
-    certificate_signatures_cache_hits: IntCounter,
-    certificate_signatures_cache_evictions: IntCounter,
-}
-
-impl VerifiedCertificateCacheMetrics {
-    pub fn new(registry: &Registry) -> Arc<Self> {
-        Arc::new(Self {
-            certificate_signatures_cache_hits: register_int_counter_with_registry!(
-                "certificate_signatures_cache_hits",
-                "Number of certificates which were known to be verified because of signature cache.",
-                registry
-            )
-            .unwrap(),
-            certificate_signatures_cache_evictions: register_int_counter_with_registry!(
-                "certificate_signatures_cache_evictions",
-                "Number of times we evict a pre-existing key were known to be verified because of signature cache.",
-                registry
-            )
-            .unwrap(),
-        })
-    }
-}
-
-pub struct VerifiedCertificateCache {
-    inner: RwLock<LruCache<CertificateDigest, ()>>,
-    metrics: Arc<VerifiedCertificateCacheMetrics>,
-}
-
-impl VerifiedCertificateCache {
-    pub fn new(metrics: Arc<VerifiedCertificateCacheMetrics>) -> Self {
-        Self {
-            inner: RwLock::new(LruCache::new(
-                NonZeroUsize::new(VERIFIED_CERTIFICATE_CACHE_SIZE).unwrap(),
-            )),
-            metrics,
-        }
-    }
-
-    pub fn is_cert_verified(&self, digest: &CertificateDigest) -> bool {
-        let inner = self.inner.read();
-        if inner.contains(digest) {
-            self.metrics.certificate_signatures_cache_hits.inc();
-            true
-        } else {
-            false
-        }
-    }
-
-    pub fn cache_cert_verified(&self, digest: CertificateDigest) {
-        let mut inner = self.inner.write();
-        if let Some(old) = inner.push(digest, ()) {
-            if old.0 != digest {
-                self.metrics.certificate_signatures_cache_evictions.inc();
-            }
-        }
-    }
-
-    pub fn cache_certs_verified(&self, digests: Vec<CertificateDigest>) {
-        let mut inner = self.inner.write();
-        digests.into_iter().for_each(|d| {
-            if let Some(old) = inner.push(d, ()) {
-                if old.0 != d {
-                    self.metrics.certificate_signatures_cache_evictions.inc();
-                }
-            }
-        });
     }
 }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -373,7 +373,7 @@ impl AuthorityPerEpochStore {
         let protocol_config = ProtocolConfig::get_for_version(protocol_version);
         let execution_component = ExecutionComponents::new(&protocol_config, store, cache_metrics);
         let batch_verifier =
-            BatchCertificateVerifier::new(committee.clone(), 8, batch_verifier_metrics);
+            BatchCertificateVerifier::new(committee.clone(), batch_verifier_metrics);
         Arc::new(Self {
             committee,
             protocol_config,

--- a/crates/sui-core/src/batch_bls_verifier.rs
+++ b/crates/sui-core/src/batch_bls_verifier.rs
@@ -1,26 +1,268 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use futures::pin_mut;
+use itertools::izip;
+use lru::LruCache;
+use parking_lot::{Mutex, MutexGuard, RwLock};
+use prometheus::{register_int_counter_with_registry, IntCounter, Registry};
 use shared_crypto::intent::{Intent, IntentScope};
+use std::sync::Arc;
 use sui_types::{
     committee::Committee,
     crypto::{AuthoritySignInfoTrait, VerificationObligation},
-    error::SuiResult,
+    digests::CertificateDigest,
+    error::{SuiError, SuiResult},
     message_envelope::Message,
-    messages::CertifiedTransaction,
+    messages::{CertifiedTransaction, VerifiedCertificate},
 };
 
 use tap::TapFallible;
+use tokio::{
+    sync::oneshot,
+    time::{timeout, Duration},
+};
 use tracing::error;
+
+type Sender = oneshot::Sender<SuiResult<VerifiedCertificate>>;
+
+struct CertBuffer {
+    certs: Vec<CertifiedTransaction>,
+    senders: Vec<Sender>,
+    id: u64,
+}
+
+impl CertBuffer {
+    fn new(capacity: usize) -> Self {
+        Self {
+            certs: Vec::with_capacity(capacity),
+            senders: Vec::with_capacity(capacity),
+            id: 0,
+        }
+    }
+
+    fn take_and_replace(&mut self) -> Self {
+        let mut new = CertBuffer::new(self.capacity());
+        new.id = self.id + 1;
+        std::mem::swap(&mut new, self);
+        new
+    }
+
+    fn capacity(&self) -> usize {
+        debug_assert_eq!(self.certs.capacity(), self.senders.capacity());
+        self.certs.capacity()
+    }
+
+    fn len(&self) -> usize {
+        debug_assert_eq!(self.certs.len(), self.senders.len());
+        self.certs.len()
+    }
+
+    fn push(&mut self, tx: Sender, cert: CertifiedTransaction) {
+        self.senders.push(tx);
+        self.certs.push(cert);
+    }
+}
+
+pub struct BatchCertificateVerifier {
+    committee: Arc<Committee>,
+    cache: VerifiedCertificateCache,
+
+    queue: Mutex<CertBuffer>,
+    pub metrics: Arc<BatchCertificateVerifierMetrics>,
+}
+
+impl BatchCertificateVerifier {
+    pub fn new(
+        committee: Arc<Committee>,
+        capacity: usize,
+        metrics: Arc<BatchCertificateVerifierMetrics>,
+    ) -> Self {
+        Self {
+            committee,
+            cache: VerifiedCertificateCache::new(metrics.clone()),
+            queue: Mutex::new(CertBuffer::new(capacity)),
+            metrics,
+        }
+    }
+
+    /// Verifies all certs, returns Ok only if all are valid.
+    pub fn verify_cert_batch(&self, certs: Vec<CertifiedTransaction>) -> SuiResult {
+        let certs: Vec<_> = certs
+            .into_iter()
+            .filter(|cert| !self.cache.is_cert_verified(&cert.certificate_digest()))
+            .collect();
+
+        // Note: this verifies user sigs
+        batch_verify_all_certificates(&self.committee, &certs).tap_ok(|_| {
+            self.cache
+                .cache_certs_verified(certs.into_iter().map(|c| c.certificate_digest()).collect())
+        })
+    }
+
+    /// Verifies one cert asynchronously, in a batch.
+    pub async fn verify_cert(&self, cert: CertifiedTransaction) -> SuiResult<VerifiedCertificate> {
+        let cert_digest = cert.certificate_digest();
+        if self.cache.is_cert_verified(&cert_digest) {
+            return Ok(VerifiedCertificate::new_unchecked(cert));
+        }
+        self.verify_cert_skip_cache(cert)
+            .await
+            .tap_ok(|_| self.cache.cache_cert_verified(cert_digest))
+    }
+
+    /// exposed as a public method for the benchmarks
+    pub async fn verify_cert_skip_cache(
+        &self,
+        cert: CertifiedTransaction,
+    ) -> SuiResult<VerifiedCertificate> {
+        // this is the only innocent error we are likely to encounter - filter it before we poison
+        // a whole batch.
+        if cert.auth_sig().epoch != self.committee.epoch() {
+            return Err(SuiError::WrongEpoch {
+                expected_epoch: self.committee.epoch(),
+                actual_epoch: cert.auth_sig().epoch,
+            });
+        }
+
+        cert.verify_sender_signatures()?;
+        self.verify_cert_inner(cert).await
+    }
+
+    async fn verify_cert_inner(
+        &self,
+        cert: CertifiedTransaction,
+    ) -> SuiResult<VerifiedCertificate> {
+        let (tx, rx) = oneshot::channel();
+        pin_mut!(rx);
+
+        let prev_id = {
+            let mut queue = self.queue.lock();
+            queue.push(tx, cert);
+            if queue.len() == queue.capacity() {
+                self.metrics.full_batches.inc();
+                self.process_queue(queue);
+                // unwrap ok - process_queue will have sent the result already
+                return rx.try_recv().unwrap();
+            }
+            queue.id
+        };
+
+        if let Ok(res) = timeout(Duration::from_millis(10), &mut rx).await {
+            // unwrap ok - tx cannot have been dropped without sending a result.
+            return res.unwrap();
+        }
+        self.metrics.timeouts.inc();
+
+        {
+            let queue = self.queue.lock();
+            // check if another thread took the queue while we were re-acquiring lock.
+            if prev_id == queue.id {
+                debug_assert_ne!(queue.len(), queue.capacity());
+                self.metrics.partial_batches.inc();
+                self.process_queue(queue);
+                // unwrap ok - process_queue will have sent the result already
+                return rx.try_recv().unwrap();
+            }
+        }
+
+        // unwrap ok - another thread took the queue while we were re-acquiring the lock and is
+        // guaranteed to process the queue immediately.
+        rx.await.unwrap()
+    }
+
+    fn process_queue(&self, mut queue: MutexGuard<'_, CertBuffer>) {
+        let taken = queue.take_and_replace();
+        drop(queue);
+
+        let results = batch_verify_certificates(&self.committee, &taken.certs);
+        izip!(
+            results.into_iter(),
+            taken.certs.into_iter(),
+            taken.senders.into_iter(),
+        )
+        .for_each(|(result, cert, tx)| {
+            tx.send(match result {
+                Ok(()) => {
+                    self.metrics.total_verified_certs.inc();
+                    Ok(VerifiedCertificate::new_unchecked(cert))
+                }
+                Err(e) => {
+                    self.metrics.total_failed_certs.inc();
+                    Err(e)
+                }
+            })
+            .ok();
+        });
+    }
+}
+
+pub struct BatchCertificateVerifierMetrics {
+    certificate_signatures_cache_hits: IntCounter,
+    certificate_signatures_cache_evictions: IntCounter,
+    timeouts: IntCounter,
+    full_batches: IntCounter,
+    partial_batches: IntCounter,
+    total_verified_certs: IntCounter,
+    total_failed_certs: IntCounter,
+}
+
+impl BatchCertificateVerifierMetrics {
+    pub fn new(registry: &Registry) -> Arc<Self> {
+        Arc::new(Self {
+            certificate_signatures_cache_hits: register_int_counter_with_registry!(
+                "certificate_signatures_cache_hits",
+                "Number of certificates which were known to be verified because of signature cache.",
+                registry
+            )
+            .unwrap(),
+            certificate_signatures_cache_evictions: register_int_counter_with_registry!(
+                "certificate_signatures_cache_evictions",
+                "Number of times we evict a pre-existing key were known to be verified because of signature cache.",
+                registry
+            )
+            .unwrap(),
+            timeouts: register_int_counter_with_registry!(
+                "async_batch_verifier_timeouts",
+                "Number of times batch verifier times out and verifies a partial batch",
+                registry
+            )
+            .unwrap(),
+            full_batches: register_int_counter_with_registry!(
+                "async_batch_verifier_full_batches",
+                "Number of times batch verifier verifies a full batch",
+                registry
+            )
+            .unwrap(),
+            partial_batches: register_int_counter_with_registry!(
+                "async_batch_verifier_partial_batches",
+                "Number of times batch verifier verifies a partial batch",
+                registry
+            )
+            .unwrap(),
+            total_verified_certs: register_int_counter_with_registry!(
+                "async_batch_verifier_total_verified_certs",
+                "Total number of certs batch verifier has verified",
+                registry
+            )
+            .unwrap(),
+            total_failed_certs: register_int_counter_with_registry!(
+                "async_batch_verifier_total_failed_certs",
+                "Total number of certs batch verifier has rejected",
+                registry
+            )
+            .unwrap(),
+        })
+    }
+}
 
 /// Verifies all certificates - if any fail return error.
 pub fn batch_verify_all_certificates(
     committee: &Committee,
     certs: &[CertifiedTransaction],
 ) -> SuiResult {
-    // Verify user signatures
     for cert in certs {
-        cert.data().verify(None)?;
+        cert.verify_sender_signatures()?;
     }
 
     batch_verify_certificates_impl(committee, certs)
@@ -72,4 +314,55 @@ fn batch_verify_certificates_impl(
     }
 
     obligation.verify_all()
+}
+
+// Cache up to 20000 verified certs. We will need to tune this number in the future - a decent
+// guess to start with is that it should be 10-20 times larger than peak transactions per second,
+// on the assumption that we should see most certs twice within about 10-20 seconds at most: Once via RPC, once via consensus.
+const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 20000;
+
+pub struct VerifiedCertificateCache {
+    inner: RwLock<LruCache<CertificateDigest, ()>>,
+    metrics: Arc<BatchCertificateVerifierMetrics>,
+}
+
+impl VerifiedCertificateCache {
+    pub fn new(metrics: Arc<BatchCertificateVerifierMetrics>) -> Self {
+        Self {
+            inner: RwLock::new(LruCache::new(
+                std::num::NonZeroUsize::new(VERIFIED_CERTIFICATE_CACHE_SIZE).unwrap(),
+            )),
+            metrics,
+        }
+    }
+
+    pub fn is_cert_verified(&self, digest: &CertificateDigest) -> bool {
+        let inner = self.inner.read();
+        if inner.contains(digest) {
+            self.metrics.certificate_signatures_cache_hits.inc();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn cache_cert_verified(&self, digest: CertificateDigest) {
+        let mut inner = self.inner.write();
+        if let Some(old) = inner.push(digest, ()) {
+            if old.0 != digest {
+                self.metrics.certificate_signatures_cache_evictions.inc();
+            }
+        }
+    }
+
+    pub fn cache_certs_verified(&self, digests: Vec<CertificateDigest>) {
+        let mut inner = self.inner.write();
+        digests.into_iter().for_each(|d| {
+            if let Some(old) = inner.push(d, ()) {
+                if old.0 != d {
+                    self.metrics.certificate_signatures_cache_evictions.inc();
+                }
+            }
+        });
+    }
 }

--- a/crates/sui-core/src/batch_bls_verifier.rs
+++ b/crates/sui-core/src/batch_bls_verifier.rs
@@ -154,6 +154,9 @@ impl BatchCertificateVerifier {
         &self,
         cert: CertifiedTransaction,
     ) -> SuiResult<VerifiedCertificate> {
+        // Cancellation safety: we use parking_lot locks, which cannot be held across awaits.
+        // Therefore once the queue has been taken by a thread, it is guaranteed to process the
+        // queue and send all results before the future can be cancelled by the caller.
         let (tx, rx) = oneshot::channel();
         pin_mut!(rx);
 

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::transaction_manager::TransactionManager;
 use narwhal_worker::TransactionValidator;
-use sui_types::message_envelope::Message;
 use sui_types::{
     crypto::{AuthoritySignInfoTrait, VerificationObligation},
     messages::{ConsensusTransaction, ConsensusTransactionKind},
@@ -68,36 +67,11 @@ impl TransactionValidator for SuiTxValidator {
 
         // let mut owned_tx_certs = Vec::new();
         let mut obligation = VerificationObligation::default();
-        let mut verified_cert_digests = Vec::new();
+        let mut cert_batch = Vec::new();
         for tx in txs.into_iter() {
             match tx.kind {
                 ConsensusTransactionKind::UserTransaction(certificate) => {
-                    let cert_digest = certificate.certificate_digest();
-                    if self
-                        .epoch_store
-                        .verified_cert_cache()
-                        .is_cert_verified(&cert_digest)
-                    {
-                        continue;
-                    }
-
-                    self.metrics.certificate_signatures_verified.inc();
-                    certificate.data().verify(None)?;
-                    let idx = obligation.add_message(
-                        certificate.data(),
-                        certificate.epoch(),
-                        Intent::default().with_scope(IntentScope::SenderSignedTransaction),
-                    );
-                    certificate.auth_sig().add_to_verification_obligation(
-                        self.epoch_store.committee(),
-                        &mut obligation,
-                        idx,
-                    )?;
-
-                    // The digest must not be added to the cache until:
-                    // - the user signature is verified (checked above)
-                    // - batch verification completes successfully.
-                    verified_cert_digests.push(cert_digest);
+                    cert_batch.push(*certificate);
 
                     // if !certificate.contains_shared_object() {
                     //     // new_unchecked safety: we do not use the certs in this list until all
@@ -123,16 +97,17 @@ impl TransactionValidator for SuiTxValidator {
                 | ConsensusTransactionKind::CapabilityNotification(_) => {}
             }
         }
-        // verify the user transaction signatures as a batch
-        obligation
-            .verify_all()
+
+        // verify the certificate signatures as a batch
+        let count = cert_batch.len();
+        self.epoch_store
+            .batch_verifier
+            .verify_cert_batch(cert_batch)
             .tap_err(|e| warn!("batch verification error: {}", e))
             .wrap_err("Malformed batch (failed to verify)")?;
-
-        // All the certs that we just batch verified can now be cached as verified.
-        self.epoch_store
-            .verified_cert_cache()
-            .cache_certs_verified(verified_cert_digests);
+        self.metrics
+            .certificate_signatures_verified
+            .inc_by(count as u64);
 
         Ok(())
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2868,7 +2868,8 @@ async fn test_authority_persist() {
         fs::create_dir(&epoch_store_path).unwrap();
         let registry = Registry::new();
         let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
-        let verified_cert_cache_metrics = VerifiedCertificateCacheMetrics::new(&registry);
+        let async_batch_verifier_metrics = BatchCertificateVerifierMetrics::new(&registry);
+
         let epoch_store = AuthorityPerEpochStore::new(
             name,
             Arc::new(committee),
@@ -2878,7 +2879,7 @@ async fn test_authority_persist() {
             EpochStartConfiguration::new_for_testing(),
             store.clone(),
             cache_metrics,
-            verified_cert_cache_metrics,
+            async_batch_verifier_metrics,
         );
 
         let checkpoint_store_path = dir.join(format!("DB_{:?}", ObjectID::random()));
@@ -4953,7 +4954,7 @@ async fn test_tallying_rule_score_updates() {
     );
 
     let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
-    let verified_cert_cache_metrics = VerifiedCertificateCacheMetrics::new(&registry);
+    let async_batch_verifier_metrics = BatchCertificateVerifierMetrics::new(&registry);
     let epoch_store = AuthorityPerEpochStore::new(
         auth_0_name,
         Arc::new(committee.clone()),
@@ -4963,7 +4964,7 @@ async fn test_tallying_rule_score_updates() {
         EpochStartConfiguration::new_for_testing(),
         store,
         cache_metrics,
-        verified_cert_cache_metrics,
+        async_batch_verifier_metrics,
     );
 
     let get_stored_seq_num_and_counter = |auth_name: &AuthorityName| {

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -53,7 +53,10 @@ fn gen_ckpts(
                 committee.epoch,
                 CheckpointSummary::new(
                     committee.epoch,
-                    1,
+                    // insert different data for each checkpoint so that we can swap sigs later
+                    // and get a failure. (otherwise every checkpoint is the same so the
+                    // AuthoritySignInfos are interchangeable).
+                    i as u64,
                     0,
                     &CheckpointContents::new_with_causally_ordered_transactions(vec![]),
                     None,

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -110,11 +110,7 @@ async fn test_async_verifier() {
 
     let registry = Registry::new();
     let metrics = BatchCertificateVerifierMetrics::new(&registry);
-    let verifier = Arc::new(BatchCertificateVerifier::new(
-        committee.clone(),
-        16,
-        metrics,
-    ));
+    let verifier = Arc::new(BatchCertificateVerifier::new(committee.clone(), metrics));
 
     let tasks: Vec<_> = (0..32)
         .into_iter()

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -1,20 +1,25 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_types::committee::Committee;
-
 use crate::batch_bls_verifier::*;
 use crate::test_utils::{make_cert_with_large_committee, make_dummy_tx};
+use futures::future::join_all;
+use prometheus::Registry;
+use rand::{thread_rng, Rng};
+use std::sync::Arc;
 use sui_macros::sim_test;
-use sui_types::crypto::{get_key_pair, AccountKeyPair};
+use sui_types::committee::Committee;
+use sui_types::crypto::{get_key_pair, AccountKeyPair, AuthorityKeyPair};
+use sui_types::messages::CertifiedTransaction;
 
-#[sim_test]
-async fn test_batch_verify() {
-    let (committee, key_pairs) = Committee::new_simple_test_committee();
-
+fn gen_certs(
+    committee: &Committee,
+    key_pairs: &[AuthorityKeyPair],
+    count: usize,
+) -> Vec<CertifiedTransaction> {
     let (receiver, _): (_, AccountKeyPair) = get_key_pair();
 
-    let senders: Vec<_> = (0..16)
+    let senders: Vec<_> = (0..count)
         .into_iter()
         .map(|_| get_key_pair::<AccountKeyPair>())
         .collect();
@@ -24,10 +29,16 @@ async fn test_batch_verify() {
         .map(|(sender, sender_sec)| make_dummy_tx(receiver, *sender, sender_sec))
         .collect();
 
-    let certs: Vec<_> = txns
-        .iter()
-        .map(|t| make_cert_with_large_committee(&committee, &key_pairs, t))
-        .collect();
+    txns.iter()
+        .map(|t| make_cert_with_large_committee(committee, key_pairs, t))
+        .collect()
+}
+
+#[sim_test]
+async fn test_batch_verify() {
+    let (committee, key_pairs) = Committee::new_simple_test_committee();
+
+    let certs = gen_certs(&committee, &key_pairs, 16);
 
     batch_verify_all_certificates(&committee, &certs).unwrap();
 
@@ -35,6 +46,7 @@ async fn test_batch_verify() {
     // this test is a bit much for the current implementation - it was originally written to verify
     // a bisecting fall back approach.
     for i in 0..16 {
+        let (receiver, _): (_, AccountKeyPair) = get_key_pair();
         let mut certs = certs.clone();
         let other_tx = make_dummy_tx(receiver, other_sender, &other_sender_sec);
         let other_cert = make_cert_with_large_committee(&committee, &key_pairs, &other_tx);
@@ -47,4 +59,47 @@ async fn test_batch_verify() {
             r.as_ref().unwrap();
         }
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn test_async_verifier() {
+    let (committee, key_pairs) = Committee::new_simple_test_committee();
+    let committee = Arc::new(committee);
+    let key_pairs = Arc::new(key_pairs);
+
+    let registry = Registry::new();
+    let metrics = BatchCertificateVerifierMetrics::new(&registry);
+    let verifier = Arc::new(BatchCertificateVerifier::new(
+        committee.clone(),
+        16,
+        metrics,
+    ));
+
+    let tasks: Vec<_> = (0..32)
+        .into_iter()
+        .map(|_| {
+            let verifier = verifier.clone();
+            let committee = committee.clone();
+            let key_pairs = key_pairs.clone();
+            tokio::task::spawn(async move {
+                let certs = gen_certs(&committee, &key_pairs, 100);
+
+                let (receiver, _): (_, AccountKeyPair) = get_key_pair();
+                let (other_sender, other_sender_sec): (_, AccountKeyPair) = get_key_pair();
+                let other_tx = make_dummy_tx(receiver, other_sender, &other_sender_sec);
+                let other_cert = make_cert_with_large_committee(&committee, &key_pairs, &other_tx);
+
+                for mut c in certs.into_iter() {
+                    if thread_rng().gen_range(0..20) == 0 {
+                        *c.auth_sig_mut_for_testing() = other_cert.auth_sig().clone();
+                        verifier.verify_cert(c).await.unwrap_err();
+                    } else {
+                        verifier.verify_cert(c).await.unwrap();
+                    }
+                }
+            })
+        })
+        .collect();
+
+    join_all(tasks).await;
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -61,7 +61,7 @@ use sui_core::state_accumulator::StateAccumulator;
 use sui_core::storage::RocksDbStore;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_core::{
-    authority::{AuthorityState, AuthorityStore, VerifiedCertificateCacheMetrics},
+    authority::{AuthorityState, AuthorityStore},
     authority_client::NetworkAuthorityClient,
 };
 use sui_json_rpc::coin_api::CoinReadApi;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -39,6 +39,7 @@ use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use sui_core::authority::epoch_start_configuration::EpochStartConfiguration;
 use sui_core::authority_aggregator::AuthorityAggregator;
 use sui_core::authority_server::ValidatorService;
+use sui_core::batch_bls_verifier::BatchCertificateVerifierMetrics;
 use sui_core::checkpoints::checkpoint_executor;
 use sui_core::checkpoints::{
     CheckpointMetrics, CheckpointService, CheckpointStore, SendCheckpointToStateSync,
@@ -194,8 +195,8 @@ impl SuiNode {
             .get_epoch_start_configuration()?
             .expect("EpochStartConfiguration of the current epoch must exist");
         let cache_metrics = Arc::new(ResolverMetrics::new(&prometheus_registry));
-        let verified_cert_cache_metrics =
-            VerifiedCertificateCacheMetrics::new(&prometheus_registry);
+        let batch_verifier_metrics = BatchCertificateVerifierMetrics::new(&prometheus_registry);
+
         let epoch_store = AuthorityPerEpochStore::new(
             config.protocol_public_key(),
             committee,
@@ -205,7 +206,7 @@ impl SuiNode {
             epoch_start_configuration,
             store.clone(),
             cache_metrics,
-            verified_cert_cache_metrics,
+            batch_verifier_metrics,
         );
 
         let checkpoint_store = CheckpointStore::new(&config.db_path().join("checkpoints"));

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -22,6 +22,10 @@ pub trait Message {
     type DigestType: Clone + Debug;
     const SCOPE: IntentScope;
 
+    fn scope(&self) -> IntentScope {
+        Self::SCOPE
+    }
+
     fn digest(&self) -> Self::DigestType;
 
     /// Verify the internal data consistency of this message.

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1822,6 +1822,10 @@ impl CertifiedTransaction {
         let hash = digest.finalize();
         CertificateDigest::new(hash.into())
     }
+
+    pub fn verify_sender_signatures(&self) -> SuiResult {
+        self.data().verify(None)
+    }
 }
 
 pub type TxCertAndSignedEffects = (


### PR DESCRIPTION
stacked on #9132 

Its difficult to give a solid prediction of how this will perform in
production, but here is some data on the raw CPU time savings:

With async batch verification:

    $ time RUST_LOG=off SIM_STRESS_TEST_QPS=30  ../../target/simulator/deps/simtest-3e38176b1c2a7e11 test_simulated_load_basic

    running 1 test
    test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 15.82s

    RUST_LOG=off SIM_STRESS_TEST_QPS=30  test_simulated_load_basic  14.53s user 0.97s system 97% cpu 15.851 total
                                                                    ^^^^^^^^^^^

Without batch verification:

    ; time RUST_LOG=off SIM_STRESS_TEST_QPS=30  ../../target/simulator/deps/simtest-3e38176b1c2a7e11 test_simulated_load_basic

    running 1 test
    test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 17.91s

    RUST_LOG=off SIM_STRESS_TEST_QPS=30  test_simulated_load_basic  16.72s user 1.06s system 98% cpu 18.065 total
                                                                    ^^^^^^^^^^^

These numbers are corroborated by profiles taken with xcode, which indicated
a drop from 55 Gigacycles down to 48Gc, about a 15% improvement.

Lastly, the async benchmarks show that 1600 certs per second per core is achievable
with the async interface. The single-threaded synchronous benchmarks top out at a
bit over 2000 certs per second. We may be able to improve the async interface a bit
more with a lower-contention locking method.
