### PR TITLE
Makes share calcluation methods public

### DIFF
--- a/crates/sui-framework/sources/governance/staking_pool.move
+++ b/crates/sui-framework/sources/governance/staking_pool.move
@@ -405,7 +405,7 @@ module sui::staking_pool {
         is_preactive(pool) || (*option::borrow(&pool.activation_epoch) > epoch)
     }
 
-    fun get_sui_amount(exchange_rate: &PoolTokenExchangeRate, token_amount: u64): u64 {
+    public fun get_sui_amount(exchange_rate: &PoolTokenExchangeRate, token_amount: u64): u64 {
         // When either amount is 0, that means we have no stakes with this pool.
         // The other amount might be non-zero when there's dust left in the pool.
         if (exchange_rate.sui_amount == 0 || exchange_rate.pool_token_amount == 0) {
@@ -417,7 +417,7 @@ module sui::staking_pool {
         (res as u64)
     }
 
-    fun get_token_amount(exchange_rate: &PoolTokenExchangeRate, sui_amount: u64): u64 {
+    public fun get_token_amount(exchange_rate: &PoolTokenExchangeRate, sui_amount: u64): u64 {
         // When either amount is 0, that means we have no stakes with this pool.
         // The other amount might be non-zero when there's dust left in the pool.
         if (exchange_rate.sui_amount == 0 || exchange_rate.pool_token_amount == 0) {


### PR DESCRIPTION
Make get_token_amount() and get_sui_amount() public to allow calculate tokens and sui amounts for particular epochs outside of the staking_pool module

## Description 

Added two `public` modifiers

## Test Plan 

Not suitable

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
