### PR TITLE
[wallet-ext] import and save Ledger accounts to the wallet

### DIFF
--- a/apps/core/tailwind.config.js
+++ b/apps/core/tailwind.config.js
@@ -100,6 +100,7 @@ module.exports = {
                 subtitleSmallExtra: ['10px', '1'],
                 caption: ['12px', '1'],
                 captionSmall: ['11px', '1'],
+                captionSmallExtra: ['10px', '1'],
                 iconTextLarge: ['48px', '1'],
 
                 // Heading sizes:

--- a/apps/wallet/src/background/keyring/Account.ts
+++ b/apps/wallet/src/background/keyring/Account.ts
@@ -1,66 +1,54 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    normalizeSuiAddress,
-    toSerializedSignature,
-    type SerializedSignature,
-    type Keypair,
-    type SuiAddress,
-} from '@mysten/sui.js';
+import { type SuiAddress } from '@mysten/sui.js';
 
-export type AccountType = 'derived' | 'imported';
-export type AccountSerialized = {
+import {
+    type DerivedAccount,
+    type SerializedDerivedAccount,
+} from './DerivedAccount';
+import {
+    type ImportedAccount,
+    type SerializedImportedAccount,
+} from './ImportedAccount';
+import {
+    type LedgerAccount,
+    type SerializedLedgerAccount,
+} from './LedgerAccount';
+
+export enum AccountType {
+    IMPORTED = 'imported',
+    DERIVED = 'derived',
+    LEDGER = 'ledger',
+}
+
+export type SerializedAccount =
+    | SerializedImportedAccount
+    | SerializedDerivedAccount
+    | SerializedLedgerAccount;
+
+export interface Account {
     type: AccountType;
     address: SuiAddress;
-    derivationPath: string | null;
-};
+    toJSON(): SerializedAccount;
+}
 
-export class Account {
-    #keypair: Keypair;
-    public readonly type: AccountType;
-    public readonly derivationPath: string | null;
-    public readonly address: SuiAddress;
+export function isImportedOrDerivedAccount(
+    account: Account
+): account is ImportedAccount | DerivedAccount {
+    return isImportedAccount(account) || isDerivedAccount(account);
+}
 
-    constructor(
-        options:
-            | { type: 'derived'; derivationPath: string; keypair: Keypair }
-            | { type: 'imported'; keypair: Keypair }
-    ) {
-        this.type = options.type;
-        this.derivationPath =
-            options.type === 'derived' ? options.derivationPath : null;
-        this.#keypair = options.keypair;
-        this.address = normalizeSuiAddress(
-            this.#keypair.getPublicKey().toSuiAddress()
-        );
-    }
+export function isImportedAccount(
+    account: Account
+): account is ImportedAccount {
+    return account.type === AccountType.IMPORTED;
+}
 
-    exportKeypair() {
-        return this.#keypair.export();
-    }
+export function isDerivedAccount(account: Account): account is DerivedAccount {
+    return account.type === AccountType.DERIVED;
+}
 
-    async sign(data: Uint8Array): Promise<SerializedSignature> {
-        const pubkey = this.#keypair.getPublicKey();
-        // This is fine to hardcode useRecoverable = false because wallet does not support Secp256k1. Ed25519 does not use this parameter.
-        const signature = this.#keypair.signData(data, false);
-        const signatureScheme = this.#keypair.getKeyScheme();
-        return toSerializedSignature({
-            signature,
-            signatureScheme,
-            pubKey: pubkey,
-        });
-    }
-
-    toJSON(): AccountSerialized {
-        return {
-            type: this.type,
-            address: this.address,
-            derivationPath: this.derivationPath,
-        };
-    }
-
-    get publicKey() {
-        return this.#keypair.getPublicKey();
-    }
+export function isLedgerAccount(account: Account): account is LedgerAccount {
+    return account.type === AccountType.LEDGER;
 }

--- a/apps/wallet/src/background/keyring/Account.ts
+++ b/apps/wallet/src/background/keyring/Account.ts
@@ -17,9 +17,9 @@ import {
 } from './LedgerAccount';
 
 export enum AccountType {
-    IMPORTED = 'imported',
-    DERIVED = 'derived',
-    LEDGER = 'ledger',
+    IMPORTED = 'IMPORTED',
+    DERIVED = 'DERIVED',
+    LEDGER = 'LEDGER',
 }
 
 export type SerializedAccount =
@@ -28,8 +28,8 @@ export type SerializedAccount =
     | SerializedLedgerAccount;
 
 export interface Account {
-    type: AccountType;
-    address: SuiAddress;
+    readonly type: AccountType;
+    readonly address: SuiAddress;
     toJSON(): SerializedAccount;
 }
 

--- a/apps/wallet/src/background/keyring/AccountKeypair.ts
+++ b/apps/wallet/src/background/keyring/AccountKeypair.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    toSerializedSignature,
+    type SerializedSignature,
+    type Keypair,
+} from '@mysten/sui.js';
+
+export class AccountKeypair {
+    #keypair: Keypair;
+
+    constructor(keypair: Keypair) {
+        this.#keypair = keypair;
+    }
+
+    async sign(data: Uint8Array): Promise<SerializedSignature> {
+        const pubkey = this.#keypair.getPublicKey();
+        // This is fine to hardcode useRecoverable = false because wallet does not support Secp256k1. Ed25519 does not use this parameter.
+        const signature = this.#keypair.signData(data, false);
+        const signatureScheme = this.#keypair.getKeyScheme();
+        return toSerializedSignature({
+            signature,
+            signatureScheme,
+            pubKey: pubkey,
+        });
+    }
+
+    exportKeypair() {
+        return this.#keypair.export();
+    }
+
+    get publicKey() {
+        return this.#keypair.getPublicKey();
+    }
+}

--- a/apps/wallet/src/background/keyring/DerivedAccount.ts
+++ b/apps/wallet/src/background/keyring/DerivedAccount.ts
@@ -17,10 +17,10 @@ export type SerializedDerivedAccount = {
 };
 
 export class DerivedAccount implements Account {
-    accountKeypair: AccountKeypair;
-    type: AccountType;
-    address: string;
-    derivationPath: string;
+    readonly accountKeypair: AccountKeypair;
+    readonly type: AccountType;
+    readonly address: SuiAddress;
+    readonly derivationPath: string;
 
     constructor({
         derivationPath,

--- a/apps/wallet/src/background/keyring/DerivedAccount.ts
+++ b/apps/wallet/src/background/keyring/DerivedAccount.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    normalizeSuiAddress,
+    type Keypair,
+    type SuiAddress,
+} from '@mysten/sui.js';
+
+import { type Account, AccountType } from './Account';
+import { AccountKeypair } from './AccountKeypair';
+
+export type SerializedDerivedAccount = {
+    type: AccountType.DERIVED;
+    address: SuiAddress;
+    derivationPath: string;
+};
+
+export class DerivedAccount implements Account {
+    accountKeypair: AccountKeypair;
+    type: AccountType;
+    address: string;
+    derivationPath: string;
+
+    constructor({
+        derivationPath,
+        keypair,
+    }: {
+        derivationPath: string;
+        keypair: Keypair;
+    }) {
+        this.type = AccountType.IMPORTED;
+        this.derivationPath = derivationPath;
+        this.accountKeypair = new AccountKeypair(keypair);
+        this.address = normalizeSuiAddress(
+            this.accountKeypair.publicKey.toSuiAddress()
+        );
+    }
+
+    toJSON(): SerializedDerivedAccount {
+        return {
+            type: AccountType.DERIVED,
+            address: this.address,
+            derivationPath: this.derivationPath,
+        };
+    }
+}

--- a/apps/wallet/src/background/keyring/ImportedAccount.ts
+++ b/apps/wallet/src/background/keyring/ImportedAccount.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    normalizeSuiAddress,
+    type Keypair,
+    type SuiAddress,
+} from '@mysten/sui.js';
+
+import { type Account, AccountType } from './Account';
+import { AccountKeypair } from './AccountKeypair';
+
+export type SerializedImportedAccount = {
+    type: AccountType.IMPORTED;
+    address: SuiAddress;
+    derivationPath: null;
+};
+
+export class ImportedAccount implements Account {
+    accountKeypair: AccountKeypair;
+    type: AccountType;
+    address: string;
+
+    constructor({ keypair }: { keypair: Keypair }) {
+        this.type = AccountType.IMPORTED;
+        this.accountKeypair = new AccountKeypair(keypair);
+        this.address = normalizeSuiAddress(
+            this.accountKeypair.publicKey.toSuiAddress()
+        );
+    }
+
+    toJSON(): SerializedImportedAccount {
+        return {
+            type: AccountType.IMPORTED,
+            address: this.address,
+            derivationPath: null,
+        };
+    }
+}

--- a/apps/wallet/src/background/keyring/ImportedAccount.ts
+++ b/apps/wallet/src/background/keyring/ImportedAccount.ts
@@ -17,9 +17,9 @@ export type SerializedImportedAccount = {
 };
 
 export class ImportedAccount implements Account {
-    accountKeypair: AccountKeypair;
-    type: AccountType;
-    address: string;
+    readonly accountKeypair: AccountKeypair;
+    readonly type: AccountType;
+    readonly address: SuiAddress;
 
     constructor({ keypair }: { keypair: Keypair }) {
         this.type = AccountType.IMPORTED;

--- a/apps/wallet/src/background/keyring/LedgerAccount.ts
+++ b/apps/wallet/src/background/keyring/LedgerAccount.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type SuiAddress } from '@mysten/sui.js';
+import { normalizeSuiAddress, type SuiAddress } from '@mysten/sui.js';
 
 import { type Account, AccountType } from './Account';
 
@@ -12,9 +12,9 @@ export type SerializedLedgerAccount = {
 };
 
 export class LedgerAccount implements Account {
-    type: AccountType;
-    address: string;
-    derivationPath: string;
+    readonly type: AccountType;
+    readonly address: SuiAddress;
+    readonly derivationPath: string;
 
     constructor({
         address,
@@ -24,7 +24,7 @@ export class LedgerAccount implements Account {
         derivationPath: string;
     }) {
         this.type = AccountType.LEDGER;
-        this.address = address;
+        this.address = normalizeSuiAddress(address);
         this.derivationPath = derivationPath;
     }
 

--- a/apps/wallet/src/background/keyring/LedgerAccount.ts
+++ b/apps/wallet/src/background/keyring/LedgerAccount.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type SuiAddress } from '@mysten/sui.js';
+
+import { type Account, AccountType } from './Account';
+
+export type SerializedLedgerAccount = {
+    type: AccountType.LEDGER;
+    address: SuiAddress;
+    derivationPath: string;
+};
+
+export class LedgerAccount implements Account {
+    type: AccountType;
+    address: string;
+    derivationPath: string;
+
+    constructor({
+        address,
+        derivationPath,
+    }: {
+        address: SuiAddress;
+        derivationPath: string;
+    }) {
+        this.type = AccountType.LEDGER;
+        this.address = address;
+        this.derivationPath = derivationPath;
+    }
+
+    toJSON(): SerializedLedgerAccount {
+        return {
+            type: AccountType.LEDGER,
+            address: this.address,
+            derivationPath: this.derivationPath,
+        };
+    }
+}

--- a/apps/wallet/src/background/keyring/VaultStorage.test.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.test.ts
@@ -10,7 +10,7 @@ import {
     setToSessionStorage,
     isSessionStorageSupported,
 } from '../storage-utils';
-import { Account } from './Account';
+import { ImportedAccount } from './ImportedAccount';
 import {
     EPHEMERAL_PASSWORD_KEY,
     EPHEMERAL_VAULT_KEY,
@@ -217,7 +217,11 @@ describe('VaultStorage', () => {
                 await VaultStorage.importKeypair(
                     testEd25519Serialized,
                     testDataVault1.password,
-                    [new Account({ type: 'imported', keypair: testEd25519 })]
+                    [
+                        new ImportedAccount({
+                            keypair: testEd25519,
+                        }),
+                    ]
                 )
             ).toBe(null);
         });

--- a/apps/wallet/src/background/keyring/VaultStorage.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fromExportedKeypair } from '@mysten/sui.js';
+import { fromExportedKeypair, normalizeSuiAddress } from '@mysten/sui.js';
 import { randomBytes } from '@noble/hashes/utils';
 
 import {
@@ -146,12 +146,12 @@ class VaultStorageClass {
             throw new Error('Error, vault is locked. Unlock the vault first.');
         }
         const keypairToImport = fromExportedKeypair(keypair);
-        const importedAddress = keypairToImport.getPublicKey().toSuiAddress();
-        const isDuplicate = existingAccounts.some((anAccount) => {
-            const suiAddress =
-                anAccount.accountKeypair.publicKey.toSuiAddress();
-            return suiAddress === importedAddress;
-        });
+        const importedAddress = normalizeSuiAddress(
+            keypairToImport.getPublicKey().toSuiAddress()
+        );
+        const isDuplicate = existingAccounts.some(
+            (anAccount) => anAccount.address === importedAddress
+        );
         if (isDuplicate) {
             return null;
         }

--- a/apps/wallet/src/background/keyring/VaultStorage.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.ts
@@ -11,7 +11,8 @@ import {
     setToLocalStorage,
     setToSessionStorage,
 } from '../storage-utils';
-import { type Account } from './Account';
+import { type DerivedAccount } from './DerivedAccount';
+import { type ImportedAccount } from './ImportedAccount';
 import { Vault } from './Vault';
 import { getRandomEntropy, toEntropy } from '_shared/utils/bip39';
 
@@ -139,17 +140,18 @@ class VaultStorageClass {
     public async importKeypair(
         keypair: ExportedKeypair,
         password: string,
-        existingAccounts: Account[]
+        existingAccounts: (ImportedAccount | DerivedAccount)[]
     ) {
         if (!this.#vault) {
             throw new Error('Error, vault is locked. Unlock the vault first.');
         }
         const keypairToImport = fromExportedKeypair(keypair);
         const importedAddress = keypairToImport.getPublicKey().toSuiAddress();
-        const isDuplicate = existingAccounts.some(
-            (anAccount) =>
-                anAccount.publicKey.toSuiAddress() === importedAddress
-        );
+        const isDuplicate = existingAccounts.some((anAccount) => {
+            const suiAddress =
+                anAccount.accountKeypair.publicKey.toSuiAddress();
+            return suiAddress === importedAddress;
+        });
         if (isDuplicate) {
             return null;
         }

--- a/apps/wallet/src/background/keyring/index.test.ts
+++ b/apps/wallet/src/background/keyring/index.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { Keyring } from '.';
 import { getFromLocalStorage, setToLocalStorage } from '../storage-utils';
+import { type DerivedAccount } from './DerivedAccount';
 import { VaultStorage } from './VaultStorage';
 import Alarm from '_src/background/Alarms';
 import {
@@ -59,12 +60,11 @@ describe('Keyring', () => {
 
         describe('getActiveAccount', () => {
             it('returns as active account the first derived from mnemonic', async () => {
-                expect((await k.getActiveAccount())!.address).toBe(
+                const account = (await k.getActiveAccount()) as DerivedAccount;
+                expect(account.address).toBe(
                     '0x9c08076187d961f1ed809a9d803fa49037a92039d04f539255072713a180dd5c'
                 );
-                expect((await k.getActiveAccount())!.derivationPath).toBe(
-                    "m/44'/784'/0'/0'/0'"
-                );
+                expect(account.derivationPath).toBe("m/44'/784'/0'/0'/0'");
             });
         });
 

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -6,12 +6,7 @@ import mitt from 'mitt';
 import { throttle } from 'throttle-debounce';
 
 import { getFromLocalStorage, setToLocalStorage } from '../storage-utils';
-import {
-    type Account,
-    isDerivedAccount,
-    isImportedAccount,
-    isImportedOrDerivedAccount,
-} from './Account';
+import { type Account, isImportedOrDerivedAccount } from './Account';
 import { DerivedAccount } from './DerivedAccount';
 import { ImportedAccount } from './ImportedAccount';
 import { VaultStorage } from './VaultStorage';
@@ -160,16 +155,10 @@ export class Keyring {
         }
         if (await VaultStorage.verifyPassword(password)) {
             const account = this.#accountsMap.get(address);
-            if (!account) {
+            if (!account || !isImportedOrDerivedAccount(account)) {
                 return null;
             }
-
-            const isImportedOrDerived =
-                isImportedAccount(account) || isDerivedAccount(account);
-
-            return isImportedOrDerived
-                ? account.accountKeypair.exportKeypair()
-                : null;
+            return account.accountKeypair.exportKeypair();
         } else {
             throw new Error('Wrong password');
         }
@@ -276,7 +265,7 @@ export class Keyring {
                     );
                 }
 
-                if (isImportedAccount(account) || isDerivedAccount(account)) {
+                if (isImportedOrDerivedAccount(account)) {
                     const signature = await account.accountKeypair.sign(
                         fromB64(data)
                     );

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -9,7 +9,7 @@ import type {
     SuiAddress,
 } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
-import type { AccountSerialized } from '_src/background/keyring/Account';
+import type { SerializedAccount } from '_src/background/keyring/Account';
 
 type MethodToPayloads = {
     create: {
@@ -29,7 +29,7 @@ type MethodToPayloads = {
         return: {
             isLocked: boolean;
             isInitialized: boolean;
-            accounts: AccountSerialized[];
+            accounts: SerializedAccount[];
             activeAddress: string | null;
         };
     };

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { isBasePayload } from '_payloads';
+import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
 
 import type {
     ExportedKeypair,
@@ -60,6 +61,10 @@ type MethodToPayloads = {
     deriveNextAccount: {
         args: void;
         return: { accountAddress: SuiAddress };
+    };
+    importLedgerAccounts: {
+        args: { ledgerAccounts: SerializedLedgerAccount[] };
+        return: void;
     };
     verifyPassword: {
         args: { password: string };

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -24,6 +24,7 @@ import { setKeyringStatus } from '_redux/slices/account';
 import { setActiveOrigin, changeActiveNetwork } from '_redux/slices/app';
 import { setPermissions } from '_redux/slices/permissions';
 import { setTransactionRequests } from '_redux/slices/transaction-requests';
+import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
 
 import type { SuiAddress, SuiTransactionResponse } from '@mysten/sui.js';
 import type { Message } from '_messages';
@@ -299,6 +300,18 @@ export class BackgroundClient {
                     );
                 })
             )
+        );
+    }
+
+    importLedgerAccounts(ledgerAccounts: SerializedLedgerAccount[]) {
+        return lastValueFrom(
+            this.sendMessage(
+                createMessage<KeyringPayload<'importLedgerAccounts'>>({
+                    type: 'keyring',
+                    method: 'importLedgerAccounts',
+                    args: { ledgerAccounts },
+                })
+            ).pipe(take(1))
         );
     }
 

--- a/apps/wallet/src/ui/app/components/ledger/ImportLedgerAccounts.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ImportLedgerAccounts.tsx
@@ -10,11 +10,15 @@ import { useCallback } from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
+import { useAccounts } from '../../hooks/useAccounts';
 import { useNextMenuUrl } from '../menu/hooks';
 import Overlay from '../overlay';
-import { type LedgerAccount } from './LedgerAccountItem';
 import { LedgerAccountList } from './LedgerAccountList';
-import { useDeriveLedgerAccounts } from './useDeriveLedgerAccounts';
+import {
+    type SelectableLedgerAccount,
+    useDeriveLedgerAccounts,
+} from './useDeriveLedgerAccounts';
+import { useImportLedgerAccountsMutation } from './useImportLedgerAccountsMutation';
 import { Button } from '_src/ui/app/shared/ButtonUI';
 import { Link } from '_src/ui/app/shared/Link';
 import { Text } from '_src/ui/app/shared/text';
@@ -36,14 +40,32 @@ export function ImportLedgerAccounts() {
             onError: onDeriveError,
         });
 
+    const importLedgerAccountsMutation = useImportLedgerAccountsMutation({
+        onSuccess: () => navigate(accountsUrl),
+        onError: () => {
+            toast.error('There was an issue importing your Ledger accounts.');
+        },
+    });
+
+    const existingAccounts = useAccounts();
+    const existingAccountAddresses = existingAccounts.map(
+        (account) => account.address
+    );
+    const filteredLedgerAccounts = ledgerAccounts.filter(
+        (account) => !existingAccountAddresses.includes(account.address)
+    );
+    const selectedLedgerAccounts = filteredLedgerAccounts.filter(
+        (account) => account.isSelected
+    );
+
     const onAccountClick = useCallback(
-        (targetAccount: LedgerAccount) => {
+        (targetAccount: SelectableLedgerAccount) => {
             setLedgerAccounts((prevState) =>
                 prevState.map((account) => {
                     if (account.address === targetAccount.address) {
                         return {
+                            ...targetAccount,
                             isSelected: !targetAccount.isSelected,
-                            address: targetAccount.address,
                         };
                     }
                     return account;
@@ -56,18 +78,11 @@ export function ImportLedgerAccounts() {
     const onSelectAllAccountsClick = useCallback(() => {
         setLedgerAccounts((prevState) =>
             prevState.map((account) => ({
+                ...account,
                 isSelected: true,
-                address: account.address,
             }))
         );
     }, [setLedgerAccounts]);
-
-    // TODO: Add logic to filter out already imported Ledger accounts
-    // so we don't allow users to import the same account twice
-    const filteredLedgerAccounts = ledgerAccounts.filter(() => true);
-    const selectedLedgerAccounts = filteredLedgerAccounts.filter(
-        (account) => account.isSelected
-    );
 
     const numAccounts = ledgerAccounts.length;
     const numFilteredAccounts = filteredLedgerAccounts.length;
@@ -147,11 +162,12 @@ export function ImportLedgerAccounts() {
                     variant="primary"
                     before={<UnlockedLockIcon />}
                     text="Unlock"
-                    onClick={() => {
-                        // TODO: Do work to actually import the selected accounts once we have
-                        // the account infrastructure setup to support Ledger accounts
-                        navigate(accountsUrl);
-                    }}
+                    loading={importLedgerAccountsMutation.isLoading}
+                    onClick={() =>
+                        importLedgerAccountsMutation.mutate(
+                            selectedLedgerAccounts
+                        )
+                    }
                     disabled={areNoAccountsSelected}
                 />
             </div>

--- a/apps/wallet/src/ui/app/components/ledger/LedgerAccountList.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/LedgerAccountList.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { LedgerAccountItem, type LedgerAccount } from './LedgerAccountItem';
+import { LedgerAccountRow } from './LedgerAccountRow';
+import { type SelectableLedgerAccount } from './useDeriveLedgerAccounts';
 
 type LedgerAccountListProps = {
-    accounts: LedgerAccount[];
-    onAccountClick: (account: LedgerAccount) => void;
+    accounts: SelectableLedgerAccount[];
+    onAccountClick: (account: SelectableLedgerAccount) => void;
 };
 
 export function LedgerAccountList({
@@ -22,7 +23,7 @@ export function LedgerAccountList({
                             onAccountClick(account);
                         }}
                     >
-                        <LedgerAccountItem
+                        <LedgerAccountRow
                             isSelected={account.isSelected}
                             address={account.address}
                         />

--- a/apps/wallet/src/ui/app/components/ledger/LedgerAccountRow.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/LedgerAccountRow.tsx
@@ -9,17 +9,15 @@ import cl from 'classnames';
 import { useGetCoinBalance } from '../../hooks';
 import { Text } from '_src/ui/app/shared/text';
 
-export type LedgerAccount = {
+type LedgerAccountRowProps = {
     isSelected: boolean;
     address: SuiAddress;
 };
 
-type LedgerAccountItemProps = LedgerAccount;
-
-export function LedgerAccountItem({
+export function LedgerAccountRow({
     isSelected,
     address,
-}: LedgerAccountItemProps) {
+}: LedgerAccountRowProps) {
     const { data: coinBalance } = useGetCoinBalance(SUI_TYPE_ARG, address);
     const [totalAmount, totalAmountSymbol] = useFormatCoin(
         coinBalance?.totalBalance ?? 0,

--- a/apps/wallet/src/ui/app/components/ledger/useImportLedgerAccountsMutation.ts
+++ b/apps/wallet/src/ui/app/components/ledger/useImportLedgerAccountsMutation.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { useBackgroundClient } from '../../hooks/useBackgroundClient';
+import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
+import { type Message } from '_src/shared/messaging/messages';
+
+type UseImportLedgerAccountsMutationOptions = Pick<
+    UseMutationOptions<Message, unknown, SerializedLedgerAccount[], unknown>,
+    'onSuccess' | 'onError'
+>;
+
+export function useImportLedgerAccountsMutation({
+    onSuccess,
+    onError,
+}: UseImportLedgerAccountsMutationOptions) {
+    const backgroundClient = useBackgroundClient();
+    return useMutation({
+        mutationFn: (ledgerAccounts: SerializedLedgerAccount[]) => {
+            return backgroundClient.importLedgerAccounts(ledgerAccounts);
+        },
+        onSuccess,
+        onError,
+    });
+}

--- a/apps/wallet/src/ui/app/components/menu/content/Account.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/Account.tsx
@@ -7,17 +7,21 @@ import { formatAddress } from '@mysten/sui.js';
 import { cx } from 'class-variance-authority';
 
 import { AccountActions } from './AccountActions';
+import { AccountType } from '_src/background/keyring/Account';
 import { useCopyToClipboard } from '_src/ui/app/hooks/useCopyToClipboard';
 import { Heading } from '_src/ui/app/shared/heading';
+import { Text } from '_src/ui/app/shared/text';
 
 export type AccountProps = {
     address: string;
+    accountType: AccountType;
 };
 
-export function Account({ address }: AccountProps) {
+export function Account({ address, accountType }: AccountProps) {
     const copyCallback = useCopyToClipboard(address, {
         copySuccessMessage: 'Address copied',
     });
+
     return (
         <Disclosure>
             {({ open }) => (
@@ -33,7 +37,7 @@ export function Account({ address }: AccountProps) {
                         as="div"
                         className="flex flex-nowrap items-center p-5 self-stretch cursor-pointer gap-3 group"
                     >
-                        <div className="transition flex flex-1 justify-start text-steel-dark group-hover:text-steel-darker ui-open:text-steel-darker">
+                        <div className="transition flex flex-1 gap-3 justify-start items-center text-steel-dark group-hover:text-steel-darker ui-open:text-steel-darker">
                             <Heading
                                 mono
                                 weight="semibold"
@@ -42,6 +46,7 @@ export function Account({ address }: AccountProps) {
                             >
                                 {formatAddress(address)}
                             </Heading>
+                            <AccountBadge accountType={accountType} />
                         </div>
                         <Copy16
                             onClick={copyCallback}
@@ -58,11 +63,43 @@ export function Account({ address }: AccountProps) {
                         leaveTo="transform opacity-0"
                     >
                         <Disclosure.Panel className="px-5 pb-4">
-                            <AccountActions accountAddress={address} />
+                            <AccountActions
+                                accountAddress={address}
+                                accountType={accountType}
+                            />
                         </Disclosure.Panel>
                     </Transition>
                 </div>
             )}
         </Disclosure>
     );
+}
+
+type AccountBadgeProps = {
+    accountType: AccountType;
+};
+
+function AccountBadge({ accountType }: AccountBadgeProps) {
+    let badgeText: string | null = null;
+    switch (accountType) {
+        case AccountType.LEDGER:
+            badgeText = 'Ledger';
+            break;
+        case AccountType.IMPORTED:
+            badgeText = 'Imported';
+            break;
+        case AccountType.DERIVED:
+            badgeText = null;
+            break;
+        default:
+            throw new Error(`Encountered unknown account type ${accountType}`);
+    }
+
+    return badgeText ? (
+        <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
+            <Text variant="captionSmallExtra" color="steel-dark">
+                {badgeText}
+            </Text>
+        </div>
+    ) : null;
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
@@ -4,24 +4,40 @@
 import { type SuiAddress } from '@mysten/sui.js';
 
 import { useNextMenuUrl } from '../hooks';
+import { AccountType } from '_src/background/keyring/Account';
 import { Link } from '_src/ui/app/shared/Link';
+import { Text } from '_src/ui/app/shared/text';
 
 export type AccountActionsProps = {
     accountAddress: SuiAddress;
+    accountType: AccountType;
 };
 
-export function AccountActions({ accountAddress }: AccountActionsProps) {
+export function AccountActions({
+    accountAddress,
+    accountType,
+}: AccountActionsProps) {
     const exportAccountUrl = useNextMenuUrl(true, `/export/${accountAddress}`);
+    const canExportPrivateKey =
+        accountType === AccountType.DERIVED ||
+        accountType === AccountType.IMPORTED;
+
     return (
         <div className="flex flex-row flex-nowrap items-center flex-1">
-            <div>
-                <Link
-                    text="Export Private Key"
-                    to={exportAccountUrl}
-                    color="heroDark"
-                    weight="medium"
-                />
-            </div>
+            {canExportPrivateKey ? (
+                <div>
+                    <Link
+                        text="Export Private Key"
+                        to={exportAccountUrl}
+                        color="heroDark"
+                        weight="medium"
+                    />
+                </div>
+            ) : (
+                <Text variant="bodySmall" weight="medium" color="steel-dark">
+                    No actions available
+                </Text>
+            )}
         </div>
     );
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
@@ -46,8 +46,12 @@ export function AccountsSettings() {
     return (
         <MenuLayout title="Accounts" back={backUrl}>
             <div className="flex flex-col gap-3">
-                {accounts.map(({ address }) => (
-                    <Account address={address} key={address} />
+                {accounts.map(({ address, type }) => (
+                    <Account
+                        key={address}
+                        address={address}
+                        accountType={type}
+                    />
                 ))}
                 {isMultiAccountsEnabled ? (
                     <>

--- a/apps/wallet/src/ui/app/redux/slices/account/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/account/index.ts
@@ -8,11 +8,15 @@ import {
 } from '@reduxjs/toolkit';
 import Browser from 'webextension-polyfill';
 
+import {
+    AccountType,
+    type SerializedAccount,
+} from '_src/background/keyring/Account';
+
 import type { SuiAddress } from '@mysten/sui.js';
 import type { PayloadAction, Reducer } from '@reduxjs/toolkit';
 import type { KeyringPayload } from '_payloads/keyring';
 import type { RootState } from '_redux/RootReducer';
-import type { AccountSerialized } from '_src/background/keyring/Account';
 import type { AppThunkConfig } from '_store/thunk-extras';
 
 export const createVault = createAsyncThunk<
@@ -51,13 +55,13 @@ export const logout = createAsyncThunk<void, void, AppThunkConfig>(
     }
 );
 
-const accountsAdapter = createEntityAdapter<AccountSerialized>({
+const accountsAdapter = createEntityAdapter<SerializedAccount>({
     selectId: ({ address }) => address,
     sortComparer: (a, b) => {
         if (a.type !== b.type) {
             // first derived accounts
-            return a.type === 'derived' ? -1 : 1;
-        } else if (a.type === 'derived') {
+            return a.type === AccountType.DERIVED ? -1 : 1;
+        } else if (a.type === AccountType.DERIVED) {
             // sort derived accounts by derivation path
             return (a.derivationPath || '').localeCompare(
                 b.derivationPath || '',

--- a/apps/wallet/src/ui/app/shared/text/index.tsx
+++ b/apps/wallet/src/ui/app/shared/text/index.tsx
@@ -19,7 +19,9 @@ const textStyles = cva([], {
             subtitleSmall: 'text-subtitleSmall',
             subtitleSmallExtra: 'text-subtitleSmallExtra',
             caption: 'uppercase text-caption',
-            captionSmall: 'uppercase text-captionSmall ',
+            captionSmall: 'uppercase text-captionSmall',
+            captionSmallExtra:
+                'uppercase tracking-wider text-captionSmallExtra',
             p1: 'text-p1',
             p2: 'text-p2',
             p3: 'text-p3',


### PR DESCRIPTION
## Description 

This PR splits the `Account` class into separate classes for each account type: `LedgerAccount`, `ImportedAccount`, and `DerivedAccount`. I think there are two options to go about supporting signing transactions with Ledger in the wallet:
  1. Make a keypair with async resolution that can connect to the user's Ledger device from the background script
  2. Remove the concept of a keypair for Ledger accounts and sign transactions using a Ledger signer in the content script

While I think option 1 is possibly the more "proper" solution based on some brief discussions with @Jordan-Mysten, there's added complexity to updating all usages of the `Keypair` interface in the SDK (or creating some discriminated union where `type Keypair = KeypairWithAsyncResolution | KeypairWIthSyncResolution`). There's also the matter of initializing a `SuiLedgerClient` instance from the background script which has added complexity (how do we handle errors when the user disconnects their device and then tries to sign a transaction?).

So this PR implements the initial work for option 2 which is to remove the concept of keypairs for Ledger accounts. While this might not be the most ideal, I think it makes sense, and having distinct Account classes allows us to be very explicit in code with what is or isn't possible for an account (e.g., can I export the private key to this account?). If option 1 might be more feasible or if there are concerns with this approach, I'm very glad to hear any feedback 😄.

Part 1 (this diff): https://github.com/MystenLabs/sui/pull/9165
Part 2 (add the ability to save/load Ledger accounts): https://github.com/MystenLabs/sui/pull/9166
Part 3 (hook-up UI to save imported Ledger accounts): https://github.com/MystenLabs/sui/pull/9167
Part 4 (add account badge for Ledger accounts): https://github.com/MystenLabs/sui/pull/9168

## Test Plan 
- Manual testing (No visible user changes and everything works the same as before)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A