### PR TITLE
[wallet-ext][part 2] Add support to keyring for importing and saving Ledger accounts

### DIFF
--- a/apps/core/tailwind.config.js
+++ b/apps/core/tailwind.config.js
@@ -100,6 +100,7 @@ module.exports = {
                 subtitleSmallExtra: ['10px', '1'],
                 caption: ['12px', '1'],
                 captionSmall: ['11px', '1'],
+                captionSmallExtra: ['10px', '1'],
                 iconTextLarge: ['48px', '1'],
 
                 // Heading sizes:

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { isBasePayload } from '_payloads';
+import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
 
 import type {
     ExportedKeypair,
@@ -60,6 +61,10 @@ type MethodToPayloads = {
     deriveNextAccount: {
         args: void;
         return: { accountAddress: SuiAddress };
+    };
+    importLedgerAccounts: {
+        args: { ledgerAccounts: SerializedLedgerAccount[] };
+        return: void;
     };
     verifyPassword: {
         args: { password: string };

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -24,6 +24,7 @@ import { setKeyringStatus } from '_redux/slices/account';
 import { setActiveOrigin, changeActiveNetwork } from '_redux/slices/app';
 import { setPermissions } from '_redux/slices/permissions';
 import { setTransactionRequests } from '_redux/slices/transaction-requests';
+import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
 
 import type { SuiAddress, SuiTransactionResponse } from '@mysten/sui.js';
 import type { Message } from '_messages';
@@ -299,6 +300,18 @@ export class BackgroundClient {
                     );
                 })
             )
+        );
+    }
+
+    importLedgerAccounts(ledgerAccounts: SerializedLedgerAccount[]) {
+        return lastValueFrom(
+            this.sendMessage(
+                createMessage<KeyringPayload<'importLedgerAccounts'>>({
+                    type: 'keyring',
+                    method: 'importLedgerAccounts',
+                    args: { ledgerAccounts },
+                })
+            ).pipe(take(1))
         );
     }
 

--- a/apps/wallet/src/ui/app/components/ledger/ImportLedgerAccounts.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ImportLedgerAccounts.tsx
@@ -10,11 +10,15 @@ import { useCallback } from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
+import { useAccounts } from '../../hooks/useAccounts';
 import { useNextMenuUrl } from '../menu/hooks';
 import Overlay from '../overlay';
-import { type LedgerAccount } from './LedgerAccountItem';
 import { LedgerAccountList } from './LedgerAccountList';
-import { useDeriveLedgerAccounts } from './useDeriveLedgerAccounts';
+import {
+    type SelectableLedgerAccount,
+    useDeriveLedgerAccounts,
+} from './useDeriveLedgerAccounts';
+import { useImportLedgerAccountsMutation } from './useImportLedgerAccountsMutation';
 import { Button } from '_src/ui/app/shared/ButtonUI';
 import { Link } from '_src/ui/app/shared/Link';
 import { Text } from '_src/ui/app/shared/text';
@@ -36,14 +40,32 @@ export function ImportLedgerAccounts() {
             onError: onDeriveError,
         });
 
+    const importLedgerAccountsMutation = useImportLedgerAccountsMutation({
+        onSuccess: () => navigate(accountsUrl),
+        onError: () => {
+            toast.error('There was an issue importing your Ledger accounts.');
+        },
+    });
+
+    const existingAccounts = useAccounts();
+    const existingAccountAddresses = existingAccounts.map(
+        (account) => account.address
+    );
+    const filteredLedgerAccounts = ledgerAccounts.filter(
+        (account) => !existingAccountAddresses.includes(account.address)
+    );
+    const selectedLedgerAccounts = filteredLedgerAccounts.filter(
+        (account) => account.isSelected
+    );
+
     const onAccountClick = useCallback(
-        (targetAccount: LedgerAccount) => {
+        (targetAccount: SelectableLedgerAccount) => {
             setLedgerAccounts((prevState) =>
                 prevState.map((account) => {
                     if (account.address === targetAccount.address) {
                         return {
+                            ...targetAccount,
                             isSelected: !targetAccount.isSelected,
-                            address: targetAccount.address,
                         };
                     }
                     return account;
@@ -56,18 +78,11 @@ export function ImportLedgerAccounts() {
     const onSelectAllAccountsClick = useCallback(() => {
         setLedgerAccounts((prevState) =>
             prevState.map((account) => ({
+                ...account,
                 isSelected: true,
-                address: account.address,
             }))
         );
     }, [setLedgerAccounts]);
-
-    // TODO: Add logic to filter out already imported Ledger accounts
-    // so we don't allow users to import the same account twice
-    const filteredLedgerAccounts = ledgerAccounts.filter(() => true);
-    const selectedLedgerAccounts = filteredLedgerAccounts.filter(
-        (account) => account.isSelected
-    );
 
     const numAccounts = ledgerAccounts.length;
     const numFilteredAccounts = filteredLedgerAccounts.length;
@@ -147,11 +162,12 @@ export function ImportLedgerAccounts() {
                     variant="primary"
                     before={<UnlockedLockIcon />}
                     text="Unlock"
-                    onClick={() => {
-                        // TODO: Do work to actually import the selected accounts once we have
-                        // the account infrastructure setup to support Ledger accounts
-                        navigate(accountsUrl);
-                    }}
+                    loading={importLedgerAccountsMutation.isLoading}
+                    onClick={() =>
+                        importLedgerAccountsMutation.mutate(
+                            selectedLedgerAccounts
+                        )
+                    }
                     disabled={areNoAccountsSelected}
                 />
             </div>

--- a/apps/wallet/src/ui/app/components/ledger/LedgerAccountList.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/LedgerAccountList.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { LedgerAccountItem, type LedgerAccount } from './LedgerAccountItem';
+import { LedgerAccountRow } from './LedgerAccountRow';
+import { type SelectableLedgerAccount } from './useDeriveLedgerAccounts';
 
 type LedgerAccountListProps = {
-    accounts: LedgerAccount[];
-    onAccountClick: (account: LedgerAccount) => void;
+    accounts: SelectableLedgerAccount[];
+    onAccountClick: (account: SelectableLedgerAccount) => void;
 };
 
 export function LedgerAccountList({
@@ -22,7 +23,7 @@ export function LedgerAccountList({
                             onAccountClick(account);
                         }}
                     >
-                        <LedgerAccountItem
+                        <LedgerAccountRow
                             isSelected={account.isSelected}
                             address={account.address}
                         />

--- a/apps/wallet/src/ui/app/components/ledger/LedgerAccountRow.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/LedgerAccountRow.tsx
@@ -9,17 +9,15 @@ import cl from 'classnames';
 import { useGetCoinBalance } from '../../hooks';
 import { Text } from '_src/ui/app/shared/text';
 
-export type LedgerAccount = {
+type LedgerAccountRowProps = {
     isSelected: boolean;
     address: SuiAddress;
 };
 
-type LedgerAccountItemProps = LedgerAccount;
-
-export function LedgerAccountItem({
+export function LedgerAccountRow({
     isSelected,
     address,
-}: LedgerAccountItemProps) {
+}: LedgerAccountRowProps) {
     const { data: coinBalance } = useGetCoinBalance(SUI_TYPE_ARG, address);
     const [totalAmount, totalAmountSymbol] = useFormatCoin(
         coinBalance?.totalBalance ?? 0,

--- a/apps/wallet/src/ui/app/components/ledger/useImportLedgerAccountsMutation.ts
+++ b/apps/wallet/src/ui/app/components/ledger/useImportLedgerAccountsMutation.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { useBackgroundClient } from '../../hooks/useBackgroundClient';
+import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
+import { type Message } from '_src/shared/messaging/messages';
+
+type UseImportLedgerAccountsMutationOptions = Pick<
+    UseMutationOptions<Message, unknown, SerializedLedgerAccount[], unknown>,
+    'onSuccess' | 'onError'
+>;
+
+export function useImportLedgerAccountsMutation({
+    onSuccess,
+    onError,
+}: UseImportLedgerAccountsMutationOptions) {
+    const backgroundClient = useBackgroundClient();
+    return useMutation({
+        mutationFn: (ledgerAccounts: SerializedLedgerAccount[]) => {
+            return backgroundClient.importLedgerAccounts(ledgerAccounts);
+        },
+        onSuccess,
+        onError,
+    });
+}

--- a/apps/wallet/src/ui/app/components/menu/content/Account.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/Account.tsx
@@ -7,17 +7,21 @@ import { formatAddress } from '@mysten/sui.js';
 import { cx } from 'class-variance-authority';
 
 import { AccountActions } from './AccountActions';
+import { AccountType } from '_src/background/keyring/Account';
 import { useCopyToClipboard } from '_src/ui/app/hooks/useCopyToClipboard';
 import { Heading } from '_src/ui/app/shared/heading';
+import { Text } from '_src/ui/app/shared/text';
 
 export type AccountProps = {
     address: string;
+    accountType: AccountType;
 };
 
-export function Account({ address }: AccountProps) {
+export function Account({ address, accountType }: AccountProps) {
     const copyCallback = useCopyToClipboard(address, {
         copySuccessMessage: 'Address copied',
     });
+
     return (
         <Disclosure>
             {({ open }) => (
@@ -33,7 +37,7 @@ export function Account({ address }: AccountProps) {
                         as="div"
                         className="flex flex-nowrap items-center p-5 self-stretch cursor-pointer gap-3 group"
                     >
-                        <div className="transition flex flex-1 justify-start text-steel-dark group-hover:text-steel-darker ui-open:text-steel-darker">
+                        <div className="transition flex flex-1 gap-3 justify-start items-center text-steel-dark group-hover:text-steel-darker ui-open:text-steel-darker">
                             <Heading
                                 mono
                                 weight="semibold"
@@ -42,6 +46,7 @@ export function Account({ address }: AccountProps) {
                             >
                                 {formatAddress(address)}
                             </Heading>
+                            <AccountBadge accountType={accountType} />
                         </div>
                         <Copy16
                             onClick={copyCallback}
@@ -58,11 +63,43 @@ export function Account({ address }: AccountProps) {
                         leaveTo="transform opacity-0"
                     >
                         <Disclosure.Panel className="px-5 pb-4">
-                            <AccountActions accountAddress={address} />
+                            <AccountActions
+                                accountAddress={address}
+                                accountType={accountType}
+                            />
                         </Disclosure.Panel>
                     </Transition>
                 </div>
             )}
         </Disclosure>
     );
+}
+
+type AccountBadgeProps = {
+    accountType: AccountType;
+};
+
+function AccountBadge({ accountType }: AccountBadgeProps) {
+    let badgeText: string | null = null;
+    switch (accountType) {
+        case AccountType.LEDGER:
+            badgeText = 'Ledger';
+            break;
+        case AccountType.IMPORTED:
+            badgeText = 'Imported';
+            break;
+        case AccountType.DERIVED:
+            badgeText = null;
+            break;
+        default:
+            throw new Error(`Encountered unknown account type ${accountType}`);
+    }
+
+    return badgeText ? (
+        <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
+            <Text variant="captionSmallExtra" color="steel-dark">
+                {badgeText}
+            </Text>
+        </div>
+    ) : null;
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
@@ -4,24 +4,40 @@
 import { type SuiAddress } from '@mysten/sui.js';
 
 import { useNextMenuUrl } from '../hooks';
+import { AccountType } from '_src/background/keyring/Account';
 import { Link } from '_src/ui/app/shared/Link';
+import { Text } from '_src/ui/app/shared/text';
 
 export type AccountActionsProps = {
     accountAddress: SuiAddress;
+    accountType: AccountType;
 };
 
-export function AccountActions({ accountAddress }: AccountActionsProps) {
+export function AccountActions({
+    accountAddress,
+    accountType,
+}: AccountActionsProps) {
     const exportAccountUrl = useNextMenuUrl(true, `/export/${accountAddress}`);
+    const canExportPrivateKey =
+        accountType === AccountType.DERIVED ||
+        accountType === AccountType.IMPORTED;
+
     return (
         <div className="flex flex-row flex-nowrap items-center flex-1">
-            <div>
-                <Link
-                    text="Export Private Key"
-                    to={exportAccountUrl}
-                    color="heroDark"
-                    weight="medium"
-                />
-            </div>
+            {canExportPrivateKey ? (
+                <div>
+                    <Link
+                        text="Export Private Key"
+                        to={exportAccountUrl}
+                        color="heroDark"
+                        weight="medium"
+                    />
+                </div>
+            ) : (
+                <Text variant="bodySmall" weight="medium" color="steel-dark">
+                    No actions available
+                </Text>
+            )}
         </div>
     );
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
@@ -46,8 +46,12 @@ export function AccountsSettings() {
     return (
         <MenuLayout title="Accounts" back={backUrl}>
             <div className="flex flex-col gap-3">
-                {accounts.map(({ address }) => (
-                    <Account address={address} key={address} />
+                {accounts.map(({ address, type }) => (
+                    <Account
+                        key={address}
+                        address={address}
+                        accountType={type}
+                    />
                 ))}
                 {isMultiAccountsEnabled ? (
                     <>

--- a/apps/wallet/src/ui/app/shared/text/index.tsx
+++ b/apps/wallet/src/ui/app/shared/text/index.tsx
@@ -19,7 +19,9 @@ const textStyles = cva([], {
             subtitleSmall: 'text-subtitleSmall',
             subtitleSmallExtra: 'text-subtitleSmallExtra',
             caption: 'uppercase text-caption',
-            captionSmall: 'uppercase text-captionSmall ',
+            captionSmall: 'uppercase text-captionSmall',
+            captionSmallExtra:
+                'uppercase tracking-wider text-captionSmallExtra',
             p1: 'text-p1',
             p2: 'text-p2',
             p3: 'text-p3',


### PR DESCRIPTION
## Description 

This PR adds functionality to the `Keyring` for saving imported Ledger accounts and retrieving them from local storage upon unlocking the wallet. The idea here is that we're going to save the entire serialized Ledger account since the accounts should be usable even when the user's Ledger device isn't connected.

Note: I'll add unit tests for the Keyring in a follow-up!

Part 1 (split account class into distinct variations): https://github.com/MystenLabs/sui/pull/9165
Part 2 (this diff): https://github.com/MystenLabs/sui/pull/9166
Part 3 (hook-up UI to save imported Ledger accounts): https://github.com/MystenLabs/sui/pull/9167
Part 4 (add account badge for Ledger accounts): https://github.com/MystenLabs/sui/pull/9168

## Test Plan 
- Manual testing (no user-visible changes in this PR)
  - Locking/unlocking the wallet saves my Ledger accounts
  - Ledger accounts show up in the account menu when imported
  - I can switch accounts to an imported Ledger account

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
