### PR TITLE
[wallet-ext][part 3] save Ledger accounts to the wallet upon import and filter out already saved accounts

### DIFF
--- a/apps/core/tailwind.config.js
+++ b/apps/core/tailwind.config.js
@@ -100,6 +100,7 @@ module.exports = {
                 subtitleSmallExtra: ['10px', '1'],
                 caption: ['12px', '1'],
                 captionSmall: ['11px', '1'],
+                captionSmallExtra: ['10px', '1'],
                 iconTextLarge: ['48px', '1'],
 
                 // Heading sizes:

--- a/apps/wallet/src/ui/app/components/ledger/ImportLedgerAccounts.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ImportLedgerAccounts.tsx
@@ -40,7 +40,12 @@ export function ImportLedgerAccounts() {
             onError: onDeriveError,
         });
 
-    const importLedgerAccountsMutation = useImportLedgerAccountsMutation();
+    const importLedgerAccountsMutation = useImportLedgerAccountsMutation({
+        onSuccess: () => navigate(accountsUrl),
+        onError: () => {
+            toast.error('There was an issue importing your Ledger accounts.');
+        },
+    });
 
     const existingAccounts = useAccounts();
     const existingAccountAddresses = existingAccounts.map(
@@ -158,18 +163,11 @@ export function ImportLedgerAccounts() {
                     before={<UnlockedLockIcon />}
                     text="Unlock"
                     loading={importLedgerAccountsMutation.isLoading}
-                    onClick={async () => {
-                        try {
-                            await importLedgerAccountsMutation.mutateAsync(
-                                selectedLedgerAccounts
-                            );
-                            navigate(accountsUrl);
-                        } catch (error) {
-                            toast.error(
-                                'There was an issue importing your Ledger accounts.'
-                            );
-                        }
-                    }}
+                    onClick={() =>
+                        importLedgerAccountsMutation.mutate(
+                            selectedLedgerAccounts
+                        )
+                    }
                     disabled={areNoAccountsSelected}
                 />
             </div>

--- a/apps/wallet/src/ui/app/components/ledger/LedgerAccountList.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/LedgerAccountList.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { LedgerAccountItem, type LedgerAccount } from './LedgerAccountItem';
+import { LedgerAccountRow } from './LedgerAccountRow';
+import { type SelectableLedgerAccount } from './useDeriveLedgerAccounts';
 
 type LedgerAccountListProps = {
-    accounts: LedgerAccount[];
-    onAccountClick: (account: LedgerAccount) => void;
+    accounts: SelectableLedgerAccount[];
+    onAccountClick: (account: SelectableLedgerAccount) => void;
 };
 
 export function LedgerAccountList({
@@ -22,7 +23,7 @@ export function LedgerAccountList({
                             onAccountClick(account);
                         }}
                     >
-                        <LedgerAccountItem
+                        <LedgerAccountRow
                             isSelected={account.isSelected}
                             address={account.address}
                         />

--- a/apps/wallet/src/ui/app/components/ledger/LedgerAccountRow.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/LedgerAccountRow.tsx
@@ -9,17 +9,15 @@ import cl from 'classnames';
 import { useGetCoinBalance } from '../../hooks';
 import { Text } from '_src/ui/app/shared/text';
 
-export type LedgerAccount = {
+type LedgerAccountRowProps = {
     isSelected: boolean;
     address: SuiAddress;
 };
 
-type LedgerAccountItemProps = LedgerAccount;
-
-export function LedgerAccountItem({
+export function LedgerAccountRow({
     isSelected,
     address,
-}: LedgerAccountItemProps) {
+}: LedgerAccountRowProps) {
     const { data: coinBalance } = useGetCoinBalance(SUI_TYPE_ARG, address);
     const [totalAmount, totalAmountSymbol] = useFormatCoin(
         coinBalance?.totalBalance ?? 0,

--- a/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
+++ b/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Ed25519PublicKey } from '@mysten/sui.js';
+import { Ed25519PublicKey, normalizeSuiAddress } from '@mysten/sui.js';
 import { useEffect, useState } from 'react';
 
 import { useSuiLedgerClient } from './SuiLedgerClientProvider';
@@ -19,15 +19,9 @@ type UseDeriveLedgerAccountOptions = {
     onError: (error: unknown) => void;
 };
 
-type UseDeriveLedgerAccountResult = [
-    SelectableLedgerAccount[],
-    React.Dispatch<React.SetStateAction<SelectableLedgerAccount[]>>,
-    boolean
-];
-
 export function useDeriveLedgerAccounts(
     options: UseDeriveLedgerAccountOptions
-): UseDeriveLedgerAccountResult {
+) {
     const { numAccountsToDerive, onError } = options;
     const [ledgerAccounts, setLedgerAccounts] = useState<
         SelectableLedgerAccount[]
@@ -64,7 +58,7 @@ export function useDeriveLedgerAccounts(
         generateLedgerAccounts();
     }, [numAccountsToDerive, onError, suiLedgerClient]);
 
-    return [ledgerAccounts, setLedgerAccounts, isLoading];
+    return [ledgerAccounts, setLedgerAccounts, isLoading] as const;
 }
 
 async function deriveAccountsFromLedger(
@@ -79,9 +73,10 @@ async function deriveAccountsFromLedger(
             derivationPath
         );
         const publicKey = new Ed25519PublicKey(publicKeyResult.publicKey);
+        const suiAddress = normalizeSuiAddress(publicKey.toSuiAddress());
         ledgerAccounts.push({
             type: AccountType.LEDGER,
-            address: `0x${publicKey.toSuiAddress()}`,
+            address: suiAddress,
             derivationPath,
             isSelected: false,
         });

--- a/apps/wallet/src/ui/app/components/ledger/useImportLedgerAccountsMutation.ts
+++ b/apps/wallet/src/ui/app/components/ledger/useImportLedgerAccountsMutation.ts
@@ -1,16 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
 
 import { useBackgroundClient } from '../../hooks/useBackgroundClient';
 import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
+import { type Message } from '_src/shared/messaging/messages';
 
-export function useImportLedgerAccountsMutation() {
+type UseImportLedgerAccountsMutationOptions = Pick<
+    UseMutationOptions<Message, unknown, SerializedLedgerAccount[], unknown>,
+    'onSuccess' | 'onError'
+>;
+
+export function useImportLedgerAccountsMutation({
+    onSuccess,
+    onError,
+}: UseImportLedgerAccountsMutationOptions) {
     const backgroundClient = useBackgroundClient();
     return useMutation({
-        mutationFn: async (ledgerAccounts: SerializedLedgerAccount[]) => {
-            return await backgroundClient.importLedgerAccounts(ledgerAccounts);
+        mutationFn: (ledgerAccounts: SerializedLedgerAccount[]) => {
+            return backgroundClient.importLedgerAccounts(ledgerAccounts);
         },
+        onSuccess,
+        onError,
     });
 }

--- a/apps/wallet/src/ui/app/components/ledger/useImportLedgerAccountsMutation.ts
+++ b/apps/wallet/src/ui/app/components/ledger/useImportLedgerAccountsMutation.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMutation } from '@tanstack/react-query';
+
+import { useBackgroundClient } from '../../hooks/useBackgroundClient';
+import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
+
+export function useImportLedgerAccountsMutation() {
+    const backgroundClient = useBackgroundClient();
+    return useMutation({
+        mutationFn: async (ledgerAccounts: SerializedLedgerAccount[]) => {
+            return await backgroundClient.importLedgerAccounts(ledgerAccounts);
+        },
+    });
+}

--- a/apps/wallet/src/ui/app/components/menu/content/Account.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/Account.tsx
@@ -7,17 +7,21 @@ import { formatAddress } from '@mysten/sui.js';
 import { cx } from 'class-variance-authority';
 
 import { AccountActions } from './AccountActions';
+import { AccountType } from '_src/background/keyring/Account';
 import { useCopyToClipboard } from '_src/ui/app/hooks/useCopyToClipboard';
 import { Heading } from '_src/ui/app/shared/heading';
+import { Text } from '_src/ui/app/shared/text';
 
 export type AccountProps = {
     address: string;
+    accountType: AccountType;
 };
 
-export function Account({ address }: AccountProps) {
+export function Account({ address, accountType }: AccountProps) {
     const copyCallback = useCopyToClipboard(address, {
         copySuccessMessage: 'Address copied',
     });
+
     return (
         <Disclosure>
             {({ open }) => (
@@ -33,7 +37,7 @@ export function Account({ address }: AccountProps) {
                         as="div"
                         className="flex flex-nowrap items-center p-5 self-stretch cursor-pointer gap-3 group"
                     >
-                        <div className="transition flex flex-1 justify-start text-steel-dark group-hover:text-steel-darker ui-open:text-steel-darker">
+                        <div className="transition flex flex-1 gap-3 justify-start items-center text-steel-dark group-hover:text-steel-darker ui-open:text-steel-darker">
                             <Heading
                                 mono
                                 weight="semibold"
@@ -42,6 +46,7 @@ export function Account({ address }: AccountProps) {
                             >
                                 {formatAddress(address)}
                             </Heading>
+                            <AccountBadge accountType={accountType} />
                         </div>
                         <Copy16
                             onClick={copyCallback}
@@ -58,11 +63,43 @@ export function Account({ address }: AccountProps) {
                         leaveTo="transform opacity-0"
                     >
                         <Disclosure.Panel className="px-5 pb-4">
-                            <AccountActions accountAddress={address} />
+                            <AccountActions
+                                accountAddress={address}
+                                accountType={accountType}
+                            />
                         </Disclosure.Panel>
                     </Transition>
                 </div>
             )}
         </Disclosure>
     );
+}
+
+type AccountBadgeProps = {
+    accountType: AccountType;
+};
+
+function AccountBadge({ accountType }: AccountBadgeProps) {
+    let badgeText: string | null = null;
+    switch (accountType) {
+        case AccountType.LEDGER:
+            badgeText = 'Ledger';
+            break;
+        case AccountType.IMPORTED:
+            badgeText = 'Imported';
+            break;
+        case AccountType.DERIVED:
+            badgeText = null;
+            break;
+        default:
+            throw new Error(`Encountered unknown account type ${accountType}`);
+    }
+
+    return badgeText ? (
+        <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
+            <Text variant="captionSmallExtra" color="steel-dark">
+                {badgeText}
+            </Text>
+        </div>
+    ) : null;
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
@@ -4,24 +4,40 @@
 import { type SuiAddress } from '@mysten/sui.js';
 
 import { useNextMenuUrl } from '../hooks';
+import { AccountType } from '_src/background/keyring/Account';
 import { Link } from '_src/ui/app/shared/Link';
+import { Text } from '_src/ui/app/shared/text';
 
 export type AccountActionsProps = {
     accountAddress: SuiAddress;
+    accountType: AccountType;
 };
 
-export function AccountActions({ accountAddress }: AccountActionsProps) {
+export function AccountActions({
+    accountAddress,
+    accountType,
+}: AccountActionsProps) {
     const exportAccountUrl = useNextMenuUrl(true, `/export/${accountAddress}`);
+    const canExportPrivateKey =
+        accountType === AccountType.DERIVED ||
+        accountType === AccountType.IMPORTED;
+
     return (
         <div className="flex flex-row flex-nowrap items-center flex-1">
-            <div>
-                <Link
-                    text="Export Private Key"
-                    to={exportAccountUrl}
-                    color="heroDark"
-                    weight="medium"
-                />
-            </div>
+            {canExportPrivateKey ? (
+                <div>
+                    <Link
+                        text="Export Private Key"
+                        to={exportAccountUrl}
+                        color="heroDark"
+                        weight="medium"
+                    />
+                </div>
+            ) : (
+                <Text variant="bodySmall" weight="medium" color="steel-dark">
+                    No actions available
+                </Text>
+            )}
         </div>
     );
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
@@ -46,8 +46,12 @@ export function AccountsSettings() {
     return (
         <MenuLayout title="Accounts" back={backUrl}>
             <div className="flex flex-col gap-3">
-                {accounts.map(({ address }) => (
-                    <Account address={address} key={address} />
+                {accounts.map(({ address, type }) => (
+                    <Account
+                        key={address}
+                        address={address}
+                        accountType={type}
+                    />
                 ))}
                 {isMultiAccountsEnabled ? (
                     <>

--- a/apps/wallet/src/ui/app/shared/text/index.tsx
+++ b/apps/wallet/src/ui/app/shared/text/index.tsx
@@ -19,7 +19,9 @@ const textStyles = cva([], {
             subtitleSmall: 'text-subtitleSmall',
             subtitleSmallExtra: 'text-subtitleSmallExtra',
             caption: 'uppercase text-caption',
-            captionSmall: 'uppercase text-captionSmall ',
+            captionSmall: 'uppercase text-captionSmall',
+            captionSmallExtra:
+                'uppercase tracking-wider text-captionSmallExtra',
             p1: 'text-p1',
             p2: 'text-p2',
             p3: 'text-p3',


### PR DESCRIPTION
## Description 
This PR adds a `importLedgerAccounts` mutation to the "Import Ledger Accounts" UI so we actually persist and save the imported Ledger accounts to local storage. I made some other small changes including:
  - Some small renaming like `LedgerAccountItem` to `LedgerAccountRow` to make things a little more explicit
  - Filtering out already imported Ledger accounts from the UI
    - i.e., I import 5 of my accounts -> those 5 accounts shouldn't be shown the next time I want to import Ledger accounts

Part 1 (split account class into distinct variations): https://github.com/MystenLabs/sui/pull/9165
Part 2 (add the ability to save/load Ledger accounts): https://github.com/MystenLabs/sui/pull/9166
Part 3 (this diff): https://github.com/MystenLabs/sui/pull/9167
Part 4 (add account badge for Ledger accounts): https://github.com/MystenLabs/sui/pull/9168

<video src="https://user-images.githubusercontent.com/7453188/224564620-41bb513c-9e6d-4f91-a110-eea4710b45bf.mov">

## Test Plan
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
