### PR TITLE
[wallet-ext][part 4] show "Ledger" account badge for imported Ledger accounts

### DIFF
--- a/apps/core/tailwind.config.js
+++ b/apps/core/tailwind.config.js
@@ -100,6 +100,7 @@ module.exports = {
                 subtitleSmallExtra: ['10px', '1'],
                 caption: ['12px', '1'],
                 captionSmall: ['11px', '1'],
+                captionSmallExtra: ['10px', '1'],
                 iconTextLarge: ['48px', '1'],
 
                 // Heading sizes:

--- a/apps/wallet/src/ui/app/components/menu/content/Account.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/Account.tsx
@@ -80,26 +80,26 @@ type AccountBadgeProps = {
 };
 
 function AccountBadge({ accountType }: AccountBadgeProps) {
+    let badgeText: string | null = null;
     switch (accountType) {
         case AccountType.LEDGER:
-            return (
-                <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
-                    <Text variant="captionSmallExtra" color="steel-dark">
-                        Ledger
-                    </Text>
-                </div>
-            );
+            badgeText = 'Ledger';
+            break;
         case AccountType.IMPORTED:
-            return (
-                <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
-                    <Text variant="captionSmallExtra" color="steel-dark">
-                        Imported
-                    </Text>
-                </div>
-            );
+            badgeText = 'Imported';
+            break;
         case AccountType.DERIVED:
-            return null;
+            badgeText = null;
+            break;
         default:
             throw new Error(`Encountered unknown account type ${accountType}`);
     }
+
+    return badgeText ? (
+        <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
+            <Text variant="captionSmallExtra" color="steel-dark">
+                {badgeText}
+            </Text>
+        </div>
+    ) : null;
 }

--- a/apps/wallet/src/ui/app/components/menu/content/Account.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/Account.tsx
@@ -89,8 +89,15 @@ function AccountBadge({ accountType }: AccountBadgeProps) {
                     </Text>
                 </div>
             );
-        case AccountType.DERIVED:
         case AccountType.IMPORTED:
+            return (
+                <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
+                    <Text variant="captionSmallExtra" color="steel-dark">
+                        Imported
+                    </Text>
+                </div>
+            );
+        case AccountType.DERIVED:
             return null;
         default:
             throw new Error(`Encountered unknown account type ${accountType}`);

--- a/apps/wallet/src/ui/app/components/menu/content/Account.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/Account.tsx
@@ -7,17 +7,21 @@ import { formatAddress } from '@mysten/sui.js';
 import { cx } from 'class-variance-authority';
 
 import { AccountActions } from './AccountActions';
+import { AccountType } from '_src/background/keyring/Account';
 import { useCopyToClipboard } from '_src/ui/app/hooks/useCopyToClipboard';
 import { Heading } from '_src/ui/app/shared/heading';
+import { Text } from '_src/ui/app/shared/text';
 
 export type AccountProps = {
     address: string;
+    accountType: AccountType;
 };
 
-export function Account({ address }: AccountProps) {
+export function Account({ address, accountType }: AccountProps) {
     const copyCallback = useCopyToClipboard(address, {
         copySuccessMessage: 'Address copied',
     });
+
     return (
         <Disclosure>
             {({ open }) => (
@@ -33,7 +37,7 @@ export function Account({ address }: AccountProps) {
                         as="div"
                         className="flex flex-nowrap items-center p-5 self-stretch cursor-pointer gap-3 group"
                     >
-                        <div className="transition flex flex-1 justify-start text-steel-dark group-hover:text-steel-darker ui-open:text-steel-darker">
+                        <div className="transition flex flex-1 gap-3 justify-start items-center text-steel-dark group-hover:text-steel-darker ui-open:text-steel-darker">
                             <Heading
                                 mono
                                 weight="semibold"
@@ -42,6 +46,7 @@ export function Account({ address }: AccountProps) {
                             >
                                 {formatAddress(address)}
                             </Heading>
+                            <AccountBadge accountType={accountType} />
                         </div>
                         <Copy16
                             onClick={copyCallback}
@@ -58,11 +63,36 @@ export function Account({ address }: AccountProps) {
                         leaveTo="transform opacity-0"
                     >
                         <Disclosure.Panel className="px-5 pb-4">
-                            <AccountActions accountAddress={address} />
+                            <AccountActions
+                                accountAddress={address}
+                                accountType={accountType}
+                            />
                         </Disclosure.Panel>
                     </Transition>
                 </div>
             )}
         </Disclosure>
     );
+}
+
+type AccountBadgeProps = {
+    accountType: AccountType;
+};
+
+function AccountBadge({ accountType }: AccountBadgeProps) {
+    switch (accountType) {
+        case AccountType.LEDGER:
+            return (
+                <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
+                    <Text variant="captionSmallExtra" color="steel-dark">
+                        Ledger
+                    </Text>
+                </div>
+            );
+        case AccountType.DERIVED:
+        case AccountType.IMPORTED:
+            return null;
+        default:
+            throw new Error(`Encountered unknown account type ${accountType}`);
+    }
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
@@ -4,24 +4,40 @@
 import { type SuiAddress } from '@mysten/sui.js';
 
 import { useNextMenuUrl } from '../hooks';
+import { AccountType } from '_src/background/keyring/Account';
 import { Link } from '_src/ui/app/shared/Link';
+import { Text } from '_src/ui/app/shared/text';
 
 export type AccountActionsProps = {
     accountAddress: SuiAddress;
+    accountType: AccountType;
 };
 
-export function AccountActions({ accountAddress }: AccountActionsProps) {
+export function AccountActions({
+    accountAddress,
+    accountType,
+}: AccountActionsProps) {
     const exportAccountUrl = useNextMenuUrl(true, `/export/${accountAddress}`);
+    const canExportPrivateKey =
+        accountType === AccountType.DERIVED ||
+        accountType === AccountType.IMPORTED;
+
     return (
         <div className="flex flex-row flex-nowrap items-center flex-1">
-            <div>
-                <Link
-                    text="Export Private Key"
-                    to={exportAccountUrl}
-                    color="heroDark"
-                    weight="medium"
-                />
-            </div>
+            {canExportPrivateKey ? (
+                <div>
+                    <Link
+                        text="Export Private Key"
+                        to={exportAccountUrl}
+                        color="heroDark"
+                        weight="medium"
+                    />
+                </div>
+            ) : (
+                <Text variant="bodySmall" weight="medium" color="steel-dark">
+                    No actions available
+                </Text>
+            )}
         </div>
     );
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
@@ -46,8 +46,12 @@ export function AccountsSettings() {
     return (
         <MenuLayout title="Accounts" back={backUrl}>
             <div className="flex flex-col gap-3">
-                {accounts.map(({ address }) => (
-                    <Account address={address} key={address} />
+                {accounts.map(({ address, type }) => (
+                    <Account
+                        key={address}
+                        address={address}
+                        accountType={type}
+                    />
                 ))}
                 {isMultiAccountsEnabled ? (
                     <>

--- a/apps/wallet/src/ui/app/shared/text/index.tsx
+++ b/apps/wallet/src/ui/app/shared/text/index.tsx
@@ -19,7 +19,9 @@ const textStyles = cva([], {
             subtitleSmall: 'text-subtitleSmall',
             subtitleSmallExtra: 'text-subtitleSmallExtra',
             caption: 'uppercase text-caption',
-            captionSmall: 'uppercase text-captionSmall ',
+            captionSmall: 'uppercase text-captionSmall',
+            captionSmallExtra:
+                'uppercase tracking-wider text-captionSmallExtra',
             p1: 'text-p1',
             p2: 'text-p2',
             p3: 'text-p3',


### PR DESCRIPTION
## Description 
This PR adds a badge beside Ledger/Imported accounts in the account menu and also disables the ability to export your private key for these accounts (your private key lives on your Ledger). @mystie711 I improvised the designs for disabling the account actions when you click an account in the account menu, we can touch base tomorrow on tweaks!

Part 1 (split account class into distinct variations): https://github.com/MystenLabs/sui/pull/9165
Part 2 (add the ability to save/load Ledger accounts): https://github.com/MystenLabs/sui/pull/9166
Part 3 (hook-up UI to save imported Ledger accounts): https://github.com/MystenLabs/sui/pull/9167
Part 4 (this diff)): https://github.com/MystenLabs/sui/pull/9168

https://user-images.githubusercontent.com/7453188/224564620-41bb513c-9e6d-4f91-a110-eea4710b45bf.mov


Badges:
<img width="419" alt="image" src="https://user-images.githubusercontent.com/7453188/224568268-874f4acb-d5b8-40cc-ae8a-123df65719a5.png">

## Test Plan 
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
