### PR TITLE
programmable transactions: reorder upgrade command args

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -266,8 +266,8 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
         Command::Publish(modules) => {
             execute_move_publish::<_, _, Mode>(context, &mut argument_updates, modules)?
         }
-        Command::Upgrade(upgrade_ticket, dep_ids, modules) => {
-            execute_move_upgrade::<_, _, Mode>(context, upgrade_ticket, dep_ids, modules)?
+        Command::Upgrade(modules, dep_ids, upgrade_ticket) => {
+            execute_move_upgrade::<_, _, Mode>(context, modules, dep_ids, upgrade_ticket)?
         }
     };
 
@@ -437,9 +437,9 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
 /// Upgrade a Move package.  Returns an `UpgradeReceipt` for the upgraded package on success.
 fn execute_move_upgrade<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     context: &mut ExecutionContext<E, S>,
-    _upgrade_ticket_arg: Argument,
-    _dep_ids: Vec<ObjectID>,
     _module_bytes: Vec<Vec<u8>>,
+    _dep_ids: Vec<ObjectID>,
+    _upgrade_ticket_arg: Argument,
 ) -> Result<Vec<Value>, ExecutionError> {
     // Check that package upgrades are supported.
     context

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -92,11 +92,11 @@ Command:
     6:
       Upgrade:
         TUPLE:
-          - TYPENAME: Argument
-          - SEQ:
-              TYPENAME: ObjectID
           - SEQ:
               SEQ: U8
+          - SEQ:
+              TYPENAME: ObjectID
+          - TYPENAME: Argument
 CommandArgumentError:
   ENUM:
     0:

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -896,7 +896,7 @@ pub enum SuiCommand {
     /// Publishes a Move package
     Publish(SuiMovePackage),
     /// Upgrades a Move package
-    Upgrade(SuiArgument, Vec<ObjectID>, SuiMovePackage),
+    Upgrade(SuiMovePackage, Vec<ObjectID>, SuiArgument),
     /// `forall T: Vec<T> -> vector<T>`
     /// Given n-values of the same type, it constructs a vector. For non objects or an empty vector,
     /// the type tag must be specified.
@@ -932,7 +932,7 @@ impl Display for SuiCommand {
                 write!(f, ")")
             }
             Self::Publish(_bytes) => write!(f, "Publish(_)"),
-            Self::Upgrade(ticket, deps, _bytes) => {
+            Self::Upgrade(_bytes, deps, ticket) => {
                 write!(f, "Upgrade({ticket},")?;
                 write_sep(f, deps, ",")?;
                 write!(f, ", _)")?;
@@ -962,12 +962,12 @@ impl From<Command> for SuiCommand {
                 tag_opt.map(|tag| tag.to_string()),
                 args.into_iter().map(SuiArgument::from).collect(),
             ),
-            Command::Upgrade(ticket, dep_ids, modules) => SuiCommand::Upgrade(
-                SuiArgument::from(ticket),
-                dep_ids,
+            Command::Upgrade(modules, dep_ids, ticket) => SuiCommand::Upgrade(
                 SuiMovePackage {
                     disassembled: disassemble_modules(modules.iter()).unwrap_or_default(),
                 },
+                dep_ids,
+                SuiArgument::from(ticket),
             ),
         }
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5505,7 +5505,7 @@
                 "type": "array",
                 "items": [
                   {
-                    "$ref": "#/components/schemas/SuiArgument"
+                    "$ref": "#/components/schemas/MovePackage"
                   },
                   {
                     "type": "array",
@@ -5514,7 +5514,7 @@
                     }
                   },
                   {
-                    "$ref": "#/components/schemas/MovePackage"
+                    "$ref": "#/components/schemas/SuiArgument"
                   }
                 ],
                 "maxItems": 3,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -542,7 +542,7 @@ pub enum Command {
     /// the type tag must be specified.
     MakeMoveVec(Option<TypeTag>, Vec<Argument>),
     /// Upgrades a Move package
-    Upgrade(Argument, Vec<ObjectID>, Vec<Vec<u8>>),
+    Upgrade(Vec<Vec<u8>>, Vec<ObjectID>, Argument),
 }
 
 /// An argument to a programmable transaction command
@@ -633,7 +633,7 @@ impl Command {
 
     fn input_objects(&self) -> Vec<InputObjectKind> {
         match self {
-            Command::Upgrade(_, _, modules) | Command::Publish(modules) => {
+            Command::Upgrade(modules, _, _) | Command::Publish(modules) => {
                 Self::publish_command_input_objects(modules)
             }
             Command::MoveCall(c) => c.input_objects(),
@@ -729,7 +729,7 @@ impl Command {
                 );
             }
             Command::SplitCoin(_, _) => (),
-            Command::Upgrade(_, _, modules) => {
+            Command::Upgrade(modules, _, _) => {
                 fp_ensure!(!modules.is_empty(), UserInputError::EmptyCommandInput);
                 fp_ensure!(
                     modules.len() < config.max_modules_in_publish() as usize,
@@ -891,7 +891,7 @@ impl Display for Command {
                 write!(f, ")")
             }
             Command::Publish(_bytes) => write!(f, "Publish(_)"),
-            Command::Upgrade(ticket, deps, _bytes) => {
+            Command::Upgrade(_bytes, deps, ticket) => {
                 write!(f, "Upgrade({ticket},")?;
                 write_sep(f, deps, ",")?;
                 write!(f, ", _")?;

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -201,7 +201,7 @@ impl ProgrammableTransactionBuilder {
         transitive_deps: Vec<ObjectID>,
         modules: Vec<Vec<u8>>,
     ) -> Argument {
-        self.command(Command::Upgrade(upgrade_ticket, transitive_deps, modules))
+        self.command(Command::Upgrade(modules, transitive_deps, upgrade_ticket))
     }
 
     pub fn transfer_arg(&mut self, recipient: SuiAddress, arg: Argument) {


### PR DESCRIPTION
## Description 

Changes 

```
Upgrade(SuiArgument, Vec<ObjectID>, SuiMovePackage),
```

to 

```
Upgrade(SuiMovePackage, Vec<ObjectID>, SuiArgument)
```

so that this aligns with upcoming `Publish` command:

```
Publish(SuiMovePackage, Vec<ObjectID>),                                                                                              
Upgrade(SuiMovePackage, Vec<ObjectID>, SuiArgument),
```


## Test Plan 

Existing tests, this just reorders values.