### PR TITLE
[programmable transactions] Make default behavior of `publish` be upgradeable

### DIFF
--- a/.changeset/clever-oranges-bathe.md
+++ b/.changeset/clever-oranges-bathe.md
@@ -1,0 +1,6 @@
+---
+"@mysten/ledgerjs-hw-app-sui": minor
+"@mysten/sui.js": minor
+---
+
+Changed the default behavior of `publish` to publish an upgreadeable-by-sender package instead of immutable.

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::authority::move_integration_tests::build_and_publish_test_package_with_upgrade_cap;
 use crate::consensus_handler::SequencedConsensusTransaction;
 use crate::{
-    authority::move_integration_tests::build_and_publish_test_package,
     authority_client::{AuthorityAPI, NetworkAuthorityClient},
     authority_server::AuthorityServer,
     checkpoints::CheckpointServiceNoop,
@@ -3914,9 +3914,14 @@ async fn test_iter_live_object_set() {
         .await
         .unwrap();
 
-    let package =
-        build_and_publish_test_package(&authority, &sender, &sender_key, &gas, "object_wrapping")
-            .await;
+    let (package, upgrade_cap) = build_and_publish_test_package_with_upgrade_cap(
+        &authority,
+        &sender,
+        &sender_key,
+        &gas,
+        "object_wrapping",
+    )
+    .await;
 
     // Create a Child object.
     let effects = call_move(
@@ -4044,6 +4049,7 @@ async fn test_iter_live_object_set() {
             (package.0, package.1),
             (gas, SequenceNumber::from_u64(8)),
             (obj_id, SequenceNumber::from_u64(2)),
+            (upgrade_cap.0, upgrade_cap.1),
         ],
     );
 }

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -9,8 +9,8 @@ expression: common_costs_actual
     "storageRebate": 0
   },
   "Publish": {
-    "computationCost": 638,
-    "storageCost": 133,
+    "computationCost": 640,
+    "storageCost": 154,
     "storageRebate": 0
   },
   "SharedCounterAssertValue": {

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -137,7 +137,7 @@ async fn test_publish_and_move_call() {
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.publish(compiled_module);
+        builder.publish_immutable(compiled_module);
         builder.finish()
     };
     let response =

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -317,7 +317,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 let cap = builder.publish_upgradeable(vec![module_bytes]);
                 builder.transfer_arg(sender, cap);
             } else {
-                builder.publish(vec![module_bytes]);
+                builder.publish_immutable(vec![module_bytes]);
             };
             let pt = builder.finish();
             TransactionData::new_programmable_with_dummy_gas_price(

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1476,7 +1476,8 @@ impl TransactionData {
     ) -> Self {
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder.publish(modules);
+            let upgrade_cap = builder.publish_upgradeable(modules);
+            builder.transfer_arg(sender, upgrade_cap);
             builder.finish()
         };
         Self::new_programmable(sender, vec![gas_payment], pt, gas_budget, gas_price)

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -183,7 +183,7 @@ impl ProgrammableTransactionBuilder {
         self.command(Command::Publish(modules))
     }
 
-    pub fn publish(&mut self, modules: Vec<Vec<u8>>) {
+    pub fn publish_immutable(&mut self, modules: Vec<Vec<u8>>) {
         let cap = self.publish_upgradeable(modules);
         self.commands
             .push(Command::MoveCall(Box::new(ProgrammableMoveCall {

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -816,7 +816,7 @@ fn test_sponsored_transaction_validity_check() {
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.publish(vec![vec![]]);
+        builder.publish_immutable(vec![vec![]]);
         builder.finish()
     };
     let kind = TransactionKind::programmable(pt);

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -116,10 +116,9 @@ export async function publishPackage(
   const cap = tx.publish(
     compiledModules.map((m: any) => Array.from(fromB64(m))),
   );
-  tx.moveCall({
-    target: '0x2::package::make_immutable',
-    arguments: [cap],
-  });
+
+  // Transfer the upgrade capability to the sender so they can upgrade the package later if they want.
+  tx.transferObjects([cap], tx.pure(await toolbox.signer.getAddress()));
 
   const publishTxn = await toolbox.signer.signAndExecuteTransaction(tx, {
     showEffects: true,


### PR DESCRIPTION
This changes the default behavior of `publish` to be an upgradeable package as opposed to an immutable package. 

## Testing

Make sure existing tests pass.