### PR TITLE
[explorer] Fix React duplicate key warning

### DIFF
--- a/apps/explorer/src/ui/TransactionAddressSection.tsx
+++ b/apps/explorer/src/ui/TransactionAddressSection.tsx
@@ -58,8 +58,11 @@ export function RecipientTransactionAddresses({
             title={recipients.length > 1 ? 'Recipients' : 'Recipient'}
         >
             <div className="flex flex-col gap-4">
-                {recipients.map(({ address, amount, coinType }) => (
-                    <div className="flex flex-col gap-0.5" key={address}>
+                {recipients.map(({ address, amount, coinType }, i) => (
+                    <div
+                        className="flex flex-col gap-0.5"
+                        key={`${address}-${i}`}
+                    >
                         <TransactionAddress
                             icon={<CheckFill16 className="text-success" />}
                             address={address}


### PR DESCRIPTION
## Description 

Saw a React warning about duplicate keys. It's common for a transaction to have multiple recipients sharing the same key.

## Test Plan 

Before
![CleanShot 2023-03-12 at 15 47 55](https://user-images.githubusercontent.com/76067158/224569403-3ae9f650-6331-4e90-84e5-7c5dc7636e6f.png)

After the fix
![CleanShot 2023-03-12 at 15 49 17](https://user-images.githubusercontent.com/76067158/224569481-080b4c6b-1bb5-4874-b0f7-78dfb1bad500.png)


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
