### PR TITLE
client publish: propagate package dependency ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9013,6 +9013,7 @@ dependencies = [
  "sui-config",
  "sui-core",
  "sui-faucet",
+ "sui-framework-build",
  "sui-json",
  "sui-json-rpc-types",
  "sui-keys",

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -263,8 +263,8 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
                 /* is_init */ false,
             )?
         }
-        Command::Publish(modules) => {
-            execute_move_publish::<_, _, Mode>(context, &mut argument_updates, modules)?
+        Command::Publish(modules, dep_ids) => {
+            execute_move_publish::<_, _, Mode>(context, &mut argument_updates, modules, dep_ids)?
         }
         Command::Upgrade(upgrade_ticket, dep_ids, modules) => {
             execute_move_upgrade::<_, _, Mode>(context, upgrade_ticket, dep_ids, modules)?
@@ -380,6 +380,7 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     context: &mut ExecutionContext<E, S>,
     argument_updates: &mut Mode::ArgumentUpdates,
     module_bytes: Vec<Vec<u8>>,
+    _dep_ids: Vec<ObjectID>,
 ) -> Result<Vec<Value>, ExecutionError> {
     assert_invariant!(
         !module_bytes.is_empty(),

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -28,6 +28,7 @@ sui-faucet = { path = "../sui-faucet" }
 sui-swarm = { path = "../sui-swarm" }
 sui = { path = "../sui" }
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }
+sui-framework-build = { path = "../sui-framework-build" }
 sui-sdk = { path = "../sui-sdk" }
 sui-keys = { path = "../sui-keys" }
 sui-types = { path = "../sui-types" }

--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -21,12 +21,15 @@ impl TestCaseImpl for FullNodeBuildPublishTransactionTest {
     }
 
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
+        let compiled_package = compile_basics_package();
         let all_module_bytes =
-            compile_basics_package().get_package_base64(/* with_unpublished_deps */ false);
+            compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+        let dependencies = compiled_package.get_dependency_original_package_ids();
 
         let params = rpc_params![
             ctx.get_wallet_address(),
             all_module_bytes,
+            dependencies,
             None::<ObjectID>,
             10000
         ];

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -963,7 +963,7 @@ fn process_package(
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         // executing in Genesis mode does not create a package upgrade
-        builder.command(Command::Publish(module_bytes));
+        builder.command(Command::Publish(module_bytes, ids));
         builder.finish()
     };
     programmable_transactions::execution::execute::<_, _, execution_mode::Genesis>(

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use bcs;
 use futures::{stream::FuturesUnordered, StreamExt};
+use move_binary_format::access::ModuleAccess;
 use move_binary_format::{
     file_format::{self, AddressIdentifierIndex, IdentifierIndex, ModuleHandle},
     CompiledModule,
@@ -1559,12 +1560,14 @@ async fn test_publish_dependent_module_ok() {
         dependent_module.serialize(&mut bytes).unwrap();
         bytes
     };
+
     let authority = init_state_with_objects(vec![gas_payment_object]).await;
 
     let data = TransactionData::new_module_with_dummy_gas_price(
         sender,
         gas_payment_object_ref,
         vec![dependent_module_bytes],
+        vec![ObjectID::from(*genesis_module.address())],
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
@@ -1603,10 +1606,12 @@ async fn test_publish_module_no_dependencies_ok() {
     let mut module_bytes = Vec::new();
     module.serialize(&mut module_bytes).unwrap();
     let module_bytes = vec![module_bytes];
+    let dependencies = vec![]; // no dependencies
     let data = TransactionData::new_module_with_dummy_gas_price(
         sender,
         gas_payment_object_ref,
         module_bytes,
+        dependencies,
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
@@ -1636,9 +1641,10 @@ async fn test_publish_non_existing_dependent_module() {
     // create a module that depends on a genesis module
     let mut dependent_module = make_dependent_module(&genesis_module);
     // Add another dependent module that points to a random address, hence does not exist on-chain.
+    let not_on_chain = ObjectID::random();
     dependent_module
         .address_identifiers
-        .push(AccountAddress::from(ObjectID::random()));
+        .push(AccountAddress::from(not_on_chain));
     dependent_module.module_handles.push(ModuleHandle {
         address: AddressIdentifierIndex((dependent_module.address_identifiers.len() - 1) as u16),
         name: IdentifierIndex(0),
@@ -1655,6 +1661,7 @@ async fn test_publish_non_existing_dependent_module() {
         sender,
         gas_payment_object_ref,
         vec![dependent_module_bytes],
+        vec![ObjectID::from(*genesis_module.address()), not_on_chain],
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
@@ -1705,6 +1712,7 @@ async fn test_package_size_limit() {
         sender,
         gas_payment_object_ref,
         package,
+        vec![],
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -302,7 +302,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
     // We need the original package bytes in order to reproduce the publish computation cost.
     let publish_bytes = match response.0.data().intent_message.value.kind() {
         TransactionKind::ProgrammableTransaction(pt) => match pt.commands.first().unwrap() {
-            Command::Publish(modules) => modules,
+            Command::Publish(modules, _dep_ids) => modules,
             _ => unreachable!(),
         },
         _ => unreachable!(),

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -79,9 +79,11 @@ Command:
               TYPENAME: Argument
     4:
       Publish:
-        NEWTYPE:
-          SEQ:
-            SEQ: U8
+        TUPLE:
+          - SEQ:
+              SEQ: U8
+          - SEQ:
+              TYPENAME: ObjectID
     5:
       MakeMoveVec:
         TUPLE:

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -277,6 +277,22 @@ impl CompiledPackage {
         }
     }
 
+    /// Return the set of Object IDs corresponding to this package's transitive dependencies'
+    /// original package IDs.
+    pub fn get_dependency_original_package_ids(&self) -> Vec<ObjectID> {
+        let ids: BTreeSet<_> = self
+            .package
+            .deps_compiled_units
+            .iter()
+            .map(|(_, m)| match &m.unit {
+                CompiledUnitEnum::Module(m) => ObjectID::from(*m.module.address()),
+                CompiledUnitEnum::Script(_) => unimplemented!("Scripts not supported in Sui Move"),
+            })
+            .collect();
+
+        ids.into_iter().collect()
+    }
+
     /// Return a serialized representation of the bytecode modules in this package, topologically sorted in dependency order
     pub fn get_package_bytes(&self, with_unpublished_deps: bool) -> Vec<Vec<u8>> {
         self.get_dependency_sorted_modules(with_unpublished_deps)

--- a/crates/sui-indexer/src/apis/transaction_builder_api.rs
+++ b/crates/sui-indexer/src/apis/transaction_builder_api.rs
@@ -98,11 +98,12 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         &self,
         sender: SuiAddress,
         compiled_modules: Vec<Base64>,
+        dep_ids: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes> {
         self.fullnode
-            .publish(sender, compiled_modules, gas, gas_budget)
+            .publish(sender, compiled_modules, dep_ids, gas, gas_budget)
             .await
     }
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -893,8 +893,9 @@ pub enum SuiCommand {
     /// `(&mut Coin<T>, Vec<Coin<T>>)`
     /// It merges n-coins into the first coin
     MergeCoins(SuiArgument, Vec<SuiArgument>),
-    /// Publishes a Move package
-    Publish(SuiMovePackage),
+    /// Publishes a Move package. It takes the package bytes and a list of the package's transitive
+    /// dependencies to link against on-chain.
+    Publish(SuiMovePackage, Vec<ObjectID>),
     /// Upgrades a Move package
     Upgrade(SuiArgument, Vec<ObjectID>, SuiMovePackage),
     /// `forall T: Vec<T> -> vector<T>`
@@ -931,7 +932,11 @@ impl Display for SuiCommand {
                 write_sep(f, coins, ",")?;
                 write!(f, ")")
             }
-            Self::Publish(_bytes) => write!(f, "Publish(_)"),
+            Self::Publish(_bytes, deps) => {
+                write!(f, "Publish(_,")?;
+                write_sep(f, deps, ",")?;
+                write!(f, ")")
+            }
             Self::Upgrade(ticket, deps, _bytes) => {
                 write!(f, "Upgrade({ticket},")?;
                 write_sep(f, deps, ",")?;
@@ -955,9 +960,12 @@ impl From<Command> for SuiCommand {
                 arg.into(),
                 args.into_iter().map(SuiArgument::from).collect(),
             ),
-            Command::Publish(modules) => SuiCommand::Publish(SuiMovePackage {
-                disassembled: disassemble_modules(modules.iter()).unwrap_or_default(),
-            }),
+            Command::Publish(modules, dep_ids) => SuiCommand::Publish(
+                SuiMovePackage {
+                    disassembled: disassemble_modules(modules.iter()).unwrap_or_default(),
+                },
+                dep_ids,
+            ),
             Command::MakeMoveVec(tag_opt, args) => SuiCommand::MakeMoveVec(
                 tag_opt.map(|tag| tag.to_string()),
                 args.into_iter().map(SuiArgument::from).collect(),

--- a/crates/sui-json-rpc/src/api/transaction_builder.rs
+++ b/crates/sui-json-rpc/src/api/transaction_builder.rs
@@ -146,6 +146,8 @@ pub trait TransactionBuilder {
         sender: SuiAddress,
         /// the compiled bytes of a move module, the
         compiled_modules: Vec<Base64>,
+        /// a list of transitive dependency addresses that this set of modules depends on.
+        dependencies: Vec<ObjectID>,
         /// gas object to be used in this transaction, node will pick one from the signer's possession if not provided
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -172,6 +172,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         &self,
         sender: SuiAddress,
         compiled_modules: Vec<Base64>,
+        dependencies: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes> {
@@ -181,7 +182,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
             .collect::<Result<Vec<_>, _>>()?;
         let data = self
             .builder
-            .publish(sender, compiled_modules, gas, gas_budget)
+            .publish(sender, compiled_modules, dependencies, gas, gas_budget)
             .await?;
         Ok(TransactionBytes::from_data(data)?)
     }

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -107,12 +107,20 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let objects = http_client.get_objects_owned_by_address(*address).await?;
     let gas = objects.first().unwrap();
 
-    let compiled_modules = BuildConfig::new_for_testing()
-        .build(Path::new("../../sui_programmability/examples/fungible_tokens").to_path_buf())?
-        .get_package_base64(/* with_unpublished_deps */ false);
+    let compiled_package = BuildConfig::new_for_testing()
+        .build(Path::new("../../sui_programmability/examples/fungible_tokens").to_path_buf())?;
+    let compiled_modules_bytes =
+        compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
 
     let transaction_bytes: TransactionBytes = http_client
-        .publish(*address, compiled_modules, Some(gas.object_id), 10000)
+        .publish(
+            *address,
+            compiled_modules_bytes,
+            dependencies,
+            Some(gas.object_id),
+            10000,
+        )
         .await?;
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
@@ -272,12 +280,20 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
     let gas = objects.first().unwrap();
 
     // Publish test coin package
-    let compiled_modules = BuildConfig::default()
-        .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?
-        .get_package_base64(/* with_unpublished_deps */ false);
+    let compiled_package = BuildConfig::default()
+        .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?;
+    let compiled_modules_bytes =
+        compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
 
     let transaction_bytes: TransactionBytes = http_client
-        .publish(*address, compiled_modules, Some(gas.object_id), 10000)
+        .publish(
+            *address,
+            compiled_modules_bytes,
+            dependencies,
+            Some(gas.object_id),
+            10000,
+        )
         .await?;
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
@@ -330,12 +346,20 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let gas = objects.first().unwrap();
 
     // Publish test coin package
-    let compiled_modules = BuildConfig::new_for_testing()
-        .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?
-        .get_package_base64(/* with_unpublished_deps */ false);
+    let compiled_package = BuildConfig::new_for_testing()
+        .build(Path::new("src/unit_tests/data/dummy_modules_publish").to_path_buf())?;
+    let compiled_modules_bytes =
+        compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
 
     let transaction_bytes: TransactionBytes = http_client
-        .publish(*address, compiled_modules, Some(gas.object_id), 10000)
+        .publish(
+            *address,
+            compiled_modules_bytes,
+            dependencies,
+            Some(gas.object_id),
+            10000,
+        )
         .await?;
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2113,6 +2113,17 @@
           }
         },
         {
+          "name": "dependencies",
+          "description": "a list of transitive dependency addresses that this set of modules depends on.",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectID"
+            }
+          }
+        },
+        {
           "name": "gas",
           "description": "gas object to be used in this transaction, node will pick one from the signer's possession if not provided",
           "schema": {
@@ -5482,14 +5493,27 @@
             "additionalProperties": false
           },
           {
-            "description": "Publishes a Move package",
+            "description": "Publishes a Move package. It takes the package bytes and a list of the package's transitive dependencies to link against on-chain.",
             "type": "object",
             "required": [
               "Publish"
             ],
             "properties": {
               "Publish": {
-                "$ref": "#/components/schemas/MovePackage"
+                "type": "array",
+                "items": [
+                  {
+                    "$ref": "#/components/schemas/MovePackage"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ObjectID"
+                    }
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
               }
             },
             "additionalProperties": false

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -125,19 +125,15 @@ async fn test_publish_and_move_call() {
     let sender = get_random_address(&network.accounts, vec![]);
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../sui_programmability/examples/fungible_tokens");
-    let package = sui_framework::build_move_package(&path, BuildConfig::new_for_testing()).unwrap();
-    let compiled_module = package
-        .get_modules()
-        .map(|m| {
-            let mut module_bytes = Vec::new();
-            m.serialize(&mut module_bytes).unwrap();
-            module_bytes
-        })
-        .collect::<Vec<_>>();
+    let compiled_package =
+        sui_framework::build_move_package(&path, BuildConfig::new_for_testing()).unwrap();
+    let compiled_modules_bytes =
+        compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.publish(compiled_module);
+        builder.publish(compiled_modules_bytes, dependencies);
         builder.finish()
     };
     let response =

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -440,6 +440,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         &self,
         sender: SuiAddress,
         compiled_modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> anyhow::Result<TransactionData> {
@@ -451,6 +452,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             sender,
             gas,
             compiled_modules,
+            dep_ids,
             gas_budget,
             gas_price,
         ))

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -30,6 +30,8 @@ pub struct SuiPublishArgs {
     pub sender: Option<String>,
     #[clap(long = "upgradeable", action = clap::ArgAction::SetTrue)]
     pub upgradeable: bool,
+    #[clap(long = "dependencies")]
+    pub dependencies: Vec<String>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -293,6 +293,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let SuiPublishArgs {
             sender,
             upgradeable,
+            dependencies: _,
         } = extra;
         let module_name = module.self_id().name().to_string();
         let module_bytes = {
@@ -304,10 +305,10 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let data = |sender, gas| {
             let mut builder = ProgrammableTransactionBuilder::new();
             if upgradeable {
-                let cap = builder.publish_upgradeable(vec![module_bytes]);
+                let cap = builder.publish_upgradeable(vec![module_bytes], vec![]);
                 builder.transfer_arg(sender, cap);
             } else {
-                builder.publish(vec![module_bytes]);
+                builder.publish(vec![module_bytes], vec![]);
             };
             let pt = builder.finish();
             TransactionData::new_programmable_with_dummy_gas_price(

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -196,6 +196,18 @@ impl MoveModulePublish {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct SuiMovePackageDependencies {
+    pub modules: Vec<ObjectRef>,
+}
+
+impl SuiMovePackageDependencies {
+    pub fn validity_check(&self, _config: &ProtocolConfig) -> UserInputResult {
+        // TODO fp_ensure!(...)
+        Ok(())
+    }
+}
+
 // TODO: we can deprecate TransferSui when its callsites on RPC & SDK are
 // fully replaced by PaySui and PayAllSui.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
@@ -535,8 +547,9 @@ pub enum Command {
     /// `(&mut Coin<T>, Vec<Coin<T>>)`
     /// It merges n-coins into the first coin
     MergeCoins(Argument, Vec<Argument>),
-    /// Publishes a Move package
-    Publish(Vec<Vec<u8>>),
+    /// Publishes a Move package. It takes the package bytes and a list of the package's transitive
+    /// dependencies to link against on-chain.
+    Publish(Vec<Vec<u8>>, Vec<ObjectID>),
     /// `forall T: Vec<T> -> vector<T>`
     /// Given n-values of the same type, it constructs a vector. For non objects or an empty vector,
     /// the type tag must be specified.
@@ -612,7 +625,10 @@ impl Command {
         }))
     }
 
-    fn publish_command_input_objects(modules: &[Vec<u8>]) -> Vec<InputObjectKind> {
+    fn publish_command_input_objects(
+        modules: &[Vec<u8>],
+        _dep_ids: &[ObjectID],
+    ) -> Vec<InputObjectKind> {
         // For module publishing, all the dependent packages are implicit input objects
         // because they must all be on-chain in order for the package to publish.
         // All authorities must have the same view of those dependencies in order
@@ -633,9 +649,10 @@ impl Command {
 
     fn input_objects(&self) -> Vec<InputObjectKind> {
         match self {
-            Command::Upgrade(_, _, modules) | Command::Publish(modules) => {
-                Self::publish_command_input_objects(modules)
+            Command::Publish(modules, dep_ids) => {
+                Self::publish_command_input_objects(modules, dep_ids)
             }
+            Command::Upgrade(_, _, modules) => Self::publish_command_input_objects(modules, &[]),
             Command::MoveCall(c) => c.input_objects(),
             Command::MakeMoveVec(Some(t), _) => {
                 let mut packages = BTreeSet::new();
@@ -717,7 +734,7 @@ impl Command {
                     }
                 );
             }
-            Command::Publish(modules) => {
+            Command::Publish(modules, _dep_ids) => {
                 fp_ensure!(!modules.is_empty(), UserInputError::EmptyCommandInput);
                 fp_ensure!(
                     modules.len() < config.max_modules_in_publish() as usize,
@@ -890,7 +907,11 @@ impl Display for Command {
                 write_sep(f, coins, ",")?;
                 write!(f, ")")
             }
-            Command::Publish(_bytes) => write!(f, "Publish(_)"),
+            Command::Publish(_bytes, deps) => {
+                write!(f, "Publish(_,")?;
+                write_sep(f, deps, ",")?;
+                write!(f, ")")
+            }
             Command::Upgrade(ticket, deps, _bytes) => {
                 write!(f, "Upgrade({ticket},")?;
                 write_sep(f, deps, ",")?;
@@ -1462,21 +1483,30 @@ impl TransactionData {
         sender: SuiAddress,
         gas_payment: ObjectRef,
         modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
         gas_budget: u64,
     ) -> Self {
-        Self::new_module(sender, gas_payment, modules, gas_budget, DUMMY_GAS_PRICE)
+        Self::new_module(
+            sender,
+            gas_payment,
+            modules,
+            dep_ids,
+            gas_budget,
+            DUMMY_GAS_PRICE,
+        )
     }
 
     pub fn new_module(
         sender: SuiAddress,
         gas_payment: ObjectRef,
         modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
         gas_budget: u64,
         gas_price: u64,
     ) -> Self {
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder.publish(modules);
+            builder.publish(modules, dep_ids);
             builder.finish()
         };
         Self::new_programmable(sender, vec![gas_payment], pt, gas_budget, gas_price)

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -179,12 +179,16 @@ impl ProgrammableTransactionBuilder {
         })))
     }
 
-    pub fn publish_upgradeable(&mut self, modules: Vec<Vec<u8>>) -> Argument {
-        self.command(Command::Publish(modules))
+    pub fn publish_upgradeable(
+        &mut self,
+        modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+    ) -> Argument {
+        self.command(Command::Publish(modules, dep_ids))
     }
 
-    pub fn publish(&mut self, modules: Vec<Vec<u8>>) {
-        let cap = self.publish_upgradeable(modules);
+    pub fn publish(&mut self, modules: Vec<Vec<u8>>, dep_ids: Vec<ObjectID>) {
+        let cap = self.publish_upgradeable(modules, dep_ids);
         self.commands
             .push(Command::MoveCall(Box::new(ProgrammableMoveCall {
                 package: SUI_FRAMEWORK_OBJECT_ID,

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -816,7 +816,7 @@ fn test_sponsored_transaction_validity_check() {
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.publish(vec![vec![]]);
+        builder.publish(vec![vec![]], vec![]);
         builder.finish()
     };
     let kind = TransactionKind::programmable(pt);

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -528,7 +528,13 @@ impl SuiClientCommands {
 
                 let data = client
                     .transaction_builder()
-                    .publish(sender, compiled_modules, gas, gas_budget)
+                    .publish(
+                        sender,
+                        compiled_modules,
+                        dependencies.published.into_values().collect(),
+                        gas,
+                        gas_budget,
+                    )
                     .await?;
                 let signature =
                     context

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -288,13 +288,16 @@ pub fn create_publish_move_package_transaction(
     gas_price: Option<u64>,
 ) -> VerifiedTransaction {
     let build_config = BuildConfig::new_for_testing();
-    let all_module_bytes = sui_framework::build_move_package(&path, build_config)
-        .unwrap()
-        .get_package_bytes(/* with_unpublished_deps */ false);
+    let compiled_package = sui_framework::build_move_package(&path, build_config).unwrap();
+    let all_module_bytes =
+        compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
+
     let data = TransactionData::new_module(
         sender,
         gas_object_ref,
         all_module_bytes,
+        dependencies,
         MAX_GAS,
         gas_price.unwrap_or(DUMMY_GAS_PRICE),
     );
@@ -326,6 +329,7 @@ pub fn make_publish_basics_transaction(gas_object: ObjectRef) -> VerifiedTransac
         sender,
         gas_object,
         all_module_bytes,
+        vec![],
         MAX_GAS,
     );
     to_sender_signed_transaction(data, &keypair)


### PR DESCRIPTION
## Description 

Propagate transitive package dependencies in `Publish` command.

## Test Plan 

TBD, this is going into https://github.com/MystenLabs/sui/pull/9096 first.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
