### PR TITLE
Gas rework as coming from Sam

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -142,7 +142,7 @@ fn execute_transaction<
 ) {
     // First smash gas into the first coin if more than 1 was provided
     let sender = tx_ctx.sender();
-    let mut gas_object_ref = match temporary_store.smash_gas(sender, gas) {
+    let gas_object_ref = match temporary_store.smash_gas(sender, gas) {
         Ok(obj_ref) => obj_ref,
         Err(_) => gas[0], // this cannot fail, but we use gas[0] anyway
     };
@@ -191,27 +191,11 @@ fn execute_transaction<
                 ))
             }
         };
-
-        if execution_result.is_err() {
-            // Roll back the temporary store if execution failed or effects too large.
-            temporary_store.reset();
-            // re-smash so temporary store is again aware of smashing
-            gas_object_ref = match temporary_store.smash_gas(sender, gas) {
-                Ok(obj_ref) => obj_ref,
-                Err(_) => gas[0], // this cannot fail, but we use gas[0] anyway
-            };
-        }
         execution_result
     });
-
-    // Make sure every mutable object's version number is incremented.
-    // This needs to happen before `charge_gas_for_storage_changes` so that it
-    // can charge gas for all mutated objects properly.
-    temporary_store.ensure_active_inputs_mutated(sender, &gas_object_ref.0);
     if !gas_status.is_unmetered() {
         temporary_store.charge_gas(sender, gas_object_ref.0, &mut gas_status, &mut result, gas);
     }
-
     if !is_system {
         #[cfg(debug_assertions)]
         {
@@ -219,7 +203,6 @@ fn execute_transaction<
             temporary_store.check_sui_conserved();
         }
     }
-
     let cost_summary = gas_status.summary();
     (cost_summary, result)
 }
@@ -357,7 +340,7 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
             temporary_store.read_object(&SUI_SYSTEM_STATE_OBJECT_ID),
             change_epoch,
         );
-        temporary_store.reset();
+        temporary_store.drop_writes();
         let function = ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME.to_owned();
         let safe_mode_pt = {
             let mut builder = ProgrammableTransactionBuilder::new();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2542,7 +2542,6 @@ async fn test_move_call_mutable_object_not_mutated() {
 }
 
 // skipped because it violates SUI conservation checks
-#[ignore]
 #[tokio::test]
 async fn test_move_call_insufficient_gas() {
     // This test attempts to trigger a transaction execution that would fail due to insufficient gas.
@@ -5214,7 +5213,6 @@ fn test_choose_next_system_packages() {
 }
 
 // skipped because it violates SUI conservation checks
-#[ignore]
 #[tokio::test]
 async fn test_gas_smashing() {
     // run a create move object transaction with a given set o gas coins and a budget
@@ -5306,7 +5304,7 @@ async fn test_gas_smashing() {
         gas_used
     }
 
-    // 1. get the cost of the transaction so we can play with multiple gas coins
+    // get the cost of the transaction so we can play with multiple gas coins
     // 100,000 should be enough money for that transaction.
     let gas_used = run_and_check(100_000, 1, 100_000, true).await;
 
@@ -5316,7 +5314,7 @@ async fn test_gas_smashing() {
     run_and_check(reference_gas_used, 10, reference_gas_used - 100, true).await;
 
     // make less then required to succeed
-    let reference_gas_used = gas_used - 10;
+    let reference_gas_used = gas_used - 1;
     run_and_check(reference_gas_used, 2, reference_gas_used - 10, false).await;
     run_and_check(reference_gas_used, 30, reference_gas_used, false).await;
     // use a small amount less than what 3 coins above reported (with success)

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -474,13 +474,9 @@ impl<S> TemporaryStore<S> {
     /// For every object from active_inputs (i.e. all mutable objects), if they are not
     /// mutated during the transaction execution, force mutating them by incrementing the
     /// sequence number. This is required to achieve safety.
-    /// We skip the gas object, because gas object will be updated separately.
-    pub fn ensure_active_inputs_mutated(&mut self, sender: SuiAddress, gas_object_id: &ObjectID) {
+    fn ensure_active_inputs_mutated(&mut self, sender: SuiAddress) {
         let mut to_be_updated = vec![];
         for (id, _seq, _) in &self.mutable_input_refs {
-            if id == gas_object_id {
-                continue;
-            }
             if !self.written.contains_key(id) && !self.deleted.contains_key(id) {
                 // We cannot update here but have to push to `to_be_updated` and update later
                 // because the for loop is holding a reference to `self`, and calling
@@ -498,30 +494,28 @@ impl<S> TemporaryStore<S> {
         }
     }
 
-    /// For every object changes, charge gas accordingly. Since by this point we haven't charged gas yet,
-    /// the gas object hasn't been mutated yet. Passing in `gas_object_size` so that we can also charge
-    /// for the gas object mutation in advance.
-    pub fn charge_gas_for_storage_changes(
+    /// Compute storage gas for each mutable input object (including the gas coin), and each created object.
+    /// Compute storage refunds for each deleted object
+    /// Will *not* charge any computation gas. Returns the total size in bytes of all deleted objects + all mutated objects,
+    /// which the caller can use to charge computation gas
+    fn charge_gas_for_storage_changes(
         &mut self,
         sender: SuiAddress,
         gas_status: &mut SuiGasStatus<'_>,
-        gas_object: &mut Object,
-    ) -> Result<(), ExecutionError> {
-        let mut objects_to_update = vec![];
+        gas_object_id: ObjectID,
+    ) -> Result<u64, ExecutionError> {
+        let mut total_bytes_written_deleted = 0;
+
         // If the gas coin was not yet written, charge gas for mutating the gas object in advance.
-        if !self.written.contains_key(&gas_object.id()) {
-            let gas_object_size = gas_object.object_size_for_gas_metering();
-            gas_object.storage_rebate = gas_status.charge_storage_mutation(
-                gas_object_size,
-                gas_object_size,
-                gas_object.storage_rebate.into(),
-            )?;
-            objects_to_update.push((
-                SingleTxContext::gas(sender),
-                gas_object.clone(),
-                WriteKind::Mutate,
-            ));
-        }
+        let gas_object = self
+            .read_object(&gas_object_id)
+            .expect("We constructed the object map so it should always have the gas object id")
+            .clone();
+        self.written
+            .entry(gas_object_id)
+            .or_insert_with(|| (SingleTxContext::gas(sender), gas_object, WriteKind::Mutate));
+        self.ensure_active_inputs_mutated(sender);
+        let mut objects_to_update = vec![];
 
         for (object_id, (ctx, object, write_kind)) in &mut self.written {
             let (old_object_size, storage_rebate) = self
@@ -529,15 +523,15 @@ impl<S> TemporaryStore<S> {
                 .get(object_id)
                 .map(|old| (old.object_size_for_gas_metering(), old.storage_rebate))
                 .unwrap_or((0, 0));
-            let new_storage_rebate = gas_status.charge_storage_mutation(
-                old_object_size,
-                object.object_size_for_gas_metering(),
-                storage_rebate.into(),
-            )?;
+
+            let new_object_size = object.object_size_for_gas_metering();
+            let new_storage_rebate =
+                gas_status.charge_storage_mutation(new_object_size, storage_rebate.into())?;
             object.storage_rebate = new_storage_rebate;
             if !object.is_immutable() {
                 objects_to_update.push((ctx.clone(), object.clone(), *write_kind));
             }
+            total_bytes_written_deleted += old_object_size + new_object_size;
         }
 
         for object_id in self.deleted.keys() {
@@ -546,11 +540,8 @@ impl<S> TemporaryStore<S> {
             // object was unwrapped and then deleted. The rebate would have been provided already when
             // mutating the object that wrapped this object.
             if let Some(old_object) = self.input_objects.get(object_id) {
-                gas_status.charge_storage_mutation(
-                    old_object.object_size_for_gas_metering(),
-                    0,
-                    old_object.storage_rebate.into(),
-                )?;
+                gas_status.charge_storage_mutation(0, old_object.storage_rebate.into())?;
+                total_bytes_written_deleted += old_object.object_size_for_gas_metering();
             }
         }
 
@@ -559,8 +550,7 @@ impl<S> TemporaryStore<S> {
         for (ctx, object, write_kind) in objects_to_update {
             self.write_object(&ctx, object, write_kind);
         }
-
-        Ok(())
+        Ok(total_bytes_written_deleted as u64)
     }
 
     pub fn to_effects(
@@ -729,46 +719,61 @@ impl<S> TemporaryStore<S> {
             .insert(object.id(), (ctx.clone(), object, kind));
     }
 
+    /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of mutated objects
+    /// 2. Deduct computation gas costs and storage costs to `gas_object_id`, credit storage rebates to `gas_object_id`.
+    // The happy path of this function follows (1) + (2) and is fairly simple. Most of the complexity is in the unhappy paths:
+    // - if execution aborted before calling this function, we have to dump all writes + re-smash gas, then charge for storage
+    // - if we run out of gas while charging for storage, we have to dump all writes + re-smash gas, then charge for storage again
     pub fn charge_gas<T>(
         &mut self,
         sender: SuiAddress,
         gas_object_id: ObjectID,
         gas_status: &mut SuiGasStatus<'_>,
-        result: &mut Result<T, ExecutionError>,
+        execution_result: &mut Result<T, ExecutionError>,
         gas: &[ObjectRef],
     ) {
-        // We must call `read_object` instead of getting it from `temporary_store.objects`
-        // because a `TransferSui` transaction may have already mutated the gas object and put
-        // it in `temporary_store.written`.
-        let mut gas_object = self
-            .read_object(&gas_object_id)
-            .expect("We constructed the object map so it should always have the gas object id")
-            .clone();
-        trace!(?gas_object_id, "Obtained gas object");
-        if let Err(err) = self.charge_gas_for_storage_changes(sender, gas_status, &mut gas_object) {
-            // If `result` is already `Err`, we basically have two errors at the same time.
-            // Users should be generally more interested in the actual execution error, so we
-            // let that shadow the out of gas error. Also in this case, we don't need to reset
-            // the `temporary_store` because `charge_gas_for_storage_changes` won't mutate
-            // `temporary_store` if gas charge failed.
-            //
-            // If `result` is `Ok`, now we failed when charging gas, we have to reset
-            // the `temporary_store` to eliminate all effects caused by the execution,
-            // and re-ensure all mutable objects' versions are incremented.
-            if result.is_ok() {
-                self.reset();
-                let gas_object_id = match self.smash_gas(sender, gas) {
-                    Ok(obj_ref) => obj_ref.0,
-                    Err(_) => gas[0].0, // this cannot fail, but we use gas[0] anyway
-                };
-                self.ensure_active_inputs_mutated(sender, &gas_object_id);
-                *result = Err(err);
+        // at this point, we have done some charging for computation, but have not yet set the storage rebate or storage gas units
+        assert!(gas_status.storage_rebate() == 0);
+        assert!(gas_status.storage_gas_units() == 0);
+
+        if execution_result.is_err() {
+            // Tx execution aborted--need to dump writes, deletes, etc before charging storage gas
+            self.reset(sender, gas, gas_status);
+        }
+
+        if let Err(err) = self
+            .charge_gas_for_storage_changes(sender, gas_status, gas_object_id)
+            .and_then(|total_bytes_written_deleted| {
+                gas_status.charge_computation_gas_for_storage_mutation(total_bytes_written_deleted)
+            })
+        {
+            // Ran out of gas while charging for storage changes. reset store, now at state just after gas smashing
+            self.reset(sender, gas, gas_status);
+
+            // charge for storage again. This will now account only for the storage cost of gas coins
+            if self
+                .charge_gas_for_storage_changes(sender, gas_status, gas_object_id)
+                .and_then(|total_bytes_written_deleted| {
+                    gas_status
+                        .charge_computation_gas_for_storage_mutation(total_bytes_written_deleted)
+                })
+                .is_err()
+            {
+                // TODO: this shouldn't happen, because we should check that the budget is enough to cover the storage costs of gas coins at signing time
+                // perhaps that check isn't there?
+                trace!("out of gas while charging for gas smashing")
+            }
+
+            // if execution succeeded, but we ran out of gas while charging for storage, overwrite the successful execution result
+            // with an out of gas failure
+            if execution_result.is_ok() {
+                *execution_result = Err(err)
             }
         }
         let cost_summary = gas_status.summary();
         let gas_used = cost_summary.gas_used();
 
-        // We must re-fetch the gas object from the temporary store, as it may have been reset
+        // Important to fetch the gas object here instead of earlier, as it may have been reset
         // previously in the case of error.
         let mut gas_object = self.read_object(&gas_object_id).unwrap().clone();
         gas::deduct_gas(
@@ -862,11 +867,20 @@ impl<S> TemporaryStore<S> {
         self.deleted.insert(*id, (ctx.clone(), version, kind));
     }
 
-    /// Resets any mutations and deletions recorded in the store.
-    pub fn reset(&mut self) {
+    pub fn drop_writes(&mut self) {
         self.written.clear();
         self.deleted.clear();
         self.events.clear();
+    }
+
+    /// Resets any mutations, deletions, and events recorded in the store, as well as any storage costs and
+    /// rebates, then Re-runs gas smashing. Effects on store are now as if we were about to begin execution
+    fn reset(&mut self, sender: SuiAddress, gas: &[ObjectRef], gas_status: &mut SuiGasStatus<'_>) {
+        self.drop_writes();
+        gas_status.reset_storage_cost_and_rebate();
+
+        self.smash_gas(sender, gas)
+            .expect("Gas smashing cannot fail because it already succeeded when we did it before on the same `gas`");
     }
 
     pub fn log_event(&mut self, event: Event) {
@@ -982,7 +996,9 @@ impl<S: ChildObjectResolver> ChildObjectResolver for TemporaryStore<S> {
 
 impl<S: ChildObjectResolver> Storage for TemporaryStore<S> {
     fn reset(&mut self) {
-        TemporaryStore::reset(self)
+        self.written.clear();
+        self.deleted.clear();
+        self.events.clear();
     }
 
     fn log_event(&mut self, event: Event) {


### PR DESCRIPTION
## Description 

https://github.com/MystenLabs/sui/pull/8920 with some fixes... let's see how it performs

## Test Plan 

existing tests.... and this re-enables all tests that were turned off because of conservation rules (@sblackshear)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
