### PR TITLE
[wallet-ext] sort accounts in the account menu in order of derived -> imported -> ledger

### DIFF
--- a/apps/wallet/src/ui/app/redux/slices/account/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/account/index.ts
@@ -55,21 +55,28 @@ export const logout = createAsyncThunk<void, void, AppThunkConfig>(
     }
 );
 
+const sortOrderByAccountType = [
+    AccountType.DERIVED,
+    AccountType.IMPORTED,
+    AccountType.LEDGER,
+];
+
 const accountsAdapter = createEntityAdapter<SerializedAccount>({
     selectId: ({ address }) => address,
     sortComparer: (a, b) => {
         if (a.type !== b.type) {
-            // first derived accounts
-            return a.type === AccountType.DERIVED ? -1 : 1;
-        } else if (a.type === AccountType.DERIVED) {
-            // sort derived accounts by derivation path
+            const sortRankForA = sortOrderByAccountType.indexOf(a.type);
+            const sortRankForB = sortOrderByAccountType.indexOf(b.type);
+            return sortRankForA - sortRankForB;
+        } else if (a.derivationPath) {
+            // Sort accounts by their derivation path if one exists
             return (a.derivationPath || '').localeCompare(
                 b.derivationPath || '',
                 undefined,
                 { numeric: true }
             );
         } else {
-            // sort imported account by address
+            // Otherwise, let's sort accounts by their address
             return a.address.localeCompare(b.address, undefined, {
                 numeric: true,
             });


### PR DESCRIPTION
## Description 



## Test Plan 
- Manual testing (created some derived accounts, added imported accounts, added Ledger accounts)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A