### PR TITLE
[sui adapter] Rewrite string validation

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.exp
@@ -18,4 +18,4 @@ written: object(108)
 
 task 5 'run'. lines 49-49:
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: Some("Unexpected non-ASCII value (outside of ASCII character range) in argument 0"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: Some("Function expects std::ascii::String but provided argument's value does not match"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.exp
@@ -3,19 +3,19 @@ processed 6 tasks
 init:
 A: object(100)
 
-task 1 'publish'. lines 6-27:
+task 1 'publish'. lines 6-28:
 created: object(105)
 written: object(104)
 
-task 2 'run'. lines 29-32:
+task 2 'run'. lines 30-33:
 written: object(106)
 
-task 3 'run'. lines 34-37:
+task 3 'run'. lines 35-38:
 written: object(107)
 
-task 4 'run'. lines 39-47:
+task 4 'run'. lines 40-48:
 written: object(108)
 
-task 5 'run'. lines 49-49:
+task 5 'run'. lines 50-50:
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: Some("Function expects std::ascii::String but provided argument's value does not match"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.move
@@ -22,6 +22,7 @@ module Test::M {
         };
         assert!(l == 10, 0);
     }
+
 }
 
 // string of ASCII characters as byte string

--- a/crates/sui-core/src/unit_tests/data/entry_point_string/sources/entry_point_string.move
+++ b/crates/sui-core/src/unit_tests/data/entry_point_string/sources/entry_point_string.move
@@ -6,22 +6,41 @@ module entry_point_string::entry_point_string {
     use std::string;
     use sui::tx_context::TxContext;
     use std::vector;
+    use std::option::Option;
 
 
-    public entry fun ascii_arg(s: ascii::String, _: &mut TxContext) {
-        assert!(ascii::length(&s) == 10, 0);
+    public entry fun ascii_arg(s: ascii::String, len: u64, _: &mut TxContext) {
+        assert!(ascii::length(&s) == len, 0);
     }
 
-    public entry fun utf8_arg(s: string::String, _: &mut TxContext) {
-        assert!(string::length(&s) == 24, 0);
+    public entry fun utf8_arg(s: string::String, len: u64, _: &mut TxContext) {
+        assert!(string::length(&s) == len, 0);
     }
 
-    public entry fun utf8_vec_arg(v: vector<string::String>, _: &mut TxContext) {
+    public entry fun utf8_vec_arg(
+        v: vector<string::String>,
+        total_len: u64,
+        _: &mut TxContext
+    ) {
         let concat = string::utf8(vector::empty());
         while (!vector::is_empty(&v)) {
             let s = vector::pop_back(&mut v);
             string::append(&mut concat, s);
         };
-        assert!(string::length(&concat) == 24, 0);
+        assert!(string::length(&concat) == total_len, 0);
+    }
+
+    public entry fun option_ascii_arg(_: Option<ascii::String>) {
+    }
+
+    public entry fun option_utf8_arg(_: Option<string::String>) {
+    }
+
+    public entry fun vec_option_utf8_arg(_: vector<Option<string::String>>) {
+    }
+
+    public entry fun option_vec_option_utf8_arg(
+        _: Option<vector<Option<string::String>>>
+    ) {
     }
 }

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -2285,6 +2285,34 @@ async fn test_entry_point_string_option_error() {
             command: Some(0)
         }
     );
+
+    // pass a vector as an option
+    let utf8_str_1 = "çå∞≠¢";
+    let utf8_str_2 = "õß∂ƒ∫";
+    let utf_str_vec_bcs = bcs::to_bytes(&vec![utf8_str_1, utf8_str_2]).unwrap();
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package.0,
+        "entry_point_string",
+        "option_utf8_arg",
+        vec![],
+        vec![TestCallArg::Pure(utf_str_vec_bcs)],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        effects.status(),
+        &ExecutionStatus::Failure {
+            error: ExecutionFailureStatus::CommandArgumentError {
+                arg_idx: 0,
+                kind: CommandArgumentError::TypeMismatch
+            },
+            command: Some(0)
+        }
+    );
 }
 
 #[tokio::test]

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -1996,6 +1996,78 @@ async fn test_nested_string() {
     .await
     .unwrap();
     assert_eq!(effects.status(), &ExecutionStatus::Success);
+
+    // pass an empty option utf8 string
+    let utf8_str: Option<String> = None;
+    let utf_str_bcs = bcs::to_bytes(&utf8_str).unwrap();
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package.0,
+        "entry_point_string",
+        "option_utf8_arg",
+        vec![],
+        vec![TestCallArg::Pure(utf_str_bcs)],
+    )
+    .await
+    .unwrap();
+    assert_eq!(effects.status(), &ExecutionStatus::Success);
+
+    // an empty vector option utf8 string
+    let utf8_str: Vec<Option<String>> = vec![];
+    let utf_str_bcs = bcs::to_bytes(&utf8_str).unwrap();
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package.0,
+        "entry_point_string",
+        "vec_option_utf8_arg",
+        vec![],
+        vec![TestCallArg::Pure(utf_str_bcs)],
+    )
+    .await
+    .unwrap();
+    assert_eq!(effects.status(), &ExecutionStatus::Success);
+
+    // an vector of None
+    let utf8_str: Vec<Option<String>> = vec![None, None];
+    let utf_str_bcs = bcs::to_bytes(&utf8_str).unwrap();
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package.0,
+        "entry_point_string",
+        "vec_option_utf8_arg",
+        vec![],
+        vec![TestCallArg::Pure(utf_str_bcs)],
+    )
+    .await
+    .unwrap();
+    assert_eq!(effects.status(), &ExecutionStatus::Success);
+
+    // vector option utf8 string
+    let utf8_str: Option<Vec<Option<String>>> = Some(vec![None, None]);
+    let utf_str_bcs = bcs::to_bytes(&utf8_str).unwrap();
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package.0,
+        "entry_point_string",
+        "option_vec_option_utf8_arg",
+        vec![],
+        vec![TestCallArg::Pure(utf_str_bcs)],
+    )
+    .await
+    .unwrap();
+    assert_eq!(effects.status(), &ExecutionStatus::Success);
 }
 
 #[tokio::test]

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -1940,6 +1940,7 @@ async fn test_nested_string() {
         &sender_key,
         &gas,
         "entry_point_string",
+        /* with_unpublished_deps */ false,
     )
     .await;
 
@@ -2298,6 +2299,7 @@ async fn test_entry_point_string_option_error() {
         &sender_key,
         &gas,
         "entry_point_string",
+        /* with_unpublished_deps */ false,
     )
     .await;
 

--- a/crates/sui-verifier/src/entry_points_verifier.rs
+++ b/crates/sui-verifier/src/entry_points_verifier.rs
@@ -250,7 +250,7 @@ pub const RESOLVED_UTF8_STR: (&AccountAddress, &IdentStr, &IdentStr) = (
     STD_UTF8_STRUCT_NAME,
 );
 
-fn is_primitive(
+pub fn is_primitive(
     view: &BinaryIndexedView,
     function_type_args: &[AbilitySet],
     s: &SignatureToken,

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -14,12 +14,16 @@ describe('Test Move call with strings', () => {
   let toolbox: TestToolbox;
   let packageId: ObjectId;
 
-  async function callWithString(str: string | string[], funcName: string) {
+  async function callWithString(
+    str: string | string[],
+    len: number,
+    funcName: string,
+  ) {
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
     tx.moveCall({
       target: `${packageId}::entry_point_string::${funcName}`,
-      arguments: [tx.pure(str)],
+      arguments: [tx.pure(str), tx.pure(len)],
     });
     const result = await toolbox.signer.signAndExecuteTransaction(tx, {
       showEffects: true,
@@ -36,14 +40,20 @@ describe('Test Move call with strings', () => {
   });
 
   it('Test ascii', async () => {
-    await callWithString('SomeString', 'ascii_arg');
+    const s = 'SomeString';
+    await callWithString(s, s.length, 'ascii_arg');
   });
 
   it('Test utf8', async () => {
-    await callWithString('çå∞≠¢õß∂ƒ∫', 'utf8_arg');
+    const s = 'çå∞≠¢õß∂ƒ∫';
+    const byte_len = 24;
+    await callWithString(s, byte_len, 'utf8_arg');
   });
 
   it('Test string vec', async () => {
-    await callWithString(['çå∞≠¢', 'õß∂ƒ∫'], 'utf8_vec_arg');
+    const s1 = 'çå∞≠¢';
+    const s2 = 'õß∂ƒ∫';
+    const byte_len = 24;
+    await callWithString([s1, s2], byte_len, 'utf8_vec_arg');
   });
 });


### PR DESCRIPTION
## Description 

- String validation has been rewritten to hopefully be more efficient
- The rewrite will allow for other custom types
- Fixed Option<String> support
- Will allow for limits to be added during deserialization

## Test Plan 

- Many new tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
