### PR TITLE
indexer: minor fixes and simple e2e txn test

### DIFF
--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -52,9 +52,10 @@ move-bytecode-utils.workspace = true
 pg_integration = []
 
 [dev-dependencies]
-test-utils = { path = "../test-utils" }
-sui-framework-build = { path = "../sui-framework-build" }
 diesel_migrations = "2.0.0"
+sui-framework-build = { path = "../sui-framework-build" }
+sui-keys = { path = "../sui-keys" }
+test-utils = { path = "../test-utils" }
 
 [[bin]]
 name = "sui-indexer"

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -118,6 +118,9 @@ impl TryFrom<SuiTransactionResponse> for Transaction {
         let recipients: Vec<String> = effects
             .mutated()
             .iter()
+            .cloned()
+            .chain(effects.created().iter().cloned())
+            .chain(effects.unwrapped().iter().cloned())
             .map(|owned_obj_ref| owned_obj_ref.owner.to_string())
             .collect();
         let created: Vec<String> = effects

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -531,6 +531,8 @@ impl IndexerStore for PgIndexerStore {
             .run(|conn| {
                 let mut boxed_query = transactions_dsl::transactions
                     .filter(transactions_dsl::mutated.contains(vec![Some(object_id.clone())]))
+                    .or_filter(transactions_dsl::created.contains(vec![Some(object_id.clone())]))
+                    .or_filter(transactions_dsl::unwrapped.contains(vec![Some(object_id.clone())]))
                     .into_boxed();
                 if let Some(start_sequence) = start_sequence {
                     if is_descending {


### PR DESCRIPTION
## Description 

- add a simple txn e2e test
- fixed a bug about txn query via mutated object
- also a bug about txn recipient indexing

## Test Plan 

we now have CI, to locally run it, we can do things like depending on the local PG DB setup
```
POSTGRES_PORT=5432 cargo test --package sui-indexer --features pg_integration --test integration_tests -- test_simple_transaction_e2e
```
The initial DB setup can be found in 
https://www.notion.so/mystenlabs/Indexer-local-run-instructions-94c6013994584fa682ff5b3efaece323
