### PR TITLE
[ts-sdk] Change all provider APIs to take objects

### DIFF
--- a/.changeset/thin-penguins-warn.md
+++ b/.changeset/thin-penguins-warn.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+All JSON-RPC APIs now accept objects instead of positional arugments.

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -58,8 +58,8 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
         setIsFail(false);
         setIsLoaded(false);
         const req = byAddress
-            ? rpc.getObjectsOwnedByAddress(id)
-            : rpc.getDynamicFields(id);
+            ? rpc.getObjectsOwnedByAddress({ owner: id })
+            : rpc.getDynamicFields({ parentId: id });
 
         req.then((objects) => {
             let ids: string[];
@@ -69,9 +69,12 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                 ids = objects.data.map(({ objectId }) => objectId);
             }
             return rpc
-                .getObjectBatch(ids, {
-                    showType: true,
-                    showContent: true,
+                .multiGetObjects({
+                    ids,
+                    options: {
+                        showType: true,
+                        showContent: true,
+                    },
                 })
                 .then((results) => {
                     setResults(

--- a/apps/explorer/src/components/recent-packages-card/RecentPackagesCard.tsx
+++ b/apps/explorer/src/components/recent-packages-card/RecentPackagesCard.tsx
@@ -75,14 +75,11 @@ export function RecentModulesCard() {
     const { data, isLoading, isSuccess, isError } = useQuery(
         ['recentPackage'],
         async () => {
-            const recentPublishMod: PaginatedEvents = await rpc.getEvents(
-                {
-                    EventType: 'Publish',
-                },
-                null,
-                RECENT_MODULES_COUNT,
-                'descending'
-            );
+            const recentPublishMod: PaginatedEvents = await rpc.getEvents({
+                query: { EventType: 'Publish' },
+                limit: RECENT_MODULES_COUNT,
+                order: 'descending',
+            });
 
             return recentPublishMod.data;
         },

--- a/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
@@ -171,10 +171,13 @@ export const getDataOnTxDigests = (
     transactions: GetTxnDigestsResponse
 ) =>
     rpc
-        .getTransactionResponseBatch(dedupe(transactions), {
-            showInput: true,
-            showEffects: true,
-            showEvents: true,
+        .multiGetTransactions({
+            digests: dedupe(transactions),
+            options: {
+                showInput: true,
+                showEffects: true,
+                showEvents: true,
+            },
         })
         .then((txEffs) =>
             txEffs

--- a/apps/explorer/src/hooks/useGetObject.ts
+++ b/apps/explorer/src/hooks/useGetObject.ts
@@ -18,12 +18,15 @@ export function useGetObject(
     const response = useQuery(
         ['object', normalizedObjId],
         async () =>
-            rpc.getObject(normalizedObjId, {
-                showType: true,
-                showContent: true,
-                showOwner: true,
-                showPreviousTransaction: true,
-                showStorageRebate: true,
+            rpc.getObject({
+                id: normalizedObjId,
+                options: {
+                    showType: true,
+                    showContent: true,
+                    showOwner: true,
+                    showPreviousTransaction: true,
+                    showStorageRebate: true,
+                },
             }),
         { enabled: !!objectId }
     );

--- a/apps/explorer/src/hooks/useGetTransaction.ts
+++ b/apps/explorer/src/hooks/useGetTransaction.ts
@@ -9,10 +9,13 @@ export function useGetTransaction(transactionId: string) {
     return useQuery(
         ['transactions-by-id', transactionId],
         async () =>
-            rpc.getTransactionResponse(transactionId, {
-                showInput: true,
-                showEffects: true,
-                showEvents: true,
+            rpc.getTransaction({
+                digest: transactionId,
+                options: {
+                    showInput: true,
+                    showEffects: true,
+                    showEvents: true,
+                },
             }),
         { enabled: !!transactionId }
     );

--- a/apps/explorer/src/hooks/useGetValidatorsEvents.ts
+++ b/apps/explorer/src/hooks/useGetValidatorsEvents.ts
@@ -28,12 +28,12 @@ export function useGetValidatorsEvents({
     const response = useQuery(
         ['validatorEvents', limit],
         () =>
-            rpc.getEvents(
-                { MoveEvent: VALIDATORS_EVENTS_QUERY },
-                eventCursor,
-                eventLimit,
-                order
-            ),
+            rpc.getEvents({
+                query: { MoveEvent: VALIDATORS_EVENTS_QUERY },
+                cursor: eventCursor?.txDigest,
+                limit: eventLimit,
+                order,
+            }),
         { enabled: !!limit }
     );
 

--- a/apps/explorer/src/hooks/useNormalizedMoveModule.ts
+++ b/apps/explorer/src/hooks/useNormalizedMoveModule.ts
@@ -13,7 +13,11 @@ export function useNormalizedMoveModule(
     const rpc = useRpcClient();
     return useQuery(
         ['normalized-module', packageId, moduleName],
-        async () => await rpc.getNormalizedMoveModule(packageId!, moduleName!),
+        async () =>
+            await rpc.getNormalizedMoveModule({
+                package: packageId!,
+                module: moduleName!,
+            }),
         {
             enabled: !!(packageId && moduleName),
         }

--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -29,7 +29,7 @@ const getResultsForTransaction = async (
 ) => {
     if (!isValidTransactionDigest(query)) return null;
 
-    const txdata = await rpc.getTransactionResponse(query);
+    const txdata = await rpc.getTransaction({ digest: query });
     return {
         label: 'transaction',
         results: [
@@ -46,7 +46,7 @@ const getResultsForObject = async (rpc: JsonRpcProvider, query: string) => {
     const normalized = normalizeSuiObjectId(query);
     if (!isValidSuiObjectId(normalized)) return null;
 
-    const { details, status } = await rpc.getObject(normalized);
+    const { details, status } = await rpc.getObject({ id: normalized });
     if (is(details, SuiObjectData) && status === 'Exists') {
         return {
             label: 'object',
@@ -64,7 +64,7 @@ const getResultsForObject = async (rpc: JsonRpcProvider, query: string) => {
 };
 
 const getResultsForCheckpoint = async (rpc: JsonRpcProvider, query: string) => {
-    const { digest } = await rpc.getCheckpoint(query);
+    const { digest } = await rpc.getCheckpoint({ id: query });
     if (digest) {
         return {
             label: 'checkpoint',
@@ -87,8 +87,11 @@ const getResultsForAddress = async (rpc: JsonRpcProvider, query: string) => {
         return null;
 
     const [from, to] = await Promise.all([
-        rpc.queryTransactions({ filter: { FromAddress: normalized } }, null, 1),
-        rpc.queryTransactions({ filter: { ToAddress: normalized } }, null, 1),
+        rpc.queryTransactions({
+            filter: { FromAddress: normalized },
+            limit: 1,
+        }),
+        rpc.queryTransactions({ filter: { ToAddress: normalized }, limit: 1 }),
     ]);
 
     if (from.data?.length || to.data?.length) {

--- a/apps/explorer/src/pages/checkpoints/CheckpointDetail.tsx
+++ b/apps/explorer/src/pages/checkpoints/CheckpointDetail.tsx
@@ -22,7 +22,7 @@ function CheckpointDetail() {
     const rpc = useRpcClient();
 
     const { data, isError, isLoading } = useQuery(['checkpoints', digest], () =>
-        rpc.getCheckpoint(digest!)
+        rpc.getCheckpoint({ id: digest! })
     );
 
     if (isError)

--- a/apps/explorer/src/pages/object-result/ObjectResult.tsx
+++ b/apps/explorer/src/pages/object-result/ObjectResult.tsx
@@ -45,12 +45,15 @@ function ObjectResultAPI({ objID }: { objID: string }) {
     const rpc = useRpcClient();
 
     useEffect(() => {
-        rpc.getObject(objID, {
-            showType: true,
-            showContent: true,
-            showOwner: true,
-            showPreviousTransaction: true,
-            showStorageRebate: true,
+        rpc.getObject({
+            id: objID,
+            options: {
+                showType: true,
+                showContent: true,
+                showOwner: true,
+                showPreviousTransaction: true,
+                showStorageRebate: true,
+            },
         })
             .then((objState) => {
                 const resp: DataType = translate(objState) as DataType;
@@ -70,8 +73,11 @@ function ObjectResultAPI({ objID }: { objID: string }) {
 
                 if (resp.objType === 'Move Package' && resp.data.tx_digest) {
                     return rpc
-                        .getTransactionResponse(resp.data.tx_digest, {
-                            showInput: true,
+                        .getTransaction({
+                            digest: resp.data.tx_digest,
+                            options: {
+                                showInput: true,
+                            },
                         })
                         .then((txEff) => ({
                             ...resp,

--- a/apps/explorer/src/utils/api/searchUtil.ts
+++ b/apps/explorer/src/utils/api/searchUtil.ts
@@ -14,10 +14,13 @@ export const navigateWithUnknown = async (
     if (isValidTransactionDigest(input)) {
         searchPromises.push(
             rpc(network)
-                .getTransactionResponse(input, {
-                    showInput: true,
-                    showEffects: true,
-                    showEvents: true,
+                .getTransaction({
+                    digest: input,
+                    options: {
+                        showInput: true,
+                        showEffects: true,
+                        showEvents: true,
+                    },
                 })
                 .then((data) => ({
                     category: 'transaction',
@@ -32,7 +35,7 @@ export const navigateWithUnknown = async (
     else if (isValidSuiAddress(input) || isGenesisLibAddress(input)) {
         const addrObjPromise = Promise.allSettled([
             rpc(network)
-                .getObjectsOwnedByAddress(input)
+                .getObjectsOwnedByAddress({ owner: input })
                 .then((data) => {
                     if (data.length <= 0)
                         throw new Error('No objects for Address');
@@ -43,12 +46,15 @@ export const navigateWithUnknown = async (
                     };
                 }),
             rpc(network)
-                .getObject(input, {
-                    showType: true,
-                    showContent: true,
-                    showOwner: true,
-                    showPreviousTransaction: true,
-                    showStorageRebate: true,
+                .getObject({
+                    id: input,
+                    options: {
+                        showType: true,
+                        showContent: true,
+                        showOwner: true,
+                        showPreviousTransaction: true,
+                        showStorageRebate: true,
+                    },
                 })
                 .then((data) => {
                     if (data.status !== 'Exists') {

--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -38,10 +38,13 @@ export async function mint(address: string) {
     });
     tx.setGasBudget(30000);
 
-    const result = await signer.signAndExecuteTransaction(tx, {
-        showInput: true,
-        showEffects: true,
-        showEvents: true,
+    const result = await signer.signAndExecuteTransaction({
+        transaction: tx,
+        options: {
+            showInput: true,
+            showEffects: true,
+            showEvents: true,
+        },
     });
 
     return result;

--- a/apps/wallet/src/ui/app/helpers/NftClient.ts
+++ b/apps/wallet/src/ui/app/helpers/NftClient.ts
@@ -194,23 +194,31 @@ export class NftClient {
         if (ids.length === 0) {
             return new Array<NftRaw>();
         }
-        const objects = await this.provider.getObjectBatch(ids, {
-            showType: true,
-            showContent: true,
-            showOwner: true,
+        const objects = await this.provider.multiGetObjects({
+            ids,
+            options: {
+                showType: true,
+                showContent: true,
+                showOwner: true,
+            },
         });
         return this.parseObjects(objects);
     };
 
     getBagContent = async (bagId: string) => {
-        const bagObjects = await this.provider.getDynamicFields(bagId);
+        const bagObjects = await this.provider.getDynamicFields({
+            parentId: bagId,
+        });
         const objectIds = bagObjects.data.map(
             (bagObject) => bagObject.objectId
         );
-        return this.provider.getObjectBatch(objectIds, {
-            showType: true,
-            showContent: true,
-            showOwner: true,
+        return this.provider.multiGetObjects({
+            ids: objectIds,
+            options: {
+                showType: true,
+                showContent: true,
+                showOwner: true,
+            },
         });
     };
 

--- a/apps/wallet/src/ui/app/hooks/useGetObject.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetObject.ts
@@ -13,10 +13,13 @@ export function useGetObject(
     const response = useQuery(
         ['object', normalizedObjId],
         async () => {
-            return rpc.getObject(normalizedObjId, {
-                showType: true,
-                showContent: true,
-                showOwner: true,
+            return rpc.getObject({
+                id: normalizedObjId,
+                options: {
+                    showType: true,
+                    showContent: true,
+                    showOwner: true,
+                },
             });
         },
         { enabled: !!objectId }

--- a/apps/wallet/src/ui/app/hooks/useObjectsOwnedByAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useObjectsOwnedByAddress.ts
@@ -10,7 +10,7 @@ export function useObjectsOwnedByAddress(address?: SuiAddress | null) {
     const rpc = useRpcClient();
     return useQuery(
         ['objects-owned', address],
-        () => rpc.getObjectsOwnedByAddress(address!),
+        () => rpc.getObjectsOwnedByAddress({ owner: address! }),
         {
             enabled: !!address,
         }

--- a/apps/wallet/src/ui/app/hooks/useQueryTransactionsByAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useQueryTransactionsByAddress.ts
@@ -28,16 +28,16 @@ export function useQueryTransactionsByAddress(address: SuiAddress | null) {
             ]);
             // TODO: replace this with queryTransactions
             // It seems to be expensive to fetch all transaction data at once though
-            const resp = await rpc.getTransactionResponseBatch(
-                dedupe(
+            const resp = await rpc.multiGetTransactions({
+                digests: dedupe(
                     [...txnIds.data, ...fromTxnIds.data].map((x) => x.digest)
                 ),
-                {
+                options: {
                     showInput: true,
                     showEffects: true,
                     showEvents: true,
-                }
-            );
+                },
+            });
 
             return resp.sort(
                 // timestamp could be null, so we need to handle

--- a/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
@@ -15,7 +15,7 @@ export function useTransactionDryRun(
     const response = useQuery({
         queryKey: ['dryRunTransaction', transaction, sender],
         queryFn: async () => {
-            return signer!.dryRunTransaction(transaction);
+            return signer!.dryRunTransaction({ transaction });
         },
         enabled: !!signer,
     });

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -48,10 +48,13 @@ export function TransferNFTForm({ objectId }: { objectId: string }) {
             const tx = new Transaction();
             tx.setGasBudget(DEFAULT_NFT_TRANSFER_GAS_FEE);
             tx.transferObjects([tx.object(objectId)], tx.pure(to));
-            return signer.signAndExecuteTransaction(tx, {
-                showInput: true,
-                showEffects: true,
-                showEvents: true,
+            return signer.signAndExecuteTransaction({
+                transaction: tx,
+                options: {
+                    showInput: true,
+                    showEffects: true,
+                    showEvents: true,
+                },
             });
         },
         onSuccess: (response) => {

--- a/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
@@ -27,10 +27,13 @@ function ReceiptPage() {
     const { data, isLoading, isError } = useQuery(
         ['transactions-by-id', transactionId],
         async () => {
-            return rpc.getTransactionResponse(transactionId!, {
-                showInput: true,
-                showEffects: true,
-                showEvents: true,
+            return rpc.getTransaction({
+                digest: transactionId!,
+                options: {
+                    showInput: true,
+                    showEffects: true,
+                    showEvents: true,
+                },
             });
         },
         { enabled: !!transactionId, retry: 8 }

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -70,10 +70,13 @@ function TransferCoinPage() {
                             }))
                     );
 
-                    return signer.signAndExecuteTransaction(tx, {
-                        showInput: true,
-                        showEffects: true,
-                        showEvents: true,
+                    return signer.signAndExecuteTransaction({
+                        transaction: tx,
+                        options: {
+                            showInput: true,
+                            showEffects: true,
+                            showEvents: true,
+                        },
                     });
                 }
 
@@ -103,10 +106,13 @@ function TransferCoinPage() {
                     tx.transferObjects([coin], tx.pure(formData.to));
                 }
 
-                return signer.signAndExecuteTransaction(tx, {
-                    showInput: true,
-                    showEffects: true,
-                    showEvents: true,
+                return signer.signAndExecuteTransaction({
+                    transaction: tx,
+                    options: {
+                        showInput: true,
+                        showEffects: true,
+                        showEvents: true,
+                    },
                 });
             } catch (error) {
                 transaction.setTag('failure', true);

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -111,10 +111,13 @@ export class Coin {
                     tx.pure(validator),
                 ],
             });
-            return await signer.signAndExecuteTransaction(tx, {
-                showInput: true,
-                showEffects: true,
-                showEvents: true,
+            return await signer.signAndExecuteTransaction({
+                transaction: tx,
+                options: {
+                    showInput: true,
+                    showEffects: true,
+                    showEvents: true,
+                },
             });
         } finally {
             span.finish();
@@ -139,10 +142,13 @@ export class Coin {
                     tx.object(stakedSuiId),
                 ],
             });
-            return await signer.signAndExecuteTransaction(tx, {
-                showInput: true,
-                showEffects: true,
-                showEvents: true,
+            return await signer.signAndExecuteTransaction({
+                transaction: tx,
+                options: {
+                    showInput: true,
+                    showEffects: true,
+                    showEvents: true,
+                },
             });
         } finally {
             transaction.finish();

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -62,20 +62,22 @@ export const respondToTransactionRequest = createAsyncThunk<
             );
             try {
                 if (txRequest.tx.type === 'sign-message') {
-                    txResult = await signer.signMessage(
-                        fromB64(txRequest.tx.message)
-                    );
+                    txResult = await signer.signMessage({
+                        message: fromB64(txRequest.tx.message),
+                    });
                 } else if (txRequest.tx.type === 'transaction') {
                     const tx = Transaction.from(txRequest.tx.data);
                     if (txRequest.tx.justSign) {
                         // Just a signing request, do not submit
-                        txSigned = await signer.signTransaction(tx);
+                        txSigned = await signer.signTransaction({
+                            transaction: tx,
+                        });
                     } else {
-                        txResult = await signer.signAndExecuteTransaction(
-                            tx,
-                            txRequest.tx.options?.contentOptions,
-                            txRequest.tx.options?.requestType
-                        );
+                        txResult = await signer.signAndExecuteTransaction({
+                            transaction: tx,
+                            options: txRequest.tx.options?.contentOptions,
+                            requestType: txRequest.tx.options?.requestType,
+                        });
                     }
                 } else {
                     throw new Error(

--- a/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
+++ b/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
@@ -11,6 +11,6 @@ export function useGetDelegatedStake(
 ): UseQueryResult<DelegatedStake[], Error> {
     const rpc = useRpcClient();
     return useQuery(['validator', address], () =>
-        rpc.getDelegatedStakes(address)
+        rpc.getDelegatedStakes({ owner: address })
     );
 }

--- a/dapps/frenemies/src/network/queries/epoch.ts
+++ b/dapps/frenemies/src/network/queries/epoch.ts
@@ -20,12 +20,11 @@ export function useEpoch() {
       prevTimestamp: number;
       data: SystemEpochInfo;
     } | null> => {
-      const { data } = await provider.getEvents(
-        { MoveEvent: SYSTEM_EPOCH_INFO },
-        null,
-        2,
-        "descending"
-      );
+      const { data } = await provider.getEvents({
+        query: { MoveEvent: SYSTEM_EPOCH_INFO },
+        limit: 2,
+        order: "descending",
+      });
       const [evt, prevEvt] = data;
 
       // should never happen; it's a platform requirement.

--- a/dapps/frenemies/src/network/queries/scorecard-history.ts
+++ b/dapps/frenemies/src/network/queries/scorecard-history.ts
@@ -27,9 +27,9 @@ export function useScorecardHistory(scorecardId?: string | null) {
       const txIds = await provider.queryTransactionsForObjectDeprecated(
         scorecardId
       );
-      const txs = await provider.getTransactionResponseBatch(
-        Array.from(new Set(txIds))
-      );
+      const txs = await provider.multiGetTransactions({
+        digests: Array.from(new Set(txIds)),
+      });
 
       return txs
         .reduce((acc: any[], tx) => acc.concat(tx.events || []), [])

--- a/dapps/frenemies/src/network/queries/use-raw.ts
+++ b/dapps/frenemies/src/network/queries/use-raw.ts
@@ -26,7 +26,8 @@ function useObjectsOwnedByAddress() {
   const { currentAccount } = useWalletKit();
   return useQuery(
     ["owned", currentAccount?.address],
-    async () => provider.getObjectsOwnedByAddress(currentAccount?.address!),
+    async () =>
+      provider.getObjectsOwnedByAddress({ owner: currentAccount?.address! }),
     {
       enabled: !!currentAccount?.address,
       refetchInterval: 2 * 60 * 1000,

--- a/dapps/frenemies/src/routes/Setup.tsx
+++ b/dapps/frenemies/src/routes/Setup.tsx
@@ -70,9 +70,9 @@ export function Setup() {
           { pkg: config.VITE_OLD_PKG, registry: config.VITE_OLD_REGISTRY },
           { pkg: config.VITE_PKG, registry: config.VITE_REGISTRY },
         ].map(({ pkg, registry }) =>
-          provider.devInspectTransaction(
-            currentAccount.address,
-            {
+          provider.devInspectTransaction({
+            sender: currentAccount.address,
+            transaction: {
               kind: "moveCall",
               data: {
                 packageObjectId: pkg,
@@ -82,8 +82,8 @@ export function Setup() {
                 arguments: [registry, username],
               },
             },
-            gasPrice
-          )
+            gasPrice,
+          })
         )
       );
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -128,9 +128,9 @@ Fetch objects owned by the address `0xbff6ccc8707aa517b4f1b95750a2a8c666012df3`
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
 const provider = new JsonRpcProvider();
-const objects = await provider.getObjectsOwnedByAddress(
-  '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3',
-);
+const objects = await provider.getObjectsOwnedByAddress({
+  owner: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3',
+});
 ```
 
 Fetch object details for the object with id `0xcff6ccc8707aa517b4f1b95750a2a8c666012df3`
@@ -138,20 +138,20 @@ Fetch object details for the object with id `0xcff6ccc8707aa517b4f1b95750a2a8c66
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
 const provider = new JsonRpcProvider();
-const txn = await provider.getObject(
-  '0xcff6ccc8707aa517b4f1b95750a2a8c666012df3',
+const txn = await provider.getObject({
+  id: '0xcff6ccc8707aa517b4f1b95750a2a8c666012df3',
   // fetch the object content field
-  { showContent: true },
-);
+  options: { showContent: true },
+});
 // You can also fetch multiple objects in one batch request
-const txns = await provider.getObjectBatch(
-  [
+const txns = await provider.multiGetObjects({
+  ids: [
     '0xcff6ccc8707aa517b4f1b95750a2a8c666012df3',
     '0xdff6ccc8707aa517b4f1b95750a2a8c666012df3',
   ],
   // only fetch the object type
-  { showType: true },
-);
+  options: { showType: true },
+});
 ```
 
 Fetch transaction details from transaction digests:
@@ -159,20 +159,20 @@ Fetch transaction details from transaction digests:
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
 const provider = new JsonRpcProvider();
-const txn = await provider.getTransactionResponse(
-  '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
+const txn = await provider.getTransaction({
+  digest: '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
   // only fetch the effects field
-  { showEffects: true },
-);
+  options: { showEffects: true },
+});
 // You can also fetch multiple transactions in one batch request
-const txns = await provider.getTransactionResponseBatch(
-  [
+const txns = await provider.multiGetTransactions({
+  digests: [
     '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
     '7mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
   ],
   // fetch both the input transaction data as well as effects
-  { showInput: true, showEffects: true },
-);
+  options: { showInput: true, showEffects: true },
+});
 ```
 
 Fetch transaction events from a transaction digest:
@@ -249,7 +249,7 @@ tx.transferObjects(
   [tx.object('0x5015b016ab570df14c87649eda918e09e5cc61e0')],
   tx.pure('0xd84058cb73bdeabe123b56632713dcd65e1a6c92'),
 );
-const result = await signer.signAndExecuteTransaction(tx);
+const result = await signer.signAndExecuteTransaction({ transaction: tx });
 console.log({ result });
 ```
 
@@ -269,7 +269,7 @@ const signer = new RawSigner(keypair, provider);
 const tx = new Transaction();
 const coin = tx.splitCoin(tx.gas, tx.pure(1000));
 tx.transferObjects([coin], tx.pure(keypair.getPublicKey().toSuiAddress()));
-const result = await signer.signAndExecuteTransaction(tx);
+const result = await signer.signAndExecuteTransaction({ transaction: tx });
 console.log({ result });
 ```
 
@@ -290,7 +290,7 @@ const tx = new Transaction();
 tx.mergeCoin(tx.object('0x5015b016ab570df14c87649eda918e09e5cc61e0'), [
   tx.object('0xcc460051569bfb888dedaf5182e76f473ee351af'),
 ]);
-const result = await signer.signAndExecuteTransaction(tx);
+const result = await signer.signAndExecuteTransaction({ transaction: tx });
 console.log({ result });
 ```
 
@@ -313,7 +313,7 @@ tx.moveCall({
   target: `${packageObjectId}::nft::mint`,
   arguments: [tx.pure('Example NFT')],
 });
-const result = await signer.signAndExecuteTransaction(tx);
+const result = await signer.signAndExecuteTransaction({ transaction: tx });
 console.log({ result });
 ```
 
@@ -325,16 +325,18 @@ const provider = new JsonRpcProvider();
 
 // calls RPC method 'sui_subscribeEvent' with params:
 // [ { SenderAddress: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3' } ]
-const subscriptionId = await provider.subscribeEvent(
-  { SenderAddress: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3' },
-  (event: SuiEventEnvelope) => {
+const subscriptionId = await provider.subscribeEvent({
+  filter: { SenderAddress: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3' },
+  onMessage(event: SuiEventEnvelope) {
     // handle subscription notification message here. This function is called once per subscription message.
   },
-);
+});
 
 // later, to unsubscribe
 // calls RPC method 'sui_unsubscribeEvent' with params: [ subscriptionId ]
-const subFoundAndRemoved = await provider.unsubscribeEvent(subscriptionId);
+const subFoundAndRemoved = await provider.unsubscribeEvent({
+  id: subscriptionId,
+});
 ```
 
 Subscribe to all events created by a package's `nft` module
@@ -351,12 +353,12 @@ const devnetNftFilter = {
     { Module: 'nft' },
   ],
 };
-const devNftSub = await provider.subscribeEvent(
-  devnetNftFilter,
-  (event: SuiEventEnvelope) => {
+const devNftSub = await provider.subscribeEvent({
+  filter: devnetNftFilter,
+  onMessage(event: SuiEventEnvelope) {
     // handle subscription notification message here
   },
-);
+});
 ```
 
 To publish a package:
@@ -381,7 +383,7 @@ const compiledModules = JSON.parse(
 );
 const tx = new Transaction();
 tx.publish(compiledModules);
-const result = await signer.signAndExecuteTransaction(tx);
+const result = await signer.signAndExecuteTransaction({ transaction: tx });
 console.log({ result });
 ```
 

--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -406,11 +406,11 @@ export class Transaction {
 
           const normalized = await expectProvider(
             provider,
-          ).getNormalizedMoveFunction(
-            normalizeSuiObjectId(packageId),
-            moduleName,
-            functionName,
-          );
+          ).getNormalizedMoveFunction({
+            package: normalizeSuiObjectId(packageId),
+            module: moduleName,
+            function: functionName,
+          });
 
           // Entry functions can have a mutable reference to an instance of the TxContext
           // struct defined in the TxContext module as the last parameter. The caller of
@@ -479,10 +479,10 @@ export class Transaction {
 
     if (objectsToResolve.length) {
       const dedupedIds = [...new Set(objectsToResolve.map(({ id }) => id))];
-      const objects = await expectProvider(provider).getObjectBatch(
-        dedupedIds,
-        { showOwner: true },
-      );
+      const objects = await expectProvider(provider).multiGetObjects({
+        ids: dedupedIds,
+        options: { showOwner: true },
+      });
       let objectsById = new Map(
         dedupedIds.map((id, index) => {
           return [id, objects[index]];

--- a/sdk/typescript/src/framework/sui-system-state.ts
+++ b/sdk/typescript/src/framework/sui-system-state.ts
@@ -52,8 +52,11 @@ export class SuiSystemStateUtil {
         tx.pure(validatorAddress),
       ],
     });
-    const coinObjects = await provider.getObjectBatch(coins, {
-      showOwner: true,
+    const coinObjects = await provider.multiGetObjects({
+      ids: coins,
+      options: {
+        showOwner: true,
+      },
     });
     tx.setGasPayment(coinObjects.map((obj) => getObjectReference(obj)!));
     return tx;

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -6,7 +6,6 @@ import {
   Coin,
   ExecuteTransactionRequestType,
   GatewayTxSeqNumber,
-  getObjectReference,
   GetTxnDigestsResponse,
   ObjectId,
   PaginatedTransactionResponse,
@@ -20,7 +19,6 @@ import {
   SuiMoveNormalizedModules,
   SuiMoveNormalizedStruct,
   SuiObjectInfo,
-  SuiObjectRef,
   SuiTransactionResponse,
   TransactionDigest,
   SuiTransactionResponseQuery,
@@ -28,7 +26,6 @@ import {
   RpcApiVersion,
   parseVersionFromString,
   EventQuery,
-  EventId,
   PaginatedEvents,
   FaucetResponse,
   Order,
@@ -69,6 +66,17 @@ import { Connection, devnetConnection } from '../rpc/connection';
 import { Transaction } from '../builder';
 
 export const TARGETED_RPC_VERSION = '0.27.0';
+
+export interface PaginationArguments {
+  /** Optional paging cursor */
+  cursor?: ObjectId | null;
+  /** Maximum item returned per page */
+  limit?: number | null;
+}
+
+export interface OrderArguments {
+  order?: Order | null;
+}
 
 /**
  * Configuration options for the JsonRpcProvider. If the value of a field is not provided,
@@ -179,7 +187,9 @@ export class JsonRpcProvider {
     return requestSuiFromFaucet(this.connection.faucet, recipient, httpHeaders);
   }
 
-  // Coins
+  /**
+   * Get all Coin<`coin_type`> objects owned by an address.
+   */
   async getCoins(input: {
     owner: SuiAddress;
     coinType?: string | null;
@@ -196,12 +206,7 @@ export class JsonRpcProvider {
 
       return await this.client.requestWithType(
         'sui_getCoins',
-        {
-          owner: input.owner,
-          coin_type: input.coinType,
-          cursor: input.cursor,
-          limit: input.limit,
-        },
+        [input.owner, input.coinType, input.cursor, input.limit],
         PaginatedCoins,
         this.options.skipDataValidation,
       );
@@ -210,11 +215,14 @@ export class JsonRpcProvider {
     }
   }
 
-  async getAllCoins(input: {
-    owner: SuiAddress;
-    cursor?: ObjectId | null;
-    limit?: number | null;
-  }): Promise<PaginatedCoins> {
+  /**
+   * Get all Coin objects owned by an address.
+   */
+  async getAllCoins(
+    input: {
+      owner: SuiAddress;
+    } & PaginationArguments,
+  ): Promise<PaginatedCoins> {
     try {
       if (
         !input.owner ||
@@ -225,7 +233,7 @@ export class JsonRpcProvider {
 
       return await this.client.requestWithType(
         'sui_getAllCoins',
-        { owner: input.owner, cursor: input.cursor, limit: input.limit },
+        [input.owner, input.cursor, input.limit],
         PaginatedCoins,
         this.options.skipDataValidation,
       );
@@ -236,8 +244,12 @@ export class JsonRpcProvider {
     }
   }
 
+  /**
+   * Get the total coin balance for one coin type, owned by the address owner.
+   */
   async getBalance(input: {
     owner: SuiAddress;
+    /** optional fully qualified type names for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC), default to 0x2::sui::SUI if not specified. */
     coinType?: string | null;
   }): Promise<CoinBalance> {
     try {
@@ -249,7 +261,7 @@ export class JsonRpcProvider {
       }
       return await this.client.requestWithType(
         'sui_getBalance',
-        { owner: input.owner, coin_type: input.coinType },
+        [input.owner, input.coinType],
         CoinBalance,
         this.options.skipDataValidation,
       );
@@ -260,6 +272,9 @@ export class JsonRpcProvider {
     }
   }
 
+  /**
+   * Get the total coin balance for all coin type, owned by the address owner.
+   */
   async getAllBalances(input: { owner: SuiAddress }): Promise<CoinBalance[]> {
     try {
       if (
@@ -270,7 +285,7 @@ export class JsonRpcProvider {
       }
       return await this.client.requestWithType(
         'sui_getAllBalances',
-        { owner: input.owner },
+        [input.owner],
         array(CoinBalance),
         this.options.skipDataValidation,
       );
@@ -281,11 +296,14 @@ export class JsonRpcProvider {
     }
   }
 
+  /**
+   * Fetch CoinMetadata for a given coin type
+   */
   async getCoinMetadata(input: { coinType: string }): Promise<CoinMetadata> {
     try {
       return await this.client.requestWithType(
         'sui_getCoinMetadata',
-        { coin_type: input.coinType },
+        [input.coinType],
         CoinMetadataStruct,
         this.options.skipDataValidation,
       );
@@ -296,11 +314,14 @@ export class JsonRpcProvider {
     }
   }
 
+  /**
+   *  Fetch total supply for a coin
+   */
   async getTotalSupply(input: { coinType: string }): Promise<CoinSupply> {
     try {
       return await this.client.requestWithType(
         'sui_getTotalSupply',
-        { coin_type: input.coinType },
+        [input.coinType],
         CoinSupply,
         this.options.skipDataValidation,
       );
@@ -311,7 +332,11 @@ export class JsonRpcProvider {
     }
   }
 
-  // RPC endpoint
+  /**
+   * Invoke any RPC endpoint
+   * @param endpoint the endpoint to be invoked
+   * @param params the arguments to be passed to the RPC request
+   */
   async call(endpoint: string, params: Array<any>): Promise<any> {
     try {
       const response = await this.client.request(endpoint, params);
@@ -324,129 +349,153 @@ export class JsonRpcProvider {
     }
   }
 
-  // Move info
-  async getMoveFunctionArgTypes(
-    packageId: string,
-    moduleName: string,
-    functionName: string,
-  ): Promise<SuiMoveFunctionArgTypes> {
+  /**
+   * Get Move function argument types like read, write and full access
+   */
+  async getMoveFunctionArgTypes(input: {
+    package: string;
+    module: string;
+    function: string;
+  }): Promise<SuiMoveFunctionArgTypes> {
     try {
       return await this.client.requestWithType(
         'sui_getMoveFunctionArgTypes',
-        [packageId, moduleName, functionName],
+        [input.package, input.module, input.function],
         SuiMoveFunctionArgTypes,
         this.options.skipDataValidation,
       );
     } catch (err) {
       throw new Error(
-        `Error fetching Move function arg types with package object ID: ${packageId}, module name: ${moduleName}, function name: ${functionName}`,
+        `Error fetching Move function arg types with package object ID: ${input.package}, module name: ${input.module}, function name: ${input.function}`,
       );
     }
   }
 
-  async getNormalizedMoveModulesByPackage(
-    packageId: string,
-  ): Promise<SuiMoveNormalizedModules> {
+  /**
+   * Get a map from module name to
+   * structured representations of Move modules
+   */
+  async getNormalizedMoveModulesByPackage(input: {
+    package: string;
+  }): Promise<SuiMoveNormalizedModules> {
     try {
       return await this.client.requestWithType(
         'sui_getNormalizedMoveModulesByPackage',
-        [packageId],
+        [input.package],
         SuiMoveNormalizedModules,
         this.options.skipDataValidation,
       );
     } catch (err) {
       throw new Error(
-        `Error fetching package: ${err} for package ${packageId}`,
+        `Error fetching package: ${err} for package ${input.package}`,
       );
     }
   }
 
-  async getNormalizedMoveModule(
-    packageId: string,
-    moduleName: string,
-  ): Promise<SuiMoveNormalizedModule> {
+  /**
+   * Get a structured representation of Move module
+   */
+  async getNormalizedMoveModule(input: {
+    package: string;
+    module: string;
+  }): Promise<SuiMoveNormalizedModule> {
     try {
       return await this.client.requestWithType(
         'sui_getNormalizedMoveModule',
-        [packageId, moduleName],
+        [input.package, input.module],
         SuiMoveNormalizedModule,
         this.options.skipDataValidation,
       );
     } catch (err) {
       throw new Error(
-        `Error fetching module: ${err} for package ${packageId}, module ${moduleName}`,
+        `Error fetching module: ${err} for package ${input.package}, module ${input.module}`,
       );
     }
   }
 
-  async getNormalizedMoveFunction(
-    packageId: string,
-    moduleName: string,
-    functionName: string,
-  ): Promise<SuiMoveNormalizedFunction> {
+  /**
+   * Get a structured representation of Move function
+   */
+  async getNormalizedMoveFunction(input: {
+    package: string;
+    module: string;
+    function: string;
+  }): Promise<SuiMoveNormalizedFunction> {
     try {
       return await this.client.requestWithType(
         'sui_getNormalizedMoveFunction',
-        [packageId, moduleName, functionName],
+        [input.package, input.module, input.function],
         SuiMoveNormalizedFunction,
         this.options.skipDataValidation,
       );
     } catch (err) {
       throw new Error(
-        `Error fetching function: ${err} for package ${packageId}, module ${moduleName} and function ${functionName}`,
+        `Error fetching function: ${err} for package ${input.package}, module ${input.module} and function ${input.function}`,
       );
     }
   }
 
-  async getNormalizedMoveStruct(
-    packageId: string,
-    moduleName: string,
-    structName: string,
-  ): Promise<SuiMoveNormalizedStruct> {
+  /**
+   * Get a structured representation of Move struct
+   */
+  async getNormalizedMoveStruct(input: {
+    package: string;
+    module: string;
+    struct: string;
+  }): Promise<SuiMoveNormalizedStruct> {
     try {
       return await this.client.requestWithType(
         'sui_getNormalizedMoveStruct',
-        [packageId, moduleName, structName],
+        [input.package, input.module, input.struct],
         SuiMoveNormalizedStruct,
         this.options.skipDataValidation,
       );
     } catch (err) {
       throw new Error(
-        `Error fetching struct: ${err} for package ${packageId}, module ${moduleName} and struct ${structName}`,
+        `Error fetching struct: ${err} for package ${input.package}, module ${input.module} and struct ${input.struct}`,
       );
     }
   }
 
-  // Objects
-  async getObjectsOwnedByAddress(
-    address: SuiAddress,
-    typeFilter?: string,
-  ): Promise<SuiObjectInfo[]> {
+  /**
+   * Get all objects owned by an address
+   */
+  async getObjectsOwnedByAddress(input: {
+    owner: SuiAddress;
+    /** a fully qualified type name for the object(e.g., 0x2::coin::Coin<0x2::sui::SUI>)
+     * or type name without generics (e.g., 0x2::coin::Coin will match all 0x2::coin::Coin<T>) */
+    typeFilter?: string;
+  }): Promise<SuiObjectInfo[]> {
     try {
-      if (!address || !isValidSuiAddress(normalizeSuiAddress(address))) {
+      if (
+        !input.owner ||
+        !isValidSuiAddress(normalizeSuiAddress(input.owner))
+      ) {
         throw new Error('Invalid Sui address');
       }
       const objects = await this.client.requestWithType(
         'sui_getObjectsOwnedByAddress',
-        [address],
+        [input.owner],
         GetOwnedObjectsResponse,
         this.options.skipDataValidation,
       );
       // TODO: remove this once we migrated to the new queryObject API
-      if (typeFilter) {
+      if (input.typeFilter) {
         return objects.filter(
           (obj: SuiObjectInfo) =>
-            obj.type === typeFilter || obj.type.startsWith(typeFilter + '<'),
+            obj.type === input.typeFilter ||
+            obj.type.startsWith(input.typeFilter + '<'),
         );
       }
       return objects;
     } catch (err) {
       throw new Error(
-        `Error fetching owned object: ${err} for address ${address}`,
+        `Error fetching owned object: ${err} for address ${input.owner}`,
       );
     }
   }
 
+  /** @deprecated */
   async selectCoinsWithBalanceGreaterThanOrEqual(
     address: SuiAddress,
     amount: bigint,
@@ -464,6 +513,7 @@ export class JsonRpcProvider {
     );
   }
 
+  /** @deprecated */
   async selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
     address: SuiAddress,
     amount: bigint,
@@ -483,75 +533,83 @@ export class JsonRpcProvider {
     );
   }
 
-  async getObject(
-    objectId: ObjectId,
-    options?: SuiObjectDataOptions,
-  ): Promise<SuiObjectResponse> {
+  /**
+   * Get details about an object
+   */
+  async getObject(input: {
+    id: ObjectId;
+    options?: SuiObjectDataOptions;
+  }): Promise<SuiObjectResponse> {
     try {
-      if (!objectId || !isValidSuiObjectId(normalizeSuiObjectId(objectId))) {
+      if (!input.id || !isValidSuiObjectId(normalizeSuiObjectId(input.id))) {
         throw new Error('Invalid Sui Object id');
       }
       return await this.client.requestWithType(
         'sui_getObject',
-        [objectId, options],
+        [input.id, input.options],
         SuiObjectResponse,
         this.options.skipDataValidation,
       );
     } catch (err) {
-      throw new Error(`Error fetching object info: ${err} for id ${objectId}`);
+      throw new Error(`Error fetching object info: ${err} for id ${input.id}`);
     }
   }
 
-  async getObjectRef(objectId: ObjectId): Promise<SuiObjectRef | undefined> {
-    const resp = await this.getObject(objectId);
-    return getObjectReference(resp);
-  }
-
-  async getObjectBatch(
-    objectIds: ObjectId[],
-    options?: SuiObjectDataOptions,
-  ): Promise<SuiObjectResponse[]> {
+  /**
+   * Batch get details about a list of objects. If any of the object ids are duplicates the call will fail
+   */
+  async multiGetObjects(input: {
+    ids: ObjectId[];
+    options?: SuiObjectDataOptions;
+  }): Promise<SuiObjectResponse[]> {
     try {
-      objectIds.forEach((id) => {
+      input.ids.forEach((id) => {
         if (!id || !isValidSuiObjectId(normalizeSuiObjectId(id))) {
           throw new Error(`Invalid Sui Object id ${id}`);
         }
       });
-      const hasDuplicates = objectIds.length !== new Set(objectIds).size;
+      const hasDuplicates = input.ids.length !== new Set(input.ids).size;
       if (hasDuplicates) {
-        throw new Error(`Duplicate object ids in batch call ${objectIds}`);
+        throw new Error(`Duplicate object ids in batch call ${input.ids}`);
       }
 
       return await this.client.requestWithType(
         'sui_multiGetObjects',
-        [objectIds, options],
+        [input.ids, input.options],
         array(SuiObjectResponse),
         this.options.skipDataValidation,
       );
     } catch (err) {
       throw new Error(
-        `Error fetching object info: ${err} for ids [${objectIds}]`,
+        `Error fetching object info: ${err} for ids [${input.ids}]`,
       );
     }
   }
 
-  // Transactions
+  /**
+   * Get transactions for a given query criteria
+   */
   async queryTransactions(
-    query: SuiTransactionResponseQuery,
-    cursor: TransactionDigest | null = null,
-    limit: number | null = null,
-    order: Order = 'descending',
+    input: SuiTransactionResponseQuery & PaginationArguments & OrderArguments,
   ): Promise<PaginatedTransactionResponse> {
     try {
       return await this.client.requestWithType(
         'sui_queryTransactions',
-        [query, cursor, limit, order === 'descending'],
+        [
+          {
+            filter: input.filter,
+            options: input.options,
+          } as SuiTransactionResponseQuery,
+          input.cursor,
+          input.limit,
+          (input.order || 'descending') === 'descending',
+        ],
         PaginatedTransactionResponse,
         this.options.skipDataValidation,
       );
     } catch (err) {
       throw new Error(
-        `Error getting transactions for query: ${err} for query ${query}`,
+        `Error getting transactions for query: ${err} for filter ${input.filter}`,
       );
     }
   }
@@ -653,71 +711,74 @@ export class JsonRpcProvider {
     }
   }
 
-  async getTransactionResponse(
-    digest: TransactionDigest,
-    options?: SuiTransactionResponseOptions,
-  ): Promise<SuiTransactionResponse> {
+  async getTransaction(input: {
+    digest: TransactionDigest;
+    options?: SuiTransactionResponseOptions;
+  }): Promise<SuiTransactionResponse> {
     try {
-      if (!isValidTransactionDigest(digest)) {
+      if (!isValidTransactionDigest(input.digest)) {
         throw new Error('Invalid Transaction digest');
       }
       const resp = await this.client.requestWithType(
         'sui_getTransaction',
-        [digest, options],
+        [input.digest, input.options],
         SuiTransactionResponse,
         this.options.skipDataValidation,
       );
       return resp;
     } catch (err) {
       throw new Error(
-        `Error getting transaction with effects: ${err} for digest ${digest}`,
+        `Error getting transaction with effects: ${err} for digest ${input.digest}`,
       );
     }
   }
 
-  async getTransactionResponseBatch(
-    digests: TransactionDigest[],
-    options?: SuiTransactionResponseOptions,
-  ): Promise<SuiTransactionResponse[]> {
+  async multiGetTransactions(input: {
+    digests: TransactionDigest[];
+    options?: SuiTransactionResponseOptions;
+  }): Promise<SuiTransactionResponse[]> {
     try {
-      digests.forEach((d) => {
+      input.digests.forEach((d) => {
         if (!isValidTransactionDigest(d)) {
           throw new Error(`Invalid Transaction digest ${d}`);
         }
       });
 
-      const hasDuplicates = digests.length !== new Set(digests).size;
+      const hasDuplicates =
+        input.digests.length !== new Set(input.digests).size;
       if (hasDuplicates) {
-        throw new Error(`Duplicate digests in batch call ${digests}`);
+        throw new Error(`Duplicate digests in batch call ${input.digests}`);
       }
 
       return await this.client.requestWithType(
         'sui_multiGetTransactions',
-        [digests, options],
+        [input.digests, input.options],
         array(SuiTransactionResponse),
         this.options.skipDataValidation,
       );
     } catch (err) {
       throw new Error(
-        `Error getting transaction effects: ${err} for digests [${digests}]`,
+        `Error getting transaction effects: ${err} for digests [${input.digests}]`,
       );
     }
   }
 
-  async executeTransaction(
-    txnBytes: Uint8Array | string,
-    signature: SerializedSignature | SerializedSignature[],
-    options?: SuiTransactionResponseOptions,
-    requestType?: ExecuteTransactionRequestType,
-  ): Promise<SuiTransactionResponse> {
+  async executeTransaction(input: {
+    transaction: Uint8Array | string;
+    signature: SerializedSignature | SerializedSignature[];
+    options?: SuiTransactionResponseOptions;
+    requestType?: ExecuteTransactionRequestType;
+  }): Promise<SuiTransactionResponse> {
     try {
       return await this.client.requestWithType(
         'sui_executeTransaction',
         [
-          typeof txnBytes === 'string' ? txnBytes : toB64(txnBytes),
-          Array.isArray(signature) ? signature : [signature],
-          options,
-          requestType,
+          typeof input.transaction === 'string'
+            ? input.transaction
+            : toB64(input.transaction),
+          Array.isArray(input.signature) ? input.signature : [input.signature],
+          input.options,
+          input.requestType,
         ],
         SuiTransactionResponse,
         this.options.skipDataValidation,
@@ -727,6 +788,9 @@ export class JsonRpcProvider {
     }
   }
 
+  /**
+   * Get total number of transactions
+   */
   async getTotalTransactionNumber(): Promise<number> {
     try {
       const resp = await this.client.requestWithType(
@@ -741,6 +805,7 @@ export class JsonRpcProvider {
     }
   }
 
+  /** @deprecated */
   async getTransactionDigestsInRangeDeprecated(
     start: GatewayTxSeqNumber,
     end: GatewayTxSeqNumber,
@@ -759,7 +824,9 @@ export class JsonRpcProvider {
     }
   }
 
-  // Governance
+  /**
+   * Getting the reference gas price for the network
+   */
   async getReferenceGasPrice(): Promise<number> {
     try {
       return await this.client.requestWithType(
@@ -773,14 +840,22 @@ export class JsonRpcProvider {
     }
   }
 
-  async getDelegatedStakes(address: SuiAddress): Promise<DelegatedStake[]> {
+  /**
+   * Return the delegated stakes for an address
+   */
+  async getDelegatedStakes(input: {
+    owner: SuiAddress;
+  }): Promise<DelegatedStake[]> {
     try {
-      if (!address || !isValidSuiAddress(normalizeSuiAddress(address))) {
+      if (
+        !input.owner ||
+        !isValidSuiAddress(normalizeSuiAddress(input.owner))
+      ) {
         throw new Error('Invalid Sui address');
       }
       const resp = await this.client.requestWithType(
         'sui_getDelegatedStakes',
-        [address],
+        [input.owner],
         array(DelegatedStake),
         this.options.skipDataValidation,
       );
@@ -790,6 +865,9 @@ export class JsonRpcProvider {
     }
   }
 
+  /**
+   * Return the latest system state content.
+   */
   async getLatestSuiSystemState(): Promise<SuiSystemStateSummary> {
     try {
       const resp = await this.client.requestWithType(
@@ -804,65 +882,91 @@ export class JsonRpcProvider {
     }
   }
 
-  // Events
+  /**
+   * Get events for a given query criteria
+   */
   async getEvents(
-    query: EventQuery,
-    cursor: EventId | null,
-    limit: number | null,
-    order: Order = 'descending',
+    input: {
+      /** the event query criteria. */
+      query: EventQuery;
+    } & PaginationArguments &
+      OrderArguments,
   ): Promise<PaginatedEvents> {
     try {
       return await this.client.requestWithType(
         'sui_getEvents',
-        [query, cursor, limit, order === 'descending'],
+        [
+          input.query,
+          input.cursor,
+          input.limit,
+          (input.order || 'descending') === 'descending',
+        ],
         PaginatedEvents,
         this.options.skipDataValidation,
       );
     } catch (err) {
       throw new Error(
-        `Error getting events for query: ${err} for query ${query}`,
+        `Error getting events for query: ${err} for query ${input.query}`,
       );
     }
   }
 
-  async subscribeEvent(
-    filter: SuiEventFilter,
-    onMessage: (event: SuiEventEnvelope) => void,
-  ): Promise<SubscriptionId> {
-    return this.wsClient.subscribeEvent(filter, onMessage);
+  /**
+   * Subscribe to get notifications whenever an event matching the filter occurs
+   */
+  async subscribeEvent(input: {
+    /** filter describing the subset of events to follow */
+    filter: SuiEventFilter;
+    /** function to run when we receive a notification of a new event matching the filter */
+    onMessage: (event: SuiEventEnvelope) => void;
+  }): Promise<SubscriptionId> {
+    return this.wsClient.subscribeEvent(input.filter, input.onMessage);
   }
 
-  async unsubscribeEvent(id: SubscriptionId): Promise<boolean> {
-    return this.wsClient.unsubscribeEvent(id);
+  /**
+   * Unsubscribe from an event subscription
+   */
+  async unsubscribeEvent(input: {
+    /** subscription id to unsubscribe from (previously received from subscribeEvent)*/
+    id: SubscriptionId;
+  }): Promise<boolean> {
+    return this.wsClient.unsubscribeEvent(input.id);
   }
 
-  async devInspectTransaction(
-    sender: SuiAddress,
-    tx: Transaction | string | Uint8Array,
-    gasPrice: number | null = null,
-    epoch: number | null = null,
-  ): Promise<DevInspectResults> {
+  /**
+   * Runs the transaction in dev-inpsect mode. Which allows for nearly any
+   * transaction (or Move call) with any arguments. Detailed results are
+   * provided, including both the transaction effects and any return values.
+   */
+  async devInspectTransaction(input: {
+    transaction: Transaction | string | Uint8Array;
+    sender: SuiAddress;
+    /** Default to use the network reference gas price stored in the Sui System State object */
+    gasPrice?: number | null;
+    /** optional. Default to use the current epoch number stored in the Sui System State object */
+    epoch?: number | null;
+  }): Promise<DevInspectResults> {
     try {
       let devInspectTxBytes;
-      if (Transaction.is(tx)) {
-        tx.setSender(sender);
+      if (Transaction.is(input.transaction)) {
+        input.transaction.setSender(input.sender);
         devInspectTxBytes = toB64(
-          await tx.build({
+          await input.transaction.build({
             provider: this,
             onlyTransactionKind: true,
           }),
         );
-      } else if (typeof tx === 'string') {
-        devInspectTxBytes = tx;
-      } else if (tx instanceof Uint8Array) {
-        devInspectTxBytes = toB64(tx);
+      } else if (typeof input.transaction === 'string') {
+        devInspectTxBytes = input.transaction;
+      } else if (input.transaction instanceof Uint8Array) {
+        devInspectTxBytes = toB64(input.transaction);
       } else {
         throw new Error('Unknown transaction format.');
       }
 
       const resp = await this.client.requestWithType(
         'sui_devInspectTransaction',
-        [sender, devInspectTxBytes, gasPrice, epoch],
+        [input.sender, devInspectTxBytes, input.gasPrice, input.epoch],
         DevInspectResults,
         this.options.skipDataValidation,
       );
@@ -874,13 +978,20 @@ export class JsonRpcProvider {
     }
   }
 
-  async dryRunTransaction(
-    txBytes: Uint8Array,
-  ): Promise<DryRunTransactionResponse> {
+  /**
+   * Dry run a transaction and return the result.
+   */
+  async dryRunTransaction(input: {
+    transaction: Uint8Array | string;
+  }): Promise<DryRunTransactionResponse> {
     try {
       const resp = await this.client.requestWithType(
         'sui_dryRunTransaction',
-        [toB64(txBytes)],
+        [
+          typeof input.transaction === 'string'
+            ? input.transaction
+            : toB64(input.transaction),
+        ],
         DryRunTransactionResponse,
         this.options.skipDataValidation,
       );
@@ -892,53 +1003,63 @@ export class JsonRpcProvider {
     }
   }
 
-  // Dynamic Fields
+  /**
+   * Return the list of dynamic field objects owned by an object
+   */
   async getDynamicFields(
-    parent_object_id: ObjectId,
-    cursor: ObjectId | null = null,
-    limit: number | null = null,
+    input: {
+      /** The id of the parent object */
+      parentId: ObjectId;
+    } & PaginationArguments,
   ): Promise<DynamicFieldPage> {
     try {
       if (
-        !parent_object_id ||
-        !isValidSuiObjectId(normalizeSuiObjectId(parent_object_id))
+        !input.parentId ||
+        !isValidSuiObjectId(normalizeSuiObjectId(input.parentId))
       ) {
         throw new Error('Invalid Sui Object id');
       }
       const resp = await this.client.requestWithType(
         'sui_getDynamicFields',
-        [parent_object_id, cursor, limit],
+        [input.parentId, input.cursor, input.limit],
         DynamicFieldPage,
         this.options.skipDataValidation,
       );
       return resp;
     } catch (err) {
       throw new Error(
-        `Error getting dynamic fields with request type: ${err} for parent_object_id: ${parent_object_id}, cursor: ${cursor} and limit: ${limit}.`,
+        `Error getting dynamic fields with request type: ${err} for parentId: ${input.parentId}, cursor: ${input.cursor} and limit: ${input.limit}.`,
       );
     }
   }
 
-  async getDynamicFieldObject(
-    parent_object_id: ObjectId,
-    name: string | DynamicFieldName,
-  ): Promise<SuiObjectResponse> {
+  /**
+   * Return the dynamic field object information for a specified object
+   */
+  async getDynamicFieldObject(input: {
+    /** The ID of the quered parent object */
+    parentId: ObjectId;
+    /** The name of the dynamic field */
+    name: string | DynamicFieldName;
+  }): Promise<SuiObjectResponse> {
     try {
       const resp = await this.client.requestWithType(
         'sui_getDynamicFieldObject',
-        [parent_object_id, name],
+        [input.parentId, input.name],
         SuiObjectResponse,
         this.options.skipDataValidation,
       );
       return resp;
     } catch (err) {
       throw new Error(
-        `Error getting dynamic field object with request type: ${err} for parent_object_id: ${parent_object_id} and name: ${name}.`,
+        `Error getting dynamic field object with request type: ${err} for parent_object_id: ${input.parentId} and name: ${input.name}.`,
       );
     }
   }
 
-  // Checkpoints
+  /**
+   * Get the sequence number of the latest checkpoint that has been executed
+   */
   async getLatestCheckpointSequenceNumber(): Promise<number> {
     try {
       const resp = await this.client.requestWithType(
@@ -955,27 +1076,39 @@ export class JsonRpcProvider {
     }
   }
 
-  async getCheckpoint(id: CheckpointDigest | number): Promise<Checkpoint> {
+  /**
+   * Returns information about a given checkpoint
+   */
+  async getCheckpoint(input: {
+    /** The checkpoint digest or sequence number */
+    id: CheckpointDigest | number;
+  }): Promise<Checkpoint> {
     try {
       const resp = await this.client.requestWithType(
         'sui_getCheckpoint',
-        [id],
+        [input.id],
         Checkpoint,
         this.options.skipDataValidation,
       );
       return resp;
     } catch (err) {
       throw new Error(
-        `Error getting checkpoint with request type: ${err} for id: ${id}.`,
+        `Error getting checkpoint with request type: ${err} for id: ${input.id}.`,
       );
     }
   }
 
-  async getCommitteeInfo(epoch?: number): Promise<CommitteeInfo> {
+  /**
+   * Return the committee information for the asked epoch
+   */
+  async getCommitteeInfo(input?: {
+    /** The epoch of interest. If null, default to the latest epoch */
+    epoch?: number;
+  }): Promise<CommitteeInfo> {
     try {
       const committeeInfo = await this.client.requestWithType(
         'sui_getCommitteeInfo',
-        [epoch],
+        [input?.epoch],
         CommitteeInfo,
       );
 

--- a/sdk/typescript/test/e2e/checkpoint.test.ts
+++ b/sdk/typescript/test/e2e/checkpoint.test.ts
@@ -18,7 +18,7 @@ describe('Checkpoints Reading API', () => {
   });
 
   it('gets checkpoint by id', async () => {
-    const resp = await toolbox.provider.getCheckpoint(0);
+    const resp = await toolbox.provider.getCheckpoint({ id: 0 });
     expect(resp.digest.length).greaterThan(0);
     expect(resp.transactions.length).greaterThan(0);
     expect(resp.epoch).not.toBeNull();
@@ -29,9 +29,9 @@ describe('Checkpoints Reading API', () => {
   });
 
   it('get checkpoint contents by digest', async () => {
-    const checkpoint_resp = await toolbox.provider.getCheckpoint(0);
+    const checkpoint_resp = await toolbox.provider.getCheckpoint({ id: 0 });
     const digest = checkpoint_resp.digest;
-    const resp = await toolbox.provider.getCheckpoint(digest);
+    const resp = await toolbox.provider.getCheckpoint({ id: digest });
     expect(checkpoint_resp).toEqual(resp);
   });
 });

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -33,11 +33,10 @@ describe('Coin related API', () => {
     });
 
     // split coins into desired amount
-    await toolbox.signer.signAndExecuteTransaction(
-      tx,
-      {},
-      'WaitForLocalExecution',
-    );
+    await toolbox.signer.signAndExecuteTransaction({
+      transaction: tx,
+      requestType: 'WaitForLocalExecution',
+    });
     coinsAfterSplit = await toolbox.getGasObjectsOwnedByAddress();
   });
 

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -61,9 +61,9 @@ describe('Test dev inspect', () => {
 
 async function validateDevInspectTransaction(
   signer: RawSigner,
-  txn: Transaction,
+  transaction: Transaction,
   status: 'success' | 'failure',
 ) {
-  const result = await signer.devInspectTransaction(txn);
+  const result = await signer.devInspectTransaction({ transaction });
   expect(result.effects.status.status).toEqual(status);
 }

--- a/sdk/typescript/test/e2e/dynamic-fields.test.ts
+++ b/sdk/typescript/test/e2e/dynamic-fields.test.ts
@@ -15,7 +15,7 @@ describe('Dynamic Fields Reading API', () => {
     ({ packageId } = await publishPackage(packagePath, toolbox));
 
     await toolbox.provider
-      .getObjectsOwnedByAddress(toolbox.address())
+      .getObjectsOwnedByAddress({ owner: toolbox.address() })
       .then(function (objects) {
         const obj = objects.filter(
           (o) => o.type === `${packageId}::dynamic_fields_test::Test`,
@@ -25,48 +25,42 @@ describe('Dynamic Fields Reading API', () => {
   });
 
   it('get all dynamic fields', async () => {
-    const dynamicFields = await toolbox.provider.getDynamicFields(
-      parentObjectId,
-      null,
-      null,
-    );
+    const dynamicFields = await toolbox.provider.getDynamicFields({
+      parentId: parentObjectId,
+    });
     expect(dynamicFields.data.length).toEqual(2);
   });
   it('limit response in page', async () => {
-    const dynamicFields = await toolbox.provider.getDynamicFields(
-      parentObjectId,
-      null,
-      1,
-    );
+    const dynamicFields = await toolbox.provider.getDynamicFields({
+      parentId: parentObjectId,
+      limit: 1,
+    });
     expect(dynamicFields.data.length).toEqual(1);
     expect(dynamicFields.nextCursor).not.toEqual(null);
   });
   it('go to next cursor', async () => {
     return await toolbox.provider
-      .getDynamicFields(parentObjectId, null, 1)
+      .getDynamicFields({ parentId: parentObjectId, limit: 1 })
       .then(async function (dynamicFields) {
         expect(dynamicFields.nextCursor).not.toEqual(null);
 
-        const dynamicFieldsCursor = await toolbox.provider.getDynamicFields(
-          parentObjectId,
-          dynamicFields.nextCursor,
-          null,
-        );
+        const dynamicFieldsCursor = await toolbox.provider.getDynamicFields({
+          parentId: parentObjectId,
+          cursor: dynamicFields.nextCursor,
+        });
         expect(dynamicFieldsCursor.data.length).greaterThanOrEqual(0);
       });
   });
   it('get dynamic object field', async () => {
-    const dynamicFields = await toolbox.provider.getDynamicFields(
-      parentObjectId,
-      null,
-      null,
-    );
+    const dynamicFields = await toolbox.provider.getDynamicFields({
+      parentId: parentObjectId,
+    });
     const objDofName = dynamicFields.data[1].name;
 
-    const dynamicObjectField = await toolbox.provider.getDynamicFieldObject(
-      parentObjectId,
-      objDofName,
-    );
+    const dynamicObjectField = await toolbox.provider.getDynamicFieldObject({
+      parentId: parentObjectId,
+      name: objDofName,
+    });
     expect(dynamicObjectField.status).toEqual('Exists');
   });
 });

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -25,8 +25,11 @@ describe('Test Move call with strings', () => {
       target: `${packageId}::entry_point_string::${funcName}`,
       arguments: [tx.pure(str), tx.pure(len)],
     });
-    const result = await toolbox.signer.signAndExecuteTransaction(tx, {
-      showEffects: true,
+    const result = await toolbox.signer.signAndExecuteTransaction({
+      transaction: tx,
+      options: {
+        showEffects: true,
+      },
     });
     expect(getExecutionStatusType(result)).toEqual('success');
   }

--- a/sdk/typescript/test/e2e/event-subscription.test.ts
+++ b/sdk/typescript/test/e2e/event-subscription.test.ts
@@ -22,23 +22,22 @@ describe('Event Subscription API', () => {
   );
 
   it('Subscribe to events', async () => {
-    const subscriptionId = await toolbox.provider.subscribeEvent(
-      { SenderAddress: toolbox.address() },
-      mockCallback,
-    );
+    const subscriptionId = await toolbox.provider.subscribeEvent({
+      filter: { SenderAddress: toolbox.address() },
+      onMessage: mockCallback,
+    });
 
     const tx = new Transaction();
     tx.setGasBudget(DEFAULT_GAS_BUDGET);
     tx.transferObjects([tx.gas], tx.pure(DEFAULT_RECIPIENT));
-    await toolbox.signer.signAndExecuteTransaction(
-      tx,
-      {},
-      'WaitForLocalExecution',
-    );
+    await toolbox.signer.signAndExecuteTransaction({
+      transaction: tx,
+      requestType: 'WaitForLocalExecution',
+    });
 
-    const subFoundAndRemoved = await toolbox.provider.unsubscribeEvent(
-      subscriptionId,
-    );
+    const subFoundAndRemoved = await toolbox.provider.unsubscribeEvent({
+      id: subscriptionId,
+    });
     expect(subFoundAndRemoved).toBeTruthy();
     expect(mockCallback).toHaveBeenCalled();
   });

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -27,7 +27,9 @@ describe('Governance API', () => {
   });
 
   it('test getDelegatedStakes', async () => {
-    const stakes = await toolbox.provider.getDelegatedStakes(toolbox.address());
+    const stakes = await toolbox.provider.getDelegatedStakes({
+      owner: toolbox.address(),
+    });
     expect(stakes.length).greaterThan(0);
   });
 
@@ -36,7 +38,7 @@ describe('Governance API', () => {
   });
 
   it('test getCommitteeInfo', async () => {
-    const committeeInfo = await toolbox.provider.getCommitteeInfo(0);
+    const committeeInfo = await toolbox.provider.getCommitteeInfo({ epoch: 0 });
     expect(committeeInfo.validators?.length).greaterThan(0);
   });
 
@@ -63,7 +65,10 @@ async function addStake(signer: RawSigner) {
 
   tx.setGasBudget(DEFAULT_GAS_BUDGET);
 
-  return await signer.signAndExecuteTransaction(tx, {
-    showEffects: true,
+  return await signer.signAndExecuteTransaction({
+    transaction: tx,
+    options: {
+      showEffects: true,
+    },
   });
 }

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -26,8 +26,11 @@ describe('Test ID as args to entry functions', () => {
         ),
       ],
     });
-    const result = await toolbox.signer.signAndExecuteTransaction(tx, {
-      showEffects: true,
+    const result = await toolbox.signer.signAndExecuteTransaction({
+      transaction: tx,
+      options: {
+        showEffects: true,
+      },
     });
     expect(getExecutionStatusType(result)).toEqual('success');
   });

--- a/sdk/typescript/test/e2e/invalid-ids.test.ts
+++ b/sdk/typescript/test/e2e/invalid-ids.test.ts
@@ -14,9 +14,9 @@ describe('Object id/Address/Transaction digest validation', () => {
   //Test that with invalid object id/address/digest, functions will throw an error before making a request to the rpc server
   it('Test all functions with invalid Sui Address', async () => {
     //empty id
-    expect(toolbox.provider.getObjectsOwnedByAddress('')).rejects.toThrowError(
-      /Invalid Sui address/,
-    );
+    expect(
+      toolbox.provider.getObjectsOwnedByAddress({ owner: '' }),
+    ).rejects.toThrowError(/Invalid Sui address/);
 
     //wrong id
     expect(
@@ -26,15 +26,16 @@ describe('Object id/Address/Transaction digest validation', () => {
 
   it('Test all functions with invalid Object Id', async () => {
     //empty id
-    expect(toolbox.provider.getObject('')).rejects.toThrowError(
+    expect(toolbox.provider.getObject({ id: '' })).rejects.toThrowError(
       /Invalid Sui Object id/,
     );
 
     //more than 20bytes
     expect(
-      toolbox.provider.getDynamicFields(
-        '0x0000000000000000000000004ce52ee7b659b610d59a1ced129291b3d0d4216322',
-      ),
+      toolbox.provider.getDynamicFields({
+        parentId:
+          '0x0000000000000000000000004ce52ee7b659b610d59a1ced129291b3d0d4216322',
+      }),
     ).rejects.toThrowError(/Invalid Sui Object id/);
     expect(
       toolbox.provider.queryTransactionsForObjectDeprecated(
@@ -44,21 +45,21 @@ describe('Object id/Address/Transaction digest validation', () => {
 
     //wrong batch request
     let objectIds = ['0xBABE', '0xCAFE', '0xWRONG', '0xFACE'];
-    expect(toolbox.provider.getObjectBatch(objectIds)).rejects.toThrowError(
-      /Invalid Sui Object id 0xWRONG/,
-    );
+    expect(
+      toolbox.provider.multiGetObjects({ ids: objectIds }),
+    ).rejects.toThrowError(/Invalid Sui Object id 0xWRONG/);
   });
 
   it('Test all functions with invalid Transaction Digest', async () => {
     //empty digest
-    expect(toolbox.provider.getTransactionResponse('')).rejects.toThrowError(
-      /Invalid Transaction digest/,
-    );
+    expect(
+      toolbox.provider.getTransaction({ digest: '' }),
+    ).rejects.toThrowError(/Invalid Transaction digest/);
 
     //wrong batch request
     let digests = ['AQ7FA8JTGs368CvMkXj2iFz2WUWwzP6AAWgsLpPLxUmr', 'wrong'];
     expect(
-      toolbox.provider.getTransactionResponseBatch(digests),
+      toolbox.provider.multiGetTransactions({ digests }),
     ).rejects.toThrowError(/Invalid Transaction digest wrong/);
   });
 });

--- a/sdk/typescript/test/e2e/normalized-modules.test.ts
+++ b/sdk/typescript/test/e2e/normalized-modules.test.ts
@@ -18,11 +18,11 @@ describe('Normalized modules API', () => {
   });
 
   it('Get Move function arg types', async () => {
-    const argTypes = await toolbox.provider.getMoveFunctionArgTypes(
-      DEFAULT_PACKAGE,
-      DEFAULT_MODULE,
-      DEFAULT_FUNCTION,
-    );
+    const argTypes = await toolbox.provider.getMoveFunctionArgTypes({
+      package: DEFAULT_PACKAGE,
+      module: DEFAULT_MODULE,
+      function: DEFAULT_FUNCTION,
+    });
     expect(argTypes).toEqual([
       {
         Object: 'ByImmutableReference',
@@ -31,37 +31,37 @@ describe('Normalized modules API', () => {
   });
 
   it('Get Normalized Modules by packages', async () => {
-    const modules = await toolbox.provider.getNormalizedMoveModulesByPackage(
-      DEFAULT_PACKAGE,
-    );
+    const modules = await toolbox.provider.getNormalizedMoveModulesByPackage({
+      package: DEFAULT_PACKAGE,
+    });
     expect(Object.keys(modules)).contains(DEFAULT_MODULE);
   });
 
   it('Get Normalized Move Module', async () => {
-    const normalized = await toolbox.provider.getNormalizedMoveModule(
-      DEFAULT_PACKAGE,
-      DEFAULT_MODULE,
-    );
+    const normalized = await toolbox.provider.getNormalizedMoveModule({
+      package: DEFAULT_PACKAGE,
+      module: DEFAULT_MODULE,
+    });
     expect(Object.keys(normalized.exposedFunctions)).toContain(
       DEFAULT_FUNCTION,
     );
   });
 
   it('Get Normalized Move Function', async () => {
-    const normalized = await toolbox.provider.getNormalizedMoveFunction(
-      DEFAULT_PACKAGE,
-      DEFAULT_MODULE,
-      DEFAULT_FUNCTION,
-    );
+    const normalized = await toolbox.provider.getNormalizedMoveFunction({
+      package: DEFAULT_PACKAGE,
+      module: DEFAULT_MODULE,
+      function: DEFAULT_FUNCTION,
+    });
     expect(normalized.isEntry).toEqual(false);
   });
 
   it('Get Normalized Move Struct ', async () => {
-    const struct = await toolbox.provider.getNormalizedMoveStruct(
-      DEFAULT_PACKAGE,
-      DEFAULT_MODULE,
-      DEFAULT_STRUCT,
-    );
+    const struct = await toolbox.provider.getNormalizedMoveStruct({
+      package: DEFAULT_PACKAGE,
+      module: DEFAULT_MODULE,
+      struct: DEFAULT_STRUCT,
+    });
     expect(struct.fields.length).toBeGreaterThan(1);
   });
 });

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -17,13 +17,16 @@ describe('Test Object Display Standard', () => {
 
   it('Test getting Display fields', async () => {
     const boarId = (
-      await toolbox.provider.getObjectsOwnedByAddress(
-        toolbox.address(),
-        `${packageId}::boars::Boar`,
-      )
+      await toolbox.provider.getObjectsOwnedByAddress({
+        owner: toolbox.address(),
+        typeFilter: `${packageId}::boars::Boar`,
+      })
     )[0].objectId;
     const display = getObjectDisplay(
-      await toolbox.provider.getObject(boarId, { showDisplay: true }),
+      await toolbox.provider.getObject({
+        id: boarId,
+        options: { showDisplay: true },
+      }),
     );
     expect(display).toEqual({
       age: '10',
@@ -42,7 +45,10 @@ describe('Test Object Display Standard', () => {
   it('Test getting Display fields for object that has no display object', async () => {
     const coinId = (await toolbox.getGasObjectsOwnedByAddress())[0].objectId;
     const display = getObjectDisplay(
-      await toolbox.provider.getObject(coinId, { showDisplay: true }),
+      await toolbox.provider.getObject({
+        id: coinId,
+        options: { showDisplay: true },
+      }),
     );
     expect(display).toEqual(undefined);
   });

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -28,8 +28,11 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
       target: `${packageId}::entry_point_vector::mint`,
       arguments: [tx.pure(String(val))],
     });
-    const result = await toolbox.signer.signAndExecuteTransaction(tx, {
-      showEffects: true,
+    const result = await toolbox.signer.signAndExecuteTransaction({
+      transaction: tx,
+      options: {
+        showEffects: true,
+      },
     });
     expect(getExecutionStatusType(result)).toEqual('success');
     return getCreatedObjects(result)![0].reference.objectId;
@@ -43,8 +46,11 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
       target: `${packageId}::entry_point_vector::two_obj_vec_destroy`,
       arguments: [vec],
     });
-    const result = await toolbox.signer.signAndExecuteTransaction(tx, {
-      showEffects: true,
+    const result = await toolbox.signer.signAndExecuteTransaction({
+      transaction: tx,
+      options: {
+        showEffects: true,
+      },
     });
     expect(getExecutionStatusType(result)).toEqual('success');
   }
@@ -75,8 +81,11 @@ describe('Test Move call with a vector of objects as input (skipped due to move 
       arguments: [tx.object(coinIDs[0]), vec],
     });
     tx.setGasPayment([coins[3]]);
-    const result = await toolbox.signer.signAndExecuteTransaction(tx, {
-      showEffects: true,
+    const result = await toolbox.signer.signAndExecuteTransaction({
+      transaction: tx,
+      options: {
+        showEffects: true,
+      },
     });
     expect(getExecutionStatusType(result)).toEqual('success');
   });

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -13,9 +13,9 @@ describe('Object Reading API', () => {
   });
 
   it('Get Owned Objects', async () => {
-    const gasObjects = await toolbox.provider.getObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const gasObjects = await toolbox.provider.getObjectsOwnedByAddress({
+      owner: toolbox.address(),
+    });
     expect(gasObjects.length).to.greaterThan(0);
   });
 
@@ -24,7 +24,10 @@ describe('Object Reading API', () => {
     expect(gasObjects.length).to.greaterThan(0);
     const objectInfos = await Promise.all(
       gasObjects.map((gasObject) =>
-        toolbox.provider.getObject(gasObject['objectId'], { showType: true }),
+        toolbox.provider.getObject({
+          id: gasObject['objectId'],
+          options: { showType: true },
+        }),
       ),
     );
     objectInfos.forEach((objectInfo) =>
@@ -38,8 +41,11 @@ describe('Object Reading API', () => {
     const gasObjects = await toolbox.getGasObjectsOwnedByAddress();
     expect(gasObjects.length).to.greaterThan(0);
     const gasObjectIds = gasObjects.map((gasObject) => gasObject['objectId']);
-    const objectInfos = await toolbox.provider.getObjectBatch(gasObjectIds, {
-      showType: true,
+    const objectInfos = await toolbox.provider.multiGetObjects({
+      ids: gasObjectIds,
+      options: {
+        showType: true,
+      },
     });
 
     expect(gasObjects.length).to.equal(objectInfos.length);

--- a/sdk/typescript/test/e2e/raw-signer.test.ts
+++ b/sdk/typescript/test/e2e/raw-signer.test.ts
@@ -39,7 +39,7 @@ describe('RawSigner', () => {
     const keypair = new Ed25519Keypair();
     const signData = new TextEncoder().encode('hello world');
     const signer = new RawSigner(keypair, toolbox.provider);
-    const { signature } = await signer.signMessage(signData);
+    const { signature } = await signer.signMessage({ message: signData });
     const isValid = await verifyMessage(signData, signature);
     expect(isValid).toBe(true);
   });
@@ -48,7 +48,7 @@ describe('RawSigner', () => {
     const keypair = new Ed25519Keypair();
     const signData = new TextEncoder().encode('hello world');
     const signer = new RawSigner(keypair, toolbox.provider);
-    const { signature } = await signer.signMessage(signData);
+    const { signature } = await signer.signMessage({ message: signData });
     const isValid = await verifyMessage(
       new TextEncoder().encode('hello worlds'),
       signature,
@@ -73,7 +73,7 @@ describe('RawSigner', () => {
     const keypair = new Secp256k1Keypair();
     const signData = new TextEncoder().encode('hello world');
     const signer = new RawSigner(keypair, toolbox.provider);
-    const { signature } = await signer.signMessage(signData);
+    const { signature } = await signer.signMessage({ message: signData });
 
     const isValid = await verifyMessage(signData, signature);
     expect(isValid).toBe(true);

--- a/sdk/typescript/test/e2e/read-events.test.ts
+++ b/sdk/typescript/test/e2e/read-events.test.ts
@@ -12,30 +12,28 @@ describe('Event Reading API', () => {
   });
 
   it('Get All Events', async () => {
-    const allEvents = await toolbox.provider.getEvents('All', null, null);
+    const allEvents = await toolbox.provider.getEvents({ query: 'All' });
     expect(allEvents.data.length).to.greaterThan(0);
   });
 
   it('Get all event paged', async () => {
-    const page1 = await toolbox.provider.getEvents('All', null, 2);
+    const page1 = await toolbox.provider.getEvents({ query: 'All', limit: 2 });
     expect(page1.nextCursor).to.not.equal(null);
   });
 
   it('Get events by sender paginated', async () => {
-    const query1 = await toolbox.provider.getEvents(
-      { Sender: toolbox.address() },
-      null,
-      2,
-    );
+    const query1 = await toolbox.provider.getEvents({
+      query: { Sender: toolbox.address() },
+      limit: 2,
+    });
     expect(query1.data.length).toEqual(0);
   });
 
   it('Get events by recipient paginated', async () => {
-    const query2 = await toolbox.provider.getEvents(
-      { Recipient: { AddressOwner: toolbox.address() } },
-      null,
-      2,
-    );
+    const query2 = await toolbox.provider.getEvents({
+      query: { Recipient: { AddressOwner: toolbox.address() } },
+      limit: 2,
+    });
     expect(query2.data.length).toEqual(2);
   });
 });

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -18,20 +18,25 @@ describe('Transaction Reading API', () => {
   });
 
   it('Get Transaction', async () => {
-    const resp = await toolbox.provider.queryTransactions({}, null, 1);
+    const resp = await toolbox.provider.queryTransactions({
+      limit: 1,
+    });
     const digest = resp.data[0].digest;
-    const txn = await toolbox.provider.getTransactionResponse(digest);
+    const txn = await toolbox.provider.getTransaction({ digest });
     expect(getTransactionDigest(txn)).toEqual(digest);
   });
 
   it('Query Transactions with opts', async () => {
     const options = { showEvents: true, showEffects: true };
-    const resp = await toolbox.provider.queryTransactions({ options }, null, 1);
+    const resp = await toolbox.provider.queryTransactions({
+      options,
+      limit: 1,
+    });
     const digest = resp.data[0].digest;
-    const response2 = await toolbox.provider.getTransactionResponse(
+    const response2 = await toolbox.provider.getTransaction({
       digest,
       options,
-    );
+    });
     expect(resp.data[0]).toEqual(response2);
   });
 
@@ -42,37 +47,29 @@ describe('Transaction Reading API', () => {
     );
     expect(resp.length).to.greaterThan(0);
 
-    const allTransactions = await toolbox.provider.queryTransactions(
-      {},
-      null,
-      10,
-    );
+    const allTransactions = await toolbox.provider.queryTransactions({
+      limit: 10,
+    });
     expect(allTransactions.data.length).to.greaterThan(0);
 
-    const resp2 = await toolbox.provider.queryTransactions(
-      { filter: { ToAddress: toolbox.address() } },
-      null,
-      null,
-    );
-    const resp3 = await toolbox.provider.queryTransactions(
-      { filter: { FromAddress: toolbox.address() } },
-      null,
-      null,
-    );
+    const resp2 = await toolbox.provider.queryTransactions({
+      filter: { ToAddress: toolbox.address() },
+    });
+    const resp3 = await toolbox.provider.queryTransactions({
+      filter: { FromAddress: toolbox.address() },
+    });
     expect([...resp2.data, ...resp3.data].map((r) => r.digest)).toEqual(resp);
   });
 
   it('Genesis exists', async () => {
-    const allTransactions = await toolbox.provider.queryTransactions(
-      {},
-      null,
-      1,
-      'ascending',
-    );
-    const resp = await toolbox.provider.getTransactionResponse(
-      allTransactions.data[0].digest,
-      { showInput: true },
-    );
+    const allTransactions = await toolbox.provider.queryTransactions({
+      limit: 1,
+      order: 'ascending',
+    });
+    const resp = await toolbox.provider.getTransaction({
+      digest: allTransactions.data[0].digest,
+      options: { showInput: true },
+    });
     const txKind = getTransactionKind(resp)!;
     expect(txKind.kind === 'Genesis').toBe(true);
   });

--- a/sdk/typescript/test/e2e/rpc-endpoint.test.ts
+++ b/sdk/typescript/test/e2e/rpc-endpoint.test.ts
@@ -12,9 +12,9 @@ describe('Invoke any RPC endpoint', () => {
   });
 
   it('sui_getObjectsOwnedByAddress', async () => {
-    const gasObjectsExpected = await toolbox.provider.getObjectsOwnedByAddress(
-      toolbox.address(),
-    );
+    const gasObjectsExpected = await toolbox.provider.getObjectsOwnedByAddress({
+      owner: toolbox.address(),
+    });
     const gasObjects = await toolbox.provider.call(
       'sui_getObjectsOwnedByAddress',
       [toolbox.address()],

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -133,8 +133,11 @@ describe('Transaction Builders', () => {
 async function validateTransaction(signer: RawSigner, tx: Transaction) {
   tx.setGasBudget(DEFAULT_GAS_BUDGET);
   const localDigest = await signer.getTransactionDigest(tx);
-  const result = await signer.signAndExecuteTransaction(tx, {
-    showEffects: true,
+  const result = await signer.signAndExecuteTransaction({
+    transaction: tx,
+    options: {
+      showEffects: true,
+    },
   });
   expect(localDigest).toEqual(getTransactionDigest(result));
   expect(getExecutionStatusType(result)).toEqual('success');

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -51,9 +51,9 @@ export class TestToolbox {
   }
 
   async getGasObjectsOwnedByAddress() {
-    const objects = await this.provider.getObjectsOwnedByAddress(
-      this.address(),
-    );
+    const objects = await this.provider.getObjectsOwnedByAddress({
+      owner: this.address(),
+    });
 
     return objects.filter((obj) => Coin.isSUI(obj));
   }
@@ -120,9 +120,12 @@ export async function publishPackage(
   // Transfer the upgrade capability to the sender so they can upgrade the package later if they want.
   tx.transferObjects([cap], tx.pure(await toolbox.signer.getAddress()));
 
-  const publishTxn = await toolbox.signer.signAndExecuteTransaction(tx, {
-    showEffects: true,
-    showEvents: true,
+  const publishTxn = await toolbox.signer.signAndExecuteTransaction({
+    transaction: tx,
+    options: {
+      showEffects: true,
+      showEvents: true,
+    },
   });
   expect(getExecutionStatusType(publishTxn)).toEqual('success');
 

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -50,22 +50,24 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
   }
 
   signMessage: WalletAdapter["signMessage"] = async (messageInput) => {
-    return this.#signer.signMessage(messageInput.message);
+    return this.#signer.signMessage({ message: messageInput.message });
   };
 
   signTransaction: WalletAdapter["signTransaction"] = async (
     transactionInput
   ) => {
-    return this.#signer.signTransaction(transactionInput.transaction);
+    return this.#signer.signTransaction({
+      transaction: transactionInput.transaction,
+    });
   };
 
   signAndExecuteTransaction: WalletAdapter["signAndExecuteTransaction"] =
     async (transactionInput) => {
-      return await this.#signer.signAndExecuteTransaction(
-        transactionInput.transaction,
-        transactionInput.options?.contentOptions,
-        transactionInput.options?.requestType
-      );
+      return await this.#signer.signAndExecuteTransaction({
+        transaction: transactionInput.transaction,
+        options: transactionInput.options?.contentOptions,
+        requestType: transactionInput.options?.requestType,
+      });
     };
 
   async connect() {


### PR DESCRIPTION
## Description 

This reworks most of the user-facing APIs to be object-based. This gives us a lot more flexibility about these API surfaces and lets us minimize breaking changes due to parameter changes. This also makes a lot of the APIs more ergonomic in cases where positional arguments required passing multiple `null` values.

## Test Plan 

Tests should continue to pass.