### PR TITLE
[Narwhal/Proposer] add batch digests to Header in LIFO order

### DIFF
--- a/narwhal/Docker/validators/parameters.json
+++ b/narwhal/Docker/validators/parameters.json
@@ -7,7 +7,7 @@
     },
     "gc_depth": 50,
     "header_num_of_batches_threshold": 32,
-    "max_header_num_of_batches": 1000,
+    "max_header_num_of_batches": 200,
     "max_batch_delay": "200ms",
     "max_concurrent_requests": 500000,
     "max_header_delay": "2000ms",

--- a/narwhal/benchmark/data/latest/README.md
+++ b/narwhal/benchmark/data/latest/README.md
@@ -41,7 +41,7 @@ We set the following `node_params` in our [fabfile](https://github.com/MystenLab
 ```python
 node_params = {
     'header_num_of_batches_threshold': 32, # number of batches
-    'max_header_num_of_batches': 1000, # number of batches
+    'max_header_num_of_batches': 200, # number of batches
     'max_header_delay': 200,  # ms
     'gc_depth': 50,  # rounds
     'sync_retry_delay': 10_000,  # ms

--- a/narwhal/benchmark/data/paper-data/README.md
+++ b/narwhal/benchmark/data/paper-data/README.md
@@ -40,8 +40,8 @@ The content of our [settings.json](https://github.com/MystenLabs/sui/blob/main/n
 We set the following `node_params` in our [fabfile](https://github.com/MystenLabs/sui/blob/main/narwhal/benchmark/fabfile.py):
 ```python
 node_params = {
-    'header_num_of_batches_threshold': 1000, # number of batches
-    'max_header_num_of_batches': 32, # number of batches
+    'header_num_of_batches_threshold': 32, # number of batches
+    'max_header_num_of_batches': 200, # number of batches
     'max_header_delay': 200,  # ms
     'gc_depth': 50,  # rounds
     'sync_retry_delay': 10_000,  # ms

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -182,7 +182,7 @@ impl Parameters {
     }
 
     fn default_max_header_num_of_batches() -> usize {
-        1_000
+        200
     }
 
     fn default_max_header_delay() -> Duration {

--- a/narwhal/config/tests/config_tests.rs
+++ b/narwhal/config/tests/config_tests.rs
@@ -173,7 +173,7 @@ fn parameters_import_snapshot_matches() {
     // GIVEN
     let input = r#"{
          "header_num_of_batches_threshold": 32,
-         "max_header_num_of_batches": 1000,
+         "max_header_num_of_batches": 200,
          "gc_depth": 50,
          "sync_retry_delay": "5s",
          "sync_retry_nodes": 3,

--- a/narwhal/config/tests/snapshots/config_tests__parameters.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters.snap
@@ -4,7 +4,7 @@ expression: parameters
 ---
 {
   "header_num_of_batches_threshold": 32,
-  "max_header_num_of_batches": 1000,
+  "max_header_num_of_batches": 200,
   "max_header_delay": "2000ms",
   "min_header_delay": "500ms",
   "gc_depth": 50,

--- a/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
@@ -4,7 +4,7 @@ expression: params
 ---
 {
   "header_num_of_batches_threshold": 32,
-  "max_header_num_of_batches": 1000,
+  "max_header_num_of_batches": 200,
   "max_header_delay": "2000ms",
   "min_header_delay": "500ms",
   "gc_depth": 50,

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -6,7 +6,7 @@ use config::{Committee, Epoch, WorkerId};
 use crypto::PublicKey;
 use fastcrypto::hash::Hash as _;
 use mysten_metrics::spawn_logged_monitored_task;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::{cmp::Ordering, sync::Arc};
 use storage::ProposerStore;
 use tokio::time::{sleep_until, Instant};
@@ -83,11 +83,12 @@ pub struct Proposer {
     /// Holds the certificate of the last leader (if any).
     last_leader: Option<Certificate>,
     /// Holds the batches' digests waiting to be included in the next header.
-    digests: Vec<(BatchDigest, WorkerId, TimestampMs)>,
+    /// Digests are popped in LIFO order from the front.
+    digests: VecDeque<OurDigestMessage>,
 
-    /// Holds the map of proposed previous round headers, used to ensure that
+    /// Holds the map of proposed previous round headers and their digest messages, to ensure that
     /// all batches' digest included will eventually be re-sent.
-    proposed_headers: BTreeMap<Round, Header>,
+    proposed_headers: BTreeMap<Round, (Header, VecDeque<OurDigestMessage>)>,
     /// Committed headers channel on which we get updates on which of
     /// our own headers have been committed.
     rx_committed_own_headers: Receiver<(Round, Vec<Round>)>,
@@ -138,7 +139,7 @@ impl Proposer {
                     round: 0,
                     last_parents: genesis,
                     last_leader: None,
-                    digests: Vec::with_capacity(2 * max_header_num_of_batches),
+                    digests: VecDeque::with_capacity(2 * max_header_num_of_batches),
                     proposed_headers: BTreeMap::new(),
                     rx_committed_own_headers,
                     metrics,
@@ -196,7 +197,9 @@ impl Proposer {
 
         // Make a new header.
         let num_of_digests = self.digests.len().min(self.max_header_num_of_batches);
-        let digests: Vec<_> = self.digests.drain(..num_of_digests).collect();
+        // Reverse the order of digests so they are closer to time order. After future MEV-related
+        // work this would be unnecessary.
+        let included_digests: VecDeque<_> = self.digests.drain(..num_of_digests).rev().collect();
         let parents: Vec<_> = self.last_parents.drain(..).collect();
 
         // Here we check that the timestamp we will include in the header is consistent with the
@@ -219,9 +222,9 @@ impl Proposer {
             self.name.clone(),
             this_round,
             this_epoch,
-            digests
+            included_digests
                 .iter()
-                .map(|(digest, worker_id, created_at)| (*digest, (*worker_id, *created_at)))
+                .map(|m| (m.digest, (m.worker_id, m.timestamp)))
                 .collect(),
             parents.iter().map(|x| x.digest()).collect(),
         )
@@ -256,15 +259,11 @@ impl Proposer {
             debug!(msg);
         }
 
-        // Register the header by the current round, to remember that we need to commit
-        // it, or re-include the batch digests that it contains.
-        self.proposed_headers.insert(this_round, header.clone());
-
         // Update metrics related to latency
         let mut total_inclusion_secs = 0.0;
-        for (_digest, _worker_id, created_at_timestamp) in digests.clone() {
+        for digest in &included_digests {
             let batch_inclusion_secs =
-                Duration::from_millis(header.created_at - created_at_timestamp).as_secs_f64();
+                Duration::from_millis(header.created_at - digest.timestamp).as_secs_f64();
             total_inclusion_secs += batch_inclusion_secs;
 
             #[cfg(feature = "benchmark")]
@@ -272,8 +271,8 @@ impl Proposer {
                 // NOTE: This log entry is used to compute performance.
                 tracing::info!(
                     "Batch {:?} from worker {} took {} seconds from creation to be included in a proposed header",
-                    _digest,
-                    _worker_id,
+                    digest.digest,
+                    digest.worker_id,
                     batch_inclusion_secs
                 );
             }
@@ -284,21 +283,27 @@ impl Proposer {
         }
 
         // NOTE: This log entry is used to compute performance.
-        let (header_creation_secs, avg_inclusion_secs) = if let Some(digest) = digests.first() {
-            (
-                Duration::from_millis(header.created_at - digest.2).as_secs_f64(),
-                total_inclusion_secs / digests.len() as f64,
-            )
-        } else {
-            (self.max_header_delay.as_secs_f64(), 0.0)
-        };
+        let (header_creation_secs, avg_inclusion_secs) =
+            if let Some(digest) = included_digests.front() {
+                (
+                    Duration::from_millis(header.created_at - digest.timestamp).as_secs_f64(),
+                    total_inclusion_secs / included_digests.len() as f64,
+                )
+            } else {
+                (self.max_header_delay.as_secs_f64(), 0.0)
+            };
         debug!(
             "Header {:?} was created in {} seconds. Contains {} batches, with average delay {} seconds.",
             header.digest(),
             header_creation_secs,
-            digests.len(),
+            included_digests.len(),
             avg_inclusion_secs,
         );
+
+        // Register the header by the current round, to remember that we need to commit
+        // it, or re-include the batch digests that it contains.
+        self.proposed_headers
+            .insert(this_round, (header.clone(), included_digests));
 
         Ok(header)
     }
@@ -317,6 +322,11 @@ impl Proposer {
             // Otherwise we keep the default timeout value.
             _ => self.max_header_delay,
         }
+    }
+
+    // Limit the size of digests queue.
+    fn max_digests_queue_len(&self) -> usize {
+        self.max_header_num_of_batches * 2
     }
 
     fn min_delay(&self) -> Duration {
@@ -512,35 +522,52 @@ impl Proposer {
 
                 Some((commit_round, commit_headers)) = self.rx_committed_own_headers.recv() => {
                     // Remove committed headers from the list of pending
-                    for round in &commit_headers {
-                        self.proposed_headers.remove(round);
+                    let mut max_committed_round = 0;
+                    for round in commit_headers {
+                        max_committed_round = max_committed_round.max(round);
+                        let Some((_header, included_digests)) = self.proposed_headers.remove(&round) else {
+                            info!("Own committed header not found at round {round}, probably because of restarts.");
+                            continue;
+                        };
+                        // Signal to the transaction submitter that the digest has been included.
+                        // NOTE: transaction submitter should see its transaction from consensus
+                        // output around this time too, so the purpose of signal here is more for
+                        // not returning an error on dropping the sender.
+                        for digest in included_digests {
+                            let _ = digest.ack_channel.send(());
+                        }
                     }
 
-                    // Now for any round much below the current commit round we re-insert
+                    // Now for any round below the current commit round we re-insert
                     // the batches into the digests we need to send, effectively re-sending
-                    // them
+                    // them in LIFO order.
                     let mut digests_to_resend = Vec::new();
                     let mut retransmit_rounds = Vec::new();
+                    let max_queue_len = self.max_digests_queue_len();
 
                     // Iterate in order of rounds of our own headers.
-                    for (round_header, header) in &mut self.proposed_headers {
-                        // If we are within 2 rounds of the commit we break
-                        if round_header + 2 >= commit_round {
+                    for (header_round, (_header, included_digests)) in &mut self.proposed_headers {
+                        // Stop once we have processed headers at and below last committed round.
+                        if *header_round > max_committed_round {
                             break;
                         }
-
-                        digests_to_resend.extend(
-                            header.payload.iter().map(|(digest, (worker, created_at))| (*digest, *worker, *created_at))
-                        );
-                        retransmit_rounds.push(*round_header);
+                        // Add payloads from oldest to newest.
+                        digests_to_resend.push(included_digests);
+                        retransmit_rounds.push(*header_round);
                     }
 
                     if !retransmit_rounds.is_empty() {
-                        // Add the digests to retransmit to the digests for the next header
-                        digests_to_resend.extend(&self.digests);
-                        self.digests = digests_to_resend;
+                        // Add digests to retransmit from newest to oldest. Dropped digests will
+                        // signal error back to the transaction submitters and clients.
+                        for included_digests in digests_to_resend.into_iter().rev() {
+                            if self.digests.len() >= max_queue_len {
+                                break;
+                            }
+                            self.digests.append(included_digests);
+                        }
+                        self.digests.truncate(self.max_digests_queue_len());
 
-                        // Now delete the headers with batches we re-transmit
+                        // Now delete the headers with batches we re-transmit or will ignore.
                         for round in &retransmit_rounds {
                             self.proposed_headers.remove(round);
                         }
@@ -621,21 +648,11 @@ impl Proposer {
                 }
 
                 // Receive digests from our workers.
-                Some(OurDigestMessage {
-                    digest,
-                    worker_id,
-                    timestamp,
-                    ack_channel,
-                }) = self.rx_our_digests.recv() => {
-                    let digest_record = (digest, worker_id, timestamp, );
-                    self.digests.push(digest_record);
-                    // Signal back to the worker that the batch is recorded on the
-                    // primary, and will be tracked until inclusion. This means that
-                    // if the primary does not fail it will attempt to send the digest
-                    // (and re-send if necessary) until it is sequenced, or the end of
-                    // the epoch is reached. For the moment this does not persist primary
-                    // crashes and re-starts.
-                    let _ = ack_channel.send(());
+                Some(message) = self.rx_our_digests.recv() => {
+                    self.digests.push_front(message);
+                    // This will signal back to the worker that the batch is dropped, so the error
+                    // can be propagated back to transaction submitter and clients.
+                    self.digests.truncate(self.max_digests_queue_len());
                 }
 
                 // Check whether any timer expired.

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -38,6 +38,7 @@ pub struct OurDigestMessage {
 pub mod proposer_tests;
 
 const DEFAULT_HEADER_RESEND_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_DIGESTS_QUEUE_LEN_MULTIPLIER: usize = 5;
 
 /// The proposer creates new headers and send them to the core for broadcasting and further processing.
 pub struct Proposer {
@@ -139,7 +140,9 @@ impl Proposer {
                     round: 0,
                     last_parents: genesis,
                     last_leader: None,
-                    digests: VecDeque::with_capacity(2 * max_header_num_of_batches),
+                    digests: VecDeque::with_capacity(
+                        MAX_DIGESTS_QUEUE_LEN_MULTIPLIER * max_header_num_of_batches,
+                    ),
                     proposed_headers: BTreeMap::new(),
                     rx_committed_own_headers,
                     metrics,
@@ -326,7 +329,7 @@ impl Proposer {
 
     // Limit the size of digests queue.
     fn max_digests_queue_len(&self) -> usize {
-        self.max_header_num_of_batches * 2
+        MAX_DIGESTS_QUEUE_LEN_MULTIPLIER * self.max_header_num_of_batches
     }
 
     fn min_delay(&self) -> Duration {

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -20,7 +20,7 @@ pub struct StateHandler {
     /// Channel to signal committee changes.
     rx_shutdown: ConditionalBroadcastReceiver,
     /// A channel to update the committed rounds
-    tx_commited_own_headers: Option<Sender<(Round, Vec<Round>)>>,
+    tx_committed_own_headers: Option<Sender<(Round, Vec<Round>)>>,
 
     network: anemo::Network,
 }
@@ -31,7 +31,7 @@ impl StateHandler {
         name: PublicKey,
         rx_committed_certificates: Receiver<(Round, Vec<Certificate>)>,
         rx_shutdown: ConditionalBroadcastReceiver,
-        tx_commited_own_headers: Option<Sender<(Round, Vec<Round>)>>,
+        tx_committed_own_headers: Option<Sender<(Round, Vec<Round>)>>,
         network: anemo::Network,
     ) -> JoinHandle<()> {
         spawn_logged_monitored_task!(
@@ -40,7 +40,7 @@ impl StateHandler {
                     name,
                     rx_committed_certificates,
                     rx_shutdown,
-                    tx_commited_own_headers,
+                    tx_committed_own_headers,
                     network,
                 }
                 .run()
@@ -69,7 +69,7 @@ impl StateHandler {
 
         // If a reporting channel is available send the committed own
         // headers to it.
-        if let Some(sender) = &self.tx_commited_own_headers {
+        if let Some(sender) = &self.tx_committed_own_headers {
             let _ = sender.send((commit_round, own_rounds_committed)).await;
         }
     }


### PR DESCRIPTION
## Description 

Currently batch digests in Proposer are included in Headers in a FIFO order: new batch digests get added to the back of the queue, digests to resend get prepended to the front, and Headers take digests from the front of the queue. When the primary is struggling to get its header signed, or its certificates included in the consensus output, batches will accumulate in the Proposer. After more than `max_header_num_of_batches` are accumulated, it becomes even harder for transactions to be included in consensus from the Narwhal instance.

Instead, a LIFO policy seems more appropriate. Newer transactions should be prioritized to be included in headers. Older transactions are more likely to have been retried at other nodes, so they have lower priority to be included, and should be evicted from the batch digests queue first.

This refactor also changes how batches are acknowledged: now successful acknowledge of transaction submission by Narwhal only comes after the certificate including the transaction has come out of consensus. This seems more correct, and helps back pressure pending batches into consensus submissions.

Also, change `max_header_num_of_batches` from 1000 to 200, which should be enough with only 1 worker. Having too many digests in headers can slow down header processing which makes the header and the certificate harder to get included into the DAG.

After weak links are implemented, the issue here will be less severe. But I believe this change would still be useful to avoid the degenerate case.

## Test Plan 

Deployed to private testnet.
TODO: unit test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
