### PR TITLE
[CI] Fix broken rosetta build

### DIFF
--- a/.github/scripts/rosetta/setup.sh
+++ b/.github/scripts/rosetta/setup.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 echo "Install binaries"
-cargo install --bin sui --path crates/sui
-cargo install --bin sui-rosetta --path crates/sui-rosetta
+cargo install --locked --bin sui --path crates/sui
+cargo install --locked --bin sui-rosetta --path crates/sui-rosetta
 
 echo "run Sui genesis"
 sui genesis

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -311,4 +311,3 @@ jobs:
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
-


### PR DESCRIPTION
## Description 

cargo install ignores the lockfile by default

## Test Plan 

Verified locally that `cargo build --bin sui-rosetta` failed but `cargo install --locked --bin sui-rosetta --path crates/sui-rosetta` succeeded.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
