### PR TITLE
move epoch_duration_ms from NodeConfig to on-chain

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -409,6 +409,10 @@ pub struct GenesisChainParameters {
     ///   kicked from the validator set
     #[serde(default)]
     pub governance_start_epoch: u64,
+
+    /// The duration of an epoch, in milliseconds.
+    #[serde(default = "GenesisChainParameters::test_epoch_duration_ms")]
+    pub epoch_duration_ms: u64,
     // Most other parameters (e.g. initial gas schedule) should be derived from protocol_version.
 }
 
@@ -421,6 +425,7 @@ impl GenesisChainParameters {
             initial_sui_custody_account_address: SuiAddress::default(),
             initial_validator_stake_mist: Self::test_initial_validator_stake_mist(),
             governance_start_epoch: 0,
+            epoch_duration_ms: Self::test_epoch_duration_ms(),
         }
     }
 
@@ -437,6 +442,10 @@ impl GenesisChainParameters {
 
     fn test_initial_validator_stake_mist() -> u64 {
         sui_types::governance::MINIMUM_VALIDATOR_STAKE_SUI * sui_types::gas_coin::MIST_PER_SUI
+    }
+
+    fn test_epoch_duration_ms() -> u64 {
+        10000
     }
 }
 
@@ -1129,6 +1138,7 @@ pub fn generate_genesis_system_object(
                     CallArg::Pure(bcs::to_bytes(&parameters.protocol_version.as_u64()).unwrap()),
                     CallArg::Pure(bcs::to_bytes(&system_state_version).unwrap()),
                     CallArg::Pure(bcs::to_bytes(&parameters.timestamp_ms).unwrap()),
+                    CallArg::Pure(bcs::to_bytes(&parameters.epoch_duration_ms).unwrap()),
                 ],
             )
             .unwrap();

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -61,13 +61,6 @@ pub struct NodeConfig {
     #[serde(default)]
     pub enable_event_processing: bool,
 
-    // TODO: It will be removed down the road.
-    /// Epoch duration in ms.
-    /// u64::MAX means reconfiguration is disabled
-    /// Exposing this in config to allow easier testing with shorter epoch.
-    #[serde(default = "default_epoch_duration_ms")]
-    pub epoch_duration_ms: u64,
-
     #[serde(default)]
     pub grpc_load_shed: Option<bool>,
 
@@ -148,11 +141,6 @@ pub fn default_websocket_address() -> Option<SocketAddr> {
 
 pub fn default_concurrency_limit() -> Option<usize> {
     Some(DEFAULT_GRPC_CONCURRENCY_LIMIT)
-}
-
-pub fn default_epoch_duration_ms() -> u64 {
-    // 24 Hrs
-    24 * 60 * 60 * 1000
 }
 
 pub fn default_end_of_epoch_broadcast_channel_capacity() -> usize {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -3,8 +3,8 @@
 
 use crate::node::AuthorityStorePruningConfig;
 use crate::node::{
-    default_end_of_epoch_broadcast_channel_capacity, default_epoch_duration_ms,
-    AuthorityKeyPairWithPath, DBCheckpointConfig, KeyPairWithPath,
+    default_end_of_epoch_broadcast_channel_capacity, AuthorityKeyPairWithPath, DBCheckpointConfig,
+    KeyPairWithPath,
 };
 use crate::p2p::{P2pConfig, SeedPeer};
 use crate::{
@@ -61,6 +61,19 @@ impl NetworkConfig {
     ) -> Self {
         builder::ConfigBuilder::new(config_dir)
             .committee_size(NonZeroUsize::new(quorum_size).unwrap())
+            .rng(rng)
+            .build()
+    }
+
+    pub fn generate_with_rng_and_epoch_duration<R: rand::CryptoRng + rand::RngCore>(
+        config_dir: &Path,
+        quorum_size: usize,
+        epoch_duration_ms: u64,
+        rng: R,
+    ) -> Self {
+        builder::ConfigBuilder::new(config_dir)
+            .committee_size(NonZeroUsize::new(quorum_size).unwrap())
+            .with_epoch_duration(epoch_duration_ms)
             .rng(rng)
             .build()
     }
@@ -267,7 +280,6 @@ impl<'a> FullnodeConfigBuilder<'a> {
             json_rpc_address,
             consensus_config: None,
             enable_event_processing: self.enable_event_store,
-            epoch_duration_ms: default_epoch_duration_ms(),
             genesis: validator_config.genesis.clone(),
             grpc_load_shed: None,
             grpc_concurrency_limit: None,

--- a/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -10,6 +10,7 @@ parameters:
   initial_sui_custody_account_address: "0x0000000000000000000000000000000000000000000000000000000000000000"
   initial_validator_stake_mist: 25000000000000000
   governance_start_epoch: 0
+  epoch_duration_ms: 10000
 committee_size: 4
 grpc_load_shed: ~
 grpc_concurrency_limit: 20000000000

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -54,7 +54,6 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -126,7 +125,6 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -198,7 +196,6 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -270,7 +267,6 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -342,7 +338,6 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -414,7 +409,6 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -486,7 +480,6 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
-    epoch-duration-ms: 86400000
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -279,6 +279,7 @@ storage_fund:
   value: 0
 parameters:
   governance_start_epoch: 0
+  epoch_duration_ms: 10000
 reference_gas_price: 1
 validator_report_records:
   contents: []

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1583,7 +1583,6 @@ impl AuthorityState {
         prometheus_registry: &Registry,
         pruning_config: AuthorityStorePruningConfig,
         genesis_objects: &[Object],
-        epoch_duration_ms: u64,
         db_checkpoint_config: &DBCheckpointConfig,
     ) -> Arc<Self> {
         Self::check_protocol_version(supported_protocol_versions, epoch_store.protocol_version());
@@ -1605,7 +1604,7 @@ impl AuthorityState {
             checkpoint_store.clone(),
             store.objects_lock_table.clone(),
             pruning_config,
-            epoch_duration_ms,
+            epoch_store.epoch_start_state().epoch_duration_ms(),
         );
         let state = Arc::new(AuthorityState {
             name,
@@ -1713,7 +1712,6 @@ impl AuthorityState {
             &registry,
             AuthorityStorePruningConfig::default(),
             genesis.objects(),
-            10000,
             &DBCheckpointConfig::default(),
         )
         .await;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2898,7 +2898,6 @@ async fn test_authority_persist() {
             &registry,
             AuthorityStorePruningConfig::default(),
             &[], // no genesis objects
-            10000,
             &DBCheckpointConfig::default(),
         )
         .await

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -55,7 +55,7 @@ It will create a singleton SuiSystemState object, which contains
 all the information we need in the system.
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(initial_sui_custody_account_address: <b>address</b>, initial_validator_stake_mist: u64, governance_start_epoch: u64, validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_p2p_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_primary_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(initial_sui_custody_account_address: <b>address</b>, initial_validator_stake_mist: u64, governance_start_epoch: u64, validator_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_network_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_pubkeys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_proof_of_possessions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_sui_addresses: <a href="">vector</a>&lt;<b>address</b>&gt;, validator_names: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_descriptions: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_image_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_project_urls: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_net_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_p2p_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_primary_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_worker_addresses: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, validator_gas_prices: <a href="">vector</a>&lt;u64&gt;, validator_commission_rates: <a href="">vector</a>&lt;u64&gt;, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, epoch_duration_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -86,6 +86,7 @@ all the information we need in the system.
     protocol_version: u64,
     system_state_version: u64,
     epoch_start_timestamp_ms: u64,
+    epoch_duration_ms: u64,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> sui_supply = <a href="sui.md#0x2_sui_new">sui::new</a>(ctx);
@@ -157,6 +158,7 @@ all the information we need in the system.
         protocol_version,
         system_state_version,
         epoch_start_timestamp_ms,
+        epoch_duration_ms,
         ctx,
     );
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -106,6 +106,12 @@ A list of system config parameters.
  - TODO validators with stake less than a 'validator_stake_threshold' are
    kicked from the validator set
 </dd>
+<dt>
+<code>epoch_duration_ms: u64</code>
+</dt>
+<dd>
+ The duration of an epoch, in milliseconds.
+</dd>
 </dl>
 
 
@@ -484,7 +490,7 @@ Create a new SuiSystemState object and make it shared.
 This function will be called only once in genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, governance_start_epoch: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, governance_start_epoch: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, epoch_duration_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -502,6 +508,7 @@ This function will be called only once in genesis.
     protocol_version: u64,
     system_state_version: u64,
     epoch_start_timestamp_ms: u64,
+    epoch_duration_ms: u64,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> validators = <a href="validator_set.md#0x2_validator_set_new">validator_set::new</a>(validators, ctx);
@@ -514,6 +521,7 @@ This function will be called only once in genesis.
         storage_fund,
         parameters: <a href="sui_system.md#0x2_sui_system_SystemParameters">SystemParameters</a> {
             governance_start_epoch,
+            epoch_duration_ms,
         },
         reference_gas_price,
         validator_report_records: <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>(),

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -44,6 +44,7 @@ module sui::genesis {
         protocol_version: u64,
         system_state_version: u64,
         epoch_start_timestamp_ms: u64,
+        epoch_duration_ms: u64,
         ctx: &mut TxContext,
     ) {
         let sui_supply = sui::new(ctx);
@@ -115,6 +116,7 @@ module sui::genesis {
             protocol_version,
             system_state_version,
             epoch_start_timestamp_ms,
+            epoch_duration_ms,
             ctx,
         );
 

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -45,6 +45,9 @@ module sui::sui_system {
         /// - TODO validators with stake less than a 'validator_stake_threshold' are
         ///   kicked from the validator set
         governance_start_epoch: u64,
+
+        /// The duration of an epoch, in milliseconds.
+        epoch_duration_ms: u64,
     }
 
     /// The top-level object containing all information of the Sui system.
@@ -147,6 +150,7 @@ module sui::sui_system {
         protocol_version: u64,
         system_state_version: u64,
         epoch_start_timestamp_ms: u64,
+        epoch_duration_ms: u64,
         ctx: &mut TxContext,
     ) {
         let validators = validator_set::new(validators, ctx);
@@ -159,6 +163,7 @@ module sui::sui_system {
             storage_fund,
             parameters: SystemParameters {
                 governance_start_epoch,
+                epoch_duration_ms,
             },
             reference_gas_price,
             validator_report_records: vec_map::empty(),

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -68,6 +68,7 @@ module sui::governance_test_utils {
             1, // protocol version
             1, // system state version
             0, // epoch_start_timestamp_ms
+            42, // epoch_duration_ms, doesn't matter what number we put here
             ctx,
         )
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6233,6 +6233,7 @@
           "activeValidators",
           "atRiskValidators",
           "epoch",
+          "epochDurationMs",
           "epochStartTimestampMs",
           "governanceStartEpoch",
           "inactivePoolsId",
@@ -6284,6 +6285,12 @@
           },
           "epoch": {
             "description": "The current epoch ID, starting from 0.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "epochDurationMs": {
+            "description": "The duration of an epoch, in milliseconds.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -21,6 +21,7 @@ pub trait EpochStartSystemStateTrait {
     fn reference_gas_price(&self) -> u64;
     fn safe_mode(&self) -> bool;
     fn epoch_start_timestamp_ms(&self) -> u64;
+    fn epoch_duration_ms(&self) -> u64;
     fn get_sui_committee(&self) -> Committee;
     fn get_narwhal_committee(&self) -> NarwhalCommittee;
     fn get_validator_as_p2p_peers(&self, excluding_self: AuthorityName) -> Vec<PeerInfo>;
@@ -48,6 +49,7 @@ impl EpochStartSystemState {
         reference_gas_price: u64,
         safe_mode: bool,
         epoch_start_timestamp_ms: u64,
+        epoch_duration_ms: u64,
         active_validators: Vec<EpochStartValidatorInfoV1>,
     ) -> Self {
         Self::V1(EpochStartSystemStateV1 {
@@ -56,6 +58,7 @@ impl EpochStartSystemState {
             reference_gas_price,
             safe_mode,
             epoch_start_timestamp_ms,
+            epoch_duration_ms,
             active_validators,
         })
     }
@@ -76,6 +79,7 @@ pub struct EpochStartSystemStateV1 {
     reference_gas_price: u64,
     safe_mode: bool,
     epoch_start_timestamp_ms: u64,
+    epoch_duration_ms: u64,
     active_validators: Vec<EpochStartValidatorInfoV1>,
 }
 
@@ -91,6 +95,7 @@ impl EpochStartSystemStateV1 {
             reference_gas_price: 1,
             safe_mode: false,
             epoch_start_timestamp_ms: 0,
+            epoch_duration_ms: 1000,
             active_validators: vec![],
         }
     }
@@ -115,6 +120,10 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
 
     fn epoch_start_timestamp_ms(&self) -> u64 {
         self.epoch_start_timestamp_ms
+    }
+
+    fn epoch_duration_ms(&self) -> u64 {
+        self.epoch_duration_ms
     }
 
     fn get_sui_committee(&self) -> Committee {

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -64,6 +64,7 @@ pub trait SuiSystemStateTrait {
     fn protocol_version(&self) -> u64;
     fn system_state_version(&self) -> u64;
     fn epoch_start_timestamp_ms(&self) -> u64;
+    fn epoch_duration_ms(&self) -> u64;
     fn safe_mode(&self) -> bool;
     fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata;
     fn into_epoch_start_state(self) -> EpochStartSystemState;

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -35,6 +35,7 @@ const E_METADATA_INVALID_WORKER_ADDR: u64 = 7;
 #[serde(rename = "SystemParameters")]
 pub struct SystemParametersV1 {
     pub governance_start_epoch: u64,
+    pub epoch_duration_ms: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
@@ -445,6 +446,10 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
         self.epoch_start_timestamp_ms
     }
 
+    fn epoch_duration_ms(&self) -> u64 {
+        self.parameters.epoch_duration_ms
+    }
+
     fn safe_mode(&self) -> bool {
         self.safe_mode
     }
@@ -479,6 +484,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
             self.reference_gas_price,
             self.safe_mode,
             self.epoch_start_timestamp_ms,
+            self.parameters.epoch_duration_ms,
             self.validators
                 .active_validators
                 .iter()
@@ -542,9 +548,11 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
                         },
                 },
             storage_fund,
-            parameters: SystemParametersV1 {
-                governance_start_epoch,
-            },
+            parameters:
+                SystemParametersV1 {
+                    governance_start_epoch,
+                    epoch_duration_ms,
+                },
             reference_gas_price,
             validator_report_records:
                 VecMap {
@@ -568,6 +576,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
             safe_mode,
             epoch_start_timestamp_ms,
             governance_start_epoch,
+            epoch_duration_ms,
             stake_subsidy_epoch_counter,
             stake_subsidy_balance: stake_subsidy_balance.value(),
             stake_subsidy_current_epoch_amount,
@@ -618,6 +627,7 @@ impl Default for SuiSystemStateInnerV1 {
             storage_fund: Balance::new(0),
             parameters: SystemParametersV1 {
                 governance_start_epoch: 0,
+                epoch_duration_ms: 10000,
             },
             reference_gas_price: 1,
             validator_report_records: VecMap { contents: vec![] },

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -41,6 +41,9 @@ pub struct SuiSystemStateSummary {
     /// The starting epoch in which various on-chain governance features take effect.
     pub governance_start_epoch: u64,
 
+    /// The duration of an epoch, in milliseconds.
+    pub epoch_duration_ms: u64,
+
     // Stake subsidy information
     /// This counter may be different from the current epoch number if
     /// in some epochs we decide to skip the subsidy.

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -339,9 +339,9 @@ async fn genesis(
     }
 
     let validator_info = genesis_conf.validator_config_info.take();
-    let mut builder = ConfigBuilder::new(sui_config_dir);
+    let builder = ConfigBuilder::new(sui_config_dir);
     if let Some(epoch_duration_ms) = epoch_duration_ms {
-        builder = builder.with_epoch_duration(epoch_duration_ms);
+        genesis_conf.parameters.epoch_duration_ms = epoch_duration_ms;
     }
     let mut network_config = if let Some(validators) = validator_info {
         builder

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -26,7 +26,12 @@ pub fn test_authority_configs() -> NetworkConfig {
 pub fn test_and_configure_authority_configs(committee_size: usize) -> NetworkConfig {
     let config_dir = tempfile::tempdir().unwrap().into_path();
     let rng = StdRng::from_seed([0; 32]);
-    let mut configs = NetworkConfig::generate_with_rng(&config_dir, committee_size, rng);
+    let mut configs = NetworkConfig::generate_with_rng_and_epoch_duration(
+        &config_dir,
+        committee_size,
+        24 * 60 * 60 * 1000, /* 24 hrs*/
+        rng,
+    );
     for config in configs.validator_configs.iter_mut() {
         let parameters = &mut config.consensus_config.as_mut().unwrap().narwhal_config;
         // NOTE: the following parameters are important to ensure tests run fast. Using the default

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -207,7 +207,6 @@ pub struct TestClusterBuilder {
     num_validators: Option<usize>,
     fullnode_rpc_port: Option<u16>,
     enable_fullnode_events: bool,
-    epoch_duration_ms: Option<u64>,
     initial_protocol_version: ProtocolVersion,
     supported_protocol_versions_config: ProtocolVersionsConfig,
     db_checkpoint_config_validators: DBCheckpointConfig,
@@ -222,7 +221,6 @@ impl TestClusterBuilder {
             fullnode_rpc_port: None,
             num_validators: None,
             enable_fullnode_events: false,
-            epoch_duration_ms: None,
             initial_protocol_version: SupportedProtocolVersions::SYSTEM_DEFAULT.max,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
             db_checkpoint_config_validators: DBCheckpointConfig::default(),
@@ -274,7 +272,11 @@ impl TestClusterBuilder {
     }
 
     pub fn with_epoch_duration_ms(mut self, epoch_duration_ms: u64) -> Self {
-        self.epoch_duration_ms = Some(epoch_duration_ms);
+        let mut genesis_config = self
+            .genesis_config
+            .unwrap_or_else(GenesisConfig::for_local_testing);
+        genesis_config.parameters.epoch_duration_ms = epoch_duration_ms;
+        self.genesis_config = Some(genesis_config);
         self
     }
 
@@ -363,10 +365,6 @@ impl TestClusterBuilder {
 
         if let Some(genesis_config) = self.genesis_config.take() {
             builder = builder.initial_accounts_config(genesis_config);
-        }
-
-        if let Some(epoch_duration_ms) = self.epoch_duration_ms {
-            builder = builder.with_epoch_duration_ms(epoch_duration_ms);
         }
 
         let mut swarm = builder.build();

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -156,6 +156,7 @@ export const SuiSystemStateSummary = object({
   safeMode: boolean(),
   epochStartTimestampMs: number(),
   governanceStartEpoch: number(),
+  epochDurationMs: number(),
   stakeSubsidyEpochCounter: number(),
   stakeSubsidyBalance: number(),
   stakeSubsidyCurrentEpochAmount: number(),


### PR DESCRIPTION
## Description 

This PR moves the length of each epoch `epoch_duration_ms` to live on-chain, instead of in the node config. At the beginning of each epoch, we read the system state from on-chain and use the value we read to populate `EpochStartSystemState`.

## Test Plan 

Making sure the existing tests pass.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
