### PR TITLE
[Event refactoring 2/n] - move event indexing to IndexStore in preparation of removing SQLite

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2452,11 +2452,11 @@ impl AuthorityState {
 
         //Get the tx_num from tx_digest
         let (tx_num, event_num) = if let Some(cursor) = cursor.as_ref() {
-            let tx_seq = index_store
-                .get_transaction_seq(&cursor.tx_digest)?
-                .ok_or_else(|| SuiError::TransactionNotFound {
+            let tx_seq = index_store.get_transaction_seq(&cursor.tx_digest)?.ok_or(
+                SuiError::TransactionNotFound {
                     digest: cursor.tx_digest,
-                })?;
+                },
+            )?;
             (tx_seq, cursor.event_seq as usize)
         } else if descending {
             (u64::MAX, usize::MAX)

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2,6 +2,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::time::Duration;
+use std::{collections::HashMap, fs, pin::Pin, sync::Arc};
+
 use anyhow::anyhow;
 use arc_swap::{ArcSwap, Guard};
 use chrono::prelude::*;
@@ -14,8 +19,6 @@ use move_binary_format::CompiledModule;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::ModuleId;
-use move_core_types::parser::parse_struct_tag;
-use mysten_metrics::spawn_monitored_task;
 use parking_lot::Mutex;
 use prometheus::{
     register_histogram_with_registry, register_int_counter_vec_with_registry,
@@ -24,20 +27,6 @@ use prometheus::{
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use shared_crypto::intent::{Intent, IntentScope};
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
-use std::time::Duration;
-use std::{collections::HashMap, fs, pin::Pin, sync::Arc};
-use sui_config::node::{AuthorityStorePruningConfig, DBCheckpointConfig};
-use sui_types::crypto::AuthoritySignInfo;
-use sui_types::error::UserInputError;
-use sui_types::message_envelope::Message;
-use sui_types::parse_sui_struct_tag;
-use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
-use sui_types::sui_system_state::SuiSystemStateTrait;
-use sui_types::MOVE_STDLIB_OBJECT_ID;
-use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 use tap::TapFallible;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::oneshot;
@@ -46,41 +35,54 @@ use tracing::{debug, error, error_span, info, instrument, trace, warn, Instrumen
 
 pub use authority_notify_read::EffectsNotifyRead;
 pub use authority_store::{AuthorityStore, ResolverWrapper, UpdateType};
+use mysten_metrics::spawn_monitored_task;
 use narwhal_config::{
     Committee as ConsensusCommittee, WorkerCache as ConsensusWorkerCache,
     WorkerId as ConsensusWorkerId,
 };
+use shared_crypto::intent::{Intent, IntentScope};
+use sui_adapter::execution_engine;
 use sui_adapter::{adapter, execution_mode};
 use sui_config::genesis::Genesis;
+use sui_config::node::{AuthorityStorePruningConfig, DBCheckpointConfig};
 use sui_json_rpc_types::{
-    type_and_fields_from_move_struct, DevInspectResults, DryRunTransactionResponse, SuiEvent,
-    SuiEventEnvelope, SuiMoveValue, SuiTransactionEvents,
+    DevInspectResults, DryRunTransactionResponse, SuiEvent, SuiEventEnvelope, SuiMoveValue,
+    SuiTransactionEvents,
 };
 use sui_macros::{fail_point, nondeterministic};
 use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use sui_storage::indexes::{ObjectIndexChanges, MAX_GET_OWNED_OBJECT_SIZE};
 use sui_storage::write_ahead_log::WriteAheadLog;
 use sui_storage::{
-    event_store::{EventStore, EventStoreType, StoredEvent},
+    event_store::EventStoreType,
     write_ahead_log::{DBTxGuard, TxGuard},
     IndexStore,
 };
 use sui_types::committee::{EpochId, ProtocolVersion};
+use sui_types::crypto::AuthoritySignInfo;
 use sui_types::crypto::{sha3_hash, AuthorityKeyPair, NetworkKeyPair, Signer};
+use sui_types::digests::TransactionEventsDigest;
 use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType, Field};
+use sui_types::error::UserInputError;
 use sui_types::event::{Event, EventID};
 use sui_types::gas::{GasCostSummary, GasPrice, SuiCostTable, SuiGasStatus};
+use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
     CheckpointSummary, CheckpointTimestamp, VerifiedCheckpoint,
 };
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::{MoveObject, Owner, PastObjectRead, OBJECT_START_VERSION};
+use sui_types::parse_sui_struct_tag;
 use sui_types::query::{EventQuery, TransactionFilter};
 use sui_types::storage::{ObjectKey, WriteKind};
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::SuiSystemState;
+use sui_types::sui_system_state::SuiSystemStateTrait;
 use sui_types::temporary_store::InnerTemporaryStore;
 pub use sui_types::temporary_store::TemporaryStore;
+use sui_types::MOVE_STDLIB_OBJECT_ID;
+use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 use sui_types::{
     base_types::*,
     committee::Committee,
@@ -91,6 +93,7 @@ use sui_types::{
     object::{Object, ObjectFormatOptions, ObjectRead},
     SUI_FRAMEWORK_ADDRESS,
 };
+use typed_store::Map;
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 pub use crate::authority::authority_per_epoch_store::{
@@ -110,8 +113,6 @@ use crate::stake_aggregator::StakeAggregator;
 use crate::{
     event_handler::EventHandler, transaction_input_checker, transaction_manager::TransactionManager,
 };
-use sui_adapter::execution_engine;
-use sui_types::digests::TransactionEventsDigest;
 
 #[cfg(test)]
 #[path = "unit_tests/authority_tests.rs"]
@@ -1183,6 +1184,7 @@ impl AuthorityState {
         // TODO: index_tx really just need the transaction data here.
         cert: &VerifiedExecutableTransaction,
         effects: &TransactionEffects,
+        events: &TransactionEvents,
         timestamp_ms: u64,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<u64> {
@@ -1210,6 +1212,7 @@ impl AuthorityState {
                 .map(|(package, module, function)| {
                     (*package, module.to_owned(), function.to_owned())
                 }),
+            events,
             changes,
             digest,
             timestamp_ms,
@@ -1407,6 +1410,7 @@ impl AuthorityState {
                     tx_digest,
                     certificate,
                     effects,
+                    events,
                     timestamp_ms,
                     epoch_store,
                 )
@@ -2327,11 +2331,13 @@ impl AuthorityState {
             .multi_get_checkpoint_by_sequence_number(sequence_numbers)?)
     }
 
-    pub async fn get_transaction_events(
+    pub fn get_transaction_events(
         &self,
-        digest: TransactionEventsDigest,
+        digest: &TransactionEventsDigest,
     ) -> SuiResult<TransactionEvents> {
-        self.database.get_events(&digest)
+        self.database
+            .get_events(digest)?
+            .ok_or(SuiError::TransactionEventsNotFound { digest: *digest })
     }
 
     fn get_indexes(&self) -> SuiResult<Arc<IndexStore>> {
@@ -2434,13 +2440,6 @@ impl AuthorityState {
         Ok(self.get_indexes()?.get_timestamp_ms(digest)?)
     }
 
-    /// Returns a full handle to the event store, including inserts... so be careful!
-    fn get_event_store(&self) -> Option<Arc<EventStoreType>> {
-        self.event_handler
-            .as_ref()
-            .map(|handler| handler.event_store.clone())
-    }
-
     pub async fn query_events(
         &self,
         query: EventQuery,
@@ -2449,101 +2448,108 @@ impl AuthorityState {
         limit: usize,
         descending: bool,
     ) -> Result<Vec<(EventID, SuiEventEnvelope)>, anyhow::Error> {
-        let es = self.get_event_store().ok_or(SuiError::NoEventStore)?;
+        let index_store = self.get_indexes()?;
 
         //Get the tx_num from tx_digest
         let (tx_num, event_num) = if let Some(cursor) = cursor.as_ref() {
-            let tx_seq = self
-                .get_indexes()?
+            let tx_seq = index_store
                 .get_transaction_seq(&cursor.tx_digest)?
-                .ok_or_else(|| anyhow!("Transaction [{:?}] not found.", cursor.tx_digest))?;
-            (tx_seq as i64, cursor.event_seq)
+                .ok_or_else(|| SuiError::TransactionNotFound {
+                    digest: cursor.tx_digest,
+                })?;
+            (tx_seq, cursor.event_seq as usize)
         } else if descending {
-            (i64::MAX, i64::MAX)
+            (u64::MAX, usize::MAX)
         } else {
             (0, 0)
         };
 
         let limit = limit + 1;
-        let mut stored_events = match query {
-            EventQuery::All => es.all_events(tx_num, event_num, limit, descending).await?,
+        let mut event_keys = match query {
+            EventQuery::All => index_store.all_events(tx_num, event_num, limit, descending)?,
             EventQuery::Transaction(digest) => {
-                es.events_by_transaction(digest, tx_num, event_num, limit, descending)
-                    .await?
+                index_store.events_by_transaction(&digest, tx_num, event_num, limit, descending)?
             }
             EventQuery::MoveModule { package, module } => {
                 let module_id = ModuleId::new(
                     AccountAddress::from(package),
                     Identifier::from_str(&module)?,
                 );
-                es.events_by_module_id(&module_id, tx_num, event_num, limit, descending)
-                    .await?
+                index_store.events_by_module_id(&module_id, tx_num, event_num, limit, descending)?
             }
             EventQuery::MoveEvent(struct_name) => {
-                let normalized_struct_name = parse_sui_struct_tag(&struct_name)?.to_string();
-                es.events_by_move_event_struct_name(
-                    &normalized_struct_name,
+                let struct_name = parse_sui_struct_tag(&struct_name)?;
+                index_store.events_by_move_event_struct_name(
+                    &struct_name,
                     tx_num,
                     event_num,
                     limit,
                     descending,
-                )
-                .await?
+                )?
             }
             EventQuery::Sender(sender) => {
-                es.events_by_sender(&sender, tx_num, event_num, limit, descending)
-                    .await?
+                index_store.events_by_sender(&sender, tx_num, event_num, limit, descending)?
             }
             EventQuery::Recipient(recipient) => {
-                es.events_by_recipient(&recipient, tx_num, event_num, limit, descending)
-                    .await?
+                index_store.events_by_recipient(&recipient, tx_num, event_num, limit, descending)?
             }
             EventQuery::Object(object) => {
-                es.events_by_object(&object, tx_num, event_num, limit, descending)
-                    .await?
+                index_store.events_by_object(&object, tx_num, event_num, limit, descending)?
             }
             EventQuery::TimeRange {
                 start_time,
                 end_time,
-            } => {
-                es.event_iterator(start_time, end_time, tx_num, event_num, limit, descending)
-                    .await?
-            }
+            } => index_store
+                .event_iterator(start_time, end_time, tx_num, event_num, limit, descending)?,
             EventQuery::EventType(event_type) => {
-                es.events_by_type(event_type, tx_num, event_num, limit, descending)
-                    .await?
+                index_store.events_by_type(&event_type, tx_num, event_num, limit, descending)?
             }
         };
+
         // skip one event if exclusive cursor is provided,
         // otherwise truncate to the original limit.
         if cursor.is_some() {
-            if !stored_events.is_empty() {
-                stored_events.remove(0);
+            if !event_keys.is_empty() {
+                event_keys.remove(0);
             }
         } else {
-            stored_events.truncate(limit - 1);
+            event_keys.truncate(limit - 1);
         }
-        let mut events = StoredEvent::into_event_envelopes(stored_events)?;
-        // populate parsed json event
-        for event in &mut events {
-            if let SuiEvent::MoveEvent {
-                type_, fields, bcs, ..
-            } = &mut event.1.event
-            {
-                let struct_tag = parse_struct_tag(type_)?;
-                let event = Event::move_event_to_move_struct(
-                    &struct_tag,
-                    bcs,
+        let keys = event_keys.iter().map(|(digest, _, seq, _)| (*digest, *seq));
+
+        let stored_events = self
+            .database
+            .perpetual_tables
+            .events
+            .multi_get(keys)?
+            .into_iter()
+            .zip(event_keys.into_iter())
+            .map(|(e, (digest, tx_digest, event_seq, timestamp))| {
+                e.map(|e| (e, tx_digest, event_seq, timestamp))
+                    .ok_or(SuiError::TransactionEventsNotFound { digest })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut events = vec![];
+        for (e, tx_digest, event_seq, timestamp) in stored_events {
+            let id = EventID {
+                tx_digest,
+                event_seq: event_seq as i64,
+            };
+            events.push((
+                id.clone(),
+                SuiEventEnvelope {
+                    timestamp,
+                    tx_digest,
+                    id,
                     // threading the epoch_store through this API does not
                     // seem possible, so we just read it from the state (self) and fetch
                     // the module cache out of it.
                     // Notice that no matter what module cache we get things
                     // should work
-                    &**self.epoch_store.load().module_cache(),
-                )?;
-                let (_, event) = type_and_fields_from_move_struct(&struct_tag, event);
-                *fields = Some(event)
-            }
+                    event: SuiEvent::try_from(e, &**self.epoch_store.load().module_cache())?,
+                },
+            ))
         }
         Ok(events)
     }
@@ -2597,7 +2603,7 @@ impl AuthorityState {
             if let Some(transaction) = self.database.get_transaction(transaction_digest)? {
                 let cert_sig = epoch_store.get_transaction_cert_sig(transaction_digest)?;
                 let events = if let Some(digest) = effects.events_digest() {
-                    self.database.get_events(digest)?
+                    self.get_transaction_events(digest)?
                 } else {
                     TransactionEvents::default()
                 };
@@ -3299,8 +3305,9 @@ impl AuthorityState {
 
 #[cfg(msim)]
 pub mod sui_framework_injection {
-    use super::*;
     use std::cell::RefCell;
+
+    use super::*;
 
     // Thread local cache because all simtests run in a single unique thread.
     thread_local! {
@@ -3360,8 +3367,9 @@ pub mod sui_framework_injection {
 
 #[cfg(not(msim))]
 pub mod sui_framework_injection {
-    use super::*;
     use move_binary_format::CompiledModule;
+
+    use super::*;
 
     pub fn get_bytes(_name: AuthorityName) -> Vec<Vec<u8>> {
         sui_framework::get_sui_framework_bytes()

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -85,7 +85,7 @@ pub struct AuthorityPerpetualTables {
     // Currently this is needed in the validator for returning events during process certificates.
     // We could potentially remove this if we decided not to provide events in the execution path.
     // TODO: Figure out what to do with this table in the long run. Also we need a pruning policy for this table.
-    pub(crate) events: DBMap<TransactionEventsDigest, TransactionEvents>,
+    pub(crate) events: DBMap<(TransactionEventsDigest, usize), Event>,
 
     /// When transaction is executed via checkpoint executor, we store association here
     pub(crate) executed_transactions_to_checkpoint:

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -314,7 +314,7 @@ impl ValidatorService {
             state.get_signed_effects_and_maybe_resign(&tx_digest, &epoch_store)?
         {
             let events = if let Some(digest) = signed_effects.events_digest() {
-                state.get_transaction_events(*digest).await?
+                state.get_transaction_events(digest)?
             } else {
                 TransactionEvents::default()
             };
@@ -421,7 +421,7 @@ impl ValidatorService {
         match res {
             Ok(effects) => {
                 let events = if let Some(event_digest) = effects.events_digest() {
-                    state.get_transaction_events(*event_digest).await?
+                    state.get_transaction_events(event_digest)?
                 } else {
                     TransactionEvents::default()
                 };

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -114,7 +114,7 @@ impl ReadStore for RocksDbStore {
         &self,
         digest: &TransactionEventsDigest,
     ) -> Result<Option<TransactionEvents>, Self::Error> {
-        self.authority_store.perpetual_tables.events.get(digest)
+        self.authority_store.get_events(digest)
     }
 }
 

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -156,7 +156,7 @@ impl LocalAuthorityClient {
             .into_inner();
 
         let events = if let Some(digest) = signed_effects.events_digest() {
-            state.get_transaction_events(*digest).await?
+            state.get_transaction_events(digest)?
         } else {
             TransactionEvents::default()
         };

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -409,7 +409,7 @@ async fn test_object_owning_another_object() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };
@@ -435,7 +435,7 @@ async fn test_object_owning_another_object() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };
@@ -535,7 +535,7 @@ async fn test_object_owning_another_object() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };
@@ -563,7 +563,7 @@ async fn test_object_owning_another_object() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };
@@ -658,7 +658,7 @@ async fn test_create_then_delete_parent_child() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };
@@ -720,7 +720,7 @@ async fn test_create_then_delete_parent_child_wrap() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };
@@ -764,7 +764,7 @@ async fn test_create_then_delete_parent_child_wrap() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };
@@ -817,7 +817,7 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };
@@ -843,7 +843,7 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };
@@ -869,7 +869,7 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };
@@ -893,7 +893,7 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     .await
     .unwrap();
     let events = if let Some(digest) = &effects.events_digest() {
-        authority.database.get_events(digest).unwrap().data
+        authority.get_transaction_events(digest).unwrap().data
     } else {
         vec![]
     };

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -143,7 +143,7 @@ impl CoinReadApi {
             .await?;
 
         let events = if let Some(digests) = effect.events_digest() {
-            self.state.get_transaction_events(*digests).await?
+            self.state.get_transaction_events(digests)?
         } else {
             TransactionEvents::default()
         };

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -370,8 +370,7 @@ impl ReadApiServer for ReadApi {
             if let Some(digest) = temp_response.effects.as_ref().unwrap().events_digest() {
                 let events = self
                     .state
-                    .get_transaction_events(*digest)
-                    .await
+                    .get_transaction_events(digest)
                     .map_err(Error::from)?;
                 match to_sui_transaction_events(self, events) {
                     Ok(e) => temp_response.events = Some(e),

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -272,7 +272,7 @@ impl IndexStore {
                 .data
                 .iter()
                 .enumerate()
-                .map(|(i, e)| ((sequence, i), (event_digest, *digest, timestamp_ms))),
+                .map(|(i, _)| ((sequence, i), (event_digest, *digest, timestamp_ms))),
         )?;
         let batch = batch.insert_batch(
             &self.tables.event_by_move_module,

--- a/crates/sui-types/src/event.rs
+++ b/crates/sui-types/src/event.rs
@@ -384,7 +384,7 @@ impl Event {
 
     /// Extract a module name, if available, from a SuiEvent
     // TODO: should we switch to IdentStr or &str?  These are more complicated to make work due to lifetimes
-    pub fn module_name(&self) -> Option<&str> {
+    pub fn module_name(&self) -> Option<&IdentStr> {
         match self {
             Event::MoveEvent {
                 transaction_module, ..
@@ -403,7 +403,7 @@ impl Event {
             }
             | Event::CoinBalanceChange {
                 transaction_module, ..
-            } => Some(transaction_module.as_str()),
+            } => Some(transaction_module),
             _ => None,
         }
     }
@@ -449,9 +449,9 @@ impl Event {
 
     /// Extracts the move event name (StructTag) from a SuiEvent, if available
     /// "0x2::devnet_nft::MintNFTEvent"
-    pub fn move_event_name(&self) -> Option<String> {
+    pub fn move_event_name(&self) -> Option<&StructTag> {
         if let Event::MoveEvent { type_, .. } = self {
-            Some(type_.to_string())
+            Some(type_)
         } else {
             None
         }

--- a/crates/sui-types/src/filter.rs
+++ b/crates/sui-types/src/filter.rs
@@ -49,7 +49,7 @@ impl EventFilter {
                 matches!(&item.event.package_id(), Some(id) if id == object_id)
             }
             EventFilter::Module(module) => {
-                matches!(item.event.module_name(), Some(name) if name == module.as_str())
+                matches!(item.event.module_name(), Some(name) if name == module.as_ident_str())
             }
             EventFilter::ObjectId(object_id) => {
                 matches!(item.event.object_id(), Some(id) if &id == object_id)


### PR DESCRIPTION
## Description 

This is needed to retain queryEvent functionality in the full node.

## Test Plan 

unit tests