### PR TITLE
[lock table] don't preallocate space

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -41,7 +41,6 @@ use super::authority_notify_read::NotifyRead;
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
 
 const NUM_SHARDS: usize = 4096;
-const SHARD_SIZE: usize = 128;
 
 /// ALL_OBJ_VER determines whether we want to store all past
 /// versions of every object in the store. Authority doesn't store
@@ -136,13 +135,13 @@ impl AuthorityStore {
         let epoch = committee.epoch;
 
         let store = Self {
-            mutex_table: MutexTable::new(NUM_SHARDS, SHARD_SIZE),
+            mutex_table: MutexTable::new(NUM_SHARDS),
             perpetual_tables,
             executed_effects_notify_read: NotifyRead::new(),
             root_state_notify_read:
                 NotifyRead::<EpochId, (CheckpointSequenceNumber, Accumulator)>::new(),
             execution_lock: RwLock::new(epoch),
-            objects_lock_table: Arc::new(RwLockTable::new(NUM_SHARDS, SHARD_SIZE)),
+            objects_lock_table: Arc::new(RwLockTable::new(NUM_SHARDS)),
             indirect_objects_threshold,
         };
         // Only initialize an empty database.

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -396,7 +396,7 @@ mod tests {
     }
 
     fn lock_table() -> Arc<RwLockTable<ObjectContentDigest>> {
-        Arc::new(RwLockTable::new(1, 10))
+        Arc::new(RwLockTable::new(1))
     }
 
     async fn run_pruner(

--- a/crates/sui-storage/src/write_ahead_log.rs
+++ b/crates/sui-storage/src/write_ahead_log.rs
@@ -217,7 +217,6 @@ where
 }
 
 pub(crate) const MUTEX_TABLE_SIZE: usize = 1024;
-pub(crate) const MUTEX_TABLE_SHARD_SIZE: usize = 128;
 
 impl<C, ExecutionOutput> DBWriteAheadLog<C, ExecutionOutput>
 where
@@ -240,7 +239,7 @@ where
         Self {
             tables,
             recoverable_txes: Mutex::new(recoverable_txes),
-            mutex_table: MutexTable::new(MUTEX_TABLE_SIZE, MUTEX_TABLE_SHARD_SIZE),
+            mutex_table: MutexTable::new(MUTEX_TABLE_SIZE),
         }
     }
 


### PR DESCRIPTION
don't preallocate space for shards for mutex table
should reduce memory usage on nodes