### PR TITLE
genesis: enable inspecting unsigned genesis checkpoint

### DIFF
--- a/crates/sui/src/genesis_inspector.rs
+++ b/crates/sui/src/genesis_inspector.rs
@@ -3,7 +3,7 @@
 
 use inquire::Select;
 use std::collections::BTreeMap;
-use sui_config::genesis::Genesis;
+use sui_config::genesis::UnsignedGenesis;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     coin::CoinMetadata,
@@ -29,7 +29,7 @@ const STR_OBJECTS: &str = "Objects";
 const STR_VALIDATORS: &str = "Validators";
 
 #[allow(clippy::or_fun_call)]
-pub(crate) fn examine_genesis_checkpoint(genesis: Genesis) {
+pub(crate) fn examine_genesis_checkpoint(genesis: UnsignedGenesis) {
     // Prepare Validator info
     let summary_set = genesis.validator_summary_set();
     let validator_map = summary_set
@@ -48,7 +48,7 @@ pub(crate) fn examine_genesis_checkpoint(genesis: Genesis) {
     validator_options.extend_from_slice(&[STR_ALL, STR_EXIT]);
     println!(
         "Total Number of Validators: {}",
-        genesis.validator_set().len()
+        genesis.validator_summary_set().len()
     );
 
     // Prepare Sui distribution info


### PR DESCRIPTION
## Description 

Enable inspecting unsigned genesis checkpoints as well as fixes a bug that displayed the digest of the contents and not the checkpoint itself.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
