### PR TITLE
indexer: multi get txns and _internal renaming

### DIFF
--- a/crates/sui-indexer/src/apis/event_api.rs
+++ b/crates/sui-indexer/src/apis/event_api.rs
@@ -31,7 +31,7 @@ impl<S: IndexerStore> EventReadApi<S> {
         }
     }
 
-    pub fn get_events(
+    pub fn get_events_internal(
         &self,
         query: EventQuery,
         cursor: Option<EventID>,
@@ -65,7 +65,7 @@ where
                 .get_events(query, cursor, limit, descending_order)
                 .await;
         }
-        Ok(self.get_events(query, cursor, limit, descending_order)?)
+        Ok(self.get_events_internal(query, cursor, limit, descending_order)?)
     }
 
     fn subscribe_event(

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -40,11 +40,11 @@ impl<S: IndexerStore> ReadApi<S> {
         }
     }
 
-    fn get_total_transaction_number(&self) -> Result<u64, IndexerError> {
+    fn get_total_transaction_number_internal(&self) -> Result<u64, IndexerError> {
         self.state.get_total_transaction_number().map(|n| n as u64)
     }
 
-    fn get_transaction_with_options(
+    fn get_transaction_with_options_internal(
         &self,
         digest: &TransactionDigest,
         _options: Option<SuiTransactionResponseOptions>,
@@ -57,7 +57,24 @@ impl<S: IndexerStore> ReadApi<S> {
         Ok(txn_resp)
     }
 
-    fn query_transactions(
+    fn multi_get_transactions_with_options_internal(
+        &self,
+        digests: &[TransactionDigest],
+        _options: Option<SuiTransactionResponseOptions>,
+    ) -> Result<Vec<SuiTransactionResponse>, IndexerError> {
+        let digest_strs = digests
+            .iter()
+            .map(|digest| digest.base58_encode())
+            .collect::<Vec<_>>();
+        let tx_vec = self.state.multi_get_transactions_by_digests(&digest_strs)?;
+        let tx_resp_vec = tx_vec
+            .into_iter()
+            .map(|txn| txn.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(tx_resp_vec)
+    }
+
+    fn query_transactions_internal(
         &self,
         query: SuiTransactionResponseQuery,
         cursor: Option<TransactionDigest>,
@@ -169,7 +186,7 @@ impl<S: IndexerStore> ReadApi<S> {
         })
     }
 
-    fn get_object_with_options(
+    fn get_object_with_options_internal(
         &self,
         object_id: ObjectID,
         options: Option<SuiObjectDataOptions>,
@@ -178,13 +195,13 @@ impl<S: IndexerStore> ReadApi<S> {
         Ok((read, options.unwrap_or_default()).try_into()?)
     }
 
-    fn get_latest_checkpoint_sequence_number(&self) -> Result<u64, IndexerError> {
+    fn get_latest_checkpoint_sequence_number_internal(&self) -> Result<u64, IndexerError> {
         self.state
             .get_latest_checkpoint_sequence_number()
             .map(|n| n as u64)
     }
 
-    fn get_checkpoint(&self, id: CheckpointId) -> Result<Checkpoint, IndexerError> {
+    fn get_checkpoint_internal(&self, id: CheckpointId) -> Result<Checkpoint, IndexerError> {
         let checkpoint = self.state.get_checkpoint(id)?;
         checkpoint.try_into()
     }
@@ -217,7 +234,7 @@ where
                 .await;
         }
 
-        Ok(self.get_object_with_options(object_id, options)?)
+        Ok(self.get_object_with_options_internal(object_id, options)?)
     }
 
     async fn multi_get_object_with_options(
@@ -259,7 +276,7 @@ where
         {
             return self.fullnode.get_total_transaction_number().await;
         }
-        Ok(self.get_total_transaction_number()?)
+        Ok(self.get_total_transaction_number_internal()?)
     }
 
     async fn query_transactions(
@@ -278,7 +295,7 @@ where
                 .query_transactions(query, cursor, limit, descending_order)
                 .await;
         }
-        Ok(self.query_transactions(query, cursor, limit, descending_order)?)
+        Ok(self.query_transactions_internal(query, cursor, limit, descending_order)?)
     }
 
     async fn get_transactions_in_range_deprecated(
@@ -305,7 +322,7 @@ where
                 .get_transaction_with_options(digest, options)
                 .await;
         }
-        Ok(self.get_transaction_with_options(&digest, options)?)
+        Ok(self.get_transaction_with_options_internal(&digest, options)?)
     }
 
     async fn multi_get_transactions_with_options(
@@ -322,8 +339,7 @@ where
                 .multi_get_transactions_with_options(digests, options)
                 .await;
         }
-        self.multi_get_transactions_with_options(digests, options)
-            .await
+        Ok(self.multi_get_transactions_with_options_internal(&digests, options)?)
     }
 
     async fn get_normalized_move_modules_by_package(
@@ -406,7 +422,7 @@ where
         {
             return self.fullnode.get_latest_checkpoint_sequence_number().await;
         }
-        Ok(self.get_latest_checkpoint_sequence_number()?)
+        Ok(self.get_latest_checkpoint_sequence_number_internal()?)
     }
 
     async fn get_checkpoint(&self, id: CheckpointId) -> RpcResult<Checkpoint> {
@@ -416,7 +432,7 @@ where
         {
             return self.fullnode.get_checkpoint(id).await;
         }
-        Ok(self.get_checkpoint(id)?)
+        Ok(self.get_checkpoint_internal(id)?)
     }
 }
 

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -44,6 +44,10 @@ pub trait IndexerStore {
 
     // TODO: combine all get_transaction* methods
     fn get_transaction_by_digest(&self, txn_digest: &str) -> Result<Transaction, IndexerError>;
+    fn multi_get_transactions_by_digests(
+        &self,
+        txn_digests: &[String],
+    ) -> Result<Vec<Transaction>, IndexerError>;
 
     fn get_all_transaction_digest_page(
         &self,

--- a/crates/sui-indexer/tests/indexer_tests.rs
+++ b/crates/sui-indexer/tests/indexer_tests.rs
@@ -177,6 +177,13 @@ impl IndexerStore for InMemoryIndexerStore {
         todo!()
     }
 
+    fn multi_get_transactions_by_digests(
+        &self,
+        _txn_digests: &[String],
+    ) -> Result<Vec<Transaction>, IndexerError> {
+        todo!()
+    }
+
     fn read_transactions(
         &self,
         _last_processed_id: i64,


### PR DESCRIPTION
## Description 

- implement multi getter for txn to avoid stack overflow
- it was error-prone that sync and async functions share the same function name, changing the sync ones to *_internal to avoid that

## Test Plan 

CI
