### PR TITLE
easy: rename mutated / all_mutated object(s) to changed / all_changed…

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1200,7 +1200,7 @@ impl AuthorityState {
                 .iter()
                 .map(|o| o.object_id()),
             effects
-                .all_mutated()
+                .all_changed_objects()
                 .into_iter()
                 .map(|(obj_ref, owner, _kind)| (*obj_ref, *owner)),
             cert.data()
@@ -1246,7 +1246,7 @@ impl AuthorityState {
         let mut new_owners = vec![];
         let mut new_dynamic_fields = vec![];
 
-        for (oref, owner, kind) in effects.all_mutated() {
+        for (oref, owner, kind) in effects.all_changed_objects() {
             let id = &oref.0;
             // For mutated objects, retrieve old owner and delete old index if there is a owner change.
             if let WriteKind::Mutate = kind {

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -123,7 +123,7 @@ impl<S: IndexerStore> ReadApi<S> {
             // serialized transaction and retrive from there.
             // This is now blocked by the endpoint on FN side.
             Some(TransactionFilter::InputObject(_input_obj_id)) => Ok(vec![]),
-            Some(TransactionFilter::MutatedObject(mutated_obj_id)) => {
+            Some(TransactionFilter::ChangedObject(mutated_obj_id)) => {
                 let indexer_seq_number = self
                     .state
                     .get_transaction_sequence_by_digest(cursor_str, is_descending)?;

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -123,7 +123,7 @@ pub trait IndexerStore {
 pub struct CheckpointData {
     pub checkpoint: RpcCheckpoint,
     pub transactions: Vec<SuiTransactionResponse>,
-    pub all_mutated_objects: Vec<(ObjectStatus, SuiObjectData)>,
+    pub changed_objects: Vec<(ObjectStatus, SuiObjectData)>,
 }
 
 // Per checkpoint indexing

--- a/crates/sui-json-rpc/src/balance_changes.rs
+++ b/crates/sui-json-rpc/src/balance_changes.rs
@@ -35,7 +35,7 @@ pub async fn get_balance_change_from_effect<P: ObjectProvider<Error = E>, E>(
         }]);
     }
 
-    let all_mutated: Vec<(&ObjectRef, &Owner, WriteKind)> = effects.all_mutated();
+    let all_mutated: Vec<(&ObjectRef, &Owner, WriteKind)> = effects.all_changed_objects();
     let all_mutated = all_mutated
         .iter()
         .map(|((id, version, _), _, _)| (*id, *version))

--- a/crates/sui-json-rpc/src/object_changes.rs
+++ b/crates/sui-json-rpc/src/object_changes.rs
@@ -15,7 +15,7 @@ pub async fn get_object_change_from_effect<P: ObjectProvider<Error = E>, E>(
 ) -> Result<Vec<ObjectChange>, E> {
     let mut object_changes = vec![];
 
-    for ((id, version, digest), owner, kind) in effects.all_mutated() {
+    for ((id, version, digest), owner, kind) in effects.all_changed_objects() {
         let o = object_provider.get_object(id, version).await?;
         if let Some(type_) = o.type_() {
             let type_ = match type_ {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6991,13 +6991,13 @@
             "additionalProperties": false
           },
           {
-            "description": "Query by mutated object.",
+            "description": "Query by changed object, including created, mutated and unwrapped objects.",
             "type": "object",
             "required": [
-              "MutatedObject"
+              "ChangedObject"
             ],
             "properties": {
-              "MutatedObject": {
+              "ChangedObject": {
                 "$ref": "#/components/schemas/ObjectID"
               }
             },

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -381,7 +381,7 @@ impl IndexStore {
             Some(TransactionFilter::InputObject(object_id)) => {
                 self.get_transactions_by_input_object(object_id, cursor, limit, reverse)?
             }
-            Some(TransactionFilter::MutatedObject(object_id)) => {
+            Some(TransactionFilter::ChangedObject(object_id)) => {
                 self.get_transactions_by_mutated_object(object_id, cursor, limit, reverse)?
             }
             Some(TransactionFilter::FromAddress(address)) => {

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2695,8 +2695,9 @@ pub trait TransactionEffectsAPI {
     fn gas_object(&self) -> &(ObjectRef, Owner);
     fn events_digest(&self) -> Option<&TransactionEventsDigest>;
     fn dependencies(&self) -> &[TransactionDigest];
-
-    fn all_mutated(&self) -> Vec<(&ObjectRef, &Owner, WriteKind)>;
+    // All changed objects include created, mutated and unwrapped objects,
+    // they do NOT include wrapped and deleted.
+    fn all_changed_objects(&self) -> Vec<(&ObjectRef, &Owner, WriteKind)>;
 
     fn all_deleted(&self) -> Vec<(&ObjectRef, DeleteKind)>;
 
@@ -2763,11 +2764,11 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
         self.executed_epoch
     }
 
-    /// Return an iterator that iterates through all mutated objects, including mutated,
+    /// Return an iterator that iterates through all changed objects, including mutated,
     /// created and unwrapped objects. In other words, all objects that still exist
     /// in the object state after this transaction.
     /// It doesn't include deleted/wrapped objects.
-    fn all_mutated(&self) -> Vec<(&ObjectRef, &Owner, WriteKind)> {
+    fn all_changed_objects(&self) -> Vec<(&ObjectRef, &Owner, WriteKind)> {
         self.mutated
             .iter()
             .map(|(r, o)| (r, o, WriteKind::Mutate))

--- a/crates/sui-types/src/query.rs
+++ b/crates/sui-types/src/query.rs
@@ -20,8 +20,8 @@ pub enum TransactionFilter {
     },
     /// Query by input object.
     InputObject(ObjectID),
-    /// Query by mutated object.
-    MutatedObject(ObjectID),
+    /// Query by changed object, including created, mutated and unwrapped objects.
+    ChangedObject(ObjectID),
     /// Query by sender address.
     FromAddress(SuiAddress),
     /// Query by recipient address.

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -245,7 +245,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     assert_eq!(txes[0], digest);
 
     let txes = node.state().get_transactions(
-        Some(TransactionFilter::MutatedObject(transferred_object)),
+        Some(TransactionFilter::ChangedObject(transferred_object)),
         None,
         None,
         false,


### PR DESCRIPTION
… objects

## Description 
 
mutated / all_mutated actually includes mutated, created and unwrapped objects, which is very error prone.

## Test Plan 

CI

