### PR TITLE
[programmable transactions] Removed dead types

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -23,8 +23,7 @@ use sui_types::base_types::{
 };
 use sui_types::error::{UserInputError, UserInputResult};
 use sui_types::gas_coin::GasCoin;
-use sui_types::messages::MoveModulePublish;
-use sui_types::move_package::{disassemble_modules, MovePackage};
+use sui_types::move_package::MovePackage;
 use sui_types::object::{Data, MoveObject, Object, ObjectFormatOptions, ObjectRead, Owner};
 use sui_types::parse_sui_struct_tag;
 
@@ -835,15 +834,6 @@ impl SuiPastObjectResponse {
 #[serde(rename = "MovePackage", rename_all = "camelCase")]
 pub struct SuiMovePackage {
     pub disassembled: BTreeMap<String, Value>,
-}
-
-impl From<MoveModulePublish> for SuiMovePackage {
-    fn from(m: MoveModulePublish) -> Self {
-        Self {
-            // In case of failed publish transaction, disassemble can fail, we can only return empty module map in that case.
-            disassembled: disassemble_modules(m.modules.iter()).unwrap_or_default(),
-        }
-    }
 }
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema, Ord, PartialOrd, Eq, PartialEq, Debug)]

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -144,9 +144,6 @@ pub struct ProtocolConfig {
     /// Maximum serialized size of a transaction (in bytes).
     max_tx_size: Option<u64>,
 
-    /// Maximum number of individual transactions in a Batch transaction.
-    max_tx_in_batch: Option<u32>,
-
     /// Maximum number of input objects.
     max_input_objects: Option<u64>,
 
@@ -174,16 +171,6 @@ pub struct ProtocolConfig {
 
     /// Maximum size of a Pure CallArg.
     max_pure_argument_size: Option<u32>,
-
-    /// Maximum size of an ObjVec CallArg.
-    max_object_vec_argument_size: Option<u32>,
-
-    /// Maximum number of coins in Pay* transactions, or a ProgrammableTransaction's
-    /// MergeCoins command.
-    max_coins: Option<u32>,
-
-    /// Maximum number of recipients in Pay* transactions.
-    max_pay_recipients: Option<u32>,
 
     /// Maximum number of Commands in a ProgrammableTransaction.
     max_programmable_tx_commands: Option<u32>,
@@ -411,9 +398,6 @@ impl ProtocolConfig {
     pub fn max_tx_size(&self) -> u64 {
         self.max_tx_size.expect(CONSTANT_ERR_MSG)
     }
-    pub fn max_tx_in_batch(&self) -> u32 {
-        self.max_tx_in_batch.expect(CONSTANT_ERR_MSG)
-    }
     pub fn max_input_objects(&self) -> u64 {
         self.max_input_objects.expect(CONSTANT_ERR_MSG)
     }
@@ -442,15 +426,6 @@ impl ProtocolConfig {
     }
     pub fn max_pure_argument_size(&self) -> u32 {
         self.max_pure_argument_size.expect(CONSTANT_ERR_MSG)
-    }
-    pub fn max_object_vec_argument_size(&self) -> u32 {
-        self.max_object_vec_argument_size.expect(CONSTANT_ERR_MSG)
-    }
-    pub fn max_coins(&self) -> u32 {
-        self.max_coins.expect(CONSTANT_ERR_MSG)
-    }
-    pub fn max_pay_recipients(&self) -> u32 {
-        self.max_pay_recipients.expect(CONSTANT_ERR_MSG)
     }
     pub fn max_programmable_tx_commands(&self) -> u32 {
         self.max_programmable_tx_commands.expect(CONSTANT_ERR_MSG)
@@ -747,7 +722,6 @@ impl ProtocolConfig {
                 feature_flags: Default::default(),
 
                 max_tx_size: Some(64 * 1024),
-                max_tx_in_batch: Some(10),
                 // We need this number to be at least 100x less than `max_serialized_tx_effects_size_bytes`otherwise effects can be huge
                 max_input_objects: Some(2048),
                 max_serialized_tx_effects_size_bytes: Some(512 * 1024),
@@ -758,9 +732,6 @@ impl ProtocolConfig {
                 max_type_arguments: Some(16),
                 max_type_argument_depth: Some(16),
                 max_pure_argument_size: Some(16 * 1024),
-                max_object_vec_argument_size: Some(128),
-                max_coins: Some(1024),
-                max_pay_recipients: Some(1024),
                 max_programmable_tx_commands: Some(1024),
                 move_binary_format_version: Some(6),
                 max_move_object_size: Some(250 * 1024),

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
@@ -6,7 +6,6 @@ version: 1
 feature_flags:
   package_upgrades: false
 max_tx_size: 65536
-max_tx_in_batch: 10
 max_input_objects: 2048
 max_serialized_tx_effects_size_bytes: 524288
 max_serialized_tx_effects_size_bytes_system_tx: 8388608
@@ -16,9 +15,6 @@ max_arguments: 512
 max_type_arguments: 16
 max_type_argument_depth: 16
 max_pure_argument_size: 16384
-max_object_vec_argument_size: 128
-max_coins: 1024
-max_pay_recipients: 1024
 max_programmable_tx_commands: 1024
 move_binary_format_version: 6
 max_move_object_size: 256000


### PR DESCRIPTION
## Description 

- Removed some dead types that were not removed with PT migration
- Fixed limit code not being called

## Test Plan 

- Suggestions? 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
