### PR TITLE
Support for future multi-tx certs

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -901,7 +901,7 @@ fn create_genesis_transaction(
                 .expect("We defined natives to not fail here"),
         );
 
-        let transaction_data = &genesis_transaction.data().intent_message.value;
+        let transaction_data = &genesis_transaction.data().intent_message().value;
         let (kind, signer, gas) = transaction_data.execution_parts();
         let (inner_temp_store, effects, _execution_error) =
             sui_adapter::execution_engine::execute_transaction_to_effects::<
@@ -1256,7 +1256,7 @@ mod test {
                 .expect("We defined natives to not fail here"),
         );
 
-        let transaction_data = &genesis_transaction.data().intent_message.value;
+        let transaction_data = &genesis_transaction.data().intent_message().value;
         let (kind, signer, gas) = transaction_data.execution_parts();
         let (_inner_temp_store, effects, _execution_error) =
             sui_adapter::execution_engine::execute_transaction_to_effects::<

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -499,7 +499,7 @@ impl AuthorityState {
         let (_gas_status, input_objects) = transaction_input_checker::check_transaction_input(
             &self.database,
             epoch_store.as_ref(),
-            &transaction.data().intent_message.value,
+            &transaction.data().intent_message().value,
         )
         .await?;
 
@@ -545,10 +545,15 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
         transaction: VerifiedTransaction,
     ) -> Result<HandleTransactionResponse, SuiError> {
+        fp_ensure!(
+            !transaction.is_system_tx(),
+            SuiError::InvalidSystemTransaction
+        );
+
         let tx_digest = *transaction.digest();
         debug!(
             "handle_transaction with transaction data: {:?}",
-            &transaction.data().intent_message.value
+            &transaction.data().intent_message().value
         );
 
         // Ensure an idempotent answer. This is checked before the system_tx check so that
@@ -923,7 +928,7 @@ impl AuthorityState {
         self.metrics.batch_size.observe(
             certificate
                 .data()
-                .intent_message
+                .intent_message()
                 .value
                 .kind()
                 .num_commands() as f64,
@@ -969,7 +974,7 @@ impl AuthorityState {
             *certificate.digest(),
             epoch_store.protocol_config(),
         );
-        let transaction_data = &certificate.data().intent_message.value;
+        let transaction_data = &certificate.data().intent_message().value;
         let (kind, signer, gas) = transaction_data.execution_parts();
         let (inner_temp_store, effects, _execution_error) =
             execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
@@ -1192,9 +1197,9 @@ impl AuthorityState {
             .tap_err(|e| warn!("{e}"))?;
 
         indexes.index_tx(
-            cert.data().intent_message.value.sender(),
+            cert.data().intent_message().value.sender(),
             cert.data()
-                .intent_message
+                .intent_message()
                 .value
                 .input_objects()?
                 .iter()
@@ -1204,7 +1209,7 @@ impl AuthorityState {
                 .into_iter()
                 .map(|(obj_ref, owner, _kind)| (*obj_ref, *owner)),
             cert.data()
-                .intent_message
+                .intent_message()
                 .value
                 .move_calls()
                 .into_iter()

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1352,7 +1352,7 @@ impl AuthorityPerEpochStore {
             .contains_key(certificate.digest())?);
         let batch = batch.insert_batch(
             &self.tables.user_signatures_for_checkpoints,
-            [(*certificate.digest(), certificate.tx_signatures.clone())],
+            [(*certificate.digest(), certificate.tx_signatures().to_vec())],
         )?;
         self.finish_consensus_transaction_process_with_batch(batch, key, consensus_index)
     }

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -992,7 +992,7 @@ where
         );
         trace!(
             "Transaction data: {:?}",
-            transaction.data().intent_message.value
+            transaction.data().intent_message().value
         );
 
         let committee = Arc::new(self.committee.clone());

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -340,7 +340,7 @@ impl ValidatorService {
         for (object_id, queue_len) in state.transaction_manager().objects_queue_len(
             certificate
                 .data()
-                .intent_message
+                .intent_message()
                 .value
                 .kind()
                 .input_objects()

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -240,7 +240,7 @@ mod tests {
             .into_iter()
             .map(|mut cert| {
                 // set it to an all-zero user signature
-                cert.tx_signatures[0] =
+                cert.tx_signatures_mut_for_testing()[0] =
                     GenericSignature::Signature(sui_types::crypto::Signature::Ed25519SuiSignature(
                         Ed25519SuiSignature::default(),
                     ));

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -138,7 +138,7 @@ pub async fn check_certificate_input(
         protocol_version
     );
 
-    let tx_data = &cert.data().intent_message.value;
+    let tx_data = &cert.data().intent_message().value;
     let input_object_kinds = tx_data.input_objects()?;
     let input_object_data = if tx_data.is_change_epoch_tx() {
         // When changing the epoch, we update a the system object, which is shared, without going

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -132,7 +132,7 @@ impl TransactionManager {
                     .inc();
                 continue;
             }
-            let input_object_kinds = cert.data().intent_message.value.input_objects()?;
+            let input_object_kinds = cert.data().intent_message().value.input_objects()?;
             let input_object_keys = self.authority_store.get_input_object_keys(
                 &digest,
                 &input_object_kinds,

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -204,8 +204,8 @@ where
                 votes.push(sig);
                 if let Some(inner_transaction) = tx_data {
                     assert_eq!(
-                        inner_transaction.intent_message.value,
-                        data.intent_message.value
+                        inner_transaction.intent_message().value,
+                        data.intent_message().value
                     );
                 }
                 tx_data = Some(data);

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -238,7 +238,7 @@ async fn test_dry_run_transaction() {
 
     let response = fullnode
         .dry_exec_transaction(
-            transaction.data().intent_message.value.clone(),
+            transaction.data().intent_message().value.clone(),
             transaction_digest,
         )
         .await
@@ -262,7 +262,7 @@ async fn test_dry_run_transaction() {
         .version();
     assert_eq!(shared_object_version, initial_shared_object_version);
 
-    let txn_data = &transaction.data().intent_message.value;
+    let txn_data = &transaction.data().intent_message().value;
     let txn_data = TransactionData::new_with_gas_coins(
         txn_data.kind().clone(),
         txn_data.sender(),
@@ -900,7 +900,7 @@ async fn test_dry_run_on_validator() {
     let transaction_digest = *transaction.digest();
     let response = validator
         .dry_exec_transaction(
-            transaction.data().intent_message.value.clone(),
+            transaction.data().intent_message().value.clone(),
             transaction_digest,
         )
         .await;
@@ -950,11 +950,12 @@ async fn test_handle_transfer_transaction_bad_signature() {
 
     let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
     let mut bad_signature_transfer_transaction = transfer_transaction.clone().into_inner();
-    bad_signature_transfer_transaction
+    *bad_signature_transfer_transaction
         .data_mut_for_testing()
-        .tx_signatures =
+        .tx_signatures_mut_for_testing() =
         vec![
-            Signature::new_secure(&transfer_transaction.data().intent_message, &unknown_key).into(),
+            Signature::new_secure(transfer_transaction.data().intent_message(), &unknown_key)
+                .into(),
         ];
 
     assert!(client
@@ -1240,8 +1241,8 @@ async fn test_handle_transfer_transaction_ok() {
     };
 
     assert_eq!(
-        envelope.data().intent_message.value,
-        transfer_transaction.data().intent_message.value
+        envelope.data().intent_message().value,
+        transfer_transaction.data().intent_message().value
     );
 }
 

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -299,7 +299,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
     // genesis objects are read during transaction since they are direct dependencies.
     let genesis_objects = create_genesis_module_packages();
     // We need the original package bytes in order to reproduce the publish computation cost.
-    let publish_bytes = match response.0.data().intent_message.value.kind() {
+    let publish_bytes = match response.0.data().intent_message().value.kind() {
         TransactionKind::ProgrammableTransaction(pt) => match pt.commands.first().unwrap() {
             Command::Publish(modules) => modules,
             _ => unreachable!(),

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -835,8 +835,8 @@ impl TryFrom<SenderSignedData> for SuiTransaction {
 
     fn try_from(data: SenderSignedData) -> Result<Self, Self::Error> {
         Ok(Self {
-            data: data.intent_message.value.try_into()?,
-            tx_signatures: data.tx_signatures,
+            data: data.intent_message().value.clone().try_into()?,
+            tx_signatures: data.tx_signatures().to_vec(),
         })
     }
 }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -397,7 +397,7 @@ impl ReadApiServer for ReadApi {
             if let (Some(effects), Some(input)) =
                 (&temp_response.effects, &temp_response.transaction)
             {
-                let sender = input.data().intent_message.value.sender();
+                let sender = input.data().intent_message().value.sender();
                 let object_changes = get_object_change_from_effect(&object_cache, sender, effects)
                     .await
                     .map_err(Error::SuiError)?;

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -427,7 +427,7 @@ impl RpcExampleProvider {
 
         let tx = to_sender_signed_transaction(data, &kp);
         let tx1 = tx.clone();
-        let signatures = tx.into_inner().tx_signatures.clone();
+        let signatures = tx.into_inner().tx_signatures().to_vec();
 
         let tx_digest = tx1.digest();
         let sui_event = SuiEvent::TransferObject {

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -300,7 +300,7 @@ pub async fn parse(
 
     let data = if request.signed {
         let tx: Transaction = bcs::from_bytes(&request.transaction.to_vec()?)?;
-        tx.into_data().intent_message.value
+        tx.into_data().intent_message().value.clone()
     } else {
         let intent: IntentMessage<TransactionData> =
             bcs::from_bytes(&request.transaction.to_vec()?)?;

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -600,7 +600,7 @@ impl<'a> SuiTestAdapter<'a> {
         let transaction_digest = TransactionDigest::new(self.rng.gen());
         let (input_objects, objects) = transaction
             .data()
-            .intent_message
+            .intent_message()
             .value
             .input_objects()?
             .into_iter()
@@ -624,7 +624,12 @@ impl<'a> SuiTestAdapter<'a> {
             transaction_digest,
             &PROTOCOL_CONSTANTS,
         );
-        let transaction_data = &transaction.into_inner().into_data().intent_message.value;
+        let transaction_data = &transaction
+            .into_inner()
+            .into_data()
+            .intent_message()
+            .value
+            .clone();
         let (kind, signer, gas) = transaction_data.execution_parts();
 
         let (

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -644,7 +644,7 @@ impl From<&ObjectRef> for ObjectKey {
 /// and immutable objects as well as the gas objects, but not move packages or shared objects.
 pub fn transaction_input_object_keys(tx: &SenderSignedData) -> SuiResult<Vec<ObjectKey>> {
     Ok(tx
-        .intent_message
+        .intent_message()
         .value
         .input_objects()?
         .into_iter()

--- a/crates/sui-types/src/unit_tests/intent_tests.rs
+++ b/crates/sui-types/src/unit_tests/intent_tests.rs
@@ -77,7 +77,7 @@ fn test_authority_signature_intent() {
     assert!(tx.verify().is_ok());
 
     // Create an intent with signed data.
-    let intent_bcs = bcs::to_bytes(&tx1.intent_message).unwrap();
+    let intent_bcs = bcs::to_bytes(tx1.intent_message()).unwrap();
 
     // Check that the first 3 bytes are the domain separation information.
     assert_eq!(
@@ -90,11 +90,11 @@ fn test_authority_signature_intent() {
     );
 
     // Check that intent's last bytes match the signed_data's bsc bytes.
-    let signed_data_bcs = bcs::to_bytes(&tx1.data().intent_message.value).unwrap();
+    let signed_data_bcs = bcs::to_bytes(&tx1.data().intent_message().value).unwrap();
     assert_eq!(&intent_bcs[3..], signed_data_bcs);
 
     // Let's ensure we can sign and verify intents.
-    let s = AuthoritySignature::new_secure(&tx1.data().intent_message, &0, &kp);
-    let verification = s.verify_secure(&tx1.data().intent_message, 0, kp.public().into());
+    let s = AuthoritySignature::new_secure(tx1.data().intent_message(), &0, &kp);
+    let verification = s.verify_secure(tx1.data().intent_message(), 0, kp.public().into());
     assert!(verification.is_ok())
 }

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -481,7 +481,7 @@ fn test_digest_caching() {
 
     signed_tx
         .data_mut_for_testing()
-        .intent_message
+        .intent_message_mut_for_testing()
         .value
         .gas_data_mut()
         .budget += 1;
@@ -925,7 +925,7 @@ fn verify_sender_signature_correctly_with_flag() {
         AuthorityPublicKeyBytes::from(sec1.public()),
     );
 
-    let s = match &transaction.data().tx_signatures[0] {
+    let s = match &transaction.data().tx_signatures()[0] {
         GenericSignature::Signature(s) => s,
         _ => panic!("invalid"),
     };
@@ -953,7 +953,7 @@ fn verify_sender_signature_correctly_with_flag() {
         &sec1,
         AuthorityPublicKeyBytes::from(sec1.public()),
     );
-    let s = match &transaction_1.data().tx_signatures[0] {
+    let s = match &transaction_1.data().tx_signatures()[0] {
         GenericSignature::Signature(s) => s,
         _ => panic!("unexpected signature scheme"),
     };
@@ -1020,7 +1020,7 @@ fn test_change_epoch_transaction() {
     assert!(tx.is_system_tx());
     assert_eq!(
         tx.data()
-            .intent_message
+            .intent_message()
             .value
             .input_objects()
             .unwrap()
@@ -1044,7 +1044,7 @@ fn test_consensus_commit_prologue_transaction() {
     assert!(tx.is_system_tx());
     assert_eq!(
         tx.data()
-            .intent_message
+            .intent_message()
             .value
             .input_objects()
             .unwrap()
@@ -1283,12 +1283,19 @@ fn test_certificate_digest() {
     let digest = cert.certificate_digest();
 
     // mutating a tx sig changes the digest.
-    cert.data_mut_for_testing().tx_signatures[0] = t2.tx_signatures[0].clone();
+    *cert
+        .data_mut_for_testing()
+        .tx_signatures_mut_for_testing()
+        .get_mut(0)
+        .unwrap() = t2.tx_signatures()[0].clone();
     assert_ne!(digest, cert.certificate_digest());
 
     // mutating intent changes the digest
     cert = orig.clone();
-    cert.data_mut_for_testing().intent_message.intent.scope = IntentScope::TransactionEffects;
+    cert.data_mut_for_testing()
+        .intent_message_mut_for_testing()
+        .intent
+        .scope = IntentScope::TransactionEffects;
     assert_ne!(digest, cert.certificate_digest());
 
     // mutating signature epoch changes digest


### PR DESCRIPTION
## Description 

Allows SenderSignedData to store multiple TXes in the future. For now it is restricted to storing exactly one.

TODO:

- [x] RPC / client changes (there weren't any, RPC and typescript don't know about SenderSignedData)

## Test Plan 

existing tests, no new functionality added.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
