### PR TITLE
[wallet-ext] fix bug where connecting to Ledger -> switching networks fails to keep track of reference

### DIFF
--- a/apps/wallet/src/ui/index.tsx
+++ b/apps/wallet/src/ui/index.tsx
@@ -57,29 +57,31 @@ function AppWrapper() {
         ({ app: { apiEnv, customRPC } }) => `${apiEnv}_${customRPC}`
     );
 
-    // NOTE: We set a top-level key here to force the entire react tree to be re-created when the network changes
-    // so that the RPC client instance (api.instance.fullNode) is updated correctly. In the future, we should look
-    // into making the API provider instance a reactive value and moving it out of the redux-thunk middleware
     return (
-        <Fragment key={network}>
-            <GrowthBookProvider growthbook={growthbook}>
-                <HashRouter>
-                    <IntlProvider locale={navigator.language}>
-                        <QueryClientProvider client={queryClient}>
-                            <RpcClientContext.Provider
-                                value={api.instance.fullNode}
-                            >
-                                <SuiLedgerClientProvider>
+        <GrowthBookProvider growthbook={growthbook}>
+            <HashRouter>
+                <IntlProvider locale={navigator.language}>
+                    <SuiLedgerClientProvider>
+                        {/*
+                         * NOTE: We set a key here to force the entire react tree to be re-created when the network changes so that
+                         * the RPC client instance (api.instance.fullNode) is updated correctly. In the future, we should look into
+                         * making the API provider instance a reactive value and moving it out of the redux-thunk middleware
+                         */}
+                        <Fragment key={network}>
+                            <QueryClientProvider client={queryClient}>
+                                <RpcClientContext.Provider
+                                    value={api.instance.fullNode}
+                                >
                                     <ErrorBoundary>
                                         <App />
                                     </ErrorBoundary>
-                                </SuiLedgerClientProvider>
-                            </RpcClientContext.Provider>
-                        </QueryClientProvider>
-                    </IntlProvider>
-                </HashRouter>
-            </GrowthBookProvider>
-        </Fragment>
+                                </RpcClientContext.Provider>
+                            </QueryClientProvider>
+                        </Fragment>
+                    </SuiLedgerClientProvider>
+                </IntlProvider>
+            </HashRouter>
+        </GrowthBookProvider>
     );
 }
 


### PR DESCRIPTION
## Description 

When you connect to Ledger and switch networks, the root `key` fragment was resetting the state of `suiLedgerClient` in `SuiLedgerClientProvider` even though we have an open connection to Ledger in the browser. This was causing a "Ledger device already opened" issue when trying to go back through the Ledger account import flow. 

The solution here is to isolate the `key` fragment to solely wrap the `RpcClientContextProvider` and `QueryClientProvider`. In an ideal world, we wouldn't have to re-create the component tree when the network changes but here we are 😬 

## Test Plan 
- Manual testing (can go through import flow -> switch networks -> go through import flow again)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
