### PR TITLE
[programmable transactions] Add current package object ID to `Upgrade` command

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -263,8 +263,14 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
         Command::Publish(modules) => {
             execute_move_publish::<_, _, Mode>(context, &mut argument_updates, modules)?
         }
-        Command::Upgrade(modules, dep_ids, upgrade_ticket) => {
-            execute_move_upgrade::<_, _, Mode>(context, modules, dep_ids, upgrade_ticket)?
+        Command::Upgrade(modules, dep_ids, current_package_id, upgrade_ticket) => {
+            execute_move_upgrade::<_, _, Mode>(
+                context,
+                modules,
+                dep_ids,
+                current_package_id,
+                upgrade_ticket,
+            )?
         }
     };
 
@@ -436,6 +442,7 @@ fn execute_move_upgrade<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     context: &mut ExecutionContext<E, S>,
     _module_bytes: Vec<Vec<u8>>,
     _dep_ids: Vec<ObjectID>,
+    _current_package_id: ObjectID,
     _upgrade_ticket_arg: Argument,
 ) -> Result<Vec<Value>, ExecutionError> {
     // Check that package upgrades are supported.

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1105,7 +1105,7 @@ async fn test_handle_transfer_transaction_unknown_sender() {
 async fn test_upgrade_module_is_feature_gated() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas_object_id = ObjectID::random();
-    let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, 10000);
+    let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, 100000);
     let authority_state = init_state().await;
     authority_state.insert_genesis_object(gas_object).await;
 
@@ -1113,7 +1113,8 @@ async fn test_upgrade_module_is_feature_gated() {
         let mut builder = ProgrammableTransactionBuilder::new();
         // Data doesn't matter here. We hit the feature flag before checking it.
         let arg = builder.pure(1).unwrap();
-        builder.upgrade(arg, vec![], vec![vec![]]);
+        let stdlib_pkg_id = ObjectID::from_hex_literal("0x1").unwrap();
+        builder.upgrade(stdlib_pkg_id, arg, vec![], vec![vec![]]);
         builder.finish()
     };
 

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -96,6 +96,7 @@ Command:
               SEQ: U8
           - SEQ:
               TYPENAME: ObjectID
+          - TYPENAME: ObjectID
           - TYPENAME: Argument
 CommandArgumentError:
   ENUM:

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -956,7 +956,7 @@ pub enum SuiCommand {
     /// Publishes a Move package
     Publish(SuiMovePackage),
     /// Upgrades a Move package
-    Upgrade(SuiMovePackage, Vec<ObjectID>, SuiArgument),
+    Upgrade(SuiMovePackage, Vec<ObjectID>, ObjectID, SuiArgument),
     /// `forall T: Vec<T> -> vector<T>`
     /// Given n-values of the same type, it constructs a vector. For non objects or an empty vector,
     /// the type tag must be specified.
@@ -992,9 +992,10 @@ impl Display for SuiCommand {
                 write!(f, ")")
             }
             Self::Publish(_bytes) => write!(f, "Publish(_)"),
-            Self::Upgrade(_bytes, deps, ticket) => {
+            Self::Upgrade(_bytes, deps, current_package_id, ticket) => {
                 write!(f, "Upgrade({ticket},")?;
                 write_sep(f, deps, ",")?;
+                write!(f, ", {current_package_id}")?;
                 write!(f, ", _)")?;
                 write!(f, ")")
             }
@@ -1022,11 +1023,12 @@ impl From<Command> for SuiCommand {
                 tag_opt.map(|tag| tag.to_string()),
                 args.into_iter().map(SuiArgument::from).collect(),
             ),
-            Command::Upgrade(modules, dep_ids, ticket) => SuiCommand::Upgrade(
+            Command::Upgrade(modules, dep_ids, current_package_id, ticket) => SuiCommand::Upgrade(
                 SuiMovePackage {
                     disassembled: disassemble_modules(modules.iter()).unwrap_or_default(),
                 },
                 dep_ids,
+                current_package_id,
                 SuiArgument::from(ticket),
             ),
         }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5219,11 +5219,14 @@
                     }
                   },
                   {
+                    "$ref": "#/components/schemas/ObjectID"
+                  },
+                  {
                     "$ref": "#/components/schemas/SuiArgument"
                   }
                 ],
-                "maxItems": 3,
-                "minItems": 3
+                "maxItems": 4,
+                "minItems": 4
               }
             },
             "additionalProperties": false

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -197,11 +197,17 @@ impl ProgrammableTransactionBuilder {
 
     pub fn upgrade(
         &mut self,
+        current_package_object_id: ObjectID,
         upgrade_ticket: Argument,
         transitive_deps: Vec<ObjectID>,
         modules: Vec<Vec<u8>>,
     ) -> Argument {
-        self.command(Command::Upgrade(modules, transitive_deps, upgrade_ticket))
+        self.command(Command::Upgrade(
+            modules,
+            transitive_deps,
+            current_package_object_id,
+            upgrade_ticket,
+        ))
     }
 
     pub fn transfer_arg(&mut self, recipient: SuiAddress, arg: Argument) {


### PR DESCRIPTION

Previously the package ID of the package being upgraded was dynamically determined by the `UpgradeTicket` that would be passed as an argument. However, this should be able to be statically determined so that it can be used in transaction input checking.

## Test Plan 

This codepath is currently not exercised, and tests will be incoming with the other package and upgrade-related PRs. 
