### PR TITLE
[sui-framework] add unstake events and add more granular info in epoch info events

### DIFF
--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -8,6 +8,7 @@
 -  [Struct `ValidatorMetadata`](#0x2_validator_ValidatorMetadata)
 -  [Struct `Validator`](#0x2_validator_Validator)
 -  [Struct `StakingRequestEvent`](#0x2_validator_StakingRequestEvent)
+-  [Struct `UnstakingRequestEvent`](#0x2_validator_UnstakingRequestEvent)
 -  [Constants](#@Constants_0)
 -  [Function `new_metadata`](#0x2_validator_new_metadata)
 -  [Function `new`](#0x2_validator_new)
@@ -370,6 +371,70 @@ Event emitted when a new stake request is received.
 </dd>
 <dt>
 <code>amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_validator_UnstakingRequestEvent"></a>
+
+## Struct `UnstakingRequestEvent`
+
+Event emitted when a new unstake request is received.
+
+
+<pre><code><b>struct</b> <a href="validator.md#0x2_validator_UnstakingRequestEvent">UnstakingRequestEvent</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>pool_id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>validator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>staker_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>stake_activation_epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>unstaking_epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>principal_amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>reward_amount: u64</code>
 </dt>
 <dd>
 
@@ -798,9 +863,23 @@ Request to withdraw stake from the validator's staking pool, processed at the en
     staked_sui: StakedSui,
     ctx: &<b>mut</b> TxContext,
 ) {
+    <b>let</b> principal_amount = <a href="staking_pool.md#0x2_staking_pool_staked_sui_amount">staking_pool::staked_sui_amount</a>(&staked_sui);
+    <b>let</b> stake_activation_epoch = <a href="staking_pool.md#0x2_staking_pool_stake_activation_epoch">staking_pool::stake_activation_epoch</a>(&staked_sui);
     <b>let</b> withdraw_amount = <a href="staking_pool.md#0x2_staking_pool_request_withdraw_stake">staking_pool::request_withdraw_stake</a>(
             &<b>mut</b> self.<a href="staking_pool.md#0x2_staking_pool">staking_pool</a>, staked_sui, ctx);
+    <b>let</b> reward_amount = withdraw_amount - principal_amount;
     self.next_epoch_stake = self.next_epoch_stake - withdraw_amount;
+    <a href="event.md#0x2_event_emit">event::emit</a>(
+        <a href="validator.md#0x2_validator_UnstakingRequestEvent">UnstakingRequestEvent</a> {
+            pool_id: <a href="validator.md#0x2_validator_staking_pool_id">staking_pool_id</a>(self),
+            validator_address: self.metadata.sui_address,
+            staker_address: <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx),
+            stake_activation_epoch,
+            unstaking_epoch: <a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
+            principal_amount,
+            reward_amount,
+        }
+    )
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -6,7 +6,7 @@
 
 
 -  [Struct `ValidatorSet`](#0x2_validator_set_ValidatorSet)
--  [Struct `ValidatorEpochInfo`](#0x2_validator_set_ValidatorEpochInfo)
+-  [Struct `ValidatorEpochInfoEvent`](#0x2_validator_set_ValidatorEpochInfoEvent)
 -  [Struct `ValidatorJoinEvent`](#0x2_validator_set_ValidatorJoinEvent)
 -  [Struct `ValidatorLeaveEvent`](#0x2_validator_set_ValidatorLeaveEvent)
 -  [Constants](#@Constants_0)
@@ -164,15 +164,15 @@
 
 </details>
 
-<a name="0x2_validator_set_ValidatorEpochInfo"></a>
+<a name="0x2_validator_set_ValidatorEpochInfoEvent"></a>
 
-## Struct `ValidatorEpochInfo`
+## Struct `ValidatorEpochInfoEvent`
 
 Event containing staking and rewards related information of
 each validator, emitted during epoch advancement.
 
 
-<pre><code><b>struct</b> <a href="validator_set.md#0x2_validator_set_ValidatorEpochInfo">ValidatorEpochInfo</a> <b>has</b> <b>copy</b>, drop
+<pre><code><b>struct</b> <a href="validator_set.md#0x2_validator_set_ValidatorEpochInfoEvent">ValidatorEpochInfoEvent</a> <b>has</b> <b>copy</b>, drop
 </code></pre>
 
 
@@ -213,7 +213,13 @@ each validator, emitted during epoch advancement.
 
 </dd>
 <dt>
-<code>stake_rewards: u64</code>
+<code>pool_staking_reward: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>storage_fund_staking_reward: u64</code>
 </dt>
 <dd>
 
@@ -878,7 +884,7 @@ It does the following things:
 
     // Emit events after we have processed all the rewards distribution and pending stakes.
     <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(new_epoch, &self.active_validators, &adjusted_staking_reward_amounts,
-        validator_report_records, &slashed_validators);
+        &adjusted_storage_fund_reward_amounts, validator_report_records, &slashed_validators);
 
     <a href="validator_set.md#0x2_validator_set_process_pending_validators">process_pending_validators</a>(self, new_epoch);
 
@@ -2408,7 +2414,7 @@ Emit events containing information of each validator for the epoch,
 including stakes, rewards, performance, etc.
 
 
-<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(new_epoch: u64, vs: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, reward_amounts: &<a href="">vector</a>&lt;u64&gt;, report_records: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;, slashed_validators: &<a href="">vector</a>&lt;<b>address</b>&gt;)
+<pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(new_epoch: u64, vs: &<a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, pool_staking_reward_amounts: &<a href="">vector</a>&lt;u64&gt;, storage_fund_staking_reward_amounts: &<a href="">vector</a>&lt;u64&gt;, report_records: &<a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;, slashed_validators: &<a href="">vector</a>&lt;<b>address</b>&gt;)
 </code></pre>
 
 
@@ -2420,7 +2426,8 @@ including stakes, rewards, performance, etc.
 <pre><code><b>fun</b> <a href="validator_set.md#0x2_validator_set_emit_validator_epoch_events">emit_validator_epoch_events</a>(
     new_epoch: u64,
     vs: &<a href="">vector</a>&lt;Validator&gt;,
-    reward_amounts: &<a href="">vector</a>&lt;u64&gt;,
+    pool_staking_reward_amounts: &<a href="">vector</a>&lt;u64&gt;,
+    storage_fund_staking_reward_amounts: &<a href="">vector</a>&lt;u64&gt;,
     report_records: &VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
     slashed_validators: &<a href="">vector</a>&lt;<b>address</b>&gt;,
 ) {
@@ -2439,13 +2446,14 @@ including stakes, rewards, performance, etc.
             <b>if</b> (<a href="_contains">vector::contains</a>(slashed_validators, &validator_address)) 0
             <b>else</b> 1;
         <a href="event.md#0x2_event_emit">event::emit</a>(
-            <a href="validator_set.md#0x2_validator_set_ValidatorEpochInfo">ValidatorEpochInfo</a> {
+            <a href="validator_set.md#0x2_validator_set_ValidatorEpochInfoEvent">ValidatorEpochInfoEvent</a> {
                 epoch: new_epoch,
                 validator_address,
                 reference_gas_survey_quote: <a href="validator.md#0x2_validator_gas_price">validator::gas_price</a>(v),
                 stake: <a href="validator.md#0x2_validator_total_stake_amount">validator::total_stake_amount</a>(v),
                 commission_rate: <a href="validator.md#0x2_validator_commission_rate">validator::commission_rate</a>(v),
-                stake_rewards: *<a href="_borrow">vector::borrow</a>(reward_amounts, i),
+                pool_staking_reward: *<a href="_borrow">vector::borrow</a>(pool_staking_reward_amounts, i),
+                storage_fund_staking_reward: *<a href="_borrow">vector::borrow</a>(storage_fund_staking_reward_amounts, i),
                 pool_token_exchange_rate: <a href="validator.md#0x2_validator_pool_token_exchange_rate_at_epoch">validator::pool_token_exchange_rate_at_epoch</a>(v, new_epoch),
                 tallying_rule_reporters,
                 tallying_rule_global_score,

--- a/crates/sui-framework/sources/governance/sui_system.move
+++ b/crates/sui-framework/sources/governance/sui_system.move
@@ -99,17 +99,19 @@ module sui::sui_system {
 
     /// Event containing system-level epoch information, emitted during
     /// the epoch advancement transaction.
-    struct SystemEpochInfo has copy, drop {
+    struct SystemEpochInfoEvent has copy, drop {
         epoch: u64,
         protocol_version: u64,
         reference_gas_price: u64,
         total_stake: u64,
-        storage_fund_inflows: u64,
-        storage_fund_outflows: u64,
+        storage_fund_reinvestment: u64,
+        storage_charge: u64,
+        storage_rebate: u64,
         storage_fund_balance: u64,
         stake_subsidy_amount: u64,
         total_gas_fees: u64,
-        total_stake_rewards: u64,
+        total_stake_rewards_distributed: u64,
+        leftover_storage_fund_inflow: u64,
     }
 
     // Errors
@@ -735,8 +737,9 @@ module sui::sui_system {
         self.epoch = self.epoch + 1;
         // Sanity check to make sure we are advancing to the right epoch.
         assert!(new_epoch == self.epoch, 0);
-        let total_rewards_amount =
-            balance::value(&computation_reward)+ balance::value(&storage_fund_reward);
+
+        let computation_reward_amount_before_distribution = balance::value(&computation_reward);
+        let storage_fund_reward_amount_before_distribution = balance::value(&storage_fund_reward);
 
         validator_set::advance_epoch(
             &mut self.validators,
@@ -751,6 +754,11 @@ module sui::sui_system {
             ctx,
         );
 
+        let computation_reward_amount_after_distribution = balance::value(&computation_reward);
+        let storage_fund_reward_amount_after_distribution = balance::value(&storage_fund_reward);
+        let computation_reward_distributed = computation_reward_amount_before_distribution - computation_reward_amount_after_distribution;
+        let storage_fund_reward_distributed = storage_fund_reward_amount_before_distribution - storage_fund_reward_amount_after_distribution;
+
         self.protocol_version = next_protocol_version;
 
         // Derive the reference gas price for the new epoch
@@ -758,6 +766,7 @@ module sui::sui_system {
         // Because of precision issues with integer divisions, we expect that there will be some
         // remaining balance in `storage_fund_reward` and `computation_reward`.
         // All of these go to the storage fund.
+        let leftover_storage_fund_inflow = balance::value(&storage_fund_reward) + balance::value(&computation_reward);
         balance::join(&mut self.storage_fund, storage_fund_reward);
         balance::join(&mut self.storage_fund, computation_reward);
 
@@ -768,17 +777,19 @@ module sui::sui_system {
         let new_total_stake = validator_set::total_stake(&self.validators);
 
         event::emit(
-            SystemEpochInfo {
+            SystemEpochInfoEvent {
                 epoch: self.epoch,
                 protocol_version: self.protocol_version,
                 reference_gas_price: self.reference_gas_price,
                 total_stake: new_total_stake,
-                storage_fund_inflows: storage_charge + (storage_fund_reinvestment_amount as u64),
-                storage_fund_outflows: storage_rebate,
+                storage_charge,
+                storage_fund_reinvestment: (storage_fund_reinvestment_amount as u64),
+                storage_rebate,
                 storage_fund_balance: balance::value(&self.storage_fund),
                 stake_subsidy_amount,
                 total_gas_fees: computation_charge,
-                total_stake_rewards: total_rewards_amount,
+                total_stake_rewards_distributed: computation_reward_distributed + storage_fund_reward_distributed,
+                leftover_storage_fund_inflow,
             }
         );
         self.safe_mode = false;


### PR DESCRIPTION


## Description 

This PR
- Adds an event emission when unstaking request happens
- Improves `SystemEpochInfo` and `ValidatorEpochInfo` to give more details and have fields with more clear names too

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
