### PR TITLE
[package-upgrades] Unit tests for MovePackage

### DIFF
--- a/crates/sui-core/src/unit_tests/data/move_package/A/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/A/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "A"
+version = "0.0.1"
+
+[addresses]
+a = "0xa1"
+
+[dependencies]
+B = { local = "../B" }

--- a/crates/sui-core/src/unit_tests/data/move_package/A/sources/a.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/A/sources/a.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module a::a {
     public fun a(): u64 {
         b::b::b()

--- a/crates/sui-core/src/unit_tests/data/move_package/A/sources/a.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/A/sources/a.move
@@ -1,0 +1,5 @@
+module a::a {
+    public fun a(): u64 {
+        b::b::b()
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_package/B/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/B/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "B"
+version = "0.0.1"
+
+[addresses]
+b = "0xb1"
+
+[dependencies]
+C = { local = "../Cv1" }

--- a/crates/sui-core/src/unit_tests/data/move_package/B/sources/b.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/B/sources/b.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module b::b {
     public fun b(): u64 {
         c::c::c()

--- a/crates/sui-core/src/unit_tests/data/move_package/B/sources/b.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/B/sources/b.move
@@ -1,0 +1,5 @@
+module b::b {
+    public fun b(): u64 {
+        c::c::c()
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv1/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv1/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "C"
+version = "0.0.1"
+
+[addresses]
+c = "0xc1"

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv1/sources/c.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv1/sources/c.move
@@ -1,0 +1,9 @@
+module c::c {
+    struct C {
+        x: u64
+    }
+
+    public fun c(): u64 {
+        42
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv1/sources/c.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv1/sources/c.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module c::c {
     struct C {
         x: u64

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv2/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "C"
+version = "0.0.2"
+
+[addresses]
+c = "0xc1"

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv2/sources/c.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv2/sources/c.move
@@ -1,0 +1,14 @@
+module c::c {
+    struct C {
+        x: u64
+    }
+
+    struct D {
+        x: u64,
+        y: u64,
+    }
+
+    public fun c(): u64 {
+        43
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv2/sources/c.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv2/sources/c.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module c::c {
     struct C {
         x: u64

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -6,14 +6,15 @@ use move_binary_format::file_format::CompiledModule;
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_types::{
     base_types::ObjectID,
+    error::ExecutionErrorKind,
     move_package::{ModuleStruct, MovePackage, UpgradeInfo},
     object::OBJECT_START_VERSION,
-    MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID,
 };
 
 use std::{collections::BTreeMap, path::PathBuf};
 
 macro_rules! type_origin_table {
+    {} => { BTreeMap::new() };
     {$($module:ident :: $type:ident => $pkg:expr),* $(,)?} => {{
         let mut table = BTreeMap::new();
         $(
@@ -30,6 +31,7 @@ macro_rules! type_origin_table {
 }
 
 macro_rules! linkage_table {
+    {} => { BTreeMap::new() };
     {$($original_id:expr => ($upgraded_id:expr, $version:expr)),* $(,)?} => {{
         let mut table = BTreeMap::new();
         $(
@@ -45,109 +47,354 @@ macro_rules! linkage_table {
     }}
 }
 
-#[tokio::test]
-async fn test_simple_move_package_create() {
-    let (std_move_pkg, sui_move_pkg) = sui_framework::make_std_sui_move_pkgs();
-    let modules = build_test_modules("object_basics");
-    let move_pkg = MovePackage::new_initial(
+#[test]
+fn test_new_initial() {
+    let c_id1 = ObjectID::from_single_byte(0xc1);
+    let c_pkg = MovePackage::new_initial(
         OBJECT_START_VERSION,
-        modules,
+        build_test_modules("Cv1"),
         u64::MAX,
-        [&std_move_pkg, &sui_move_pkg],
+        [],
     )
     .unwrap();
 
-    let pkg_id = move_pkg.id();
+    let b_id1 = ObjectID::from_single_byte(0xb1);
+    let b_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("B"),
+        u64::MAX,
+        [&c_pkg],
+    )
+    .unwrap();
+
+    let a_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("A"),
+        u64::MAX,
+        [&b_pkg, &c_pkg],
+    )
+    .unwrap();
+
     assert_eq!(
-        move_pkg.type_origin_table(),
-        &type_origin_table! {
-            object_basics::Name => pkg_id,
-            object_basics::NewValueEvent => pkg_id,
-            object_basics::Object => pkg_id,
-            object_basics::Wrapper => pkg_id,
+        a_pkg.linkage_table(),
+        &linkage_table! {
+            b_id1 => (b_id1, OBJECT_START_VERSION),
+            c_id1 => (c_id1, OBJECT_START_VERSION),
         }
     );
 
     assert_eq!(
-        move_pkg.linkage_table(),
+        b_pkg.linkage_table(),
         &linkage_table! {
-            MOVE_STDLIB_OBJECT_ID => (MOVE_STDLIB_OBJECT_ID, OBJECT_START_VERSION),
-            SUI_FRAMEWORK_OBJECT_ID => (SUI_FRAMEWORK_OBJECT_ID, OBJECT_START_VERSION),
+            c_id1 => (c_id1, OBJECT_START_VERSION),
+        }
+    );
+
+    assert_eq!(c_pkg.linkage_table(), &linkage_table! {},);
+
+    assert_eq!(
+        c_pkg.type_origin_table(),
+        &type_origin_table! {
+            c::C => c_id1,
         }
     );
 }
 
-#[tokio::test]
-async fn test_simple_move_upgraded_package_create() {
-    let (std_move_pkg, sui_move_pkg) = sui_framework::make_std_sui_move_pkgs();
-    let modules = build_test_modules("object_basics");
-    let move_pkg = MovePackage::new_initial(
+#[test]
+fn test_upgraded() {
+    let c_id1 = ObjectID::from_single_byte(0xc1);
+    let c_pkg = MovePackage::new_initial(
         OBJECT_START_VERSION,
-        modules,
+        build_test_modules("Cv1"),
         u64::MAX,
-        [&std_move_pkg, &sui_move_pkg],
+        [],
     )
     .unwrap();
 
-    let upgraded_modules = build_test_modules("object_basics_upgraded");
-    let upgraded_id = ObjectID::random();
-    let upgraded_move_pkg = move_pkg
-        .new_upgraded(
-            upgraded_id,
-            upgraded_modules,
-            u64::MAX,
-            [&std_move_pkg, &sui_move_pkg],
-        )
+    let c_id2 = ObjectID::from_single_byte(0xc2);
+    let c_new = c_pkg
+        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
         .unwrap();
 
-    let pkg_id = move_pkg.id();
+    let mut expected_version = OBJECT_START_VERSION;
+    expected_version.increment();
+    assert_eq!(expected_version, c_new.version());
+
     assert_eq!(
-        move_pkg.type_origin_table(),
+        c_new.type_origin_table(),
         &type_origin_table! {
-            object_basics::Name => pkg_id,
-            object_basics::NewValueEvent => pkg_id,
-            object_basics::Object => pkg_id,
-            object_basics::Wrapper => pkg_id,
-        }
+            c::C => c_id1,
+            c::D => c_id2,
+        },
     );
+}
+
+#[test]
+fn test_depending_on_upgrade() {
+    let c_id1 = ObjectID::from_single_byte(0xc1);
+    let c_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("Cv1"),
+        u64::MAX,
+        [],
+    )
+    .unwrap();
+
+    let c_id2 = ObjectID::from_single_byte(0xc2);
+    let c_new = c_pkg
+        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .unwrap();
+
+    let b_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("B"),
+        u64::MAX,
+        [&c_new],
+    )
+    .unwrap();
 
     assert_eq!(
-        move_pkg.linkage_table(),
+        b_pkg.linkage_table(),
         &linkage_table! {
-            MOVE_STDLIB_OBJECT_ID => (MOVE_STDLIB_OBJECT_ID, OBJECT_START_VERSION),
-            SUI_FRAMEWORK_OBJECT_ID => (SUI_FRAMEWORK_OBJECT_ID, OBJECT_START_VERSION),
-        }
+            c_id1 => (c_id2, c_new.version()),
+        },
     );
+}
+
+#[test]
+fn test_upgrade_upgrades_linkage() {
+    let c_id1 = ObjectID::from_single_byte(0xc1);
+    let c_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("Cv1"),
+        u64::MAX,
+        [],
+    )
+    .unwrap();
+
+    let c_id2 = ObjectID::from_single_byte(0xc2);
+    let c_new = c_pkg
+        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .unwrap();
+
+    let b_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("B"),
+        u64::MAX,
+        [&c_pkg],
+    )
+    .unwrap();
+
+    let b_id2 = ObjectID::from_single_byte(0xb2);
+    let b_new = b_pkg.new_upgraded(b_id2, build_test_modules("B"), u64::MAX, [&c_new]).unwrap();
 
     assert_eq!(
-        upgraded_move_pkg.type_origin_table(),
-        &type_origin_table! {
-            object_basics::Name => pkg_id,
-            object_basics::NewValueEvent => pkg_id,
-            object_basics::Object => pkg_id,
-            object_basics::Wrapper => pkg_id,
-            object_basics::ObjectNewVersion => upgraded_id,
-        }
-    );
-
-    // the linkage table in this upgraded package is actually the same as in the original version as
-    // dependencies haven't changed
-    assert_eq!(
-        upgraded_move_pkg.linkage_table(),
+        b_pkg.linkage_table(),
         &linkage_table! {
-            MOVE_STDLIB_OBJECT_ID => (MOVE_STDLIB_OBJECT_ID, OBJECT_START_VERSION),
-            SUI_FRAMEWORK_OBJECT_ID => (SUI_FRAMEWORK_OBJECT_ID, OBJECT_START_VERSION),
-        }
+            c_id1 => (c_id1, OBJECT_START_VERSION),
+        },
     );
+
+    assert_eq!(
+        b_new.linkage_table(),
+        &linkage_table! {
+            c_id1 => (c_id2, c_new.version()),
+        },
+    );
+}
+
+#[test]
+fn test_upgrade_downngrades_linkage() {
+    let c_id1 = ObjectID::from_single_byte(0xc1);
+    let c_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("Cv1"),
+        u64::MAX,
+        [],
+    )
+    .unwrap();
+
+    let c_id2 = ObjectID::from_single_byte(0xc2);
+    let c_new = c_pkg
+        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .unwrap();
+
+    let b_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("B"),
+        u64::MAX,
+        [&c_new],
+    )
+    .unwrap();
+
+    let b_id2 = ObjectID::from_single_byte(0xb2);
+    let b_new = b_pkg.new_upgraded(b_id2, build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
+
+    assert_eq!(
+        b_pkg.linkage_table(),
+        &linkage_table! {
+            c_id1 => (c_id2, c_new.version()),
+        },
+    );
+
+    assert_eq!(
+        b_new.linkage_table(),
+        &linkage_table! {
+            c_id1 => (c_id1, OBJECT_START_VERSION),
+        },
+    );
+}
+
+#[test]
+fn test_transitively_depending_on_upgrade() {
+    let c_id1 = ObjectID::from_single_byte(0xc1);
+    let c_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("Cv1"),
+        u64::MAX,
+        [],
+    )
+    .unwrap();
+
+    let c_id2 = ObjectID::from_single_byte(0xc2);
+    let c_new = c_pkg
+        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .unwrap();
+
+    let b_id1 = ObjectID::from_single_byte(0xb1);
+    let b_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("B"),
+        u64::MAX,
+        [&c_pkg],
+    )
+    .unwrap();
+
+    let a_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("A"),
+        u64::MAX,
+        [&b_pkg, &c_new],
+    )
+    .unwrap();
+
+    assert_eq!(
+        a_pkg.linkage_table(),
+        &linkage_table! {
+            b_id1 => (b_id1, OBJECT_START_VERSION),
+            c_id1 => (c_id2, c_new.version()),
+        },
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_panic_on_empty_package() {
+    let _ = MovePackage::new_initial(OBJECT_START_VERSION, vec![], u64::MAX, []);
+}
+
+#[test]
+fn test_fail_on_missing_dep() {
+    let err = MovePackage::new_initial(OBJECT_START_VERSION, build_test_modules("B"), u64::MAX, [])
+        .unwrap_err();
+
+    assert_eq!(
+        err.kind(),
+        &ExecutionErrorKind::PublishUpgradeMissingImmediateDependency
+    );
+}
+
+#[test]
+fn test_fail_on_missing_transitive_dep() {
+    let c_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("Cv1"),
+        u64::MAX,
+        [],
+    )
+    .unwrap();
+
+    let b_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("B"),
+        u64::MAX,
+        [&c_pkg],
+    )
+    .unwrap();
+
+    let err = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("A"),
+        u64::MAX,
+        [&b_pkg],
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        err.kind(),
+        &ExecutionErrorKind::PublishUpgradeMissingIndirectDependency
+    );
+}
+
+#[test]
+fn test_fail_on_transitive_dependency_downgrade() {
+    let c_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("Cv1"),
+        u64::MAX,
+        [],
+    )
+    .unwrap();
+
+    let c_id2 = ObjectID::from_single_byte(0xc2);
+    let c_new = c_pkg
+        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .unwrap();
+
+    let b_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("B"),
+        u64::MAX,
+        [&c_new],
+    )
+    .unwrap();
+
+    let err = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("A"),
+        u64::MAX,
+        [&b_pkg, &c_pkg],
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        err.kind(),
+        &ExecutionErrorKind::PublishUpgradeDependencyDowngrade
+    );
+}
+
+#[test]
+fn test_fail_on_upgrade_missing_type() {
+    let c_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("Cv2"),
+        u64::MAX,
+        [],
+    )
+    .unwrap();
+
+    let c_id2 = ObjectID::from_single_byte(0xc2);
+    let err = c_pkg
+        .new_upgraded(c_id2, build_test_modules("Cv1"), u64::MAX, [])
+        .unwrap_err();
+
+    assert_eq!(err.kind(), &ExecutionErrorKind::InvariantViolation);
 }
 
 pub fn build_test_modules(test_dir: &str) -> Vec<CompiledModule> {
     let build_config = BuildConfig::new_for_testing();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("src");
-    path.push("unit_tests");
-    path.push("data");
-    path.push(test_dir);
+    path.extend(["src", "unit_tests", "data", "move_package", test_dir]);
     sui_framework::build_move_package(&path, build_config)
         .unwrap()
         .get_modules()

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -186,7 +186,9 @@ fn test_upgrade_upgrades_linkage() {
     .unwrap();
 
     let b_id2 = ObjectID::from_single_byte(0xb2);
-    let b_new = b_pkg.new_upgraded(b_id2, build_test_modules("B"), u64::MAX, [&c_new]).unwrap();
+    let b_new = b_pkg
+        .new_upgraded(b_id2, build_test_modules("B"), u64::MAX, [&c_new])
+        .unwrap();
 
     assert_eq!(
         b_pkg.linkage_table(),
@@ -228,7 +230,9 @@ fn test_upgrade_downngrades_linkage() {
     .unwrap();
 
     let b_id2 = ObjectID::from_single_byte(0xb2);
-    let b_new = b_pkg.new_upgraded(b_id2, build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
+    let b_new = b_pkg
+        .new_upgraded(b_id2, build_test_modules("B"), u64::MAX, [&c_pkg])
+        .unwrap();
 
     assert_eq!(
         b_pkg.linkage_table(),


### PR DESCRIPTION
## Description

Augmenting the existing unit tests for `MovePackage` related to linkage tables, type origin tables, and upgrades.

This change ports the test over to a new family of simpler packages (A, B, C v1, and C v2).

## Test Plan

```
$ cargo nextest run -- 'move_package_tests'
```
