### PR TITLE
crypto: hash with intent

### DIFF
--- a/crates/shared-crypto/src/intent.rs
+++ b/crates/shared-crypto/src/intent.rs
@@ -169,3 +169,11 @@ pub(crate) mod private {
     pub trait SealedIntent {}
     impl<T> SealedIntent for IntentMessage<T> {}
 }
+
+/// Hashing intent is used to prevent hash collision when hashing a message.
+#[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[repr(u8)]
+pub enum HashingIntentScope {
+    ChildObjectId = 0,
+    RegularObjectId = 1,
+}

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.exp
@@ -12,7 +12,7 @@ created: object(108), object(109), object(110)
 written: object(107)
 
 task 3 'view-object'. lines 50-54:
-Owner: Shared
+Owner: Object ID: ( fake(108) )
 Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}}
 

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.exp
@@ -12,6 +12,6 @@ created: object(108), object(109), object(110)
 written: object(107)
 
 task 3 'view-object'. lines 40-40:
-Owner: Shared
+Owner: Object ID: ( fake(108) )
 Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}}

--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -24,7 +24,7 @@ created: object(113), object(114)
 written: object(111), object(112)
 
 task 6 'run'. lines 89-89:
-Error: Object 0xcbc830e8ea72f6683a00726dfdeb2aab857cab6219d557d9c8def5110fb6484f is owned by object 0x06b70f0fddd32895de05c5682c623e06dd60863d5a6688d0736907ac3cf1c59a. Objects owned by other objects cannot be used as input arguments.
+Error: Object 0x41831e44a69c2bfc396f8223635fae3728f3cf6351290365076002f6baf6f333 is owned by object 0x298ef834951a32859e4516ec26d422ea78c442e9f01f332b52506dd5ede1b693. Objects owned by other objects cannot be used as input arguments.
 
 task 7 'run'. lines 91-91:
-Error: Object 0xcbc830e8ea72f6683a00726dfdeb2aab857cab6219d557d9c8def5110fb6484f is owned by object 0x06b70f0fddd32895de05c5682c623e06dd60863d5a6688d0736907ac3cf1c59a. Objects owned by other objects cannot be used as input arguments.
+Error: Object 0x41831e44a69c2bfc396f8223635fae3728f3cf6351290365076002f6baf6f333 is owned by object 0x298ef834951a32859e4516ec26d422ea78c442e9f01f332b52506dd5ede1b693. Objects owned by other objects cannot be used as input arguments.

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate_object.exp
@@ -12,5 +12,4 @@ created: object(107), object(108), object(109)
 written: object(106)
 
 task 3 'run'. lines 35-35:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::dynamic_field::add (function index 0) at offset 15, Abort Code: 0
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 0, instruction: 15, function_name: Some("add") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("sui::dynamic_field::add at offset 15"), exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("dynamic_object_field") }), FunctionDefinitionIndex(0), 9), (Some(ModuleId { address: a, name: Identifier("m") }), FunctionDefinitionIndex(1), 6)] }), location: Module(ModuleId { address: sui, name: Identifier("dynamic_field") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 15)] }), command: Some(0) } }
+Error: Object 0x10657ef7b778bf4c19b3a32a445a7634f0388b82b53799c7deabda07d101d337 is owned by object 0xf2c06d97f4ad9da4a8a6cfb80dd73173302be0c6c245c62279a4bc86a366f33c. Objects owned by other objects cannot be used as input arguments.

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type_object.exp
@@ -12,9 +12,7 @@ created: object(107), object(108), object(109)
 written: object(106)
 
 task 3 'run'. lines 43-43:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::dynamic_field::borrow_child_object (function index 10) at offset 0, Abort Code: 2
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 10, instruction: 0, function_name: Some("borrow_child_object") }, 2), source: Some(VMError { major_status: ABORTED, sub_status: Some(2), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("dynamic_field") }), indices: [], offsets: [(FunctionDefinitionIndex(10), 0)] }), command: Some(0) } }
+Error: Object 0x10657ef7b778bf4c19b3a32a445a7634f0388b82b53799c7deabda07d101d337 is owned by object 0xf2c06d97f4ad9da4a8a6cfb80dd73173302be0c6c245c62279a4bc86a366f33c. Objects owned by other objects cannot be used as input arguments.
 
 task 4 'run'. lines 45-45:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::dynamic_field::borrow_child_object_mut (function index 11) at offset 0, Abort Code: 2
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object_mut") }, 2), source: Some(VMError { major_status: ABORTED, sub_status: Some(2), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("dynamic_field") }), indices: [], offsets: [(FunctionDefinitionIndex(11), 0)] }), command: Some(0) } }
+Error: Object 0x10657ef7b778bf4c19b3a32a445a7634f0388b82b53799c7deabda07d101d337 is owned by object 0xf2c06d97f4ad9da4a8a6cfb80dd73173302be0c6c245c62279a4bc86a366f33c. Objects owned by other objects cannot be used as input arguments.

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive_object.exp
@@ -29,7 +29,7 @@ written: object(107), object(118)
 
 task 8 'run'. lines 118-118:
 written: object(107), object(119)
-deleted: object(110), object(111), object(113), object(114)
+deleted: object(109), object(110), object(113), object(114)
 
 task 9 'run'. lines 120-120:
 written: object(107), object(120)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type_object.exp
@@ -12,5 +12,4 @@ created: object(107), object(108), object(109)
 written: object(106)
 
 task 3 'run'. lines 40-40:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::dynamic_field::remove_child_object (function index 12) at offset 0, Abort Code: 2
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 12, instruction: 0, function_name: Some("remove_child_object") }, 2), source: Some(VMError { major_status: ABORTED, sub_status: Some(2), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("dynamic_field") }), indices: [], offsets: [(FunctionDefinitionIndex(12), 0)] }), command: Some(0) } }
+Error: Object 0x10657ef7b778bf4c19b3a32a445a7634f0388b82b53799c7deabda07d101d337 is owned by object 0xf2c06d97f4ad9da4a8a6cfb80dd73173302be0c6c245c62279a4bc86a366f33c. Objects owned by other objects cannot be used as input arguments.

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrap_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrap_object.exp
@@ -12,42 +12,38 @@ created: object(107), object(108), object(109)
 written: object(106)
 
 task 3 'view-object'. lines 45-45:
-Owner: Object ID: ( fake(109) )
+Owner: Account Address ( A )
 Version: 2
 Contents: a::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(108)}}}
 
 task 4 'run'. lines 47-47:
-created: object(111)
-written: object(107), object(110)
-deleted: object(108), object(109)
+Error: Object 0x10657ef7b778bf4c19b3a32a445a7634f0388b82b53799c7deabda07d101d337 is owned by object 0xf2c06d97f4ad9da4a8a6cfb80dd73173302be0c6c245c62279a4bc86a366f33c. Objects owned by other objects cannot be used as input arguments.
 
 task 5 'run'. lines 50-50:
-created: object(113), object(114), object(115)
-written: object(112)
+created: object(112), object(113), object(114)
+written: object(111)
 
 task 6 'view-object'. lines 52-52:
-Owner: Object ID: ( fake(115) )
+Owner: Object ID: ( fake(113) )
 Version: 2
-Contents: a::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(114)}}}
+Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(114)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(112)}}
 
 task 7 'run'. lines 54-54:
-written: object(113), object(116)
-deleted: object(114), object(115)
+written: object(113), object(115)
+deleted: object(112), object(114)
 
 task 8 'run'. lines 57-57:
-created: object(118), object(119), object(120)
-written: object(117)
+created: object(117), object(118), object(119)
+written: object(116)
 
 task 9 'view-object'. lines 59-59:
-Owner: Object ID: ( fake(120) )
+Owner: Object ID: ( fake(118) )
 Version: 2
-Contents: a::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(119)}}}
+Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(119)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(117)}}
 
 task 10 'run'. lines 61-61:
-written: object(118), object(119), object(121)
-deleted: object(120)
+written: object(117), object(118), object(120)
+deleted: object(119)
 
 task 11 'view-object'. lines 63-63:
-Owner: Account Address ( A )
-Version: 3
-Contents: a::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(119)}}}
+No object at id 119

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -27,7 +27,7 @@ created: object(113), object(114)
 written: object(111), object(112)
 
 task 7 'run'. lines 132-136:
-Error: Object 0x01b2156087ad45d0d2fb96eb055cd6257a53618f4086e94ee301ec3388d82896 is owned by object 0xedf1619bc141398837261810dc56b3072eb6676658b95b9e480fe62cd358336a. Objects owned by other objects cannot be used as input arguments.
+Error: Object 0x643e4088c9f71f7637e1a3084ad0d4d8b2556f97e448c252b4da755dc5caf220 is owned by object 0x8a45165b87d2b63f05ca24326c378a858f946d7ff998168ab4d2b4e07ad44880. Objects owned by other objects cannot be used as input arguments.
 
 task 8 'run'. lines 138-138:
 created: object(117)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
@@ -24,7 +24,7 @@ created: object(112), object(113)
 written: object(110), object(111)
 
 task 6 'run'. lines 129-133:
-Error: Object 0x032f88b6c64f0b334f8b020b385d08aa9df5c5625f1df486ace408ebf6096f6e is owned by object 0xf3f97aded2468cfa0b47d7c0a44b495a5e299d983aea6ebe250ef2aeb1d17638. Objects owned by other objects cannot be used as input arguments.
+Error: Object 0xcf80bf30078ce4f91c860388770d3f3542287a3a3ba798b6e81f22dbd53a3984 is owned by object 0x08cd65ed618d9f45a884b6e53d941dc87ca5db4c0c06ddf22040efcc5299742f. Objects owned by other objects cannot be used as input arguments.
 
 task 7 'run'. lines 135-135:
 created: object(116)

--- a/crates/sui-adapter-transactional-tests/tests/shared/upgrade.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/upgrade.exp
@@ -12,18 +12,15 @@ created: object(107), object(108), object(109), object(110)
 written: object(106)
 
 task 3 'view-object'. lines 44-44:
-Owner: Account Address ( A )
+Owner: Object ID: ( fake(107) )
 Version: 2
 Contents: t::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(110)}}}
 
 task 4 'run'. lines 46-46:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::share_object (function index 2) at offset 0, Abort Code: 0
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 2, instruction: 0, function_name: Some("share_object") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 0)] }), command: Some(0) } }
+Error: Object 0xe6ff026a903dda0711f951bab1d01161791f0f6fe94badadcb0424cf05bd591d is owned by object 0xf2c06d97f4ad9da4a8a6cfb80dd73173302be0c6c245c62279a4bc86a366f33c. Objects owned by other objects cannot be used as input arguments.
 
 task 5 'run'. lines 48-48:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::share_object (function index 2) at offset 0, Abort Code: 0
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 2, instruction: 0, function_name: Some("share_object") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 0)] }), command: Some(0) } }
+Error: Object 0xe6ff026a903dda0711f951bab1d01161791f0f6fe94badadcb0424cf05bd591d is owned by object 0xf2c06d97f4ad9da4a8a6cfb80dd73173302be0c6c245c62279a4bc86a366f33c. Objects owned by other objects cannot be used as input arguments.
 
 task 6 'run'. lines 50-50:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::share_object (function index 2) at offset 0, Abort Code: 0
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 2, instruction: 0, function_name: Some("share_object") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 0)] }), command: Some(0) } }
+Error: Object 0xe6ff026a903dda0711f951bab1d01161791f0f6fe94badadcb0424cf05bd591d is owned by object 0xf2c06d97f4ad9da4a8a6cfb80dd73173302be0c6c245c62279a4bc86a366f33c. Objects owned by other objects cannot be used as input arguments.

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
@@ -11,7 +11,7 @@ task 2 'view-object'. lines 13-13:
 106::m
 
 task 3 'transfer-object'. lines 15-15:
-Error: A move object is expected, instead a move package is passed: 0x3d018ae3eb4670e1f112839d8343a6702525cbe9ea60ad59ff9f2f2743cccf6f
+Error: A move object is expected, instead a move package is passed: 0x563a472643fb0c8ef390968f3a631521623b19bf7a229111e97731f9dd7b596b
 
 task 4 'view-object'. lines 17-17:
 106::m

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
@@ -21,7 +21,7 @@ Version: 3
 Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(110)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(111)}}
 
 task 5 'transfer-object'. lines 35-35:
-Error: Object 0xe59d4d64de85ab9e962e5ea8e0dda45c7544543a1714166c50644e49e2422b84 is owned by object 0x745ea5d547883aa753c1f9ad61290dafd7a462cc162ae5ddf2ede94917e3bf49. Objects owned by other objects cannot be used as input arguments.
+Error: Object 0xa674c5d5ea9b99cdfd28ba8fe8dcb35c70922afbc81d64a2b6b6afaee353578f is owned by object 0x1357b03c3a886f73d3868d2018c0ed739d8a55c8426e534d9c64fc9559ec0dc5. Objects owned by other objects cannot be used as input arguments.
 
 task 6 'view-object'. lines 37-37:
 Owner: Object ID: ( fake(108) )

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -239,10 +239,10 @@ validators:
         next_epoch_primary_address: ~
         next_epoch_worker_address: ~
       voting_power: 10000
-      operation_cap_id: "0x18b8140c8a6ea340142f128061016fc4bd8220ec88875a8e573a5f72a85a15c1"
+      operation_cap_id: "0x16bb51edad1714f14cae3a3b1265f619900cee6126bafed1e743e68f2928a536"
       gas_price: 1
       staking_pool:
-        id: "0xd5d9aa879b78dc1f516d71ab979189086eff752f65e4b0dea15829e3157962e1"
+        id: "0xb0cf62387a5526d51debd3ee28576c60417ba2e8187b94f7d311a312ba0c4c08"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 25000000000000000
@@ -250,7 +250,7 @@ validators:
           value: 0
         pool_token_balance: 25000000000000000
         exchange_rates:
-          id: "0xe63945cec193ca7ac76960370028110a907ad1c22ff90b1fd57ea3c441c766b4"
+          id: "0x4d3f360db730ab473ac315c7d5c96840698e1bf49b8e5bb3d49047c8d131519b"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
@@ -261,17 +261,17 @@ validators:
       next_epoch_commission_rate: 0
   pending_active_validators:
     contents:
-      id: "0x1ace65f54d65a96251b3f46bfa720ab65a7ebe0174caa9fa1dc0d65a56ae7872"
+      id: "0xeca89a922a8cc4f984973ba697f4a4c4c1f37f41bddaa96e29de0d1e924ad550"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x628ffd0e51e9a6ea32c13c2739a31a8f344b557d3429e057b377a9c499b9bb13"
+    id: "0x21b9800ce7318a8f51d3672e177e67635cbcec39fc0f36ea64e620967b4a63dd"
     size: 1
   inactive_pools:
-    id: "0x9dc97c4be6f1d0e61fbdf2cc9d78f9df04cdff7a473e2ec3a65853766dca1177"
+    id: "0x3461b4ad7e16e4f2e9477d40f0c47ab4c7019fb761e3b4e312ba2ce69c84a3cc"
     size: 0
   validator_candidates:
-    id: "0x6d3ffc5213ed4df6802cd4535d3c18f66d85bab5e9f004a7087a005e2f8dc455"
+    id: "0x5285255b1da4e1124de1ec08c5e632851134bb18966e8eddf0b8a1f84b50edca"
     size: 0
   at_risk_validators:
     contents: []

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -8,6 +8,7 @@ use crate::coin::LockedCoin;
 use crate::coin::COIN_MODULE_NAME;
 use crate::coin::COIN_STRUCT_NAME;
 pub use crate::committee::EpochId;
+use crate::crypto::InternalHash;
 use crate::crypto::{
     AuthorityPublicKey, AuthorityPublicKeyBytes, KeypairTraits, PublicKey, SignatureScheme,
     SuiPublicKey, SuiSignature, UserHash,
@@ -50,6 +51,7 @@ use rand::Rng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use shared_crypto::intent::HashingIntentScope;
 use std::cmp::max;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -890,9 +892,8 @@ impl ObjectID {
     /// Create an ObjectID from `TransactionDigest` and `creation_num`.
     /// Caller is responsible for ensuring that `creation_num` is fresh
     pub fn derive_id(digest: TransactionDigest, creation_num: u64) -> Self {
-        // TODO(https://github.com/MystenLabs/sui/issues/58):audit ID derivation
-
-        let mut hasher = UserHash::default();
+        let mut hasher = InternalHash::default();
+        hasher.update([HashingIntentScope::RegularObjectId as u8]);
         hasher.update(digest);
         hasher.update(creation_num.to_le_bytes());
         let hash = hasher.finalize();

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 use serde_json::Value;
 use serde_with::serde_as;
 use serde_with::DisplayFromStr;
+use shared_crypto::intent::HashingIntentScope;
 use std::fmt::{Display, Formatter};
 
 /// Rust version of the Move sui::dynamic_field::Field type
@@ -218,6 +219,7 @@ where
 
     // hash(parent || key || key_type_tag)
     let mut hasher = InternalHash::default();
+    hasher.update([HashingIntentScope::ChildObjectId as u8]);
     hasher.update(parent.into());
     hasher.update(key_bytes.len().to_le_bytes());
     hasher.update(key_bytes);

--- a/sui_programmability/examples/games/tests/drand_based_scratch_card_tests.move
+++ b/sui_programmability/examples/games/tests/drand_based_scratch_card_tests.move
@@ -33,7 +33,7 @@ module games::drand_based_scratch_card_tests {
         let drand_final_round = drand_based_scratch_card::end_of_game_round(drand_based_scratch_card::get_game_base_drand_round(&game));
         assert!(drand_final_round == 5890, 1);
 
-        // Since everything here is deterministic, we know that the 4th ticket will be a winner.
+        // Since everything here is deterministic, we know that the 49th ticket will be a winner.
         let i = 0;
         loop {
             // User2 buys a ticket.
@@ -62,7 +62,8 @@ module games::drand_based_scratch_card_tests {
             };
             i = i + 1;
         };
-        assert!(i == 2, 1);
+        // This value may change if the object ID is changed.
+        assert!(i == 49, 1);
 
         // Claim the reward.
         let winner = test_scenario::take_from_sender<drand_based_scratch_card::Winner>(scenario);


### PR DESCRIPTION
## Description 

This adds one hashing intent byte at the beginning of the message when hashing for an object id. this domain separator ensures for unintended hash collision. closes https://github.com/MystenLabs/sui/issues/9207
## Test Plan 

existing test passes. 
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
