### PR TITLE
Committee creation cannot fail

### DIFF
--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -84,8 +84,7 @@ impl<S: SignatureVerifier + Default> ReconfigObserver<NetworkAuthorityClient, S>
                                 // Safe to unwrap, checked above
                                 Committee::new(
                                     committee.epoch,
-                                    BTreeMap::from_iter(committee.validators.into_iter())).unwrap_or_else(
-                                    |e| panic!("Can't create a valid Committee given info returned from Full Node: {:?}", e)
+                                    BTreeMap::from_iter(committee.validators.into_iter()),
                                 )
                             }
                             other => {

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -184,7 +184,7 @@ impl LocalValidatorAggregatorProxy {
             .unwrap();
 
         let validator_info = genesis.validator_set();
-        let committee = Committee::new(0, ValidatorInfo::voting_rights(&validator_info)).unwrap();
+        let committee = Committee::new(0, ValidatorInfo::voting_rights(&validator_info));
         let clients = make_authority_clients(
             &validator_info,
             DEFAULT_CONNECT_TIMEOUT_SEC,
@@ -212,7 +212,7 @@ impl LocalValidatorAggregatorProxy {
             .unwrap();
 
         let validator_info = configs.validator_set();
-        let committee = Committee::new(0, ValidatorInfo::voting_rights(&validator_info)).unwrap();
+        let committee = Committee::new(0, ValidatorInfo::voting_rights(&validator_info));
         let clients = make_authority_clients(
             &validator_info,
             DEFAULT_CONNECT_TIMEOUT_SEC,
@@ -528,7 +528,7 @@ impl FullNodeProxy {
         let committee_vec = resp.validators;
         let committee_map =
             BTreeMap::from_iter(committee_vec.into_iter().map(|(name, stake)| (name, stake)));
-        let committee = Committee::new(epoch, committee_map)?;
+        let committee = Committee::new(epoch, committee_map);
 
         Ok(Self {
             sui_client,

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1041,7 +1041,7 @@ where
                                 }
                                 if err.is_object_or_package_not_found() {
                                     // Special case for object not found because we can
-                                    // retry if we have < 2f+1 object not found errors. 
+                                    // retry if we have < 2f+1 object not found errors.
                                     // However once we reach >= 2f+1 object not found errors
                                     // we cannot retry.
                                     state.object_or_package_not_found_stake += weight;
@@ -1592,7 +1592,7 @@ impl<'a> AuthorityAggregatorBuilder<'a> {
         } else {
             anyhow::bail!("need either NetworkConfig or Genesis.");
         };
-        let committee = Committee::new(0, ValidatorInfo::voting_rights(&validator_info))?;
+        let committee = Committee::new(0, ValidatorInfo::voting_rights(&validator_info));
         let mut registry = &prometheus::Registry::new();
         if self.registry.is_some() {
             registry = self.registry.unwrap();

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -737,7 +737,7 @@ mod adapter_tests {
                 )
             })
             .collect::<Vec<_>>();
-        let committee = Committee::new(0, authorities.iter().cloned().collect()).unwrap();
+        let committee = Committee::new(0, authorities.iter().cloned().collect());
 
         // generate random transaction digests, and account for validator selection
         const NUM_TEST_TRANSACTIONS: usize = 1000;

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -126,8 +126,7 @@ impl WriteStore for RocksDbStore {
         }) = checkpoint.end_of_epoch_data.as_ref()
         {
             let next_committee = next_epoch_committee.iter().cloned().collect();
-            let committee = Committee::new(checkpoint.epoch().saturating_add(1), next_committee)
-                .expect("new committee from consensus should be constructable");
+            let committee = Committee::new(checkpoint.epoch().saturating_add(1), next_committee);
             self.insert_committee(committee)?;
         }
 

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -629,7 +629,7 @@ fn get_genesis_agg<A>(
     authorities: BTreeMap<AuthorityName, StakeUnit>,
     clients: BTreeMap<AuthorityName, A>,
 ) -> AuthorityAggregator<A> {
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::new(0, authorities);
     let committee_store = Arc::new(CommitteeStore::new_for_testing(&committee));
 
     AuthorityAggregator::new_with_timeouts(
@@ -653,7 +653,7 @@ where
     A: Clone,
 {
     let mut agg = get_genesis_agg(authorities.clone(), clients);
-    let committee = Committee::new(epoch, authorities).unwrap();
+    let committee = Committee::new(epoch, authorities);
     agg.committee_store
         .insert_new_committee(&committee)
         .unwrap();
@@ -825,7 +825,7 @@ async fn test_handle_transaction_response() {
     println!("Case 2 - Retryable Transaction (WrongEpoch Error)");
     // Validators return signed-tx with epoch 0, client expects 1
     // Update client to epoch 1
-    let committee_1 = Committee::new(1, authorities.clone()).unwrap();
+    let committee_1 = Committee::new(1, authorities.clone());
     agg.committee_store
         .insert_new_committee(&committee_1)
         .unwrap();
@@ -879,7 +879,7 @@ async fn test_handle_transaction_response() {
     )
     .await;
 
-    let committee_1 = Committee::new(1, authorities.clone()).unwrap();
+    let committee_1 = Committee::new(1, authorities.clone());
     agg.committee_store
         .insert_new_committee(&committee_1)
         .unwrap();
@@ -1159,7 +1159,7 @@ async fn test_handle_transaction_response() {
 
     println!("Case 7.1 - Retryable Transaction (WrongEpoch Error)");
     // Update committee store, now SafeClient will pass
-    let committee_1 = Committee::new(1, authorities.clone()).unwrap();
+    let committee_1 = Committee::new(1, authorities.clone());
     agg.committee_store
         .insert_new_committee(&committee_1)
         .unwrap();
@@ -1731,7 +1731,7 @@ async fn test_handle_conflicting_transaction_response() {
 
     println!("Case 5.1 - Retryable Transaction (WrongEpoch Error)");
     // Update committee store to epoch 2, now SafeClient will pass
-    let committee_2 = Committee::new(2, authorities.clone()).unwrap();
+    let committee_2 = Committee::new(2, authorities.clone());
     agg.committee_store
         .insert_new_committee(&committee_2)
         .unwrap();

--- a/crates/sui-framework/docs/voting_power.md
+++ b/crates/sui-framework/docs/voting_power.md
@@ -63,6 +63,15 @@
 ## Constants
 
 
+<a name="0x2_voting_power_EInvalidVotingPower"></a>
+
+
+
+<pre><code><b>const</b> <a href="voting_power.md#0x2_voting_power_EInvalidVotingPower">EInvalidVotingPower</a>: u64 = 4;
+</code></pre>
+
+
+
 <a name="0x2_voting_power_ERelativePowerMismatch"></a>
 
 
@@ -369,6 +378,7 @@ Check a few invariants that must hold after setting the voting power.
     <b>let</b> total = 0;
     <b>while</b> (i &lt; len) {
         <b>let</b> <a href="voting_power.md#0x2_voting_power">voting_power</a> = <a href="validator.md#0x2_validator_voting_power">validator::voting_power</a>(<a href="_borrow">vector::borrow</a>(v, i));
+        <b>assert</b>!(<a href="voting_power.md#0x2_voting_power">voting_power</a> &gt; 0, <a href="voting_power.md#0x2_voting_power_EInvalidVotingPower">EInvalidVotingPower</a>);
         total = total + <a href="voting_power.md#0x2_voting_power">voting_power</a>;
         i = i + 1;
     };

--- a/crates/sui-framework/sources/governance/voting_power.move
+++ b/crates/sui-framework/sources/governance/voting_power.move
@@ -31,6 +31,7 @@ module sui::voting_power {
     const ETotalPowerMismatch: u64 = 1;
     const ERelativePowerMismatch: u64 = 2;
     const EVotingPowerOverThreshold: u64 = 3;
+    const EInvalidVotingPower: u64 = 4;
 
     /// Set the voting power of all validators.
     /// Each validator's voting power is initialized using their stake. We then attempt to cap their voting power
@@ -142,6 +143,7 @@ module sui::voting_power {
         let total = 0;
         while (i < len) {
             let voting_power = validator::voting_power(vector::borrow(v, i));
+            assert!(voting_power > 0, EInvalidVotingPower);
             total = total + voting_power;
             i = i + 1;
         };

--- a/crates/sui-network/src/state_sync/test_utils.rs
+++ b/crates/sui-network/src/state_sync/test_utils.rs
@@ -38,8 +38,7 @@ impl CommitteeFixture {
                 .iter()
                 .map(|(name, (_, stake))| (*name, *stake))
                 .collect(),
-        )
-        .unwrap();
+        );
 
         Self {
             epoch,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -64,7 +64,7 @@ pub const APPROX_SIZE_OF_EXECUTION_STATUS: usize = 120;
 // Approximate size of `EpochId` type in bytes
 pub const APPROX_SIZE_OF_EPOCH_ID: usize = 10;
 // Approximate size of `GasCostSummary` type in bytes
-pub const APPROX_SIZE_OF_GAS_COST_SUMARY: usize = 30;
+pub const APPROX_SIZE_OF_GAS_COST_SUMMARY: usize = 30;
 // Approximate size of `Option<TransactionEventsDigest>` type in bytes
 pub const APPROX_SIZE_OF_OPT_TX_EVENTS_DIGEST: usize = 40;
 // Approximate size of `TransactionDigest` type in bytes
@@ -2510,7 +2510,7 @@ impl TransactionEffects {
     ) -> usize {
         let fixed_sizes = APPROX_SIZE_OF_EXECUTION_STATUS
             + APPROX_SIZE_OF_EPOCH_ID
-            + APPROX_SIZE_OF_GAS_COST_SUMARY
+            + APPROX_SIZE_OF_GAS_COST_SUMMARY
             + APPROX_SIZE_OF_OPT_TX_EVENTS_DIGEST;
 
         // Each write or delete contributes at roughly this amount because:

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -357,8 +357,7 @@ impl InMemoryStore {
                 .iter()
                 .cloned()
                 .collect();
-            let committee = Committee::new(checkpoint.epoch().saturating_add(1), next_committee)
-                .expect("new committee from consensus should be constructable");
+            let committee = Committee::new(checkpoint.epoch().saturating_add(1), next_committee);
             self.insert_committee(committee);
         }
 

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -133,9 +133,6 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
             .map(|validator| (validator.authority_name(), validator.voting_power))
             .collect();
         Committee::new(self.epoch, voting_rights)
-            // unwrap is safe because we should have verified the committee on-chain.
-            // MUSTFIX: Make sure we always have a valid committee.
-            .unwrap()
     }
 
     #[allow(clippy::mutable_key_type)]

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -457,10 +457,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
             );
         }
         CommitteeWithNetworkMetadata {
-            committee: Committee::new(self.epoch, voting_rights)
-                // unwrap is safe because we should have verified the committee on-chain.
-                // MUSTFIX: Make sure we always have a valid committee
-                .unwrap(),
+            committee: Committee::new(self.epoch, voting_rights),
             network_metadata,
         }
     }

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -99,7 +99,7 @@ impl SuiSystemStateSummary {
             );
         }
         CommitteeWithNetworkMetadata {
-            committee: Committee::new(self.epoch, voting_rights).unwrap(),
+            committee: Committee::new(self.epoch, voting_rights),
             network_metadata,
         }
     }

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -43,7 +43,7 @@ fn test_signed_values() {
         /* address */ AuthorityPublicKeyBytes::from(sec2.public()),
         /* voting right */ 0,
     );
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::new(0, authorities);
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -120,7 +120,7 @@ fn test_certificates() {
         /* address */ AuthorityPublicKeyBytes::from(sec2.public()),
         /* voting right */ 1,
     );
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::new(0, authorities);
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -193,7 +193,7 @@ fn test_new_with_signatures() {
     let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
     authorities.insert(AuthorityPublicKeyBytes::from(sec.public()), 1);
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone());
     let quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures.clone(), &committee)
             .unwrap();
@@ -240,7 +240,7 @@ fn test_handle_reject_malicious_signature() {
         };
     }
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone());
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
     {
@@ -321,7 +321,7 @@ fn test_bitmap_out_of_range() {
         ));
     }
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone());
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
 
@@ -362,7 +362,7 @@ fn test_reject_extra_public_key() {
         signatures[3].clone(),
     ];
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone());
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(used_signatures, &committee)
             .unwrap();
@@ -400,7 +400,7 @@ fn test_reject_reuse_signatures() {
         signatures[2].clone(),
     ];
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone());
     let quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(used_signatures, &committee)
             .unwrap();
@@ -429,7 +429,7 @@ fn test_empty_bitmap() {
         ));
     }
 
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone());
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
     quorum.signers_map = RoaringBitmap::new();
@@ -453,7 +453,7 @@ fn test_digest_caching() {
     authorities.insert(sec1.public().into(), 1);
     authorities.insert(sec2.public().into(), 0);
 
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::new(0, authorities);
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -620,7 +620,7 @@ fn test_user_signature_committed_in_signed_transactions() {
     // Ensure that signed tx verifies against the transaction with a correct user signature.
     let mut authorities: BTreeMap<AuthorityPublicKeyBytes, u64> = BTreeMap::new();
     authorities.insert(AuthorityPublicKeyBytes::from(sec1.public()), 1);
-    let committee = Committee::new(0, authorities.clone()).unwrap();
+    let committee = Committee::new(0, authorities.clone());
     assert!(signed_tx_a
         .auth_sig()
         .verify_secure(
@@ -883,7 +883,7 @@ fn verify_sender_signature_correctly_with_flag() {
     let (_, sec2): (_, AuthorityKeyPair) = get_key_pair();
     authorities.insert(sec1.public().into(), 1);
     authorities.insert(sec2.public().into(), 0);
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::new(0, authorities);
 
     // create a receiver keypair with Secp256k1
     let receiver_kp = SuiKeyPair::Secp256k1(get_key_pair().1);
@@ -1316,8 +1316,8 @@ fn check_approx_effects_components_size() {
     use std::mem::size_of;
 
     assert!(
-        size_of::<GasCostSummary>() < APPROX_SIZE_OF_GAS_COST_SUMARY,
-        "Update APPROX_SIZE_OF_GAS_COST_SUMARY constant"
+        size_of::<GasCostSummary>() < APPROX_SIZE_OF_GAS_COST_SUMMARY,
+        "Update APPROX_SIZE_OF_GAS_COST_SUMMARY constant"
     );
     assert!(
         size_of::<EpochId>() < APPROX_SIZE_OF_EPOCH_ID,

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -44,7 +44,7 @@ where
         keys.push(inner_authority_key);
     }
 
-    let committee = Committee::new(0, authorities).unwrap();
+    let committee = Committee::new(0, authorities);
     (keys, committee)
 }
 


### PR DESCRIPTION
This PR removes the error returns in Committee creation, and replace them with assert.
This is ok because can never fail.