### PR TITLE
[Narwhal] introduce consensus randomized tests

### DIFF
--- a/.github/workflows/nightly-narwhal.yml
+++ b/.github/workflows/nightly-narwhal.yml
@@ -45,7 +45,7 @@ jobs:
       # These are considered the end-to-end "slow" tests for us
       - name: cargo nextest
         run: |
-          cargo nextest run -E 'kind(test) and package(narwhal-primary)' --profile narwhalnightly --run-ignored ignored-only
+          cargo nextest run -E 'kind(test) and package(narwhal-primary) and package(narwhal-consensus)' --profile narwhalnightly --run-ignored ignored-only
 
   report-status:
     name: Report Status

--- a/narwhal/config/src/committee.rs
+++ b/narwhal/config/src/committee.rs
@@ -177,14 +177,14 @@ impl Committee {
     fn calculate_quorum_threshold(&self) -> NonZeroU64 {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (2 N + 3) / 3 = 2f + 1 + (2k + 2)/3 = 2f + 1 + k = N - f
-        let total_votes: Stake = self.authorities.values().map(|x| x.stake).sum();
+        let total_votes: Stake = self.total_stake();
         NonZeroU64::new(2 * total_votes / 3 + 1).unwrap()
     }
 
     fn calculate_validity_threshold(&self) -> NonZeroU64 {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (N + 2) / 3 = f + 1 + k/3 = f + 1
-        let total_votes: Stake = self.authorities.values().map(|x| x.stake).sum();
+        let total_votes: Stake = self.total_stake();
         NonZeroU64::new((total_votes + 2) / 3).unwrap()
     }
 
@@ -270,6 +270,10 @@ impl Committee {
     /// Returns the stake required to reach availability (f+1).
     pub fn validity_threshold(&self) -> Stake {
         self.validity_threshold
+    }
+
+    pub fn total_stake(&self) -> Stake {
+        self.authorities.values().map(|x| x.stake).sum()
     }
 
     /// Returns a leader node as a weighted choice seeded by the provided integer

--- a/narwhal/config/src/committee.rs
+++ b/narwhal/config/src/committee.rs
@@ -272,6 +272,16 @@ impl Committee {
         self.validity_threshold
     }
 
+    /// Returns true if the provided stake has reached quorum (2f+1)
+    pub fn reached_quorum(&self, stake: Stake) -> bool {
+        stake >= self.quorum_threshold()
+    }
+
+    /// Returns true if the provided stake has reached availability (f+1)
+    pub fn reached_validity(&self, stake: Stake) -> bool {
+        stake >= self.validity_threshold()
+    }
+
     pub fn total_stake(&self) -> Stake {
         self.authorities.values().map(|x| x.stake).sum()
     }

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -24,7 +24,6 @@ use thiserror::Error;
 use tracing::info;
 use utils::get_available_port;
 
-pub mod committee;
 pub use committee::*;
 mod duration_format;
 pub mod utils;

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -24,6 +24,7 @@ use thiserror::Error;
 use tracing::info;
 use utils::get_available_port;
 
+pub mod committee;
 pub use committee::*;
 mod duration_format;
 pub mod utils;

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -20,6 +20,10 @@ use types::{
 #[path = "tests/bullshark_tests.rs"]
 pub mod bullshark_tests;
 
+#[cfg(test)]
+#[path = "tests/randomized_tests.rs"]
+pub mod randomized_tests;
+
 /// LastRound is a helper struct to keep necessary info
 /// around the leader election on the last election round.
 /// When both the leader_found = true & leader_has_support = true

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -8,7 +8,6 @@ use super::*;
 use crate::consensus::ConsensusRound;
 use crate::consensus_utils::*;
 use crate::{metrics::ConsensusMetrics, Consensus, NUM_SHUTDOWN_RECEIVERS};
-use fastcrypto::hash::Hash;
 #[allow(unused_imports)]
 use fastcrypto::traits::KeyPair;
 use prometheus::Registry;

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -6,6 +6,7 @@
 use super::*;
 
 use crate::consensus::ConsensusRound;
+use crate::consensus_utils::NUM_SUB_DAGS_PER_SCHEDULE;
 use crate::consensus_utils::*;
 use crate::{metrics::ConsensusMetrics, Consensus, NUM_SHUTDOWN_RECEIVERS};
 #[allow(unused_imports)]
@@ -24,8 +25,6 @@ use types::{CertificateAPI, HeaderAPI, PreSubscribedBroadcastSender};
 // the leader of round 2.
 #[tokio::test]
 async fn commit_one() {
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
-
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     // Make certificates for rounds 1 and 2.
@@ -105,8 +104,6 @@ async fn commit_one() {
 // rounds 2, 4, 6 and 10. The leader of round 8 will be missing, but eventually the leader 10 will get committed.
 #[tokio::test]
 async fn dead_node() {
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
-
     // Make the certificates.
     let fixture = CommitteeFixture::builder().build();
     let committee: Committee = fixture.committee();
@@ -217,7 +214,6 @@ async fn dead_node() {
 // round 4 does. The leader of rounds 2 and 4 should thus be committed (because they are linked).
 #[tokio::test]
 async fn not_enough_support() {
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     let mut ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
@@ -369,7 +365,6 @@ async fn not_enough_support() {
 // and reappears from round 3.
 #[tokio::test]
 async fn missing_leader() {
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     let mut ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
@@ -468,7 +463,6 @@ async fn committed_round_after_restart() {
     let committee = fixture.committee();
     let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
     let epoch = committee.epoch();
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     // Make certificates for rounds 1 to 11.
     let genesis = Certificate::genesis(&committee)
@@ -562,8 +556,6 @@ async fn committed_round_after_restart() {
 /// from round 2. Certificate 2 should not get committed.
 #[tokio::test]
 async fn delayed_certificates_are_rejected() {
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
-
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
@@ -736,7 +728,6 @@ async fn restart_with_new_committee() {
     let fixture = CommitteeFixture::builder().build();
     let mut committee: Committee = fixture.committee();
     let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     // Run for a few epochs.
     for epoch in 0..5 {
@@ -831,7 +822,6 @@ async fn restart_with_new_committee() {
 #[tokio::test]
 async fn garbage_collection_basic() {
     const GC_DEPTH: Round = 4;
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     let fixture = CommitteeFixture::builder().build();
     let committee: Committee = fixture.committee();
@@ -920,7 +910,6 @@ async fn garbage_collection_basic() {
 #[tokio::test]
 async fn slow_node() {
     const GC_DEPTH: Round = 4;
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     let fixture = CommitteeFixture::builder().build();
     let committee: Committee = fixture.committee();
@@ -1056,7 +1045,6 @@ async fn slow_node() {
 #[tokio::test]
 async fn not_enough_support_and_missing_leaders_and_gc() {
     const GC_DEPTH: Round = 4;
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     let fixture = CommitteeFixture::builder().build();
     let committee: Committee = fixture.committee();

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -14,6 +14,7 @@ use tokio::sync::watch;
 
 use crate::bullshark::Bullshark;
 use crate::consensus::ConsensusRound;
+use crate::consensus_utils::NUM_SUB_DAGS_PER_SCHEDULE;
 use crate::metrics::ConsensusMetrics;
 use crate::Consensus;
 use crate::NUM_SHUTDOWN_RECEIVERS;
@@ -40,7 +41,6 @@ async fn test_consensus_recovery_with_bullshark() {
 
     let consensus_store = storage.consensus_store;
     let certificate_store = storage.certificate_store;
-    const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 
     // AND Setup consensus
     let fixture = CommitteeFixture::builder().build();

--- a/narwhal/consensus/src/tests/consensus_utils.rs
+++ b/narwhal/consensus/src/tests/consensus_utils.rs
@@ -10,6 +10,8 @@ use types::{
     Certificate, CertificateDigest, CommittedSubDagShell, ConsensusStore, Round, SequenceNumber,
 };
 
+pub(crate) const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
+
 pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore> {
     const LAST_COMMITTED_CF: &str = "last_committed";
     const SEQUENCE_CF: &str = "sequence";

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -1,0 +1,502 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::bullshark::Bullshark;
+use crate::consensus::ConsensusProtocol;
+use crate::consensus::ConsensusState;
+use crate::consensus_utils::make_consensus_store;
+use crate::metrics::ConsensusMetrics;
+use config::{Committee, Stake};
+use crypto::PublicKey;
+use fastcrypto::hash::Hash;
+use fastcrypto::hash::HashFunction;
+use prometheus::Registry;
+use rand::distributions::Bernoulli;
+use rand::distributions::Distribution;
+use rand::prelude::SliceRandom;
+use rand::rngs::StdRng;
+use rand::Rng;
+use rand::SeedableRng;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::num::NonZeroUsize;
+use std::ops::RangeInclusive;
+use std::sync::Arc;
+use test_utils::mock_certificate;
+use test_utils::CommitteeFixture;
+#[allow(unused_imports)]
+use tokio::sync::mpsc::channel;
+use types::Round;
+use types::{Certificate, CertificateDigest};
+
+#[derive(Copy, Clone)]
+pub struct FailureModes {
+    // The probability of having failures per round. The failures should
+    // be <=f , otherwise no DAG could be created. The provided number gives the probability of having
+    // failures up to f. Ex for input `failures_probability = 0.2` it means we'll have 20% change of
+    // having failures up to 33% of the nodes.
+    pub nodes_failure_probability: f64,
+
+    // The percentage of slow nodes we want to introduce to our sample. Basically a slow node is one
+    // that might be able to produce certificates, but those are never get referenced by others. That has
+    // as an effect that when they are leaders might also not get enough support - or no support at all.
+    // For example, a value of 0.2 means that we want up to 20% of our nodes to behave as slow nodes.
+    pub slow_nodes_percentage: f64,
+
+    // The probability of failing to include a slow node certificate to from the certificates of next
+    // round. For example a value of 0.1 means that 10% of the time fail get referenced by the
+    // certificates of the next round.
+    pub slow_nodes_failure_probability: f64,
+}
+
+struct ExecutionPlan {
+    certificates: Vec<Certificate>,
+}
+
+impl ExecutionPlan {
+    fn hash(&self) -> [u8; crypto::DIGEST_LENGTH] {
+        let mut hasher = crypto::DefaultHashFunction::new();
+        self.certificates.iter().for_each(|c| {
+            hasher.update(c.digest());
+        });
+        hasher.finalize().into()
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn bullshark_randomised_tests() {
+    // Configuration regarding the randomized tests. The tests will run for different values
+    // on the below parameters to increase the different cases we can generate.
+
+    // A range of gc_depth to be used
+    const GC_DEPTH: RangeInclusive<Round> = 4..=15;
+    // A range of the committee size to be used
+    const COMMITTEE_SIZE: RangeInclusive<usize> = 4..=8;
+    // A range of rounds for which we will create DAGs
+    const DAG_ROUNDS: RangeInclusive<Round> = 8..=15;
+    // The number of different execution plans to be created and tested against for every generated DAG
+    const EXECUTION_PLANS: u64 = 10_000;
+    // The number of DAGs that should be generated and tested against for every set of properties.
+    const DAGS_PER_SETUP: u64 = 1_000;
+    // DAGs will be created for these failure modes
+    let failure_modes: Vec<FailureModes> = vec![
+        // No failures
+        FailureModes {
+            nodes_failure_probability: 0.0,
+            slow_nodes_percentage: 0.0,
+            slow_nodes_failure_probability: 0.0,
+        },
+        // Some failures
+        FailureModes {
+            nodes_failure_probability: 0.05,     // 5%
+            slow_nodes_percentage: 0.05,         // 5%
+            slow_nodes_failure_probability: 0.3, // 30%
+        },
+        // Severe failures
+        FailureModes {
+            nodes_failure_probability: 0.0,      // 0%
+            slow_nodes_percentage: 0.2,          // 20%
+            slow_nodes_failure_probability: 0.7, // 70%
+        },
+    ];
+
+    let mut run_id = 0;
+    for committee_size in COMMITTEE_SIZE {
+        for gc_depth in GC_DEPTH {
+            for dag_rounds in DAG_ROUNDS {
+                for _ in 0..DAGS_PER_SETUP {
+                    for mode in &failure_modes {
+                        // we want to skip this test as gc_depth will never be enforced
+                        if gc_depth > dag_rounds {
+                            continue;
+                        }
+
+                        run_id += 1;
+
+                        // Create a randomized DAG
+                        let (certificates, committee) =
+                            generate_randomised_dag(committee_size, dag_rounds, run_id, *mode);
+
+                        // Now provide the DAG to create execution plans, run them via consensus
+                        // and compare output against each other to ensure they are the same.
+                        generate_and_run_execution_plans(
+                            certificates,
+                            EXECUTION_PLANS,
+                            committee,
+                            gc_depth,
+                            dag_rounds,
+                            run_id,
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Creates a DAG with the known parameters but with some sort of randomness
+// to ensure that the DAG will create:
+// * weak references to leaders
+// * missing leaders
+// * missing certificates
+
+// Note: the slow nodes precede of the failures_probability - meaning that first we calculate the
+// failures per round and then the behaviour of the slow nodes to ensure that we'll always produce
+// 2f+1 certificates per round.
+fn generate_randomised_dag(
+    committee_size: usize,
+    number_of_rounds: Round,
+    seed: u64,
+    modes: FailureModes,
+) -> (VecDeque<Certificate>, Committee) {
+    // Create an RNG to share for the committee creation
+    let rand = StdRng::seed_from_u64(seed);
+
+    let fixture = CommitteeFixture::builder()
+        .committee_size(NonZeroUsize::new(committee_size).unwrap())
+        .rng(rand)
+        .build();
+    let committee: Committee = fixture.committee();
+    let genesis = Certificate::genesis(&committee);
+
+    // Create a known DAG
+    let (original_certificates, _last_round) =
+        make_certificates_with_parameters(seed, &committee, 1..=number_of_rounds, genesis, modes);
+
+    (original_certificates, committee)
+}
+
+/// This method is creating DAG using the following quality properties under consideration:
+/// * nodes that don't create certificates at all for some rounds (failures)
+/// * leaders that don't get enough support (f+1) for their immediate round
+/// * slow nodes - nodes that create certificates but those might not referenced by nodes of
+/// subsequent rounds.
+pub fn make_certificates_with_parameters(
+    seed: u64,
+    committee: &Committee,
+    range: RangeInclusive<Round>,
+    initial_parents: Vec<Certificate>,
+    modes: FailureModes,
+) -> (VecDeque<Certificate>, Vec<Certificate>) {
+    let mut rand = StdRng::seed_from_u64(seed);
+
+    //Pick the slow nodes - ensure we don't have more than 33% of slow nodes
+    assert!(modes.slow_nodes_percentage <= 0.33, "Slow nodes can't be more than 33% of total nodes - otherwise we'll basically simulate a consensus stall");
+
+    let mut keys: Vec<PublicKey> = committee
+        .authorities()
+        .map(|(key, _)| key.clone())
+        .collect();
+
+    // Now shuffle authorities and pick the slow nodes, if should exist
+    keys.shuffle(&mut rand);
+
+    // Step 1 - determine the slow nodes , assuming those should exist
+    let slow_node_keys: Vec<(PublicKey, f64)> = {
+        let num_of_slow_nodes =
+            (committee.total_stake() as f64 * modes.slow_nodes_percentage) as Stake;
+        let s = num_of_slow_nodes.min(committee.validity_threshold() - 1);
+
+        keys.iter()
+            .take(s as usize)
+            .map(|k| (k.clone(), 1.0 - modes.slow_nodes_failure_probability))
+            .collect()
+    };
+
+    println!("Slow nodes: {:?}", slow_node_keys);
+
+    let mut certificates = VecDeque::new();
+    let mut parents = initial_parents;
+    let mut next_parents = Vec::new();
+    let mut certificates_per_round: HashMap<Round, Vec<Certificate>> = HashMap::new();
+
+    parents.iter().for_each(|c| {
+        certificates_per_round
+            .entry(c.round())
+            .or_default()
+            .push(c.clone());
+    });
+
+    for round in range {
+        next_parents.clear();
+
+        let mut total_failures = 0;
+
+        // shuffle keys to introduce extra randomness
+        keys.shuffle(&mut rand);
+
+        for name in keys.iter() {
+            let current_parents = parents.clone();
+
+            // Step 2 -- introduce failures (assuming those are enabled)
+            // We disable the failure probability if we have already reached the maximum number
+            // of allowed failures (f)
+            let should_fail = if total_failures + 1 == committee.validity_threshold() {
+                false
+            } else {
+                let b = Bernoulli::new(modes.nodes_failure_probability).unwrap();
+                b.sample(&mut rand)
+            };
+
+            if should_fail {
+                total_failures += 1;
+                continue;
+            }
+
+            // Step 3 -- figure out the parents taking into account the slow nodes - assuming they
+            // are provide such.
+            let parent_digests = test_utils::this_cert_parents_with_slow_nodes(
+                name,
+                current_parents.clone(),
+                slow_node_keys.as_slice(),
+                &mut rand,
+            );
+            let mut parent_digests: Vec<CertificateDigest> = parent_digests.into_iter().collect();
+
+            // Step 3 -- references to previous round
+            // Now from the rest of current_parents, pick a random number - uniform - to how many
+            // should create references to. It should strictly be between [2f+1..3f+1].
+            let num_of_parents_to_pick =
+                rand.gen_range(committee.quorum_threshold()..=committee.total_stake());
+
+            // shuffle the parents
+            parent_digests.shuffle(&mut rand);
+
+            // now keep only the num_of_parents_to_pick
+            let parents_digests = parent_digests
+                .into_iter()
+                .take(num_of_parents_to_pick as usize)
+                .collect();
+
+            // Now create the certificate with the provided parents
+            let (_, certificate) =
+                mock_certificate(committee, name.clone(), round, parents_digests);
+
+            // group certificates by round for easy access
+            certificates_per_round
+                .entry(certificate.round())
+                .or_default()
+                .push(certificate.clone());
+
+            certificates.push_back(certificate.clone());
+            next_parents.push(certificate);
+        }
+        parents = next_parents.clone();
+    }
+
+    // sanity check - before return, ensure that we have at least 2f+1 certificates per round and
+    // not certificate exists (except the genesis ones) whose parent is missing.
+    certificates_per_round
+        .iter()
+        .for_each(|(round, round_certs)| {
+            assert!(round_certs.len() >= committee.quorum_threshold() as usize);
+
+            if *round > 0 {
+                let parents = certificates_per_round.get(&(round - 1)).unwrap();
+                round_certs
+                    .iter()
+                    .flat_map(|c| c.header.parents.clone())
+                    .for_each(|digest| {
+                        parents
+                            .iter()
+                            .find(|c| c.digest() == digest)
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "Certificate with digest {} should be found in parents",
+                                    digest
+                                )
+                            });
+                    });
+            }
+        });
+
+    (certificates, next_parents)
+}
+
+/// Creates various execution plans (`test_iterations` in total) by permuting the order we feed the
+/// DAG certificates to consensus and compare the output to ensure is the same.
+fn generate_and_run_execution_plans(
+    original_certificates: VecDeque<Certificate>,
+    test_iterations: u64,
+    committee: Committee,
+    gc_depth: Round,
+    dag_rounds: Round,
+    run_id: u64,
+) {
+    let mut executed_plans = HashSet::new();
+    let mut committed_certificates = Vec::new();
+
+    // Create a single store to be re-used across Bullshark instances to avoid hitting
+    // a "too many files open" issue.
+    let store = make_consensus_store(&test_utils::temp_dir());
+
+    for i in 0..test_iterations {
+        // clear store before using for next test
+        store.clear().unwrap();
+
+        let seed = (i + 1) * run_id;
+
+        let plan = create_execution_plan(original_certificates.clone(), seed);
+
+        let hash = plan.hash();
+        if !executed_plans.insert(hash) {
+            println!("Skipping plan with seed {}, same executed already", seed);
+            continue;
+        }
+
+        // Now create a new Bullshark engine
+        const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
+
+        let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
+        let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
+        let mut bullshark = Bullshark::new(
+            committee.clone(),
+            store.clone(),
+            metrics,
+            NUM_SUB_DAGS_PER_SCHEDULE,
+        );
+
+        let mut inserted_certificates = HashSet::new();
+
+        let mut plan_committed_certificates = Vec::new();
+        for c in plan.certificates {
+            //print!("R {} - D {}", c.round(), c.digest());
+
+            // A sanity check that we indeed attempt to send to Bullshark a certificate
+            // whose parents have already been inserted.
+            if c.round() > 1 {
+                for parent in &c.header.parents {
+                    assert!(inserted_certificates.contains(parent));
+                }
+            }
+            inserted_certificates.insert(c.digest());
+
+            // Now commit one by one the certificates and gather the results
+            let (_outcome, committed_sub_dags) =
+                bullshark.process_certificate(&mut state, c).unwrap();
+            //println!(" -> Outcome: {:?}", outcome);
+            for sub_dag in committed_sub_dags {
+                plan_committed_certificates.extend(sub_dag.certificates);
+            }
+        }
+
+        // Compare the results with the previously executed plan results
+        if committed_certificates.is_empty() {
+            committed_certificates = plan_committed_certificates.clone();
+        } else {
+            assert_eq!(
+                committed_certificates,
+                plan_committed_certificates,
+                "Fork detected in plans for seed={}, rounds={}, committee={}, gc_depth={}",
+                seed,
+                dag_rounds,
+                committee.authorities.len(),
+                gc_depth
+            );
+        }
+
+        println!(
+            "Successfully committed plan with seed {} for rounds={}, committee={}, gc_depth={}",
+            seed,
+            dag_rounds,
+            committee.authorities.len(),
+            gc_depth
+        );
+    }
+}
+
+/// This method is accepting a list of certificates that have been created to represent a valid
+/// DAG and puts them in a causally valid order to be sent to consensus but different than just
+/// sending them round by round, so we can simulate more real life scenarios.
+/// Basically it is creating an execution plan. A seed value is provided to be used in a random
+/// function in order to perform random permutations when creating the sequence to help construct
+/// different paths.
+/// Using Kahn's DAG topological sort algorithm, we basically try to sort the certificate DAG
+/// <https://en.wikipedia.org/wiki/Topological_sorting> always respecting the causal order of
+/// certificates - meaning for every certificate on round R, we must first have  submitted all
+/// parent certificates of round R-1.
+fn create_execution_plan(
+    certificates: impl IntoIterator<Item = Certificate> + Clone,
+    seed: u64,
+) -> ExecutionPlan {
+    // Initialise the source of randomness
+    let mut rand = StdRng::seed_from_u64(seed);
+
+    // Create a map of digest -> certificate
+    let digest_to_certificate: HashMap<CertificateDigest, Certificate> = certificates
+        .clone()
+        .into_iter()
+        .map(|c| (c.digest(), c))
+        .collect();
+
+    // To model the DAG in form of edges and vertexes build an adjacency matrix.
+    // The matrix will capture the dependencies between the parent certificates --> children certificates.
+    // This is important because the algorithm ensures that no children will be added to the final list
+    // unless all their dependencies (parent certificates) have first been added earlier - so we
+    // respect the causal order.
+    let mut adjacency_parent_to_children: HashMap<CertificateDigest, Vec<CertificateDigest>> =
+        HashMap::new();
+
+    // The nodes that have no incoming edges/dependencies (parent certificates) - initially are the certificates of
+    // round 1 (we have no parents)
+    let mut nodes_without_dependencies = Vec::new();
+
+    for certificate in certificates {
+        // for the first round of certificates we don't want to include their parents, as we won't
+        // have them available anyways - so we want those to be our roots.
+        if certificate.round() > 1 {
+            for parent in &certificate.header.parents {
+                adjacency_parent_to_children
+                    .entry(*parent)
+                    .or_default()
+                    .push(certificate.digest());
+            }
+        } else {
+            nodes_without_dependencies.push(certificate.digest());
+        }
+    }
+
+    // The list that will keep the "sorted" certificates
+    let mut sorted = Vec::new();
+
+    while !nodes_without_dependencies.is_empty() {
+        // randomize the pick from nodes_without_dependencies to get a different result
+        let index = rand.gen_range(0..nodes_without_dependencies.len());
+
+        let node = nodes_without_dependencies.remove(index);
+        sorted.push(node);
+
+        // now get their children references - if they have none then this is a certificate of last round
+        if let Some(mut children) = adjacency_parent_to_children.remove(&node) {
+            // shuffle the children here again to create a different execution plan
+            children.shuffle(&mut rand);
+
+            while !children.is_empty() {
+                let c = children.pop().unwrap();
+
+                // has this children any other dependencies (certificate parents that have not been
+                // already sorted)? If not, then add it to the candidate of nodes without incoming edges.
+                let has_more_dependencies = adjacency_parent_to_children
+                    .iter()
+                    .any(|(_, entries)| entries.contains(&c));
+
+                if !has_more_dependencies {
+                    nodes_without_dependencies.push(c);
+                }
+            }
+        }
+    }
+
+    assert!(
+        adjacency_parent_to_children.is_empty(),
+        "By now no edge should be left!"
+    );
+
+    let sorted = sorted
+        .into_iter()
+        .map(|c| digest_to_certificate.get(&c).unwrap().clone())
+        .collect();
+
+    ExecutionPlan {
+        certificates: sorted,
+    }
+}

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -31,13 +31,13 @@ use types::{Certificate, CertificateDigest};
 pub struct FailureModes {
     // The probability of having failures per round. The failures should
     // be <=f , otherwise no DAG could be created. The provided number gives the probability of having
-    // failures up to f. Ex for input `failures_probability = 0.2` it means we'll have 20% change of
+    // failures up to f. Ex for input `failures_probability = 0.2` it means we'll have 20% chance of
     // having failures up to 33% of the nodes.
     pub nodes_failure_probability: f64,
 
     // The percentage of slow nodes we want to introduce to our sample. Basically a slow node is one
-    // that might be able to produce certificates, but those are never get referenced by others. That has
-    // as an effect that when they are leaders might also not get enough support - or no support at all.
+    // that might be able to produce certificates, but these certificates never get referenced by others.
+    // Consequently when those nodes are leaders they might also not get enough support - or no support at all.
     // For example, a value of 0.2 means that we want up to 20% of our nodes to behave as slow nodes.
     pub slow_nodes_percentage: f64,
 
@@ -72,7 +72,7 @@ async fn bullshark_randomised_tests() {
     // A range of the committee size to be used
     const COMMITTEE_SIZE: RangeInclusive<usize> = 4..=8;
     // A range of rounds for which we will create DAGs
-    const DAG_ROUNDS: RangeInclusive<Round> = 7..=15;
+    const DAG_ROUNDS: RangeInclusive<Round> = 7..=20;
     // The number of different execution plans to be created and tested against for every generated DAG
     const EXECUTION_PLANS: u64 = 1_000;
     // The number of DAGs that should be generated and tested against for every set of properties.

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -73,13 +73,13 @@ async fn bullshark_randomised_tests() {
     // A range of gc_depth to be used
     const GC_DEPTH: RangeInclusive<Round> = 4..=15;
     // A range of the committee size to be used
-    const COMMITTEE_SIZE: RangeInclusive<usize> = 4..=8;
+    const COMMITTEE_SIZE: RangeInclusive<usize> = 4..=6;
     // A range of rounds for which we will create DAGs
     const DAG_ROUNDS: RangeInclusive<Round> = 7..=20;
     // The number of different execution plans to be created and tested against for every generated DAG
-    const EXECUTION_PLANS: u64 = 1_000;
+    const EXECUTION_PLANS: u64 = 500;
     // The number of DAGs that should be generated and tested against for every set of properties.
-    const DAGS_PER_SETUP: u64 = 200;
+    const DAGS_PER_SETUP: u64 = 100;
     // DAGs will be created for these failure modes
     let failure_modes: Vec<FailureModes> = vec![
         // No failures

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -268,7 +268,7 @@ pub fn make_certificates_with_parameters(
             // Step 2 -- introduce failures (assuming those are enabled)
             // We disable the failure probability if we have already reached the maximum number
             // of allowed failures (f)
-            let should_fail = if total_failures + 1 == committee.validity_threshold() {
+            let should_fail = if committee.reached_validity(total_failures + 1) {
                 false
             } else {
                 let b = Bernoulli::new(modes.nodes_failure_probability).unwrap();
@@ -361,7 +361,7 @@ pub fn make_certificates_with_parameters(
         // Sanity checks
         // Ensure total stake of the round provides strong quorum
         assert!(
-            total_round_stake >= committee.quorum_threshold(),
+            committee.reached_quorum(total_round_stake),
             "Strong quorum is needed per round to ensure DAG advance"
         );
 

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -24,6 +24,7 @@ use test_utils::mock_certificate_with_rand;
 use test_utils::CommitteeFixture;
 #[allow(unused_imports)]
 use tokio::sync::mpsc::channel;
+use types::CertificateAPI;
 use types::HeaderAPI;
 use types::Round;
 use types::{Certificate, CertificateDigest};
@@ -368,7 +369,7 @@ pub fn make_certificates_with_parameters(
         // Ensure each certificate's parents exist from previous processing
         parents
             .iter()
-            .flat_map(|c| c.header.parents())
+            .flat_map(|c| c.header().parents())
             .for_each(|digest| {
                 assert!(
                     certificate_digests.contains(digest),
@@ -439,7 +440,7 @@ fn generate_and_run_execution_plans(
             // A sanity check that we indeed attempt to send to Bullshark a certificate
             // whose parents have already been inserted.
             if c.round() > 1 {
-                for parent in c.header.parents() {
+                for parent in c.header().parents() {
                     assert!(inserted_certificates.contains(parent));
                 }
             }
@@ -512,7 +513,7 @@ fn create_execution_plan(
         // for the first round of certificates we don't want to include their parents, as we won't
         // have them available anyways - so we want those to be our roots.
         if certificate.round() > 1 {
-            for parent in certificate.header.parents() {
+            for parent in certificate.header().parents() {
                 adjacency_parent_to_children
                     .entry(*parent)
                     .or_default()

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -4,6 +4,7 @@ use crate::bullshark::Bullshark;
 use crate::consensus::ConsensusProtocol;
 use crate::consensus::ConsensusState;
 use crate::consensus_utils::make_consensus_store;
+use crate::consensus_utils::NUM_SUB_DAGS_PER_SCHEDULE;
 use crate::metrics::ConsensusMetrics;
 use config::{AuthorityIdentifier, Committee, Stake};
 use fastcrypto::hash::Hash;
@@ -419,8 +420,6 @@ fn generate_and_run_execution_plans(
         }
 
         // Now create a new Bullshark engine
-        const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
-
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
         let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
         let mut bullshark = Bullshark::new(

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -34,7 +34,6 @@ use store::rocks::MetricConf;
 use store::rocks::ReadWriteOptions;
 use store::{reopen, rocks, rocks::DBMap};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
-use tonic::codegen::http::uri::Authority;
 use tracing::info;
 use types::{
     Batch, BatchDigest, Certificate, CertificateAPI, CertificateDigest, CommittedSubDagShell,
@@ -531,7 +530,8 @@ pub fn make_certificates_with_slow_nodes(
     for round in range {
         next_parents.clear();
         for name in names {
-            let this_cert_parents = this_cert_parents_with_slow_nodes(name, parents.clone(), slow_nodes, &mut rand);
+            let this_cert_parents =
+                this_cert_parents_with_slow_nodes(name, parents.clone(), slow_nodes, &mut rand);
             let (_, certificate) = mock_certificate(committee, *name, round, this_cert_parents);
             certificates.push_back(certificate.clone());
             next_parents.push(certificate);
@@ -628,12 +628,12 @@ pub fn make_signed_certificates(
 
 pub fn mock_certificate_with_rand<R: RngCore + ?Sized>(
     committee: &Committee,
-    origin: PublicKey,
+    origin: AuthorityIdentifier,
     round: Round,
     parents: BTreeSet<CertificateDigest>,
     rand: &mut R,
 ) -> (CertificateDigest, Certificate) {
-    let header_builder = HeaderBuilder::default();
+    let header_builder = HeaderV1Builder::default();
     let header = header_builder
         .author(origin)
         .round(round)
@@ -642,7 +642,7 @@ pub fn mock_certificate_with_rand<R: RngCore + ?Sized>(
         .payload(fixture_payload_with_rand(1, rand))
         .build()
         .unwrap();
-    let certificate = Certificate::new_unsigned(committee, header, Vec::new()).unwrap();
+    let certificate = Certificate::new_unsigned(committee, Header::V1(header), Vec::new()).unwrap();
     (certificate.digest(), certificate)
 }
 


### PR DESCRIPTION
## Description 

This PR is introducing "randomised" tests for our consensus engine. A main test has been added `bullshark_randomised_tests` where the test orchestration is taking place. Basically the test is running for multiple core properties (ex various DAG rounds, gc_depth, committee size) where for each test iteration it:
* `creates random DAGs` based on some quality characteristics (`FailureModes`)
* `creates multiple execution plans` - different order of feeding the certificates to consensus -  using a variation of [Kahn's algorithm](https://en.wikipedia.org/wiki/Topological_sorting), and executes those via the Bullshark consensus engine
* `compares the output of each execution plan` to ensure they don't diverge - for the same DAG we should expect to have the exact same output for different execution plans

All the random generators used across the above process are seeded by known seeds - and printed on informative output - so we can later easily reproduce a scenario in case of a failure.

The test will run as part of the nightly CI workflow, as it can take quite some time to execute. Also, I have added some finger in the air parameters for the time being, but we can tune them further based on run time etc.

The DAG generation and the execution plan creation is using (seeded) randomness in order to achieve various permutations - which of course is not exhaustive and the different combinations depend to the number of iterations. To reproduce an error someone can use the provided seeds to replay the specific scenario.

### Running the tests manually
To run the tests manually can do via the nextest:
```
 cargo nextest run -p narwhal-consensus bullshark_randomised_tests --run-ignored ignored-only --no-capture
```

If a failure is detected then a log line like the following will be printed:
```
Fork detected in plans for run_id=7, seed=18, rounds=7, committee=4, gc_depth=7, modes=FailureModes { nodes_failure_probability: 0.0, slow_nodes_percentage: 0.33, slow_nodes_failure_probability: 0.7 }'
```

Then the `run_id` can be used to go back to the `bullshark_randomised_tests`, set it to that number and run the test , so can reproduce the result and investigate.

### Running against "fork" bug
As part of https://github.com/MystenLabs/sui/pull/8403 we fixed a fork bug that got introduced in earlier work. When running the randomised tests against the code with the bug managers to successfully detect the fork and report it. To test this I cherry picked the randomised test on top the commit with the issue and ran the tests. The branch can be [found on this branch](https://github.com/MystenLabs/sui/blob/577e722b96925e9161a6d5522ae6024fd937ba3b/narwhal/consensus/src/tests/randomized_tests.rs#L66) .

Running like this:
```
 cargo nextest run -p narwhal-consensus bullshark_randomised_tests --run-ignored ignored-only --no-capture
```

will output:

```
thread 'bullshark::randomized_tests::bullshark_randomised_tests' panicked at 'assertion failed: `(left == right)`
  left: `[dwwml/yqkhsUT8G7: C1(spJhWejffj1vEBGZgKdW972Zvu/4J0xMhJN9MmHAjGcVqE4VwT13lolJZdTgZHANERCqwhOs1+wZBlG3XfqjwDr8ShhIdxG9x/WJBoihhd7wV6mnw4H37TVyfwc+8hFj, eKp5YZF6ApG6lTS9, E0), XwSoL1Tx0XzPywRx: C1(qFHWDpkBDWYzUPieD7zvu6vT0eTcUEeRmZ7r9Bd6nVSKZN8/VTXOtBF7I6uTNsZgF0sjkxgE6sTv6rHzYYQXhepALY49pCXzAk1bwd30esNmQxTxKnWOIBl/c5dnnINP, RTmx44i8TAq6UJrn, E0), IerZdSvQBNXmie6x: C1(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, OcqdgfvXy0lsqb4p, E0), 0bNKLmBEzcgw+pbR: C2(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, wZtJ2NyeHrAKU7PF, E0), jC8y2AbMI2GMF56d: C1(hsHWobFaIM1WzZYy+mgfv7ABPS0G10Wf2iAWd/xmOla/oarahIEHvNlxCoOnrbteE3O7wsVFwl0HPBZvGCRbdemwudJk1xcPfEc7R9rGmWPP3lkogbw2QK/MVrg2spqG, uvP+CGnDrCSqi4ZP, E0), 1oPpAISn93H9n9ao: C2(spJhWejffj1vEBGZgKdW972Zvu/4J0xMhJN9MmHAjGcVqE4VwT13lolJZdTgZHANERCqwhOs1+wZBlG3XfqjwDr8ShhIdxG9x/WJBoihhd7wV6mnw4H37TVyfwc+8hFj, zVms6gWDMBzVG/Xm, E0), yZ400cpb93I9TnzX: C2(qFHWDpkBDWYzUPieD7zvu6vT0eTcUEeRmZ7r9Bd6nVSKZN8/VTXOtBF7I6uTNsZgF0sjkxgE6sTv6rHzYYQXhepALY49pCXzAk1bwd30esNmQxTxKnWOIBl/c5dnnINP, TtlXcRyUU2u0+eDQ, E0), 75QIn5xjThJarMUM: C3(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, yUZRIIA32ljxlifT, E0), k2Zqd75XK7Onak9o: C3(qFHWDpkBDWYzUPieD7zvu6vT0eTcUEeRmZ7r9Bd6nVSKZN8/VTXOtBF7I6uTNsZgF0sjkxgE6sTv6rHzYYQXhepALY49pCXzAk1bwd30esNmQxTxKnWOIBl/c5dnnINP, L1zUn/wKugYLV+Xv, E0), JzxeOnfWcbpAQcts: C3(spJhWejffj1vEBGZgKdW972Zvu/4J0xMhJN9MmHAjGcVqE4VwT13lolJZdTgZHANERCqwhOs1+wZBlG3XfqjwDr8ShhIdxG9x/WJBoihhd7wV6mnw4H37TVyfwc+8hFj, 5ZyjwRmHNMmAOZ/L, E0), fPAjkOz5Tt+mxOZC: C4(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, vJWr4dIDXo0F30Vl, E0), TL8Kydc5sdhSxnP/: C3(hsHWobFaIM1WzZYy+mgfv7ABPS0G10Wf2iAWd/xmOla/oarahIEHvNlxCoOnrbteE3O7wsVFwl0HPBZvGCRbdemwudJk1xcPfEc7R9rGmWPP3lkogbw2QK/MVrg2spqG, fSYvLRNdKrQhcCp+, E0), yMpRyHGQo2cGi/tv: C4(spJhWejffj1vEBGZgKdW972Zvu/4J0xMhJN9MmHAjGcVqE4VwT13lolJZdTgZHANERCqwhOs1+wZBlG3XfqjwDr8ShhIdxG9x/WJBoihhd7wV6mnw4H37TVyfwc+8hFj, ME1XmO723pJhuSqt, E0), ltALm4ODvtotkhyC: C4(qFHWDpkBDWYzUPieD7zvu6vT0eTcUEeRmZ7r9Bd6nVSKZN8/VTXOtBF7I6uTNsZgF0sjkxgE6sTv6rHzYYQXhepALY49pCXzAk1bwd30esNmQxTxKnWOIBl/c5dnnINP, s80s5UMIrXpXbkXK, E0), nSH6bchZOV93PJho: C4(hsHWobFaIM1WzZYy+mgfv7ABPS0G10Wf2iAWd/xmOla/oarahIEHvNlxCoOnrbteE3O7wsVFwl0HPBZvGCRbdemwudJk1xcPfEc7R9rGmWPP3lkogbw2QK/MVrg2spqG, p4EPG6LVG3S32DMW, E0), f2iy8HuuaxfcspQY: C5(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, cIDSU9Bg3xMrDA4V, E0), fTRna0aA8xNa6N0O: C5(qFHWDpkBDWYzUPieD7zvu6vT0eTcUEeRmZ7r9Bd6nVSKZN8/VTXOtBF7I6uTNsZgF0sjkxgE6sTv6rHzYYQXhepALY49pCXzAk1bwd30esNmQxTxKnWOIBl/c5dnnINP, sbD8udPdVTQooLuG, E0), HtGRM6uo63WTNzzz: C5(spJhWejffj1vEBGZgKdW972Zvu/4J0xMhJN9MmHAjGcVqE4VwT13lolJZdTgZHANERCqwhOs1+wZBlG3XfqjwDr8ShhIdxG9x/WJBoihhd7wV6mnw4H37TVyfwc+8hFj, rXqqkKkUMUkpmbGJ, E0), rem1TN11AkWXsqaq: C6(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, mXOWLEy6W0f4XGtk, E0)]`,
 right: `[dwwml/yqkhsUT8G7: C1(spJhWejffj1vEBGZgKdW972Zvu/4J0xMhJN9MmHAjGcVqE4VwT13lolJZdTgZHANERCqwhOs1+wZBlG3XfqjwDr8ShhIdxG9x/WJBoihhd7wV6mnw4H37TVyfwc+8hFj, eKp5YZF6ApG6lTS9, E0), XwSoL1Tx0XzPywRx: C1(qFHWDpkBDWYzUPieD7zvu6vT0eTcUEeRmZ7r9Bd6nVSKZN8/VTXOtBF7I6uTNsZgF0sjkxgE6sTv6rHzYYQXhepALY49pCXzAk1bwd30esNmQxTxKnWOIBl/c5dnnINP, RTmx44i8TAq6UJrn, E0), IerZdSvQBNXmie6x: C1(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, OcqdgfvXy0lsqb4p, E0), 0bNKLmBEzcgw+pbR: C2(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, wZtJ2NyeHrAKU7PF, E0), jC8y2AbMI2GMF56d: C1(hsHWobFaIM1WzZYy+mgfv7ABPS0G10Wf2iAWd/xmOla/oarahIEHvNlxCoOnrbteE3O7wsVFwl0HPBZvGCRbdemwudJk1xcPfEc7R9rGmWPP3lkogbw2QK/MVrg2spqG, uvP+CGnDrCSqi4ZP, E0), 1oPpAISn93H9n9ao: C2(spJhWejffj1vEBGZgKdW972Zvu/4J0xMhJN9MmHAjGcVqE4VwT13lolJZdTgZHANERCqwhOs1+wZBlG3XfqjwDr8ShhIdxG9x/WJBoihhd7wV6mnw4H37TVyfwc+8hFj, zVms6gWDMBzVG/Xm, E0), yZ400cpb93I9TnzX: C2(qFHWDpkBDWYzUPieD7zvu6vT0eTcUEeRmZ7r9Bd6nVSKZN8/VTXOtBF7I6uTNsZgF0sjkxgE6sTv6rHzYYQXhepALY49pCXzAk1bwd30esNmQxTxKnWOIBl/c5dnnINP, TtlXcRyUU2u0+eDQ, E0), 75QIn5xjThJarMUM: C3(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, yUZRIIA32ljxlifT, E0), k2Zqd75XK7Onak9o: C3(qFHWDpkBDWYzUPieD7zvu6vT0eTcUEeRmZ7r9Bd6nVSKZN8/VTXOtBF7I6uTNsZgF0sjkxgE6sTv6rHzYYQXhepALY49pCXzAk1bwd30esNmQxTxKnWOIBl/c5dnnINP, L1zUn/wKugYLV+Xv, E0), JzxeOnfWcbpAQcts: C3(spJhWejffj1vEBGZgKdW972Zvu/4J0xMhJN9MmHAjGcVqE4VwT13lolJZdTgZHANERCqwhOs1+wZBlG3XfqjwDr8ShhIdxG9x/WJBoihhd7wV6mnw4H37TVyfwc+8hFj, 5ZyjwRmHNMmAOZ/L, E0), fPAjkOz5Tt+mxOZC: C4(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, vJWr4dIDXo0F30Vl, E0), n5mpACbbClwrs3OK: C2(hsHWobFaIM1WzZYy+mgfv7ABPS0G10Wf2iAWd/xmOla/oarahIEHvNlxCoOnrbteE3O7wsVFwl0HPBZvGCRbdemwudJk1xcPfEc7R9rGmWPP3lkogbw2QK/MVrg2spqG, MeOvYaDWid+gWdAA, E0), TL8Kydc5sdhSxnP/: C3(hsHWobFaIM1WzZYy+mgfv7ABPS0G10Wf2iAWd/xmOla/oarahIEHvNlxCoOnrbteE3O7wsVFwl0HPBZvGCRbdemwudJk1xcPfEc7R9rGmWPP3lkogbw2QK/MVrg2spqG, fSYvLRNdKrQhcCp+, E0), yMpRyHGQo2cGi/tv: C4(spJhWejffj1vEBGZgKdW972Zvu/4J0xMhJN9MmHAjGcVqE4VwT13lolJZdTgZHANERCqwhOs1+wZBlG3XfqjwDr8ShhIdxG9x/WJBoihhd7wV6mnw4H37TVyfwc+8hFj, ME1XmO723pJhuSqt, E0), ltALm4ODvtotkhyC: C4(qFHWDpkBDWYzUPieD7zvu6vT0eTcUEeRmZ7r9Bd6nVSKZN8/VTXOtBF7I6uTNsZgF0sjkxgE6sTv6rHzYYQXhepALY49pCXzAk1bwd30esNmQxTxKnWOIBl/c5dnnINP, s80s5UMIrXpXbkXK, E0), nSH6bchZOV93PJho: C4(hsHWobFaIM1WzZYy+mgfv7ABPS0G10Wf2iAWd/xmOla/oarahIEHvNlxCoOnrbteE3O7wsVFwl0HPBZvGCRbdemwudJk1xcPfEc7R9rGmWPP3lkogbw2QK/MVrg2spqG, p4EPG6LVG3S32DMW, E0), f2iy8HuuaxfcspQY: C5(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, cIDSU9Bg3xMrDA4V, E0), fTRna0aA8xNa6N0O: C5(qFHWDpkBDWYzUPieD7zvu6vT0eTcUEeRmZ7r9Bd6nVSKZN8/VTXOtBF7I6uTNsZgF0sjkxgE6sTv6rHzYYQXhepALY49pCXzAk1bwd30esNmQxTxKnWOIBl/c5dnnINP, sbD8udPdVTQooLuG, E0), HtGRM6uo63WTNzzz: C5(spJhWejffj1vEBGZgKdW972Zvu/4J0xMhJN9MmHAjGcVqE4VwT13lolJZdTgZHANERCqwhOs1+wZBlG3XfqjwDr8ShhIdxG9x/WJBoihhd7wV6mnw4H37TVyfwc+8hFj, rXqqkKkUMUkpmbGJ, E0), rem1TN11AkWXsqaq: C6(gM7/G81TYckTfJAIEkHv5ituvxNqFP9/ENpMq5+fFkzo+gmIP2GIZNcgbrEKm5e8Ay5FulFJESCqFR70Og9i3kMtvtbzkOA1R4nKyXTWuzAzuvJHo2ezl+5eu/LebwKv, mXOWLEy6W0f4XGtk, E0)]`: Fork detected in plans for run_id=7, seed=18, rounds=7, committee=4, gc_depth=7, modes=FailureModes { nodes_failure_probability: 0.0, slow_nodes_percentage: 0.33, slow_nodes_failure_probability: 0.7 }'
```

where one extra certificate gets committed in one case compared to the other

### Future work
- [ ] Parallelise test runs
- [ ] pretify DAG output and improve the reporting to allow easier debugging
- [ ] add more properties on DAG generator to support more cases
- [ ] currently works when authority per stake = 1, change tests to support variable stakes

## Test Plan 


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
