### PR TITLE
Don't delete tx/effects from store on end-of-epoch reversion.

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1184,11 +1184,10 @@ impl AuthorityStore {
         assert!(effects.shared_objects().is_empty());
 
         let mut write_batch = self.perpetual_tables.transactions.batch();
-        write_batch = write_batch
-            .delete_batch(
-                &self.perpetual_tables.executed_effects,
-                iter::once(tx_digest),
-            )?;
+        write_batch = write_batch.delete_batch(
+            &self.perpetual_tables.executed_effects,
+            iter::once(tx_digest),
+        )?;
 
         let all_new_refs = effects
             .mutated()

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -533,12 +533,11 @@ fn extract_tx_data(
         .enumerate()
         .map(|(i, tx)| {
             VerifiedExecutableTransaction::new_from_checkpoint(
-                tx.expect(
-                    format!(
+                tx.unwrap_or_else(||
+                    panic!(
                         "state-sync should have ensured that transaction with digest {:?} exists for checkpoint: {checkpoint:?}",
                         all_tx_digests[i]
                     )
-                    .as_str(),
                 ),
                 epoch_store.epoch(),
                 *checkpoint_sequence,

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -530,9 +530,16 @@ fn extract_tx_data(
         .multi_get_transactions(&all_tx_digests)
         .expect("Failed to get checkpoint txes from store")
         .into_iter()
-        .map(|tx| {
+        .enumerate()
+        .map(|(i, tx)| {
             VerifiedExecutableTransaction::new_from_checkpoint(
-                tx.expect("state-sync should have ensured that the transaction exists"),
+                tx.expect(
+                    format!(
+                        "state-sync should have ensured that transaction with digest {:?} exists for checkpoint: {checkpoint:?}",
+                        all_tx_digests[i]
+                    )
+                    .as_str(),
+                ),
                 epoch_store.epoch(),
                 *checkpoint_sequence,
             )


### PR DESCRIPTION
## Description 

We might need them if the tx reappears in a later checkpoint.

## Test Plan 

Fixes simtest failure.