### PR TITLE
wallet-ext: add titles in dapp interaction views

### DIFF
--- a/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
@@ -8,6 +8,7 @@ import { UserApproveContainer } from '../../components/user-approve-container';
 import { useAppDispatch } from '../../hooks';
 import { respondToTransactionRequest } from '../../redux/slices/transaction-requests';
 import { Heading } from '../../shared/heading';
+import { PageMainLayoutTitle } from '../../shared/page-main-layout/PageMainLayoutTitle';
 import { Text } from '../../shared/text';
 import { type SignMessageApprovalRequest } from '_payloads/transactions/ApprovalRequest';
 
@@ -38,6 +39,7 @@ export function SignMessageRequest({ request }: SignMessageRequestProps) {
             address={request.tx.accountAddress}
             scrollable
         >
+            <PageMainLayoutTitle title="Sign Message" />
             <div className="flex flex-col flex-nowrap items-stretch border border-solid border-gray-50 rounded-15 overflow-y-auto overflow-x-hidden">
                 <div className="sticky top-0 bg-white p-5 pb-2.5">
                     <Heading

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
@@ -12,6 +12,7 @@ import { UserApproveContainer } from '_components/user-approve-container';
 import { useAppDispatch } from '_hooks';
 import { type TransactionApprovalRequest } from '_payloads/transactions/ApprovalRequest';
 import { respondToTransactionRequest } from '_redux/slices/transaction-requests';
+import { PageMainLayoutTitle } from '_src/ui/app/shared/page-main-layout/PageMainLayoutTitle';
 
 import st from './TransactionRequest.module.scss';
 
@@ -124,6 +125,7 @@ export function TransactionRequest({ txRequest }: TransactionRequestProps) {
             onSubmit={handleOnSubmit}
             address={addressForTransaction}
         >
+            <PageMainLayoutTitle title="Approve Transaction" />
             <section className={st.txInfo}>
                 <TransactionSummaryCard
                     transaction={tx}

--- a/apps/wallet/src/ui/app/pages/site-connect/index.tsx
+++ b/apps/wallet/src/ui/app/pages/site-connect/index.tsx
@@ -9,6 +9,7 @@ import { useParams } from 'react-router-dom';
 import { DAppPermissionsList } from '../../components/DAppPermissionsList';
 import { SummaryCard } from '../../components/SummaryCard';
 import { WalletListSelect } from '../../components/WalletListSelect';
+import { PageMainLayoutTitle } from '../../shared/page-main-layout/PageMainLayoutTitle';
 import { Text } from '../../shared/text';
 import Loading from '_components/loading';
 import { UserApproveContainer } from '_components/user-approve-container';
@@ -103,6 +104,7 @@ function SiteConnectPage() {
                         isConnect
                         addressHidden
                     >
+                        <PageMainLayoutTitle title="Insecure Website" />
                         <div className={st.warningWrapper}>
                             <h1 className={st.warningTitle}>
                                 Your Connection is Not Secure
@@ -129,6 +131,7 @@ function SiteConnectPage() {
                         addressHidden
                         approveDisabled={!accountsToConnect.length}
                     >
+                        <PageMainLayoutTitle title="Approve Connection" />
                         <SummaryCard
                             header="Permissions requested"
                             body={

--- a/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayoutTitle.tsx
+++ b/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayoutTitle.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useContext } from 'react';
+import { createPortal } from 'react-dom';
+
+import { PageMainLayoutContext } from '.';
+import { Heading } from '../heading';
+
+export type PageMainLayoutTitleProps = {
+    title: string;
+};
+export function PageMainLayoutTitle({ title }: PageMainLayoutTitleProps) {
+    const titleNode = useContext(PageMainLayoutContext);
+    if (titleNode) {
+        return createPortal(
+            <Heading
+                variant="heading4"
+                truncate
+                weight="semibold"
+                color="gray-90"
+            >
+                {title}
+            </Heading>,
+            titleNode
+        );
+    }
+    return null;
+}

--- a/apps/wallet/src/ui/app/shared/page-main-layout/index.tsx
+++ b/apps/wallet/src/ui/app/shared/page-main-layout/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
-import { type ReactNode } from 'react';
+import { createContext, type ReactNode, useState } from 'react';
 
 import { useAppSelector } from '../../hooks';
 import { AppType } from '../../redux/slices/app/AppType';
@@ -14,6 +14,8 @@ import { MenuButton, MenuContent } from '_components/menu';
 import Navigation from '_components/navigation';
 
 import st from './PageMainLayout.module.scss';
+
+export const PageMainLayoutContext = createContext<HTMLDivElement | null>(null);
 
 export type PageMainLayoutProps = {
     children: ReactNode | ReactNode[];
@@ -33,7 +35,8 @@ export default function PageMainLayout({
     const networkName = useAppSelector(({ app: { apiEnv } }) => apiEnv);
     const appType = useAppSelector((state) => state.app.appType);
     const isFullScreen = appType === AppType.fullscreen;
-
+    const [titlePortalContainer, setTitlePortalContainer] =
+        useState<HTMLDivElement | null>(null);
     return (
         <div
             className={cl(st.container, {
@@ -42,7 +45,13 @@ export default function PageMainLayout({
         >
             <Header
                 networkName={networkName}
-                middleContent={dappStatusEnabled ? <DappStatus /> : undefined}
+                middleContent={
+                    dappStatusEnabled ? (
+                        <DappStatus />
+                    ) : (
+                        <div ref={setTitlePortalContainer} />
+                    )
+                }
                 rightContent={topNavMenuEnabled ? <MenuButton /> : undefined}
             />
             <div
@@ -57,7 +66,11 @@ export default function PageMainLayout({
                         className
                     )}
                 >
-                    <ErrorBoundary>{children}</ErrorBoundary>
+                    <PageMainLayoutContext.Provider
+                        value={titlePortalContainer}
+                    >
+                        <ErrorBoundary>{children}</ErrorBoundary>
+                    </PageMainLayoutContext.Provider>
                 </main>
                 {bottomNavEnabled ? <Navigation /> : null}
                 {topNavMenuEnabled ? <MenuContent /> : null}


### PR DESCRIPTION
## Description 

* titles for site-connect and request approval pages

<img width="362" alt="Screenshot 2023-03-14 at 00 15 20" src="https://user-images.githubusercontent.com/10210143/224860278-bd953fd3-1431-4fca-8a8c-b5d1deff7892.png">
<img width="362" alt="Screenshot 2023-03-14 at 00 15 34" src="https://user-images.githubusercontent.com/10210143/224860285-b87e524a-c41a-4e4d-9ec5-bf3b9792c44b.png">
<img width="362" alt="Screenshot 2023-03-14 at 00 15 51" src="https://user-images.githubusercontent.com/10210143/224860286-b1a2619b-601d-4be1-a968-86f9243cff23.png">
<img width="362" alt="Screenshot 2023-03-14 at 00 15 58" src="https://user-images.githubusercontent.com/10210143/224860288-9d5afaa4-7cfb-4b41-a62a-1fdc1024ed14.png">

closes APPS-605