### PR TITLE
[gas checker] remove unnecessary check & rename gas error

### DIFF
--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -195,7 +195,7 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
 
     assert!(matches!(
         UserInputError::try_from(response.unwrap_err()).unwrap(),
-        UserInputError::GasBalanceTooLowToCoverGasBudget { .. }
+        UserInputError::GasBalanceTooLow { .. }
     ));
 
     Ok(())

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -68,9 +68,9 @@ async fn test_tx_gas_balance_less_than_budget() {
     let result = execute_transfer_with_price(gas_balance, budget, gas_price, false).await;
     assert_eq!(
         UserInputError::try_from(result.response.unwrap_err()).unwrap(),
-        UserInputError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::GasBalanceTooLow {
             gas_balance: gas_balance as u128,
-            gas_budget: (gas_price * budget) as u128,
+            needed_gas_amount: (gas_price * budget) as u128,
         }
     );
 }
@@ -164,9 +164,9 @@ async fn test_native_transfer_gas_price_is_used() {
     let result = execute_transfer_with_price(gas_balance, gas_budget, gas_price, true).await;
     assert_eq!(
         UserInputError::try_from(result.response.unwrap_err()).unwrap(),
-        UserInputError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::GasBalanceTooLow {
             gas_balance: (gas_balance as u128),
-            gas_budget: (gas_budget as u128),
+            needed_gas_amount: ((gas_budget as u128) * (gas_price as u128)),
         }
     );
 }

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -57,9 +57,9 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
 
     assert_eq!(
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
-        UserInputError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::GasBalanceTooLow {
             gas_balance: 1000,
-            gas_budget: 1200,
+            needed_gas_amount: 1200,
         }
     );
 }
@@ -110,9 +110,9 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
 
     assert_eq!(
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
-        UserInputError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::GasBalanceTooLow {
             gas_balance: 1000,
-            gas_budget: 1001,
+            needed_gas_amount: 1001,
         }
     );
 }
@@ -299,9 +299,9 @@ async fn test_pay_all_sui_failure_insufficient_gas_one_input_coin() {
 
     assert_eq!(
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
-        UserInputError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::GasBalanceTooLow {
             gas_balance: 1000,
-            gas_budget: 2000,
+            needed_gas_amount: 2000,
         }
     );
 }
@@ -316,9 +316,9 @@ async fn test_pay_all_sui_failure_insufficient_gas_budget_multiple_input_coins()
 
     assert_eq!(
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
-        UserInputError::GasBalanceTooLowToCoverGasBudget {
+        UserInputError::GasBalanceTooLow {
             gas_balance: 2000,
-            gas_budget: 2500,
+            needed_gas_amount: 2500,
         }
     );
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -127,11 +127,14 @@ pub enum UserInputError {
     #[error("Gas budget: {:?} is lower than min: {:?}.", gas_budget, min_budget)]
     GasBudgetTooLow { gas_budget: u64, min_budget: u64 },
     #[error(
-        "Balance of gas object {:?} is lower than gas budget: {:?}.",
+        "Balance of gas object {:?} is lower than the needed amount: {:?}.",
         gas_balance,
-        gas_budget
+        needed_gas_amount
     )]
-    GasBalanceTooLowToCoverGasBudget { gas_balance: u128, gas_budget: u128 },
+    GasBalanceTooLow {
+        gas_balance: u128,
+        needed_gas_amount: u128,
+    },
     #[error("Transaction kind does not support Sponsored Transaction")]
     UnsupportedSponsoredTransactionKind,
     #[error(

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -37,11 +37,11 @@ pub type GasPrice = GasQuantity<GasPriceUnit>;
 pub type SuiGas = GasQuantity<SuiGasUnit>;
 
 macro_rules! ok_or_gas_balance_error {
-    ($balance:expr, $budget:expr) => {
-        if $balance < $budget {
-            Err(UserInputError::GasBalanceTooLowToCoverGasBudget {
+    ($balance:expr, $required:expr) => {
+        if $balance < $required {
+            Err(UserInputError::GasBalanceTooLow {
                 gas_balance: $balance,
-                gas_budget: $budget,
+                needed_gas_amount: $required,
             })
         } else {
             Ok(())
@@ -503,15 +503,11 @@ pub fn check_gas_balance(
     }
 
     let mut gas_balance = get_gas_balance(gas_object)? as u128;
-    let gas_budget_amount = (gas_budget as u128) * (gas_price as u128);
+    let required_gas_amount = (gas_budget as u128) * (gas_price as u128);
     for extra_obj in more_gas_objs {
         gas_balance += get_gas_balance(&extra_obj)? as u128;
     }
-    ok_or_gas_balance_error!(gas_balance, gas_budget_amount)?;
-
-    let total_balance = gas_balance;
-    let total_amount = gas_budget as u128;
-    ok_or_gas_balance_error!(total_balance, total_amount)
+    ok_or_gas_balance_error!(gas_balance, required_gas_amount)
 }
 
 /// Create a new gas status with the given `gas_budget`, and charge the transaction flat fee.


### PR DESCRIPTION
## Description 

1. Removes the unnecessary check at the end of `check_gas_balance`
2. Rename `GasBalanceTooLowToCoverGasBudget` to `GasBalanceTooLow` as it has been always confusing.

## Test Plan 

unit test 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Rename `GasBalanceTooLowToCoverGasBudget` to `GasBalanceTooLow`