### PR TITLE
wallet-ext: increase popup window size

### DIFF
--- a/apps/wallet/src/background/Window.ts
+++ b/apps/wallet/src/background/Window.ts
@@ -26,8 +26,8 @@ export class Window {
         const w = await Browser.windows.create({
             url: this._url,
             focused: true,
-            width: 360,
-            height: 595,
+            width: 380,
+            height: 640,
             type: 'popup',
             top: top,
             left: Math.floor(left + width - 450),


### PR DESCRIPTION
## Description 

* to avoid app scrolling increase the default popup window size (the window used for site-connect, transaction approval etc)

| before | after |
| - | - |
| <img width="385" alt="Screenshot 2023-03-14 at 00 34 36" src="https://user-images.githubusercontent.com/10210143/224862602-2b499b14-acc5-4714-a9f0-46f5d938aa6b.png"> | <img width="391" alt="Screenshot 2023-03-14 at 00 32 32" src="https://user-images.githubusercontent.com/10210143/224862641-79a7f979-2ffb-4d42-9ac2-5089d395b1ee.png"> |
| <img width="385" alt="Screenshot 2023-03-14 at 00 35 02" src="https://user-images.githubusercontent.com/10210143/224862693-90da5894-b547-4456-aba4-a5d0103c7208.png"> | <img width="391" alt="Screenshot 2023-03-14 at 00 32 43" src="https://user-images.githubusercontent.com/10210143/224862720-4734657a-2a18-4b6a-9708-a0187bb13080.png"> |
| <img width="385" alt="Screenshot 2023-03-14 at 00 34 44" src="https://user-images.githubusercontent.com/10210143/224862770-06f41733-281e-435a-b02b-2d191085b955.png"> | <img width="391" alt="Screenshot 2023-03-14 at 00 33 00" src="https://user-images.githubusercontent.com/10210143/224862793-5a5fd2b1-ceb9-4d46-a81b-a7e5002a9ffc.png"> |
 