### PR TITLE
Use checkpoint execution to detect stuck transactions in TransactionManager

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -609,10 +609,34 @@ async fn execute_transactions(
                     )
                     .collect();
 
+                if missing_digests.is_empty() {
+                    // All effects just become available.
+                    continue;
+                }
+
                 warn!(
-                    "Transaction effects for tx digests {:?} checkpoint not present within {:?}. ",
+                    "Transaction effects for checkpoint tx digests {:?} not present within {:?}. ",
                     missing_digests,
                     log_timeout_sec * periods,
+                );
+
+                // Print out more information for the 1st pending transaction, which should have
+                // all of its input available.
+                let pending_digest = missing_digests.first().unwrap();
+                let missing_input = transaction_manager.get_missing_input(pending_digest);
+                let pending_transaction = authority_store
+                    .get_transaction(pending_digest)?
+                    .expect("state-sync should have ensured that the transaction exists");
+
+                warn!(
+                    "Transaction {pending_digest:?} has missing input objects {missing_input:?}\
+                    \nTransaction input: {:?}\nTransaction content: {:?}",
+                    pending_transaction
+                        .data()
+                        .intent_message()
+                        .value
+                        .input_objects(),
+                    pending_transaction,
                 );
                 periods += 1;
             }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -374,6 +374,15 @@ impl TransactionManager {
         let _ = self.tx_ready_certificates.send(certificate);
     }
 
+    /// Gets the missing input object keys for the given transaction.
+    pub(crate) fn get_missing_input(&self, digest: &TransactionDigest) -> Option<Vec<InputKey>> {
+        let inner = self.inner.read();
+        inner
+            .pending_certificates
+            .get(digest)
+            .map(|cert| cert.missing.clone().into_iter().collect())
+    }
+
     // Returns the number of transactions waiting on each object ID.
     pub(crate) fn objects_queue_len(&self, keys: Vec<ObjectID>) -> Vec<(ObjectID, usize)> {
         let inner = self.inner.read();


### PR DESCRIPTION
## Description 

Since transactions are causally ordered in checkpoints, executing transactions sequentially in checkpoint should encounter no missing input object. We can rely on this to detect and print diagnostic information for stuck transactions in TransactionManager: if the stuck transaction is already part of a checkpoint, its missing input objects should be printed to help debug why the transaction is not ready for execution.

However this change does not help when a transaction cannot execute at any node and is not part of a checkpoint. We can add debug logging in checkpoint builder if needed.

## Test Plan 

Tried it out in a test with stuck transactions.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
