### PR TITLE
package publish: error for unpublished deps with nonzero addrs

### DIFF
--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -572,7 +572,13 @@ impl CompiledPackage {
             "The following modules in package dependencies set a non-zero self-address:".into(),
         );
         error_message.extend(errors);
-        error_message.push("If these packages really are unpublished, their self-addresses should be set to \"0x0\" in the [addresses] section of the manifest when publishing.".into(),);
+        error_message.push(
+            "If these packages really are unpublished, their self-addresses should be set \
+	     to \"0x0\" in the [addresses] section of the manifest when publishing. If they \
+	     are already published, ensure they specify the address in the `published-at` of \
+	     their Move.toml manifest."
+                .into(),
+        );
 
         Err(SuiError::ModulePublishFailure {
             error: error_message.join("\n"),

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -529,6 +529,55 @@ impl CompiledPackage {
                 _ => None,
             })
     }
+
+    pub fn verify_unpublished_dependencies(
+        &self,
+        unpublished_deps: &BTreeSet<Symbol>,
+    ) -> SuiResult<()> {
+        if unpublished_deps.is_empty() {
+            return Ok(());
+        }
+
+        let errors = self
+            .package
+            .deps_compiled_units
+            .iter()
+            .filter_map(|(p, m)| {
+                if !unpublished_deps.contains(p) {
+                    return None;
+                }
+                match &m.unit {
+                    CompiledUnitEnum::Module(m) if m.module.address() != &AccountAddress::ZERO => {
+                        Some(format!(
+                            " - {}::{} in dependency {}",
+                            m.module.address(),
+                            m.name,
+                            p
+                        ))
+                    }
+                    CompiledUnitEnum::Module(_) => None,
+                    CompiledUnitEnum::Script(_) => {
+                        unimplemented!("Scripts are not supported in Sui Move")
+                    }
+                }
+            })
+            .collect::<Vec<String>>();
+
+        if errors.is_empty() {
+            return Ok(());
+        }
+
+        let mut error_message = vec![];
+        error_message.push(
+            "The following modules in package dependencies set a non-zero self-address:".into(),
+        );
+        error_message.extend(errors);
+        error_message.push("If these packages really are unpublished, their self-addresses should be set to \"0x0\" in the [addresses] section of the manifest when publishing.".into(),);
+
+        Err(SuiError::ModulePublishFailure {
+            error: error_message.join("\n"),
+        })
+    }
 }
 
 impl Default for BuildConfig {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1217,6 +1217,9 @@ async fn compile_package(
             .into());
         }
     }
+    if with_unpublished_dependencies {
+        compiled_package.verify_unpublished_dependencies(&dependencies.unpublished)?;
+    }
     let compiled_modules = compiled_package.get_package_bytes(with_unpublished_dependencies);
     if !skip_dependency_verification {
         BytecodeSourceVerifier::new(client.read_api(), false)

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -766,6 +766,49 @@ async fn test_package_publish_command_with_unpublished_dependency_fails(
 }
 
 #[sim_test]
+async fn test_package_publish_command_non_zero_unpublished_dep_fails() -> Result<(), anyhow::Error>
+{
+    let with_unpublished_dependencies = true; // Value under test, incompatible with dependencies that specify non-zero address.
+
+    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let address = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let client = context.get_client().await?;
+    let object_refs = client
+        .read_api()
+        .get_owned_objects(address, None, None, None, None)
+        .await?
+        .data;
+
+    let gas_obj_id = object_refs.first().unwrap().object().unwrap().object_id;
+
+    let mut package_path = PathBuf::from(TEST_DATA_DIR);
+    package_path.push("module_publish_with_unpublished_dependency_with_non_zero_address");
+    let build_config = BuildConfig::new_for_testing().config;
+    let result = SuiClientCommands::Publish {
+        package_path,
+        build_config,
+        gas: Some(gas_obj_id),
+        gas_budget: 20_000,
+        skip_dependency_verification: false,
+        with_unpublished_dependencies,
+    }
+    .execute(context)
+    .await;
+
+    let expect = expect![[r#"
+        Err(
+            ModulePublishFailure {
+                error: "The following modules in package dependencies set a non-zero self-address:\n - 0000000000000000000000000000000000000000000000000000000000000bad::non_zero in dependency UnpublishedNonZeroAddress\nIf these packages really are unpublished, their self-addresses should be set to \"0x0\" in the [addresses] section of the manifest when publishing.",
+            },
+        )
+    "#]];
+    expect.assert_debug_eq(&result);
+    Ok(())
+}
+
+#[sim_test]
 async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Error> {
     let with_unpublished_dependencies = true; // Invalid packages should fail to pubilsh, even if we allow unpublished dependencies.
 

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -800,7 +800,7 @@ async fn test_package_publish_command_non_zero_unpublished_dep_fails() -> Result
     let expect = expect![[r#"
         Err(
             ModulePublishFailure {
-                error: "The following modules in package dependencies set a non-zero self-address:\n - 0000000000000000000000000000000000000000000000000000000000000bad::non_zero in dependency UnpublishedNonZeroAddress\nIf these packages really are unpublished, their self-addresses should be set to \"0x0\" in the [addresses] section of the manifest when publishing.",
+                error: "The following modules in package dependencies set a non-zero self-address:\n - 0000000000000000000000000000000000000000000000000000000000000bad::non_zero in dependency UnpublishedNonZeroAddress\nIf these packages really are unpublished, their self-addresses should be set to \"0x0\" in the [addresses] section of the manifest when publishing. If they are already published, ensure they specify the address in the `published-at` of their Move.toml manifest.",
             },
         )
     "#]];

--- a/crates/sui/src/unit_tests/data/module_dependency_unpublished_non_zero_address/Move.toml
+++ b/crates/sui/src/unit_tests/data/module_dependency_unpublished_non_zero_address/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "UnpublishedNonZeroAddress"
+version = "0.0.1"
+# No published-at address for this package.
+# published-at = "0x0"
+
+[addresses]
+# Address not set to 0x0. Error if --with-unpublished-dependencies is set.
+non_zero = "0xbad"

--- a/crates/sui/src/unit_tests/data/module_dependency_unpublished_non_zero_address/sources/non_zero.move
+++ b/crates/sui/src/unit_tests/data/module_dependency_unpublished_non_zero_address/sources/non_zero.move
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module non_zero::non_zero {
+    public entry fun main() {}
+}

--- a/crates/sui/src/unit_tests/data/module_publish_with_unpublished_dependency_with_non_zero_address/Move.toml
+++ b/crates/sui/src/unit_tests/data/module_publish_with_unpublished_dependency_with_non_zero_address/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "Examples"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework" }
+UnpublishedNonZeroAddress = { local = "../module_dependency_unpublished_non_zero_address" }
+
+[addresses]
+examples = "0x0"

--- a/crates/sui/src/unit_tests/data/module_publish_with_unpublished_dependency_with_non_zero_address/Move.toml
+++ b/crates/sui/src/unit_tests/data/module_publish_with_unpublished_dependency_with_non_zero_address/Move.toml
@@ -3,7 +3,7 @@ name = "Examples"
 version = "0.0.1"
 
 [dependencies]
-Sui = { local = "../../../../../sui-framework" }
+Sui = { local = "../../../../../sui-framework/packages/sui-framework" }
 UnpublishedNonZeroAddress = { local = "../module_dependency_unpublished_non_zero_address" }
 
 [addresses]

--- a/crates/sui/src/unit_tests/data/module_publish_with_unpublished_dependency_with_non_zero_address/sources/main.move
+++ b/crates/sui/src/unit_tests/data/module_publish_with_unpublished_dependency_with_non_zero_address/sources/main.move
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module examples::main {
+  public entry fun main() {}
+}


### PR DESCRIPTION
## Description 

Error if we see that package dependencies have self-addresses other than `0x0` on `publish` and advise action. 

Follow up of second part in https://github.com/MystenLabs/sui/pull/8919#discussion_r1130923990: 

>  we may also want to check that a dependency without a published-at address truly isn't published (i.e. has the self-addresses of its modules set to 0x0) otherwise that will also be a problem

Note: source verification will catch errors where addresses are nonzero and cannot be resolved. But, source verification can also be disabled with CLI flags (which will then miss this issue).

I thought about making this a warning, but it seems moot if we warn on this error without giving an opportunity to fix the issue, and proceed to try publish anyway. Maybe a "I know what I'm doing [Y/n]" prompt is ideal, but at this stage the conservative choice is to fail. Unless there's a real reason to end up publishing something in this state that I'm not aware of 🙂 

## Test Plan 

Added test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

If a user attempts to `publish` a package where the package's dependencies are set non-zero addresses _and_ the user sets `--with-unpublished-dependencies` in the command line, we error and advise action: either set dependency addresses to `0x0` (the zero address) or remove `--with-unpublished-dependencies` after ensuruing that dependencies are published.