### PR TITLE
[Narwhal] switch to DBMap for batch store

### DIFF
--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -17,7 +17,7 @@ use std::{
 };
 use storage::NodeStorage;
 use storage::{CertificateStore, PayloadToken};
-use store::Store;
+use store::{rocks::DBMap, Map, Store};
 use test_utils::{
     fixture_batch_with_transactions, make_optimal_certificates, make_optimal_signed_certificates,
     temp_dir, AuthorityFixture, CommitteeFixture,
@@ -91,10 +91,7 @@ async fn test_get_collections() {
             .expect("couldn't store batches");
         if n != 4 {
             // Add batches to the workers store
-            store
-                .batch_store
-                .async_write(batch.digest(), batch.clone())
-                .await;
+            store.batch_store.insert(&batch.digest(), &batch).unwrap();
         } else {
             missing_certificate = digest;
         }
@@ -310,10 +307,7 @@ async fn test_remove_collections() {
             .expect("couldn't store batches");
         if n != 4 {
             // Add batches to the workers store
-            store
-                .batch_store
-                .async_write(batch.digest(), batch.clone())
-                .await;
+            store.batch_store.insert(&batch.digest(), &batch).unwrap();
         }
     }
 
@@ -1179,7 +1173,7 @@ async fn fixture_certificate(
     header_store: Store<HeaderDigest, Header>,
     certificate_store: CertificateStore,
     payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
-    batch_store: Store<BatchDigest, Batch>,
+    batch_store: DBMap<BatchDigest, Batch>,
 ) -> (Certificate, Batch) {
     let batch = fixture_batch_with_transactions(10);
     let worker_id = 0;
@@ -1212,7 +1206,7 @@ async fn fixture_certificate(
         .expect("couldn't store batches");
 
     // Add a batch to the workers store
-    batch_store.async_write(batch_digest, batch.clone()).await;
+    batch_store.insert(&batch_digest, &batch).unwrap();
 
     (certificate, batch)
 }

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -24,7 +24,7 @@ pub struct NodeStorage {
     pub header_store: Store<HeaderDigest, Header>,
     pub certificate_store: CertificateStore,
     pub payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
-    pub batch_store: Store<BatchDigest, Batch>,
+    pub batch_store: DBMap<BatchDigest, Batch>,
     pub consensus_store: Arc<ConsensusStore>,
 }
 
@@ -95,7 +95,7 @@ impl NodeStorage {
             certificate_digest_by_origin_map,
         );
         let payload_store = Store::new(payload_map);
-        let batch_store = Store::new(batch_map);
+        let batch_store = batch_map;
         let consensus_store = Arc::new(ConsensusStore::new(last_committed_map, sub_dag_index_map));
 
         Self {

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -29,7 +29,7 @@ use std::{
 };
 use store::rocks::MetricConf;
 use store::rocks::ReadWriteOptions;
-use store::{reopen, rocks, rocks::DBMap, Store};
+use store::{reopen, rocks, rocks::DBMap};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tracing::info;
 use types::{
@@ -362,16 +362,15 @@ pub fn batch_with_transactions(num_of_transactions: usize) -> Batch {
 
 const BATCHES_CF: &str = "batches";
 
-pub fn open_batch_store() -> Store<BatchDigest, Batch> {
-    let db = DBMap::<BatchDigest, Batch>::open(
+pub fn open_batch_store() -> DBMap<BatchDigest, Batch> {
+    DBMap::<BatchDigest, Batch>::open(
         temp_dir(),
         MetricConf::default(),
         None,
         Some(BATCHES_CF),
         &ReadWriteOptions::default(),
     )
-    .unwrap();
-    Store::new(db)
+    .unwrap()
 }
 
 // Creates one certificate per authority starting and finishing at the specified rounds (inclusive).

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -11,16 +11,15 @@ use store::rocks::ReadWriteOptions;
 use test_utils::{temp_dir, transaction};
 use types::PreSubscribedBroadcastSender;
 
-fn create_batches_store() -> Store<BatchDigest, Batch> {
-    let db = rocks::DBMap::<BatchDigest, Batch>::open(
+fn create_batches_store() -> DBMap<BatchDigest, Batch> {
+    rocks::DBMap::<BatchDigest, Batch>::open(
         temp_dir(),
         MetricConf::default(),
         None,
         Some("batches"),
         &ReadWriteOptions::default(),
     )
-    .unwrap();
-    Store::new(db)
+    .unwrap()
 }
 
 #[tokio::test]
@@ -71,11 +70,7 @@ async fn make_batch() {
     assert!(r1.await.is_ok());
 
     // Ensure the batch is stored
-    assert!(store
-        .notify_read(expected_batch.digest())
-        .await
-        .unwrap()
-        .is_some());
+    assert!(store.get(&expected_batch.digest()).unwrap().is_some());
 }
 
 #[tokio::test]
@@ -122,5 +117,5 @@ async fn batch_timeout() {
     assert!(r0.await.is_ok());
 
     // Ensure the batch is stored
-    assert!(store.notify_read(batch.digest()).await.unwrap().is_some());
+    assert!(store.get(&batch.digest()).unwrap().is_some());
 }

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -57,7 +57,7 @@ async fn synchronize() {
     let _recv_network = target_worker.new_network(routes);
 
     // Check not in store
-    assert!(store.read(digest).await.unwrap().is_none());
+    assert!(store.get(&digest).unwrap().is_none());
 
     // Send a sync request.
     let mut request = anemo::Request::new(message);
@@ -76,7 +76,7 @@ async fn synchronize() {
     handler.synchronize(request).await.unwrap();
 
     // Check its now stored
-    assert!(store.notify_read(digest).await.unwrap().is_some())
+    assert!(store.get(&digest).unwrap().is_some())
 }
 
 #[tokio::test]
@@ -107,7 +107,7 @@ async fn synchronize_when_batch_exists() {
     let batch = test_utils::batch();
     let batch_id = batch.digest();
     let missing = vec![batch_id];
-    store.async_write(batch_id, batch).await;
+    store.insert(&batch_id, &batch).unwrap();
 
     // Set up mock behavior for child RequestBatches RPC.
     let target_primary = fixture.authorities().nth(1).unwrap();
@@ -139,7 +139,7 @@ async fn delete_batches() {
     let store = test_utils::open_batch_store();
     let batch = test_utils::batch();
     let digest = batch.digest();
-    store.async_write(digest, batch.clone()).await;
+    store.insert(&digest, &batch).unwrap();
 
     // Send a delete request.
     let handler = PrimaryReceiverHandler {
@@ -160,5 +160,5 @@ async fn delete_batches() {
         .await
         .unwrap();
 
-    assert!(store.read(digest).await.unwrap().is_none());
+    assert!(store.get(&digest).unwrap().is_none());
 }

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -56,7 +56,7 @@ async fn reject_invalid_clients_transactions() {
     };
 
     // Create a new test store.
-    let db = rocks::DBMap::<BatchDigest, Batch>::open(
+    let batch_store = rocks::DBMap::<BatchDigest, Batch>::open(
         temp_dir(),
         MetricConf::default(),
         None,
@@ -64,7 +64,6 @@ async fn reject_invalid_clients_transactions() {
         &ReadWriteOptions::default(),
     )
     .unwrap();
-    let store = Store::new(db);
 
     let registry = Registry::new();
     let metrics = initialise_metrics(&registry);
@@ -80,7 +79,7 @@ async fn reject_invalid_clients_transactions() {
         worker_cache.clone(),
         parameters,
         NilTxValidator,
-        store,
+        batch_store,
         metrics,
         &mut tx_shutdown,
     );
@@ -146,7 +145,7 @@ async fn handle_clients_transactions() {
     };
 
     // Create a new test store.
-    let db = rocks::DBMap::<BatchDigest, Batch>::open(
+    let batch_store = rocks::DBMap::<BatchDigest, Batch>::open(
         temp_dir(),
         MetricConf::default(),
         None,
@@ -154,7 +153,6 @@ async fn handle_clients_transactions() {
         &ReadWriteOptions::default(),
     )
     .unwrap();
-    let store = Store::new(db);
 
     let registry = Registry::new();
     let metrics = initialise_metrics(&registry);
@@ -170,7 +168,7 @@ async fn handle_clients_transactions() {
         worker_cache.clone(),
         parameters,
         TrivialTransactionValidator::default(),
-        store,
+        batch_store,
         metrics,
         &mut tx_shutdown,
     );

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -28,7 +28,7 @@ use network::metrics::MetricsMakeCallbackHandler;
 use std::collections::HashMap;
 use std::time::Duration;
 use std::{net::Ipv4Addr, sync::Arc, thread::sleep};
-use store::Store;
+use store::rocks::DBMap;
 use tap::TapFallible;
 use tokio::task::JoinHandle;
 use tower::ServiceBuilder;
@@ -63,7 +63,7 @@ pub struct Worker {
     /// The configuration parameters
     parameters: Parameters,
     /// The persistent storage.
-    store: Store<BatchDigest, Batch>,
+    store: DBMap<BatchDigest, Batch>,
 }
 
 impl Worker {
@@ -75,7 +75,7 @@ impl Worker {
         worker_cache: WorkerCache,
         parameters: Parameters,
         validator: impl TransactionValidator,
-        store: Store<BatchDigest, Batch>,
+        store: DBMap<BatchDigest, Batch>,
         metrics: Metrics,
         tx_shutdown: &mut PreSubscribedBroadcastSender,
     ) -> Vec<JoinHandle<()>> {


### PR DESCRIPTION
## Description 

Payload writes and reads can take significant time transferring non-trivial amount of bytes. It does not make sense to do this in a single threaded loop in `typed_store::Store`. Use `DBMap` interface for multithreaded processing instead.

## Test Plan 

Existing unit tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
