### PR TITLE
Update groth16.md

### DIFF
--- a/crates/sui-framework/docs/groth16.md
+++ b/crates/sui-framework/docs/groth16.md
@@ -252,7 +252,7 @@ Creates a Groth16 <code><a href="groth16.md#0x2_groth16_ProofPoints">ProofPoints
 
 ## Function `prepare_verifying_key`
 
-@param veriyfing_key: An Arkworks canonical serialization of a verifying key.
+@param veriyfing_key: An Arkworks canonical compressed serialization of a verifying key.
 
 Returns four vectors of bytes representing the four components of a prepared verifying key.
 This step computes one pairing e(P, Q), and binds the verification to one particular proof statement.

--- a/crates/sui-framework/docs/groth16.md
+++ b/crates/sui-framework/docs/groth16.md
@@ -252,7 +252,7 @@ Creates a Groth16 <code><a href="groth16.md#0x2_groth16_ProofPoints">ProofPoints
 
 ## Function `prepare_verifying_key`
 
-@param veriyfing_key: An Arkworks canonical compressed serialization of a verifying key.
+@param veriyfing_key: An Arkworks canonical serialization of a verifying key.
 
 Returns four vectors of bytes representing the four components of a prepared verifying key.
 This step computes one pairing e(P, Q), and binds the verification to one particular proof statement.

--- a/crates/sui-framework/sources/crypto/groth16.move
+++ b/crates/sui-framework/sources/crypto/groth16.move
@@ -55,7 +55,7 @@ module sui::groth16 {
         ProofPoints { bytes }
     }
 
-    /// @param veriyfing_key: An Arkworks canonical serialization of a verifying key.
+    /// @param veriyfing_key: An Arkworks canonical compressed serialization of a verifying key.
     ///
     /// Returns four vectors of bytes representing the four components of a prepared verifying key.
     /// This step computes one pairing e(P, Q), and binds the verification to one particular proof statement.


### PR DESCRIPTION
With fastcrypto updated there were changes in Arkworks dependency (ark_serialize) from 0.3.0 to 0.4.0. As you can see, now there is no serialize/deserialize, but now the same method is called serialize_compressed/deserialize_compressed https://github.com/MystenLabs/fastcrypto/blob/524808f3a8ada33d53ea0dd453d31b1de90a68e0/fastcrypto-zkp/src/bls12381/api.rs#L20

Perhaps, this should be stated explicitly for developers. That they must choose serialize_compressed instead of serialize_uncompressed. Because just saying an Arkworks canonical serialization would sound ambiguous right now.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
