### PR TITLE
Refactor sui benchmark code for simplicity

### DIFF
--- a/crates/sui-benchmark/src/bank.rs
+++ b/crates/sui-benchmark/src/bank.rs
@@ -1,0 +1,200 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::util::{make_pay_tx, UpdatedAndNewlyMintedGasCoins};
+use crate::workloads::payload::Payload;
+use crate::workloads::workload::{Workload, WorkloadBuilder};
+use crate::workloads::{Gas, GasCoinConfig};
+use crate::ValidatorProxy;
+use anyhow::{Error, Result};
+use itertools::Itertools;
+use move_core_types::language_storage::TypeTag;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use sui_types::base_types::{ObjectRef, SuiAddress};
+use sui_types::crypto::AccountKeyPair;
+use sui_types::gas_coin::GAS;
+use sui_types::messages::{
+    CallArg, ObjectArg, TransactionData, VerifiedTransaction, DUMMY_GAS_PRICE,
+};
+use sui_types::utils::to_sender_signed_transaction;
+use sui_types::{coin, SUI_FRAMEWORK_OBJECT_ID};
+
+/// Bank is used for generating gas for running the benchmark. It is initialized with two gas coins i.e.
+/// `pay_coin` which is split into smaller gas coins and `primary_gas` which is the gas coin used
+/// for executing coin split transactions
+#[derive(Clone)]
+pub struct BenchmarkBank {
+    pub proxy: Arc<dyn ValidatorProxy + Send + Sync>,
+    // Gas to use for execution of gas generation transaction
+    pub primary_gas: Gas,
+    // Coin to use for splitting and generating small gas coins
+    pub pay_coin: Gas,
+}
+
+impl BenchmarkBank {
+    pub fn new(
+        proxy: Arc<dyn ValidatorProxy + Send + Sync>,
+        primary_gas: Gas,
+        pay_coin: Gas,
+    ) -> Self {
+        BenchmarkBank {
+            proxy,
+            primary_gas,
+            pay_coin,
+        }
+    }
+    pub async fn generate(
+        &mut self,
+        builders: Vec<Box<dyn WorkloadBuilder<dyn Payload>>>,
+        gas_price: u64,
+        chunk_size: u64,
+    ) -> Result<Vec<Box<dyn Workload<dyn Payload>>>> {
+        let mut coin_configs = VecDeque::new();
+        for builder in builders.iter() {
+            let init_gas_config = builder.generate_coin_config_for_init().await;
+            let payload_gas_config = builder.generate_coin_config_for_payloads().await;
+            coin_configs.push_back(init_gas_config);
+            coin_configs.push_back(payload_gas_config);
+        }
+        let mut all_coin_configs = vec![];
+        coin_configs
+            .iter()
+            .for_each(|v| all_coin_configs.extend(v.clone()));
+
+        let mut new_gas_coins: Vec<Gas> = vec![];
+        let chunked_coin_configs = all_coin_configs.chunks(chunk_size as usize);
+        eprintln!("Number of gas requests = {}", chunked_coin_configs.len());
+        for chunk in chunked_coin_configs {
+            let (updated_primary_gas, updated_coin, gas_coins) =
+                self.split_coin_and_pay(chunk, gas_price).await?;
+            self.primary_gas = updated_primary_gas;
+            self.pay_coin = updated_coin;
+            new_gas_coins.extend(gas_coins);
+        }
+        let mut workloads = vec![];
+        for builder in builders.iter() {
+            let init_gas_config = coin_configs.pop_front().unwrap();
+            let payload_gas_config = coin_configs.pop_front().unwrap();
+            let init_gas: Vec<Gas> = init_gas_config
+                .iter()
+                .map(|c| {
+                    let (index, _) = new_gas_coins
+                        .iter()
+                        .find_position(|g| g.1 == c.address)
+                        .unwrap();
+                    new_gas_coins.remove(index)
+                })
+                .collect();
+            let payload_gas: Vec<Gas> = payload_gas_config
+                .iter()
+                .map(|c| {
+                    let (index, _) = new_gas_coins
+                        .iter()
+                        .find_position(|g| g.1 == c.address)
+                        .unwrap();
+                    new_gas_coins.remove(index)
+                })
+                .collect();
+            workloads.push(builder.build(init_gas, payload_gas).await);
+        }
+        Ok(workloads)
+    }
+    fn make_split_coin_tx(
+        &self,
+        split_amounts: Vec<u64>,
+        gas_price: Option<u64>,
+        keypair: &AccountKeyPair,
+    ) -> Result<VerifiedTransaction> {
+        let split_coin = TransactionData::new_move_call(
+            self.primary_gas.1,
+            SUI_FRAMEWORK_OBJECT_ID,
+            coin::PAY_MODULE_NAME.to_owned(),
+            coin::PAY_SPLIT_VEC_FUNC_NAME.to_owned(),
+            vec![TypeTag::Struct(Box::new(GAS::type_()))],
+            self.primary_gas.0,
+            vec![
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(self.pay_coin.0)),
+                CallArg::Pure(bcs::to_bytes(&split_amounts).unwrap()),
+            ],
+            1000000,
+            gas_price.unwrap_or(DUMMY_GAS_PRICE),
+        )?;
+        let verified_tx = to_sender_signed_transaction(split_coin, keypair);
+        Ok(verified_tx)
+    }
+    async fn split_coin_and_pay(
+        &mut self,
+        coin_configs: &[GasCoinConfig],
+        gas_price: u64,
+    ) -> Result<UpdatedAndNewlyMintedGasCoins> {
+        // split one coin into smaller coins of different amounts and send them to recipients
+        let split_amounts: Vec<u64> = coin_configs.iter().map(|c| c.amount).collect();
+        // TODO: Instead of splitting the coin and then using pay tx to transfer it to recipients,
+        // we can do both in one tx with pay_sui which will split the coin out for us before
+        // transferring it to recipients
+        let verified_tx =
+            self.make_split_coin_tx(split_amounts.clone(), Some(gas_price), &self.primary_gas.2)?;
+        let effects = self.proxy.execute_transaction(verified_tx.into()).await?;
+        let updated_gas = effects
+            .mutated()
+            .into_iter()
+            .find(|(k, _)| k.0 == self.primary_gas.0 .0)
+            .ok_or("Input gas missing in the effects")
+            .map_err(Error::msg)?;
+        let created_coins: Vec<ObjectRef> = effects.created().into_iter().map(|c| c.0).collect();
+        assert_eq!(created_coins.len(), split_amounts.len());
+        let updated_coin = effects
+            .mutated()
+            .into_iter()
+            .find(|(k, _)| k.0 == self.pay_coin.0 .0)
+            .ok_or("Input gas missing in the effects")
+            .map_err(Error::msg)?;
+        let recipient_addresses: Vec<SuiAddress> = coin_configs.iter().map(|g| g.address).collect();
+        let verified_tx = make_pay_tx(
+            created_coins,
+            self.primary_gas.1,
+            recipient_addresses,
+            split_amounts,
+            updated_gas.0,
+            &self.primary_gas.2,
+            Some(gas_price),
+        )?;
+        let effects = self.proxy.execute_transaction(verified_tx.into()).await?;
+        let address_map: HashMap<SuiAddress, Arc<AccountKeyPair>> = coin_configs
+            .iter()
+            .map(|c| (c.address, c.keypair.clone()))
+            .collect();
+        let transferred_coins: Result<Vec<Gas>> = effects
+            .created()
+            .into_iter()
+            .map(|c| {
+                let address = c.1.get_owner_address()?;
+                let keypair = address_map
+                    .get(&address)
+                    .ok_or("Owner address missing in the address map")
+                    .map_err(Error::msg)?;
+                Ok((c.0, address, keypair.clone()))
+            })
+            .collect();
+        let updated_gas = effects
+            .mutated()
+            .into_iter()
+            .find(|(k, _)| k.0 == self.primary_gas.0 .0)
+            .ok_or("Input gas missing in the effects")
+            .map_err(Error::msg)?;
+        Ok((
+            (
+                updated_gas.0,
+                updated_gas.1.get_owner_address()?,
+                self.primary_gas.2.clone(),
+            ),
+            (
+                updated_coin.0,
+                updated_coin.1.get_owner_address()?,
+                self.primary_gas.2.clone(),
+            ),
+            transferred_coins?,
+        ))
+    }
+}

--- a/crates/sui-benchmark/src/drivers/driver.rs
+++ b/crates/sui-benchmark/src/drivers/driver.rs
@@ -9,13 +9,14 @@ use crate::ValidatorProxy;
 use async_trait::async_trait;
 use prometheus::Registry;
 
-use crate::workloads::workload::WorkloadInfo;
+use crate::workloads::WorkloadInfo;
 
 #[async_trait]
 pub trait Driver<T> {
     async fn run(
         &self,
-        proxy_workloads: Vec<(Arc<dyn ValidatorProxy + Send + Sync>, Vec<WorkloadInfo>)>,
+        proxies: Vec<Arc<dyn ValidatorProxy + Send + Sync>>,
+        workloads: Vec<WorkloadInfo>,
         system_state_observer: Arc<SystemStateObserver>,
         registry: &Registry,
         show_progress: bool,

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -53,6 +53,7 @@ use sui_types::{
 use tokio::{task::JoinSet, time::timeout};
 use tracing::{error, info};
 
+pub mod bank;
 pub mod benchmark_setup;
 pub mod drivers;
 pub mod embedded_reconfig_observer;

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -82,12 +82,6 @@ pub struct Opts {
     /// Whether or no to download TXes during follow
     #[clap(long, global = true)]
     pub download_txes: bool,
-    /// Run in disjoint_mode when we don't want different workloads
-    /// to interfere with each other. This mode is useful when
-    /// we don't want backoff to penalize all workloads even if only
-    /// one (or some) is slow.
-    #[clap(long, parse(try_from_str), default_value = "true", global = true)]
-    pub disjoint_mode: bool,
     /// Number of transactions or duration to
     /// run the benchmark for. Default set to
     /// "unbounded" i.e. benchmark runs forever

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -1,27 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Error, Result};
-use std::collections::HashMap;
+use anyhow::Result;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore};
-use sui_types::{base_types::SuiAddress, coin, crypto::SuiKeyPair, SUI_FRAMEWORK_OBJECT_ID};
+use sui_types::{base_types::SuiAddress, crypto::SuiKeyPair};
 
 use crate::ValidatorProxy;
-use itertools::Itertools;
-use move_core_types::language_storage::TypeTag;
 use std::path::PathBuf;
 use std::sync::Arc;
 use sui_types::base_types::ObjectRef;
-use sui_types::messages::{
-    CallArg, ObjectArg, TransactionData, VerifiedTransaction, DUMMY_GAS_PRICE,
-};
+use sui_types::messages::{TransactionData, VerifiedTransaction, DUMMY_GAS_PRICE};
 use sui_types::utils::to_sender_signed_transaction;
-use tracing::log::info;
 
-use crate::workloads::{
-    Gas, GasCoinConfig, WorkloadGasConfig, WorkloadInitGas, WorkloadPayloadGas,
-};
+use crate::workloads::Gas;
 use sui_types::crypto::{AccountKeyPair, KeypairTraits};
+use test_utils::messages::create_publish_move_package_transaction;
+use test_utils::transaction::parse_package_ref;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
 // for running the benchmark
@@ -38,33 +32,6 @@ pub fn get_ed25519_keypair_from_keystore(
         Ok(SuiKeyPair::Ed25519(kp)) => Ok(kp.copy()),
         other => Err(anyhow::anyhow!("Invalid key type: {:?}", other)),
     }
-}
-
-pub fn make_split_coin_tx(
-    sender: SuiAddress,
-    coin: ObjectRef,
-    coin_type_tag: TypeTag,
-    split_amounts: Vec<u64>,
-    gas: ObjectRef,
-    keypair: &AccountKeyPair,
-    gas_price: Option<u64>,
-) -> Result<VerifiedTransaction> {
-    let split_coin = TransactionData::new_move_call(
-        sender,
-        SUI_FRAMEWORK_OBJECT_ID,
-        coin::PAY_MODULE_NAME.to_owned(),
-        coin::PAY_SPLIT_VEC_FUNC_NAME.to_owned(),
-        vec![coin_type_tag],
-        gas,
-        vec![
-            CallArg::Object(ObjectArg::ImmOrOwnedObject(coin)),
-            CallArg::Pure(bcs::to_bytes(&split_amounts).unwrap()),
-        ],
-        1000000,
-        gas_price.unwrap_or(DUMMY_GAS_PRICE),
-    )?;
-    let verified_tx = to_sender_signed_transaction(split_coin, keypair);
-    Ok(verified_tx)
 }
 
 pub fn make_pay_tx(
@@ -88,234 +55,17 @@ pub fn make_pay_tx(
     Ok(to_sender_signed_transaction(pay, keypair))
 }
 
-pub async fn split_coin_and_pay(
-    proxy: Arc<dyn ValidatorProxy + Send + Sync>,
-    coin: ObjectRef,
-    coin_sender: SuiAddress,
-    coin_type_tag: TypeTag,
-    coin_configs: &[GasCoinConfig],
-    gas: Gas,
+pub async fn publish_basics_package(
+    gas: ObjectRef,
+    proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+    sender: SuiAddress,
+    keypair: &AccountKeyPair,
     gas_price: u64,
-) -> Result<UpdatedAndNewlyMintedGasCoins> {
-    // split one coin into smaller coins of different amounts and send them to recipients
-    let split_amounts: Vec<u64> = coin_configs.iter().map(|c| c.amount).collect();
-    // TODO: Instead of splitting the coin and then using pay tx to transfer it to recipients,
-    // we can do both in one tx with pay_sui which will split the coin out for us before
-    // transferring it to recipients
-    let verified_tx = make_split_coin_tx(
-        coin_sender,
-        coin,
-        coin_type_tag,
-        split_amounts.clone(),
-        gas.0,
-        &gas.2,
-        Some(gas_price),
-    )?;
-    let effects = proxy.execute_transaction(verified_tx.into()).await?;
-    let updated_gas = effects
-        .mutated()
-        .into_iter()
-        .find(|(k, _)| k.0 == gas.0 .0)
-        .ok_or("Input gas missing in the effects")
-        .map_err(Error::msg)?;
-    let created_coins: Vec<ObjectRef> = effects.created().into_iter().map(|c| c.0).collect();
-    assert_eq!(created_coins.len(), split_amounts.len());
-    let updated_coin = effects
-        .mutated()
-        .into_iter()
-        .find(|(k, _)| k.0 == coin.0)
-        .ok_or("Input gas missing in the effects")
-        .map_err(Error::msg)?;
-    let recipient_addresses: Vec<SuiAddress> = coin_configs.iter().map(|g| g.address).collect();
-    let verified_tx = make_pay_tx(
-        created_coins,
-        gas.1.get_owner_address()?,
-        recipient_addresses,
-        split_amounts,
-        updated_gas.0,
-        &gas.2,
-        Some(gas_price),
-    )?;
-    let effects = proxy.execute_transaction(verified_tx.into()).await?;
-    let address_map: HashMap<SuiAddress, Arc<AccountKeyPair>> = coin_configs
-        .iter()
-        .map(|c| (c.address, c.keypair.clone()))
-        .collect();
-    let transferred_coins: Result<Vec<Gas>> = effects
-        .created()
-        .into_iter()
-        .map(|c| {
-            let address = c.1.get_owner_address()?;
-            let keypair = address_map
-                .get(&address)
-                .ok_or("Owner address missing in the address map")
-                .map_err(Error::msg)?;
-            Ok((c.0, c.1, keypair.clone()))
-        })
-        .collect();
-    let updated_gas = effects
-        .mutated()
-        .into_iter()
-        .find(|(k, _)| k.0 == gas.0 .0)
-        .ok_or("Input gas missing in the effects")
-        .map_err(Error::msg)?;
-    Ok((
-        (updated_gas.0, updated_gas.1, gas.2.clone()),
-        (updated_coin.0, updated_coin.1, gas.2),
-        transferred_coins?,
-    ))
-}
-
-pub async fn generate_all_gas_for_test(
-    proxy: Arc<dyn ValidatorProxy + Send + Sync>,
-    gas: Gas,
-    coin: Gas,
-    coin_type_tag: TypeTag,
-    workload_gas_config: WorkloadGasConfig,
-    gas_price: u64,
-    chunk_size: u64,
-) -> Result<(WorkloadInitGas, WorkloadPayloadGas)> {
-    info!(
-        "Generating gas with number of coins for shared counter init = {:?}, number of coins for \
-    shared counter payloads = {:?}, number of transfer object token = {:?}, number of coins for \
-    transfer object payloads = {:?}, number of coins for delegation payloads = {:?}, number of coins for batch payment payloads = {:?}",
-        workload_gas_config
-            .shared_counter_workload_init_gas_config
-            .len(),
-        workload_gas_config
-            .shared_counter_workload_payload_gas_config
-            .len(),
-        workload_gas_config.transfer_object_workload_tokens.len(),
-        workload_gas_config
-            .transfer_object_workload_payload_gas_config
-            .len(),
-        workload_gas_config.delegation_gas_configs.len(),
-        workload_gas_config.batch_payment_gas_config.len()
-    );
-    let mut coin_configs = vec![];
-    coin_configs.extend(
-        workload_gas_config
-            .shared_counter_workload_init_gas_config
-            .iter()
-            .cloned(),
-    );
-    coin_configs.extend(
-        workload_gas_config
-            .shared_counter_workload_payload_gas_config
-            .iter()
-            .cloned(),
-    );
-    coin_configs.extend(
-        workload_gas_config
-            .transfer_object_workload_tokens
-            .iter()
-            .cloned(),
-    );
-    coin_configs.extend(
-        workload_gas_config
-            .transfer_object_workload_payload_gas_config
-            .iter()
-            .cloned(),
-    );
-    coin_configs.extend(workload_gas_config.delegation_gas_configs.iter().cloned());
-    coin_configs.extend(workload_gas_config.batch_payment_gas_config.iter().cloned());
-    let mut primary_gas = gas;
-    let mut pay_coin = coin;
-    let mut new_gas_coins: Vec<Gas> = vec![];
-    let chunked_coin_configs = coin_configs.chunks(chunk_size as usize);
-    eprintln!("Number of gas requests = {}", chunked_coin_configs.len());
-    for chunk in chunked_coin_configs {
-        let (updated_primary_gas, updated_coin, gas_coins) = split_coin_and_pay(
-            proxy.clone(),
-            pay_coin.0,
-            pay_coin.1.get_owner_address()?,
-            coin_type_tag.clone(),
-            chunk,
-            primary_gas,
-            gas_price,
-        )
-        .await?;
-        primary_gas = updated_primary_gas;
-        pay_coin = updated_coin;
-        new_gas_coins.extend(gas_coins);
-    }
-    let transfer_tokens: Vec<Gas> = workload_gas_config
-        .transfer_object_workload_tokens
-        .iter()
-        .map(|c| {
-            let (index, _) = new_gas_coins
-                .iter()
-                .find_position(|g| g.1.get_owner_address().unwrap() == c.address)
-                .unwrap();
-            new_gas_coins.remove(index)
-        })
-        .collect();
-    let transfer_object_payload_gas: Vec<Gas> = workload_gas_config
-        .transfer_object_workload_payload_gas_config
-        .iter()
-        .map(|c| {
-            let (index, _) = new_gas_coins
-                .iter()
-                .find_position(|g| g.1.get_owner_address().unwrap() == c.address)
-                .unwrap();
-            new_gas_coins.remove(index)
-        })
-        .collect();
-    let shared_counter_init_gas: Vec<Gas> = workload_gas_config
-        .shared_counter_workload_init_gas_config
-        .iter()
-        .map(|c| {
-            let (index, _) = new_gas_coins
-                .iter()
-                .find_position(|g| g.1.get_owner_address().unwrap() == c.address)
-                .unwrap();
-            new_gas_coins.remove(index)
-        })
-        .collect();
-    let shared_counter_payload_gas: Vec<Gas> = workload_gas_config
-        .shared_counter_workload_payload_gas_config
-        .iter()
-        .map(|c| {
-            let (index, _) = new_gas_coins
-                .iter()
-                .find_position(|g| g.1.get_owner_address().unwrap() == c.address)
-                .unwrap();
-            new_gas_coins.remove(index)
-        })
-        .collect();
-    let delegation_payload_gas: Vec<Gas> = workload_gas_config
-        .delegation_gas_configs
-        .iter()
-        .map(|c| {
-            let (index, _) = new_gas_coins
-                .iter()
-                .find_position(|g| g.1.get_owner_address().unwrap() == c.address)
-                .unwrap();
-            new_gas_coins.remove(index)
-        })
-        .collect();
-    let batch_payment_payload_gas: Vec<Gas> = workload_gas_config
-        .batch_payment_gas_config
-        .iter()
-        .map(|c| {
-            let (index, _) = new_gas_coins
-                .iter()
-                .find_position(|g| g.1.get_owner_address().unwrap() == c.address)
-                .unwrap();
-            new_gas_coins.remove(index)
-        })
-        .collect();
-    let workload_init_config = WorkloadInitGas {
-        shared_counter_init_gas,
-    };
-
-    let workload_payload_config = WorkloadPayloadGas {
-        transfer_tokens,
-        transfer_object_payload_gas,
-        shared_counter_payload_gas,
-        delegation_payload_gas,
-        batch_payment_payload_gas,
-    };
-
-    Ok((workload_init_config, workload_payload_config))
+) -> ObjectRef {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("../../sui_programmability/examples/basics");
+    let transaction =
+        create_publish_move_package_transaction(gas, path, sender, keypair, Some(gas_price));
+    let effects = proxy.execute_transaction(transaction.into()).await.unwrap();
+    parse_package_ref(&effects.created()).unwrap()
 }

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -3,8 +3,8 @@
 
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::payload::Payload;
-use crate::workloads::workload::{Workload, WorkloadType, MAX_GAS_FOR_TESTING};
-use crate::workloads::{GasCoinConfig, WorkloadInitGas, WorkloadPayloadGas};
+use crate::workloads::workload::{Workload, WorkloadBuilder, MAX_GAS_FOR_TESTING};
+use crate::workloads::{Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams};
 use crate::{ExecutionEffects, ValidatorProxy};
 use async_trait::async_trait;
 use rand::seq::IteratorRandom;
@@ -23,6 +23,12 @@ pub struct DelegationTestPayload {
     sender: SuiAddress,
     keypair: Arc<AccountKeyPair>,
     system_state_observer: Arc<SystemStateObserver>,
+}
+
+impl std::fmt::Display for DelegationTestPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "delegation")
+    }
 }
 
 impl Payload for DelegationTestPayload {
@@ -58,22 +64,50 @@ impl Payload for DelegationTestPayload {
             ),
         }
     }
-
-    fn get_workload_type(&self) -> WorkloadType {
-        WorkloadType::Delegation
-    }
 }
 
 #[derive(Debug)]
-pub struct DelegationWorkload;
+pub struct DelegationWorkloadBuilder {
+    count: u64,
+}
 
-impl DelegationWorkload {
-    pub fn new_boxed() -> Box<dyn Workload<dyn Payload>> {
-        Box::<dyn Workload<dyn Payload>>::from(Box::new(DelegationWorkload))
+impl DelegationWorkloadBuilder {
+    pub fn from(
+        workload_weight: f32,
+        target_qps: u64,
+        num_workers: u64,
+        in_flight_ratio: u64,
+    ) -> Option<WorkloadBuilderInfo> {
+        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
+        let max_ops = target_qps * in_flight_ratio;
+        if max_ops == 0 || num_workers == 0 {
+            None
+        } else {
+            let workload_params = WorkloadParams {
+                target_qps,
+                num_workers,
+                max_ops,
+            };
+            let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
+                DelegationWorkloadBuilder { count: max_ops },
+            ));
+            let builder_info = WorkloadBuilderInfo {
+                workload_params,
+                workload_builder,
+            };
+            Some(builder_info)
+        }
     }
+}
 
-    pub fn generate_gas_config_for_payloads(count: u64) -> Vec<GasCoinConfig> {
-        (0..count)
+#[async_trait]
+impl WorkloadBuilder<dyn Payload> for DelegationWorkloadBuilder {
+    async fn generate_coin_config_for_init(&self) -> Vec<GasCoinConfig> {
+        vec![]
+    }
+    async fn generate_coin_config_for_payloads(&self) -> Vec<GasCoinConfig> {
+        (0..self.count)
             .map(|_| {
                 let (address, keypair) = get_key_pair();
                 GasCoinConfig {
@@ -84,13 +118,24 @@ impl DelegationWorkload {
             })
             .collect()
     }
+    async fn build(
+        &self,
+        _init_gas: Vec<Gas>,
+        payload_gas: Vec<Gas>,
+    ) -> Box<dyn Workload<dyn Payload>> {
+        Box::<dyn Workload<dyn Payload>>::from(Box::new(DelegationWorkload { payload_gas }))
+    }
+}
+
+#[derive(Debug)]
+pub struct DelegationWorkload {
+    payload_gas: Vec<Gas>,
 }
 
 #[async_trait]
 impl Workload<dyn Payload> for DelegationWorkload {
     async fn init(
         &mut self,
-        _: WorkloadInitGas,
         _: Arc<dyn ValidatorProxy + Sync + Send>,
         _system_state_observer: Arc<SystemStateObserver>,
     ) {
@@ -98,8 +143,6 @@ impl Workload<dyn Payload> for DelegationWorkload {
 
     async fn make_test_payloads(
         &self,
-        _num_payloads: u64,
-        gas_config: WorkloadPayloadGas,
         proxy: Arc<dyn ValidatorProxy + Sync + Send>,
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Vec<Box<dyn Payload>> {
@@ -108,25 +151,20 @@ impl Workload<dyn Payload> for DelegationWorkload {
             .await
             .expect("failed to fetch validators");
 
-        gas_config
-            .delegation_payload_gas
-            .into_iter()
+        self.payload_gas
+            .iter()
             .map(|(gas, owner, keypair)| {
                 let validator = *validators.iter().choose(&mut rand::thread_rng()).unwrap();
                 Box::new(DelegationTestPayload {
                     coin: None,
-                    gas,
+                    gas: *gas,
                     validator,
-                    sender: owner.get_owner_address().unwrap(),
-                    keypair,
+                    sender: *owner,
+                    keypair: keypair.clone(),
                     system_state_observer: system_state_observer.clone(),
                 })
             })
             .map(|b| Box::<dyn Payload>::from(b))
             .collect()
-    }
-
-    fn get_workload_type(&self) -> WorkloadType {
-        WorkloadType::Delegation
     }
 }

--- a/crates/sui-benchmark/src/workloads/mod.rs
+++ b/crates/sui-benchmark/src/workloads/mod.rs
@@ -9,21 +9,33 @@ pub mod transfer_object;
 pub mod workload;
 pub mod workload_configuration;
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::workloads::payload::Payload;
-use delegation::DelegationWorkload;
-use shared_counter::SharedCounterWorkload;
 use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::AccountKeyPair;
-use sui_types::object::Owner;
-use transfer_object::TransferObjectWorkload;
 use workload::*;
 
-use self::batch_payment::BatchPaymentWorkload;
+#[derive(Debug)]
+pub struct WorkloadParams {
+    pub target_qps: u64,
+    pub num_workers: u64,
+    pub max_ops: u64,
+}
 
-pub type Gas = (ObjectRef, Owner, Arc<AccountKeyPair>);
+#[derive(Debug)]
+pub struct WorkloadBuilderInfo {
+    pub workload_params: WorkloadParams,
+    pub workload_builder: Box<dyn WorkloadBuilder<dyn Payload>>,
+}
+
+#[derive(Debug)]
+pub struct WorkloadInfo {
+    pub workload_params: WorkloadParams,
+    pub workload: Box<dyn Workload<dyn Payload>>,
+}
+
+pub type Gas = (ObjectRef, SuiAddress, Arc<AccountKeyPair>);
 
 #[derive(Clone)]
 pub struct GasCoinConfig {
@@ -33,165 +45,4 @@ pub struct GasCoinConfig {
     pub address: SuiAddress,
     // recipient account key pair (useful for signing txns)
     pub keypair: Arc<AccountKeyPair>,
-}
-
-#[derive(Clone)]
-pub struct WorkloadInitGas {
-    // Gas coins to initialize shared counter workload
-    // This includes the coins to publish the package and create
-    // shared counters
-    pub shared_counter_init_gas: Vec<Gas>,
-}
-
-#[derive(Clone, Debug)]
-pub struct WorkloadPayloadGas {
-    // Gas coins to be used as transfer tokens
-    // These are the objects which get transferred
-    // between different accounts during the course of benchmark
-    pub transfer_tokens: Vec<Gas>,
-    // Gas coins needed to run transfer transactions during
-    // the course of benchmark
-    pub transfer_object_payload_gas: Vec<Gas>,
-    // Gas coins needed to run shared counter increment during
-    // the course of benchmark
-    pub shared_counter_payload_gas: Vec<Gas>,
-    // Gas coins needed to run delegation flow
-    pub delegation_payload_gas: Vec<Gas>,
-    // Gas coins needed to run batch payment flow
-    pub batch_payment_payload_gas: Vec<Gas>,
-}
-
-#[derive(Clone)]
-pub struct WorkloadGasConfig {
-    pub shared_counter_workload_init_gas_config: Vec<GasCoinConfig>,
-    pub shared_counter_workload_payload_gas_config: Vec<GasCoinConfig>,
-    pub transfer_object_workload_tokens: Vec<GasCoinConfig>,
-    pub transfer_object_workload_payload_gas_config: Vec<GasCoinConfig>,
-    pub delegation_gas_configs: Vec<GasCoinConfig>,
-    pub batch_payment_gas_config: Vec<GasCoinConfig>,
-}
-
-pub fn make_combination_workload(
-    target_qps: u64,
-    num_workers: u64,
-    in_flight_ratio: u64,
-    num_transfer_accounts: u64,
-    shared_counter_weight: u32,
-    transfer_object_weight: u32,
-    delegation_weight: u32,
-    batch_payment_weight: u32,
-    payload_config: WorkloadPayloadGas,
-) -> WorkloadInfo {
-    let mut workloads = HashMap::<WorkloadType, (u32, Box<dyn Workload<dyn Payload>>)>::new();
-    if shared_counter_weight > 0 {
-        let workload = SharedCounterWorkload::new_boxed(None, vec![]);
-        workloads
-            .entry(WorkloadType::SharedCounter)
-            .or_insert((shared_counter_weight, workload));
-    }
-    if transfer_object_weight > 0 {
-        let workload = TransferObjectWorkload::new_boxed(num_transfer_accounts);
-        workloads
-            .entry(WorkloadType::TransferObject)
-            .or_insert((transfer_object_weight, workload));
-    }
-    if delegation_weight > 0 {
-        let workload = DelegationWorkload::new_boxed();
-        workloads
-            .entry(WorkloadType::Delegation)
-            .or_insert((delegation_weight, workload));
-    }
-    if batch_payment_weight > 0 {
-        let workload = Box::new(BatchPaymentWorkload::default());
-        workloads
-            .entry(WorkloadType::BatchPayment)
-            .or_insert((batch_payment_weight, workload));
-    }
-    let workload = CombinationWorkload::new_boxed(workloads);
-    WorkloadInfo {
-        target_qps,
-        num_workers,
-        max_in_flight_ops: in_flight_ratio * target_qps,
-        workload,
-        payload_config,
-    }
-}
-
-pub fn make_shared_counter_workload(
-    target_qps: u64,
-    num_workers: u64,
-    max_in_flight_ops: u64,
-    payload_config: WorkloadPayloadGas,
-) -> Option<WorkloadInfo> {
-    if target_qps == 0 || max_in_flight_ops == 0 || num_workers == 0 {
-        None
-    } else {
-        let workload = SharedCounterWorkload::new_boxed(None, vec![]);
-        Some(WorkloadInfo {
-            target_qps,
-            num_workers,
-            max_in_flight_ops,
-            workload,
-            payload_config,
-        })
-    }
-}
-
-pub fn make_transfer_object_workload(
-    target_qps: u64,
-    num_workers: u64,
-    max_in_flight_ops: u64,
-    num_transfer_accounts: u64,
-    payload_config: WorkloadPayloadGas,
-) -> Option<WorkloadInfo> {
-    if target_qps == 0 || max_in_flight_ops == 0 || num_workers == 0 {
-        None
-    } else {
-        let workload = TransferObjectWorkload::new_boxed(num_transfer_accounts);
-        Some(WorkloadInfo {
-            target_qps,
-            num_workers,
-            max_in_flight_ops,
-            workload,
-            payload_config,
-        })
-    }
-}
-
-pub fn make_delegation_workload(
-    target_qps: u64,
-    num_workers: u64,
-    max_in_flight_ops: u64,
-    payload_config: WorkloadPayloadGas,
-) -> Option<WorkloadInfo> {
-    if target_qps == 0 || max_in_flight_ops == 0 || num_workers == 0 {
-        None
-    } else {
-        Some(WorkloadInfo {
-            target_qps,
-            num_workers,
-            max_in_flight_ops,
-            workload: DelegationWorkload::new_boxed(),
-            payload_config,
-        })
-    }
-}
-
-pub fn make_batch_payment_workload(
-    target_qps: u64,
-    num_workers: u64,
-    max_in_flight_ops: u64,
-    payload_config: WorkloadPayloadGas,
-) -> Option<WorkloadInfo> {
-    if target_qps == 0 || max_in_flight_ops == 0 || num_workers == 0 {
-        None
-    } else {
-        Some(WorkloadInfo {
-            target_qps,
-            num_workers,
-            max_in_flight_ops,
-            workload: Box::new(BatchPaymentWorkload::default()),
-            payload_config,
-        })
-    }
 }

--- a/crates/sui-benchmark/src/workloads/payload.rs
+++ b/crates/sui-benchmark/src/workloads/payload.rs
@@ -1,47 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::ExecutionEffects;
+use std::fmt::Display;
 use sui_types::messages::VerifiedTransaction;
 
-use crate::ExecutionEffects;
-use rand::{prelude::*, rngs::OsRng};
-use rand_distr::WeightedAliasIndex;
-
-use crate::workloads::workload::WorkloadType;
-
-pub trait Payload: Send + Sync + std::fmt::Debug {
+/// A Payload is a transaction wrapper of a particular type (transfer object, shared counter, etc).
+/// Calling `make_transaction()` on a payload produces the transaction it is wrapping. Once that
+/// transaction is returned with effects (by quorum driver), a new payload can be generated with that
+/// effect by invoking `make_new_payload(effects)`
+pub trait Payload: Send + Sync + std::fmt::Debug + Display {
     fn make_new_payload(&mut self, effects: &ExecutionEffects);
     fn make_transaction(&mut self) -> VerifiedTransaction;
-    fn get_workload_type(&self) -> WorkloadType;
-}
-
-#[derive(Debug)]
-pub struct CombinationPayload {
-    pub payloads: Vec<Box<dyn Payload>>,
-    pub dist: WeightedAliasIndex<u32>,
-    pub curr_index: usize,
-    pub rng: OsRng,
-}
-
-impl Payload for CombinationPayload {
-    fn make_new_payload(&mut self, effects: &ExecutionEffects) {
-        for (pos, e) in self.payloads.iter_mut().enumerate() {
-            if pos == self.curr_index {
-                e.make_new_payload(effects);
-            }
-        }
-        let mut rng = self.rng;
-        let next_index = self.dist.sample(&mut rng);
-        self.curr_index = next_index;
-    }
-    fn make_transaction(&mut self) -> VerifiedTransaction {
-        let curr = self.payloads.get_mut(self.curr_index).unwrap();
-        curr.make_transaction()
-    }
-    fn get_workload_type(&self) -> WorkloadType {
-        self.payloads
-            .get(self.curr_index)
-            .unwrap()
-            .get_workload_type()
-    }
 }

--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -11,16 +11,16 @@ use sui_types::{
     base_types::{ObjectRef, SuiAddress},
     crypto::{get_key_pair, AccountKeyPair},
     messages::VerifiedTransaction,
-    object::Owner,
 };
 
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::payload::Payload;
-use crate::workloads::{Gas, GasCoinConfig, WorkloadInitGas, WorkloadPayloadGas};
+use crate::workloads::workload::WorkloadBuilder;
+use crate::workloads::{Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams};
 use crate::{ExecutionEffects, ValidatorProxy};
 use sui_core::test_utils::make_transfer_object_transaction;
 
-use super::workload::{Workload, WorkloadType, MAX_GAS_FOR_TESTING};
+use super::workload::{Workload, MAX_GAS_FOR_TESTING};
 
 #[derive(Debug)]
 pub struct TransferObjectTestPayload {
@@ -33,22 +33,13 @@ pub struct TransferObjectTestPayload {
 
 impl Payload for TransferObjectTestPayload {
     fn make_new_payload(&mut self, effects: &ExecutionEffects) {
-        let recipient = self
-            .gas
-            .iter()
-            .find(|x| x.1.get_owner_address().unwrap() != self.transfer_to)
-            .unwrap()
-            .1;
+        let recipient = self.gas.iter().find(|x| x.1 != self.transfer_to).unwrap().1;
         let updated_gas: Vec<Gas> = self
             .gas
             .iter()
             .map(|x| {
-                if x.1.get_owner_address().unwrap() == self.transfer_from {
-                    (
-                        effects.gas_object().0,
-                        Owner::AddressOwner(self.transfer_from),
-                        x.2.clone(),
-                    )
+                if x.1 == self.transfer_from {
+                    (effects.gas_object().0, self.transfer_from, x.2.clone())
                 } else {
                     x.clone()
                 }
@@ -61,15 +52,11 @@ impl Payload for TransferObjectTestPayload {
             .map(|x| x.0)
             .unwrap();
         self.transfer_from = self.transfer_to;
-        self.transfer_to = recipient.get_owner_address().unwrap();
+        self.transfer_to = recipient;
         self.gas = updated_gas;
     }
     fn make_transaction(&mut self) -> VerifiedTransaction {
-        let (gas_obj, _, keypair) = self
-            .gas
-            .iter()
-            .find(|x| x.1.get_owner_address().unwrap() == self.transfer_from)
-            .unwrap();
+        let (gas_obj, _, keypair) = self.gas.iter().find(|x| x.1 == self.transfer_from).unwrap();
         make_transfer_object_transaction(
             self.transfer_object,
             *gas_obj,
@@ -79,39 +66,69 @@ impl Payload for TransferObjectTestPayload {
             Some(*self.system_state_observer.reference_gas_price.borrow()),
         )
     }
-    fn get_workload_type(&self) -> WorkloadType {
-        WorkloadType::TransferObject
+}
+
+impl std::fmt::Display for TransferObjectTestPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "transfer_object")
     }
 }
 
 #[derive(Debug)]
-pub struct TransferObjectWorkload {
-    pub transfer_keypairs: Arc<HashMap<SuiAddress, AccountKeyPair>>,
+pub struct TransferObjectWorkloadBuilder {
+    num_transfer_accounts: u64,
+    num_payloads: u64,
 }
 
-impl TransferObjectWorkload {
-    pub fn new_boxed(num_accounts: u64) -> Box<dyn Workload<dyn Payload>> {
-        // create several accounts to transfer object between
-        let keypairs: Arc<HashMap<SuiAddress, AccountKeyPair>> =
-            Arc::new((0..num_accounts).map(|_| get_key_pair()).collect());
-        Box::new(TransferObjectWorkload {
-            transfer_keypairs: keypairs,
-        })
-    }
-    pub fn generate_coin_config_for_payloads(
-        num_tokens: u64,
+impl TransferObjectWorkloadBuilder {
+    pub fn from(
+        workload_weight: f32,
+        target_qps: u64,
+        num_workers: u64,
+        in_flight_ratio: u64,
         num_transfer_accounts: u64,
-        num_payloads: u64,
-    ) -> (Vec<GasCoinConfig>, Vec<GasCoinConfig>) {
+    ) -> Option<WorkloadBuilderInfo> {
+        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
+        let max_ops = target_qps * in_flight_ratio;
+        if max_ops == 0 || num_workers == 0 {
+            None
+        } else {
+            let workload_params = WorkloadParams {
+                target_qps,
+                num_workers,
+                max_ops,
+            };
+            let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
+                TransferObjectWorkloadBuilder {
+                    num_transfer_accounts,
+                    num_payloads: max_ops,
+                },
+            ));
+            let builder_info = WorkloadBuilderInfo {
+                workload_params,
+                workload_builder,
+            };
+            Some(builder_info)
+        }
+    }
+}
+
+#[async_trait]
+impl WorkloadBuilder<dyn Payload> for TransferObjectWorkloadBuilder {
+    async fn generate_coin_config_for_init(&self) -> Vec<GasCoinConfig> {
+        vec![]
+    }
+    async fn generate_coin_config_for_payloads(&self) -> Vec<GasCoinConfig> {
         let mut address_map = HashMap::new();
 
         // gas for payloads
         let mut payload_configs = vec![];
-        for _i in 0..num_transfer_accounts {
+        for _i in 0..self.num_transfer_accounts {
             let (address, keypair) = get_key_pair();
             let cloned_keypair: Arc<AccountKeyPair> = Arc::new(keypair);
             address_map.insert(address, cloned_keypair.clone());
-            for _j in 0..num_payloads {
+            for _j in 0..self.num_payloads {
                 payload_configs.push(GasCoinConfig {
                     amount: MAX_GAS_FOR_TESTING,
                     address,
@@ -123,25 +140,41 @@ impl TransferObjectWorkload {
         let owner = *address_map.keys().choose(&mut rand::thread_rng()).unwrap();
 
         // transfer tokens
-        let mut token_configs = vec![];
-        for _i in 0..num_tokens {
+        let mut gas_configs = vec![];
+        for _i in 0..self.num_payloads {
             let (address, keypair) = (owner, address_map.get(&owner).unwrap().clone());
-            token_configs.push(GasCoinConfig {
+            gas_configs.push(GasCoinConfig {
                 amount: MAX_GAS_FOR_TESTING,
                 address,
                 keypair: keypair.clone(),
             });
         }
 
-        (token_configs, payload_configs)
+        gas_configs.extend(payload_configs);
+        gas_configs
     }
+    async fn build(
+        &self,
+        _init_gas: Vec<Gas>,
+        payload_gas: Vec<Gas>,
+    ) -> Box<dyn Workload<dyn Payload>> {
+        Box::<dyn Workload<dyn Payload>>::from(Box::new(TransferObjectWorkload {
+            num_tokens: self.num_payloads,
+            payload_gas,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct TransferObjectWorkload {
+    num_tokens: u64,
+    payload_gas: Vec<Gas>,
 }
 
 #[async_trait]
 impl Workload<dyn Payload> for TransferObjectWorkload {
     async fn init(
         &mut self,
-        _init_config: WorkloadInitGas,
         _proxy: Arc<dyn ValidatorProxy + Sync + Send>,
         _system_state_observer: Arc<SystemStateObserver>,
     ) {
@@ -149,22 +182,21 @@ impl Workload<dyn Payload> for TransferObjectWorkload {
     }
     async fn make_test_payloads(
         &self,
-        num_payloads: u64,
-        payload_config: WorkloadPayloadGas,
         _proxy: Arc<dyn ValidatorProxy + Sync + Send>,
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Vec<Box<dyn Payload>> {
+        let (transfer_tokens, payload_gas) = self.payload_gas.split_at(self.num_tokens as usize);
         let mut gas_by_address: HashMap<SuiAddress, Vec<Gas>> = HashMap::new();
-        for gas in payload_config.transfer_object_payload_gas.iter() {
+        for gas in payload_gas.iter() {
             gas_by_address
-                .entry(gas.1.get_owner_address().unwrap())
+                .entry(gas.1)
                 .or_insert_with(|| Vec::with_capacity(1))
                 .push(gas.clone());
         }
 
         let addresses: Vec<SuiAddress> = gas_by_address.keys().cloned().collect();
         let mut transfer_gas: Vec<Vec<Gas>> = vec![];
-        for i in 0..num_payloads {
+        for i in 0..self.num_tokens {
             let mut account_transfer_gas = vec![];
             for address in addresses.iter() {
                 account_transfer_gas.push(gas_by_address[address][i as usize].clone());
@@ -173,8 +205,8 @@ impl Workload<dyn Payload> for TransferObjectWorkload {
         }
         let refs: Vec<(Vec<Gas>, Gas)> = transfer_gas
             .into_iter()
-            .zip(payload_config.transfer_tokens.into_iter())
-            .map(|(g, t)| (g, t))
+            .zip(transfer_tokens.iter())
+            .map(|(g, t)| (g, t.clone()))
             .collect();
         refs.iter()
             .map(|(g, t)| {
@@ -182,16 +214,13 @@ impl Workload<dyn Payload> for TransferObjectWorkload {
                 let to = g.iter().find(|x| x.1 != from).unwrap().1;
                 Box::new(TransferObjectTestPayload {
                     transfer_object: t.0,
-                    transfer_from: from.get_owner_address().unwrap(),
-                    transfer_to: to.get_owner_address().unwrap(),
+                    transfer_from: from,
+                    transfer_to: to,
                     gas: g.to_vec(),
                     system_state_observer: system_state_observer.clone(),
                 })
             })
             .map(|b| Box::<dyn Payload>::from(b))
             .collect()
-    }
-    fn get_workload_type(&self) -> WorkloadType {
-        WorkloadType::TransferObject
     }
 }

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -3,143 +3,42 @@
 
 use async_trait::async_trait;
 use std::sync::Arc;
-use std::{collections::HashMap, fmt};
 
 use crate::system_state_observer::SystemStateObserver;
-use crate::workloads::{WorkloadInitGas, WorkloadPayloadGas};
-use rand::rngs::OsRng;
-use rand_distr::WeightedAliasIndex;
+use crate::workloads::{Gas, GasCoinConfig};
 
-use crate::workloads::payload::{CombinationPayload, Payload};
+use crate::workloads::payload::Payload;
 use crate::ValidatorProxy;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
 // for running the benchmark
 pub const MAX_GAS_FOR_TESTING: u64 = 1_000_000_000;
 
-#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
-pub enum WorkloadType {
-    BatchPayment,
-    SharedCounter,
-    TransferObject,
-    Combination,
-    Delegation,
+#[async_trait]
+pub trait WorkloadBuilder<T: Payload + ?Sized>: Send + Sync + std::fmt::Debug {
+    async fn generate_coin_config_for_init(&self) -> Vec<GasCoinConfig>;
+    async fn generate_coin_config_for_payloads(&self) -> Vec<GasCoinConfig>;
+    async fn build(&self, init_gas: Vec<Gas>, payload_gas: Vec<Gas>) -> Box<dyn Workload<T>>;
 }
 
-impl fmt::Display for WorkloadType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            WorkloadType::BatchPayment => write!(f, "batch_payment"),
-            WorkloadType::SharedCounter => write!(f, "shared_counter"),
-            WorkloadType::TransferObject => write!(f, "transfer_object"),
-            WorkloadType::Combination => write!(f, "combination"),
-            WorkloadType::Delegation => write!(f, "delegation"),
-        }
-    }
-}
-
+/// A Workload is used to generate multiple payloads during setup phase with `make_test_payloads()`
+/// which are added to a local queue. We execute transactions (the queue is drained based on the
+/// target qps i.e. for 100 tps, the queue will be popped 100 times every second) with those payloads
+/// and generate new payloads (which are enqueued back to the queue) with the returned effects. The
+/// total number of payloads to generate depends on how much transaction throughput we want and the
+/// maximum number of transactions we want to have in flight. For instance, for a 100 target_qps and
+/// in_flight_ratio of 5, a maximum of 500 transactions is expected to be in flight and that many
+/// payloads are created.
 #[async_trait]
 pub trait Workload<T: Payload + ?Sized>: Send + Sync + std::fmt::Debug {
     async fn init(
         &mut self,
-        init_config: WorkloadInitGas,
         proxy: Arc<dyn ValidatorProxy + Sync + Send>,
         system_state_observer: Arc<SystemStateObserver>,
     );
     async fn make_test_payloads(
         &self,
-        num_payloads: u64,
-        payload_config: WorkloadPayloadGas,
         proxy: Arc<dyn ValidatorProxy + Sync + Send>,
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Vec<Box<T>>;
-    fn get_workload_type(&self) -> WorkloadType;
-}
-
-type WeightAndPayload = (u32, Box<dyn Workload<dyn Payload>>);
-
-#[derive(Debug)]
-pub struct CombinationWorkload {
-    workloads: HashMap<WorkloadType, WeightAndPayload>,
-}
-
-#[async_trait]
-impl Workload<dyn Payload> for CombinationWorkload {
-    async fn init(
-        &mut self,
-        init_config: WorkloadInitGas,
-        proxy: Arc<dyn ValidatorProxy + Sync + Send>,
-        system_state_observer: Arc<SystemStateObserver>,
-    ) {
-        for (_, (_, workload)) in self.workloads.iter_mut() {
-            workload
-                .init(
-                    init_config.clone(),
-                    proxy.clone(),
-                    system_state_observer.clone(),
-                )
-                .await;
-        }
-    }
-    async fn make_test_payloads(
-        &self,
-        num_payloads: u64,
-        payload_config: WorkloadPayloadGas,
-        proxy: Arc<dyn ValidatorProxy + Sync + Send>,
-        system_state_observer: Arc<SystemStateObserver>,
-    ) -> Vec<Box<dyn Payload>> {
-        let mut workloads: HashMap<WorkloadType, (u32, Vec<Box<dyn Payload>>)> = HashMap::new();
-        for (workload_type, (weight, workload)) in self.workloads.iter() {
-            let payloads: Vec<Box<dyn Payload>> = workload
-                .make_test_payloads(
-                    num_payloads,
-                    payload_config.clone(),
-                    proxy.clone(),
-                    system_state_observer.clone(),
-                )
-                .await;
-            assert_eq!(payloads.len() as u64, num_payloads);
-            workloads
-                .entry(*workload_type)
-                .or_insert_with(|| (*weight, payloads));
-        }
-        let mut res = vec![];
-        for _i in 0..num_payloads {
-            let mut all_payloads: Vec<Box<dyn Payload>> = vec![];
-            let mut dist = vec![];
-            for (_type, (weight, payloads)) in workloads.iter_mut() {
-                all_payloads.push(payloads.pop().unwrap());
-                dist.push(*weight);
-            }
-            res.push(Box::new(CombinationPayload {
-                payloads: all_payloads,
-                dist: WeightedAliasIndex::new(dist).unwrap(),
-                curr_index: 0,
-                rng: OsRng::default(),
-            }));
-        }
-        res.into_iter()
-            .map(|b| Box::<dyn Payload>::from(b))
-            .collect()
-    }
-    fn get_workload_type(&self) -> WorkloadType {
-        WorkloadType::Combination
-    }
-}
-
-impl CombinationWorkload {
-    pub fn new_boxed(
-        workloads: HashMap<WorkloadType, WeightAndPayload>,
-    ) -> Box<dyn Workload<dyn Payload>> {
-        Box::new(CombinationWorkload { workloads })
-    }
-}
-
-#[derive(Debug)]
-pub struct WorkloadInfo {
-    pub target_qps: u64,
-    pub num_workers: u64,
-    pub max_in_flight_ops: u64,
-    pub workload: Box<dyn Workload<dyn Payload>>,
-    pub payload_config: WorkloadPayloadGas,
 }

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -1,38 +1,25 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::benchmark_setup::ProxyGasAndCoin;
+
+use crate::bank::BenchmarkBank;
 use crate::options::{Opts, RunSpec};
 use crate::system_state_observer::SystemStateObserver;
-use crate::util::generate_all_gas_for_test;
-use crate::workloads::delegation::DelegationWorkload;
-use crate::workloads::shared_counter::SharedCounterWorkload;
-use crate::workloads::transfer_object::TransferObjectWorkload;
-use crate::workloads::workload::WorkloadInfo;
-use crate::workloads::{
-    make_batch_payment_workload, make_combination_workload, make_delegation_workload,
-    make_shared_counter_workload, make_transfer_object_workload, WorkloadGasConfig,
-    WorkloadInitGas, WorkloadPayloadGas,
-};
-use crate::ValidatorProxy;
+use crate::workloads::batch_payment::BatchPaymentWorkloadBuilder;
+use crate::workloads::delegation::DelegationWorkloadBuilder;
+use crate::workloads::shared_counter::SharedCounterWorkloadBuilder;
+use crate::workloads::transfer_object::TransferObjectWorkloadBuilder;
+use crate::workloads::WorkloadInfo;
 use anyhow::Result;
 use std::sync::Arc;
 
-use super::batch_payment::BatchPaymentWorkload;
-
-pub enum WorkloadConfiguration {
-    // Each worker runs all workloads with similar configuration. Backpressure for one workload impact others
-    Combined,
-    // Different workers run with different workloads configuration, backpressure on one does not impact others
-    Disjoint,
-}
+pub struct WorkloadConfiguration;
 
 impl WorkloadConfiguration {
     pub async fn configure(
-        &self,
-        proxy_gas_and_coins: Vec<ProxyGasAndCoin>,
+        bank: BenchmarkBank,
         opts: &Opts,
         system_state_observer: Arc<SystemStateObserver>,
-    ) -> Result<Vec<(Arc<dyn ValidatorProxy + Send + Sync>, Vec<WorkloadInfo>)>> {
+    ) -> Result<Vec<WorkloadInfo>> {
         match opts.run_spec {
             RunSpec::Bench {
                 target_qps,
@@ -44,47 +31,27 @@ impl WorkloadConfiguration {
                 batch_payment,
                 shared_counter_hotness_factor,
                 ..
-            } => match self {
-                WorkloadConfiguration::Combined => {
-                    configure_combined_mode(
-                        num_workers,
-                        opts.num_transfer_accounts,
-                        shared_counter,
-                        transfer_object,
-                        delegation,
-                        batch_payment,
-                        shared_counter_hotness_factor,
-                        target_qps,
-                        in_flight_ratio,
-                        proxy_gas_and_coins,
-                        system_state_observer,
-                        opts.gas_request_chunk_size,
-                    )
-                    .await
-                }
-                WorkloadConfiguration::Disjoint => {
-                    self.configure_disjoint_mode(
-                        num_workers,
-                        opts.num_transfer_accounts,
-                        shared_counter,
-                        transfer_object,
-                        delegation,
-                        batch_payment,
-                        shared_counter_hotness_factor,
-                        target_qps,
-                        in_flight_ratio,
-                        proxy_gas_and_coins,
-                        system_state_observer,
-                        opts.gas_request_chunk_size,
-                    )
-                    .await
-                }
-            },
+            } => {
+                Self::build_workloads(
+                    num_workers,
+                    opts.num_transfer_accounts,
+                    shared_counter,
+                    transfer_object,
+                    delegation,
+                    batch_payment,
+                    shared_counter_hotness_factor,
+                    target_qps,
+                    in_flight_ratio,
+                    bank,
+                    system_state_observer,
+                    opts.gas_request_chunk_size,
+                )
+                .await
+            }
         }
     }
 
-    async fn configure_disjoint_mode(
-        &self,
+    pub async fn build_workloads(
         num_workers: u64,
         num_transfer_accounts: u64,
         shared_counter_weight: u32,
@@ -94,326 +61,66 @@ impl WorkloadConfiguration {
         shared_counter_hotness_factor: u32,
         target_qps: u64,
         in_flight_ratio: u64,
-        proxy_gas_and_coins: Vec<ProxyGasAndCoin>,
+        mut bank: BenchmarkBank,
         system_state_observer: Arc<SystemStateObserver>,
         chunk_size: u64,
-    ) -> Result<Vec<(Arc<dyn ValidatorProxy + Send + Sync>, Vec<WorkloadInfo>)>> {
-        let num_proxies = proxy_gas_and_coins.len();
-        let split_target_qps = (target_qps as f64 / num_proxies as f64).ceil() as u64;
-        let split_shared_counter_weight =
-            (shared_counter_weight as f64 / num_proxies as f64).ceil() as u32;
-        let split_transfer_object_weight =
-            (transfer_object_weight as f64 / num_proxies as f64).ceil() as u32;
-        let split_delegation_weight = (delegation_weight as f64 / num_proxies as f64).ceil() as u32;
-        let split_batch_payment_weight =
-            (batch_payment_weight as f64 / num_proxies as f64).ceil() as u32;
-        let sum_weights = (split_shared_counter_weight
-            + split_transfer_object_weight
-            + split_delegation_weight
-            + split_batch_payment_weight) as f32;
-
-        let shared_counter_weight_ratio = split_shared_counter_weight as f32 / sum_weights;
-        let shared_counter_qps = (shared_counter_weight_ratio * split_target_qps as f32) as u64;
-        let shared_counter_num_workers =
-            (shared_counter_weight_ratio * num_workers as f32).ceil() as u64;
-        let shared_counter_max_ops = shared_counter_qps * in_flight_ratio;
-        let shared_counter_ratio =
-            1.0 - (std::cmp::min(shared_counter_hotness_factor, 100) as f32 / 100.0);
-        let num_shared_counters = (shared_counter_max_ops as f32 * shared_counter_ratio) as u64;
-
-        let transfer_object_weight_ratio = split_transfer_object_weight as f32 / sum_weights;
-        let transfer_object_qps = (transfer_object_weight_ratio * split_target_qps as f32) as u64;
-        let transfer_object_num_workers =
-            (transfer_object_weight_ratio * num_workers as f32).ceil() as u64;
-        let transfer_object_max_ops = transfer_object_qps * in_flight_ratio;
-
-        let delegate_weight_ratio = split_delegation_weight as f32 / sum_weights;
-        let delegate_qps = (delegate_weight_ratio * split_target_qps as f32) as u64;
-        let delegate_num_workers = (delegate_weight_ratio * num_workers as f32).ceil() as u64;
-        let delegate_max_ops = delegate_qps * in_flight_ratio;
-
-        let batch_payment_weight_ratio = batch_payment_weight as f32 / sum_weights;
-        let batch_payment_qps = (batch_payment_weight_ratio * split_target_qps as f32) as u64;
-        let batch_payment_num_workers =
-            (batch_payment_weight_ratio * num_workers as f32).ceil() as u64;
-        let batch_payment_max_ops = batch_payment_qps * in_flight_ratio;
-
-        let mut workload_gas_configs = vec![];
-
-        for _ in 0..num_proxies {
-            let (
-                shared_counter_workload_init_gas_config,
-                shared_counter_workload_payload_gas_config,
-            ) = if shared_counter_qps == 0
-                || shared_counter_max_ops == 0
-                || shared_counter_num_workers == 0
-            {
-                (vec![], vec![])
-            } else {
-                let shared_counter_init_coin_configs =
-                    SharedCounterWorkload::generate_coin_config_for_init(num_shared_counters);
-                let shared_counter_payload_coin_configs =
-                    SharedCounterWorkload::generate_coin_config_for_payloads(
-                        shared_counter_max_ops,
-                    );
-                (
-                    shared_counter_init_coin_configs,
-                    shared_counter_payload_coin_configs,
-                )
-            };
-            let (transfer_object_workload_tokens, transfer_object_workload_payload_gas_config) =
-                if transfer_object_qps == 0
-                    || transfer_object_max_ops == 0
-                    || transfer_object_num_workers == 0
-                {
-                    (vec![], vec![])
-                } else {
-                    TransferObjectWorkload::generate_coin_config_for_payloads(
-                        transfer_object_max_ops,
-                        num_transfer_accounts,
-                        transfer_object_max_ops,
-                    )
-                };
-            let delegation_gas_configs = if delegation_weight > 0 {
-                DelegationWorkload::generate_gas_config_for_payloads(delegate_max_ops)
-            } else {
-                vec![]
-            };
-            let batch_payment_gas_config = if batch_payment_weight > 0 {
-                BatchPaymentWorkload::generate_gas_config_for_payloads(batch_payment_max_ops)
-            } else {
-                Vec::new()
-            };
-            workload_gas_configs.push(WorkloadGasConfig {
-                shared_counter_workload_init_gas_config,
-                shared_counter_workload_payload_gas_config,
-                transfer_object_workload_tokens,
-                transfer_object_workload_payload_gas_config,
-                delegation_gas_configs,
-                batch_payment_gas_config,
-            });
-        }
-
-        let mut proxy_workloads: Vec<(Arc<dyn ValidatorProxy + Send + Sync>, Vec<WorkloadInfo>)> =
-            Vec::new();
-
-        let reference_gas_price = *system_state_observer.reference_gas_price.borrow();
-
-        for (i, proxy_gas_and_coin) in proxy_gas_and_coins.iter().enumerate() {
-            let mut workloads = vec![];
-
-            let (workload_init_gas, workload_payload_gas) = generate_all_gas_for_test(
-                proxy_gas_and_coin.proxy.clone(),
-                proxy_gas_and_coin.primary_gas.clone(),
-                proxy_gas_and_coin.pay_coin.clone(),
-                proxy_gas_and_coin.pay_coin_type_tag.clone(),
-                workload_gas_configs[i].clone(),
-                reference_gas_price,
-                chunk_size,
-            )
-            .await?;
-            if let Some(mut shared_counter_workload) = make_shared_counter_workload(
-                shared_counter_qps,
-                shared_counter_num_workers,
-                shared_counter_max_ops,
-                WorkloadPayloadGas {
-                    transfer_tokens: vec![],
-                    transfer_object_payload_gas: vec![],
-                    shared_counter_payload_gas: workload_payload_gas.shared_counter_payload_gas,
-                    delegation_payload_gas: vec![],
-                    batch_payment_payload_gas: vec![],
-                },
-            ) {
-                shared_counter_workload
-                    .workload
-                    .init(
-                        workload_init_gas,
-                        proxy_gas_and_coin.proxy.clone(),
-                        system_state_observer.clone(),
-                    )
-                    .await;
-                workloads.push(shared_counter_workload);
-            }
-            if let Some(mut transfer_object_workload) = make_transfer_object_workload(
-                transfer_object_qps,
-                transfer_object_num_workers,
-                transfer_object_max_ops,
-                num_transfer_accounts,
-                WorkloadPayloadGas {
-                    transfer_tokens: workload_payload_gas.transfer_tokens,
-                    transfer_object_payload_gas: workload_payload_gas.transfer_object_payload_gas,
-                    shared_counter_payload_gas: vec![],
-                    delegation_payload_gas: vec![],
-                    batch_payment_payload_gas: vec![],
-                },
-            ) {
-                transfer_object_workload
-                    .workload
-                    .init(
-                        WorkloadInitGas {
-                            shared_counter_init_gas: vec![],
-                        },
-                        proxy_gas_and_coin.proxy.clone(),
-                        system_state_observer.clone(),
-                    )
-                    .await;
-                workloads.push(transfer_object_workload);
-            }
-            if let Some(delegation_workload) = make_delegation_workload(
-                delegate_qps,
-                delegate_num_workers,
-                delegate_max_ops,
-                WorkloadPayloadGas {
-                    transfer_tokens: vec![],
-                    transfer_object_payload_gas: vec![],
-                    shared_counter_payload_gas: vec![],
-                    delegation_payload_gas: workload_payload_gas.delegation_payload_gas,
-                    batch_payment_payload_gas: vec![],
-                },
-            ) {
-                workloads.push(delegation_workload);
-            }
-            if let Some(batch_payment_workload) = make_batch_payment_workload(
-                batch_payment_qps,
-                batch_payment_num_workers,
-                batch_payment_max_ops,
-                WorkloadPayloadGas {
-                    transfer_tokens: vec![],
-                    transfer_object_payload_gas: vec![],
-                    shared_counter_payload_gas: vec![],
-                    delegation_payload_gas: vec![],
-                    batch_payment_payload_gas: workload_payload_gas.batch_payment_payload_gas,
-                },
-            ) {
-                workloads.push(batch_payment_workload);
-            }
-
-            proxy_workloads.push((proxy_gas_and_coin.proxy.clone(), workloads));
-        }
-        Ok(proxy_workloads)
-    }
-}
-
-pub async fn configure_combined_mode(
-    num_workers: u64,
-    num_transfer_accounts: u64,
-    shared_counter_weight: u32,
-    transfer_object_weight: u32,
-    delegation_weight: u32,
-    batch_payment_weight: u32,
-    shared_counter_hotness_factor: u32,
-    target_qps: u64,
-    in_flight_ratio: u64,
-    proxy_gas_and_coins: Vec<ProxyGasAndCoin>,
-    system_state_observer: Arc<SystemStateObserver>,
-    chunk_size: u64,
-) -> std::result::Result<
-    Vec<(Arc<dyn ValidatorProxy + Send + Sync>, Vec<WorkloadInfo>)>,
-    anyhow::Error,
-> {
-    let num_proxies = proxy_gas_and_coins.len();
-    let split_target_qps = (target_qps as f64 / num_proxies as f64).ceil() as u64;
-    let split_shared_counter_weight =
-        (shared_counter_weight as f64 / num_proxies as f64).ceil() as u32;
-    let split_transfer_object_weight =
-        (transfer_object_weight as f64 / num_proxies as f64).ceil() as u32;
-    let split_delegation_weight = (delegation_weight as f64 / num_proxies as f64).ceil() as u32;
-    let split_batch_payment_weight =
-        (batch_payment_weight as f64 / num_proxies as f64).ceil() as u32;
-
-    let shared_counter_ratio =
-        1.0 - (std::cmp::min(shared_counter_hotness_factor, 100) as f32 / 100.0);
-    let max_ops = split_target_qps * in_flight_ratio;
-
-    let mut workload_gas_configs = vec![];
-
-    for _ in 0..num_proxies {
-        let all_shared_counter_coin_configs = if split_shared_counter_weight == 0 {
-            None
-        } else {
-            let num_shared_counters = (max_ops as f32 * shared_counter_ratio) as u64;
-            let shared_counter_init_coin_configs =
-                SharedCounterWorkload::generate_coin_config_for_init(num_shared_counters);
-            let shared_counter_payload_coin_configs =
-                SharedCounterWorkload::generate_coin_config_for_payloads(max_ops);
-            Some((
-                shared_counter_init_coin_configs,
-                shared_counter_payload_coin_configs,
-            ))
-        };
-        let all_transfer_object_coin_configs = if split_transfer_object_weight == 0 {
-            None
-        } else {
-            Some(TransferObjectWorkload::generate_coin_config_for_payloads(
-                max_ops,
-                num_transfer_accounts,
-                max_ops,
-            ))
-        };
-        let delegation_gas_configs = if split_delegation_weight > 0 {
-            DelegationWorkload::generate_gas_config_for_payloads(max_ops)
-        } else {
-            vec![]
-        };
-        let batch_payment_gas_config = if split_batch_payment_weight > 0 {
-            BatchPaymentWorkload::generate_gas_config_for_payloads(max_ops)
-        } else {
-            vec![]
-        };
-        let (shared_counter_workload_init_gas_config, shared_counter_workload_payload_gas_config) =
-            all_shared_counter_coin_configs.unwrap_or((vec![], vec![]));
-        let (transfer_object_workload_tokens, transfer_object_workload_payload_gas_config) =
-            all_transfer_object_coin_configs.unwrap_or((vec![], vec![]));
-
-        workload_gas_configs.push(WorkloadGasConfig {
-            shared_counter_workload_init_gas_config,
-            shared_counter_workload_payload_gas_config,
-            transfer_object_workload_tokens,
-            transfer_object_workload_payload_gas_config,
-            delegation_gas_configs,
-            batch_payment_gas_config,
-        });
-    }
-
-    let mut proxy_workloads: Vec<(Arc<dyn ValidatorProxy + Send + Sync>, Vec<WorkloadInfo>)> =
-        Vec::new();
-
-    let reference_gas_price = *system_state_observer.reference_gas_price.borrow();
-
-    for (i, proxy_gas_and_coin) in proxy_gas_and_coins.iter().enumerate() {
-        let (workload_init_gas, workload_payload_gas) = generate_all_gas_for_test(
-            proxy_gas_and_coin.proxy.clone(),
-            proxy_gas_and_coin.primary_gas.clone(),
-            proxy_gas_and_coin.pay_coin.clone(),
-            proxy_gas_and_coin.pay_coin_type_tag.clone(),
-            workload_gas_configs[i].clone(),
-            reference_gas_price,
-            chunk_size,
-        )
-        .await?;
-
-        let mut combination_workload = make_combination_workload(
-            split_target_qps,
+    ) -> Result<Vec<WorkloadInfo>> {
+        let total_weight = shared_counter_weight
+            + transfer_object_weight
+            + delegation_weight
+            + batch_payment_weight;
+        let mut workload_builders = vec![];
+        let shared_workload = SharedCounterWorkloadBuilder::from(
+            shared_counter_weight as f32 / total_weight as f32,
+            target_qps,
+            num_workers,
+            in_flight_ratio,
+            shared_counter_hotness_factor,
+        );
+        workload_builders.push(shared_workload);
+        let transfer_workload = TransferObjectWorkloadBuilder::from(
+            transfer_object_weight as f32 / total_weight as f32,
+            target_qps,
             num_workers,
             in_flight_ratio,
             num_transfer_accounts,
-            split_shared_counter_weight,
-            split_transfer_object_weight,
-            split_delegation_weight,
-            split_batch_payment_weight,
-            workload_payload_gas,
         );
-        combination_workload
-            .workload
-            .init(
-                workload_init_gas,
-                proxy_gas_and_coin.proxy.clone(),
-                system_state_observer.clone(),
-            )
-            .await;
-
-        proxy_workloads.push((proxy_gas_and_coin.proxy.clone(), vec![combination_workload]));
+        workload_builders.push(transfer_workload);
+        let delegation_workload = DelegationWorkloadBuilder::from(
+            delegation_weight as f32 / total_weight as f32,
+            target_qps,
+            num_workers,
+            in_flight_ratio,
+        );
+        workload_builders.push(delegation_workload);
+        let batch_payment_workload = BatchPaymentWorkloadBuilder::from(
+            batch_payment_weight as f32 / total_weight as f32,
+            target_qps,
+            num_workers,
+            in_flight_ratio,
+        );
+        workload_builders.push(batch_payment_workload);
+        let (workload_params, workload_builders): (Vec<_>, Vec<_>) = workload_builders
+            .into_iter()
+            .flatten()
+            .map(|x| (x.workload_params, x.workload_builder))
+            .unzip();
+        let reference_gas_price = *system_state_observer.reference_gas_price.borrow();
+        let mut workloads = bank
+            .generate(workload_builders, reference_gas_price, chunk_size)
+            .await?;
+        for workload in workloads.iter_mut() {
+            workload
+                .init(bank.proxy.clone(), system_state_observer.clone())
+                .await;
+        }
+        Ok(workloads
+            .into_iter()
+            .zip(workload_params)
+            .map(|(workload, workload_params)| WorkloadInfo {
+                workload_params,
+                workload,
+            })
+            .collect())
     }
-
-    Ok(proxy_workloads)
 }

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -8,10 +8,9 @@ mod test {
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
-    use sui_benchmark::benchmark_setup::ProxyGasAndCoin;
+    use sui_benchmark::bank::BenchmarkBank;
     use sui_benchmark::system_state_observer::SystemStateObserver;
-    use sui_benchmark::workloads::batch_payment;
-    use sui_benchmark::workloads::workload_configuration::configure_combined_mode;
+    use sui_benchmark::workloads::workload_configuration::WorkloadConfiguration;
     use sui_benchmark::{
         drivers::{bench_driver::BenchDriver, driver::Driver, Interval},
         util::get_ed25519_keypair_from_keystore,
@@ -23,7 +22,6 @@ mod test {
     use sui_macros::{register_fail_points, sim_test};
     use sui_simulator::{configs::*, SimConfig};
     use sui_types::messages_checkpoint::VerifiedCheckpoint;
-    use sui_types::object::Owner;
     use test_utils::messages::get_sui_gas_object_with_wallet_context;
     use test_utils::network::{TestCluster, TestClusterBuilder};
     use tracing::info;
@@ -225,18 +223,9 @@ mod test {
             Arc::new(get_ed25519_keypair_from_keystore(keystore_path, &sender).unwrap());
         let all_gas = get_sui_gas_object_with_wallet_context(context, &sender).await;
         let (_, gas) = all_gas.get(0).unwrap();
-        let (move_struct, pay_coin) = all_gas.get(1).unwrap();
-        let primary_gas = (
-            gas.clone(),
-            Owner::AddressOwner(sender),
-            ed25519_keypair.clone(),
-        );
-        let pay_coin = (
-            pay_coin.clone(),
-            Owner::AddressOwner(sender),
-            ed25519_keypair.clone(),
-        );
-        let pay_coin_type_tag = move_struct.type_params[0].clone();
+        let (_move_struct, pay_coin) = all_gas.get(1).unwrap();
+        let primary_gas = (gas.clone(), sender, ed25519_keypair.clone());
+        let pay_coin = (pay_coin.clone(), sender, ed25519_keypair.clone());
 
         let registry = prometheus::Registry::new();
         let proxy: Arc<dyn ValidatorProxy + Send + Sync> = Arc::new(
@@ -244,13 +233,7 @@ mod test {
                 .await,
         );
 
-        let proxy_gas_and_coins = vec![ProxyGasAndCoin {
-            primary_gas,
-            pay_coin,
-            pay_coin_type_tag,
-            proxy: proxy.clone(),
-        }];
-
+        let bank = BenchmarkBank::new(proxy.clone(), primary_gas, pay_coin);
         let system_state_observer = {
             let mut system_state_observer = SystemStateObserver::new(proxy.clone());
             if let Ok(_) = system_state_observer.reference_gas_price.changed().await {
@@ -258,6 +241,7 @@ mod test {
             }
             Arc::new(system_state_observer)
         };
+
         // The default test parameters are somewhat conservative in order to keep the running time
         // of the test reasonable in CI.
         let target_qps = get_var("SIM_STRESS_TEST_QPS", 10);
@@ -270,7 +254,7 @@ mod test {
         let batch_payment_weight = 1;
         let shared_counter_hotness_factor = 50;
 
-        let proxy_workloads = configure_combined_mode(
+        let workloads = WorkloadConfiguration::build_workloads(
             num_workers,
             num_transfer_accounts,
             shared_counter_weight,
@@ -280,9 +264,9 @@ mod test {
             shared_counter_hotness_factor,
             target_qps,
             in_flight_ratio,
-            proxy_gas_and_coins,
+            bank,
             system_state_observer.clone(),
-            1000,
+            100,
         )
         .await
         .unwrap();
@@ -301,7 +285,8 @@ mod test {
         let show_progress = interval.is_unbounded();
         let (benchmark_stats, _) = driver
             .run(
-                proxy_workloads,
+                vec![proxy],
+                workloads,
                 system_state_observer,
                 &registry,
                 show_progress,


### PR DESCRIPTION
## Description 

This PR does a few things to simplify adding new workloads:

1.  Simplifications in workload_configuration.rs: There is no need to handle individual workload in an error prone way to configure workload weight, tps, etc. It only requires one call to the workload to configure it now. For example, there is only one call to shared_counter workload to configure it which looks like this:
```
let shared_workload = SharedCounterWorkloadBuilder::from(
            shared_counter_weight as f32 / total_weight as f32,
            target_qps,
            num_workers,
            in_flight_ratio,
            shared_counter_hotness_factor,
        );
```
2. Simplification in generating gas: There is no need to handle individual workload while generating gas. The call to generate gas is handled by a trait now in:
```
pub async fn generate(
        &mut self,
        builders: Vec<Box<dyn WorkloadBuilder<dyn Payload>>>,
        gas_price: u64,
        chunk_size: u64,
    ) -> Result<Vec<Box<dyn Workload<dyn Payload>>>> {
```
3. Remove the concept of combination workload as it was hard to maintain while it was not being used in production anymore. This helped remove a lot of code which simplified the crate a lot.
4. Structs like `WorkloadInitGas`, `WorkloadPayloadGas`, etc are all removed now
5. `Payload` and `Workload` abstractions are much cleaner
## Test Plan 

Existing tests