### PR TITLE
wallet-ext: add auto lock e2e test

### DIFF
--- a/apps/wallet/src/ui/app/components/menu/content/AutoLockTimerSelector.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AutoLockTimerSelector.tsx
@@ -55,6 +55,7 @@ export default function AutoLockTimerSelector() {
                         step="1"
                         actionDisabled="auto"
                         actionText="Save"
+                        placeholder="Auto lock minutes"
                     />
                 </Form>
             </Formik>

--- a/apps/wallet/tests/lock.spec.ts
+++ b/apps/wallet/tests/lock.spec.ts
@@ -12,3 +12,23 @@ test('wallet unlock', async ({ page, context, extensionUrl }) => {
     await page.getByRole('button', { name: /Unlock Wallet/ }).click();
     await expect(page.getByTestId('coin-page')).toBeVisible();
 });
+
+test('wallet auto-lock', async ({ page, extensionUrl }) => {
+    test.setTimeout(65 * 1000);
+    await createWallet(page, extensionUrl);
+    await page.getByTestId('menu').click();
+    await page.getByText(/Auto-lock/).click();
+    await page.getByPlaceholder(/Auto lock minutes/i).fill('1');
+    await page.getByRole('button', { name: /Save/i }).click();
+    await page.getByText(/Auto lock updated/i);
+    await page.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+            value: 'hidden',
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.waitForTimeout(60 * 1000);
+    await expect(
+        page.getByRole('button', { name: /Unlock Wallet/ })
+    ).toBeVisible();
+});

--- a/apps/wallet/tests/lock.spec.ts
+++ b/apps/wallet/tests/lock.spec.ts
@@ -14,6 +14,10 @@ test('wallet unlock', async ({ page, context, extensionUrl }) => {
 });
 
 test('wallet auto-lock', async ({ page, extensionUrl }) => {
+    test.skip(
+        process.env.CI !== 'true',
+        'Runs only on CI since it takes at least 1 minute to complete'
+    );
     test.setTimeout(65 * 1000);
     await createWallet(page, extensionUrl);
     await page.getByTestId('menu').click();


### PR DESCRIPTION
## Description 

* update auto lock interval to 1 minute
* wait 1 minute
* set app is in background
* check wallet is locked

Note this test only runs on CI (when CI env variable is `true`) since it takes at least 1 minute to finish.

part of APPS-330