### PR TITLE
wallet-ext: site-connect view show new for every new account

### DIFF
--- a/apps/wallet/src/ui/app/components/WalletListSelect.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelect.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { cx } from 'class-variance-authority';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useAccounts } from '../hooks/useAccounts';
 import { useDeriveNextAccountMutation } from '../hooks/useDeriveNextAccountMutation';
@@ -30,6 +30,7 @@ export function WalletListSelect({
     disabled = false,
     onChange,
 }: WalletListSelectProps) {
+    const [newAccounts, setNewAccounts] = useState<string[]>([]);
     const accounts = useAccounts();
     const filteredAccounts = useMemo(() => {
         if (visibleValues) {
@@ -77,7 +78,7 @@ export function WalletListSelect({
                                 selected={values.includes(address)}
                                 mode={mode}
                                 disabled={disabled}
-                                isNew={deriveNextAccount.data === address}
+                                isNew={newAccounts.includes(address)}
                             />
                         </li>
                     ))}
@@ -113,6 +114,10 @@ export function WalletListSelect({
                                 onClick={async () => {
                                     const newAccountAddress =
                                         await deriveNextAccount.mutateAsync();
+                                    setNewAccounts([
+                                        ...newAccounts,
+                                        newAccountAddress,
+                                    ]);
                                     if (
                                         !visibleValues ||
                                         visibleValues.includes(


### PR DESCRIPTION
* in site-connect view for every newly created account show NEW next to it, instead of only the last one


https://user-images.githubusercontent.com/10210143/224995430-5da654bd-366d-43b6-ac26-81add33707f2.mov

closes APPS-577