### PR TITLE
[framework] Adds "sui::object::new_id(): ID"

### DIFF
--- a/crates/sui-framework/docs/object.md
+++ b/crates/sui-framework/docs/object.md
@@ -11,6 +11,7 @@ Sui object identifiers
 -  [Resource `Ownership`](#0x2_object_Ownership)
 -  [Resource `DynamicFields`](#0x2_object_DynamicFields)
 -  [Constants](#@Constants_0)
+-  [Function `new_id`](#0x2_object_new_id)
 -  [Function `id_to_bytes`](#0x2_object_id_to_bytes)
 -  [Function `id_to_address`](#0x2_object_id_to_address)
 -  [Function `id_from_bytes`](#0x2_object_id_from_bytes)
@@ -193,6 +194,32 @@ The hardcoded ID for the singleton Sui System State Object.
 </code></pre>
 
 
+
+<a name="0x2_object_new_id"></a>
+
+## Function `new_id`
+
+Create an <code><a href="object.md#0x2_object_ID">ID</a></code>. Not to be mistaken for <code><a href="object.md#0x2_object_new">object::new</a></code> which
+generates a new UID.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_new_id">new_id</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object.md#0x2_object_ID">object::ID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_new_id">new_id</a>(ctx: &<b>mut</b> TxContext): <a href="object.md#0x2_object_ID">ID</a> {
+    <a href="object.md#0x2_object_ID">ID</a> { bytes: <a href="tx_context.md#0x2_tx_context_new_object">tx_context::new_object</a>(ctx) }
+}
+</code></pre>
+
+
+
+</details>
 
 <a name="0x2_object_id_to_bytes"></a>
 

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -48,6 +48,12 @@ module sui::object {
 
     // === id ===
 
+    /// Create an `ID`. Not to be mistaken for `object::new()` which
+    /// generates a new UID.
+    public fun new_id(ctx: &mut TxContext): ID {
+        ID { bytes: tx_context::new_object(ctx) }
+    }
+
     /// Get the raw bytes of a `ID`
     public fun id_to_bytes(id: &ID): vector<u8> {
         bcs::to_bytes(&id.bytes)

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -48,7 +48,7 @@ module sui::object {
 
     // === id ===
 
-    /// Create an `ID`. Not to be mistaken for `object::new()` which
+    /// Create an `ID`. Not to be mistaken for `object::new` which
     /// generates a new UID.
     public fun new_id(ctx: &mut TxContext): ID {
         ID { bytes: tx_context::new_object(ctx) }


### PR DESCRIPTION
## Description 

Covers a very common scenario of generating an ID.
Replaces the code that I found in many projects:
```move
module me::something {
    fun new_id(ctx: &mut TxContext): ID {
        let new_uid = object::new(ctx);
        let new_id = object::uid_to_inner(&new_uid);
        object::delete(new_uid);
        new_id
    }
}
```

## Test Plan 

Current tests pass.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

## Release Notes

Adds new `sui::object::new_id(ctx)` method which creates an `ID`. Meant to give a tool for a common scenario where IDs are used for unique identification while using a `UID` is not necessary.
