### PR TITLE
[wallet-ext] add signing capabilities for Ledger accounts

### DIFF
--- a/apps/wallet/src/ui/app/LedgerSigner.ts
+++ b/apps/wallet/src/ui/app/LedgerSigner.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    Ed25519PublicKey,
+    type SerializedSignature,
+    type SignatureScheme,
+    SignerWithProvider,
+    type SuiAddress,
+    toSerializedSignature,
+    type JsonRpcProvider,
+} from '@mysten/sui.js';
+
+import type SuiLedgerClient from '@mysten/ledgerjs-hw-app-sui';
+
+export class LedgerSigner extends SignerWithProvider {
+    readonly #suiLedgerClient: SuiLedgerClient;
+    readonly #derivationPath: string;
+    readonly #signatureScheme: SignatureScheme = 'ED25519';
+
+    constructor(
+        suiLedgerClient: SuiLedgerClient,
+        derivationPath: string,
+        provider: JsonRpcProvider
+    ) {
+        super(provider);
+        this.#suiLedgerClient = suiLedgerClient;
+        this.#derivationPath = derivationPath;
+    }
+
+    async getAddress(): Promise<SuiAddress> {
+        const publicKeyResult = await this.#suiLedgerClient.getPublicKey(
+            this.#derivationPath
+        );
+        const publicKey = new Ed25519PublicKey(publicKeyResult.publicKey);
+        return publicKey.toSuiAddress();
+    }
+
+    async getPublicKey(): Promise<Ed25519PublicKey> {
+        const { publicKey } = await this.#suiLedgerClient.getPublicKey(
+            this.#derivationPath
+        );
+        return new Ed25519PublicKey(publicKey);
+    }
+
+    async signData(data: Uint8Array): Promise<SerializedSignature> {
+        const { signature } = await this.#suiLedgerClient.signTransaction(
+            this.#derivationPath,
+            data
+        );
+        const pubKey = await this.getPublicKey();
+        return toSerializedSignature({
+            signature,
+            signatureScheme: this.#signatureScheme,
+            pubKey,
+        });
+    }
+
+    connect(provider: JsonRpcProvider): SignerWithProvider {
+        return new LedgerSigner(
+            this.#suiLedgerClient,
+            this.#derivationPath,
+            provider
+        );
+    }
+}

--- a/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModal.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModal.tsx
@@ -23,7 +23,7 @@ export function ConnectLedgerModal({
     onError,
 }: ConnectLedgerModalProps) {
     const [isConnectingToLedger, setConnectingToLedger] = useState(false);
-    const [, connectToLedger] = useSuiLedgerClient();
+    const { connectToLedger } = useSuiLedgerClient();
 
     const onContinueClick = async () => {
         try {

--- a/apps/wallet/src/ui/app/components/ledger/LedgerExceptions.ts
+++ b/apps/wallet/src/ui/app/components/ledger/LedgerExceptions.ts
@@ -14,3 +14,10 @@ export class LedgerNoTransportMechanismError extends Error {
         Object.setPrototypeOf(this, LedgerNoTransportMechanismError.prototype);
     }
 }
+
+export class LedgerDeviceNotFoundError extends Error {
+    constructor(message: string) {
+        super(message);
+        Object.setPrototypeOf(this, LedgerDeviceNotFoundError.prototype);
+    }
+}

--- a/apps/wallet/src/ui/app/components/ledger/SuiLedgerClientProvider.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/SuiLedgerClientProvider.tsx
@@ -13,21 +13,25 @@ import {
     useState,
 } from 'react';
 
+import { LedgerSigner } from '../../LedgerSigner';
+import { api } from '../../redux/store/thunk-extras';
 import {
     LedgerConnectionFailedError,
+    LedgerDeviceNotFoundError,
     LedgerNoTransportMechanismError,
 } from './LedgerExceptions';
-
-import type Transport from '@ledgerhq/hw-transport';
 
 type SuiLedgerClientProviderProps = {
     children: React.ReactNode;
 };
 
-type SuiLedgerClientContextValue = [
-    SuiLedgerClient | undefined,
-    () => Promise<SuiLedgerClient>
-];
+type SuiLedgerClientContextValue = {
+    suiLedgerClient: SuiLedgerClient | undefined;
+    connectToLedger: () => Promise<SuiLedgerClient>;
+    initializeLedgerSignerInstance: (
+        derivationPath: string
+    ) => Promise<LedgerSigner>;
+};
 
 const SuiLedgerClientContext = createContext<
     SuiLedgerClientContextValue | undefined
@@ -47,6 +51,33 @@ export function SuiLedgerClientProvider({
         return () => suiLedgerClient?.transport.off('disconnect', onDisconnect);
     }, [suiLedgerClient?.transport]);
 
+    const initializeLedgerSignerInstance = useCallback(
+        async (derivationPath: string) => {
+            if (!suiLedgerClient) {
+                try {
+                    const transport = await forceConnectionToLedger();
+                    const newClient = new SuiLedgerClient(transport);
+                    setSuiLedgerClient(newClient);
+
+                    return new LedgerSigner(
+                        newClient,
+                        derivationPath,
+                        api.instance.fullNode
+                    );
+                } catch (error) {
+                    throw new Error('Failed to connect');
+                }
+            }
+
+            return new LedgerSigner(
+                suiLedgerClient,
+                derivationPath,
+                api.instance.fullNode
+            );
+        },
+        [suiLedgerClient]
+    );
+
     const connectToLedger = useCallback(async () => {
         if (suiLedgerClient?.transport) {
             // If we've already connected to a Ledger device, we need
@@ -54,16 +85,19 @@ export function SuiLedgerClientProvider({
             await suiLedgerClient.transport.close();
         }
 
-        const ledgerTransport = await getLedgerTransport();
+        const ledgerTransport = await requestConnectionToLedger();
         const ledgerClient = new SuiLedgerClient(ledgerTransport);
         setSuiLedgerClient(ledgerClient);
         return ledgerClient;
     }, [suiLedgerClient]);
 
-    const contextValue: SuiLedgerClientContextValue = useMemo(
-        () => [suiLedgerClient, connectToLedger],
-        [connectToLedger, suiLedgerClient]
-    );
+    const contextValue: SuiLedgerClientContextValue = useMemo(() => {
+        return {
+            suiLedgerClient,
+            connectToLedger,
+            initializeLedgerSignerInstance,
+        };
+    }, [connectToLedger, suiLedgerClient, initializeLedgerSignerInstance]);
 
     return (
         <SuiLedgerClientContext.Provider value={contextValue}>
@@ -82,31 +116,41 @@ export function useSuiLedgerClient() {
     return suiLedgerClientContext;
 }
 
-async function getLedgerTransport() {
-    let ledgerTransport: Transport | null | undefined;
-
+async function requestConnectionToLedger() {
     try {
-        ledgerTransport = await initiateLedgerConnection();
+        if (await TransportWebHID.isSupported()) {
+            return await TransportWebHID.request();
+        } else if (await TransportWebUSB.isSupported()) {
+            return await TransportWebUSB.request();
+        }
+    } catch (error) {
+        throw new LedgerConnectionFailedError(
+            "Unable to connect to the user's Ledger device"
+        );
+    }
+    throw new LedgerNoTransportMechanismError(
+        "There are no supported transport mechanisms to connect to the user's Ledger device"
+    );
+}
+
+async function forceConnectionToLedger() {
+    let transport: TransportWebHID | TransportWebUSB | null | undefined;
+    try {
+        if (await TransportWebHID.isSupported()) {
+            transport = await TransportWebHID.openConnected();
+        } else if (await TransportWebUSB.isSupported()) {
+            transport = await TransportWebUSB.openConnected();
+        }
     } catch (error) {
         throw new LedgerConnectionFailedError(
             "Unable to connect to the user's Ledger device"
         );
     }
 
-    if (!ledgerTransport) {
-        throw new LedgerNoTransportMechanismError(
-            "There are no supported transport mechanisms to connect to the user's Ledger device"
+    if (!transport) {
+        throw new LedgerDeviceNotFoundError(
+            'Connected Ledger device not found'
         );
     }
-
-    return ledgerTransport;
-}
-
-async function initiateLedgerConnection(): Promise<Transport | null> {
-    if (await TransportWebHID.isSupported()) {
-        return await TransportWebHID.request();
-    } else if (await TransportWebUSB.isSupported()) {
-        return await TransportWebUSB.request();
-    }
-    return null;
+    return transport;
 }

--- a/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
+++ b/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
@@ -26,7 +26,7 @@ export function useDeriveLedgerAccounts(
     const [ledgerAccounts, setLedgerAccounts] = useState<
         SelectableLedgerAccount[]
     >([]);
-    const [suiLedgerClient] = useSuiLedgerClient();
+    const { suiLedgerClient } = useSuiLedgerClient();
     const [isLoading, setLoading] = useState(false);
 
     useEffect(() => {

--- a/apps/wallet/src/ui/app/hooks/useSigner.ts
+++ b/apps/wallet/src/ui/app/hooks/useSigner.ts
@@ -1,17 +1,34 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useActiveAddress } from './useActiveAddress';
+import { useSuiLedgerClient } from '../components/ledger/SuiLedgerClientProvider';
+import { useAccounts } from './useAccounts';
+import { useActiveAccount } from './useActiveAccount';
 import { thunkExtras } from '_redux/store/thunk-extras';
+import { AccountType } from '_src/background/keyring/Account';
 
 import type { SuiAddress } from '@mysten/sui.js';
 
 export function useSigner(address?: SuiAddress) {
-    const activeAddress = useActiveAddress();
-    const signerAddress = address || activeAddress;
+    const activeAccount = useActiveAccount();
+    const existingAccounts = useAccounts();
+    const signerAccount = address
+        ? existingAccounts.find((account) => account.address === address)
+        : activeAccount;
+
+    const { initializeLedgerSignerInstance } = useSuiLedgerClient();
     const { api, background } = thunkExtras;
-    if (!signerAddress) {
-        return null;
+
+    if (!signerAccount) {
+        throw new Error("Can't find account for the signer address");
     }
-    return api.getSignerInstance(signerAddress, background);
+
+    return async () => {
+        if (signerAccount.type === AccountType.LEDGER) {
+            return await initializeLedgerSignerInstance(
+                signerAccount.derivationPath
+            );
+        }
+        return api.getSignerInstance(signerAccount, background);
+    };
 }

--- a/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { type SuiAddress, type Transaction } from '@mysten/sui.js';
 import { useQuery } from '@tanstack/react-query';
 
 import { useSigner } from '_hooks';
-
-import type { SuiAddress, Transaction } from '@mysten/sui.js';
 
 export function useTransactionDryRun(
     sender: SuiAddress,
@@ -15,7 +14,8 @@ export function useTransactionDryRun(
     const response = useQuery({
         queryKey: ['dryRunTransaction', transaction, sender],
         queryFn: async () => {
-            return signer!.dryRunTransaction({ transaction });
+            const initializedSigner = await signer();
+            return initializedSigner.dryRunTransaction({ transaction });
         },
         enabled: !!signer,
     });

--- a/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
@@ -3,9 +3,12 @@
 
 import { fromB64 } from '@mysten/sui.js';
 import { useMemo } from 'react';
+import toast from 'react-hot-toast';
 
+import { useSuiLedgerClient } from '../../components/ledger/SuiLedgerClientProvider';
 import { UserApproveContainer } from '../../components/user-approve-container';
 import { useAppDispatch } from '../../hooks';
+import { useAccounts } from '../../hooks/useAccounts';
 import { respondToTransactionRequest } from '../../redux/slices/transaction-requests';
 import { Heading } from '../../shared/heading';
 import { PageMainLayoutTitle } from '../../shared/page-main-layout/PageMainLayoutTitle';
@@ -34,22 +37,36 @@ export function SignMessageRequest({ request }: SignMessageRequestProps) {
             type,
         };
     }, [request.tx.message]);
+
+    const accounts = useAccounts();
+    const accountForTransaction = accounts.find(
+        (account) => account.address === request.tx.accountAddress
+    );
     const dispatch = useAppDispatch();
+    const { initializeLedgerSignerInstance } = useSuiLedgerClient();
+
     return (
         <UserApproveContainer
             origin={request.origin}
             originFavIcon={request.originFavIcon}
             approveTitle="Sign"
             rejectTitle="Reject"
-            onSubmit={(approved) =>
-                dispatch(
-                    respondToTransactionRequest({
-                        txRequestID: request.id,
-                        approved,
-                        addressForTransaction: request.tx.accountAddress,
-                    })
-                )
-            }
+            onSubmit={(approved) => {
+                if (accountForTransaction) {
+                    dispatch(
+                        respondToTransactionRequest({
+                            txRequestID: request.id,
+                            approved,
+                            accountForTransaction,
+                            initializeLedgerSignerInstance,
+                        })
+                    );
+                } else {
+                    toast.error(
+                        `Account for address ${request.tx.accountAddress} not found`
+                    );
+                }
+            }}
             address={request.tx.accountAddress}
             scrollable
         >

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -29,13 +29,15 @@ export function TransferNFTForm({ objectId }: { objectId: string }) {
     const queryClient = useQueryClient();
     const navigate = useNavigate();
     const transferNFT = useMutation({
-        mutationFn: (to: string) => {
+        mutationFn: async (to: string) => {
             if (!to || !signer) {
                 throw new Error('Missing data');
             }
             const tx = new Transaction();
             tx.transferObjects([tx.object(objectId)], tx.pure(to));
-            return signer.signAndExecuteTransaction({
+
+            const initializedSigner = await signer();
+            return initializedSigner.signAndExecuteTransaction({
                 transaction: tx,
                 options: {
                     showInput: true,

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -62,7 +62,8 @@ function TransferCoinPage() {
                     props: { coinType: coinType! },
                 });
 
-                return signer.signAndExecuteTransaction({
+                const initializedSigner = await signer();
+                return initializedSigner.signAndExecuteTransaction({
                     transaction,
                     options: {
                         showInput: true,

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -135,7 +135,8 @@ function StakingCard() {
                     amount,
                     validatorAddress
                 );
-                return await signer.signAndExecuteTransaction({
+                const initializedSigner = await signer();
+                return await initializedSigner.signAndExecuteTransaction({
                     transaction,
                     options: {
                         showInput: true,
@@ -162,7 +163,8 @@ function StakingCard() {
             });
             try {
                 const transaction = createUnstakeTransaction(stakedSuiId);
-                return await signer.signAndExecuteTransaction({
+                const initializedSigner = await signer();
+                return await initializedSigner.signAndExecuteTransaction({
                     transaction,
                     options: {
                         showInput: true,


### PR DESCRIPTION
## Description 

This PR adds signing capabilities to the wallet extension for Ledger accounts. Will update this with a video once I get a Ledger application build that has blind signing enabled (and of course, I won't land until then either).

I'll say that I don't *love* this approach, but I tried several other approaches that just didn't work out with the current architecture of the wallet. I left some comments in the code explaining these issues, but basically, the Ledger signer needs to live in the content script of the wallet extension and be initialized on demand. If someone has other ideas, I'd be glad to hear them but this PR also needs to land today if we want to make our Ledger deadline.

## Test Plan 
- Manual testing (this is a lie atm but I'll be sure to test all of this when possible)
  - Signed transactions for sending money from one Ledger account to another
  - Successfully responded to a request to sign a transaction with my Ledger account
  - Tested signing with multiple Ledger accounts
  - Tested out some error scenarios (Ledger device not connected when signing, signing with a connection open)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A