### PR TITLE
wallet-ext: sign message display byte arrays in base64

### DIFF
--- a/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
@@ -17,8 +17,22 @@ export type SignMessageRequestProps = {
 };
 
 export function SignMessageRequest({ request }: SignMessageRequestProps) {
-    const message = useMemo(() => {
-        return new TextDecoder().decode(fromB64(request.tx.message));
+    const { message, type } = useMemo(() => {
+        const messageBytes = fromB64(request.tx.message);
+        let message: string = request.tx.message;
+        let type: 'utf8' | 'base64' = 'base64';
+        try {
+            message = new TextDecoder('utf8', { fatal: true }).decode(
+                messageBytes
+            );
+            type = 'utf8';
+        } catch (e) {
+            // do nothing
+        }
+        return {
+            message,
+            type,
+        };
     }, [request.tx.message]);
     const dispatch = useAppDispatch();
     return (
@@ -52,7 +66,12 @@ export function SignMessageRequest({ request }: SignMessageRequestProps) {
                     </Heading>
                 </div>
                 <div className="px-5 pb-5 break-words">
-                    <Text variant="p2" weight="medium" color="steel-darker">
+                    <Text
+                        variant="p2"
+                        weight="medium"
+                        color="steel-darker"
+                        mono={type === 'base64'}
+                    >
                         {message}
                     </Text>
                 </div>


### PR DESCRIPTION
* check if message to sign is valid utf8
* if not display the message in base64 format

signing a Uint8Array with values from 0 to 255.

| before | after |
| - | - |
| <img width="385" alt="Screenshot 2023-03-14 at 14 01 27" src="https://user-images.githubusercontent.com/10210143/225027620-536916b5-a0ed-4c93-8e40-9f114c78afa2.png"> | <img width="385" alt="Screenshot 2023-03-14 at 14 01 55" src="https://user-images.githubusercontent.com/10210143/225027684-534d8878-0da9-4c24-8b9c-fc56ee750093.png"> |

closes APPS-612