### PR TITLE
change default epoch duration back to 24 hrs

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -411,7 +411,7 @@ pub struct GenesisChainParameters {
     pub governance_start_epoch: u64,
 
     /// The duration of an epoch, in milliseconds.
-    #[serde(default = "GenesisChainParameters::test_epoch_duration_ms")]
+    #[serde(default = "GenesisChainParameters::default_epoch_duration_ms")]
     pub epoch_duration_ms: u64,
     // Most other parameters (e.g. initial gas schedule) should be derived from protocol_version.
 }
@@ -425,7 +425,7 @@ impl GenesisChainParameters {
             initial_sui_custody_account_address: SuiAddress::default(),
             initial_validator_stake_mist: Self::test_initial_validator_stake_mist(),
             governance_start_epoch: 0,
-            epoch_duration_ms: Self::test_epoch_duration_ms(),
+            epoch_duration_ms: Self::default_epoch_duration_ms(),
         }
     }
 
@@ -444,8 +444,9 @@ impl GenesisChainParameters {
         sui_types::governance::MINIMUM_VALIDATOR_STAKE_SUI * sui_types::gas_coin::MIST_PER_SUI
     }
 
-    fn test_epoch_duration_ms() -> u64 {
-        10000
+    fn default_epoch_duration_ms() -> u64 {
+        // 24 hrs
+        24 * 60 * 60 * 1000
     }
 }
 

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -65,19 +65,6 @@ impl NetworkConfig {
             .build()
     }
 
-    pub fn generate_with_rng_and_epoch_duration<R: rand::CryptoRng + rand::RngCore>(
-        config_dir: &Path,
-        quorum_size: usize,
-        epoch_duration_ms: u64,
-        rng: R,
-    ) -> Self {
-        builder::ConfigBuilder::new(config_dir)
-            .committee_size(NonZeroUsize::new(quorum_size).unwrap())
-            .with_epoch_duration(epoch_duration_ms)
-            .rng(rng)
-            .build()
-    }
-
     pub fn generate(config_dir: &Path, quorum_size: usize) -> Self {
         Self::generate_with_rng(config_dir, quorum_size, OsRng)
     }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -10,7 +10,7 @@ parameters:
   initial_sui_custody_account_address: "0x0000000000000000000000000000000000000000000000000000000000000000"
   initial_validator_stake_mist: 25000000000000000
   governance_start_epoch: 0
-  epoch_duration_ms: 10000
+  epoch_duration_ms: 86400000
 committee_size: 4
 grpc_load_shed: ~
 grpc_concurrency_limit: 20000000000

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -279,7 +279,7 @@ storage_fund:
   value: 0
 parameters:
   governance_start_epoch: 0
-  epoch_duration_ms: 10000
+  epoch_duration_ms: 86400000
 reference_gas_price: 1
 validator_report_records:
   contents: []

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -26,12 +26,7 @@ pub fn test_authority_configs() -> NetworkConfig {
 pub fn test_and_configure_authority_configs(committee_size: usize) -> NetworkConfig {
     let config_dir = tempfile::tempdir().unwrap().into_path();
     let rng = StdRng::from_seed([0; 32]);
-    let mut configs = NetworkConfig::generate_with_rng_and_epoch_duration(
-        &config_dir,
-        committee_size,
-        24 * 60 * 60 * 1000, /* 24 hrs*/
-        rng,
-    );
+    let mut configs = NetworkConfig::generate_with_rng(&config_dir, committee_size, rng);
     for config in configs.validator_configs.iter_mut() {
         let parameters = &mut config.consensus_config.as_mut().unwrap().narwhal_config;
         // NOTE: the following parameters are important to ensure tests run fast. Using the default


### PR DESCRIPTION
## Description 

10s default epoch duration is causing a lot of confusion and some test failures so this PR changes the default back to 24 hrs. 

## Test Plan 

making sure the existing tests pass
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
