### PR TITLE
add gas summary to transactional test runner

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.exp
@@ -12,6 +12,7 @@ written: object(106)
 
 task 4 'run'. lines 41-43:
 written: object(107)
+gas summary: computation_cost: 36966, storage_cost: 13,  storage_rebate: 0
 
 task 5 'run'. lines 44-46:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 5) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.move
@@ -38,7 +38,7 @@ module Test::M1 {
 //# run Test::M1::create_n_ids --args 256
 
 // create at create count limit should succeed
-//# run Test::M1::create_n_ids --args 2048
+//# run Test::M1::create_n_ids --args 2048 --view-gas-used
 
 // create above create count limit should fail
 //# run Test::M1::create_n_ids --args 2049

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -22,6 +22,8 @@ pub struct SuiRunArgs {
     pub sender: Option<String>,
     #[clap(long = "view-events")]
     pub view_events: bool,
+    #[clap(long = "view-gas-used")]
+    pub view_gas_used: bool,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -30,6 +32,8 @@ pub struct SuiPublishArgs {
     pub sender: Option<String>,
     #[clap(long = "upgradeable", action = clap::ArgAction::SetTrue)]
     pub upgradeable: bool,
+    #[clap(long = "view-gas-used")]
+    pub view_gas_used: bool,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -52,6 +56,8 @@ pub struct TransferObjectCommand {
     pub sender: Option<String>,
     #[clap(long = "gas-budget")]
     pub gas_budget: Option<u64>,
+    #[clap(long = "view-gas-used")]
+    pub view_gas_used: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -163,6 +163,16 @@ impl GasCostSummary {
     }
 }
 
+impl std::fmt::Display for GasCostSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "computation_cost: {}, storage_cost: {},  storage_rebate: {}",
+            self.computation_cost, self.storage_cost, self.storage_rebate
+        )
+    }
+}
+
 // Fixed cost type
 #[derive(Clone)]
 pub struct FixedCost(InternalGas);


### PR DESCRIPTION
## Description 

Adds `view-gas-used` to transactional tests. Needed for easily finetuning natives costs.

## Test Plan 

Transactional test sample

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
