### PR TITLE
[programmable transactions] Add `fetch_package` and `fetch_packages` to execution. Simplify dependency-not-found error.

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -34,7 +34,7 @@ use sui_types::{
     messages::{
         Argument, Command, CommandArgumentError, ProgrammableMoveCall, ProgrammableTransaction,
     },
-    move_package::UpgradeCap,
+    move_package::{MovePackage, UpgradeCap},
     SUI_FRAMEWORK_ADDRESS,
 };
 use sui_verifier::{
@@ -407,24 +407,7 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
         })
         .collect::<Vec<_>>();
 
-    let mut dependencies = vec![];
-    for id in dep_ids {
-        match context.state_view.get_package(&id) {
-            Ok(Some(package_dep)) => dependencies.push(package_dep),
-            Ok(None) => {
-                return Err(ExecutionError::new(
-                    ExecutionErrorKind::PublishUnresolvedPackageDependency { object: id },
-                    None,
-                ))
-            }
-            Err(e) => {
-                return Err(ExecutionError::new_with_source(
-                    ExecutionErrorKind::PublishUnresolvedPackageDependency { object: id },
-                    e,
-                ))
-            }
-        }
-    }
+    let dependencies = fetch_packages(context, &dep_ids)?;
 
     // new_package also initializes type origin table in the package object
     let package_object = context.new_package(modules, &dependencies, None)?;
@@ -475,6 +458,51 @@ fn execute_move_upgrade<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
         .map_err(|_| ExecutionError::from_kind(ExecutionErrorKind::FeatureNotYetSupported))?;
 
     invariant_violation!("Package upgrades are turned off. We should NEVER get here.")
+}
+
+#[allow(dead_code)]
+fn fetch_package<'a, E: fmt::Debug, S: StorageView<E>>(
+    context: &'a ExecutionContext<E, S>,
+    package_id: &ObjectID,
+) -> Result<MovePackage, ExecutionError> {
+    let mut fetched_packages = fetch_packages(context, vec![package_id])?;
+    assert_invariant!(
+        fetched_packages.len() == 1,
+        "Number of fetched packages must match the number of package object IDs if successful."
+    );
+    match fetched_packages.pop() {
+        Some(pkg) => Ok(pkg),
+        None => invariant_violation!(
+            "We should always fetch a package for each object or return a dependency error."
+        ),
+    }
+}
+
+fn fetch_packages<'a, E: fmt::Debug, S: StorageView<E>>(
+    context: &'a ExecutionContext<E, S>,
+    package_ids: impl IntoIterator<Item = &'a ObjectID>,
+) -> Result<Vec<MovePackage>, ExecutionError> {
+    match context.state_view.get_packages(package_ids) {
+        Err(e) => Err(ExecutionError::new_with_source(
+            ExecutionErrorKind::PublishUpgradeMissingDependency,
+            e,
+        )),
+        Ok(Err(missing_deps)) => {
+            let msg = format!(
+                "Missing dependencies: {}",
+                missing_deps
+                    .into_iter()
+                    .map(|dep| format!("{}", dep))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::PublishUpgradeMissingDependency,
+                msg,
+            ))
+        }
+        Ok(Ok(pkgs)) => Ok(pkgs),
+    }
 }
 
 /***************************************************************************************************

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -318,7 +318,7 @@ fn test_fail_on_missing_dep() {
 
     assert_eq!(
         err.kind(),
-        &ExecutionErrorKind::PublishUpgradeMissingImmediateDependency
+        &ExecutionErrorKind::PublishUpgradeMissingDependency
     );
 }
 
@@ -350,7 +350,7 @@ fn test_fail_on_missing_transitive_dep() {
 
     assert_eq!(
         err.kind(),
-        &ExecutionErrorKind::PublishUpgradeMissingIndirectDependency
+        &ExecutionErrorKind::PublishUpgradeMissingDependency
     );
 }
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2123,18 +2123,11 @@ pub enum ExecutionFailureStatus {
     )]
     PublishErrorNonZeroAddress,
     #[error(
-        "Publish/Upgrade Error, Missing immediate dependency. \
-         Immediate dependency of published or upgraded package has not been assigned an on-chain \
+        "Publish/Upgrade Error, Missing dependency. \
+         A dependency of a published or upgraded package has not been assigned an on-chain \
          address."
     )]
-    PublishUpgradeMissingImmediateDependency,
-
-    #[error(
-        "Publish/Upgrade Error, Missing indirect dependency. \
-         Indirect (transitive) dependency of published or upgraded package has not been assigned an \
-         on-chain address."
-    )]
-    PublishUpgradeMissingIndirectDependency,
+    PublishUpgradeMissingDependency,
 
     #[error(
         "Publish/Upgrade Error, Dependency downgrade. \
@@ -2143,9 +2136,6 @@ pub enum ExecutionFailureStatus {
          transitive dependencies."
     )]
     PublishUpgradeDependencyDowngrade,
-
-    #[error("Could not resolve dependency of package at {object}.")]
-    PublishUnresolvedPackageDependency { object: ObjectID },
 
     #[error(
         "Sui Move Bytecode Verification Error. \

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -486,14 +486,14 @@ fn build_linkage_table<'p>(
     }
     // (1) Every dependency is represented in the transitive dependencies
     if !immediate_dependencies.is_empty() {
-        return Err(ExecutionErrorKind::PublishUpgradeMissingImmediateDependency.into());
+        return Err(ExecutionErrorKind::PublishUpgradeMissingDependency.into());
     }
 
     // (2) Every dependency's linkage table is superseded by this linkage table
     for dep_linkage_table in dep_linkage_tables {
         for (original_id, dep_info) in dep_linkage_table {
             let Some(our_info) = linkage_table.get(original_id) else {
-                return Err(ExecutionErrorKind::PublishUpgradeMissingIndirectDependency.into());
+                return Err(ExecutionErrorKind::PublishUpgradeMissingDependency.into());
             };
 
             if our_info.upgraded_version < dep_info.upgraded_version {


### PR DESCRIPTION
Adds a `fetch_package` and `fetch_packages` function that does the correct error handling.

This also updates the `get_packages` and `get_package_objects` commands to a result containing the list of failed objects that were not able to be loaded instead of a `None` when any object failed to be loaded. 
