### PR TITLE
[consensus_adapter] Count and limit number of in-flight transactions submitted to narwhal

### DIFF
--- a/crates/mysten-metrics/src/guards.rs
+++ b/crates/mysten-metrics/src/guards.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::IntGauge;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Increments gauge when acquired, decrements when guard drops
+pub struct GaugeGuard<'a>(&'a IntGauge);
+
+impl<'a> GaugeGuard<'a> {
+    pub fn acquire(g: &'a IntGauge) -> Self {
+        g.inc();
+        Self(g)
+    }
+}
+
+impl<'a> Drop for GaugeGuard<'a> {
+    fn drop(&mut self) {
+        self.0.dec();
+    }
+}
+
+pub trait GaugeGuardFutureExt: Future + Sized {
+    /// Count number of in flight futures running
+    fn count_in_flight(self, g: &IntGauge) -> GaugeGuardFuture<Self>;
+}
+
+impl<F: Future> GaugeGuardFutureExt for F {
+    fn count_in_flight(self, g: &IntGauge) -> GaugeGuardFuture<Self> {
+        GaugeGuardFuture {
+            f: Box::pin(self),
+            _guard: GaugeGuard::acquire(g),
+        }
+    }
+}
+
+pub struct GaugeGuardFuture<'a, F: Sized> {
+    f: Pin<Box<F>>,
+    _guard: GaugeGuard<'a>,
+}
+
+impl<'a, F: Future> Future for GaugeGuardFuture<'a, F> {
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.f.as_mut().poll(cx)
+    }
+}

--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -16,7 +16,9 @@ use tracing::warn;
 pub use scopeguard;
 use uuid::Uuid;
 
+mod guards;
 pub mod histogram;
+pub use guards::*;
 
 #[derive(Debug)]
 pub struct Metrics {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -35,10 +35,6 @@ use crate::{
 #[path = "unit_tests/server_tests.rs"]
 mod server_tests;
 
-// Assuming 2000 txn tps * 10 sec consensus latency = 20000 inflight consensus txns.
-// Leaving a bit more headroom to cap the max inflight consensus txns to 40000.
-const MAX_PENDING_CONSENSUS_TRANSACTIONS: u64 = 40000;
-
 pub struct AuthorityServerHandle {
     tx_cancellation: tokio::sync::oneshot::Sender<()>,
     local_addr: Multiaddr,
@@ -377,13 +373,10 @@ impl ValidatorService {
             // For owned objects this will return without waiting for certificate to be sequenced
             // First do quick dirty non-async check
             if !epoch_store.is_tx_cert_consensus_message_processed(&certificate)? {
-                if consensus_adapter.num_inflight_transactions()
-                    > MAX_PENDING_CONSENSUS_TRANSACTIONS
-                {
-                    return Err(tonic::Status::resource_exhausted(format!(
-                        "Reached {} transactions pending in consensus. Consensus is overloaded.",
-                        MAX_PENDING_CONSENSUS_TRANSACTIONS
-                    )));
+                if !consensus_adapter.check_limits() {
+                    return Err(tonic::Status::resource_exhausted(
+                        "Reached maximum transactions pending in consensus. Consensus is overloaded.".to_string()
+                    ));
                 }
                 let _metrics_guard = if shared_object_tx {
                     Some(metrics.consensus_latency.start_timer())


### PR DESCRIPTION
This PR also removes annoying Option<Metrics> pattern from consensus adapter (planned it long time ago)
