### PR TITLE
remove tallying rule score metrics

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -61,8 +61,8 @@ use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
 use sui_storage::mutex_table::MutexGuard;
 use sui_types::message_envelope::TrustedEnvelope;
 use sui_types::messages_checkpoint::{
-    CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
-    CheckpointSignatureMessage, CheckpointSummary, CheckpointTimestamp,
+    CheckpointContents, CheckpointSequenceNumber, CheckpointSignatureMessage, CheckpointSummary,
+    CheckpointTimestamp,
 };
 use sui_types::storage::{transaction_input_object_keys, ObjectKey, ParentSync};
 use sui_types::sui_system_state::epoch_start_sui_system_state::{
@@ -268,12 +268,6 @@ pub struct AuthorityEpochTables {
 
     /// Maps sequence number to checkpoint summary, used by CheckpointBuilder to build checkpoint within epoch
     builder_checkpoint_summary: DBMap<CheckpointSequenceNumber, CheckpointSummary>,
-
-    /// Stores the sequence number of the last certified checkpoint we have recorded for idempotency and
-    /// the number of checkpoint each validator participated in certifying during the current
-    /// epoch, used for tallying rule scores.
-    num_certified_checkpoint_signatures:
-        DBMap<AuthorityName, (Option<CheckpointSequenceNumber>, u64)>,
 
     // Maps checkpoint sequence number to an accumulator with accumulated state
     // only for the checkpoint that the key references. Append-only, i.e.,
@@ -1170,71 +1164,6 @@ impl AuthorityPerEpochStore {
         self.finish_consensus_transaction_process_with_batch(write_batch, key, consensus_index)
     }
 
-    /// Called when a ceritified checkpoint is inserted into the checkpoint store.
-    /// This function records the validators' participation in the certified checkpoint by
-    /// incrementing the counters stored in the epoch tables. Tallying score metrics are
-    /// also updated at this point to send the most up-to-date scores.
-    pub fn record_certified_checkpoint_signatures(
-        &self,
-        certified_checkpoint: &CertifiedCheckpointSummary,
-    ) -> Result<(), TypedStoreError> {
-        let signed_authorities = certified_checkpoint
-            .auth_sig()
-            .authorities(&self.committee)
-            .collect::<Result<Vec<&AuthorityName>, _>>()
-            // using `expect` here is fine because this error would be caught much earlier
-            .expect("Certified checkpoint should be valid");
-
-        debug!(
-            "Recording certified checkpoint signatures from {:?}",
-            signed_authorities
-        );
-
-        let seq_num = *certified_checkpoint.sequence_number();
-
-        let old_values = self
-            .tables
-            .num_certified_checkpoint_signatures
-            .multi_get(signed_authorities.clone())?;
-
-        let new_key_values = signed_authorities
-            .into_iter()
-            .zip(old_values.into_iter().map(|v| v.unwrap_or((None, 0))))
-            // Only keep the entries whose values we haven't recorded for this checkpoint for idempotency.
-            .filter(|(_, (last_processed_seq_num, _))| {
-                last_processed_seq_num.is_none() || last_processed_seq_num.unwrap() < seq_num
-            })
-            // Increment counter and update the last processed ckpt sequence num
-            .map(|(name, (_, counter))| (name, (Some(seq_num), counter + 1)))
-            .collect::<Vec<_>>();
-
-        // Send tallying rule score through prometheus.
-        new_key_values
-            .iter()
-            .for_each(|(authority_name, (_, score))| {
-                self.metrics
-                    .tallying_rule_scores
-                    .with_label_values(&[
-                        &format!("{:?}", authority_name.concise()),
-                        &self.epoch().to_string(),
-                    ])
-                    .set(*score as i64)
-            });
-
-        // Batch update the counters to new values.
-        let batch = self
-            .tables
-            .num_certified_checkpoint_signatures
-            .batch()
-            .insert_batch(
-                &self.tables.num_certified_checkpoint_signatures,
-                new_key_values,
-            )?;
-        batch.write()?;
-
-        Ok(())
-    }
-
     pub fn finish_consensus_certificate_process(
         &self,
         key: SequencedConsensusTransactionKey,
@@ -1872,13 +1801,6 @@ impl AuthorityPerEpochStore {
             .next()
             .map(|((_, index), _)| index)
             .unwrap_or_default()
-    }
-
-    pub fn get_num_certified_checkpoint_sigs_by(
-        &self,
-        name: &AuthorityName,
-    ) -> SuiResult<Option<(Option<CheckpointSequenceNumber>, u64)>> {
-        Ok(self.tables.num_certified_checkpoint_signatures.get(name)?)
     }
 
     pub fn insert_checkpoint_signature(

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -294,11 +294,6 @@ impl CheckpointExecutor {
             epoch_store.epoch(),
         );
 
-        // Record checkpoint participation for tallying rule.
-        epoch_store
-            .record_certified_checkpoint_signatures(checkpoint.inner())
-            .unwrap();
-
         let metrics = self.metrics.clone();
         let local_execution_timeout_sec = self.config.local_execution_timeout_sec;
         let authority_store = self.authority_store.clone();

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::{
-    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, IntGauge, IntGaugeVec,
-    Registry,
-};
+use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
 use std::sync::Arc;
 
 pub struct EpochMetrics {
@@ -71,9 +68,6 @@ pub struct EpochMetrics {
     /// to become useful in the network after reconfiguration.
     // TODO: This needs to be reported properly.
     pub epoch_first_checkpoint_ready_time_since_epoch_begin_ms: IntGauge,
-
-    /// Tallying rule scores for all validators this epoch.
-    pub tallying_rule_scores: IntGaugeVec,
 
     /// Whether we are running in safe mode where reward distribution and tokenomics are disabled.
     pub is_safe_mode: IntGauge,
@@ -147,12 +141,6 @@ impl EpochMetrics {
             epoch_first_checkpoint_ready_time_since_epoch_begin_ms: register_int_gauge_with_registry!(
                 "epoch_first_checkpoint_created_time_since_epoch_begin_ms",
                 "Time interval from when the epoch opens at new epoch to the first checkpoint is created locally",
-                registry
-            ).unwrap(),
-            tallying_rule_scores: register_int_gauge_vec_with_registry!(
-                "tallying_rule_scores",
-                "Tallying rule scores for validators each epoch",
-                &["validator", "epoch"],
                 registry
             ).unwrap(),
             is_safe_mode: register_int_gauge_with_registry!(


### PR DESCRIPTION
## Description 

We decided not to use checkpoint certification participation to determine tallying rule scores of validators so this PR removes the metrics and corresponding table from epoch store. If a validator would like to monitor others' checkpoint participation, `CheckpointMetrics::checkpoint_participation` should be good enough.

## Test Plan 

existing tests pass.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
