### PR TITLE
Incorrect flag used in docs

### DIFF
--- a/doc/src/build/cli-client.md
+++ b/doc/src/build/cli-client.md
@@ -62,7 +62,7 @@ override this setting by providing a path to the directory where this
 file is stored:
 
 ```shell
-sui console --config /workspace/config-files
+sui console --client.config /workspace/config-files
 ```
 
 The Sui interactive client console supports the following shell functionality:


### PR DESCRIPTION
## Description 
sui console has no `--config` option  - only `--client.config`
