### PR TITLE
[sui-test-validator] Allow configurable epoch duration

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -169,6 +169,9 @@ impl Cluster for LocalNewCluster {
             .set_genesis_config(genesis_config)
             .enable_fullnode_events();
 
+        if let Some(epoch_duration_ms) = options.epoch_duration_ms {
+            cluster_builder = cluster_builder.with_epoch_duration_ms(epoch_duration_ms);
+        }
         if let Some(rpc_port) = fullnode_port {
             cluster_builder = cluster_builder.set_fullnode_rpc_port(rpc_port);
         }

--- a/crates/sui-cluster-test/src/config.rs
+++ b/crates/sui-cluster-test/src/config.rs
@@ -22,6 +22,8 @@ pub struct ClusterTestOpt {
     pub faucet_address: Option<String>,
     #[clap(long)]
     pub fullnode_address: Option<String>,
+    #[clap(long)]
+    pub epoch_duration_ms: Option<u64>,
 }
 
 impl ClusterTestOpt {
@@ -30,6 +32,7 @@ impl ClusterTestOpt {
             env: Env::NewLocal,
             faucet_address: None,
             fullnode_address: None,
+            epoch_duration_ms: None,
         }
     }
 }

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -34,6 +34,10 @@ struct Args {
     /// Port to start the Sui faucet on
     #[clap(long, default_value = "9123")]
     faucet_port: u16,
+
+    /// The duration for epochs (defaults to one minute)
+    #[clap(long, default_value = "60000")]
+    epoch_duration_ms: u64,
 }
 
 #[tokio::main]
@@ -48,6 +52,7 @@ async fn main() -> Result<()> {
         env: Env::NewLocal,
         fullnode_address: Some(format!("127.0.0.1:{}", args.fullnode_rpc_port)),
         faucet_address: None,
+        epoch_duration_ms: Some(args.epoch_duration_ms),
     })
     .await?;
 


### PR DESCRIPTION
## Description 

I ran into a case where I needed to modify the epoch length, so I added this to the CLI so that it can easily be configured.

## Test Plan 

Ran locally + CI.