### PR TITLE
Removed tilde from title

### DIFF
--- a/doc/src/build/move/lock-file.md
+++ b/doc/src/build/move/lock-file.md
@@ -1,5 +1,5 @@
 ---
-title: `Move.lock` File for Move Packages
+title: Move.lock
 ---
 
 When you build a Move package, the process creates a `Move.lock` file at the root of your package. The file acts as a communication layer between the Move compiler and other tools, like chain-specific command line interfaces and third-party package managers. The `Move.lock` file contains information about your package, including its dependencies, that aids operations like verification of source code against on-chain packages and package manager compatibility.    

--- a/doc/src/build/move/manifest.md
+++ b/doc/src/build/move/manifest.md
@@ -9,7 +9,7 @@ The manifest contains information divided into three sections:
 * `[dependencies]`: List of packages that your package depends on. Initially, the Sui Framework is the only dependency, but you add third-party dependencies to this section as needed.
 * `[addresses]`: A list of *named addresses*. You can use the names listed as convenient aliases for the given addresses in the source code.
 
-## `[package]` section
+## [package] section
 
 The `[package]` section contains the following information:
 
@@ -17,7 +17,7 @@ The `[package]` section contains the following information:
 * `version`: The current version of your package. The Sui Move compiler creates the first value.
 * `published-at`: The published address of the package. The Sui Move compiler does not automatically create this entry.
 
-### `published-at` property
+### The published-at property
 
 Package dependencies in `Move.toml` must include a `published-at` field that specifies the published address of the dependency. For example, the Sui framework is published at address `0x2`, so its `Move.toml` file includes the `published-at` entry:
 
@@ -27,7 +27,7 @@ published-at = "0x2"
 
 If your package depends on another package, like the Sui framework, the network links your package against the `published-at` address specified by the on-chain dependency after you publish your package. When publishing, the compiler resolves all package dependencies (i.e., transitive dependencies) to link against. Consequently, you should only publish packages where all dependencies have a `published-at` address in their manifest. By default, the publish command fails if this is not the case. If necessary, you can use the `--with-unpublished-dependencies` flag with the publish command to bypass the requirement that all dependencies require a `published-at` address. When using `--with-unpublished-dependencies`, all unpublished dependencies are treated as if they are part of your package.
 
-## `[dependencies]` section
+## [dependencies] section
 
 The Sui Move compiler creates the `[dependencies]` section for you with a single entry for the GitHub address of the Sui network. If you need to use a local version of the network, you can edit the address to point to the local version. For example, 
 
@@ -37,7 +37,7 @@ Sui = { local = "../crates/sui-framework" }
 
 You place each additional dependency your package has on a new line directly below the previous one.
 
-## `[addresses]` section
+## [addresses] section
 
 The Sui Move compiler creates the `[addresses]` section for you with an entry for your package and one for the Sui network.
 


### PR DESCRIPTION
## Description 

Fixing error caused by starting title with tilde char.

## Test Plan 

Local

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
