### PR TITLE
Enqueue transactions off of the consensus thread

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -48,7 +48,6 @@ use crate::epoch::epoch_metrics::EpochMetrics;
 use crate::epoch::reconfiguration::ReconfigState;
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::stake_aggregator::StakeAggregator;
-use crate::transaction_manager::TransactionManager;
 use move_bytecode_utils::module_cache::SyncModuleCache;
 use move_vm_runtime::move_vm::MoveVM;
 use move_vm_runtime::native_functions::NativeFunctionTable;
@@ -1554,18 +1553,10 @@ impl AuthorityPerEpochStore {
         &self,
         transaction: VerifiedSequencedConsensusTransaction,
         checkpoint_service: &Arc<C>,
-        transaction_manager: &Arc<TransactionManager>,
         parent_sync_store: impl ParentSync,
-    ) -> SuiResult {
-        if let Some(certificate) = self
-            .process_consensus_transaction(transaction, checkpoint_service, parent_sync_store)
-            .await?
-        {
-            // The certificate has already been inserted into the pending_certificates table by
-            // process_consensus_transaction() above.
-            transaction_manager.enqueue(vec![certificate], self)?;
-        }
-        Ok(())
+    ) -> SuiResult<Option<VerifiedExecutableTransaction>> {
+        self.process_consensus_transaction(transaction, checkpoint_service, parent_sync_store)
+            .await
     }
 
     /// Depending on the type of the VerifiedSequencedConsensusTransaction wrapper,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4331,7 +4331,6 @@ pub(crate) async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCe
             .handle_consensus_transaction(
                 transaction,
                 &Arc::new(CheckpointServiceNoop {}),
-                authority.transaction_manager(),
                 authority.db(),
             )
             .await

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -115,10 +115,10 @@ async fn submit_transaction_to_consensus_adapter() {
                 .handle_consensus_transaction(
                     VerifiedSequencedConsensusTransaction::new_test(transaction.clone()),
                     &Arc::new(CheckpointServiceNoop {}),
-                    self.0.transaction_manager(),
                     self.0.db(),
                 )
-                .await
+                .await?;
+            Ok(())
         }
     }
     // Make a new consensus adapter instance.


### PR DESCRIPTION
Should greatly reduce consensus CPU utilization.

Question for reviewers: Do we feel like we need to limit the number of pending enqueue task?