### PR TITLE
indexer fix: chunk PG commit

### DIFF
--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -142,6 +142,7 @@ pub struct TemporaryCheckpointStore {
     pub recipients: Vec<Recipient>,
 }
 
+#[derive(Debug)]
 pub struct TransactionObjectChanges {
     pub mutated_objects: Vec<Object>,
     pub deleted_objects: Vec<DeletedObject>,


### PR DESCRIPTION
## Description 

PG commit has a limit of 65535, which is number of rows * number of columns, reported issue can be found here 
https://mysten-labs.slack.com/archives/C047ZSH8KV5/p1678836415370179
Because now all tables has < 64 rows, so 1000 should be fine for now.

## Test Plan 

- Run with labnet to make sure it works
- CI

