### PR TITLE
[APPS-120/APPS-635]: add icons to buttons and links

### DIFF
--- a/apps/explorer/src/ui/Button.tsx
+++ b/apps/explorer/src/ui/Button.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { cva, type VariantProps } from 'class-variance-authority';
+import clsx from 'clsx';
 import { type ReactNode } from 'react';
 
 import { LoadingSpinner } from './LoadingSpinner';
@@ -43,30 +44,27 @@ export function Button({
     after,
     ...props
 }: ButtonProps) {
-    const childrenContent = (
-        <div className="inline-flex flex-nowrap gap-2">
-            {before}
-            {children}
-            {after}
-        </div>
-    );
-
     return (
         <ButtonOrLink
             className={buttonStyles({ variant, size })}
             {...props}
             disabled={props.disabled || loading}
         >
-            {loading ? (
-                <>
-                    <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-                        <LoadingSpinner />
-                    </div>
-                    <div className="text-transparent">{childrenContent}</div>
-                </>
-            ) : (
-                childrenContent
+            {loading && (
+                <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+                    <LoadingSpinner />
+                </div>
             )}
+            <div
+                className={clsx(
+                    'inline-flex flex-nowrap gap-2',
+                    loading && 'text-transparent'
+                )}
+            >
+                {before}
+                {children}
+                {after}
+            </div>
         </ButtonOrLink>
     );
 }

--- a/apps/explorer/src/ui/Button.tsx
+++ b/apps/explorer/src/ui/Button.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { cva, type VariantProps } from 'class-variance-authority';
+import { type ReactNode } from 'react';
 
 import { LoadingSpinner } from './LoadingSpinner';
 import { ButtonOrLink, type ButtonOrLinkProps } from './utils/ButtonOrLink';
@@ -29,6 +30,8 @@ export interface ButtonProps
     extends VariantProps<typeof buttonStyles>,
         ButtonOrLinkProps {
     loading?: boolean;
+    before?: ReactNode;
+    after?: ReactNode;
 }
 
 export function Button({
@@ -36,8 +39,18 @@ export function Button({
     size,
     loading,
     children,
+    before,
+    after,
     ...props
 }: ButtonProps) {
+    const childrenContent = (
+        <div className="inline-flex flex-nowrap gap-2">
+            {before}
+            {children}
+            {after}
+        </div>
+    );
+
     return (
         <ButtonOrLink
             className={buttonStyles({ variant, size })}
@@ -49,10 +62,10 @@ export function Button({
                     <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
                         <LoadingSpinner />
                     </div>
-                    <div className="text-transparent">{children}</div>
+                    <div className="text-transparent">{childrenContent}</div>
                 </>
             ) : (
-                children
+                childrenContent
             )}
         </ButtonOrLink>
     );

--- a/apps/explorer/src/ui/Link.tsx
+++ b/apps/explorer/src/ui/Link.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { cva, type VariantProps } from 'class-variance-authority';
+import { type ReactNode } from 'react';
 
 import { ButtonOrLink, type ButtonOrLinkProps } from './utils/ButtonOrLink';
-import { ReactNode } from 'react';
 
 const linkStyles = cva([], {
     variants: {

--- a/apps/explorer/src/ui/Link.tsx
+++ b/apps/explorer/src/ui/Link.tsx
@@ -4,6 +4,7 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { ButtonOrLink, type ButtonOrLinkProps } from './utils/ButtonOrLink';
+import { ReactNode } from 'react';
 
 const linkStyles = cva([], {
     variants: {
@@ -26,10 +27,26 @@ const linkStyles = cva([], {
 
 export interface LinkProps
     extends ButtonOrLinkProps,
-        VariantProps<typeof linkStyles> {}
+        VariantProps<typeof linkStyles> {
+    before?: ReactNode;
+    after?: ReactNode;
+}
 
-export function Link({ variant, size, ...props }: LinkProps) {
+export function Link({
+    variant,
+    size,
+    before,
+    after,
+    children,
+    ...props
+}: LinkProps) {
     return (
-        <ButtonOrLink className={linkStyles({ variant, size })} {...props} />
+        <ButtonOrLink className={linkStyles({ variant, size })} {...props}>
+            <div className="inline-flex flex-nowrap gap-2">
+                {before}
+                {children}
+                {after}
+            </div>
+        </ButtonOrLink>
     );
 }

--- a/apps/explorer/src/ui/stories/Button.stories.tsx
+++ b/apps/explorer/src/ui/stories/Button.stories.tsx
@@ -1,12 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CheckFill16 } from '@mysten/icons';
+import { CheckFill16, Search16 } from '@mysten/icons';
 import { type StoryObj, type Meta } from '@storybook/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { Button, type ButtonProps } from '../Button';
-import { ReactComponent as CallIcon } from '../icons/transactions/call.svg';
 
 export default {
     component: Button,
@@ -75,12 +74,12 @@ export const OutlineLoading: StoryObj<ButtonProps> = {
 
 export const ButtonWithPrefixIcon: StoryObj<ButtonProps> = {
     ...Primary,
-    args: { prefixIcon: <CheckFill16 /> },
+    args: { before: <CheckFill16 /> },
 };
 
 export const ButtonWithPostfixIcon: StoryObj<ButtonProps> = {
     ...Primary,
-    args: { postfixIcon: <CallIcon /> },
+    args: { after: <Search16 /> },
 };
 
 export const ButtonWithIcons: StoryObj<ButtonProps> = {

--- a/apps/explorer/src/ui/stories/Button.stories.tsx
+++ b/apps/explorer/src/ui/stories/Button.stories.tsx
@@ -1,10 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { CheckFill16 } from '@mysten/icons';
 import { type StoryObj, type Meta } from '@storybook/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { Button, type ButtonProps } from '../Button';
+import { ReactComponent as CallIcon } from '../icons/transactions/call.svg';
 
 export default {
     component: Button,
@@ -69,4 +71,19 @@ export const SecondaryLoading: StoryObj<ButtonProps> = {
 export const OutlineLoading: StoryObj<ButtonProps> = {
     ...Outline,
     args: { ...Outline.args, loading: true },
+};
+
+export const ButtonWithPrefixIcon: StoryObj<ButtonProps> = {
+    ...Primary,
+    args: { prefixIcon: <CheckFill16 /> },
+};
+
+export const ButtonWithPostfixIcon: StoryObj<ButtonProps> = {
+    ...Primary,
+    args: { postfixIcon: <CallIcon /> },
+};
+
+export const ButtonWithIcons: StoryObj<ButtonProps> = {
+    ...Outline,
+    args: { ...ButtonWithPrefixIcon.args, ...ButtonWithPostfixIcon.args },
 };

--- a/apps/explorer/src/ui/stories/Link.stories.tsx
+++ b/apps/explorer/src/ui/stories/Link.stories.tsx
@@ -3,7 +3,9 @@
 
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { CheckFill16 } from '../../../../icons';
 import { Link, type LinkProps } from '../Link';
+import { ReactComponent as CallIcon } from '../icons/transactions/call.svg';
 
 export default {
     component: Link,
@@ -28,5 +30,30 @@ export const Mono: StoryObj<LinkProps> = {
     args: {
         variant: 'mono',
         children: '0x0000000000000000000000000000000000000002',
+    },
+};
+
+export const LinkWithPrefixIcon: StoryObj<LinkProps> = {
+    args: {
+        variant: 'text',
+        children: 'View more',
+        prefixIcon: <CheckFill16 />,
+    },
+};
+
+export const LinkWithPostfixIcon: StoryObj<LinkProps> = {
+    args: {
+        variant: 'mono',
+        children: '0x0000000000000000000000000000000000000002',
+        postfixIcon: <CallIcon />,
+    },
+};
+
+export const LinkWithIcons: StoryObj<LinkProps> = {
+    args: {
+        variant: 'text',
+        children: 'View more',
+        prefixIcon: <CheckFill16 />,
+        postfixIcon: <CallIcon />,
     },
 };

--- a/apps/explorer/src/ui/stories/Link.stories.tsx
+++ b/apps/explorer/src/ui/stories/Link.stories.tsx
@@ -3,9 +3,8 @@
 
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { CheckFill16 } from '../../../../icons';
+import { CheckFill16, Search16 } from '../../../../icons';
 import { Link, type LinkProps } from '../Link';
-import { ReactComponent as CallIcon } from '../icons/transactions/call.svg';
 
 export default {
     component: Link,
@@ -37,7 +36,7 @@ export const LinkWithPrefixIcon: StoryObj<LinkProps> = {
     args: {
         variant: 'text',
         children: 'View more',
-        prefixIcon: <CheckFill16 />,
+        before: <CheckFill16 />,
     },
 };
 
@@ -45,7 +44,7 @@ export const LinkWithPostfixIcon: StoryObj<LinkProps> = {
     args: {
         variant: 'mono',
         children: '0x0000000000000000000000000000000000000002',
-        postfixIcon: <CallIcon />,
+        after: <Search16 />,
     },
 };
 
@@ -53,7 +52,7 @@ export const LinkWithIcons: StoryObj<LinkProps> = {
     args: {
         variant: 'text',
         children: 'View more',
-        prefixIcon: <CheckFill16 />,
-        postfixIcon: <CallIcon />,
+        before: <CheckFill16 />,
+        after: <Search16 />,
     },
 };

--- a/apps/explorer/src/ui/stories/Link.stories.tsx
+++ b/apps/explorer/src/ui/stories/Link.stories.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { CheckFill16, Search16 } from '@mysten/icons';
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { CheckFill16, Search16 } from '../../../../icons';
 import { Link, type LinkProps } from '../Link';
 
 export default {

--- a/apps/explorer/src/ui/utils/ButtonOrLink.tsx
+++ b/apps/explorer/src/ui/utils/ButtonOrLink.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type ComponentProps, forwardRef, useMemo } from 'react';
+import { type ComponentProps, forwardRef } from 'react';
 
 import { LinkWithQuery, type LinkProps } from './LinkWithQuery';
 
@@ -9,29 +9,13 @@ export interface ButtonOrLinkProps
     extends Omit<
         Partial<LinkProps> & ComponentProps<'a'> & ComponentProps<'button'>,
         'ref'
-    > {
-    prefixIcon?: JSX.Element;
-    postfixIcon?: JSX.Element;
-}
+    > {}
 
 export const ButtonOrLink = forwardRef<
     HTMLAnchorElement | HTMLButtonElement,
     ButtonOrLinkProps
->(({ href, to, prefixIcon, postfixIcon, children, ...props }, ref: any) => {
-    const childrenContent = useMemo(() => {
-        if (prefixIcon || postfixIcon) {
-            return (
-                <div className="inline-flex flex-nowrap gap-2">
-                    {prefixIcon}
-                    {children}
-                    {postfixIcon}
-                </div>
-            );
-        }
-
-        return children;
-    }, [children, postfixIcon, prefixIcon]);
-
+>(({ href, to, ...props }, ref: any) => {
+    // External link:
     if (href) {
         return (
             // eslint-disable-next-line jsx-a11y/anchor-has-content
@@ -41,26 +25,16 @@ export const ButtonOrLink = forwardRef<
                 rel="noreferrer noopener"
                 href={href}
                 {...props}
-            >
-                {childrenContent}
-            </a>
+            />
         );
     }
 
     // Internal router link:
     if (to) {
-        return (
-            <LinkWithQuery to={to} ref={ref} {...props}>
-                {childrenContent}
-            </LinkWithQuery>
-        );
+        return <LinkWithQuery to={to} ref={ref} {...props} />;
     }
 
-    return (
-        // We set the default type to be "button" to avoid accidentally submitting forms.
-        // eslint-disable-next-line react/button-has-type
-        <button {...props} type={props.type || 'button'} ref={ref}>
-            {childrenContent}
-        </button>
-    );
+    // We set the default type to be "button" to avoid accidentally submitting forms.
+    // eslint-disable-next-line react/button-has-type
+    return <button {...props} type={props.type || 'button'} ref={ref} />;
 });

--- a/apps/explorer/src/ui/utils/ButtonOrLink.tsx
+++ b/apps/explorer/src/ui/utils/ButtonOrLink.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type ComponentProps, forwardRef } from 'react';
+import { type ComponentProps, forwardRef, useMemo } from 'react';
 
 import { LinkWithQuery, type LinkProps } from './LinkWithQuery';
 
@@ -9,13 +9,29 @@ export interface ButtonOrLinkProps
     extends Omit<
         Partial<LinkProps> & ComponentProps<'a'> & ComponentProps<'button'>,
         'ref'
-    > {}
+    > {
+    prefixIcon?: JSX.Element;
+    postfixIcon?: JSX.Element;
+}
 
 export const ButtonOrLink = forwardRef<
     HTMLAnchorElement | HTMLButtonElement,
     ButtonOrLinkProps
->(({ href, to, ...props }, ref: any) => {
-    // External link:
+>(({ href, to, prefixIcon, postfixIcon, children, ...props }, ref: any) => {
+    const childrenContent = useMemo(() => {
+        if (prefixIcon || postfixIcon) {
+            return (
+                <div className="inline-flex flex-nowrap gap-2">
+                    {prefixIcon}
+                    {children}
+                    {postfixIcon}
+                </div>
+            );
+        }
+
+        return children;
+    }, [children, postfixIcon, prefixIcon]);
+
     if (href) {
         return (
             // eslint-disable-next-line jsx-a11y/anchor-has-content
@@ -25,16 +41,26 @@ export const ButtonOrLink = forwardRef<
                 rel="noreferrer noopener"
                 href={href}
                 {...props}
-            />
+            >
+                {childrenContent}
+            </a>
         );
     }
 
     // Internal router link:
     if (to) {
-        return <LinkWithQuery to={to} ref={ref} {...props} />;
+        return (
+            <LinkWithQuery to={to} ref={ref} {...props}>
+                {childrenContent}
+            </LinkWithQuery>
+        );
     }
 
-    // We set the default type to be "button" to avoid accidentally submitting forms.
-    // eslint-disable-next-line react/button-has-type
-    return <button {...props} type={props.type || 'button'} ref={ref} />;
+    return (
+        // We set the default type to be "button" to avoid accidentally submitting forms.
+        // eslint-disable-next-line react/button-has-type
+        <button {...props} type={props.type || 'button'} ref={ref}>
+            {childrenContent}
+        </button>
+    );
 });


### PR DESCRIPTION
## Description 

- Add icons as pre/postfix for Buttons/Links
https://mysten.atlassian.net/browse/APPS-120
https://mysten.atlassian.net/browse/APPS-635

<img width="148" alt="Screenshot 2023-03-14 at 5 51 56 PM" src="https://user-images.githubusercontent.com/127577476/225175304-7164f434-35a2-442a-a7b3-fd8ea8ec4f68.png">
<img width="374" alt="Screenshot 2023-03-14 at 5 51 53 PM" src="https://user-images.githubusercontent.com/127577476/225175306-c5415fe9-5b8d-4e12-aa1c-66f548aad44e.png">
<img width="126" alt="Screenshot 2023-03-14 at 5 51 49 PM" src="https://user-images.githubusercontent.com/127577476/225175307-a81a79f6-d96f-4f07-a056-8a656019607a.png">
<img width="229" alt="Screenshot 2023-03-14 at 5 51 43 PM" src="https://user-images.githubusercontent.com/127577476/225175308-f3328312-046f-457e-90f5-bc571aa055e4.png">
<img width="207" alt="Screenshot 2023-03-14 at 5 51 39 PM" src="https://user-images.githubusercontent.com/127577476/225175310-81b5af89-b5c9-454a-b389-a16d25a14e22.png">
<img width="201" alt="Screenshot 2023-03-14 at 5 51 35 PM" src="https://user-images.githubusercontent.com/127577476/225175311-0b60a509-e30a-4321-9d34-6d0af0e6f0a0.png">


## Test Plan 

- N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
