### PR TITLE
[wallet-ext] fix toasts being hidden behind overlay screens

### DIFF
--- a/apps/wallet/src/ui/app/components/overlay/Overlay.module.scss
+++ b/apps/wallet/src/ui/app/components/overlay/Overlay.module.scss
@@ -5,12 +5,16 @@
 
 .container {
     background: rgba(42 54 69 / 50%);
-    width: val.$sizing-popup-width;
-    height: val.$sizing-popup-height;
     display: flex;
     flex-flow: column nowrap;
     align-items: center;
     backdrop-filter: blur(20px);
+    z-index: 9999;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
 }
 
 .full-screen-container {

--- a/apps/wallet/src/ui/app/components/overlay/index.tsx
+++ b/apps/wallet/src/ui/app/components/overlay/index.tsx
@@ -3,10 +3,10 @@
 
 import cl from 'classnames';
 import { useCallback } from 'react';
-import ReactDOM from 'react-dom';
 
 import useAppSelector from '../../hooks/useAppSelector';
 import { AppType } from '../../redux/slices/app/AppType';
+import { Portal } from '../../shared/Portal';
 import Icon, { SuiIcons } from '_components/icon';
 
 import type { ReactNode } from 'react';
@@ -40,31 +40,28 @@ function Overlay({
     const appType = useAppSelector((state) => state.app.appType);
     const isFullScreen = appType === AppType.fullscreen;
 
-    return ReactDOM.createPortal(
-        <>
-            {showModal ? (
-                <div
-                    className={cl(st.container, {
-                        [st.fullScreenContainer]: isFullScreen,
-                    })}
-                >
-                    <div className="bg-gray-40 h-12 w-full">
-                        <div className="text-steel-darker bg-gray-40 flex justify-center h-12 items-center text-heading4 font-semibold">
-                            {title}
-                        </div>
+    return showModal ? (
+        <Portal containerId="overlay-portal-container">
+            <div
+                className={cl(st.container, {
+                    [st.fullScreenContainer]: isFullScreen,
+                })}
+            >
+                <div className="bg-gray-40 h-12 w-full">
+                    <div className="text-steel-darker bg-gray-40 flex justify-center h-12 items-center text-heading4 font-semibold">
+                        {title}
                     </div>
-                    <div className={st.content}>{children}</div>
-                    <button className={st.closeOverlay} onClick={closeModal}>
-                        <Icon
-                            icon={closeIcon}
-                            className={cl(st.close, st[closeIcon])}
-                        />
-                    </button>
                 </div>
-            ) : null}
-        </>,
-        document.getElementById('overlay-container')!
-    );
+                <div className={st.content}>{children}</div>
+                <button className={st.closeOverlay} onClick={closeModal}>
+                    <Icon
+                        icon={closeIcon}
+                        className={cl(st.close, st[closeIcon])}
+                    />
+                </button>
+            </div>
+        </Portal>
+    ) : null;
 }
 
 export default Overlay;

--- a/apps/wallet/src/ui/app/pages/layout/index.tsx
+++ b/apps/wallet/src/ui/app/pages/layout/index.tsx
@@ -38,6 +38,8 @@ function PageLayout({
                 )}
             >
                 {children}
+                <div id="overlay-portal-container"></div>
+                <div id="toaster-portal-container"></div>
             </div>
         </Loading>
     );

--- a/apps/wallet/src/ui/app/shared/Portal.tsx
+++ b/apps/wallet/src/ui/app/shared/Portal.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type PortalProps = {
+    children: React.ReactNode;
+    containerId: string;
+};
+
+export function Portal({ children, containerId }: PortalProps) {
+    const [hasMounted, setHasMounted] = useState(false);
+
+    useEffect(() => {
+        setHasMounted(true);
+    }, []);
+
+    if (!hasMounted) {
+        return null;
+    }
+
+    return createPortal(children, document.getElementById(containerId)!);
+}

--- a/apps/wallet/src/ui/app/shared/toaster/index.tsx
+++ b/apps/wallet/src/ui/app/shared/toaster/index.tsx
@@ -5,6 +5,7 @@ import cl from 'classnames';
 import { Toaster as ToasterLib } from 'react-hot-toast';
 import { useLocation } from 'react-router-dom';
 
+import { Portal } from '../Portal';
 import { useMenuIsOpen } from '_components/menu/hooks';
 import { useAppSelector } from '_hooks';
 import { getNavIsVisible } from '_redux/slices/app';
@@ -24,28 +25,30 @@ export function Toaster({ bottomNavEnabled }: ToasterProps) {
     const includeExtraBottomNavSpace =
         includeBottomNavSpace && isExtraNavTabsVisible;
     return (
-        <ToasterLib
-            containerClassName={cl(
-                '!absolute !z-[99999] transition-all',
-                includeBottomNavSpace &&
-                    'mb-[var(--sizing-navigation-placeholder-height)]',
-                includeExtraBottomNavSpace && '!bottom-10'
-            )}
-            position="bottom-center"
-            toastOptions={{
-                loading: {
-                    icon: null,
-                    className: `${commonToastClasses} !bg-steel !text-white`,
-                },
-                error: {
-                    icon: null,
-                    className: `${commonToastClasses} !border !border-solid !border-issue-dark/20 !bg-issue-light !text-issue-dark`,
-                },
-                success: {
-                    icon: null,
-                    className: `${commonToastClasses} !border !border-solid !border-success-dark/20 !bg-success-light !text-success-dark`,
-                },
-            }}
-        />
+        <Portal containerId="toaster-portal-container">
+            <ToasterLib
+                containerClassName={cl(
+                    '!absolute !z-[99999] transition-all',
+                    includeBottomNavSpace &&
+                        'mb-[var(--sizing-navigation-placeholder-height)]',
+                    includeExtraBottomNavSpace && '!bottom-10'
+                )}
+                position="bottom-center"
+                toastOptions={{
+                    loading: {
+                        icon: null,
+                        className: `${commonToastClasses} !bg-steel !text-white`,
+                    },
+                    error: {
+                        icon: null,
+                        className: `${commonToastClasses} !border !border-solid !border-issue-dark/20 !bg-issue-light !text-issue-dark`,
+                    },
+                    success: {
+                        icon: null,
+                        className: `${commonToastClasses} !border !border-solid !border-success-dark/20 !bg-success-light !text-success-dark`,
+                    },
+                }}
+            />
+        </Portal>
     );
 }

--- a/apps/wallet/src/ui/index.template.html
+++ b/apps/wallet/src/ui/index.template.html
@@ -10,6 +10,5 @@
     </head>
     <body class="app-initializing">
         <div id="root"></div>
-        <div id="overlay-container"></div>
     </body>
 </html>

--- a/apps/wallet/src/ui/styles/global.scss
+++ b/apps/wallet/src/ui/styles/global.scss
@@ -59,11 +59,6 @@ body {
     flex-flow: column nowrap;
 }
 
-#overlay-container {
-    position: absolute;
-    z-index: 99999;
-}
-
 * {
     box-sizing: border-box;
 }


### PR DESCRIPTION
## Description 

I introduced a bug the other day where toast messages were being hidden on overlay screens. This PR makes a generic `Portal` component and portals both the overlay and toaster components inside the main page layout container. To get the correct stacking order, we're just going to use `9999` for the toaster and `999` for the overlay (it would be nice to figure out a better way to manage these types of stacking contexts in the future so these types of bugs don't happen as frequently). I did consider pulling out `toaster-portal-container` to the `body` of the document, but that came with its own positioning and layout issues.

<img width="460" alt="image" src="https://user-images.githubusercontent.com/7453188/225321997-dea14413-ef63-45e8-a33a-2aea0436d756.png">

## Test Plan 
- Opened an overlay and then kicked off a toast message
- Opened the account menu and played around there
- Tested in both full-screen and pop-up mode

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A