### PR TITLE
Easy chore: reduce usage of size_of

### DIFF
--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -373,6 +373,7 @@ pub struct SuiAddress(
 );
 
 impl SuiAddress {
+    pub const LENGTH: usize = SUI_ADDRESS_LENGTH;
     pub const ZERO: Self = Self([0u8; SUI_ADDRESS_LENGTH]);
 
     pub fn to_vec(&self) -> Vec<u8> {

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -9,6 +9,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Bytes};
 
+const DIGEST_LENGTH: usize = 32;
 /// A representation of a 32 byte digest
 #[serde_as]
 #[derive(
@@ -17,18 +18,19 @@ use serde_with::{serde_as, Bytes};
 pub struct Digest(
     #[schemars(with = "Base58")]
     #[serde_as(as = "Readable<Base58, Bytes>")]
-    [u8; 32],
+    [u8; DIGEST_LENGTH],
 );
 
 impl Digest {
-    pub const ZERO: Self = Digest([0; 32]);
+    pub const LENGTH: usize = DIGEST_LENGTH;
+    pub const ZERO: Self = Digest([0; DIGEST_LENGTH]);
 
-    pub const fn new(digest: [u8; 32]) -> Self {
+    pub const fn new(digest: [u8; DIGEST_LENGTH]) -> Self {
         Self(digest)
     }
 
     pub fn generate<R: rand::RngCore + rand::CryptoRng>(mut rng: R) -> Self {
-        let mut bytes = [0; 32];
+        let mut bytes = [0; Self::LENGTH];
         rng.fill_bytes(&mut bytes);
         Self(bytes)
     }
@@ -37,11 +39,11 @@ impl Digest {
         Self::generate(rand::thread_rng())
     }
 
-    pub const fn inner(&self) -> &[u8; 32] {
+    pub const fn inner(&self) -> &[u8; DIGEST_LENGTH] {
         &self.0
     }
 
-    pub const fn into_inner(self) -> [u8; 32] {
+    pub const fn into_inner(self) -> [u8; DIGEST_LENGTH] {
         self.0
     }
 }
@@ -52,20 +54,20 @@ impl AsRef<[u8]> for Digest {
     }
 }
 
-impl AsRef<[u8; 32]> for Digest {
-    fn as_ref(&self) -> &[u8; 32] {
+impl AsRef<[u8; DIGEST_LENGTH]> for Digest {
+    fn as_ref(&self) -> &[u8; DIGEST_LENGTH] {
         &self.0
     }
 }
 
-impl From<Digest> for [u8; 32] {
+impl From<Digest> for [u8; DIGEST_LENGTH] {
     fn from(digest: Digest) -> Self {
         digest.into_inner()
     }
 }
 
-impl From<[u8; 32]> for Digest {
-    fn from(digest: [u8; 32]) -> Self {
+impl From<[u8; DIGEST_LENGTH]> for Digest {
+    fn from(digest: [u8; DIGEST_LENGTH]) -> Self {
         Self::new(digest)
     }
 }
@@ -311,6 +313,7 @@ impl Default for TransactionDigest {
 }
 
 impl TransactionDigest {
+    pub const LENGTH: usize = Digest::LENGTH;
     pub const ZERO: Self = Self(Digest::ZERO);
 
     pub const fn new(digest: [u8; 32]) -> Self {

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -439,6 +439,9 @@ pub enum Owner {
 }
 
 impl Owner {
+    // Max element size + 8 bytes for enum discriminant
+    pub const SIZE_FOR_GAS_METERING: usize = SuiAddress::LENGTH + 8;
+
     pub fn get_owner_address(&self) -> SuiResult<SuiAddress> {
         match self {
             Self::AddressOwner(address) | Self::ObjectOwner(address) => Ok(*address),
@@ -651,7 +654,8 @@ impl Object {
     /// we also don't want to serialize the object just to get the size.
     /// This approximation should be good enough for gas metering.
     pub fn object_size_for_gas_metering(&self) -> usize {
-        let meta_data_size = size_of::<Owner>() + size_of::<TransactionDigest>() + size_of::<u64>();
+        let meta_data_size =
+            Owner::SIZE_FOR_GAS_METERING + TransactionDigest::LENGTH + size_of::<u64>();
         let data_size = match &self.data {
             Data::Move(m) => m.object_size_for_gas_metering(),
             Data::Package(p) => p.object_size_for_gas_metering(),


### PR DESCRIPTION
## Description 

std::mem::size_of can be unstable across platforms.
We try to avoid using it especially for gas metering and execution-sensitive logic

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
