### PR TITLE
[programmable transactions] Fixed Option serialization. Fixed MakeMoveVec checks     

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.exp
@@ -17,5 +17,5 @@ task 4 'run'. lines 40-48:
 written: object(108)
 
 task 5 'run'. lines 50-50:
-Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: Some("Function expects std::ascii::String but provided argument's value does not match"), command: Some(0) } }
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::ascii::String but provided argument's value does not match"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.exp
@@ -1,4 +1,4 @@
-processed 18 tasks
+processed 20 tasks
 
 init:
 A: object(100)
@@ -35,38 +35,46 @@ task 8 'programmable'. lines 37-38:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<u256> but provided argument's value does not match"), command: Some(0) } }
 
-task 9 'programmable'. lines 40-43:
+task 9 'programmable'. lines 40-41:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<address> but provided argument's value does not match"), command: Some(0) } }
 
-task 10 'programmable'. lines 45-46:
+task 10 'programmable'. lines 43-47:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<address> but provided argument's value does not match"), command: Some(0) } }
+
+task 11 'programmable'. lines 49-50:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<bool>> but provided argument's value does not match"), command: Some(0) } }
 
-task 11 'programmable'. lines 48-49:
+task 12 'programmable'. lines 52-53:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u8>> but provided argument's value does not match"), command: Some(0) } }
 
-task 12 'programmable'. lines 51-52:
+task 13 'programmable'. lines 55-56:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u16>> but provided argument's value does not match"), command: Some(0) } }
 
-task 13 'programmable'. lines 54-55:
+task 14 'programmable'. lines 58-59:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u32>> but provided argument's value does not match"), command: Some(0) } }
 
-task 14 'programmable'. lines 57-58:
+task 15 'programmable'. lines 61-62:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u64>> but provided argument's value does not match"), command: Some(0) } }
 
-task 15 'programmable'. lines 60-61:
+task 16 'programmable'. lines 64-65:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u128>> but provided argument's value does not match"), command: Some(0) } }
 
-task 16 'programmable'. lines 63-64:
+task 17 'programmable'. lines 67-68:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u256>> but provided argument's value does not match"), command: Some(0) } }
 
-task 17 'programmable'. lines 66-67:
+task 18 'programmable'. lines 70-71:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<address>> but provided argument's value does not match"), command: Some(0) } }
+
+task 19 'programmable'. lines 73-74:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<address>> but provided argument's value does not match"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.exp
@@ -1,0 +1,72 @@
+processed 18 tasks
+
+init:
+A: object(100)
+
+task 1 'publish'. lines 8-17:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 19-20:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<bool> but provided argument's value does not match"), command: Some(0) } }
+
+task 3 'programmable'. lines 22-23:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<u8> but provided argument's value does not match"), command: Some(0) } }
+
+task 4 'programmable'. lines 25-26:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<u16> but provided argument's value does not match"), command: Some(0) } }
+
+task 5 'programmable'. lines 28-29:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<u32> but provided argument's value does not match"), command: Some(0) } }
+
+task 6 'programmable'. lines 31-32:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<u64> but provided argument's value does not match"), command: Some(0) } }
+
+task 7 'programmable'. lines 34-35:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<u128> but provided argument's value does not match"), command: Some(0) } }
+
+task 8 'programmable'. lines 37-38:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<u256> but provided argument's value does not match"), command: Some(0) } }
+
+task 9 'programmable'. lines 40-43:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<address> but provided argument's value does not match"), command: Some(0) } }
+
+task 10 'programmable'. lines 45-46:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<bool>> but provided argument's value does not match"), command: Some(0) } }
+
+task 11 'programmable'. lines 48-49:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u8>> but provided argument's value does not match"), command: Some(0) } }
+
+task 12 'programmable'. lines 51-52:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u16>> but provided argument's value does not match"), command: Some(0) } }
+
+task 13 'programmable'. lines 54-55:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u32>> but provided argument's value does not match"), command: Some(0) } }
+
+task 14 'programmable'. lines 57-58:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u64>> but provided argument's value does not match"), command: Some(0) } }
+
+task 15 'programmable'. lines 60-61:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u128>> but provided argument's value does not match"), command: Some(0) } }
+
+task 16 'programmable'. lines 63-64:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<u256>> but provided argument's value does not match"), command: Some(0) } }
+
+task 17 'programmable'. lines 66-67:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<vector<address>> but provided argument's value does not match"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.move
@@ -17,51 +17,58 @@ module test::m1 {
 }
 
 //# programmable --inputs vector[false,true]
-test::m1::option_prim<bool>(Input(0));
+//> test::m1::option_prim<bool>(Input(0));
 
 //# programmable --inputs vector[0u8,0u8]
-test::m1::option_prim<u8>(Input(0));
+//> test::m1::option_prim<u8>(Input(0));
 
 //# programmable --inputs vector[0u16,0u16]
-test::m1::option_prim<u16>(Input(0));
+//> test::m1::option_prim<u16>(Input(0));
 
 //# programmable --inputs vector[0u32,0u32]
-test::m1::option_prim<u32>(Input(0));
+//> test::m1::option_prim<u32>(Input(0));
 
 //# programmable --inputs vector[0u64,0u64]
-test::m1::option_prim<u64>(Input(0));
+//> test::m1::option_prim<u64>(Input(0));
 
 //# programmable --inputs vector[0u128,0u128]
-test::m1::option_prim<u128>(Input(0));
+//> test::m1::option_prim<u128>(Input(0));
 
 //# programmable --inputs vector[0u256,0u256]
-test::m1::option_prim<u256>(Input(0));
+//> test::m1::option_prim<u256>(Input(0));
 
 //# programmable --inputs vector[@0,@0]
-test::m1::option_prim<address>(Input(0));
+//> test::m1::option_prim<address>(Input(0));
+
+//# programmable --inputs vector[@0,@0]
+//> test::m1::option_prim<sui::object::ID>(Input(0));
+
 
 // vectors
 
 //# programmable --inputs vector[vector[],vector[]]
-test::m1::option_prim<vector<bool>>(Input(0));
+//> test::m1::option_prim<vector<bool>>(Input(0));
 
 //# programmable --inputs vector[vector[],vector[]]
-test::m1::option_prim<vector<u8>>(Input(0));
+//> test::m1::option_prim<vector<u8>>(Input(0));
 
 //# programmable --inputs vector[vector[],vector[]]
-test::m1::option_prim<vector<u16>>(Input(0));
+//> test::m1::option_prim<vector<u16>>(Input(0));
 
 //# programmable --inputs vector[vector[],vector[]]
-test::m1::option_prim<vector<u32>>(Input(0));
+//> test::m1::option_prim<vector<u32>>(Input(0));
 
 //# programmable --inputs vector[vector[],vector[]]
-test::m1::option_prim<vector<u64>>(Input(0));
+//> test::m1::option_prim<vector<u64>>(Input(0));
 
 //# programmable --inputs vector[vector[],vector[]]
-test::m1::option_prim<vector<u128>>(Input(0));
+//> test::m1::option_prim<vector<u128>>(Input(0));
 
 //# programmable --inputs vector[vector[],vector[]]
-test::m1::option_prim<vector<u256>>(Input(0));
+//> test::m1::option_prim<vector<u256>>(Input(0));
 
 //# programmable --inputs vector[vector[],vector[]]
-test::m1::option_prim<vector<address>>(Input(0));
+//> test::m1::option_prim<vector<address>>(Input(0));
+
+//# programmable --inputs vector[vector[],vector[]]
+//> test::m1::option_prim<vector<sui::object::ID>>(Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.move
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tessts various invalid vector instantions for types
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use std::option::{Self, Option};
+
+    public entry fun option_prim<T: copy + drop>(opt: Option<T>) {
+        if (option::is_some(&opt)) {
+            option::destroy_some(opt);
+        }
+    }
+}
+
+//# programmable --inputs vector[false,true]
+test::m1::option_prim<bool>(Input(0));
+
+//# programmable --inputs vector[0u8,0u8]
+test::m1::option_prim<u8>(Input(0));
+
+//# programmable --inputs vector[0u16,0u16]
+test::m1::option_prim<u16>(Input(0));
+
+//# programmable --inputs vector[0u32,0u32]
+test::m1::option_prim<u32>(Input(0));
+
+//# programmable --inputs vector[0u64,0u64]
+test::m1::option_prim<u64>(Input(0));
+
+//# programmable --inputs vector[0u128,0u128]
+test::m1::option_prim<u128>(Input(0));
+
+//# programmable --inputs vector[0u256,0u256]
+test::m1::option_prim<u256>(Input(0));
+
+//# programmable --inputs vector[@0,@0]
+test::m1::option_prim<address>(Input(0));
+
+// vectors
+
+//# programmable --inputs vector[vector[],vector[]]
+test::m1::option_prim<vector<bool>>(Input(0));
+
+//# programmable --inputs vector[vector[],vector[]]
+test::m1::option_prim<vector<u8>>(Input(0));
+
+//# programmable --inputs vector[vector[],vector[]]
+test::m1::option_prim<vector<u16>>(Input(0));
+
+//# programmable --inputs vector[vector[],vector[]]
+test::m1::option_prim<vector<u32>>(Input(0));
+
+//# programmable --inputs vector[vector[],vector[]]
+test::m1::option_prim<vector<u64>>(Input(0));
+
+//# programmable --inputs vector[vector[],vector[]]
+test::m1::option_prim<vector<u128>>(Input(0));
+
+//# programmable --inputs vector[vector[],vector[]]
+test::m1::option_prim<vector<u256>>(Input(0));
+
+//# programmable --inputs vector[vector[],vector[]]
+test::m1::option_prim<vector<address>>(Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.exp
@@ -1,0 +1,16 @@
+processed 4 tasks
+
+init:
+A: object(100)
+
+task 1 'publish'. lines 8-31:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 33-36:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::option::Option<u64> but provided argument's value does not match"), command: Some(0) } }
+
+task 3 'programmable'. lines 38-41:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::string::String but provided argument's value does not match"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests that MakeMoveVec performs necessary validation for special types like Option or String
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use std::vector;
+    use std::string::{Self, String};
+    use std::option::{Self, Option};
+
+    public entry fun vec_option_u64(v: vector<Option<u64>>) {
+        while (!vector::is_empty(&v)) {
+            let opt = vector::pop_back(&mut v);
+            if (option::is_some(&opt)) {
+                option::destroy_some(opt);
+            }
+        }
+    }
+
+    public entry fun vec_option_string(v: vector<Option<String>>) {
+        while (!vector::is_empty(&v)) {
+            let opt = vector::pop_back(&mut v);
+            if (option::is_some(&opt)) {
+                string::utf8(*string::bytes(&option::destroy_some(opt)));
+            }
+        }
+    }
+}
+
+//# programmable --inputs vector[0u64,0u64]
+// INVALID option, using a vetor of length 2
+0: MakeMoveVec<std::option::Option<u64>>([Input(0)]);
+1: test::m1::vec_option_u64(Result(0));
+
+//# programmable --inputs vector[255u8,157u8,164u8,239u8,184u8,143u8]
+// INVALID string                ^^^ modified the bytes to make an invalid UTF8 string
+0: MakeMoveVec<std::string::String>([Input(0), Input(0)]);
+1: test::m1::vec_string(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.move
@@ -32,10 +32,10 @@ module test::m1 {
 
 //# programmable --inputs vector[0u64,0u64]
 // INVALID option, using a vetor of length 2
-0: MakeMoveVec<std::option::Option<u64>>([Input(0)]);
-1: test::m1::vec_option_u64(Result(0));
+//> 0: MakeMoveVec<std::option::Option<u64>>([Input(0)]);
+//> 1: test::m1::vec_option_u64(Result(0));
 
 //# programmable --inputs vector[255u8,157u8,164u8,239u8,184u8,143u8]
 // INVALID string                ^^^ modified the bytes to make an invalid UTF8 string
-0: MakeMoveVec<std::string::String>([Input(0), Input(0)]);
-1: test::m1::vec_string(Result(0));
+//> 0: MakeMoveVec<std::string::String>([Input(0), Input(0)]);
+//> 1: test::m1::vec_string(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.exp
@@ -1,0 +1,24 @@
+processed 7 tasks
+
+init:
+A: object(100)
+
+task 1 'publish'. lines 6-53:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 55-61:
+written: object(106)
+
+task 3 'programmable'. lines 63-69:
+written: object(107)
+
+task 4 'programmable'. lines 71-74:
+written: object(108)
+
+task 5 'programmable'. lines 76-79:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects std::string::String but provided argument's value does not match"), command: Some(0) } }
+
+task 6 'programmable'. lines 81-85:
+written: object(110)

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.move
@@ -1,0 +1,85 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use std::vector;
+    use std::string::{Self, String};
+    use std::option::{Self, Option};
+
+    struct CoolMarker has key, store { id: UID }
+
+    public entry fun vec_u64(_: vector<u64>) {
+    }
+
+    public entry fun vec_vec_u64(_: vector<vector<u64>>) {
+    }
+
+    public entry fun vec_string(v: vector<String>) {
+        while (!vector::is_empty(&v)) {
+            string::utf8(*string::bytes(&vector::pop_back(&mut v)));
+        }
+    }
+
+    public entry fun vec_vec_string(v: vector<vector<String>>) {
+        while (!vector::is_empty(&v)) vec_string(vector::pop_back(&mut v))
+    }
+
+    public entry fun vec_option_string(v: vector<Option<String>>) {
+        while (!vector::is_empty(&v)) {
+            let opt = vector::pop_back(&mut v);
+            if (option::is_some(&opt)) {
+                string::utf8(*string::bytes(&option::destroy_some(opt)));
+            }
+        }
+    }
+
+    public fun marker(ctx: &mut TxContext): CoolMarker {
+        CoolMarker { id: object::new(ctx) }
+    }
+
+    public fun burn_markers(markers: vector<CoolMarker>) {
+        while (!vector::is_empty(&markers)) {
+            let CoolMarker { id } = vector::pop_back(&mut markers);
+            object::delete(id);
+        };
+        vector::destroy_empty(markers);
+    }
+
+}
+
+//# programmable --inputs 112u64
+// vector<u64>
+0: MakeMoveVec<u64>([Input(0), Input(0)]);
+1: test::m1::vec_u64(Result(0));
+// vector<vector<u64>>
+2: MakeMoveVec<vector<u64>>([Result(0), Result(0)]);
+3: test::m1::vec_vec_u64(Result(2));
+
+//# programmable --inputs vector[226u8,157u8,164u8,239u8,184u8,143u8]
+// vector<String>
+0: MakeMoveVec<std::string::String>([Input(0), Input(0)]);
+1: test::m1::vec_string(Result(0));
+// vector<vector<String>>
+2: MakeMoveVec<vector<std::string::String>>([Result(0), Result(0)]);
+3: test::m1::vec_vec_string(Result(2));
+
+//# programmable --inputs vector[vector[226u8,157u8,164u8,239u8,184u8,143u8]] vector[]
+// Option<String>
+0: MakeMoveVec<std::option::Option<std::string::String>>([Input(0), Input(1)]);
+1: test::m1::vec_option_string(Result(0));
+
+//# programmable --inputs vector[255u8,157u8,164u8,239u8,184u8,143u8]
+// INVALID string                ^^^ modified the bytes to make an invalid UTF8 string
+0: MakeMoveVec<std::string::String>([Input(0), Input(0)]);
+1: test::m1::vec_string(Result(0));
+
+//# programmable --sender A
+0: test::m1::marker();
+1: test::m1::marker();
+2: MakeMoveVec([Result(0), Result(1)]);
+3: test::m1::burn_markers(Result(2));

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.move
@@ -54,32 +54,32 @@ module test::m1 {
 
 //# programmable --inputs 112u64
 // vector<u64>
-0: MakeMoveVec<u64>([Input(0), Input(0)]);
-1: test::m1::vec_u64(Result(0));
+//> 0: MakeMoveVec<u64>([Input(0), Input(0)]);
+//> 1: test::m1::vec_u64(Result(0));
 // vector<vector<u64>>
-2: MakeMoveVec<vector<u64>>([Result(0), Result(0)]);
-3: test::m1::vec_vec_u64(Result(2));
+//> 2: MakeMoveVec<vector<u64>>([Result(0), Result(0)]);
+//> 3: test::m1::vec_vec_u64(Result(2));
 
 //# programmable --inputs vector[226u8,157u8,164u8,239u8,184u8,143u8]
 // vector<String>
-0: MakeMoveVec<std::string::String>([Input(0), Input(0)]);
-1: test::m1::vec_string(Result(0));
+//> 0: MakeMoveVec<std::string::String>([Input(0), Input(0)]);
+//> 1: test::m1::vec_string(Result(0));
 // vector<vector<String>>
-2: MakeMoveVec<vector<std::string::String>>([Result(0), Result(0)]);
-3: test::m1::vec_vec_string(Result(2));
+//> 2: MakeMoveVec<vector<std::string::String>>([Result(0), Result(0)]);
+//> 3: test::m1::vec_vec_string(Result(2));
 
 //# programmable --inputs vector[vector[226u8,157u8,164u8,239u8,184u8,143u8]] vector[]
 // Option<String>
-0: MakeMoveVec<std::option::Option<std::string::String>>([Input(0), Input(1)]);
-1: test::m1::vec_option_string(Result(0));
+//> 0: MakeMoveVec<std::option::Option<std::string::String>>([Input(0), Input(1)]);
+//> 1: test::m1::vec_option_string(Result(0));
 
 //# programmable --inputs vector[255u8,157u8,164u8,239u8,184u8,143u8]
 // INVALID string                ^^^ modified the bytes to make an invalid UTF8 string
-0: MakeMoveVec<std::string::String>([Input(0), Input(0)]);
-1: test::m1::vec_string(Result(0));
+//> 0: MakeMoveVec<std::string::String>([Input(0), Input(0)]);
+//> 1: test::m1::vec_string(Result(0));
 
 //# programmable --sender A
-0: test::m1::marker();
-1: test::m1::marker();
-2: MakeMoveVec([Result(0), Result(1)]);
-3: test::m1::burn_markers(Result(2));
+//> 0: test::m1::marker();
+//> 1: test::m1::marker();
+//> 2: MakeMoveVec([Result(0), Result(1)]);
+//> 3: test::m1::burn_markers(Result(2));

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -13,13 +13,14 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
+    u256::U256_NUM_BYTES,
 };
 use move_vm_runtime::{
     move_vm::MoveVM,
     session::{LoadedFunctionInstantiation, SerializedReturnValues},
 };
 use move_vm_types::loaded_data::runtime_types::{StructType, Type};
-use serde::de::DeserializeSeed;
+use serde::{de::DeserializeSeed, Deserialize};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     base_types::{
@@ -922,13 +923,6 @@ fn build_move_args<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
             value.write_bcs_bytes(&mut v);
             v
         };
-        // Any means this was just some bytes passed in as an argument (as opposed to being
-        // generated from a Move function). Meaning we will need to run validation
-        if matches!(value, Value::Raw(RawValueType::Any, _)) {
-            if let Some(layout) = additional_validation_layout(context, param_ty)? {
-                special_argument_validate(&bytes, idx as u16, layout)?;
-            }
-        }
         serialized_args.push(bytes);
     }
     Ok((tx_ctx_kind, by_mut_ref, serialized_args))
@@ -943,9 +937,8 @@ fn check_param_type<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
 ) -> Result<(), ExecutionError> {
     let obj_ty;
     let ty = match value {
-        Value::Raw(_, _) if Mode::allow_arbitrary_values() => return Ok(()),
-        Value::Raw(RawValueType::Any, _) => {
-            if !is_entry_primitive_type(context, param_ty)? {
+        Value::Raw(RawValueType::Any, bytes) => {
+            if !Mode::allow_arbitrary_values() && !is_entry_primitive_type(context, param_ty)? {
                 let msg = format!(
                     "Non-primitive argument at index {}. If it is an object, it must be \
                     populated by an object",
@@ -958,9 +951,14 @@ fn check_param_type<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
                     ),
                     msg,
                 ));
-            } else {
-                return Ok(());
             }
+
+            // Any means this was just some bytes passed in as an argument (as opposed to being
+            // generated from a Move function). Meaning we will need to run validation
+            if let Some(layout) = additional_validation_layout(context, param_ty)? {
+                special_argument_validate(bytes, idx as u16, layout)?;
+            }
+            return Ok(());
         }
         Value::Raw(RawValueType::Loaded { ty, abilities, .. }, _) => {
             assert_invariant!(
@@ -1082,6 +1080,7 @@ fn is_entry_primitive_type<E: fmt::Debug, S: StorageView<E>>(
 /// Special enum for values that need additional validation, in other words
 /// There is validation to do on top of the BCS layout. Currently only needed for
 /// strings
+#[derive(Debug)]
 pub enum SpecialArgumentLayout {
     /// An option
     Option(Box<SpecialArgumentLayout>),
@@ -1091,6 +1090,39 @@ pub enum SpecialArgumentLayout {
     Ascii,
     /// A UTF8 encoded string
     UTF8,
+    // needed for Option validation
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+    Address,
+}
+impl SpecialArgumentLayout {
+    /// returns true iff all BCS compatible bytes are actually values for this type.
+    /// For example, this function returns false for Option and Strings since they need additional
+    /// validation.
+    fn bcs_only(&self) -> bool {
+        match self {
+            // have additional restrictions past BCS
+            SpecialArgumentLayout::Option(_)
+            | SpecialArgumentLayout::Ascii
+            | SpecialArgumentLayout::UTF8 => false,
+            // Move primitives are BCS compatible and do not need additional validation
+            SpecialArgumentLayout::Bool
+            | SpecialArgumentLayout::U8
+            | SpecialArgumentLayout::U16
+            | SpecialArgumentLayout::U32
+            | SpecialArgumentLayout::U64
+            | SpecialArgumentLayout::U128
+            | SpecialArgumentLayout::U256
+            | SpecialArgumentLayout::Address => true,
+            // vector only needs validation if it's inner type does
+            SpecialArgumentLayout::Vector(inner) => inner.bcs_only(),
+        }
+    }
 }
 
 /// If the type is a string, returns the name of the string type and the layout
@@ -1099,51 +1131,65 @@ fn additional_validation_layout<E: fmt::Debug, S: StorageView<E>>(
     context: &mut ExecutionContext<E, S>,
     param_ty: &Type,
 ) -> Result<Option<SpecialArgumentLayout>, ExecutionError> {
-    match param_ty {
-        Type::Bool
-        | Type::U8
-        | Type::U16
-        | Type::U32
-        | Type::U64
-        | Type::U128
-        | Type::U256
-        | Type::Address
-        | Type::Signer
-        | Type::Reference(_)
-        | Type::MutableReference(_)
-        | Type::TyParam(_) => Ok(None),
-        Type::StructInstantiation(idx, targs) => {
-            let Some(s) = context.session.get_struct_type(*idx) else {
-                invariant_violation!("Loaded struct not found")
-            };
-            let resolved_struct = get_struct_ident(&s);
-            // is option of a string
-            if resolved_struct == RESOLVED_STD_OPTION && targs.len() == 1 {
-                let info_opt = additional_validation_layout(context, &targs[0])?;
-                Ok(info_opt.map(|layout| SpecialArgumentLayout::Option(Box::new(layout))))
-            } else {
-                Ok(None)
+    fn layout_for_type<E: fmt::Debug, S: StorageView<E>>(
+        context: &mut ExecutionContext<E, S>,
+        param_ty: &Type,
+    ) -> Result<Option<SpecialArgumentLayout>, ExecutionError> {
+        Ok(match param_ty {
+            Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
+                invariant_violation!("references and type parameters should be checked elsewhere")
             }
-        }
-        Type::Vector(inner) => {
-            let info_opt = additional_validation_layout(context, inner)?;
-            Ok(info_opt.map(|layout| SpecialArgumentLayout::Vector(Box::new(layout))))
-        }
-        Type::Struct(idx) => {
-            let Some(s) = context.session.get_struct_type(*idx) else {
-                invariant_violation!("Loaded struct not found")
-            };
-            let resolved_struct = get_struct_ident(&s);
-            let layout = if resolved_struct == RESOLVED_ASCII_STR {
-                Some(SpecialArgumentLayout::Ascii)
-            } else if resolved_struct == RESOLVED_UTF8_STR {
-                Some(SpecialArgumentLayout::UTF8)
-            } else {
-                None
-            };
-            Ok(layout)
-        }
+
+            Type::Bool => Some(SpecialArgumentLayout::Bool),
+            Type::U8 => Some(SpecialArgumentLayout::U8),
+            Type::U16 => Some(SpecialArgumentLayout::U16),
+            Type::U32 => Some(SpecialArgumentLayout::U32),
+            Type::U64 => Some(SpecialArgumentLayout::U64),
+            Type::U128 => Some(SpecialArgumentLayout::U128),
+            Type::U256 => Some(SpecialArgumentLayout::U256),
+            Type::Address | Type::Signer => Some(SpecialArgumentLayout::Address),
+
+            Type::Vector(inner) => {
+                let info_opt = layout_for_type(context, inner)?;
+                info_opt.map(|layout| SpecialArgumentLayout::Vector(Box::new(layout)))
+            }
+            Type::StructInstantiation(idx, targs) => {
+                let Some(s) = context.session.get_struct_type(*idx) else {
+                    invariant_violation!("Loaded struct not found")
+                };
+                let resolved_struct = get_struct_ident(&s);
+                // is option of a string
+                if resolved_struct == RESOLVED_STD_OPTION && targs.len() == 1 {
+                    let info_opt = layout_for_type(context, &targs[0])?;
+                    info_opt.map(|layout| SpecialArgumentLayout::Option(Box::new(layout)))
+                } else {
+                    None
+                }
+            }
+            Type::Struct(idx) => {
+                let Some(s) = context.session.get_struct_type(*idx) else {
+                    invariant_violation!("Loaded struct not found")
+                };
+                let resolved_struct = get_struct_ident(&s);
+                if resolved_struct == RESOLVED_ASCII_STR {
+                    Some(SpecialArgumentLayout::Ascii)
+                } else if resolved_struct == RESOLVED_UTF8_STR {
+                    Some(SpecialArgumentLayout::UTF8)
+                } else {
+                    None
+                }
+            }
+        })
     }
+
+    let layout_opt = layout_for_type(context, param_ty)?;
+    Ok(layout_opt.and_then(|layout| {
+        if layout.bcs_only() {
+            None
+        } else {
+            Some(layout)
+        }
+    }))
 }
 
 /// Checks the bytes against the `SpecialArgumentLayout` using `bcs`. It does not actually generate
@@ -1155,7 +1201,7 @@ pub fn special_argument_validate(
 ) -> Result<(), ExecutionError> {
     bcs::from_bytes_seed(&layout, bytes).map_err(|_| {
         ExecutionError::new_with_source(
-            ExecutionErrorKind::command_argument_error(CommandArgumentError::TypeMismatch, idx),
+            ExecutionErrorKind::command_argument_error(CommandArgumentError::InvalidBCSBytes, idx),
             format!("Function expects {layout} but provided argument's value does not match",),
         )
     })
@@ -1186,6 +1232,40 @@ impl<'d> serde::de::DeserializeSeed<'d> for &SpecialArgumentLayout {
             }
             SpecialArgumentLayout::Vector(layout) => {
                 deserializer.deserialize_seq(VectorElementVisitor(layout))
+            }
+            // primitive move value cases, which are hit to make sure the correct number of bytes
+            // are removed for elements of an option/vector
+            SpecialArgumentLayout::Bool => {
+                deserializer.deserialize_bool(serde::de::IgnoredAny)?;
+                Ok(())
+            }
+            SpecialArgumentLayout::U8 => {
+                deserializer.deserialize_u8(serde::de::IgnoredAny)?;
+                Ok(())
+            }
+            SpecialArgumentLayout::U16 => {
+                deserializer.deserialize_u16(serde::de::IgnoredAny)?;
+                Ok(())
+            }
+            SpecialArgumentLayout::U32 => {
+                deserializer.deserialize_u32(serde::de::IgnoredAny)?;
+                Ok(())
+            }
+            SpecialArgumentLayout::U64 => {
+                deserializer.deserialize_u64(serde::de::IgnoredAny)?;
+                Ok(())
+            }
+            SpecialArgumentLayout::U128 => {
+                deserializer.deserialize_u128(serde::de::IgnoredAny)?;
+                Ok(())
+            }
+            SpecialArgumentLayout::U256 => {
+                <[u8; U256_NUM_BYTES]>::deserialize(deserializer)?;
+                Ok(())
+            }
+            SpecialArgumentLayout::Address => {
+                SuiAddress::deserialize(deserializer)?;
+                Ok(())
             }
         }
     }
@@ -1248,6 +1328,14 @@ impl fmt::Display for SpecialArgumentLayout {
             SpecialArgumentLayout::UTF8 => {
                 write!(f, "std::{}::{}", RESOLVED_UTF8_STR.1, RESOLVED_UTF8_STR.2)
             }
+            SpecialArgumentLayout::Bool => write!(f, "bool"),
+            SpecialArgumentLayout::U8 => write!(f, "u8"),
+            SpecialArgumentLayout::U16 => write!(f, "u16"),
+            SpecialArgumentLayout::U32 => write!(f, "u32"),
+            SpecialArgumentLayout::U64 => write!(f, "u64"),
+            SpecialArgumentLayout::U128 => write!(f, "u128"),
+            SpecialArgumentLayout::U256 => write!(f, "u256"),
+            SpecialArgumentLayout::Address => write!(f, "address"),
         }
     }
 }

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -2037,7 +2037,7 @@ async fn test_entry_point_string_error() {
         &ExecutionStatus::Failure {
             error: ExecutionFailureStatus::CommandArgumentError {
                 arg_idx: 0,
-                kind: CommandArgumentError::TypeMismatch
+                kind: CommandArgumentError::InvalidBCSBytes
             },
             command: Some(0)
         }
@@ -2072,7 +2072,7 @@ async fn test_entry_point_string_error() {
         &ExecutionStatus::Failure {
             error: ExecutionFailureStatus::CommandArgumentError {
                 arg_idx: 0,
-                kind: CommandArgumentError::TypeMismatch
+                kind: CommandArgumentError::InvalidBCSBytes
             },
             command: Some(0)
         }
@@ -2107,7 +2107,7 @@ async fn test_entry_point_string_error() {
         &ExecutionStatus::Failure {
             error: ExecutionFailureStatus::CommandArgumentError {
                 arg_idx: 0,
-                kind: CommandArgumentError::TypeMismatch
+                kind: CommandArgumentError::InvalidBCSBytes
             },
             command: Some(0)
         }
@@ -2162,7 +2162,7 @@ async fn test_entry_point_string_vec_error() {
         &ExecutionStatus::Failure {
             error: ExecutionFailureStatus::CommandArgumentError {
                 arg_idx: 0,
-                kind: CommandArgumentError::TypeMismatch
+                kind: CommandArgumentError::InvalidBCSBytes
             },
             command: Some(0)
         }
@@ -2207,7 +2207,7 @@ async fn test_entry_point_string_option_error() {
         &ExecutionStatus::Failure {
             error: ExecutionFailureStatus::CommandArgumentError {
                 arg_idx: 0,
-                kind: CommandArgumentError::TypeMismatch
+                kind: CommandArgumentError::InvalidBCSBytes
             },
             command: Some(0)
         }
@@ -2237,7 +2237,7 @@ async fn test_entry_point_string_option_error() {
         &ExecutionStatus::Failure {
             error: ExecutionFailureStatus::CommandArgumentError {
                 arg_idx: 0,
-                kind: CommandArgumentError::TypeMismatch
+                kind: CommandArgumentError::InvalidBCSBytes
             },
             command: Some(0)
         }
@@ -2265,7 +2265,7 @@ async fn test_entry_point_string_option_error() {
         &ExecutionStatus::Failure {
             error: ExecutionFailureStatus::CommandArgumentError {
                 arg_idx: 0,
-                kind: CommandArgumentError::TypeMismatch
+                kind: CommandArgumentError::InvalidBCSBytes
             },
             command: Some(0)
         }


### PR DESCRIPTION
## Description 

- Fixed Option serialization not checking for more than 1 element
- Fixed MakeMoveVec not checking for additional serialization checks

## Test Plan 

- New tests 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
