### PR TITLE
VerificationObligation should use refs of public keys instead of cloning them

### DIFF
--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -117,11 +117,10 @@ impl Committee {
         self.epoch
     }
 
-    pub fn public_key(&self, authority: &AuthorityName) -> SuiResult<AuthorityPublicKey> {
+    pub fn public_key(&self, authority: &AuthorityName) -> SuiResult<&AuthorityPublicKey> {
         debug_assert_eq!(self.expanded_keys.len(), self.voting_rights.len());
         match self.expanded_keys.get(authority) {
-            // TODO: Check if this is unnecessary copying.
-            Some(v) => Ok(v.clone()),
+            Some(v) => Ok(v),
             None => Err(SuiError::InvalidCommittee(format!(
                 "Authority #{} not found, committee size {}",
                 authority,


### PR DESCRIPTION
## Description 
VerificationObligation should use refs to public keys instead of cloning them.

## Test Plan 
All tests pass

### Release notes
VerificationObligation should use refs to public keys instead of cloning them.