### PR TITLE
[benchmark] generalize weight and init parameters for new workloads

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,7 +91,7 @@ jobs:
           cargo nextest run --profile ci
       - name: benchmark (smoke)
         run: |
-          cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s --stress-stat-collection
+          cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  -w transfer_object=50 -w shared_counter=50 --run-duration 10s --stress-stat-collection
           pushd narwhal/benchmark && fab smoke && popd
       - name: doctests
         run: |

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -121,7 +121,7 @@ async fn main() -> Result<()> {
         client_runtime.block_on(async move {
             let workloads = WorkloadConfiguration::configure(
                 bench_setup.bank,
-                &opts,
+                opts.clone(),
                 system_state_observer.clone(),
             )
             .await?;

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -360,7 +360,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                             if let Some(mut b) = retry_queue.pop_front() {
                                 num_error += 1;
                                 num_submitted += 1;
-                                metrics_cloned.num_submitted.with_label_values(&[&b.1.to_string()]).inc();
+                                metrics_cloned.num_submitted.with_label_values(&[&b.1.workload_type().to_string()]).inc();
                                 let metrics_cloned = metrics_cloned.clone();
                                 // TODO: clone committee for each request is not ideal.
                                 let committee_cloned = Arc::new(worker.proxy.clone_committee());
@@ -378,11 +378,11 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                                 }
 
                                                 let square_latency_ms = latency.as_secs_f64().powf(2.0);
-                                                metrics_cloned.latency_s.with_label_values(&[&b.1.to_string()]).observe(latency.as_secs_f64());
-                                                metrics_cloned.latency_squared_s.with_label_values(&[&b.1.to_string()]).inc_by(square_latency_ms);
+                                                metrics_cloned.latency_s.with_label_values(&[&b.1.workload_type().to_string()]).observe(latency.as_secs_f64());
+                                                metrics_cloned.latency_squared_s.with_label_values(&[&b.1.workload_type().to_string()]).inc_by(square_latency_ms);
 
-                                                metrics_cloned.num_success.with_label_values(&[&b.1.to_string()]).inc();
-                                                metrics_cloned.num_in_flight.with_label_values(&[&b.1.to_string()]).dec();
+                                                metrics_cloned.num_success.with_label_values(&[&b.1.workload_type().to_string()]).inc();
+                                                metrics_cloned.num_in_flight.with_label_values(&[&b.1.workload_type().to_string()]).dec();
                                                 // let auth_sign_info = AuthorityStrongQuorumSignInfo::try_from(&cert.auth_sign_info).unwrap();
                                                 // auth_sign_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_tx_cert.with_label_values(&[&name.unwrap().to_string()]).inc());
                                                 if let Some(sig_info) = effects.quorum_sig() {
@@ -396,7 +396,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                             }
                                             Err(err) => {
                                                 error!("{}", err);
-                                                metrics_cloned.num_error.with_label_values(&[&b.1.to_string()]).inc();
+                                                metrics_cloned.num_error.with_label_values(&[&b.1.workload_type().to_string()]).inc();
                                                 NextOp::Retry(b)
                                             }
                                         }
@@ -412,8 +412,8 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                 let mut payload = free_pool.pop().unwrap();
                                 num_in_flight += 1;
                                 num_submitted += 1;
-                                metrics_cloned.num_in_flight.with_label_values(&[&payload.to_string()]).inc();
-                                metrics_cloned.num_submitted.with_label_values(&[&payload.to_string()]).inc();
+                                metrics_cloned.num_in_flight.with_label_values(&[&payload.workload_type().to_string()]).inc();
+                                metrics_cloned.num_submitted.with_label_values(&[&payload.workload_type().to_string()]).inc();
                                 let tx = payload.make_transaction();
                                 let start = Arc::new(Instant::now());
                                 let metrics_cloned = metrics_cloned.clone();
@@ -432,11 +432,11 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                             }
 
                                             let square_latency_ms = latency.as_secs_f64().powf(2.0);
-                                            metrics_cloned.latency_s.with_label_values(&[&payload.to_string()]).observe(latency.as_secs_f64());
-                                            metrics_cloned.latency_squared_s.with_label_values(&[&payload.to_string()]).inc_by(square_latency_ms);
+                                            metrics_cloned.latency_s.with_label_values(&[&payload.workload_type().to_string()]).observe(latency.as_secs_f64());
+                                            metrics_cloned.latency_squared_s.with_label_values(&[&payload.workload_type().to_string()]).inc_by(square_latency_ms);
 
-                                            metrics_cloned.num_success.with_label_values(&[&payload.to_string()]).inc();
-                                            metrics_cloned.num_in_flight.with_label_values(&[&payload.to_string()]).dec();
+                                            metrics_cloned.num_success.with_label_values(&[&payload.workload_type().to_string()]).inc();
+                                            metrics_cloned.num_in_flight.with_label_values(&[&payload.workload_type().to_string()]).dec();
                                             // let auth_sign_info = AuthorityStrongQuorumSignInfo::try_from(&cert.auth_sign_info).unwrap();
                                             // auth_sign_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_tx_cert.with_label_values(&[&name.unwrap().to_string()]).inc());
                                             if let Some(sig_info) = effects.quorum_sig() { sig_info.authorities(&committee_cloned).for_each(|name| metrics_cloned.validators_in_effects_cert.with_label_values(&[&name.unwrap().to_string()]).inc()) }
@@ -448,7 +448,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                         }
                                         Err(err) => {
                                             error!("Retry due to error: {}", err);
-                                            metrics_cloned.num_error.with_label_values(&[&payload.to_string()]).inc();
+                                            metrics_cloned.num_error.with_label_values(&[&payload.workload_type().to_string()]).inc();
                                             NextOp::Retry(Box::new((tx, payload)))
                                         }
                                     }

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -1,13 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::anyhow;
 use clap::*;
 
 use strum_macros::EnumString;
 
 use crate::drivers::Interval;
+use crate::workloads::workload::{WorkloadInitParameter, WorkloadType};
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 #[clap(name = "Stress Testing Framework")]
 pub struct Opts {
     /// Si&ze of the Sui committee.
@@ -144,7 +146,7 @@ pub enum RunSpec {
         shared_counter_hotness_factor: u32,
         // relative weight of transfer object
         // transactions in the benchmark workload
-        #[clap(long, default_value = "1")]
+        #[clap(long, default_value = "0")]
         transfer_object: u32,
         // relative weight of delegation transactions in the benchmark workload
         #[clap(long, default_value = "0")]
@@ -164,5 +166,23 @@ pub enum RunSpec {
         // Max in-flight ratio
         #[clap(long, default_value = "5", global = true)]
         in_flight_ratio: u64,
+        #[clap(long, short='w', value_parser = parse_weight_pair, value_delimiter=',')]
+        weights: Vec<(WorkloadType, u32)>,
+        #[clap(long, short='p', value_parser = parse_parameter_pair, value_delimiter=',')]
+        workload_parameters: Vec<(WorkloadInitParameter, u32)>,
     },
+}
+
+fn parse_weight_pair(input: &str) -> Result<(WorkloadType, u32), anyhow::Error> {
+    let pos = input
+        .find('=')
+        .ok_or_else(|| anyhow!("invalid input `{input}`"))?;
+    Ok((input[..pos].parse()?, input[pos + 1..].parse()?))
+}
+
+fn parse_parameter_pair(input: &str) -> Result<(WorkloadInitParameter, u32), anyhow::Error> {
+    let pos = input
+        .find('=')
+        .ok_or_else(|| anyhow!("invalid input `{input}`"))?;
+    Ok((input[..pos].parse()?, input[pos + 1..].parse()?))
 }

--- a/crates/sui-benchmark/src/workloads/payload.rs
+++ b/crates/sui-benchmark/src/workloads/payload.rs
@@ -1,15 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::workloads::workload::WorkloadType;
 use crate::ExecutionEffects;
-use std::fmt::Display;
 use sui_types::messages::VerifiedTransaction;
 
 /// A Payload is a transaction wrapper of a particular type (transfer object, shared counter, etc).
 /// Calling `make_transaction()` on a payload produces the transaction it is wrapping. Once that
 /// transaction is returned with effects (by quorum driver), a new payload can be generated with that
 /// effect by invoking `make_new_payload(effects)`
-pub trait Payload: Send + Sync + std::fmt::Debug + Display {
+pub trait Payload: Send + Sync {
     fn make_new_payload(&mut self, effects: &ExecutionEffects);
     fn make_transaction(&mut self) -> VerifiedTransaction;
+    fn workload_type(&self) -> WorkloadType;
 }

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -3,13 +3,13 @@
 
 #[cfg(msim)]
 mod test {
-
     use rand::{thread_rng, Rng};
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
     use sui_benchmark::bank::BenchmarkBank;
     use sui_benchmark::system_state_observer::SystemStateObserver;
+    use sui_benchmark::workloads::workload::{WorkloadInitParameter, WorkloadType};
     use sui_benchmark::workloads::workload_configuration::WorkloadConfiguration;
     use sui_benchmark::{
         drivers::{bench_driver::BenchDriver, driver::Driver, Interval},
@@ -247,28 +247,31 @@ mod test {
         let target_qps = get_var("SIM_STRESS_TEST_QPS", 10);
         let num_workers = get_var("SIM_STRESS_TEST_WORKERS", 10);
         let in_flight_ratio = get_var("SIM_STRESS_TEST_IFR", 2);
-        let batch_payment_size = get_var("SIM_BATCH_PAYMENT_SIZE", 15);
-        let shared_counter_weight = 1;
-        let transfer_object_weight = 1;
-        let num_transfer_accounts = 2;
-        let delegation_weight = 1;
-        let batch_payment_weight = 1;
-        let shared_counter_hotness_factor = 50;
+
+        let weights = vec![
+            (WorkloadType::TransferObject, 1),
+            (WorkloadType::SharedCounter, 1),
+            (WorkloadType::Delegation, 1),
+            (WorkloadType::BatchPayment, 1),
+        ];
+        let init_parameters = vec![
+            (WorkloadInitParameter::SharedCounterHotnessFactor, 50),
+            (WorkloadInitParameter::NumTransferAccounts, 2),
+            (
+                WorkloadInitParameter::BatchPaymentSize,
+                get_var("SIM_BATCH_PAYMENT_SIZE", 15),
+            ),
+        ];
 
         let workloads = WorkloadConfiguration::build_workloads(
             num_workers,
-            num_transfer_accounts,
-            shared_counter_weight,
-            transfer_object_weight,
-            delegation_weight,
-            batch_payment_weight,
-            batch_payment_size,
-            shared_counter_hotness_factor,
             target_qps,
             in_flight_ratio,
             bank,
             system_state_observer.clone(),
             100,
+            weights,
+            init_parameters,
         )
         .await
         .unwrap();


### PR DESCRIPTION
Complementary PR to the main [refactoring](https://github.com/MystenLabs/sui/pull/9261/).
PR generalizes weight and init parameters and further reduces code duplication related to adding new workloads.
To add a new workflow, add an entry to the `WorkloadType` enum and custom initializer to `WORKLOAD_REGISTRY`.
To add a custom init parameter, add an entry to the `WorkloadInitParameter` enum and it will be passed to an initializer. 

Example of a new usage:
> cargo run --package sui-benchmark --bin stress --  --num-client-threads 1 --num-server-threads 20  bench --target-qps 10 --in-flight-ratio 1 -w transfer_object=1 -w delegation=1 -p num_transfer_accounts=10 --run-duration 30s
