### PR TITLE
Remove delegation input from request_withdraw_stake

### DIFF
--- a/doc/src/doc-updates/sui-migration-guide.md
+++ b/doc/src/doc-updates/sui-migration-guide.md
@@ -486,8 +486,6 @@ Effective with release .28, the function names are:
         &self,
         /// the transaction signer's Sui address
         signer: SuiAddress,
-        /// Delegation object ID
-        delegation: ObjectID,
         /// StakedSui object ID
         staked_sui: ObjectID,
         /// gas object to be used in this transaction, node will pick one from the signer's possession if not provided


### PR DESCRIPTION
## Description 

Remove delegation input from request_withdraw_stake in the migration guide.

## Test Plan 
crates/sui-json-rpc/src/api/transaction_builder.rs does not have it.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
