### PR TITLE
RPC - Change results property of DevInspectResult

### DIFF
--- a/.changeset/breezy-planets-jog.md
+++ b/.changeset/breezy-planets-jog.md
@@ -1,0 +1,6 @@
+---
+"@mysten/sui.js": minor
+---
+
+Removed DevInspectResultsType and now DevInspectResults has a property results of ExecutionResultType and a property error  
+

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -560,7 +560,7 @@ async fn test_dev_inspect_dynamic_field() {
         }))],
     };
     let kind = TransactionKind::programmable(pt);
-    let DevInspectResults { results, error, .. } = fullnode
+    let DevInspectResults { error, .. } = fullnode
         .dev_inspect_transaction(sender, kind, Some(1))
         .await
         .unwrap();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -560,12 +560,12 @@ async fn test_dev_inspect_dynamic_field() {
         }))],
     };
     let kind = TransactionKind::programmable(pt);
-    let DevInspectResults { results, .. } = fullnode
+    let DevInspectResults { results, error, .. } = fullnode
         .dev_inspect_transaction(sender, kind, Some(1))
         .await
         .unwrap();
     // produces an error
-    let err = results.unwrap_err();
+    let err = error.unwrap();
     assert!(
         err.contains("kind: CircularObjectOwnership"),
         "unexpected error: {}",

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -613,24 +613,27 @@ impl DevInspectResults {
         let mut results = None;
         match return_values {
             Err(e) => error = Some(e.to_string()),
-            Ok(srvs) => results = Some(srvs
-                .into_iter()
-                .map(|srv| {
-                    let (mutable_reference_outputs, return_values) = srv;
-                    let mutable_reference_outputs = mutable_reference_outputs
-                        .into_iter()
-                        .map(|(a, bytes, tag)| (a.into(), bytes, SuiTypeTag::from(tag)))
-                        .collect();
-                    let return_values = return_values
-                        .into_iter()
-                        .map(|(bytes, tag)| (bytes, SuiTypeTag::from(tag)))
-                        .collect();
-                    SuiExecutionResult {
-                        mutable_reference_outputs,
-                        return_values,
-                    }
-                })
-                .collect()),
+            Ok(srvs) => {
+                results = Some(
+                    srvs.into_iter()
+                        .map(|srv| {
+                            let (mutable_reference_outputs, return_values) = srv;
+                            let mutable_reference_outputs = mutable_reference_outputs
+                                .into_iter()
+                                .map(|(a, bytes, tag)| (a.into(), bytes, SuiTypeTag::from(tag)))
+                                .collect();
+                            let return_values = return_values
+                                .into_iter()
+                                .map(|(bytes, tag)| (bytes, SuiTypeTag::from(tag)))
+                                .collect();
+                            SuiExecutionResult {
+                                mutable_reference_outputs,
+                                return_values,
+                            }
+                        })
+                        .collect(),
+                )
+            }
         };
         Ok(Self {
             effects: effects.try_into()?,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -3042,8 +3042,7 @@
         "type": "object",
         "required": [
           "effects",
-          "events",
-          "results"
+          "events"
         ],
         "properties": {
           "effects": {
@@ -3052,6 +3051,13 @@
               {
                 "$ref": "#/components/schemas/TransactionEffects"
               }
+            ]
+          },
+          "error": {
+            "description": "Execution error from executing the transaction commands",
+            "type": [
+              "string",
+              "null"
             ]
           },
           "events": {
@@ -3063,11 +3069,13 @@
           },
           "results": {
             "description": "Execution results (including return values) from executing the transaction commands",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Result_of_Array_of_SuiExecutionResult_or_String"
-              }
-            ]
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SuiExecutionResult"
+            }
           }
         }
       },
@@ -4765,35 +4773,6 @@
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
-              }
-            }
-          }
-        ]
-      },
-      "Result_of_Array_of_SuiExecutionResult_or_String": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "Ok"
-            ],
-            "properties": {
-              "Ok": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/SuiExecutionResult"
-                }
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "Err"
-            ],
-            "properties": {
-              "Err": {
-                "type": "string"
               }
             }
           }

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -232,15 +232,11 @@ const ExecutionResultType = object({
   returnValues: optional(array(ReturnValueType)),
 });
 
-const DevInspectResultsType = union([
-  object({ Ok: array(ExecutionResultType) }),
-  object({ Err: string() }),
-]);
-
 export const DevInspectResults = object({
   effects: TransactionEffects,
   events: TransactionEvents,
-  results: DevInspectResultsType,
+  results: optional(array(ExecutionResultType)),
+  error: optional(string()),
 });
 export type DevInspectResults = Infer<typeof DevInspectResults>;
 


### PR DESCRIPTION
Change results property of DevInspectResult from `Result<Vec<SuiExecutionResult>, String>` to 2 different properties.
`pub results: Option<Vec<SuiExecutionResult>>` and `pub error: Option<String>`