### PR TITLE
indexer: fix object deletion commit

### DIFF
--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -60,8 +60,7 @@ impl FromSql<Nullable<BcsBytes>, Pg> for NamedBcsBytes {
     }
 }
 
-#[derive(Insertable, Debug, Identifiable, Clone)]
-#[diesel(table_name = objects, primary_key(object_id))]
+#[derive(Debug, Clone)]
 pub struct DeletedObject {
     // epoch id in which this object got deleted.
     pub epoch: i64,
@@ -75,6 +74,27 @@ pub struct DeletedObject {
     pub object_type: String,
     pub object_status: ObjectStatus,
     pub has_public_transfer: bool,
+}
+
+impl From<DeletedObject> for Object {
+    fn from(o: DeletedObject) -> Self {
+        Object {
+            epoch: o.epoch,
+            checkpoint: o.checkpoint,
+            object_id: o.object_id,
+            version: o.version,
+            object_digest: o.object_digest,
+            owner_type: o.owner_type,
+            owner_address: None,
+            initial_shared_version: None,
+            previous_transaction: o.previous_transaction,
+            object_type: o.object_type,
+            object_status: o.object_status,
+            has_public_transfer: o.has_public_transfer,
+            storage_rebate: 0,
+            bcs: vec![],
+        }
+    }
 }
 
 #[derive(DbEnum, Debug, Clone, Copy)]


### PR DESCRIPTION
## Description 

- DeletedObject as an insertable does not include storage rebate -- which will cause error on DB commit
- Also after breaking / chunking the changes of commit, in case indexer failed in the middle of one checkpoint commit

Later todos:
- see if we want to keep DeletedObject any more
- try to see if the unnest trick would bring back the atomic commit

## Test Plan 

- local test with labnet and make sure that it passes deletions
```
2023-03-15T15:57:03.720198Z  INFO sui_indexer: Getting new RPC client...
2023-03-15T15:57:05.787211Z  INFO sui_indexer::handlers::checkpoint_handler: Indexer checkpoint handler started...
2023-03-15T15:57:05.792924Z  INFO sui_indexer::handlers::checkpoint_handler: Resuming from checkpoint 65
2023-03-15T15:57:09.304176Z  INFO sui_indexer::handlers::checkpoint_handler: Checkpoint 66 committed with 4 transactions and 4 objects.
2023-03-15T15:57:13.228257Z  INFO sui_indexer::handlers::checkpoint_handler: Checkpoint 67 committed with 6 transactions and 6 objects.
2023-03-15T15:57:16.703581Z  INFO sui_indexer::handlers::checkpoint_handler: Checkpoint 68 committed with 5 transactions and 5 objects.
2023-03-15T15:57:19.171762Z  INFO sui_indexer::handlers::checkpoint_handler: Checkpoint 69 committed with 4 transactions and 4 objects.
2023-03-15T15:57:21.261670Z  INFO sui_indexer::handlers::checkpoint_handler: Checkpoint 70 committed with 4 transactions and 4 objects.
2023-03-15T15:57:24.095009Z  INFO sui_indexer::handlers::checkpoint_handler: Checkpoint 71 committed with 5 transactions and 5 objects.
2023-03-15T15:57:26.500991Z  INFO sui_indexer::handlers::checkpoint_handler: Checkpoint 72 committed with 3 transactions and 3 objects.
2023-03-15T15:57:29.017261Z  INFO sui_indexer::handlers::checkpoint_handler: Checkpoint 73 committed with 5 transactions and 5 objects.
2023-03-15T15:57:31.376371Z  INFO sui_indexer::handlers::checkpoint_handler: Checkpoint 74 committed with 5 transactions and 5 objects.
...
```