### PR TITLE
[sui-test-validator] Increase local faucet amount

### DIFF
--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -114,7 +114,7 @@ impl FaucetClient for LocalFaucetClient {
     async fn request_sui_coins(&self, request_address: SuiAddress) -> FaucetResponse {
         let receipt = self
             .simple_faucet
-            .send(Uuid::new_v4(), request_address, &[200000; 5])
+            .send(Uuid::new_v4(), request_address, &[200000000; 5])
             .await
             .unwrap_or_else(|err| panic!("Failed to get gas tokens with error: {}", err));
 

--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -172,7 +172,7 @@ export class Transaction {
     this.#transactionData.gasConfig.budget = String(budget);
   }
   setGasPayment(payments: SuiObjectRef[]) {
-    if (payments.length > MAX_GAS_OBJECTS) {
+    if (payments.length >= MAX_GAS_OBJECTS) {
       throw new Error(
         `Payment objects exceed maximum amount ${MAX_GAS_OBJECTS}`,
       );
@@ -344,7 +344,7 @@ export class Transaction {
 
         return !matchingInput;
       })
-      .slice(0, MAX_GAS_OBJECTS)
+      .slice(0, MAX_GAS_OBJECTS - 1)
       .map((coin) => ({
         objectId: coin.coinObjectId,
         digest: coin.digest,


### PR DESCRIPTION
## Description 

I was trying to test staking locally and I noticed I would need to invoke the faucet thousands of times to get 1 SUI. This seems bad, so I bumped the default distribution locally to 1 SUI.

## Test Plan 

Tests should still pass.