### PR TITLE
indexer: configurable rpc server url and port

### DIFF
--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -1,13 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_indexer::errors::IndexerError;
-use sui_indexer::{new_pg_connection_pool, Indexer};
-use sui_node::metrics::start_prometheus_server;
-
 use clap::Parser;
-
+use sui_indexer::errors::IndexerError;
 use sui_indexer::store::PgIndexerStore;
+use sui_indexer::{new_pg_connection_pool, Indexer, IndexerConfig};
+use sui_node::metrics::start_prometheus_server;
 
 #[tokio::main]
 async fn main() -> Result<(), IndexerError> {
@@ -31,22 +29,5 @@ async fn main() -> Result<(), IndexerError> {
     let pg_connection_pool = new_pg_connection_pool(&indexer_config.db_url).await?;
     let store = PgIndexerStore::new(pg_connection_pool);
 
-    Indexer::start(&indexer_config.rpc_client_url, &registry, store).await
-}
-
-#[derive(Parser)]
-#[clap(
-    name = "Sui indexer",
-    about = "An off-fullnode service serving data from Sui protocol",
-    rename_all = "kebab-case"
-)]
-pub struct IndexerConfig {
-    #[clap(long)]
-    pub db_url: String,
-    #[clap(long)]
-    pub rpc_client_url: String,
-    #[clap(long, default_value = "0.0.0.0", global = true)]
-    pub client_metric_host: String,
-    #[clap(long, default_value = "9184", global = true)]
-    pub client_metric_port: u16,
+    Indexer::start(&indexer_config, &registry, store).await
 }

--- a/crates/sui-indexer/tests/indexer_tests.rs
+++ b/crates/sui-indexer/tests/indexer_tests.rs
@@ -9,7 +9,7 @@ use sui_indexer::models::checkpoints::Checkpoint;
 use sui_indexer::models::objects::Object;
 use sui_indexer::models::transactions::Transaction;
 use sui_indexer::store::{IndexerStore, TemporaryCheckpointStore, TemporaryEpochStore};
-use sui_indexer::Indexer;
+use sui_indexer::{Indexer, IndexerConfig};
 use sui_json_rpc_types::{CheckpointId, EventFilter};
 use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::object::ObjectRead;
@@ -22,7 +22,9 @@ async fn test_genesis() {
 
     let s = store.clone();
     let _handle = tokio::task::spawn(async move {
-        Indexer::start(test_cluster.rpc_url(), &Registry::default(), s).await
+        let mut config = IndexerConfig::default();
+        config.rpc_client_url = test_cluster.rpc_url().to_string();
+        Indexer::start(&config, &Registry::default(), s).await
     });
 
     // Allow indexer to process the data

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -13,8 +13,7 @@ mod pg_integration {
     use sui_config::SUI_KEYSTORE_FILENAME;
     use sui_indexer::errors::IndexerError;
     use sui_indexer::store::{IndexerStore, PgIndexerStore};
-    use sui_indexer::PgPoolConnection;
-    use sui_indexer::{new_pg_connection_pool, Indexer};
+    use sui_indexer::{new_pg_connection_pool, Indexer, IndexerConfig, PgPoolConnection};
     use sui_json_rpc::api::{ReadApiClient, TransactionBuilderClient, WriteApiClient};
     use sui_json_rpc_types::{
         SuiMoveObject, SuiObjectDataOptions, SuiObjectResponse, SuiParsedMoveObject,
@@ -226,14 +225,19 @@ mod pg_integration {
         let store_clone = store.clone();
         let registry = Registry::default();
 
-        let rpc_url = test_cluster.rpc_url().to_string();
+        let mut config = IndexerConfig::default();
+        config.rpc_client_url = test_cluster.rpc_url().to_string();
+        let indexer_config = config.clone();
         let handle =
-            tokio::spawn(async move { Indexer::start(&rpc_url, &registry, store_clone).await });
+            tokio::spawn(
+                async move { Indexer::start(&indexer_config, &registry, store_clone).await },
+            );
 
-        // TODO: make indexer port configurable
-        let http_client = HttpClientBuilder::default()
-            .build("http://0.0.0.0:3030")
-            .unwrap();
+        let http_addr_port = format!(
+            "http://{}:{}",
+            config.rpc_server_url, config.rpc_server_port
+        );
+        let http_client = HttpClientBuilder::default().build(http_addr_port).unwrap();
 
         (test_cluster, http_client, store, handle)
     }


### PR DESCRIPTION
## Description 

configurable RPC server addr and port

## Test Plan 

- CI
- local run to make sure the addr and port can be configured
```
cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost/gegao" --rpc-client-url "http://0.0.0.0:9000" --client-metric-host "127.0.0.1" --client-metric-port 9184 --rpc-server-port 3030
    Finished dev [unoptimized + debuginfo] target(s) in 0.57s
     Running `/Users/gegao/Documents/sui/target/debug/sui-indexer --db-url 'postgres://postgres:postgres@localhost/gegao' --rpc-client-url 'http://0.0.0.0:9000' --client-metric-host 127.0.0.1 --client-metric-port 9184 --rpc-server-port 3030`
2023-03-15T19:02:36.943632Z  INFO sui_indexer::store::pg_indexer_store: Found 2 tables with partitions : [{"objects_history": "5", "owner_history": "5"}]
2023-03-15T19:02:36.953308Z  INFO sui_json_rpc: acl=Const("*")
2023-03-15T19:02:36.954266Z  INFO sui_json_rpc: Compatibility method routing enabled.
2023-03-15T19:02:36.954544Z  INFO sui_json_rpc: Sui JSON-RPC server listening on 0.0.0.0:3030 local_addr=0.0.0.0:3030
```

