### PR TITLE
[consensus_handler] Local in-memory cache for processed transactions

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -195,6 +195,7 @@ pub struct AuthorityMetrics {
     pub(crate) execution_driver_executed_transactions: IntCounter,
 
     pub(crate) skipped_consensus_txns: IntCounter,
+    pub(crate) skipped_consensus_txns_cache_hit: IntCounter,
 
     /// Post processing metrics
     post_processing_total_events_emitted: IntCounter,
@@ -368,6 +369,12 @@ impl AuthorityMetrics {
             skipped_consensus_txns: register_int_counter_with_registry!(
                 "skipped_consensus_txns",
                 "Total number of consensus transactions skipped",
+                registry,
+            )
+            .unwrap(),
+            skipped_consensus_txns_cache_hit: register_int_counter_with_registry!(
+                "skipped_consensus_txns_cache_hit",
+                "Total number of consensus transactions skipped because of local cache hit",
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
We noticed that DB read into consensus_message_processed table takes significant time, and using simple in-memory cache would speed this up for duplicate transactions.

The cache is implemented in ConsensusHandler and not on the PerEpochStore. The drawback is that other use cases would not make use of that cache, but on the flip side the benefit is that it optimizes for consensus handler performance:

* It avoids lock conflicts between consensus handler and other threads. Even more, if/when we change handle_consensus_transaction to non-async, we could only acquire lock once for entire consensus handler task duration

* I think down the line we are likely to optimize this even more and make this in memory cache even more specialized to skip deserialization for the duplicated transaction.

