### PR TITLE
[rpc] Disable batch transaction (#9295)

### DIFF
--- a/.changeset/khaki-penguins-walk.md
+++ b/.changeset/khaki-penguins-walk.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Remove support for RPC Batch Request in favor of multiGetTransactions and multiGetObjects

--- a/apps/core/src/api/SentryRpcClient.ts
+++ b/apps/core/src/api/SentryRpcClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { JsonRpcClient, type RpcParams } from '@mysten/sui.js';
+import { JsonRpcClient } from '@mysten/sui.js';
 import * as Sentry from '@sentry/react';
 import { type SpanStatusType } from '@sentry/tracing';
 
@@ -43,12 +43,6 @@ export class SentryRpcClient extends JsonRpcClient {
     async request(method: string, args: any) {
         return this.#withRequest(method, { args }, () =>
             super.request(method, args)
-        );
-    }
-
-    async batchRequest(requests: RpcParams[]) {
-        return this.#withRequest('batch', { requests }, () =>
-            super.batchRequest(requests)
         );
     }
 }

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -148,6 +148,7 @@ impl JsonRpcServerBuilder {
             .layer(routing_layer);
 
         let server = ServerBuilder::default()
+            .batch_requests_supported(false)
             .max_response_body_size(MAX_REQUEST_SIZE)
             .max_connections(max_connection)
             .set_host_filtering(AllowHosts::Any)

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -647,35 +647,23 @@ export class JsonRpcProvider {
     objectID: ObjectId,
     descendingOrder: boolean = true,
   ): Promise<GetTxnDigestsResponse> {
-    const requests = [
-      {
-        method: 'sui_queryTransactions',
-        args: [
-          { filter: { InputObject: objectID } },
-          null,
-          null,
-          descendingOrder,
-        ],
-      },
-      {
-        method: 'sui_queryTransactions',
-        args: [
-          { filter: { MutatedObject: objectID } },
-          null,
-          null,
-          descendingOrder,
-        ],
-      },
+    const filters = [
+      { filter: { InputObject: objectID } },
+      { filter: { MutatedObject: objectID } },
     ];
-
     try {
       if (!objectID || !isValidSuiObjectId(normalizeSuiObjectId(objectID))) {
         throw new Error('Invalid Sui Object id');
       }
-      const results = await this.client.batchRequestWithType(
-        requests,
-        PaginatedTransactionResponse,
-        this.options.skipDataValidation,
+      const results = await Promise.all(
+        filters.map((filter) =>
+          this.client.requestWithType(
+            'sui_queryTransactions',
+            [{ filter }, null, null, descendingOrder],
+            PaginatedTransactionResponse,
+            this.options.skipDataValidation,
+          ),
+        ),
       );
       return [
         ...results[0].data.map((r) => r.digest),
@@ -696,34 +684,20 @@ export class JsonRpcProvider {
     addressID: SuiAddress,
     descendingOrder: boolean = true,
   ): Promise<GetTxnDigestsResponse> {
-    const requests = [
-      {
-        method: 'sui_queryTransactions',
-        args: [
-          { filter: { ToAddress: addressID } },
-          null,
-          null,
-          descendingOrder,
-        ],
-      },
-      {
-        method: 'sui_queryTransactions',
-        args: [
-          { filter: { FromAddress: addressID } },
-          null,
-          null,
-          descendingOrder,
-        ],
-      },
-    ];
+    const filters = [{ ToAddress: addressID }, { FromAddress: addressID }];
     try {
       if (!addressID || !isValidSuiAddress(normalizeSuiAddress(addressID))) {
         throw new Error('Invalid Sui address');
       }
-      const results = await this.client.batchRequestWithType(
-        requests,
-        PaginatedTransactionResponse,
-        this.options.skipDataValidation,
+      const results = await Promise.all(
+        filters.map((filter) =>
+          this.client.requestWithType(
+            'sui_queryTransactions',
+            [{ filter }, null, null, descendingOrder],
+            PaginatedTransactionResponse,
+            this.options.skipDataValidation,
+          ),
+        ),
       );
       return [
         ...results[0].data.map((r) => r.digest),


### PR DESCRIPTION
## Description 

Disable rpc batch transaction in favor of the recently added`multiGetTransactions` and `multiGetObjects`

## Test Plan 

- CI and verify that batch requests no longer works

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Disable RPC Batch requests in favor of `sui_multiGetTransactions` and `sui_multiGetObjects`

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
