### PR TITLE
[ts-sdk] Fix incorrect param serialize

### DIFF
--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -482,7 +482,7 @@ export class Transaction {
             if (arg.kind !== 'Input') return;
             const input = inputs[arg.index];
             // Skip if the input is already resolved
-            if (is(input, BuilderCallArg)) return;
+            if (is(input.value, BuilderCallArg)) return;
 
             const inputValue = input.value;
 


### PR DESCRIPTION
## Description 

This fixes a bug with incorrect input serialization checks. This mostly happened when double-serializing a transaction.

## Test Plan 

Tests should still pass.