### PR TITLE
[upgrades] Make framework upgrades compatible with package upgrades

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -4,13 +4,12 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use crate::execution_mode::{self, ExecutionMode};
-use move_binary_format::{access::ModuleAccess, CompiledModule};
+use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::language_storage::ModuleId;
 use move_vm_runtime::move_vm::MoveVM;
 use sui_types::base_types::ObjectID;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 use tracing::{debug, info, instrument, warn};
 
 use crate::programmable_transactions;
@@ -369,30 +368,14 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
         )?;
     }
 
-    for (version, modules) in change_epoch.system_packages.into_iter() {
+    for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {
         let modules: Vec<_> = modules
             .into_iter()
             .map(|m| CompiledModule::deserialize(&m).unwrap())
             .collect();
 
-        assert_invariant!(
-            !modules.is_empty(),
-            "System package must have at least one module"
-        );
-
-        let pkg_id = ObjectID::from(*modules[0].address());
-        let mut dependencies = vec![];
-        // Sui framework package has one dependency while Move stdlib package (the other one) has
-        // none.
-        // TODO: Should we assert that there could only be two system package here to avoid
-        // potential surprises with passing the right type of dependencies?
-        if pkg_id == SUI_FRAMEWORK_OBJECT_ID {
-            let (std_move_pkg, _) = sui_framework::make_std_sui_move_pkgs();
-            dependencies.push(std_move_pkg);
-        }
-
         let mut new_package =
-            Object::new_system_package(modules, version, tx_ctx.digest(), &dependencies)?;
+            Object::new_system_package(modules, version, dependencies, tx_ctx.digest());
 
         info!(
             "upgraded system package {:?}",

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -47,6 +47,7 @@ use sui_types::sui_system_state::{
     SuiSystemStateInnerGenesis, SuiSystemStateTrait, SuiSystemStateWrapper,
 };
 use sui_types::temporary_store::{InnerTemporaryStore, TemporaryStore};
+use sui_types::MOVE_STDLIB_ADDRESS;
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 use sui_types::{
     base_types::TxContext,
@@ -54,7 +55,6 @@ use sui_types::{
     error::SuiResult,
     object::Object,
 };
-use sui_types::{MOVE_STDLIB_ADDRESS, MOVE_STDLIB_OBJECT_ID};
 use tracing::trace;
 
 #[derive(Clone, Debug)]
@@ -803,10 +803,13 @@ fn build_unsigned_genesis_data(
 
     // Get Move and Sui Framework
     let modules = [
-        (sui_framework::get_move_stdlib(), vec![]),
+        (
+            sui_framework::get_move_stdlib(),
+            sui_framework::get_move_stdlib_transitive_dependencies(),
+        ),
         (
             sui_framework::get_sui_framework(),
-            vec![MOVE_STDLIB_OBJECT_ID],
+            sui_framework::get_sui_framework_transitive_dependencies(),
         ),
     ];
 
@@ -1041,7 +1044,7 @@ fn process_package(
         .collect();
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        // executing in Genesis mode does not create a package upgrade
+        // executing in Genesis mode does not create an `UpgradeCap`.
         builder.command(Command::Publish(module_bytes, dependencies));
         builder.finish()
     };

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -152,13 +152,12 @@ async fn init_genesis(
         .into_iter()
         .cloned()
         .collect();
-    let (std_move_pkg, sui_move_pkg) = sui_framework::make_std_sui_move_pkgs();
     let pkg = Object::new_package(
         modules,
         OBJECT_START_VERSION,
         TransactionDigest::genesis(),
         ProtocolConfig::get_for_max_version().max_move_package_size(),
-        [&std_move_pkg, &sui_move_pkg],
+        &sui_framework::make_system_packages(),
     )
     .unwrap();
     let pkg_id = pkg.id();

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use sui_framework::make_std_sui_move_pkgs;
+use sui_framework::make_system_packages;
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_types::crypto::get_key_pair_from_rng;
 use sui_types::crypto::{get_key_pair, AccountKeyPair, AuthorityKeyPair};
@@ -330,11 +330,10 @@ async fn test_quorum_map_and_reduce_timeout() {
         .into_iter()
         .cloned()
         .collect();
-    let (std_move_pkg, sui_move_pkg) = make_std_sui_move_pkgs();
     let pkg = Object::new_package_for_testing(
         modules,
         TransactionDigest::genesis(),
-        [&std_move_pkg, &sui_move_pkg],
+        &make_system_packages(),
     )
     .unwrap();
     let (addr1, key1): (_, AccountKeyPair) = get_key_pair();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -28,6 +28,7 @@ use rand::{
     Rng, SeedableRng,
 };
 use serde_json::json;
+use sui_framework::{make_system_objects, make_system_packages};
 use tracing::info;
 
 use sui_json_rpc_types::{
@@ -218,17 +219,6 @@ async fn construct_shared_object_transaction_with_sequence_number(
         gas_object_id,
         shared_object_id,
     )
-}
-
-pub fn create_genesis_module_packages() -> Vec<Object> {
-    let sui_modules = sui_framework::get_sui_framework();
-    let std_modules = sui_framework::get_move_stdlib();
-    let (std_move_pkg, _) = sui_framework::make_std_sui_move_pkgs();
-    vec![
-        Object::new_package_for_testing(std_modules, TransactionDigest::genesis(), &[]).unwrap(),
-        Object::new_package_for_testing(sui_modules, TransactionDigest::genesis(), [&std_move_pkg])
-            .unwrap(),
-    ]
 }
 
 #[tokio::test]
@@ -1553,7 +1543,7 @@ async fn test_publish_dependent_module_ok() {
     let gas_payment_object = Object::with_id_owner_for_testing(gas_payment_object_id, sender);
     let gas_payment_object_ref = gas_payment_object.compute_object_reference();
     // create a genesis state that contains the gas object and genesis modules
-    let genesis_module_objects = create_genesis_module_packages();
+    let genesis_module_objects = make_system_objects();
     let genesis_module = match &genesis_module_objects[0].data {
         Data::Package(m) => {
             CompiledModule::deserialize(m.serialized_module_map().values().next().unwrap()).unwrap()
@@ -1638,7 +1628,7 @@ async fn test_publish_non_existing_dependent_module() {
     let gas_payment_object = Object::with_id_owner_for_testing(gas_payment_object_id, sender);
     let gas_payment_object_ref = gas_payment_object.compute_object_reference();
     // create a genesis state that contains the gas object and genesis modules
-    let genesis_module_objects = create_genesis_module_packages();
+    let genesis_module_objects = make_system_objects();
     let genesis_module = match &genesis_module_objects[0].data {
         Data::Package(m) => {
             CompiledModule::deserialize(m.serialized_module_map().values().next().unwrap()).unwrap()
@@ -4193,9 +4183,7 @@ async fn publish_object_basics(state: Arc<AuthorityState>) -> (Arc<AuthorityStat
         .cloned()
         .collect();
     let digest = TransactionDigest::genesis();
-    let (std_move_pkg, sui_move_pkg) = sui_framework::make_std_sui_move_pkgs();
-    let pkg =
-        Object::new_package_for_testing(modules, digest, [&std_move_pkg, &sui_move_pkg]).unwrap();
+    let pkg = Object::new_package_for_testing(modules, digest, &make_system_packages()).unwrap();
     let pkg_ref = pkg.compute_object_reference();
     state.insert_genesis_object(pkg).await;
     (state, pkg_ref)
@@ -4227,9 +4215,7 @@ pub async fn init_state_with_ids_and_object_basics_with_fullnode<
         .cloned()
         .collect();
     let digest = TransactionDigest::genesis();
-    let (std_move_pkg, sui_move_pkg) = sui_framework::make_std_sui_move_pkgs();
-    let pkg =
-        Object::new_package_for_testing(modules, digest, [&std_move_pkg, &sui_move_pkg]).unwrap();
+    let pkg = Object::new_package_for_testing(modules, digest, &make_system_packages()).unwrap();
     let pkg_ref = pkg.compute_object_reference();
     validator.insert_genesis_object(pkg.clone()).await;
     fullnode.insert_genesis_object(pkg).await;

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -3,14 +3,13 @@
 
 use super::*;
 
-use super::authority_tests::{
-    create_genesis_module_packages, init_state_with_ids, send_and_confirm_transaction,
-};
+use super::authority_tests::{init_state_with_ids, send_and_confirm_transaction};
 use super::move_integration_tests::build_and_try_publish_test_package;
 use crate::authority::authority_tests::{init_state, init_state_with_ids_and_object_basics};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use once_cell::sync::Lazy;
+use sui_framework::make_system_objects;
 use sui_types::crypto::AccountKeyPair;
 use sui_types::gas_coin::GasCoin;
 use sui_types::is_system_package;
@@ -295,7 +294,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
         expected_gas_balance,
     );
     // genesis objects are read during transaction since they are direct dependencies.
-    let genesis_objects = create_genesis_module_packages();
+    let genesis_objects = make_system_objects();
     // We need the original package bytes in order to reproduce the publish computation cost.
     let publish_bytes = match response.0.data().intent_message().value.kind() {
         TransactionKind::ProgrammableTransaction(pt) => match pt.commands.first().unwrap() {

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -54,6 +54,8 @@ ChangeEpoch:
             - TYPENAME: SequenceNumber
             - SEQ:
                 SEQ: U8
+            - SEQ:
+                TYPENAME: ObjectID
 Command:
   ENUM:
     0:

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -10,7 +10,7 @@ use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, value::MoveTypeLayout,
 };
 use serde_json::{json, Value};
-use sui_framework::make_std_sui_move_pkgs;
+use sui_framework::make_system_packages;
 use sui_framework_build::compiled_package::BuildConfig;
 use test_fuzz::runtime::num_traits::ToPrimitive;
 
@@ -406,11 +406,10 @@ fn test_basic_args_linter_top_level() {
         .build(path)
         .unwrap()
         .into_modules();
-    let (std_move_pkg, sui_move_pkg) = make_std_sui_move_pkgs();
     let example_package = Object::new_package_for_testing(
         compiled_modules,
         TransactionDigest::genesis(),
-        [&std_move_pkg, &sui_move_pkg],
+        &make_system_packages(),
     )
     .unwrap();
     let example_package = example_package.data.try_as_package().unwrap();
@@ -531,11 +530,10 @@ fn test_basic_args_linter_top_level() {
         .build(path)
         .unwrap()
         .into_modules();
-    let (std_move_pkg, sui_move_pkg) = make_std_sui_move_pkgs();
     let example_package = Object::new_package_for_testing(
         compiled_modules,
         TransactionDigest::genesis(),
-        [&std_move_pkg, &sui_move_pkg],
+        &make_system_packages(),
     )
     .unwrap();
     let framework_pkg = example_package.data.try_as_package().unwrap();
@@ -635,11 +633,10 @@ fn test_basic_args_linter_top_level() {
         .build(path)
         .unwrap()
         .into_modules();
-    let (std_move_pkg, sui_move_pkg) = make_std_sui_move_pkgs();
     let example_package = Object::new_package_for_testing(
         compiled_modules,
         TransactionDigest::genesis(),
-        [&std_move_pkg, &sui_move_pkg],
+        &make_system_packages(),
     )
     .unwrap();
     let example_package = example_package.data.try_as_package().unwrap();

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -152,9 +152,10 @@ pub struct ChangeEpoch {
     pub epoch_start_timestamp_ms: u64,
     /// System packages (specifically framework and move stdlib) that are written before the new
     /// epoch starts. This tracks framework upgrades on chain. When executing the ChangeEpoch txn,
-    /// the validator must write out the modules below.  Modules are given in their serialized form,
-    /// and include the ObjectID within their serialized form.
-    pub system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>)>,
+    /// the validator must write out the modules below.  Modules are provided with the version they
+    /// will be upgraded to, their modules in serialized form (which include their package ID), and
+    /// a list of their transitive dependencies.
+    pub system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
@@ -1808,7 +1809,7 @@ impl VerifiedTransaction {
         computation_charge: u64,
         storage_rebate: u64,
         epoch_start_timestamp_ms: u64,
-        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>)>,
+        system_packages: Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>,
     ) -> Self {
         ChangeEpoch {
             epoch: next_epoch,

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -542,22 +542,19 @@ impl Object {
 
     /// Create a system package which is not subject to size limits. Panics if the object ID is not
     /// a known system package.
-    pub fn new_system_package<'p>(
+    pub fn new_system_package(
         modules: Vec<CompiledModule>,
         version: SequenceNumber,
+        dependencies: Vec<ObjectID>,
         previous_transaction: TransactionDigest,
-        dependencies: impl IntoIterator<Item = &'p MovePackage>,
-    ) -> Result<Self, ExecutionError> {
-        let ret = Self::new_package(
-            modules,
-            version,
+    ) -> Self {
+        let ret = Self::new_package_from_data(
+            Data::Package(MovePackage::new_system(version, modules, dependencies)),
             previous_transaction,
-            // System objects are not subject to limits
-            u64::MAX,
-            dependencies,
-        )?;
+        );
+
         assert!(ret.is_system_package());
-        Ok(ret)
+        ret
     }
 
     pub fn new_package_from_data(data: Data, previous_transaction: TransactionDigest) -> Self {

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -61,7 +61,7 @@ mod sim_only_tests {
     use std::path::PathBuf;
     use std::sync::Arc;
     use sui_core::authority::sui_framework_injection;
-    use sui_framework::make_std_sui_move_pkgs;
+    use sui_framework::get_move_stdlib_package;
     use sui_framework_build::compiled_package::BuildConfig;
     use sui_json_rpc::api::WriteApiClient;
     use sui_macros::*;
@@ -596,13 +596,12 @@ mod sim_only_tests {
 
     /// Like `sui_framework`, but package the modules in an `Object`.
     fn sui_framework_object(fixture: &str) -> Object {
-        let (std_move_pkg, _) = make_std_sui_move_pkgs();
         Object::new_package(
             sui_framework(fixture),
             OBJECT_START_VERSION,
             TransactionDigest::genesis(),
             u64::MAX,
-            [&std_move_pkg],
+            &[get_move_stdlib_package()],
         )
         .unwrap()
     }

--- a/crates/test-utils/tests/network_tests.rs
+++ b/crates/test-utils/tests/network_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::access::ModuleAccess;
-use sui_framework::make_std_sui_move_pkgs;
+use sui_framework::get_move_stdlib_package;
 use sui_json_rpc::api::ReadApiClient;
 use sui_json_rpc_types::SuiObjectResponse;
 use sui_types::{
@@ -54,11 +54,10 @@ async fn test_package_override() {
         // entirely because we will call into it for genesis.
         framework_modules.push(test_module);
 
-        let (std_move_pkg, _) = make_std_sui_move_pkgs();
         let package_override = Object::new_package_for_testing(
             framework_modules,
             TransactionDigest::genesis(),
-            [&std_move_pkg],
+            &[get_move_stdlib_package()],
         )
         .unwrap();
 


### PR DESCRIPTION
## Description 

Rather than hard-code the dependencies of a system package in the execution logic for `ChangeEpoch`, pass them in as parameters, because if the set of dependecies changes (or a new framework package is added), we don't want to use the newest set of dependencies everywhere, but the historical versions at the time the `ChangeEpoch` was agreed upon and signed.

## Test Plan 

```
$ cargo simtest protocol_version_tests
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [x] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
