### PR TITLE
[package-upgrades] Fix a lint warning in type_origin_table macro

### DIFF
--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -17,15 +17,11 @@ use std::{collections::BTreeMap, path::PathBuf};
 macro_rules! type_origin_table {
     {} => { Vec::new() };
     {$($module:ident :: $type:ident => $pkg:expr),* $(,)?} => {{
-        let mut table = Vec::new();
-        $(
-            table.push(TypeOrigin {
-                module_name: stringify!($module).to_string(),
-                struct_name: stringify!($type).to_string(),
-                package: $pkg,
-            });
-        )*
-        table
+        vec![$(TypeOrigin {
+            module_name: stringify!($module).to_string(),
+            struct_name: stringify!($type).to_string(),
+            package: $pkg,
+        },)*]
     }}
 }
 


### PR DESCRIPTION
Create a vector literal rather than a new vector to push into.

Test Plan:

```
$ cargo fmt && cargo xlint && cargo xclippy
$ cargo nextest run -- 'move_package_tests'
```